### PR TITLE
Add force revoke / lock stealing for distributed semaphore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- **@overeng/utils**: Force revoke / lock stealing for file-system semaphore backing
+  - `forceRevoke(options, key, holderId)` - Forcibly revoke a specific holder's permits
+  - `forceRevokeAll(options, key)` - Revoke all holders for a semaphore key
+  - `listHolders(options, key)` - List active holders with permit counts and expiry times
+  - `HolderInfo` type for holder information
+  - `HolderNotFoundError` for when target holder doesn't exist
+  - See upstream feature request: https://github.com/ethanniser/effect-distributed-lock/issues/9
+
 - **@overeng/notion-effect-schema**: New `PropertySchema` discriminated union for typed database property definitions
   - Full support for all 23 Notion property types using `Schema.TaggedStruct`
   - `SelectOptionConfig`, `StatusGroupConfig` for select/multi-select/status options


### PR DESCRIPTION
## Summary

Implement force revoke / lock stealing for file-system backed distributed semaphore:
- `forceRevoke`: Forcibly revoke a specific holder's permits
- `listHolders`: List all active holders with their permit info  
- `forceRevokeAll`: Revoke all holders for a semaphore key (nuclear option)

After force revoke, the victim holder's next TTL refresh fails, triggering `LockLostError` in their `withPermits` scope.

## Implementation details

- Added `HolderInfo` type and `HolderNotFoundError` for clear error handling
- All functions include comprehensive docstrings
- Added 11 tests covering happy paths, error cases, and state transitions
- Updated README with usage examples and documented the feature

## Motivation

Lock stealing is a common pattern in distributed systems (e.g., Web Locks API) for recovering from dead processes or administrative intervention. See upstream feature request: https://github.com/ethanniser/effect-distributed-lock/issues/9

🤖 Generated with [Claude Code](https://claude.com/claude-code)