### PR TITLE
Port genie config generation to effect-utils

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Genie-generated files - collapse in GitHub PR diffs
+# These files are generated from *.genie.ts sources
+package.json linguist-generated=true
+**/package.json linguist-generated=true
+tsconfig.json linguist-generated=true
+**/tsconfig.json linguist-generated=true
+tsconfig.*.json linguist-generated=true
+.github/workflows/*.yml linguist-generated=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,6 @@
+# Generated file - DO NOT EDIT
+# Source: .github/workflows/ci.yml.genie.ts
+
 name: CI
 
 on:
@@ -14,26 +17,19 @@ jobs:
         shell: devenv shell bash -- -e {0}
     steps:
       - uses: actions/checkout@v4
-
       - name: Install Nix
         uses: cachix/install-nix-action@v31
-
       - name: Enable devenv Cachix cache
         uses: cachix/cachix-action@v16
         with:
           name: devenv
-
       - name: Install devenv
-        run: nix profile install nixpkgs#devenv
+        run: 'nix profile install nixpkgs#devenv'
         shell: bash
-
       - run: bun install --frozen-lockfile
-
       - name: Type check
         run: mono ts
-
       - name: Format + lint
         run: mono lint
-
       - name: Unit tests
         run: mono test --unit

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -1,0 +1,51 @@
+import { githubWorkflow } from '../../packages/@overeng/genie/src/lib/mod.ts'
+
+export default githubWorkflow({
+  name: 'CI',
+  on: {
+    push: { branches: ['main'] },
+    pull_request: { branches: ['main'] },
+  },
+  jobs: {
+    check: {
+      'runs-on': 'ubuntu-latest',
+      defaults: {
+        run: {
+          shell: 'devenv shell bash -- -e {0}',
+        },
+      },
+      steps: [
+        { uses: 'actions/checkout@v4' },
+        {
+          name: 'Install Nix',
+          uses: 'cachix/install-nix-action@v31',
+        },
+        {
+          name: 'Enable devenv Cachix cache',
+          uses: 'cachix/cachix-action@v16',
+          with: {
+            name: 'devenv',
+          },
+        },
+        {
+          name: 'Install devenv',
+          run: 'nix profile install nixpkgs#devenv',
+          shell: 'bash',
+        },
+        { run: 'bun install --frozen-lockfile' },
+        {
+          name: 'Type check',
+          run: 'mono ts',
+        },
+        {
+          name: 'Format + lint',
+          run: 'mono lint',
+        },
+        {
+          name: 'Unit tests',
+          run: 'mono test --unit',
+        },
+      ],
+    },
+  },
+})

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,9 +7,19 @@ The `mono` CLI provides shortcuts for common development workflows:
 - **Testing**: `mono test [--unit|--integration] [--watch]` to run tests
 - **Build**: `mono build` to build all packages
 - **Clean**: `mono clean` to remove all build artifacts
-- **Check**: `mono check` to run all checks (ts + lint + test)
+- **Genie**: `mono genie [--check] [--watch]` to generate config files from `.genie.ts` sources
+- **Check**: `mono check` to run all checks (genie + ts + lint + test)
 
 If tools aren't directly in `$PATH`, prefix commands with `direnv exec .` (e.g., `direnv exec . mono ts`).
+
+# Genie (Config File Generation)
+
+Config files like `package.json`, `tsconfig.base.json`, and `.github/workflows/ci.yml` are generated from TypeScript source files using genie. The source files have a `.genie.ts` suffix (e.g., `package.json.genie.ts`).
+
+- **Never edit generated files directly** - they are read-only and will be overwritten
+- **Edit the `.genie.ts` source file** and run `mono genie` to regenerate
+- Shared constants (catalog versions, tsconfig options) live in `genie/repo.ts`
+- `mono check` verifies generated files are up to date via `mono genie --check`
 
 # Changelog
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,20 @@ Key features:
 - File system-backed distributed locks with TTL expiration
 - Workspace-aware command helpers with optional logging/retention
 
+### Developer Tools
+
+| Package                                               | Description                            |
+| ----------------------------------------------------- | -------------------------------------- |
+| [@overeng/genie](./packages/@overeng/genie)           | TypeScript-based config file generator |
+| [@overeng/oxc-config](./packages/@overeng/oxc-config) | Shared oxlint and oxfmt configuration  |
+
+**Genie** generates `package.json`, `tsconfig.json`, and GitHub workflow files from TypeScript sources (`.genie.ts` files). Features include:
+
+- **Type-safe config** - Define configs as TypeScript with full autocomplete
+- **Consistent formatting** - Auto-formats via oxfmt
+- **Read-only protection** - Generated files are read-only by default
+- **CI integration** - `--check` mode verifies files are up to date
+
 ## Quick Start
 
 ### Enter the dev shell

--- a/bun.lock
+++ b/bun.lock
@@ -94,6 +94,27 @@
         "react-dom": "catalog:",
       },
     },
+    "packages/@overeng/genie": {
+      "name": "@overeng/genie",
+      "version": "0.1.0",
+      "bin": {
+        "genie": "./bin/genie",
+      },
+      "devDependencies": {
+        "@effect/cli": "catalog:",
+        "@effect/platform": "catalog:",
+        "@effect/platform-node": "catalog:",
+        "@types/node": "catalog:",
+        "effect": "catalog:",
+        "typescript": "catalog:",
+      },
+      "peerDependencies": {
+        "@effect/cli": "catalog:",
+        "@effect/platform": "catalog:",
+        "@effect/platform-node": "catalog:",
+        "effect": "catalog:",
+      },
+    },
     "packages/@overeng/notion-effect-cli": {
       "name": "@overeng/notion-effect-cli",
       "version": "0.1.0",
@@ -230,6 +251,7 @@
         "@effect/cli": "catalog:",
         "@effect/platform": "catalog:",
         "@effect/platform-node": "catalog:",
+        "@overeng/genie": "workspace:*",
         "@overeng/utils": "workspace:*",
         "effect": "catalog:",
       },
@@ -487,6 +509,8 @@
     "@overeng/effect-schema-form": ["@overeng/effect-schema-form@workspace:packages/@overeng/effect-schema-form"],
 
     "@overeng/effect-schema-form-aria": ["@overeng/effect-schema-form-aria@workspace:packages/@overeng/effect-schema-form-aria"],
+
+    "@overeng/genie": ["@overeng/genie@workspace:packages/@overeng/genie"],
 
     "@overeng/notion-effect-cli": ["@overeng/notion-effect-cli@workspace:packages/@overeng/notion-effect-cli"],
 
@@ -1030,7 +1054,7 @@
 
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
-    "detect-libc": ["detect-libc@1.0.3", "", { "bin": { "detect-libc": "./bin/detect-libc.js" } }, "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg=="],
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "doctrine": ["doctrine@3.0.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w=="],
 
@@ -1456,6 +1480,8 @@
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
+    "@parcel/watcher/detect-libc": ["detect-libc@1.0.3", "", { "bin": { "detect-libc": "./bin/detect-libc.js" } }, "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg=="],
+
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "@storybook/builder-vite/@vitest/mocker": ["@vitest/mocker@3.2.4", "", { "dependencies": { "@vitest/spy": "3.2.4", "estree-walker": "^3.0.3", "magic-string": "^0.30.17" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ=="],
@@ -1484,11 +1510,7 @@
 
     "happy-dom/@types/node": ["@types/node@20.19.27", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-N2clP5pJhB2YnZJ3PIHFk5RkygRX5WO/5f0WC08tp0wd+sv0rsJk3MqWn3CbNmT2J505a5336jaQj4ph1AdMug=="],
 
-    "lightningcss/detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
-
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
-
-    "node-gyp-build-optional-packages/detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "path-scurry/lru-cache": ["lru-cache@11.2.4", "", {}, "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg=="],
 

--- a/context/effect/socket/package.json.genie.ts
+++ b/context/effect/socket/package.json.genie.ts
@@ -1,0 +1,17 @@
+import { catalogRef } from '../../../genie/repo.ts'
+import { packageJSON } from '../../../packages/@overeng/genie/src/lib/mod.ts'
+
+export default packageJSON({
+  name: 'effect-socket-examples',
+  private: true,
+  type: 'module',
+  dependencies: {
+    '@effect/platform': catalogRef,
+    '@effect/platform-node': catalogRef,
+    '@effect/rpc': catalogRef,
+    effect: catalogRef,
+  },
+  devDependencies: {
+    '@types/node': catalogRef,
+  },
+})

--- a/context/effect/socket/tsconfig.json
+++ b/context/effect/socket/tsconfig.json
@@ -1,3 +1,5 @@
+// Generated file - DO NOT EDIT
+// Source: context/effect/socket/tsconfig.json.genie.ts
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
@@ -8,5 +10,11 @@
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "types": ["node"]
   },
-  "include": ["examples/**/*.ts"]
+  "include": ["examples/**/*.ts"],
+  "exclude": ["*.genie.ts"],
+  "references": [
+    {
+      "path": "../../../packages/@overeng/genie"
+    }
+  ]
 }

--- a/context/effect/socket/tsconfig.json.genie.ts
+++ b/context/effect/socket/tsconfig.json.genie.ts
@@ -1,0 +1,17 @@
+import { domLib } from '../../../genie/repo.ts'
+import { tsconfigJSON } from '../../../packages/@overeng/genie/src/lib/mod.ts'
+
+export default tsconfigJSON({
+  extends: '../../../tsconfig.base.json',
+  compilerOptions: {
+    composite: true,
+    rootDir: '.',
+    noEmit: true,
+    tsBuildInfoFile: './tsconfig.tsbuildinfo',
+    lib: [...domLib],
+    types: ['node'],
+  },
+  include: ['examples/**/*.ts'],
+  exclude: ['*.genie.ts'],
+  references: [{ path: '../../../packages/@overeng/genie' }],
+})

--- a/genie/repo.ts
+++ b/genie/repo.ts
@@ -1,0 +1,139 @@
+/**
+ * Shared constants and utilities for genie configuration files
+ */
+
+/**
+ * Catalog versions - single source of truth for dependency versions
+ *
+ * Note: packages/@overeng/react-inspector is a git submodule with its own tooling (tsup, ESLint)
+ * We include it in the workspace but keep its build system separate
+ */
+export const catalog = {
+  // Observability
+  '@opentelemetry/api': '1.9.0',
+
+  // Effect ecosystem
+  'effect-distributed-lock': '0.0.10',
+  effect: '3.19.14',
+  '@effect/platform': '0.94.1',
+  '@effect/platform-node': '0.104.0',
+  '@effect/cli': '0.73.0',
+  '@effect/vitest': '0.27.0',
+  '@effect/printer': '0.47.0',
+  '@effect/printer-ansi': '0.47.0',
+  '@effect/typeclass': '0.38.0',
+  '@effect/cluster': '0.56.0',
+  '@effect/sql': '0.49.0',
+  '@effect/experimental': '0.58.0',
+  '@effect/workflow': '0.16.0',
+  '@effect/language-service': '0.63.2',
+  '@effect/rpc': '0.73.0',
+  '@effect/opentelemetry': '0.60.0',
+
+  // React ecosystem
+  react: '19.2.3',
+  'react-dom': '19.2.3',
+  'react-aria-components': '1.14.0',
+
+  // Type definitions
+  '@types/react': '19.2.7',
+  '@types/react-dom': '19.2.3',
+  '@types/node': '25.0.3',
+
+  // Build tools
+  typescript: '5.9.3',
+  '@playwright/test': '1.57.0',
+  vite: '7.3.0',
+  vitest: '4.0.16',
+  '@vitejs/plugin-react': '5.1.2',
+
+  // Styling
+  tailwindcss: '4.1.18',
+  '@tailwindcss/vite': '4.1.18',
+
+  // Storybook
+  storybook: '10.1.11',
+  '@storybook/react': '10.1.11',
+  '@storybook/react-vite': '10.1.11',
+} as const
+
+/** Use catalog reference for dependencies */
+export const catalogRef = 'catalog:' as const
+
+/** Workspace reference paths for tsconfig.all.json */
+export const workspaceReferences = [
+  './scripts',
+  './context/effect/socket',
+  './packages/@overeng/genie',
+  './packages/@overeng/notion-effect-schema',
+  './packages/@overeng/notion-effect-cli',
+  './packages/@overeng/notion-effect-client',
+  './packages/@overeng/effect-schema-form',
+  './packages/@overeng/effect-schema-form-aria',
+  './packages/@overeng/effect-react',
+  './packages/@overeng/react-inspector',
+  './packages/@overeng/utils',
+  './packages/@overeng/oxc-config',
+] as const
+
+/**
+ * Computes the relative path to tsconfig.base.json from a package directory
+ * @example getRelativeBasePath('./packages/@overeng/utils') // '../../../tsconfig.base.json'
+ */
+export const getRelativeBasePath = (packagePath: string): string => {
+  const depth = packagePath.split('/').filter(Boolean).length
+  return '../'.repeat(depth) + 'tsconfig.base.json'
+}
+
+/** Standard package tsconfig compiler options (composite mode with src/dist structure) */
+export const packageTsconfigCompilerOptions = {
+  composite: true,
+  rootDir: '.',
+  outDir: './dist',
+  tsBuildInfoFile: './tsconfig.tsbuildinfo',
+} as const
+
+/** DOM library set for browser-compatible packages */
+export const domLib = ['ES2022', 'DOM', 'DOM.Iterable'] as const
+
+/** React JSX configuration for React packages */
+export const reactJsx = { jsx: 'react-jsx' as const }
+
+/** Base tsconfig compiler options shared across all packages */
+export const baseTsconfigCompilerOptions = {
+  target: 'ES2023' as const,
+  lib: ['ES2023'],
+  module: 'ESNext' as const,
+  moduleResolution: 'Bundler' as const,
+  allowImportingTsExtensions: true,
+  rewriteRelativeImportExtensions: true,
+  allowSyntheticDefaultImports: true,
+  esModuleInterop: true,
+  allowJs: false,
+  declaration: true,
+  declarationMap: true,
+  sourceMap: true,
+  outDir: 'dist',
+  strict: true,
+  noUncheckedIndexedAccess: true,
+  exactOptionalPropertyTypes: true,
+  noImplicitReturns: true,
+  noFallthroughCasesInSwitch: true,
+  noImplicitOverride: true,
+  isolatedModules: true,
+  verbatimModuleSyntax: true,
+  skipLibCheck: true,
+  forceConsistentCasingInFileNames: true,
+  plugins: [
+    {
+      name: '@effect/language-service',
+      reportSuggestionsAsWarningsInTsc: true,
+      pipeableMinArgCount: 2,
+      diagnosticSeverity: {
+        missedPipeableOpportunity: 'suggestion',
+        schemaUnionOfLiterals: 'warning',
+        anyUnknownInErrorContext: 'warning',
+      },
+    },
+  ],
+}

--- a/package.json.genie.ts
+++ b/package.json.genie.ts
@@ -1,0 +1,28 @@
+import { catalog, catalogRef } from './genie/repo.ts'
+import { packageJSON } from './packages/@overeng/genie/src/lib/mod.ts'
+
+export default packageJSON({
+  name: 'effect-notion',
+  private: true,
+  workspaces: ['packages/**', 'scripts/**', 'context/**'],
+  type: 'module',
+  scripts: {
+    prepare: 'effect-language-service patch || true',
+  },
+  devDependencies: {
+    '@effect/cli': catalogRef,
+    '@effect/language-service': catalogRef,
+    '@effect/platform': catalogRef,
+    '@effect/platform-node': catalogRef,
+    '@overeng/utils': 'workspace:*',
+    effect: catalogRef,
+    oxfmt: '0.21.0',
+    oxlint: '1.36.0',
+    typescript: catalogRef,
+    vitest: catalogRef,
+  },
+  catalog,
+  patchedDependencies: {
+    'effect-distributed-lock@0.0.10': 'patches/effect-distributed-lock@0.0.10.patch',
+  },
+})

