### PR TITLE
Fix Storybook Vercel URLs and add react-inspector README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ dist
 
 # Storybook
 storybook-static
+.vercel

--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ A collection of [Effect](https://effect.website) utilities and integrations.
 | Package | Description |
 |---------|-------------|
 | [@overeng/effect-schema-form](./packages/@overeng/effect-schema-form) | Headless form component for Effect Schemas |
-| [@overeng/effect-schema-form-aria](./packages/@overeng/effect-schema-form-aria) | React Aria implementation with Tailwind CSS ([Storybook](https://overeng-effect-utils-schema-form-aria.vercel.app)) |
+| [@overeng/effect-schema-form-aria](./packages/@overeng/effect-schema-form-aria) | React Aria implementation with Tailwind CSS ([Storybook](https://overeng-effect-utils-schema-form-ar.vercel.app)) |
 
 ### React Integration
 
 | Package | Description |
 |---------|-------------|
 | [@overeng/effect-react](./packages/@overeng/effect-react) | React integration for Effect runtime |
-| [@overeng/react-inspector](./packages/@overeng/react-inspector) | DevTools-style inspectors with Effect Schema support ([Storybook](https://overeng-effect-utils-react-inspector.vercel.app)) |
+| [@overeng/react-inspector](./packages/@overeng/react-inspector) | DevTools-style inspectors with Effect Schema support ([Storybook](https://overeng-effect-utils-react-inspecto.vercel.app)) |
 
 ## Development
 

--- a/packages/@overeng/effect-schema-form-aria/README.md
+++ b/packages/@overeng/effect-schema-form-aria/README.md
@@ -2,7 +2,7 @@
 
 Styled React Aria implementation for `@overeng/effect-schema-form`. Provides accessible, styled form components using React Aria Components and Tailwind CSS.
 
-[**Storybook**](https://overeng-effect-utils-schema-form-aria.vercel.app) - Interactive component documentation and examples
+[**Storybook**](https://overeng-effect-utils-schema-form-ar.vercel.app) - Interactive component documentation and examples
 
 ## Installation
 

--- a/packages/@overeng/react-inspector/README.md
+++ b/packages/@overeng/react-inspector/README.md
@@ -1,0 +1,50 @@
+# @overeng/react-inspector
+
+Power of Browser DevTools inspectors right inside your React app. Fork of [storybookjs/react-inspector](https://github.com/storybookjs/react-inspector) with Effect Schema support.
+
+[**Storybook**](https://overeng-effect-utils-react-inspecto.vercel.app) - Interactive component documentation and examples
+
+## Installation
+
+```bash
+pnpm add @overeng/react-inspector
+```
+
+## Usage
+
+### Basic Usage
+
+```tsx
+import { ObjectInspector } from '@overeng/react-inspector'
+
+const data = {
+  id: 1,
+  name: 'John Doe',
+  nested: { foo: 'bar' },
+}
+
+<ObjectInspector data={data} />
+```
+
+### With Effect Schema Support
+
+```tsx
+import { ObjectInspector, withSchemaSupport, SchemaProvider } from '@overeng/react-inspector'
+import { Schema } from 'effect'
+
+const UserSchema = Schema.Struct({
+  id: Schema.Number,
+  name: Schema.String,
+}).annotations({ title: 'User' })
+
+// Option 1: Using HOC
+const SchemaInspector = withSchemaSupport(ObjectInspector)
+<SchemaInspector data={user} schema={UserSchema} />
+
+// Option 2: Using SchemaProvider directly
+<SchemaProvider schema={UserSchema}>
+  <ObjectInspector data={user} />
+</SchemaProvider>
+```
+
+See [FORK_CHANGELOG.md](./FORK_CHANGELOG.md) for details on fork-specific features.


### PR DESCRIPTION
## Summary

- Fixed truncated Storybook Vercel URLs (Vercel truncates long project names)
- Added README for @overeng/react-inspector package with Storybook link
- Added .vercel to .gitignore

The Vercel URLs were returning 404 errors because the project names were too long:
- `overeng-effect-utils-schema-form-aria.vercel.app` → `overeng-effect-utils-schema-form-ar.vercel.app`
- `overeng-effect-utils-react-inspector.vercel.app` → `overeng-effect-utils-react-inspecto.vercel.app`