### PR TITLE
feat(storybook): include port in process name for TUI visibility

### DIFF
--- a/nix/devenv-modules/tasks/shared/storybook.nix
+++ b/nix/devenv-modules/tasks/shared/storybook.nix
@@ -17,7 +17,7 @@
 #     - storybook:build:<name> - Build storybook for specific package
 #     - storybook:build - Aggregate task to build all storybooks
 #   Processes (for dev servers):
-#     - storybook-<name> - Run with: devenv up storybook-<name>
+#     - storybook-<name>-<port> - Run with: devenv up storybook-<name>-<port>
 #
 # Port allocation:
 #   Uses devenv's automatic port allocation (processes.<name>.ports.<port>.allocate)
@@ -47,7 +47,8 @@ let
   # Dev servers as processes (long-running, with TUI via process-compose)
   # Uses automatic port allocation to avoid conflicts
   # --host 0.0.0.0 allows access from other machines (useful for remote dev environments)
-  processName = pkg: "storybook-${pkg.name}";
+  # Process name includes port for visibility in process-compose TUI
+  processName = pkg: "storybook-${pkg.name}-${toString pkg.port}";
   
   # Get the allocated port from config at Nix evaluation time
   # This follows the same pattern as postgres.nix in devenv


### PR DESCRIPTION
## Summary
- Include the base port number in storybook process names (e.g., `storybook-tui-react-6006`)
- Makes it easier to identify which storybook is running on which port in the process-compose TUI

## Test plan
- [x] Verified devenv parses configuration correctly
- [x] Verified process names include port numbers

🤖 Generated with [Claude Code](https://claude.ai/code)