--- a/packages/@overeng/effect-react/package.json.genie.ts
+++ b/packages/@overeng/effect-react/package.json.genie.ts
@@ -1,0 +1,39 @@
+import { catalogRef } from '../../../genie/repo.ts'
+import { packageJSON } from '../genie/src/lib/mod.ts'
+
+export default packageJSON({
+  name: '@overeng/effect-react',
+  version: '0.1.0',
+  private: true,
+  type: 'module',
+  exports: {
+    '.': './src/mod.ts',
+    './react-aria': './src/react-aria/mod.ts',
+  },
+  publishConfig: {
+    access: 'public',
+    exports: {
+      '.': './dist/mod.js',
+      './react-aria': './dist/react-aria/mod.js',
+    },
+  },
+  devDependencies: {
+    '@storybook/react': catalogRef,
+    '@storybook/react-vite': catalogRef,
+    '@types/react': catalogRef,
+    '@vitejs/plugin-react': catalogRef,
+    effect: catalogRef,
+    react: catalogRef,
+    'react-aria-components': catalogRef,
+    'react-dom': catalogRef,
+    storybook: catalogRef,
+    vite: catalogRef,
+    vitest: catalogRef,
+  },
+  peerDependencies: {
+    effect: catalogRef,
+    react: catalogRef,
+    'react-aria-components': catalogRef,
+    'react-dom': catalogRef,
+  },
+})

--- a/packages/@overeng/effect-react/tsconfig.json
+++ b/packages/@overeng/effect-react/tsconfig.json
@@ -1,8 +1,10 @@
+// Generated file - DO NOT EDIT
+// Source: packages/@overeng/effect-react/tsconfig.json.genie.ts
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "composite": true,
-    "rootDir": "src",
+    "rootDir": ".",
     "outDir": "./dist",
     "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
     "jsx": "react-jsx",

--- a/packages/@overeng/effect-react/tsconfig.json.genie.ts
+++ b/packages/@overeng/effect-react/tsconfig.json.genie.ts
@@ -1,0 +1,13 @@
+import { domLib, packageTsconfigCompilerOptions, reactJsx } from '../../../genie/repo.ts'
+import { tsconfigJSON } from '../genie/src/lib/mod.ts'
+
+export default tsconfigJSON({
+  extends: '../../../tsconfig.base.json',
+  compilerOptions: {
+    ...packageTsconfigCompilerOptions,
+    ...reactJsx,
+    jsxImportSource: 'react',
+    lib: [...domLib],
+  },
+  include: ['src/**/*'],
+})

--- a/packages/@overeng/effect-schema-form-aria/package.json.genie.ts
+++ b/packages/@overeng/effect-schema-form-aria/package.json.genie.ts
@@ -1,0 +1,42 @@
+import { catalogRef } from '../../../genie/repo.ts'
+import { packageJSON } from '../genie/src/lib/mod.ts'
+
+export default packageJSON({
+  name: '@overeng/effect-schema-form-aria',
+  version: '0.1.0',
+  private: true,
+  type: 'module',
+  exports: {
+    '.': './src/mod.ts',
+  },
+  publishConfig: {
+    access: 'public',
+    exports: {
+      '.': './dist/mod.js',
+    },
+  },
+  dependencies: {
+    '@overeng/effect-schema-form': 'workspace:*',
+  },
+  devDependencies: {
+    '@storybook/react': catalogRef,
+    '@storybook/react-vite': catalogRef,
+    '@tailwindcss/vite': catalogRef,
+    '@types/react': catalogRef,
+    '@vitejs/plugin-react': catalogRef,
+    effect: catalogRef,
+    react: catalogRef,
+    'react-aria-components': catalogRef,
+    'react-dom': catalogRef,
+    storybook: catalogRef,
+    tailwindcss: catalogRef,
+    vite: catalogRef,
+    vitest: catalogRef,
+  },
+  peerDependencies: {
+    effect: catalogRef,
+    react: catalogRef,
+    'react-aria-components': catalogRef,
+    'react-dom': catalogRef,
+  },
+})

--- a/packages/@overeng/effect-schema-form-aria/tsconfig.json
+++ b/packages/@overeng/effect-schema-form-aria/tsconfig.json
@@ -1,13 +1,19 @@
+// Generated file - DO NOT EDIT
+// Source: packages/@overeng/effect-schema-form-aria/tsconfig.json.genie.ts
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "composite": true,
-    "rootDir": "src",
+    "rootDir": ".",
     "outDir": "./dist",
     "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
     "jsx": "react-jsx",
     "lib": ["ES2022", "DOM", "DOM.Iterable"]
   },
   "include": ["src/**/*"],
-  "references": [{ "path": "../effect-schema-form" }]
+  "references": [
+    {
+      "path": "../effect-schema-form"
+    }
+  ]
 }

--- a/packages/@overeng/effect-schema-form-aria/tsconfig.json.genie.ts
+++ b/packages/@overeng/effect-schema-form-aria/tsconfig.json.genie.ts
@@ -1,0 +1,13 @@
+import { domLib, packageTsconfigCompilerOptions, reactJsx } from '../../../genie/repo.ts'
+import { tsconfigJSON } from '../genie/src/lib/mod.ts'
+
+export default tsconfigJSON({
+  extends: '../../../tsconfig.base.json',
+  compilerOptions: {
+    ...packageTsconfigCompilerOptions,
+    ...reactJsx,
+    lib: [...domLib],
+  },
+  include: ['src/**/*'],
+  references: [{ path: '../effect-schema-form' }],
+})

--- a/packages/@overeng/effect-schema-form/package.json.genie.ts
+++ b/packages/@overeng/effect-schema-form/package.json.genie.ts
@@ -1,0 +1,28 @@
+import { catalogRef } from '../../../genie/repo.ts'
+import { packageJSON } from '../genie/src/lib/mod.ts'
+
+export default packageJSON({
+  name: '@overeng/effect-schema-form',
+  version: '0.1.0',
+  private: true,
+  type: 'module',
+  exports: {
+    '.': './src/mod.ts',
+  },
+  publishConfig: {
+    access: 'public',
+    exports: {
+      '.': './dist/mod.js',
+    },
+  },
+  devDependencies: {
+    '@types/react': catalogRef,
+    effect: catalogRef,
+    react: catalogRef,
+    vitest: catalogRef,
+  },
+  peerDependencies: {
+    effect: catalogRef,
+    react: catalogRef,
+  },
+})

--- a/packages/@overeng/effect-schema-form/tsconfig.json
+++ b/packages/@overeng/effect-schema-form/tsconfig.json
@@ -1,8 +1,10 @@
+// Generated file - DO NOT EDIT
+// Source: packages/@overeng/effect-schema-form/tsconfig.json.genie.ts
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "composite": true,
-    "rootDir": "src",
+    "rootDir": ".",
     "outDir": "./dist",
     "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
     "jsx": "react-jsx",

--- a/packages/@overeng/effect-schema-form/tsconfig.json.genie.ts
+++ b/packages/@overeng/effect-schema-form/tsconfig.json.genie.ts
@@ -1,0 +1,12 @@
+import { domLib, packageTsconfigCompilerOptions, reactJsx } from '../../../genie/repo.ts'
+import { tsconfigJSON } from '../genie/src/lib/mod.ts'
+
+export default tsconfigJSON({
+  extends: '../../../tsconfig.base.json',
+  compilerOptions: {
+    ...packageTsconfigCompilerOptions,
+    ...reactJsx,
+    lib: [...domLib],
+  },
+  include: ['src/**/*'],
+})

--- a/packages/@overeng/genie/README.md
+++ b/packages/@overeng/genie/README.md
@@ -1,0 +1,191 @@
+# @overeng/genie
+
+TypeScript-based code generator for config files. Define your `package.json`, `tsconfig.json`, `oxlint.jsonc`, `oxfmt.jsonc`, and GitHub workflow files as TypeScript and generate them with consistent formatting.
+
+## Usage
+
+### CLI
+
+```bash
+# Generate all config files
+mono genie
+
+# Check if files are up to date (for CI)
+mono genie --check
+
+# Watch mode - regenerate on changes
+mono genie --watch
+
+# Generate writable files (default is read-only)
+mono genie --writeable
+```
+
+### Creating a Generator
+
+Create a `.genie.ts` file next to the config file you want to generate:
+
+```ts
+// package.json.genie.ts
+import { packageJSON } from '@overeng/genie/lib'
+
+export default packageJSON({
+  name: '@myorg/my-package',
+  version: '1.0.0',
+  type: 'module',
+  exports: {
+    '.': './src/mod.ts',
+  },
+  dependencies: {
+    effect: '^3.12.0',
+  },
+})
+```
+
+Run `mono genie` to generate `package.json` from the source file.
+
+## Generators
+
+### `packageJSON`
+
+Generate `package.json` files with proper field ordering and formatting.
+
+```ts
+import { packageJSON } from '@overeng/genie/lib'
+
+export default packageJSON({
+  name: '@myorg/my-package',
+  version: '1.0.0',
+  private: true,
+  type: 'module',
+  exports: { '.': './src/mod.ts' },
+  dependencies: { effect: '^3.12.0' },
+  devDependencies: { typescript: '^5.9.0' },
+})
+```
+
+### `tsconfigJSON`
+
+Generate `tsconfig.json` files with TypeScript compiler options.
+
+```ts
+import { tsconfigJSON } from '@overeng/genie/lib'
+
+export default tsconfigJSON({
+  extends: '../tsconfig.base.json',
+  compilerOptions: {
+    composite: true,
+    rootDir: '.',
+    outDir: './dist',
+  },
+  include: ['src/**/*.ts'],
+  references: [{ path: '../other-package' }],
+})
+```
+
+### `githubWorkflow`
+
+Generate GitHub Actions workflow YAML files.
+
+```ts
+import { githubWorkflow } from '@overeng/genie/lib'
+
+export default githubWorkflow({
+  name: 'CI',
+  on: {
+    push: { branches: ['main'] },
+    pull_request: { branches: ['main'] },
+  },
+  jobs: {
+    test: {
+      'runs-on': 'ubuntu-latest',
+      steps: [
+        { uses: 'actions/checkout@v4' },
+        { run: 'npm test' },
+      ],
+    },
+  },
+})
+```
+
+### `oxlintConfig`
+
+Generate `oxlint.jsonc` configuration files. See [oxlint configuration docs](https://oxc.rs/docs/guide/usage/linter/config) for reference.
+
+```ts
+import { oxlintConfig } from '@overeng/genie/lib'
+
+export default oxlintConfig({
+  plugins: ['import', 'typescript', 'unicorn', 'oxc'],
+  jsPlugins: ['./custom-rules.ts'],
+  categories: {
+    correctness: 'error',
+    suspicious: 'warn',
+    pedantic: 'off',
+    perf: 'warn',
+    style: 'off',
+    restriction: 'off',
+  },
+  rules: {
+    'import/no-cycle': 'warn',
+    'oxc/no-barrel-file': ['warn', { threshold: 0 }],
+  },
+  overrides: [
+    { files: ['**/mod.ts'], rules: { 'oxc/no-barrel-file': 'off' } },
+    { files: ['**/*.test.ts'], rules: { 'import/no-cycle': 'off' } },
+  ],
+})
+```
+
+### `oxfmtConfig`
+
+Generate `oxfmt.jsonc` configuration files. See [oxfmt repository](https://github.com/nicksrandall/oxfmt) for reference.
+
+```ts
+import { oxfmtConfig } from '@overeng/genie/lib'
+
+export default oxfmtConfig({
+  semi: false,
+  singleQuote: true,
+  printWidth: 100,
+  tabWidth: 2,
+  useTabs: false,
+  trailingComma: 'all',
+  experimentalSortImports: {
+    groups: ['builtin', 'external', 'internal', ['parent', 'sibling', 'index']],
+    internalPattern: ['@myorg/'],
+    newlinesBetween: true,
+  },
+  experimentalSortPackageJson: true,
+})
+```
+
+## Features
+
+- **Read-only output** - Generated files are marked read-only by default to prevent accidental edits
+- **Header comments** - Adds source file reference to generated files (where supported)
+- **Formatting** - Automatically formats JSON/YAML output via oxfmt
+- **Check mode** - Verify files are up to date in CI without regenerating
+- **Watch mode** - Auto-regenerate on source file changes
+
+## Shared Constants
+
+For monorepos, define shared constants in a central file:
+
+```ts
+// genie/repo.ts
+export const catalogRef = 'catalog:'
+export const domLib = ['ES2022', 'DOM', 'DOM.Iterable'] as const
+```
+
+Then import in your `.genie.ts` files:
+
+```ts
+import { catalogRef } from '../genie/repo.ts'
+import { packageJSON } from '@overeng/genie/lib'
+
+export default packageJSON({
+  dependencies: {
+    effect: catalogRef,
+  },
+})
+```

--- a/packages/@overeng/genie/bin/genie
+++ b/packages/@overeng/genie/bin/genie
@@ -1,0 +1,2 @@
+#!/usr/bin/env bun
+import '../src/cli.ts'

--- a/packages/@overeng/genie/package.json
+++ b/packages/@overeng/genie/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@overeng/genie",
+  "version": "0.1.0",
+  "private": true,
+  "bin": {
+    "genie": "./bin/genie"
+  },
+  "type": "module",
+  "exports": {
+    ".": "./src/lib/mod.ts",
+    "./cli": "./src/cli.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": "./dist/lib/mod.js",
+      "./cli": "./dist/cli.js"
+    }
+  },
+  "devDependencies": {
+    "@effect/cli": "catalog:",
+    "@effect/platform": "catalog:",
+    "@effect/platform-node": "catalog:",
+    "@types/node": "catalog:",
+    "effect": "catalog:",
+    "typescript": "catalog:"
+  },
+  "peerDependencies": {
+    "@effect/cli": "catalog:",
+    "@effect/platform": "catalog:",
+    "@effect/platform-node": "catalog:",
+    "effect": "catalog:"
+  }
+}

--- a/packages/@overeng/genie/package.json.genie.ts
+++ b/packages/@overeng/genie/package.json.genie.ts
@@ -1,0 +1,37 @@
+import { catalogRef } from '../../../genie/repo.ts'
+import { packageJSON } from './src/lib/mod.ts'
+
+export default packageJSON({
+  name: '@overeng/genie',
+  version: '0.1.0',
+  private: true,
+  bin: {
+    genie: './bin/genie',
+  },
+  type: 'module',
+  exports: {
+    '.': './src/lib/mod.ts',
+    './cli': './src/cli.ts',
+  },
+  publishConfig: {
+    access: 'public',
+    exports: {
+      '.': './dist/lib/mod.js',
+      './cli': './dist/cli.js',
+    },
+  },
+  devDependencies: {
+    '@effect/cli': catalogRef,
+    '@effect/platform': catalogRef,
+    '@effect/platform-node': catalogRef,
+    '@types/node': catalogRef,
+    effect: catalogRef,
+    typescript: catalogRef,
+  },
+  peerDependencies: {
+    '@effect/cli': catalogRef,
+    '@effect/platform': catalogRef,
+    '@effect/platform-node': catalogRef,
+    effect: catalogRef,
+  },
+})

