### PR TITLE
fix(vercel): use pnpm install for Vercel deployments

### DIFF
--- a/packages/@overeng/effect-schema-form-aria/vercel.json
+++ b/packages/@overeng/effect-schema-form-aria/vercel.json
@@ -2,5 +2,5 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "storybook build",
   "outputDirectory": "storybook-static",
-  "installCommand": "cd ../../.. && bun install"
+  "installCommand": "pnpm install"
 }

--- a/packages/@overeng/react-inspector/vercel.json
+++ b/packages/@overeng/react-inspector/vercel.json
@@ -2,5 +2,5 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "storybook build",
   "outputDirectory": "storybook-static",
-  "installCommand": "cd ../../.. && bun install"
+  "installCommand": "pnpm install"
 }


### PR DESCRIPTION
## Summary

- Fix Vercel deployments by using `pnpm install` instead of `cd ../../.. && bun install`
- Each package now has its own `pnpm-workspace.yaml` and `pnpm-lock.yaml`, so Vercel can install dependencies directly in the package directory

## Background

The previous configuration navigated to the repo root and tried to run `bun install`, which fails because:
1. There's no root `package.json` file
2. The repo uses pnpm (not bun) for package management

Each storybook package (`effect-schema-form-aria` and `react-inspector`) is a self-contained pnpm workspace with its own lockfile, making the fix straightforward.

## Test plan

- [x] Verified `pnpm install` works in the package directory
- [x] Verified `storybook build` succeeds after pnpm install
- [ ] Verify Vercel deployment succeeds with this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)