### PR TITLE
feat(megarepo): add colorEnvVar option for VSCode workspace color

### DIFF
--- a/packages/@overeng/genie/src/runtime/megarepo-config/mod.ts
+++ b/packages/@overeng/genie/src/runtime/megarepo-config/mod.ts
@@ -46,8 +46,20 @@ export type VscodeGeneratorConfig = {
    * Primary accent color for the workspace (hex format, e.g. "#372d8e").
    * Auto-generates titleBar, activityBar, and statusBar background colors
    * with white foreground for contrast.
+   *
+   * Note: Prefer using `colorEnvVar` to keep megarepo.json stable across worktrees.
    */
   color?: string
+  /**
+   * Environment variable name to read the workspace color from at generation time.
+   * This allows per-worktree colors without changing megarepo.json.
+   *
+   * Example: Set `colorEnvVar: "MEGAREPO_COLOR"` in config, then in .envrc.local:
+   *   export MEGAREPO_COLOR="#372d8e"
+   *
+   * Takes precedence over the `color` field if both are set.
+   */
+  colorEnvVar?: string
   /**
    * Raw VSCode workspace settings passthrough.
    * Merged with (and overrides) auto-generated settings.

--- a/packages/@overeng/megarepo/src/lib/config.ts
+++ b/packages/@overeng/megarepo/src/lib/config.ts
@@ -62,8 +62,20 @@ export class VscodeGeneratorConfig extends Schema.Class<VscodeGeneratorConfig>(
    * Primary accent color for the workspace (hex format, e.g. "#372d8e").
    * Auto-generates titleBar, activityBar, and statusBar background colors
    * with white foreground for contrast.
+   *
+   * Note: Prefer using `colorEnvVar` to keep megarepo.json stable across worktrees.
    */
   color: Schema.optional(Schema.String),
+  /**
+   * Environment variable name to read the workspace color from at generation time.
+   * This allows per-worktree colors without changing megarepo.json.
+   *
+   * Example: Set `colorEnvVar: "MEGAREPO_COLOR"` in config, then in .envrc.local:
+   *   export MEGAREPO_COLOR="#372d8e"
+   *
+   * Takes precedence over the `color` field if both are set.
+   */
+  colorEnvVar: Schema.optional(Schema.String),
   /**
    * Raw VSCode workspace settings passthrough.
    * Merged with (and overrides) auto-generated settings.

--- a/packages/@overeng/megarepo/src/lib/generators/vscode.ts
+++ b/packages/@overeng/megarepo/src/lib/generators/vscode.ts
@@ -220,12 +220,14 @@ export const generateVscodeContent = (options: VscodeGeneratorOptions): string =
     },
   }
 
-  // Apply color shorthand if provided
-  if (vscodeConfig?.color) {
+  // Apply color: prefer env var (if configured) over static color field
+  const colorFromEnv = vscodeConfig?.colorEnvVar ? process.env[vscodeConfig.colorEnvVar] : undefined
+  const color = colorFromEnv ?? vscodeConfig?.color
+  if (color) {
     settings = deepMerge({
       target: settings,
       source: {
-        'workbench.colorCustomizations': generateColorCustomizations(vscodeConfig.color),
+        'workbench.colorCustomizations': generateColorCustomizations(color),
       },
     })
   }


### PR DESCRIPTION
## Summary

- Add `colorEnvVar` option to VSCode generator config
- When set, reads workspace color from the specified env var at generation time
- Falls back to `color` field if env var is not set

## Motivation

This solves the chicken-egg bootstrap problem in megarepos:

1. `megarepo.json` was gitignored because it contained dynamic `color` from env var
2. But `megarepo.json` is needed to run `mr sync` which clones repos
3. And the `.genie.ts` file imports from `repos/effect-utils` which doesn't exist until after sync

By moving the env var reading to generation time (in the VSCode generator), `megarepo.json` becomes fully static and committable.

## Usage

```json
{
  "generators": {
    "vscode": {
      "enabled": true,
      "colorEnvVar": "MEGAREPO_COLOR"
    }
  }
}
```

Then in `.envrc.local`:
```bash
export MEGAREPO_COLOR="#372d8e"
```

## Changes

- `packages/@overeng/megarepo/src/lib/config.ts` - Add `colorEnvVar` to schema
- `packages/@overeng/megarepo/src/lib/generators/vscode.ts` - Read from env var if configured
- `packages/@overeng/genie/src/runtime/megarepo-config/mod.ts` - Add `colorEnvVar` to type