--- a/packages/@overeng/genie/src/cli.ts
+++ b/packages/@overeng/genie/src/cli.ts
@@ -1,0 +1,413 @@
+import path from 'node:path'
+
+import * as Cli from '@effect/cli'
+import { Command, Error as PlatformError, FileSystem, Path } from '@effect/platform'
+import * as PlatformNode from '@effect/platform-node'
+import { Array as A, Effect, pipe, Schema, Stream } from 'effect'
+
+/** Error when importing a .genie.ts file fails */
+export class GenieImportError extends Schema.TaggedError<GenieImportError>()('GenieImportError', {
+  genieFilePath: Schema.String,
+  cause: Schema.Defect,
+}) {
+  override get message(): string {
+    const causeMsg = this.cause instanceof Error ? this.cause.message : String(this.cause)
+    return `Failed to import ${this.genieFilePath}: ${causeMsg}`
+  }
+}
+
+/** Error when generated file content doesn't match (in check mode) */
+export class GenieCheckError extends Schema.TaggedError<GenieCheckError>()('GenieCheckError', {
+  targetFilePath: Schema.String,
+  message: Schema.String,
+}) {}
+
+/** Warning info for tsconfig references that don't match workspace dependencies */
+type TsconfigReferencesWarning = {
+  tsconfigPath: string
+  missingReferences: string[]
+  extraReferences: string[]
+}
+
+/** File extensions that oxfmt can format */
+const oxfmtSupportedExtensions = new Set(['.json', '.jsonc', '.yml', '.yaml'])
+
+/** Get the appropriate header comment for a generated file based on its extension */
+// oxlint-disable-next-line overeng/named-args -- simple internal helper
+const getHeaderComment = (targetFilePath: string, sourceFile: string): string => {
+  const ext = path.extname(targetFilePath)
+  const basename = path.basename(targetFilePath)
+
+  // tsconfig*.json files support JS-style comments
+  if (basename.startsWith('tsconfig') && ext === '.json') {
+    return `// Generated file - DO NOT EDIT\n// Source: ${sourceFile}\n`
+  }
+
+  // JSONC files support JS-style comments
+  if (ext === '.jsonc') {
+    return `// Generated file - DO NOT EDIT\n// Source: ${sourceFile}\n`
+  }
+
+  // Regular JSON files don't support comments - rely on read-only permissions + .gitattributes
+  if (ext === '.json') {
+    return ''
+  }
+
+  if (ext === '.yml' || ext === '.yaml') {
+    return `# Generated file - DO NOT EDIT\n# Source: ${sourceFile}\n\n`
+  }
+
+  // Default to JS/TS style comments
+  return `// Generated file - DO NOT EDIT\n// Source: ${sourceFile}\n`
+}
+
+/** oxfmt config file path (relative to cwd) */
+const OXFMT_CONFIG = 'packages/@overeng/oxc-config/fmt.jsonc'
+
+/** Format content using oxfmt if the file type is supported */
+// oxlint-disable-next-line overeng/named-args -- simple internal helper
+const formatWithOxfmt = (targetFilePath: string, content: string) =>
+  Effect.gen(function* () {
+    const ext = path.extname(targetFilePath)
+
+    if (!oxfmtSupportedExtensions.has(ext)) {
+      return content
+    }
+
+    const result = yield* Command.make(
+      'oxfmt',
+      '-c',
+      OXFMT_CONFIG,
+      '--stdin-filepath',
+      targetFilePath,
+    ).pipe(
+      Command.feed(content),
+      Command.string,
+      Effect.catchAll(() => Effect.succeed(content)),
+    )
+
+    return result
+  }).pipe(Effect.withSpan('formatWithOxfmt'))
+
+const isGenieFile = (file: string) => file.endsWith('.genie.ts')
+
+/** Directories to skip when searching for .genie.ts files */
+const shouldSkipDirectory = (name: string): boolean => {
+  if (name === 'node_modules' || name === 'dist' || name === 'tmp') return true
+  if (name === '.git' || name === '.devenv' || name === '.direnv') return true
+  return false
+}
+
+const findGenieFiles = (dir: string) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem
+    const pathService = yield* Path.Path
+
+    const walk = (
+      currentDir: string,
+    ): Effect.Effect<string[], PlatformError.PlatformError, never> =>
+      Effect.gen(function* () {
+        const entries = yield* fs.readDirectory(currentDir)
+        const results: string[] = []
+
+        for (const entry of entries) {
+          if (shouldSkipDirectory(entry)) {
+            continue
+          }
+
+          const fullPath = pathService.join(currentDir, entry)
+          const stat = yield* fs.stat(fullPath)
+
+          if (stat.type === 'Directory') {
+            const nested = yield* walk(fullPath)
+            results.push(...nested)
+          } else if (isGenieFile(entry)) {
+            results.push(fullPath)
+          }
+        }
+
+        return results
+      })
+
+    return yield* walk(dir)
+  }).pipe(Effect.withSpan('findGenieFiles'))
+
+/** Import a genie file and return its default export (the raw content string) */
+const importGenieFile = (genieFilePath: string) =>
+  Effect.gen(function* () {
+    /** Cache-bust the import to ensure we get fresh code on each regeneration */
+    const importPath = `${genieFilePath}?import=${Date.now()}`
+
+    const module = yield* Effect.tryPromise({
+      // oxlint-disable-next-line eslint-plugin-import/no-dynamic-require -- dynamic import path required for genie
+      try: () => import(importPath),
+      catch: (error) => new GenieImportError({ genieFilePath, cause: error }),
+    })
+
+    return module.default as string
+  })
+
+const generateFile = ({
+  genieFilePath,
+  readOnly,
+  cwd,
+}: {
+  genieFilePath: string
+  readOnly: boolean
+  cwd: string
+}) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem
+    const targetFilePath = genieFilePath.replace('.genie.ts', '')
+    const sourceFile = path.relative(cwd, genieFilePath)
+
+    const rawContent = yield* importGenieFile(genieFilePath)
+    const header = getHeaderComment(targetFilePath, sourceFile)
+    const formattedContent = yield* formatWithOxfmt(targetFilePath, rawContent)
+    const fileContentString = header + formattedContent
+
+    yield* fs.remove(targetFilePath, { force: true })
+    yield* fs.writeFileString(targetFilePath, fileContentString)
+    yield* Effect.log(`Generated ${targetFilePath} ${readOnly ? '(read-only)' : '(writable)'}`)
+
+    if (readOnly) {
+      yield* fs.chmod(targetFilePath, 0o444)
+    }
+  }).pipe(Effect.withSpan('generateFile'))
+
+const checkFile = ({ genieFilePath, cwd }: { genieFilePath: string; cwd: string }) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem
+    const targetFilePath = genieFilePath.replace('.genie.ts', '')
+    const sourceFile = path.relative(cwd, genieFilePath)
+
+    const rawContent = yield* importGenieFile(genieFilePath)
+    const header = getHeaderComment(targetFilePath, sourceFile)
+    const formattedContent = yield* formatWithOxfmt(targetFilePath, rawContent)
+    const expectedContent = header + formattedContent
+
+    const fileExists = yield* fs.exists(targetFilePath)
+    if (!fileExists) {
+      return yield* new GenieCheckError({
+        targetFilePath,
+        message: `File does not exist. Run 'mono genie' to generate it.`,
+      })
+    }
+
+    const actualContent = yield* fs.readFileString(targetFilePath)
+
+    if (actualContent !== expectedContent) {
+      return yield* new GenieCheckError({
+        targetFilePath,
+        message: `File content is out of date. Run 'mono genie' to regenerate it.`,
+      })
+    }
+
+    yield* Effect.log(`✓ ${targetFilePath} is up to date`)
+  }).pipe(Effect.withSpan('checkFile'))
+
+/** Extract workspace dependencies from package.json content */
+const getWorkspaceDependencies = (packageJsonContent: string): string[] => {
+  try {
+    const pkg = JSON.parse(packageJsonContent) as {
+      dependencies?: Record<string, string>
+      devDependencies?: Record<string, string>
+    }
+    const deps = { ...pkg.dependencies, ...pkg.devDependencies }
+    return Object.entries(deps)
+      .filter(([_, version]) => version === 'workspace:*' || version.startsWith('workspace:'))
+      .map(([name]) => name)
+  } catch {
+    return []
+  }
+}
+
+/** Extract references from tsconfig.json content */
+const getTsconfigReferences = (tsconfigContent: string): string[] => {
+  try {
+    // Remove comments from JSON (tsconfig supports // comments)
+    const withoutComments = tsconfigContent.replace(/\/\/.*$/gm, '')
+    const tsconfig = JSON.parse(withoutComments) as {
+      references?: Array<{ path: string }>
+    }
+    return (tsconfig.references ?? []).map((ref) => ref.path)
+  } catch {
+    return []
+  }
+}
+
+/** Map package name to expected tsconfig reference path */
+// oxlint-disable-next-line overeng/named-args -- simple internal mapper
+const packageNameToReferencePath = (
+  packageName: string,
+  currentPackageDir: string,
+  cwd: string,
+): string | undefined => {
+  // Common patterns for @overeng packages
+  if (packageName.startsWith('@overeng/')) {
+    const shortName = packageName.replace('@overeng/', '')
+    const currentRelative = path.relative(cwd, currentPackageDir)
+
+    // If current package is in packages/@overeng/*, sibling reference is ../{shortName}
+    if (currentRelative.startsWith('packages/@overeng/')) {
+      return `../${shortName}`
+    }
+  }
+  return undefined
+}
+
+/** Validate tsconfig references against package.json workspace dependencies */
+const validateTsconfigReferences = ({ genieFiles, cwd }: { genieFiles: string[]; cwd: string }) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem
+    const warnings: TsconfigReferencesWarning[] = []
+
+    // Find pairs of tsconfig.json.genie.ts and package.json.genie.ts in the same directory
+    const tsconfigGenieFiles = genieFiles.filter((f) => f.endsWith('tsconfig.json.genie.ts'))
+
+    for (const tsconfigGenieFile of tsconfigGenieFiles) {
+      const dir = path.dirname(tsconfigGenieFile)
+      const packageJsonPath = path.join(dir, 'package.json')
+      const tsconfigPath = tsconfigGenieFile.replace('.genie.ts', '')
+
+      // Check if package.json exists
+      const packageJsonExists = yield* fs.exists(packageJsonPath)
+      if (!packageJsonExists) continue
+
+      // Check if tsconfig.json exists (generated)
+      const tsconfigExists = yield* fs.exists(tsconfigPath)
+      if (!tsconfigExists) continue
+
+      const packageJsonContent = yield* fs.readFileString(packageJsonPath)
+      const tsconfigContent = yield* fs.readFileString(tsconfigPath)
+
+      const workspaceDeps = getWorkspaceDependencies(packageJsonContent)
+      const currentReferences = getTsconfigReferences(tsconfigContent)
+
+      // Convert workspace deps to expected reference paths
+      const expectedReferences = workspaceDeps
+        .map((dep) => packageNameToReferencePath(dep, dir, cwd))
+        .filter((ref): ref is string => ref !== undefined)
+
+      // Find missing and extra references
+      const missingReferences = A.differenceWith<string>((a, b) => a === b)(
+        expectedReferences,
+        currentReferences,
+      )
+      const extraReferences = A.differenceWith<string>((a, b) => a === b)(
+        currentReferences,
+        expectedReferences,
+      )
+
+      if (missingReferences.length > 0 || extraReferences.length > 0) {
+        warnings.push({
+          tsconfigPath: path.relative(cwd, tsconfigPath),
+          missingReferences,
+          extraReferences,
+        })
+      }
+    }
+
+    return warnings
+  }).pipe(Effect.withSpan('validateTsconfigReferences'))
+
+/** Log tsconfig reference warnings */
+const logTsconfigWarnings = (warnings: TsconfigReferencesWarning[]) =>
+  Effect.gen(function* () {
+    if (warnings.length === 0) return
+
+    yield* Effect.log('')
+    yield* Effect.log('⚠ Tsconfig reference warnings:')
+
+    for (const warning of warnings) {
+      yield* Effect.log(`  ${warning.tsconfigPath}:`)
+      for (const missing of warning.missingReferences) {
+        yield* Effect.log(`    - Missing reference: ${missing}`)
+      }
+      for (const extra of warning.extraReferences) {
+        yield* Effect.log(`    - Extra reference (not in package.json deps): ${extra}`)
+      }
+    }
+
+    yield* Effect.log('')
+  })
+
+/** Genie CLI command - generates files from .genie.ts source files */
+export const genieCommand = Cli.Command.make(
+  'genie',
+  {
+    cwd: Cli.Options.text('cwd').pipe(
+      Cli.Options.withDescription('Working directory to search for .genie.ts files'),
+      Cli.Options.withDefault(process.cwd()),
+    ),
+    watch: Cli.Options.boolean('watch').pipe(
+      Cli.Options.withDescription('Watch for changes and regenerate automatically'),
+      Cli.Options.withDefault(false),
+    ),
+    writeable: Cli.Options.boolean('writeable').pipe(
+      Cli.Options.withDescription('Generate files as writable (default: read-only)'),
+      Cli.Options.withDefault(false),
+    ),
+    check: Cli.Options.boolean('check').pipe(
+      Cli.Options.withDescription('Check if generated files are up to date (for CI)'),
+      Cli.Options.withDefault(false),
+    ),
+  },
+  ({ cwd, writeable, watch, check }) =>
+    Effect.gen(function* () {
+      const readOnly = !writeable
+      const fs = yield* FileSystem.FileSystem
+
+      const genieFiles = yield* findGenieFiles(cwd)
+
+      if (genieFiles.length === 0) {
+        yield* Effect.log('No .genie.ts files found')
+        return
+      }
+
+      yield* Effect.log(`Found ${genieFiles.length} .genie.ts files`)
+
+      if (check) {
+        yield* Effect.all(
+          genieFiles.map((genieFilePath) => checkFile({ genieFilePath, cwd })),
+          { concurrency: 'unbounded' },
+        )
+        yield* Effect.log('✓ All generated files are up to date')
+
+        // Validate tsconfig references
+        const warnings = yield* validateTsconfigReferences({ genieFiles, cwd })
+        yield* logTsconfigWarnings(warnings)
+
+        return
+      }
+
+      yield* Effect.all(
+        genieFiles.map((genieFilePath) => generateFile({ genieFilePath, readOnly, cwd })),
+        { concurrency: 'unbounded' },
+      )
+
+      if (watch) {
+        yield* Effect.log('Watching for changes...')
+        yield* pipe(
+          fs.watch(cwd),
+          Stream.filter(({ path: p }) => p.endsWith('.genie.ts')),
+          Stream.tap(({ path: p }) => {
+            const genieFilePath = path.join(cwd, p)
+            return generateFile({ genieFilePath, readOnly, cwd })
+          }),
+          Stream.runDrain,
+        )
+      }
+    }).pipe(Effect.withSpan('genie')),
+)
+
+if (import.meta.main) {
+  pipe(
+    Cli.Command.run(genieCommand, {
+      name: 'genie',
+      version: '0.1.0',
+    })(process.argv),
+    Effect.provide(PlatformNode.NodeContext.layer),
+    PlatformNode.NodeRuntime.runMain,
+  )
+}

--- a/packages/@overeng/genie/src/lib/github-workflow.ts
+++ b/packages/@overeng/genie/src/lib/github-workflow.ts
@@ -1,0 +1,284 @@
+import * as yaml from './yaml.ts'
+
+/**
+ * Type-safe GitHub Actions workflow generator
+ * Reference: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
+ */
+
+type Expression = `\${{ ${string} }}`
+
+type EventTrigger =
+  | 'branch_protection_rule'
+  | 'check_run'
+  | 'check_suite'
+  | 'create'
+  | 'delete'
+  | 'deployment'
+  | 'deployment_status'
+  | 'discussion'
+  | 'discussion_comment'
+  | 'fork'
+  | 'gollum'
+  | 'issue_comment'
+  | 'issues'
+  | 'label'
+  | 'merge_group'
+  | 'milestone'
+  | 'page_build'
+  | 'project'
+  | 'project_card'
+  | 'project_column'
+  | 'public'
+  | 'pull_request'
+  | 'pull_request_comment'
+  | 'pull_request_review'
+  | 'pull_request_review_comment'
+  | 'pull_request_target'
+  | 'push'
+  | 'registry_package'
+  | 'release'
+  | 'repository_dispatch'
+  | 'schedule'
+  | 'status'
+  | 'watch'
+  | 'workflow_call'
+  | 'workflow_dispatch'
+  | 'workflow_run'
+
+type PushPullRequestTriggerConfig = {
+  branches?: string[]
+  'branches-ignore'?: string[]
+  paths?: string[]
+  'paths-ignore'?: string[]
+  tags?: string[]
+  'tags-ignore'?: string[]
+}
+
+type ScheduleTrigger = {
+  cron: string
+}
+
+type WorkflowDispatchInput = {
+  description?: string
+  required?: boolean
+  default?: string | boolean | number
+  type?: 'boolean' | 'choice' | 'environment' | 'string' | 'number'
+  options?: string[]
+}
+
+type WorkflowDispatchConfig = {
+  inputs?: Record<string, WorkflowDispatchInput>
+}
+
+type WorkflowCallInput = {
+  description?: string
+  required?: boolean
+  default?: string | boolean | number
+  type: 'boolean' | 'number' | 'string'
+}
+
+type WorkflowCallSecret = {
+  description?: string
+  required?: boolean
+}
+
+type WorkflowCallOutput = {
+  description?: string
+  value: string
+}
+
+type WorkflowCallConfig = {
+  inputs?: Record<string, WorkflowCallInput>
+  outputs?: Record<string, WorkflowCallOutput>
+  secrets?: Record<string, WorkflowCallSecret>
+}
+
+type WorkflowRunConfig = {
+  workflows: string[]
+  types?: ('completed' | 'requested' | 'in_progress')[]
+  branches?: string[]
+  'branches-ignore'?: string[]
+}
+
+type OnConfig = {
+  [K in EventTrigger]?: K extends 'push' | 'pull_request' | 'pull_request_target'
+    ? PushPullRequestTriggerConfig | null
+    : K extends 'schedule'
+      ? ScheduleTrigger[]
+      : K extends 'workflow_dispatch'
+        ? WorkflowDispatchConfig | null
+        : K extends 'workflow_call'
+          ? WorkflowCallConfig | null
+          : K extends 'workflow_run'
+            ? WorkflowRunConfig
+            : null
+}
+
+type PermissionLevel = 'read' | 'write' | 'none'
+
+type Permissions =
+  | 'read-all'
+  | 'write-all'
+  | {
+      actions?: PermissionLevel
+      attestations?: PermissionLevel
+      checks?: PermissionLevel
+      contents?: PermissionLevel
+      deployments?: PermissionLevel
+      'id-token'?: PermissionLevel
+      issues?: PermissionLevel
+      discussions?: PermissionLevel
+      packages?: PermissionLevel
+      pages?: PermissionLevel
+      'pull-requests'?: PermissionLevel
+      'repository-projects'?: PermissionLevel
+      'security-events'?: PermissionLevel
+      statuses?: PermissionLevel
+    }
+
+type Environment = {
+  name: string
+  url?: string
+}
+
+type Matrix = {
+  include?: Array<Record<string, unknown>>
+  exclude?: Array<Record<string, unknown>>
+} & Record<string, unknown[] | undefined>
+
+type Strategy = {
+  matrix?: Matrix | Expression
+  'fail-fast'?: boolean
+  'max-parallel'?: number
+}
+
+type Container = {
+  image: string
+  credentials?: {
+    username: string
+    password: string
+  }
+  env?: Record<string, string>
+  ports?: number[]
+  volumes?: string[]
+  options?: string
+}
+
+type Service = {
+  image: string
+  credentials?: {
+    username: string
+    password: string
+  }
+  env?: Record<string, string>
+  ports?: (number | string)[]
+  volumes?: string[]
+  options?: string
+}
+
+type StepBase = {
+  id?: string
+  name?: string
+  if?: string
+  env?: Record<string, string>
+  'continue-on-error'?: boolean
+  'timeout-minutes'?: number
+  'working-directory'?: string
+}
+
+type RunStep = StepBase & {
+  run: string
+  shell?: 'bash' | 'pwsh' | 'python' | 'sh' | 'cmd' | 'powershell' | string
+}
+
+type UsesStep = StepBase & {
+  uses: string
+  with?: Record<string, string | number | boolean>
+}
+
+type Step = RunStep | UsesStep
+
+type Defaults = {
+  run?: {
+    shell?: string
+    'working-directory'?: string
+  }
+}
+
+type Concurrency = {
+  group: string
+  'cancel-in-progress'?: boolean
+}
+
+type Job = {
+  name?: string
+  'runs-on': string | string[]
+  needs?: string | string[]
+  if?: string
+  permissions?: Permissions
+  environment?: string | Environment
+  concurrency?: string | Concurrency
+  outputs?: Record<string, string>
+  env?: Record<string, string>
+  defaults?: Defaults
+  steps: Step[]
+  'timeout-minutes'?: number
+  strategy?: Strategy
+  'continue-on-error'?: boolean
+  container?: string | Container
+  services?: Record<string, Service>
+}
+
+/** Arguments for generating a GitHub Actions workflow file */
+export type GitHubWorkflowArgs = {
+  /** Workflow name displayed in GitHub UI */
+  name?: string
+  /** Event triggers for the workflow */
+  on: OnConfig | EventTrigger | EventTrigger[]
+  /** Workflow-level permissions */
+  permissions?: Permissions
+  /** Environment variables for all jobs */
+  env?: Record<string, string>
+  /** Default settings for all jobs */
+  defaults?: Defaults
+  /** Concurrency settings */
+  concurrency?: string | Concurrency
+  /** Jobs to run */
+  jobs: Record<string, Job>
+  /** Workflow run name */
+  'run-name'?: string
+}
+
+/** Options for customizing GitHub workflow generation (reserved for future use) */
+export type GitHubWorkflowOptions = Record<string, never>
+
+/**
+ * Creates a GitHub Actions workflow YAML string
+ *
+ * @example
+ * ```ts
+ * export default githubWorkflow({
+ *   name: "CI",
+ *   on: {
+ *     push: { branches: ["main"] },
+ *     pull_request: { branches: ["main"] }
+ *   },
+ *   jobs: {
+ *     build: {
+ *       "runs-on": "ubuntu-latest",
+ *       steps: [
+ *         { uses: "actions/checkout@v4" },
+ *         { run: "npm test" }
+ *       ]
+ *     }
+ *   }
+ * })
+ * ```
+ */
+// oxlint-disable-next-line overeng/named-args -- DSL-style API: fn(config, options?)
+export const githubWorkflow = (
+  args: GitHubWorkflowArgs,
+  _options?: GitHubWorkflowOptions,
+): string => {
+  return yaml.stringify(args)
+}

--- a/packages/@overeng/genie/src/lib/mod.ts
+++ b/packages/@overeng/genie/src/lib/mod.ts
@@ -1,0 +1,5 @@
+export * from './package-json.ts'
+export * from './tsconfig-json.ts'
+export * from './github-workflow.ts'
+export * from './oxlint-config.ts'
+export * from './oxfmt-config.ts'

--- a/packages/@overeng/genie/src/lib/oxfmt-config.ts
+++ b/packages/@overeng/genie/src/lib/oxfmt-config.ts
@@ -1,0 +1,131 @@
+/**
+ * Oxfmt configuration generator.
+ *
+ * Generates `.jsonc` configuration files for oxfmt (Oxc formatter).
+ *
+ * @see https://oxc.rs/docs/guide/usage/formatter
+ * @see https://oxc.rs/docs/guide/usage/formatter/migrate-from-prettier
+ */
+
+/** Import sorting group types */
+type ImportGroup = 'builtin' | 'external' | 'internal' | 'parent' | 'sibling' | 'index'
+
+/** Import sorting configuration */
+export type ImportSortConfig = {
+  /** Import group ordering. Arrays create merged groups. */
+  groups?: (ImportGroup | ImportGroup[])[]
+  /** Patterns to treat as internal imports (e.g., ['@myorg/']) */
+  internalPattern?: string[]
+  /** Insert newlines between import groups */
+  newlinesBetween?: boolean
+}
+
+/** Arguments for generating an oxfmt configuration file */
+export type OxfmtConfigArgs = {
+  /** Print semicolons at the end of statements (default: true) */
+  semi?: boolean
+  /** Use single quotes instead of double quotes (default: false) */
+  singleQuote?: boolean
+  /** Specify the line length for wrapping (default: 100 in oxfmt, 80 in prettier) */
+  printWidth?: number
+  /** Specify the number of spaces per indentation level (default: 2) */
+  tabWidth?: number
+  /** Indent lines with tabs instead of spaces (default: false) */
+  useTabs?: boolean
+  /** Print trailing commas wherever possible (default: 'all') */
+  trailingComma?: 'all' | 'es5' | 'none'
+  /** Print spaces between brackets in object literals (default: true) */
+  bracketSpacing?: boolean
+  /** Include parentheses around a sole arrow function parameter (default: 'always') */
+  arrowParens?: 'always' | 'avoid'
+  /** End of line character (default: 'lf') */
+  endOfLine?: 'lf' | 'crlf' | 'cr' | 'auto'
+  /** Experimental import sorting configuration */
+  experimentalSortImports?: ImportSortConfig
+  /** Experimental package.json sorting (default: false) */
+  experimentalSortPackageJson?: boolean
+  /** Glob patterns to ignore */
+  ignorePatterns?: string[]
+}
+
+/** Options for customizing oxfmt config generation (reserved for future use) */
+export type OxfmtConfigOptions = Record<string, never>
+
+/**
+ * Generate an oxfmt configuration file (.jsonc).
+ *
+ * @see https://oxc.rs/docs/guide/usage/formatter
+ *
+ * @example
+ * ```ts
+ * export default oxfmtConfig({
+ *   semi: false,
+ *   singleQuote: true,
+ *   printWidth: 100,
+ *   tabWidth: 2,
+ *   experimentalSortImports: {
+ *     groups: ['builtin', 'external', 'internal', ['parent', 'sibling', 'index']],
+ *     internalPattern: ['@myorg/'],
+ *     newlinesBetween: true,
+ *   },
+ *   experimentalSortPackageJson: true,
+ * })
+ * ```
+ */
+// oxlint-disable-next-line overeng/named-args -- DSL-style API: fn(config, options?)
+export const oxfmtConfig = (args: OxfmtConfigArgs, _options?: OxfmtConfigOptions): string => {
+  const config: Record<string, unknown> = {
+    $schema:
+      'https://raw.githubusercontent.com/nicksrandall/oxfmt/refs/heads/main/configuration_schema.json',
+  }
+
+  if (args.semi !== undefined) {
+    config.semi = args.semi
+  }
+
+  if (args.singleQuote !== undefined) {
+    config.singleQuote = args.singleQuote
+  }
+
+  if (args.printWidth !== undefined) {
+    config.printWidth = args.printWidth
+  }
+
+  if (args.tabWidth !== undefined) {
+    config.tabWidth = args.tabWidth
+  }
+
+  if (args.useTabs !== undefined) {
+    config.useTabs = args.useTabs
+  }
+
+  if (args.trailingComma !== undefined) {
+    config.trailingComma = args.trailingComma
+  }
+
+  if (args.bracketSpacing !== undefined) {
+    config.bracketSpacing = args.bracketSpacing
+  }
+
+  if (args.arrowParens !== undefined) {
+    config.arrowParens = args.arrowParens
+  }
+
+  if (args.endOfLine !== undefined) {
+    config.endOfLine = args.endOfLine
+  }
+
+  if (args.experimentalSortImports !== undefined) {
+    config.experimentalSortImports = args.experimentalSortImports
+  }
+
+  if (args.experimentalSortPackageJson !== undefined) {
+    config.experimentalSortPackageJson = args.experimentalSortPackageJson
+  }
+
+  if (args.ignorePatterns !== undefined) {
+    config.ignorePatterns = args.ignorePatterns
+  }
+
+  return JSON.stringify(config, null, 2) + '\n'
+}

--- a/packages/@overeng/genie/src/lib/oxlint-config.ts
+++ b/packages/@overeng/genie/src/lib/oxlint-config.ts
@@ -1,0 +1,142 @@
+/**
+ * Oxlint configuration generator.
+ *
+ * Generates `.jsonc` configuration files for oxlint.
+ *
+ * @see https://oxc.rs/docs/guide/usage/linter/configuration
+ * @see https://raw.githubusercontent.com/oxc-project/oxc/main/npm/oxlint/configuration_schema.json
+ */
+
+/** Rule severity levels */
+type RuleSeverity = 'off' | 'warn' | 'error' | 'allow' | 'deny' | 0 | 1 | 2
+
+/** Rule configuration - either severity alone or [severity, options] */
+type RuleConfig = RuleSeverity | [RuleSeverity, Record<string, unknown>]
+
+/** Built-in oxlint plugins */
+type OxlintPlugin =
+  | 'eslint'
+  | 'react'
+  | 'unicorn'
+  | 'typescript'
+  | 'oxc'
+  | 'import'
+  | 'jsdoc'
+  | 'jest'
+  | 'vitest'
+  | 'jsx-a11y'
+  | 'nextjs'
+  | 'react-perf'
+  | 'promise'
+  | 'node'
+  | 'vue'
+
+/** Rule category severity levels */
+type CategorySeverity = 'off' | 'warn' | 'error'
+
+/** Rule categories for bulk configuration */
+type RuleCategories = {
+  correctness?: CategorySeverity
+  suspicious?: CategorySeverity
+  pedantic?: CategorySeverity
+  perf?: CategorySeverity
+  style?: CategorySeverity
+  restriction?: CategorySeverity
+  nursery?: CategorySeverity
+}
+
+/** File-specific rule overrides */
+export type OxlintOverride = {
+  files: string[]
+  rules?: Record<string, RuleConfig>
+  plugins?: OxlintPlugin[]
+  settings?: Record<string, unknown>
+}
+
+/** Arguments for generating an oxlint configuration file */
+export type OxlintConfigArgs = {
+  /** Built-in plugins to enable */
+  plugins?: OxlintPlugin[]
+  /** Custom JS plugin paths (experimental) */
+  jsPlugins?: string[]
+  /** Rule category severity levels */
+  categories?: RuleCategories
+  /** Individual rule configurations */
+  rules?: Record<string, RuleConfig>
+  /** File-specific overrides */
+  overrides?: OxlintOverride[]
+  /** Environment globals */
+  env?: Record<string, boolean>
+  /** Custom global variables */
+  globals?: Record<string, 'readonly' | 'writable' | 'off'>
+  /** Paths to extend from */
+  extends?: string[]
+  /** Glob patterns to ignore */
+  ignorePatterns?: string[]
+  /** Plugin-specific settings */
+  settings?: {
+    react?: Record<string, unknown>
+    typescript?: Record<string, unknown>
+    'jsx-a11y'?: Record<string, unknown>
+    next?: Record<string, unknown>
+    jsdoc?: Record<string, unknown>
+    vitest?: Record<string, unknown>
+  }
+}
+
+/** Options for customizing oxlint config generation (reserved for future use) */
+export type OxlintConfigOptions = Record<string, never>
+
+/**
+ * Generate an oxlint configuration file (.jsonc).
+ * @see https://oxc.rs/docs/guide/usage/linter/configuration
+ */
+// oxlint-disable-next-line overeng/named-args -- DSL-style API: fn(config, options?)
+export const oxlintConfig = (args: OxlintConfigArgs, _options?: OxlintConfigOptions): string => {
+  const config: Record<string, unknown> = {
+    $schema:
+      'https://raw.githubusercontent.com/oxc-project/oxc/main/npm/oxlint/configuration_schema.json',
+  }
+
+  if (args.plugins !== undefined) {
+    config.plugins = args.plugins
+  }
+
+  if (args.jsPlugins !== undefined) {
+    config.jsPlugins = args.jsPlugins
+  }
+
+  if (args.env !== undefined) {
+    config.env = args.env
+  }
+
+  if (args.globals !== undefined) {
+    config.globals = args.globals
+  }
+
+  if (args.extends !== undefined) {
+    config.extends = args.extends
+  }
+
+  if (args.ignorePatterns !== undefined) {
+    config.ignorePatterns = args.ignorePatterns
+  }
+
+  if (args.settings !== undefined) {
+    config.settings = args.settings
+  }
+
+  if (args.categories !== undefined) {
+    config.categories = args.categories
+  }
+
+  if (args.rules !== undefined) {
+    config.rules = args.rules
+  }
+
+  if (args.overrides !== undefined) {
+    config.overrides = args.overrides
+  }
+
+  return JSON.stringify(config, null, 2) + '\n'
+}

--- a/packages/@overeng/genie/src/lib/package-json.ts
+++ b/packages/@overeng/genie/src/lib/package-json.ts
@@ -1,0 +1,201 @@
+/**
+ * Type-safe package.json generator
+ * Reference: https://github.com/sindresorhus/type-fest/blob/main/source/package-json.d.ts
+ */
+
+type Person =
+  | string
+  | {
+      name: string
+      email?: string
+      url?: string
+    }
+
+type Bugs =
+  | string
+  | {
+      url?: string
+      email?: string
+    }
+
+type Repository =
+  | string
+  | {
+      type: string
+      url: string
+      directory?: string
+    }
+
+type ExportsEntry =
+  | string
+  | Record<string, string>
+  | {
+      import?: string
+      require?: string
+      node?: string
+      default?: string
+      types?: string
+      browser?: string
+    }
+
+type Funding =
+  | string
+  | {
+      type?: string
+      url?: string
+    }
+
+/** Arguments for generating a package.json file */
+export type PackageJSONArgs = {
+  /** Package name */
+  name?: string
+  /** Package version (semver) */
+  version?: string
+  /** Short package description */
+  description?: string
+  /** Keywords for npm search */
+  keywords?: string[]
+  /** Homepage URL */
+  homepage?: string
+  /** Bug tracker URL or configuration */
+  bugs?: Bugs
+  /** License identifier (SPDX) */
+  license?: string
+  /** Package author */
+  author?: Person
+  /** Package contributors */
+  contributors?: Person[]
+  /** Repository information */
+  repository?: Repository
+  /** Main entry point (CJS) */
+  main?: string
+  /** Module entry point (ESM) */
+  module?: string
+  /** TypeScript types definition file */
+  types?: string
+  /** TypeScript types definition file (legacy alias) */
+  typings?: string
+  /** Files to include when publishing */
+  files?: string[]
+  /** Package entry points (modern ESM exports) */
+  exports?: Record<string, ExportsEntry>
+  /** Package type: "module" for ESM, "commonjs" for CJS */
+  type?: 'module' | 'commonjs'
+  /** Binary executables */
+  bin?: string | Record<string, string>
+  /** Man pages */
+  man?: string | string[]
+  /** Directory structure */
+  directories?: {
+    lib?: string
+    bin?: string
+    man?: string
+    doc?: string
+    example?: string
+    test?: string
+  }
+  /** npm scripts */
+  scripts?: Record<string, string>
+  /** Package configuration values */
+  config?: Record<string, unknown>
+  /** Production dependencies */
+  dependencies?: Record<string, string>
+  /** Development dependencies */
+  devDependencies?: Record<string, string>
+  /** Peer dependencies */
+  peerDependencies?: Record<string, string>
+  /** Peer dependency metadata */
+  peerDependenciesMeta?: Record<string, { optional?: boolean }>
+  /** Optional dependencies */
+  optionalDependencies?: Record<string, string>
+  /** Bundled dependencies */
+  bundledDependencies?: string[]
+  /** Engine requirements */
+  engines?: {
+    node?: string
+    npm?: string
+    pnpm?: string
+    yarn?: string
+  }
+  /** Supported operating systems */
+  os?: string[]
+  /** Supported CPU architectures */
+  cpu?: string[]
+  /** Mark as private (prevents publishing) */
+  private?: boolean
+  /** Publishing configuration */
+  publishConfig?: {
+    access?: 'public' | 'restricted'
+    registry?: string
+    tag?: string
+    [key: string]: unknown
+  }
+  /** Workspace configuration */
+  workspaces?: string[] | { packages?: string[] }
+  /** pnpm-specific configuration */
+  pnpm?: {
+    overrides?: Record<string, string>
+    packageExtensions?: Record<
+      string,
+      {
+        dependencies?: Record<string, string>
+        peerDependencies?: Record<string, string>
+      }
+    >
+    peerDependencyRules?: {
+      allowedVersions?: Record<string, string>
+      ignoreMissing?: string[]
+    }
+  }
+  /** npm/pnpm hooks */
+  hooks?: Record<string, string>
+  /** Tree-shaking side effects configuration */
+  sideEffects?: boolean | string[]
+  /** Browser field for bundlers */
+  browser?: string | Record<string, string | false>
+  /** Funding information */
+  funding?: Funding | Funding[]
+  /** Yarn resolutions */
+  resolutions?: Record<string, string>
+  /** pnpm: prefer unplugged */
+  preferUnplugged?: boolean
+  /** Package manager for corepack */
+  packageManager?: string
+  /** pnpm catalog references */
+  catalog?: Record<string, string>
+  /** pnpm patched dependencies */
+  patchedDependencies?: Record<string, string>
+}
+
+/** Options for customizing package.json generation */
+export type PackageJSONOptions = {
+  /** Custom stringify function */
+  stringify?: (args: PackageJSONArgs) => string
+}
+
+/**
+ * Creates a package.json configuration string
+ *
+ * @example
+ * ```ts
+ * export default packageJSON({
+ *   name: "my-package",
+ *   version: "1.0.0",
+ *   type: "module",
+ *   exports: { ".": "./src/mod.ts" }
+ * })
+ * ```
+ */
+// oxlint-disable-next-line overeng/named-args -- DSL-style API: fn(config, options?)
+export const packageJSON = (args: PackageJSONArgs, options?: PackageJSONOptions): string => {
+  if (args.private !== true) {
+    if (args.name === undefined) {
+      console.warn('Warning: Package is not private but missing a name')
+    }
+    if (args.version === undefined) {
+      console.warn('Warning: Package is not private but missing a version')
+    }
+  }
+
+  return options?.stringify?.(args) ?? JSON.stringify(args, null, 2)
+}

--- a/packages/@overeng/genie/src/lib/tsconfig-json.ts
+++ b/packages/@overeng/genie/src/lib/tsconfig-json.ts
@@ -1,0 +1,299 @@
+/**
+ * Type-safe tsconfig.json generator
+ * Reference: https://www.typescriptlang.org/tsconfig
+ */
+
+type Target =
+  | 'ES3'
+  | 'ES5'
+  | 'ES6'
+  | 'ES2015'
+  | 'ES2016'
+  | 'ES2017'
+  | 'ES2018'
+  | 'ES2019'
+  | 'ES2020'
+  | 'ES2021'
+  | 'ES2022'
+  | 'ES2023'
+  | 'ES2024'
+  | 'ESNext'
+
+type Module =
+  | 'CommonJS'
+  | 'AMD'
+  | 'System'
+  | 'UMD'
+  | 'ES6'
+  | 'ES2015'
+  | 'ES2020'
+  | 'ES2022'
+  | 'ESNext'
+  | 'Node16'
+  | 'NodeNext'
+  | 'None'
+  | 'Preserve'
+
+type ModuleResolution = 'Node' | 'Node10' | 'Node16' | 'NodeNext' | 'Classic' | 'Bundler'
+
+type JSX = 'preserve' | 'react' | 'react-native' | 'react-jsx' | 'react-jsxdev'
+
+type WatchFile =
+  | 'useFsEvents'
+  | 'dynamicPriorityPolling'
+  | 'fixedPollingInterval'
+  | 'priorityPollingInterval'
+
+type WatchDirectory =
+  | 'useFsEvents'
+  | 'dynamicPriorityPolling'
+  | 'fixedPollingInterval'
+  | 'fixedChunkSizePolling'
+
+type FallbackPolling =
+  | 'dynamicPriority'
+  | 'priorityPolling'
+  | 'fixedPolling'
+  | 'fixedInterval'
+  | 'dynamicPriorityPolling'
+
+/** TypeScript compiler options */
+export type TSConfigCompilerOptions = {
+  /** Allow JavaScript files to be compiled */
+  allowJs?: boolean
+  /** Allow default imports from modules with no default export */
+  allowSyntheticDefaultImports?: boolean
+  /** Allow importing .ts/.tsx files with .ts/.tsx extensions */
+  allowImportingTsExtensions?: boolean
+  /** Rewrite relative import extensions from .ts to .js */
+  rewriteRelativeImportExtensions?: boolean
+  /** Enable 'import x from y' when module doesn't have default export */
+  esModuleInterop?: boolean
+  /** ECMAScript target version */
+  target?: Target
+  /** Module code generation */
+  module?: Module
+  /** Library files to include */
+  lib?: string[]
+  /** JSX code generation */
+  jsx?: JSX
+  /** JSX factory function */
+  jsxFactory?: string
+  /** JSX Fragment factory */
+  jsxFragmentFactory?: string
+  /** Specify module specifier for importing jsx factory functions */
+  jsxImportSource?: string
+  /** Generate .d.ts declaration files */
+  declaration?: boolean
+  /** Generate .d.ts.map source maps for declaration files */
+  declarationMap?: boolean
+  /** Output directory for declaration files */
+  declarationDir?: string
+  /** Incremental compilation info file */
+  tsBuildInfoFile?: string
+  /** Output directory */
+  outDir?: string
+  /** Concatenate and emit to single file */
+  outFile?: string
+  /** Root directory of input files */
+  rootDir?: string
+  /** Multiple root folders for project structure */
+  rootDirs?: string[]
+  /** Skip type checking declaration files */
+  skipLibCheck?: boolean
+  /** Enable all strict type checking options */
+  strict?: boolean
+  /** Error on expressions with implied 'any' type */
+  noImplicitAny?: boolean
+  /** Enable strict null checks */
+  strictNullChecks?: boolean
+  /** Ensure class properties initialized in constructor */
+  strictPropertyInitialization?: boolean
+  /** Enable strict function type checking */
+  strictFunctionTypes?: boolean
+  /** Enable strict bind/call/apply checking */
+  strictBindCallApply?: boolean
+  /** Disable project reference redirect */
+  disableSourceOfProjectReferenceRedirect?: boolean
+  /** Error on missing return statements */
+  noImplicitReturns?: boolean
+  /** Error on unused local variables */
+  noUnusedLocals?: boolean
+  /** Error on unused parameters */
+  noUnusedParameters?: boolean
+  /** Error on switch case fallthrough */
+  noFallthroughCasesInSwitch?: boolean
+  /** Use colors in error messages */
+  pretty?: boolean
+  /** Enable incremental compilation */
+  incremental?: boolean
+  /** Generate source maps */
+  sourceMap?: boolean
+  /** Module resolution strategy */
+  moduleResolution?: ModuleResolution
+  /** Base directory for non-relative module names */
+  baseUrl?: string
+  /** Path mappings for module names */
+  paths?: Record<string, string[]>
+  /** Emit design-type metadata for decorators */
+  emitDecoratorMetadata?: boolean
+  /** Enable experimental decorator support */
+  experimentalDecorators?: boolean
+  /** Import helper functions from tslib */
+  importHelpers?: boolean
+  /** Enable project compilation */
+  composite?: boolean
+  /** Enforce consistent file name casing */
+  forceConsistentCasingInFileNames?: boolean
+  /** Require override modifier for derived class members */
+  noImplicitOverride?: boolean
+  /** Remove comments from output */
+  removeComments?: boolean
+  /** Don't truncate error messages */
+  noErrorTruncation?: boolean
+  /** Don't emit on errors */
+  noEmitOnError?: boolean
+  /** Error on indexing objects without index signatures */
+  noUncheckedIndexedAccess?: boolean
+  /** Don't emit @internal declarations */
+  stripInternal?: boolean
+  /** Don't emit output files */
+  noEmit?: boolean
+  /** Allow UMD global access from modules */
+  allowUmdGlobalAccess?: boolean
+  /** Ensure imports can be safely transpiled in isolation */
+  isolatedModules?: boolean
+  /** Suppress excess property errors */
+  suppressExcessPropertyErrors?: boolean
+  /** Suppress implicit any index errors */
+  suppressImplicitAnyIndexErrors?: boolean
+  /** Type declaration root directories */
+  typeRoots?: string[]
+  /** Type declarations to include */
+  types?: string[]
+  /** Language service plugins */
+  plugins?: Array<{
+    name: string
+    transform?: string
+    after?: boolean
+    afterDeclarations?: boolean
+    [key: string]: unknown
+  }>
+  /** Enable resolution tracing */
+  traceResolution?: boolean
+  /** keyof only yields string-valued properties */
+  keyofStringsOnly?: boolean
+  /** Use defineProperty for class fields */
+  useDefineForClassFields?: boolean
+  /** Emit imports/exports as written */
+  verbatimModuleSyntax?: boolean
+  /** Exact optional property types */
+  exactOptionalPropertyTypes?: boolean
+  /** Allow arbitrary extensions in imports */
+  allowArbitraryExtensions?: boolean
+  /** Resolve package.json exports */
+  resolvePackageJsonExports?: boolean
+  /** Resolve package.json imports */
+  resolvePackageJsonImports?: boolean
+  /** Resolve JSON modules */
+  resolveJsonModule?: boolean
+  /** Disable solution searching */
+  disableSolutionSearching?: boolean
+  /** Disable referenced project load */
+  disableReferencedProjectLoad?: boolean
+  /** Use case-sensitive file names */
+  useCaseSensitiveFileNames?: boolean
+  /** Custom conditions for exports/imports resolution */
+  customConditions?: string[]
+}
+
+/** TypeScript watch mode options */
+export type TSConfigWatchOptions = {
+  /** File watching strategy */
+  watchFile?: WatchFile
+  /** Directory watching strategy */
+  watchDirectory?: WatchDirectory
+  /** Fallback polling strategy */
+  fallbackPolling?: FallbackPolling
+  /** Synchronous directory watching */
+  synchronousWatchDirectory?: boolean
+  /** Files to exclude from watching */
+  excludeFiles?: string[]
+  /** Directories to exclude from watching */
+  excludeDirectories?: string[]
+}
+
+/** ts-node specific configuration options */
+export type TSNodeOptions = {
+  /** Use TypeScript compiler host API */
+  compilerHost?: boolean
+  /** Merge with compiler options */
+  compilerOptions?: Record<string, unknown>
+  /** Emit output files */
+  emit?: boolean
+  /** Load files from tsconfig.json */
+  files?: boolean
+  /** Path patterns to skip */
+  ignore?: string[]
+  /** Diagnostic codes to ignore */
+  ignoreDiagnostics?: (string | number)[]
+  /** Transpile with swc */
+  swc?: boolean
+  /** Use pretty diagnostic formatter */
+  pretty?: boolean
+  /** Use transpileModule for faster compilation */
+  transpileOnly?: boolean
+  /** Prefer .ts extensions in imports */
+  preferTsExts?: boolean
+  /** Modules to require */
+  require?: string[]
+  /** Skip ignore check */
+  skipIgnore?: boolean
+  /** Custom compiler path */
+  compiler?: string
+  /** Custom transpiler */
+  transpiler?: string
+}
+
+/** Arguments for generating a tsconfig.json file */
+export type TSConfigArgs = {
+  /** Files to include (glob patterns) */
+  include?: string[]
+  /** Files to exclude (glob patterns) */
+  exclude?: string[]
+  /** Explicit file list */
+  files?: string[]
+  /** Base configuration to extend */
+  extends?: string | string[]
+  /** Project references */
+  references?: Array<{ path: string; prepend?: boolean }>
+  /** Compiler options */
+  compilerOptions?: TSConfigCompilerOptions
+  /** Watch options */
+  watchOptions?: TSConfigWatchOptions
+  /** ts-node options */
+  ts_node?: TSNodeOptions
+}
+
+/** Options for customizing tsconfig.json generation (reserved for future use) */
+export type TSConfigOptions = Record<string, never>
+
+/**
+ * Creates a tsconfig.json configuration string
+ *
+ * @example
+ * ```ts
+ * export default tsconfigJSON({
+ *   extends: "../tsconfig.base.json",
+ *   compilerOptions: {
+ *     rootDir: ".",
+ *     outDir: "dist"
+ *   },
+ *   include: ["src/**\/*.ts"]
+ * })
+ * ```
+ */
+// oxlint-disable-next-line overeng/named-args -- DSL-style API: fn(config, options?)
+export const tsconfigJSON = (args: TSConfigArgs, _options?: TSConfigOptions): string => {
+  return JSON.stringify(args, null, 2)
+}

--- a/packages/@overeng/genie/src/lib/yaml.ts
+++ b/packages/@overeng/genie/src/lib/yaml.ts
@@ -1,0 +1,131 @@
+/**
+ * Simple YAML stringifier for GitHub Actions workflows
+ * Handles the subset of YAML features needed for workflows
+ */
+
+const INDENT = '  '
+
+const needsQuoting = (str: string): boolean => {
+  if (str === '') return true
+  if (str === 'true' || str === 'false' || str === 'null') return true
+  if (/^\d+$/.test(str) || /^\d+\.\d+$/.test(str)) return true
+  if (str.startsWith('${{') && str.endsWith('}}')) return false
+  if (/^[{[\]!@#%&*|>?]/.test(str)) return true
+  if (/[:#]/.test(str)) return true
+  if (str.includes('\n')) return true
+  return false
+}
+
+const quoteString = (str: string): string => {
+  if (str.includes('\n')) {
+    return `|\n${str
+      .split('\n')
+      .map((line) => INDENT + line)
+      .join('\n')}`
+  }
+  if (needsQuoting(str)) {
+    return `"${str.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
+  }
+  return str
+}
+
+// oxlint-disable-next-line overeng/named-args -- simple internal recursive helper
+const stringifyValue = (value: unknown, indent: number): string => {
+  if (value === null || value === undefined) {
+    return 'null'
+  }
+
+  if (typeof value === 'boolean') {
+    return value ? 'true' : 'false'
+  }
+
+  if (typeof value === 'number') {
+    return String(value)
+  }
+
+  if (typeof value === 'string') {
+    return quoteString(value)
+  }
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) return '[]'
+
+    const isSimpleArray = value.every(
+      (item) => typeof item === 'string' || typeof item === 'number' || typeof item === 'boolean',
+    )
+
+    if (isSimpleArray && value.length <= 5) {
+      const items = value.map((item) =>
+        typeof item === 'string' ? quoteString(item) : String(item),
+      )
+      return `[${items.join(', ')}]`
+    }
+
+    const prefix = INDENT.repeat(indent)
+    return value
+      .map((item) => `\n${prefix}- ${stringifyValue(item, indent + 1).trimStart()}`)
+      .join('')
+  }
+
+  if (typeof value === 'object') {
+    const entries = Object.entries(value).filter(([, v]) => v !== undefined)
+    if (entries.length === 0) return '{}'
+
+    const prefix = INDENT.repeat(indent)
+    const lines = entries.map(([key, val]) => {
+      const stringifiedVal = stringifyValue(val, indent + 1)
+      if (
+        typeof val === 'object' &&
+        val !== null &&
+        !Array.isArray(val) &&
+        Object.keys(val).length > 0
+      ) {
+        return `${prefix}${key}:\n${stringifiedVal}`
+      }
+      if (Array.isArray(val) && val.length > 0 && !isSimpleInlineArray(val)) {
+        return `${prefix}${key}:${stringifiedVal}`
+      }
+      return `${prefix}${key}: ${stringifiedVal}`
+    })
+
+    return lines.join('\n')
+  }
+
+  return String(value)
+}
+
+const isSimpleInlineArray = (arr: unknown[]): boolean => {
+  if (arr.length > 5) return false
+  return arr.every(
+    (item) => typeof item === 'string' || typeof item === 'number' || typeof item === 'boolean',
+  )
+}
+
+/**
+ * Stringify a value to YAML format
+ * Designed for GitHub Actions workflow files
+ */
+export const stringify = (value: unknown): string => {
+  if (typeof value !== 'object' || value === null) {
+    return stringifyValue(value, 0)
+  }
+
+  const entries = Object.entries(value).filter(([, v]) => v !== undefined)
+  const lines = entries.map(([key, val]) => {
+    const stringifiedVal = stringifyValue(val, 1)
+    if (
+      typeof val === 'object' &&
+      val !== null &&
+      !Array.isArray(val) &&
+      Object.keys(val).length > 0
+    ) {
+      return `${key}:\n${stringifiedVal}`
+    }
+    if (Array.isArray(val) && val.length > 0 && !isSimpleInlineArray(val)) {
+      return `${key}:${stringifiedVal}`
+    }
+    return `${key}: ${stringifiedVal}`
+  })
+
+  return lines.join('\n\n') + '\n'
+}

--- a/packages/@overeng/genie/tsconfig.json
+++ b/packages/@overeng/genie/tsconfig.json
@@ -1,0 +1,12 @@
+// Generated file - DO NOT EDIT
+// Source: packages/@overeng/genie/tsconfig.json.genie.ts
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": ".",
+    "outDir": "./dist",
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts", "bin/**/*.ts"]
+}

--- a/packages/@overeng/genie/tsconfig.json.genie.ts
+++ b/packages/@overeng/genie/tsconfig.json.genie.ts
@@ -1,0 +1,8 @@
+import { packageTsconfigCompilerOptions } from '../../../genie/repo.ts'
+import { tsconfigJSON } from './src/lib/mod.ts'
+
+export default tsconfigJSON({
+  extends: '../../../tsconfig.base.json',
+  compilerOptions: packageTsconfigCompilerOptions,
+  include: ['src/**/*.ts', 'bin/**/*.ts'],
+})

--- a/packages/@overeng/notion-effect-cli/package.json.genie.ts
+++ b/packages/@overeng/notion-effect-cli/package.json.genie.ts
@@ -1,0 +1,47 @@
+import { catalogRef } from '../../../genie/repo.ts'
+import { packageJSON } from '../genie/src/lib/mod.ts'
+
+export default packageJSON({
+  name: '@overeng/notion-effect-cli',
+  version: '0.1.0',
+  private: true,
+  type: 'module',
+  exports: {
+    '.': './src/mod.ts',
+    './config': './src/config-def.ts',
+  },
+  publishConfig: {
+    access: 'public',
+    bin: {
+      'notion-effect-cli': './dist/cli.js',
+    },
+    exports: {
+      '.': './dist/mod.js',
+      './config': './dist/config-def.js',
+    },
+  },
+  dependencies: {
+    '@effect/cli': catalogRef,
+    '@effect/cluster': catalogRef,
+    '@effect/experimental': catalogRef,
+    '@effect/platform': catalogRef,
+    '@effect/platform-node': catalogRef,
+    '@effect/printer': catalogRef,
+    '@effect/printer-ansi': catalogRef,
+    '@effect/rpc': catalogRef,
+    '@effect/sql': catalogRef,
+    '@effect/typeclass': catalogRef,
+    '@effect/workflow': catalogRef,
+    '@overeng/notion-effect-client': 'workspace:*',
+    '@overeng/notion-effect-schema': 'workspace:*',
+    '@overeng/utils': 'workspace:*',
+  },
+  devDependencies: {
+    '@effect/vitest': catalogRef,
+    effect: catalogRef,
+    vitest: catalogRef,
+  },
+  peerDependencies: {
+    effect: catalogRef,
+  },
+})

--- a/packages/@overeng/notion-effect-cli/tsconfig.json
+++ b/packages/@overeng/notion-effect-cli/tsconfig.json
@@ -1,11 +1,17 @@
+// Generated file - DO NOT EDIT
+// Source: packages/@overeng/notion-effect-cli/tsconfig.json.genie.ts
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "composite": true,
-    "rootDir": "src",
+    "rootDir": ".",
     "outDir": "./dist",
     "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
   },
-  "include": ["src/**/*"],
-  "references": [{ "path": "../notion-effect-schema" }]
+  "include": ["src/**/*", "bin/**/*.ts"],
+  "references": [
+    {
+      "path": "../notion-effect-schema"
+    }
+  ]
 }

--- a/packages/@overeng/notion-effect-cli/tsconfig.json.genie.ts
+++ b/packages/@overeng/notion-effect-cli/tsconfig.json.genie.ts
@@ -1,0 +1,9 @@
+import { packageTsconfigCompilerOptions } from '../../../genie/repo.ts'
+import { tsconfigJSON } from '../genie/src/lib/mod.ts'
+
+export default tsconfigJSON({
+  extends: '../../../tsconfig.base.json',
+  compilerOptions: packageTsconfigCompilerOptions,
+  include: ['src/**/*', 'bin/**/*.ts'],
+  references: [{ path: '../notion-effect-schema' }],
+})

--- a/packages/@overeng/notion-effect-client/package.json.genie.ts
+++ b/packages/@overeng/notion-effect-client/package.json.genie.ts
@@ -1,0 +1,33 @@
+import { catalogRef } from '../../../genie/repo.ts'
+import { packageJSON } from '../genie/src/lib/mod.ts'
+
+export default packageJSON({
+  name: '@overeng/notion-effect-client',
+  version: '0.1.0',
+  private: true,
+  type: 'module',
+  exports: {
+    '.': './src/mod.ts',
+  },
+  publishConfig: {
+    access: 'public',
+    exports: {
+      '.': './dist/mod.js',
+    },
+  },
+  dependencies: {
+    '@overeng/notion-effect-schema': 'workspace:*',
+  },
+  devDependencies: {
+    '@effect/platform': catalogRef,
+    '@effect/vitest': catalogRef,
+    '@overeng/utils': 'workspace:*',
+    '@types/node': catalogRef,
+    effect: catalogRef,
+    vitest: catalogRef,
+  },
+  peerDependencies: {
+    '@effect/platform': catalogRef,
+    effect: catalogRef,
+  },
+})

--- a/packages/@overeng/notion-effect-client/tsconfig.json
+++ b/packages/@overeng/notion-effect-client/tsconfig.json
@@ -1,11 +1,17 @@
+// Generated file - DO NOT EDIT
+// Source: packages/@overeng/notion-effect-client/tsconfig.json.genie.ts
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "composite": true,
-    "rootDir": "src",
+    "rootDir": ".",
     "outDir": "./dist",
     "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
   },
   "include": ["src/**/*"],
-  "references": [{ "path": "../notion-effect-schema" }]
+  "references": [
+    {
+      "path": "../notion-effect-schema"
+    }
+  ]
 }

--- a/packages/@overeng/notion-effect-client/tsconfig.json.genie.ts
+++ b/packages/@overeng/notion-effect-client/tsconfig.json.genie.ts
@@ -1,0 +1,9 @@
+import { packageTsconfigCompilerOptions } from '../../../genie/repo.ts'
+import { tsconfigJSON } from '../genie/src/lib/mod.ts'
+
+export default tsconfigJSON({
+  extends: '../../../tsconfig.base.json',
+  compilerOptions: packageTsconfigCompilerOptions,
+  include: ['src/**/*'],
+  references: [{ path: '../notion-effect-schema' }],
+})

--- a/packages/@overeng/notion-effect-schema/package.json.genie.ts
+++ b/packages/@overeng/notion-effect-schema/package.json.genie.ts
@@ -1,0 +1,27 @@
+import { catalogRef } from '../../../genie/repo.ts'
+import { packageJSON } from '../genie/src/lib/mod.ts'
+
+export default packageJSON({
+  name: '@overeng/notion-effect-schema',
+  version: '0.1.0',
+  private: true,
+  type: 'module',
+  exports: {
+    '.': './src/mod.ts',
+  },
+  publishConfig: {
+    access: 'public',
+    exports: {
+      '.': './dist/mod.js',
+    },
+  },
+  devDependencies: {
+    '@effect/vitest': catalogRef,
+    '@types/node': catalogRef,
+    effect: catalogRef,
+    vitest: catalogRef,
+  },
+  peerDependencies: {
+    effect: catalogRef,
+  },
+})

--- a/packages/@overeng/notion-effect-schema/tsconfig.json
+++ b/packages/@overeng/notion-effect-schema/tsconfig.json
@@ -1,8 +1,10 @@
+// Generated file - DO NOT EDIT
+// Source: packages/@overeng/notion-effect-schema/tsconfig.json.genie.ts
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "composite": true,
-    "rootDir": "src",
+    "rootDir": ".",
     "outDir": "./dist",
     "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
   },

--- a/packages/@overeng/notion-effect-schema/tsconfig.json.genie.ts
+++ b/packages/@overeng/notion-effect-schema/tsconfig.json.genie.ts
@@ -1,0 +1,8 @@
+import { packageTsconfigCompilerOptions } from '../../../genie/repo.ts'
+import { tsconfigJSON } from '../genie/src/lib/mod.ts'
+
+export default tsconfigJSON({
+  extends: '../../../tsconfig.base.json',
+  compilerOptions: packageTsconfigCompilerOptions,
+  include: ['src/**/*'],
+})

--- a/packages/@overeng/oxc-config/fmt.jsonc
+++ b/packages/@overeng/oxc-config/fmt.jsonc
@@ -1,3 +1,5 @@
+// Generated file - DO NOT EDIT
+// Source: packages/@overeng/oxc-config/fmt.jsonc.genie.ts
 {
   "$schema": "https://raw.githubusercontent.com/nicksrandall/oxfmt/refs/heads/main/configuration_schema.json",
   "semi": false,
@@ -6,19 +8,6 @@
   "tabWidth": 2,
   "useTabs": false,
   "trailingComma": "all",
-  // Import sorting configuration
-  // Groups imports into 3 blocks separated by newlines:
-  //
-  // 1. External packages (effect, @effect/*)
-  //    import { Effect } from 'effect'
-  //    import { HttpClient } from '@effect/platform'
-  //
-  // 2. Internal monorepo packages (@overeng/*)
-  //    import { foo } from '@overeng/utils'
-  //
-  // 3. Relative imports (parent, sibling, index)
-  //    import { bar } from '../some-module.ts'
-  //    import { baz } from './local.ts'
   "experimentalSortImports": {
     "groups": ["builtin", "external", "internal", ["parent", "sibling", "index"]],
     "internalPattern": ["@overeng/"],

--- a/packages/@overeng/oxc-config/fmt.jsonc.genie.ts
+++ b/packages/@overeng/oxc-config/fmt.jsonc.genie.ts
@@ -1,0 +1,21 @@
+import { oxfmtConfig } from '../genie/src/lib/mod.ts'
+
+export default oxfmtConfig({
+  semi: false,
+  singleQuote: true,
+  printWidth: 100,
+  tabWidth: 2,
+  useTabs: false,
+  trailingComma: 'all',
+  // Import sorting configuration
+  // Groups imports into 3 blocks separated by newlines:
+  // 1. External packages (effect, @effect/*)
+  // 2. Internal monorepo packages (@overeng/*)
+  // 3. Relative imports (parent, sibling, index)
+  experimentalSortImports: {
+    groups: ['builtin', 'external', 'internal', ['parent', 'sibling', 'index']],
+    internalPattern: ['@overeng/'],
+    newlinesBetween: true,
+  },
+  experimentalSortPackageJson: true,
+})

--- a/packages/@overeng/oxc-config/lint.jsonc
+++ b/packages/@overeng/oxc-config/lint.jsonc
@@ -1,14 +1,9 @@
+// Generated file - DO NOT EDIT
+// Source: packages/@overeng/oxc-config/lint.jsonc.genie.ts
 {
   "$schema": "https://raw.githubusercontent.com/oxc-project/oxc/main/npm/oxlint/configuration_schema.json",
-
-  // Enable plugins for additional rule sets
   "plugins": ["import", "typescript", "unicorn", "oxc"],
-
-  // Custom JS plugins (experimental) - TypeScript files work directly, no build step needed
-  // See: https://oxc.rs/blog/2025-10-09-oxlint-js-plugins.html
   "jsPlugins": ["./src/mod.ts"],
-
-  // Rule categories - see https://oxc.rs/docs/guide/usage/linter/rules
   "categories": {
     "correctness": "error",
     "suspicious": "warn",
@@ -17,50 +12,40 @@
     "style": "off",
     "restriction": "off",
   },
-
   "rules": {
-    // Disallow dynamic import() and require() - helps with static analysis and bundling
-    // https://oxc.rs/docs/guide/usage/linter/rules/import/no-dynamic-require
-    "import/no-dynamic-require": ["warn", { "esmodule": true }],
-
-    // Disallow re-exports except in mod.ts entry points
-    // Use threshold=0 to catch any re-exports, then override for mod.ts
-    // https://oxc.rs/docs/guide/usage/linter/rules/oxc/no-barrel-file
-    "oxc/no-barrel-file": ["warn", { "threshold": 0 }],
-
-    // Enforce named arguments (options objects) instead of positional parameters
-    // Callbacks are automatically exempt; use disable comment for interface implementations
+    "import/no-dynamic-require": [
+      "warn",
+      {
+        "esmodule": true,
+      },
+    ],
+    "oxc/no-barrel-file": [
+      "warn",
+      {
+        "threshold": 0,
+      },
+    ],
     "overeng/named-args": "warn",
-
-    // Disallow CommonJS (require/module.exports) - enforce ESM
     "import/no-commonjs": "error",
-
-    // Detect circular dependencies
     "import/no-cycle": "warn",
-
-    // Prefer function expressions over declarations
-    // Note: oxlint doesn't have prefer-arrow-callback yet, so we use func-style
-    // with allowArrowFunctions to encourage expressions/arrows over declarations
-    // https://oxc.rs/docs/guide/usage/linter/rules/eslint/func-style
-    "func-style": ["warn", "expression", { "allowArrowFunctions": true }],
-
-    // Enforce exported declarations come before non-exported declarations (custom plugin)
+    "func-style": [
+      "warn",
+      "expression",
+      {
+        "allowArrowFunctions": true,
+      },
+    ],
     "overeng/exports-first": "warn",
-
-    // Require JSDoc comments on type/wildcard exports (custom plugin)
     "overeng/jsdoc-require-exports": "warn",
   },
-
   "overrides": [
     {
-      // Allow re-exports in mod.ts entry point files
       "files": ["**/mod.ts"],
       "rules": {
         "oxc/no-barrel-file": "off",
       },
     },
     {
-      // react-inspector is a fork with its own style - don't lint it strictly
       "files": ["**/react-inspector/**"],
       "rules": {
         "func-style": "off",
@@ -74,7 +59,6 @@
       },
     },
     {
-      // Storybook files have a specific pattern (meta before stories)
       "files": ["**/*.stories.tsx", "**/*.stories.ts", "**/*.stories.jsx", "**/.storybook/**"],
       "rules": {
         "overeng/exports-first": "off",
@@ -82,21 +66,18 @@
       },
     },
     {
-      // Config files don't need JSDoc
       "files": ["**/vitest.config.ts", "**/vite.config.ts", "**/playwright.config.ts"],
       "rules": {
         "overeng/jsdoc-require-exports": "off",
       },
     },
     {
-      // Allow CSS side-effect imports in storybook previews
       "files": ["**/.storybook/**"],
       "rules": {
         "import/no-unassigned-import": "off",
       },
     },
     {
-      // Test files have more relaxed rules
       "files": [
         "**/*.test.ts",
         "**/*.test.tsx",
@@ -112,7 +93,4 @@
       },
     },
   ],
-
-  // NOTE: TypeScript config support is coming in Q1 2026
-  // See: https://github.com/oxc-project/oxc/issues/17527
 }

--- a/packages/@overeng/oxc-config/lint.jsonc.genie.ts
+++ b/packages/@overeng/oxc-config/lint.jsonc.genie.ts
@@ -1,0 +1,103 @@
+import { oxlintConfig } from '../genie/src/lib/mod.ts'
+
+export default oxlintConfig({
+  plugins: ['import', 'typescript', 'unicorn', 'oxc'],
+  jsPlugins: ['./src/mod.ts'],
+  categories: {
+    correctness: 'error',
+    suspicious: 'warn',
+    pedantic: 'off',
+    perf: 'warn',
+    style: 'off',
+    restriction: 'off',
+  },
+  rules: {
+    // Disallow dynamic import() and require() - helps with static analysis and bundling
+    // https://oxc.rs/docs/guide/usage/linter/rules/import/no-dynamic-require
+    'import/no-dynamic-require': ['warn', { esmodule: true }],
+
+    // Disallow re-exports except in mod.ts entry points
+    // https://oxc.rs/docs/guide/usage/linter/rules/oxc/no-barrel-file
+    'oxc/no-barrel-file': ['warn', { threshold: 0 }],
+
+    // Enforce named arguments (options objects) instead of positional parameters
+    'overeng/named-args': 'warn',
+
+    // Disallow CommonJS (require/module.exports) - enforce ESM
+    'import/no-commonjs': 'error',
+
+    // Detect circular dependencies
+    'import/no-cycle': 'warn',
+
+    // Prefer function expressions over declarations
+    // https://oxc.rs/docs/guide/usage/linter/rules/eslint/func-style
+    'func-style': ['warn', 'expression', { allowArrowFunctions: true }],
+
+    // Enforce exported declarations come before non-exported declarations (custom plugin)
+    'overeng/exports-first': 'warn',
+
+    // Require JSDoc comments on type/wildcard exports (custom plugin)
+    'overeng/jsdoc-require-exports': 'warn',
+  },
+  overrides: [
+    // Allow re-exports in mod.ts entry point files
+    {
+      files: ['**/mod.ts'],
+      rules: {
+        'oxc/no-barrel-file': 'off',
+      },
+    },
+    // react-inspector is a fork with its own style
+    {
+      files: ['**/react-inspector/**'],
+      rules: {
+        'func-style': 'off',
+        'overeng/named-args': 'off',
+        'unicorn/no-new-array': 'off',
+        'unicorn/no-array-sort': 'off',
+        'unicorn/consistent-function-scoping': 'off',
+        'import/no-named-as-default': 'off',
+        'overeng/exports-first': 'off',
+        'overeng/jsdoc-require-exports': 'off',
+      },
+    },
+    // Storybook files have a specific pattern (meta before stories)
+    {
+      files: ['**/*.stories.tsx', '**/*.stories.ts', '**/*.stories.jsx', '**/.storybook/**'],
+      rules: {
+        'overeng/exports-first': 'off',
+        'overeng/jsdoc-require-exports': 'off',
+      },
+    },
+    // Config files don't need JSDoc
+    {
+      files: ['**/vitest.config.ts', '**/vite.config.ts', '**/playwright.config.ts'],
+      rules: {
+        'overeng/jsdoc-require-exports': 'off',
+      },
+    },
+    // Allow CSS side-effect imports in storybook previews
+    {
+      files: ['**/.storybook/**'],
+      rules: {
+        'import/no-unassigned-import': 'off',
+      },
+    },
+    // Test files have more relaxed rules
+    {
+      files: [
+        '**/*.test.ts',
+        '**/*.test.tsx',
+        '**/*.spec.ts',
+        '**/*.spec.tsx',
+        '**/*.spec.jsx',
+        '**/test/**',
+      ],
+      rules: {
+        'overeng/named-args': 'off',
+        'unicorn/no-array-sort': 'off',
+        'unicorn/consistent-function-scoping': 'off',
+      },
+    },
+  ],
+})

--- a/packages/@overeng/oxc-config/package.json.genie.ts
+++ b/packages/@overeng/oxc-config/package.json.genie.ts
@@ -1,0 +1,21 @@
+import { catalogRef } from '../../../genie/repo.ts'
+import { packageJSON } from '../genie/src/lib/mod.ts'
+
+export default packageJSON({
+  name: '@overeng/oxc-config',
+  version: '0.1.0',
+  private: true,
+  type: 'module',
+  exports: {
+    './lint': './lint.jsonc',
+    './fmt': './fmt.jsonc',
+    './plugin': './src/mod.ts',
+  },
+  devDependencies: {
+    '@types/eslint': '^9.6.1',
+    eslint: '^9.28.0',
+    typescript: catalogRef,
+    'typescript-eslint': '^8.34.0',
+    vitest: catalogRef,
+  },
+})

--- a/packages/@overeng/oxc-config/src/exports-first.ts
+++ b/packages/@overeng/oxc-config/src/exports-first.ts
@@ -125,7 +125,7 @@ const getExportDeclaration = (node: any): any => {
 
 export const exportsFirstRule = {
   meta: {
-    type: 'suggestion',
+    type: 'suggestion' as const,
     docs: {
       description: 'Enforce exported declarations come before non-exported declarations',
       recommended: false,

--- a/packages/@overeng/oxc-config/src/named-args.ts
+++ b/packages/@overeng/oxc-config/src/named-args.ts
@@ -161,7 +161,7 @@ const getFunctionContext = (node: any): string => {
 
 export const namedArgsRule = {
   meta: {
-    type: 'suggestion',
+    type: 'suggestion' as const,
     docs: {
       description:
         'Enforce functions use named arguments (options objects) instead of positional parameters',

--- a/packages/@overeng/oxc-config/tsconfig.json
+++ b/packages/@overeng/oxc-config/tsconfig.json
@@ -1,3 +1,5 @@
+// Generated file - DO NOT EDIT
+// Source: packages/@overeng/oxc-config/tsconfig.json.genie.ts
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {

--- a/packages/@overeng/oxc-config/tsconfig.json.genie.ts
+++ b/packages/@overeng/oxc-config/tsconfig.json.genie.ts
@@ -1,0 +1,12 @@
+import { tsconfigJSON } from '../genie/src/lib/mod.ts'
+
+export default tsconfigJSON({
+  extends: '../../../tsconfig.base.json',
+  compilerOptions: {
+    composite: true,
+    rootDir: '.',
+    outDir: './dist',
+    tsBuildInfoFile: './tsconfig.tsbuildinfo',
+  },
+  include: ['src/**/*.ts'],
+})

--- a/packages/@overeng/react-inspector/package.json.genie.ts
+++ b/packages/@overeng/react-inspector/package.json.genie.ts
@@ -1,0 +1,50 @@
+import { catalogRef } from '../../../genie/repo.ts'
+import { packageJSON } from '../genie/src/lib/mod.ts'
+
+export default packageJSON({
+  name: '@overeng/react-inspector',
+  version: '8.0.0',
+  description: 'Power of Browser DevTools inspectors right inside your React app',
+  type: 'module',
+  exports: {
+    '.': './src/index.tsx',
+  },
+  publishConfig: {
+    access: 'public',
+    exports: {
+      '.': {
+        types: './dist/index.d.ts',
+        require: './dist/index.cjs',
+        import: './dist/index.js',
+      },
+    },
+  },
+  dependencies: {
+    'is-dom': '1.1.0',
+  },
+  devDependencies: {
+    '@storybook/react': catalogRef,
+    '@storybook/react-vite': catalogRef,
+    '@testing-library/react': '16.3.1',
+    '@testing-library/user-event': '14.6.1',
+    '@types/is-dom': '1.1.2',
+    '@types/react': catalogRef,
+    '@vitejs/plugin-react': catalogRef,
+    effect: catalogRef,
+    'happy-dom': '18.0.1',
+    react: catalogRef,
+    'react-dom': catalogRef,
+    storybook: catalogRef,
+    vite: catalogRef,
+    vitest: catalogRef,
+  },
+  peerDependencies: {
+    effect: catalogRef,
+    react: catalogRef,
+  },
+  peerDependenciesMeta: {
+    effect: {
+      optional: true,
+    },
+  },
+})

--- a/packages/@overeng/react-inspector/tsconfig.json
+++ b/packages/@overeng/react-inspector/tsconfig.json
@@ -1,3 +1,5 @@
+// Generated file - DO NOT EDIT
+// Source: packages/@overeng/react-inspector/tsconfig.json.genie.ts
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {

--- a/packages/@overeng/react-inspector/tsconfig.json.genie.ts
+++ b/packages/@overeng/react-inspector/tsconfig.json.genie.ts
@@ -1,0 +1,23 @@
+import { reactJsx } from '../../../genie/repo.ts'
+import { tsconfigJSON } from '../genie/src/lib/mod.ts'
+
+/** react-inspector is a git submodule with relaxed type checking for legacy code */
+export default tsconfigJSON({
+  extends: '../../../tsconfig.base.json',
+  compilerOptions: {
+    lib: ['ES2023', 'DOM'],
+    rootDir: 'src',
+    outDir: './dist',
+    ...reactJsx,
+    allowJs: true,
+    checkJs: false,
+    strict: false,
+    noImplicitAny: false,
+    strictNullChecks: false,
+    exactOptionalPropertyTypes: false,
+    noUncheckedIndexedAccess: false,
+    verbatimModuleSyntax: false,
+    noImplicitReturns: false,
+  },
+  include: ['src/**/*'],
+})

--- a/packages/@overeng/utils/package.json.genie.ts
+++ b/packages/@overeng/utils/package.json.genie.ts
@@ -1,0 +1,59 @@
+import { catalogRef } from '../../../genie/repo.ts'
+import { packageJSON } from '../genie/src/lib/mod.ts'
+
+export default packageJSON({
+  name: '@overeng/utils',
+  version: '0.1.0',
+  private: true,
+  type: 'module',
+  exports: {
+    '.': './src/isomorphic/mod.ts',
+    './node': './src/node/mod.ts',
+    './node/playwright': './src/node/playwright/mod.ts',
+    './browser': './src/browser/mod.ts',
+    './cuid': {
+      browser: './src/cuid/cuid.browser.ts',
+      node: './src/cuid/cuid.node.ts',
+      default: './src/cuid/mod.ts',
+    },
+  },
+  publishConfig: {
+    access: 'public',
+    exports: {
+      '.': './dist/isomorphic/mod.js',
+      './node': './dist/node/mod.js',
+      './node/playwright': './dist/node/playwright/mod.js',
+      './browser': './dist/browser/mod.js',
+      './cuid': {
+        browser: './dist/cuid/cuid.browser.js',
+        node: './dist/cuid/cuid.node.js',
+        default: './dist/cuid/mod.js',
+      },
+    },
+  },
+  dependencies: {
+    '@noble/hashes': '1.7.1',
+    '@opentelemetry/api': catalogRef,
+    'effect-distributed-lock': catalogRef,
+  },
+  devDependencies: {
+    '@effect/opentelemetry': catalogRef,
+    '@effect/platform': catalogRef,
+    '@effect/platform-node': catalogRef,
+    '@effect/rpc': catalogRef,
+    '@effect/vitest': catalogRef,
+    '@playwright/test': catalogRef,
+    '@types/node': catalogRef,
+    effect: catalogRef,
+    vite: catalogRef,
+    vitest: catalogRef,
+  },
+  peerDependencies: {
+    '@effect/opentelemetry': catalogRef,
+    '@effect/platform': catalogRef,
+    '@effect/platform-node': catalogRef,
+    '@effect/rpc': catalogRef,
+    '@playwright/test': catalogRef,
+    effect: catalogRef,
+  },
+})

--- a/packages/@overeng/utils/src/cuid/cuid.node.ts
+++ b/packages/@overeng/utils/src/cuid/cuid.node.ts
@@ -15,6 +15,7 @@
 import crypto from 'node:crypto'
 import os from 'node:os'
 
+/** Collision-resistant unique identifier string */
 export type Cuid = string
 
 const lim = 2 ** 32 - 1

--- a/packages/@overeng/utils/src/isomorphic/misc.ts
+++ b/packages/@overeng/utils/src/isomorphic/misc.ts
@@ -128,6 +128,7 @@ export const notYetImplemented = (msg?: string): never => {
 
 export const noop = () => {}
 
+/** A lazy value - a function that returns T when called */
 export type Thunk<T> = () => T
 
 export const unwrapThunk = <T>(_: T | (() => T)): T => {

--- a/packages/@overeng/utils/src/isomorphic/object/mod.ts
+++ b/packages/@overeng/utils/src/isomorphic/object/mod.ts
@@ -20,6 +20,7 @@ export const mapObjectValues = <O_In extends Record<string, any>, V_Out>({
   return Object.fromEntries(mappedEntries) as any
 }
 
+/** Type-safe Object.entries return type */
 export type Entries<T> = { [K in keyof T]: [K, T[K]] }[keyof T][]
 
 export const objectEntries = <T extends Record<string, any>>(obj: T): Entries<T> =>
@@ -33,6 +34,7 @@ export const keyObjectFromObject = <TObj extends Record<string, any>>(
     Object.fromEntries,
   ) as any
 
+/** Convert undefined-able fields to nullable (undefined -> null) */
 export type UndefinedFieldsToNull<T> = PrettifyFlat<{
   [K in keyof T]-?: undefined extends T[K] ? (T[K] & {}) | null : T[K]
 }>

--- a/packages/@overeng/utils/src/isomorphic/types/mod.ts
+++ b/packages/@overeng/utils/src/isomorphic/types/mod.ts
@@ -1,20 +1,31 @@
 export * from './json.ts'
 
+/** Recursively expand all properties of a type for better IDE display */
 export type Prettify<T> = T extends infer U ? { [K in keyof U]: Prettify<U[K]> } : never
+
+/** Expand properties one level deep for better IDE display */
 export type PrettifyFlat<T> = T extends infer U ? { [K in keyof U]: U[K] } : never
 
+/** Check if two types are exactly equal */
 export type TypeEq<A, B> =
   (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false
 
 /** `A` is subtype of `B` */
 export type IsSubtype<A, B> = A extends B ? true : false
+
+/** Utility type that constrains T to true - useful for type-level assertions */
 export type AssertTrue<T extends true> = T
 
+/** Remove readonly modifier from all properties */
 export type Writeable<T> = { -readonly [P in keyof T]: T[P] }
+
+/** Recursively remove readonly modifier from all properties */
 export type DeepWriteable<T> = { -readonly [P in keyof T]: DeepWriteable<T[P]> }
 
+/** JavaScript primitive types */
 export type Primitive = null | undefined | string | number | boolean | symbol | bigint
 
+/** Allow both literal types and their base type for autocomplete while accepting any value */
 export type LiteralUnion<LiteralType, BaseType extends Primitive> =
   | LiteralType
   | (BaseType & Record<never, never>)
@@ -28,7 +39,7 @@ export type NullableFieldsToOptional<T> = PrettifyFlat<
   }
 >
 
-// Keeps `| null` additionally to optional fields
+/** Same as NullableFieldsToOptional but keeps `| null` in addition to making fields optional */
 export type NullableFieldsToOptional_<T> = PrettifyFlat<
   Partial<T> & {
     [K in keyof T as null extends T[K] ? K : never]?: T[K]
@@ -46,4 +57,5 @@ export type UndefinedFieldsToOptional<T> = PrettifyFlat<
   }
 >
 
+/** Make only specific keys K optional while keeping other keys required */
 export type PartialPick<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>

--- a/packages/@overeng/utils/tsconfig.json
+++ b/packages/@overeng/utils/tsconfig.json
@@ -1,3 +1,5 @@
+// Generated file - DO NOT EDIT
+// Source: packages/@overeng/utils/tsconfig.json.genie.ts
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {

--- a/packages/@overeng/utils/tsconfig.json.genie.ts
+++ b/packages/@overeng/utils/tsconfig.json.genie.ts
@@ -1,0 +1,11 @@
+import { domLib, packageTsconfigCompilerOptions } from '../../../genie/repo.ts'
+import { tsconfigJSON } from '../genie/src/lib/mod.ts'
+
+export default tsconfigJSON({
+  extends: '../../../tsconfig.base.json',
+  compilerOptions: {
+    ...packageTsconfigCompilerOptions,
+    lib: [...domLib],
+  },
+  include: ['src/**/*'],
+})

--- a/scripts/mono.ts
+++ b/scripts/mono.ts
@@ -7,6 +7,7 @@ import type { PlatformError } from '@effect/platform/Error'
 import type { Scope } from 'effect'
 import { Cause, Console, Duration, Effect, Layer, Logger, LogLevel, Schema } from 'effect'
 
+import { genieCommand } from '@overeng/genie/cli'
 import { CurrentWorkingDirectory, cmd, cmdStart } from '@overeng/utils/node'
 
 const IS_CI = process.env.CI === 'true' || process.env.GITHUB_ACTIONS === 'true'
@@ -303,6 +304,10 @@ const checkCommand = Command.make('check', {}, () =>
   Effect.gen(function* () {
     yield* Console.log('Running all checks...\n')
 
+    yield* ciGroup('Genie check')
+    yield* runCommand({ command: 'mono', args: ['genie', '--check'] })
+    yield* ciGroupEnd
+
     yield* ciGroup('Type checking')
     yield* runCommand({ command: 'tsc', args: ['--build', 'tsconfig.all.json'] })
     yield* ciGroupEnd
@@ -324,7 +329,7 @@ const checkCommand = Command.make('check', {}, () =>
 
     yield* Console.log('\n✓ All checks passed')
   }),
-).pipe(Command.withDescription('Run all checks (typecheck + format + lint + test)'))
+).pipe(Command.withDescription('Run all checks (genie + typecheck + format + lint + test)'))
 
 // -----------------------------------------------------------------------------
 // Context Command
@@ -452,6 +457,7 @@ const command = Command.make('mono').pipe(
     tsCommand,
     cleanCommand,
     checkCommand,
+    genieCommand,
     contextCommand,
   ]),
   Command.withDescription('Monorepo management CLI'),

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -6,6 +6,7 @@
     "@effect/cli": "catalog:",
     "@effect/platform": "catalog:",
     "@effect/platform-node": "catalog:",
+    "@overeng/genie": "workspace:*",
     "@overeng/utils": "workspace:*",
     "effect": "catalog:"
   },

--- a/scripts/package.json.genie.ts
+++ b/scripts/package.json.genie.ts
@@ -1,0 +1,20 @@
+import { catalogRef } from '../genie/repo.ts'
+import { packageJSON } from '../packages/@overeng/genie/src/lib/mod.ts'
+
+export default packageJSON({
+  name: 'effect-utils-scripts',
+  private: true,
+  type: 'module',
+  dependencies: {
+    '@effect/cli': catalogRef,
+    '@effect/platform': catalogRef,
+    '@effect/platform-node': catalogRef,
+    '@overeng/genie': 'workspace:*',
+    '@overeng/utils': 'workspace:*',
+    effect: catalogRef,
+  },
+  devDependencies: {
+    '@types/node': catalogRef,
+    typescript: '^5.9.3',
+  },
+})

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,3 +1,5 @@
+// Generated file - DO NOT EDIT
+// Source: scripts/tsconfig.json.genie.ts
 {
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
@@ -8,5 +10,11 @@
     "lib": ["ES2022"],
     "types": ["node"]
   },
-  "include": ["**/*.ts"]
+  "include": ["**/*.ts"],
+  "exclude": ["*.genie.ts"],
+  "references": [
+    {
+      "path": "../packages/@overeng/genie"
+    }
+  ]
 }

--- a/scripts/tsconfig.json.genie.ts
+++ b/scripts/tsconfig.json.genie.ts
@@ -1,0 +1,16 @@
+import { tsconfigJSON } from '../packages/@overeng/genie/src/lib/mod.ts'
+
+export default tsconfigJSON({
+  extends: '../tsconfig.base.json',
+  compilerOptions: {
+    composite: true,
+    rootDir: '.',
+    noEmit: true,
+    tsBuildInfoFile: './tsconfig.tsbuildinfo',
+    lib: ['ES2022'],
+    types: ['node'],
+  },
+  include: ['**/*.ts'],
+  exclude: ['*.genie.ts'],
+  references: [{ path: '../packages/@overeng/genie' }],
+})

--- a/tsconfig.all.json
+++ b/tsconfig.all.json
@@ -1,16 +1,44 @@
+// Generated file - DO NOT EDIT
+// Source: tsconfig.all.json.genie.ts
 {
   "extends": "./tsconfig.base.json",
   "references": [
-    { "path": "./scripts" },
-    { "path": "./context/effect/socket" },
-    { "path": "./packages/@overeng/notion-effect-schema" },
-    { "path": "./packages/@overeng/notion-effect-cli" },
-    { "path": "./packages/@overeng/notion-effect-client" },
-    { "path": "./packages/@overeng/effect-schema-form" },
-    { "path": "./packages/@overeng/effect-schema-form-aria" },
-    { "path": "./packages/@overeng/effect-react" },
-    { "path": "./packages/@overeng/react-inspector" },
-    { "path": "./packages/@overeng/utils" }
+    {
+      "path": "./scripts"
+    },
+    {
+      "path": "./context/effect/socket"
+    },
+    {
+      "path": "./packages/@overeng/genie"
+    },
+    {
+      "path": "./packages/@overeng/notion-effect-schema"
+    },
+    {
+      "path": "./packages/@overeng/notion-effect-cli"
+    },
+    {
+      "path": "./packages/@overeng/notion-effect-client"
+    },
+    {
+      "path": "./packages/@overeng/effect-schema-form"
+    },
+    {
+      "path": "./packages/@overeng/effect-schema-form-aria"
+    },
+    {
+      "path": "./packages/@overeng/effect-react"
+    },
+    {
+      "path": "./packages/@overeng/react-inspector"
+    },
+    {
+      "path": "./packages/@overeng/utils"
+    },
+    {
+      "path": "./packages/@overeng/oxc-config"
+    }
   ],
   "files": []
 }

--- a/tsconfig.all.json.genie.ts
+++ b/tsconfig.all.json.genie.ts
@@ -1,0 +1,8 @@
+import { workspaceReferences } from './genie/repo.ts'
+import { tsconfigJSON } from './packages/@overeng/genie/src/lib/mod.ts'
+
+export default tsconfigJSON({
+  extends: './tsconfig.base.json',
+  references: workspaceReferences.map((path) => ({ path })),
+  files: [],
+})

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,9 +1,11 @@
+// Generated file - DO NOT EDIT
+// Source: tsconfig.base.json.genie.ts
 {
   "compilerOptions": {
     "target": "ES2023",
     "lib": ["ES2023"],
     "module": "ESNext",
-    "moduleResolution": "bundler",
+    "moduleResolution": "Bundler",
     "allowImportingTsExtensions": true,
     "rewriteRelativeImportExtensions": true,
     "allowSyntheticDefaultImports": true,

--- a/tsconfig.base.json.genie.ts
+++ b/tsconfig.base.json.genie.ts
@@ -1,0 +1,7 @@
+import { baseTsconfigCompilerOptions } from './genie/repo.ts'
+import { tsconfigJSON } from './packages/@overeng/genie/src/lib/mod.ts'
+
+export default tsconfigJSON({
+  compilerOptions: baseTsconfigCompilerOptions,
+  exclude: ['node_modules', 'dist'],
+})


### PR DESCRIPTION
## Summary

Ports genie—a TypeScript-based code generator—to the effect-utils monorepo for generating config files from `.genie.ts` source files. Adds infrastructure for generating package.json, tsconfig.json, and .github/workflows/ci.yml with automatic formatting via oxfmt and read-only file protections.

## What's included

- **Genie CLI**: Command-line tool with `--check` mode for CI and `--watch` mode for development
- **Code generators**: Libraries for generating package.json, tsconfig.json, and GitHub workflows
- **Configuration**: Shared constants (catalog versions, TypeScript options) in `genie/repo.ts`
- **Type safety**: JSDoc for all exported types and lint error suppressions (named-args, no-dynamic-require)

🤖 Generated with [Claude Code](https://claude.com/claude-code)