### PR TITLE
Refactor storybook fixtures and standardize layout configuration

### DIFF
--- a/packages/@overeng/genie/src/build/GenieOutput/stories/Errors.stories.tsx
+++ b/packages/@overeng/genie/src/build/GenieOutput/stories/Errors.stories.tsx
@@ -12,7 +12,12 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React, { useMemo } from 'react'
 
-import { ALL_OUTPUT_TABS, commonArgTypes, defaultStoryArgs, TuiStoryPreview } from '@overeng/tui-react/storybook'
+import {
+  ALL_OUTPUT_TABS,
+  commonArgTypes,
+  defaultStoryArgs,
+  TuiStoryPreview,
+} from '@overeng/tui-react/storybook'
 
 import { GenieApp } from '../../app.ts'
 import type { GenieMode } from '../../schema.ts'

--- a/packages/@overeng/genie/src/build/GenieOutput/stories/Errors.stories.tsx
+++ b/packages/@overeng/genie/src/build/GenieOutput/stories/Errors.stories.tsx
@@ -12,24 +12,12 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React, { useMemo } from 'react'
 
-import type { OutputTab } from '@overeng/tui-react/storybook'
-import { TuiStoryPreview } from '@overeng/tui-react/storybook'
+import { ALL_OUTPUT_TABS, commonArgTypes, defaultStoryArgs, TuiStoryPreview } from '@overeng/tui-react/storybook'
 
 import { GenieApp } from '../../app.ts'
 import type { GenieMode } from '../../schema.ts'
 import { GenieView } from '../../view.tsx'
 import * as fixtures from './_fixtures.ts'
-
-const ALL_TABS: OutputTab[] = [
-  'tty',
-  'alt-screen',
-  'ci',
-  'ci-plain',
-  'pipe',
-  'log',
-  'json',
-  'ndjson',
-]
 
 type StoryArgs = {
   height: number
@@ -45,25 +33,11 @@ export default {
     layout: 'fullscreen',
   },
   args: {
-    height: 400,
-    interactive: false,
-    playbackSpeed: 1,
+    ...defaultStoryArgs,
     mode: 'generate',
   },
   argTypes: {
-    height: {
-      description: 'Terminal height in pixels',
-      control: { type: 'range', min: 200, max: 600, step: 50 },
-    },
-    interactive: {
-      description: 'Enable animated timeline playback',
-      control: { type: 'boolean' },
-    },
-    playbackSpeed: {
-      description: 'Playback speed multiplier (when interactive)',
-      control: { type: 'range', min: 0.5, max: 3, step: 0.5 },
-      if: { arg: 'interactive' },
-    },
+    ...commonArgTypes,
     mode: {
       description: 'Operation mode',
       control: { type: 'select' },
@@ -165,7 +139,7 @@ export const WithErrors: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline } : {})}
       />
     )
@@ -261,7 +235,7 @@ export const CheckModeFailed: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline } : {})}
       />
     )
@@ -301,7 +275,7 @@ export const GlobalError: Story = {
         initialState={stateConfig}
         height={args.height}
         autoRun={false}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
       />
     )
   },
@@ -436,7 +410,7 @@ export const MixedErrorTypes: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline } : {})}
       />
     )
@@ -545,7 +519,7 @@ export const WithSkipped: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline } : {})}
       />
     )

--- a/packages/@overeng/genie/src/build/GenieOutput/stories/Overflow.stories.tsx
+++ b/packages/@overeng/genie/src/build/GenieOutput/stories/Overflow.stories.tsx
@@ -5,23 +5,11 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React, { useMemo } from 'react'
 
-import type { OutputTab } from '@overeng/tui-react/storybook'
-import { TuiStoryPreview } from '@overeng/tui-react/storybook'
+import { ALL_OUTPUT_TABS, commonArgTypes, defaultStoryArgs, TuiStoryPreview } from '@overeng/tui-react/storybook'
 
 import { GenieApp } from '../../app.ts'
 import { GenieView } from '../../view.tsx'
 import * as fixtures from './_fixtures.ts'
-
-const ALL_TABS: OutputTab[] = [
-  'tty',
-  'alt-screen',
-  'ci',
-  'ci-plain',
-  'pipe',
-  'log',
-  'json',
-  'ndjson',
-]
 
 type StoryArgs = {
   height: number
@@ -37,25 +25,12 @@ export default {
     layout: 'fullscreen',
   },
   args: {
+    ...defaultStoryArgs,
     height: 300,
-    interactive: false,
-    playbackSpeed: 1,
     mode: 'generate',
   },
   argTypes: {
-    height: {
-      description: 'Terminal height in pixels - reduce height to see truncation behavior',
-      control: { type: 'range', min: 150, max: 600, step: 25 },
-    },
-    interactive: {
-      description: 'Enable animated timeline playback',
-      control: { type: 'boolean' },
-    },
-    playbackSpeed: {
-      description: 'Playback speed multiplier (when interactive)',
-      control: { type: 'range', min: 0.5, max: 3, step: 0.5 },
-      if: { arg: 'interactive' },
-    },
+    ...commonArgTypes,
     mode: {
       description: 'Genie operation mode',
       control: { type: 'select' },
@@ -89,7 +64,7 @@ export const ManyFilesGenerating: Story = {
         initialState={initialState}
         height={args.height}
         autoRun={false}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
       />
     )
   },
@@ -118,7 +93,7 @@ export const ManyFilesComplete: Story = {
         initialState={initialState}
         height={args.height}
         autoRun={false}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
       />
     )
   },

--- a/packages/@overeng/genie/src/build/GenieOutput/stories/Overflow.stories.tsx
+++ b/packages/@overeng/genie/src/build/GenieOutput/stories/Overflow.stories.tsx
@@ -5,7 +5,12 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React, { useMemo } from 'react'
 
-import { ALL_OUTPUT_TABS, commonArgTypes, defaultStoryArgs, TuiStoryPreview } from '@overeng/tui-react/storybook'
+import {
+  ALL_OUTPUT_TABS,
+  commonArgTypes,
+  defaultStoryArgs,
+  TuiStoryPreview,
+} from '@overeng/tui-react/storybook'
 
 import { GenieApp } from '../../app.ts'
 import { GenieView } from '../../view.tsx'

--- a/packages/@overeng/genie/src/build/GenieOutput/stories/Success.stories.tsx
+++ b/packages/@overeng/genie/src/build/GenieOutput/stories/Success.stories.tsx
@@ -5,23 +5,11 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React, { useMemo } from 'react'
 
-import type { OutputTab } from '@overeng/tui-react/storybook'
-import { TuiStoryPreview } from '@overeng/tui-react/storybook'
+import { ALL_OUTPUT_TABS, commonArgTypes, defaultStoryArgs, TuiStoryPreview } from '@overeng/tui-react/storybook'
 
 import { GenieApp } from '../../app.ts'
 import { GenieView } from '../../view.tsx'
 import * as fixtures from './_fixtures.ts'
-
-const ALL_TABS: OutputTab[] = [
-  'tty',
-  'alt-screen',
-  'ci',
-  'ci-plain',
-  'pipe',
-  'log',
-  'json',
-  'ndjson',
-]
 
 type StoryArgs = {
   height: number
@@ -37,25 +25,11 @@ export default {
     layout: 'fullscreen',
   },
   args: {
-    height: 400,
-    interactive: false,
-    playbackSpeed: 1,
+    ...defaultStoryArgs,
     mode: 'generate',
   },
   argTypes: {
-    height: {
-      description: 'Terminal height in pixels',
-      control: { type: 'range', min: 200, max: 600, step: 50 },
-    },
-    interactive: {
-      description: 'Enable animated timeline playback',
-      control: { type: 'boolean' },
-    },
-    playbackSpeed: {
-      description: 'Playback speed multiplier (when interactive)',
-      control: { type: 'range', min: 0.5, max: 3, step: 0.5 },
-      if: { arg: 'interactive' },
-    },
+    ...commonArgTypes,
     mode: {
       description: 'Operation mode',
       control: { type: 'select' },
@@ -148,7 +122,7 @@ export const MixedResults: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline } : {})}
       />
     )
@@ -193,7 +167,7 @@ export const AllUnchanged: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline } : {})}
       />
     )
@@ -272,7 +246,7 @@ export const DryRun: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline } : {})}
       />
     )
@@ -320,7 +294,7 @@ export const CheckModeSuccess: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline } : {})}
       />
     )

--- a/packages/@overeng/genie/src/build/GenieOutput/stories/Success.stories.tsx
+++ b/packages/@overeng/genie/src/build/GenieOutput/stories/Success.stories.tsx
@@ -5,7 +5,12 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React, { useMemo } from 'react'
 
-import { ALL_OUTPUT_TABS, commonArgTypes, defaultStoryArgs, TuiStoryPreview } from '@overeng/tui-react/storybook'
+import {
+  ALL_OUTPUT_TABS,
+  commonArgTypes,
+  defaultStoryArgs,
+  TuiStoryPreview,
+} from '@overeng/tui-react/storybook'
 
 import { GenieApp } from '../../app.ts'
 import { GenieView } from '../../view.tsx'

--- a/packages/@overeng/megarepo/src/cli/renderers/AddOutput/stories/Errors.stories.tsx
+++ b/packages/@overeng/megarepo/src/cli/renderers/AddOutput/stories/Errors.stories.tsx
@@ -5,23 +5,11 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React, { useMemo } from 'react'
 
-import type { OutputTab } from '@overeng/tui-react/storybook'
-import { TuiStoryPreview } from '@overeng/tui-react/storybook'
+import { ALL_OUTPUT_TABS, TuiStoryPreview } from '@overeng/tui-react/storybook'
 
 import { AddApp } from '../mod.ts'
 import { AddView } from '../view.tsx'
 import * as fixtures from './_fixtures.ts'
-
-const ALL_TABS: OutputTab[] = [
-  'tty',
-  'alt-screen',
-  'ci',
-  'ci-plain',
-  'pipe',
-  'log',
-  'json',
-  'ndjson',
-]
 
 type StoryArgs = {
   height: number
@@ -71,7 +59,7 @@ export const ErrorNotInMegarepo: Story = {
       app={AddApp}
       initialState={fixtures.createErrorNotInMegarepoState()}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -86,7 +74,7 @@ export const ErrorInvalidRepo: Story = {
         app={AddApp}
         initialState={state}
         height={args.height}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
       />
     )
   },
@@ -102,7 +90,7 @@ export const ErrorAlreadyExists: Story = {
         app={AddApp}
         initialState={state}
         height={args.height}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
       />
     )
   },

--- a/packages/@overeng/megarepo/src/cli/renderers/AddOutput/stories/Success.stories.tsx
+++ b/packages/@overeng/megarepo/src/cli/renderers/AddOutput/stories/Success.stories.tsx
@@ -5,7 +5,12 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React, { useMemo } from 'react'
 
-import { ALL_OUTPUT_TABS, commonArgTypes, defaultStoryArgs, TuiStoryPreview } from '@overeng/tui-react/storybook'
+import {
+  ALL_OUTPUT_TABS,
+  commonArgTypes,
+  defaultStoryArgs,
+  TuiStoryPreview,
+} from '@overeng/tui-react/storybook'
 
 import { AddApp } from '../mod.ts'
 import { AddView } from '../view.tsx'

--- a/packages/@overeng/megarepo/src/cli/renderers/AddOutput/stories/Success.stories.tsx
+++ b/packages/@overeng/megarepo/src/cli/renderers/AddOutput/stories/Success.stories.tsx
@@ -5,23 +5,11 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React, { useMemo } from 'react'
 
-import type { OutputTab } from '@overeng/tui-react/storybook'
-import { TuiStoryPreview } from '@overeng/tui-react/storybook'
+import { ALL_OUTPUT_TABS, commonArgTypes, defaultStoryArgs, TuiStoryPreview } from '@overeng/tui-react/storybook'
 
 import { AddApp } from '../mod.ts'
 import { AddView } from '../view.tsx'
 import * as fixtures from './_fixtures.ts'
-
-const ALL_TABS: OutputTab[] = [
-  'tty',
-  'alt-screen',
-  'ci',
-  'ci-plain',
-  'pipe',
-  'log',
-  'json',
-  'ndjson',
-]
 
 type StoryArgs = {
   height: number
@@ -46,27 +34,13 @@ export default {
     },
   },
   args: {
-    height: 400,
-    interactive: false,
-    playbackSpeed: 1,
+    ...defaultStoryArgs,
     sync: false,
     name: 'effect',
     source: 'effect-ts/effect',
   },
   argTypes: {
-    height: {
-      description: 'Terminal height in pixels',
-      control: { type: 'range', min: 200, max: 600, step: 50 },
-    },
-    interactive: {
-      description: 'Enable animated timeline playback',
-      control: { type: 'boolean' },
-    },
-    playbackSpeed: {
-      description: 'Playback speed multiplier',
-      control: { type: 'range', min: 0.5, max: 3, step: 0.5 },
-      if: { arg: 'interactive' },
-    },
+    ...commonArgTypes,
     sync: {
       description: '--sync flag: sync the added repo immediately',
       control: { type: 'boolean' },
@@ -106,7 +80,7 @@ export const AddSimple: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createTimeline(stateConfig) } : {})}
       />
     )
@@ -136,7 +110,7 @@ export const AddWithSync: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createTimeline(stateConfig) } : {})}
       />
     )
@@ -166,7 +140,7 @@ export const AddWithSyncExisting: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createTimeline(stateConfig) } : {})}
       />
     )
@@ -196,7 +170,7 @@ export const AddWithSyncError: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createTimeline(stateConfig) } : {})}
       />
     )

--- a/packages/@overeng/megarepo/src/cli/renderers/ExecOutput/stories/Complete.stories.tsx
+++ b/packages/@overeng/megarepo/src/cli/renderers/ExecOutput/stories/Complete.stories.tsx
@@ -5,24 +5,12 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React, { useMemo } from 'react'
 
-import type { OutputTab } from '@overeng/tui-react/storybook'
-import { TuiStoryPreview } from '@overeng/tui-react/storybook'
+import { ALL_OUTPUT_TABS, commonArgTypes, defaultStoryArgs, TuiStoryPreview } from '@overeng/tui-react/storybook'
 
 import type { ExecStateType } from '../mod.ts'
 import { ExecApp } from '../mod.ts'
 import { ExecView } from '../view.tsx'
 import * as fixtures from './_fixtures.ts'
-
-const ALL_TABS: OutputTab[] = [
-  'tty',
-  'alt-screen',
-  'ci',
-  'ci-plain',
-  'pipe',
-  'log',
-  'json',
-  'ndjson',
-]
 
 type StoryArgs = {
   height: number
@@ -40,27 +28,13 @@ export default {
     layout: 'fullscreen',
   },
   args: {
-    height: 400,
-    interactive: false,
-    playbackSpeed: 1,
+    ...defaultStoryArgs,
     verbose: false,
     mode: 'parallel',
     member: '',
   },
   argTypes: {
-    height: {
-      description: 'Terminal height in pixels',
-      control: { type: 'range', min: 200, max: 600, step: 50 },
-    },
-    interactive: {
-      description: 'Enable animated timeline playback',
-      control: { type: 'boolean' },
-    },
-    playbackSpeed: {
-      description: 'Playback speed multiplier (when interactive)',
-      control: { type: 'range', min: 0.5, max: 3, step: 0.5 },
-      if: { arg: 'interactive' },
-    },
+    ...commonArgTypes,
     verbose: {
       description: '--verbose flag',
       control: { type: 'boolean' },
@@ -194,7 +168,7 @@ export const CompleteSuccess: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createTimeline(stateConfig) } : {})}
       />
     )
@@ -230,7 +204,7 @@ export const CompleteMixed: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createTimeline(stateConfig) } : {})}
       />
     )
@@ -266,7 +240,7 @@ export const CompleteWithSkipped: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createTimeline(stateConfig) } : {})}
       />
     )
@@ -302,7 +276,7 @@ export const CompleteAllErrors: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createTimeline(stateConfig) } : {})}
       />
     )
@@ -341,7 +315,7 @@ export const CompleteVerbose: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createTimeline(stateConfig) } : {})}
       />
     )

--- a/packages/@overeng/megarepo/src/cli/renderers/ExecOutput/stories/Complete.stories.tsx
+++ b/packages/@overeng/megarepo/src/cli/renderers/ExecOutput/stories/Complete.stories.tsx
@@ -5,7 +5,12 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React, { useMemo } from 'react'
 
-import { ALL_OUTPUT_TABS, commonArgTypes, defaultStoryArgs, TuiStoryPreview } from '@overeng/tui-react/storybook'
+import {
+  ALL_OUTPUT_TABS,
+  commonArgTypes,
+  defaultStoryArgs,
+  TuiStoryPreview,
+} from '@overeng/tui-react/storybook'
 
 import type { ExecStateType } from '../mod.ts'
 import { ExecApp } from '../mod.ts'

--- a/packages/@overeng/megarepo/src/cli/renderers/ExecOutput/stories/Errors.stories.tsx
+++ b/packages/@overeng/megarepo/src/cli/renderers/ExecOutput/stories/Errors.stories.tsx
@@ -5,23 +5,11 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React from 'react'
 
-import type { OutputTab } from '@overeng/tui-react/storybook'
-import { TuiStoryPreview } from '@overeng/tui-react/storybook'
+import { ALL_OUTPUT_TABS, TuiStoryPreview } from '@overeng/tui-react/storybook'
 
 import { ExecApp } from '../mod.ts'
 import { ExecView } from '../view.tsx'
 import * as fixtures from './_fixtures.ts'
-
-const ALL_TABS: OutputTab[] = [
-  'tty',
-  'alt-screen',
-  'ci',
-  'ci-plain',
-  'pipe',
-  'log',
-  'json',
-  'ndjson',
-]
 
 type StoryArgs = {
   height: number
@@ -53,7 +41,7 @@ export const NotInMegarepo: Story = {
       app={ExecApp}
       initialState={fixtures.errorState}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -65,7 +53,7 @@ export const MemberNotFound: Story = {
       app={ExecApp}
       initialState={fixtures.memberNotFoundState}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }

--- a/packages/@overeng/megarepo/src/cli/renderers/ExecOutput/stories/Running.stories.tsx
+++ b/packages/@overeng/megarepo/src/cli/renderers/ExecOutput/stories/Running.stories.tsx
@@ -5,23 +5,11 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React, { useMemo } from 'react'
 
-import type { OutputTab } from '@overeng/tui-react/storybook'
-import { TuiStoryPreview } from '@overeng/tui-react/storybook'
+import { ALL_OUTPUT_TABS, commonArgTypes, defaultStoryArgs, TuiStoryPreview } from '@overeng/tui-react/storybook'
 
 import { ExecApp } from '../mod.ts'
 import { ExecView } from '../view.tsx'
 import * as fixtures from './_fixtures.ts'
-
-const ALL_TABS: OutputTab[] = [
-  'tty',
-  'alt-screen',
-  'ci',
-  'ci-plain',
-  'pipe',
-  'log',
-  'json',
-  'ndjson',
-]
 
 type StoryArgs = {
   height: number
@@ -39,27 +27,13 @@ export default {
     layout: 'fullscreen',
   },
   args: {
-    height: 400,
-    interactive: false,
-    playbackSpeed: 1,
+    ...defaultStoryArgs,
     verbose: true,
     mode: 'parallel',
     member: '',
   },
   argTypes: {
-    height: {
-      description: 'Terminal height in pixels',
-      control: { type: 'range', min: 200, max: 600, step: 50 },
-    },
-    interactive: {
-      description: 'Enable animated timeline playback',
-      control: { type: 'boolean' },
-    },
-    playbackSpeed: {
-      description: 'Playback speed multiplier (when interactive)',
-      control: { type: 'range', min: 0.5, max: 3, step: 0.5 },
-      if: { arg: 'interactive' },
-    },
+    ...commonArgTypes,
     verbose: {
       description: '--verbose flag',
       control: { type: 'boolean' },
@@ -126,7 +100,7 @@ export const RunningVerboseParallel: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createTimeline(stateConfig) } : {})}
       />
     )
@@ -156,7 +130,7 @@ export const RunningVerboseSequential: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createTimeline(stateConfig) } : {})}
       />
     )

--- a/packages/@overeng/megarepo/src/cli/renderers/ExecOutput/stories/Running.stories.tsx
+++ b/packages/@overeng/megarepo/src/cli/renderers/ExecOutput/stories/Running.stories.tsx
@@ -5,7 +5,12 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React, { useMemo } from 'react'
 
-import { ALL_OUTPUT_TABS, commonArgTypes, defaultStoryArgs, TuiStoryPreview } from '@overeng/tui-react/storybook'
+import {
+  ALL_OUTPUT_TABS,
+  commonArgTypes,
+  defaultStoryArgs,
+  TuiStoryPreview,
+} from '@overeng/tui-react/storybook'
 
 import { ExecApp } from '../mod.ts'
 import { ExecView } from '../view.tsx'

--- a/packages/@overeng/megarepo/src/cli/renderers/LsOutput/stories/Basic.stories.tsx
+++ b/packages/@overeng/megarepo/src/cli/renderers/LsOutput/stories/Basic.stories.tsx
@@ -5,23 +5,11 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React from 'react'
 
-import type { OutputTab } from '@overeng/tui-react/storybook'
-import { TuiStoryPreview } from '@overeng/tui-react/storybook'
+import { ALL_OUTPUT_TABS, TuiStoryPreview } from '@overeng/tui-react/storybook'
 
 import { LsApp } from '../mod.ts'
 import { LsView } from '../view.tsx'
 import * as fixtures from './_fixtures.ts'
-
-const ALL_TABS: OutputTab[] = [
-  'tty',
-  'alt-screen',
-  'ci',
-  'ci-plain',
-  'pipe',
-  'log',
-  'json',
-  'ndjson',
-]
 
 type StoryArgs = {
   height: number
@@ -60,7 +48,7 @@ export const Default: Story = {
       app={LsApp}
       initialState={fixtures.createDefaultState({ all: args.all })}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -73,7 +61,7 @@ export const SingleMember: Story = {
       app={LsApp}
       initialState={fixtures.createSingleMemberState({ all: args.all })}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -86,7 +74,7 @@ export const EmptyWorkspace: Story = {
       app={LsApp}
       initialState={fixtures.createEmptyState({ all: args.all })}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -99,7 +87,7 @@ export const ManyMembers: Story = {
       app={LsApp}
       initialState={fixtures.createManyMembersState({ all: args.all })}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -112,7 +100,7 @@ export const AllMegarepos: Story = {
       app={LsApp}
       initialState={fixtures.createAllMegareposState({ all: args.all })}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }

--- a/packages/@overeng/megarepo/src/cli/renderers/LsOutput/stories/Nested.stories.tsx
+++ b/packages/@overeng/megarepo/src/cli/renderers/LsOutput/stories/Nested.stories.tsx
@@ -5,23 +5,11 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React from 'react'
 
-import type { OutputTab } from '@overeng/tui-react/storybook'
-import { TuiStoryPreview } from '@overeng/tui-react/storybook'
+import { ALL_OUTPUT_TABS, TuiStoryPreview } from '@overeng/tui-react/storybook'
 
 import { LsApp } from '../mod.ts'
 import { LsView } from '../view.tsx'
 import * as fixtures from './_fixtures.ts'
-
-const ALL_TABS: OutputTab[] = [
-  'tty',
-  'alt-screen',
-  'ci',
-  'ci-plain',
-  'pipe',
-  'log',
-  'json',
-  'ndjson',
-]
 
 type StoryArgs = {
   height: number
@@ -60,7 +48,7 @@ export const WithAllFlag: Story = {
       app={LsApp}
       initialState={fixtures.createWithAllFlagState({ all: args.all })}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -73,7 +61,7 @@ export const DeeplyNested: Story = {
       app={LsApp}
       initialState={fixtures.createDeeplyNestedState({ all: args.all })}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }

--- a/packages/@overeng/megarepo/src/cli/renderers/LsOutput/stories/Sources.stories.tsx
+++ b/packages/@overeng/megarepo/src/cli/renderers/LsOutput/stories/Sources.stories.tsx
@@ -5,23 +5,11 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React from 'react'
 
-import type { OutputTab } from '@overeng/tui-react/storybook'
-import { TuiStoryPreview } from '@overeng/tui-react/storybook'
+import { ALL_OUTPUT_TABS, TuiStoryPreview } from '@overeng/tui-react/storybook'
 
 import { LsApp } from '../mod.ts'
 import { LsView } from '../view.tsx'
 import * as fixtures from './_fixtures.ts'
-
-const ALL_TABS: OutputTab[] = [
-  'tty',
-  'alt-screen',
-  'ci',
-  'ci-plain',
-  'pipe',
-  'log',
-  'json',
-  'ndjson',
-]
 
 type StoryArgs = {
   height: number
@@ -60,7 +48,7 @@ export const LocalPaths: Story = {
       app={LsApp}
       initialState={fixtures.createLocalPathsState({ all: args.all })}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -73,7 +61,7 @@ export const ErrorState: Story = {
       app={LsApp}
       initialState={fixtures.createErrorState()}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }

--- a/packages/@overeng/megarepo/src/cli/renderers/PinOutput/stories/DryRun.stories.tsx
+++ b/packages/@overeng/megarepo/src/cli/renderers/PinOutput/stories/DryRun.stories.tsx
@@ -5,23 +5,11 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React, { useMemo } from 'react'
 
-import type { OutputTab } from '@overeng/tui-react/storybook'
-import { TuiStoryPreview } from '@overeng/tui-react/storybook'
+import { ALL_OUTPUT_TABS, commonArgTypes, defaultStoryArgs, TuiStoryPreview } from '@overeng/tui-react/storybook'
 
 import { PinApp } from '../mod.ts'
 import { PinView } from '../view.tsx'
 import * as fixtures from './_fixtures.ts'
-
-const ALL_TABS: OutputTab[] = [
-  'tty',
-  'alt-screen',
-  'ci',
-  'ci-plain',
-  'pipe',
-  'log',
-  'json',
-  'ndjson',
-]
 
 type StoryArgs = {
   height: number
@@ -36,24 +24,10 @@ export default {
     layout: 'fullscreen',
   },
   args: {
-    height: 400,
-    interactive: false,
-    playbackSpeed: 1,
+    ...defaultStoryArgs,
   },
   argTypes: {
-    height: {
-      description: 'Terminal height in pixels',
-      control: { type: 'range', min: 200, max: 600, step: 50 },
-    },
-    interactive: {
-      description: 'Enable animated timeline playback',
-      control: { type: 'boolean' },
-    },
-    playbackSpeed: {
-      description: 'Playback speed multiplier',
-      control: { type: 'range', min: 0.5, max: 3, step: 0.5 },
-      if: { arg: 'interactive' },
-    },
+    ...commonArgTypes,
   },
 } satisfies Meta
 
@@ -71,7 +45,7 @@ export const DryRunFull: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createTimeline(finalState) } : {})}
       />
     )
@@ -90,7 +64,7 @@ export const DryRunSimple: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createTimeline(finalState) } : {})}
       />
     )

--- a/packages/@overeng/megarepo/src/cli/renderers/PinOutput/stories/DryRun.stories.tsx
+++ b/packages/@overeng/megarepo/src/cli/renderers/PinOutput/stories/DryRun.stories.tsx
@@ -5,7 +5,12 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React, { useMemo } from 'react'
 
-import { ALL_OUTPUT_TABS, commonArgTypes, defaultStoryArgs, TuiStoryPreview } from '@overeng/tui-react/storybook'
+import {
+  ALL_OUTPUT_TABS,
+  commonArgTypes,
+  defaultStoryArgs,
+  TuiStoryPreview,
+} from '@overeng/tui-react/storybook'
 
 import { PinApp } from '../mod.ts'
 import { PinView } from '../view.tsx'

--- a/packages/@overeng/megarepo/src/cli/renderers/PinOutput/stories/Errors.stories.tsx
+++ b/packages/@overeng/megarepo/src/cli/renderers/PinOutput/stories/Errors.stories.tsx
@@ -5,23 +5,11 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React, { useMemo } from 'react'
 
-import type { OutputTab } from '@overeng/tui-react/storybook'
-import { TuiStoryPreview } from '@overeng/tui-react/storybook'
+import { ALL_OUTPUT_TABS, commonArgTypes, defaultStoryArgs, TuiStoryPreview } from '@overeng/tui-react/storybook'
 
 import { PinApp } from '../mod.ts'
 import { PinView } from '../view.tsx'
 import * as fixtures from './_fixtures.ts'
-
-const ALL_TABS: OutputTab[] = [
-  'tty',
-  'alt-screen',
-  'ci',
-  'ci-plain',
-  'pipe',
-  'log',
-  'json',
-  'ndjson',
-]
 
 type StoryArgs = {
   height: number
@@ -36,24 +24,10 @@ export default {
     layout: 'fullscreen',
   },
   args: {
-    height: 400,
-    interactive: false,
-    playbackSpeed: 1,
+    ...defaultStoryArgs,
   },
   argTypes: {
-    height: {
-      description: 'Terminal height in pixels',
-      control: { type: 'range', min: 200, max: 600, step: 50 },
-    },
-    interactive: {
-      description: 'Enable animated timeline playback',
-      control: { type: 'boolean' },
-    },
-    playbackSpeed: {
-      description: 'Playback speed multiplier',
-      control: { type: 'range', min: 0.5, max: 3, step: 0.5 },
-      if: { arg: 'interactive' },
-    },
+    ...commonArgTypes,
   },
 } satisfies Meta
 
@@ -71,7 +45,7 @@ export const ErrorNotInMegarepo: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createTimeline(finalState) } : {})}
       />
     )
@@ -90,7 +64,7 @@ export const ErrorMemberNotFound: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createTimeline(finalState) } : {})}
       />
     )
@@ -109,7 +83,7 @@ export const ErrorNotSynced: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createTimeline(finalState) } : {})}
       />
     )
@@ -128,7 +102,7 @@ export const ErrorLocalPath: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createTimeline(finalState) } : {})}
       />
     )
@@ -147,7 +121,7 @@ export const ErrorNotInLock: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createTimeline(finalState) } : {})}
       />
     )

--- a/packages/@overeng/megarepo/src/cli/renderers/PinOutput/stories/Errors.stories.tsx
+++ b/packages/@overeng/megarepo/src/cli/renderers/PinOutput/stories/Errors.stories.tsx
@@ -5,7 +5,12 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React, { useMemo } from 'react'
 
-import { ALL_OUTPUT_TABS, commonArgTypes, defaultStoryArgs, TuiStoryPreview } from '@overeng/tui-react/storybook'
+import {
+  ALL_OUTPUT_TABS,
+  commonArgTypes,
+  defaultStoryArgs,
+  TuiStoryPreview,
+} from '@overeng/tui-react/storybook'
 
 import { PinApp } from '../mod.ts'
 import { PinView } from '../view.tsx'

--- a/packages/@overeng/megarepo/src/cli/renderers/PinOutput/stories/Success.stories.tsx
+++ b/packages/@overeng/megarepo/src/cli/renderers/PinOutput/stories/Success.stories.tsx
@@ -5,23 +5,11 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React, { useMemo } from 'react'
 
-import type { OutputTab } from '@overeng/tui-react/storybook'
-import { TuiStoryPreview } from '@overeng/tui-react/storybook'
+import { ALL_OUTPUT_TABS, commonArgTypes, defaultStoryArgs, TuiStoryPreview } from '@overeng/tui-react/storybook'
 
 import { PinApp } from '../mod.ts'
 import { PinView } from '../view.tsx'
 import * as fixtures from './_fixtures.ts'
-
-const ALL_TABS: OutputTab[] = [
-  'tty',
-  'alt-screen',
-  'ci',
-  'ci-plain',
-  'pipe',
-  'log',
-  'json',
-  'ndjson',
-]
 
 type StoryArgs = {
   height: number
@@ -36,24 +24,10 @@ export default {
     layout: 'fullscreen',
   },
   args: {
-    height: 400,
-    interactive: false,
-    playbackSpeed: 1,
+    ...defaultStoryArgs,
   },
   argTypes: {
-    height: {
-      description: 'Terminal height in pixels',
-      control: { type: 'range', min: 200, max: 600, step: 50 },
-    },
-    interactive: {
-      description: 'Enable animated timeline playback',
-      control: { type: 'boolean' },
-    },
-    playbackSpeed: {
-      description: 'Playback speed multiplier',
-      control: { type: 'range', min: 0.5, max: 3, step: 0.5 },
-      if: { arg: 'interactive' },
-    },
+    ...commonArgTypes,
   },
 } satisfies Meta
 
@@ -71,7 +45,7 @@ export const PinWithRef: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createTimeline(finalState) } : {})}
       />
     )
@@ -90,7 +64,7 @@ export const PinCurrentCommit: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createTimeline(finalState) } : {})}
       />
     )
@@ -109,7 +83,7 @@ export const Unpin: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createTimeline(finalState) } : {})}
       />
     )
@@ -128,7 +102,7 @@ export const AlreadyPinned: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createTimeline(finalState) } : {})}
       />
     )
@@ -147,7 +121,7 @@ export const AlreadyUnpinned: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createTimeline(finalState) } : {})}
       />
     )

--- a/packages/@overeng/megarepo/src/cli/renderers/PinOutput/stories/Success.stories.tsx
+++ b/packages/@overeng/megarepo/src/cli/renderers/PinOutput/stories/Success.stories.tsx
@@ -5,7 +5,12 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React, { useMemo } from 'react'
 
-import { ALL_OUTPUT_TABS, commonArgTypes, defaultStoryArgs, TuiStoryPreview } from '@overeng/tui-react/storybook'
+import {
+  ALL_OUTPUT_TABS,
+  commonArgTypes,
+  defaultStoryArgs,
+  TuiStoryPreview,
+} from '@overeng/tui-react/storybook'
 
 import { PinApp } from '../mod.ts'
 import { PinView } from '../view.tsx'

--- a/packages/@overeng/megarepo/src/cli/renderers/PinOutput/stories/Warnings.stories.tsx
+++ b/packages/@overeng/megarepo/src/cli/renderers/PinOutput/stories/Warnings.stories.tsx
@@ -5,23 +5,11 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React, { useMemo } from 'react'
 
-import type { OutputTab } from '@overeng/tui-react/storybook'
-import { TuiStoryPreview } from '@overeng/tui-react/storybook'
+import { ALL_OUTPUT_TABS, commonArgTypes, defaultStoryArgs, TuiStoryPreview } from '@overeng/tui-react/storybook'
 
 import { PinApp } from '../mod.ts'
 import { PinView } from '../view.tsx'
 import * as fixtures from './_fixtures.ts'
-
-const ALL_TABS: OutputTab[] = [
-  'tty',
-  'alt-screen',
-  'ci',
-  'ci-plain',
-  'pipe',
-  'log',
-  'json',
-  'ndjson',
-]
 
 type StoryArgs = {
   height: number
@@ -36,24 +24,10 @@ export default {
     layout: 'fullscreen',
   },
   args: {
-    height: 400,
-    interactive: false,
-    playbackSpeed: 1,
+    ...defaultStoryArgs,
   },
   argTypes: {
-    height: {
-      description: 'Terminal height in pixels',
-      control: { type: 'range', min: 200, max: 600, step: 50 },
-    },
-    interactive: {
-      description: 'Enable animated timeline playback',
-      control: { type: 'boolean' },
-    },
-    playbackSpeed: {
-      description: 'Playback speed multiplier',
-      control: { type: 'range', min: 0.5, max: 3, step: 0.5 },
-      if: { arg: 'interactive' },
-    },
+    ...commonArgTypes,
   },
 } satisfies Meta
 
@@ -71,7 +45,7 @@ export const WarningWorktreeNotAvailable: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createTimeline(finalState) } : {})}
       />
     )
@@ -90,7 +64,7 @@ export const WarningMemberRemovedFromConfig: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createTimeline(finalState) } : {})}
       />
     )

--- a/packages/@overeng/megarepo/src/cli/renderers/PinOutput/stories/Warnings.stories.tsx
+++ b/packages/@overeng/megarepo/src/cli/renderers/PinOutput/stories/Warnings.stories.tsx
@@ -5,7 +5,12 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React, { useMemo } from 'react'
 
-import { ALL_OUTPUT_TABS, commonArgTypes, defaultStoryArgs, TuiStoryPreview } from '@overeng/tui-react/storybook'
+import {
+  ALL_OUTPUT_TABS,
+  commonArgTypes,
+  defaultStoryArgs,
+  TuiStoryPreview,
+} from '@overeng/tui-react/storybook'
 
 import { PinApp } from '../mod.ts'
 import { PinView } from '../view.tsx'

--- a/packages/@overeng/megarepo/src/cli/renderers/StatusOutput/stories/Basic.stories.tsx
+++ b/packages/@overeng/megarepo/src/cli/renderers/StatusOutput/stories/Basic.stories.tsx
@@ -32,7 +32,7 @@ export default {
   component: StatusView,
   title: 'CLI/Status/Basic',
   parameters: {
-    layout: 'padded',
+    layout: 'fullscreen',
   },
   args: {
     height: 400,

--- a/packages/@overeng/megarepo/src/cli/renderers/StatusOutput/stories/Basic.stories.tsx
+++ b/packages/@overeng/megarepo/src/cli/renderers/StatusOutput/stories/Basic.stories.tsx
@@ -5,23 +5,11 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React from 'react'
 
-import type { OutputTab } from '@overeng/tui-react/storybook'
-import { TuiStoryPreview } from '@overeng/tui-react/storybook'
+import { ALL_OUTPUT_TABS, TuiStoryPreview } from '@overeng/tui-react/storybook'
 
 import { StatusApp } from '../mod.ts'
 import { StatusView } from '../view.tsx'
 import * as fixtures from './_fixtures.ts'
-
-const ALL_TABS: OutputTab[] = [
-  'tty',
-  'alt-screen',
-  'ci',
-  'ci-plain',
-  'pipe',
-  'log',
-  'json',
-  'ndjson',
-]
 
 type StoryArgs = {
   height: number
@@ -60,7 +48,7 @@ export const Default: Story = {
       app={StatusApp}
       initialState={fixtures.createDefaultState({ all: args.all })}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -73,7 +61,7 @@ export const AllClean: Story = {
       app={StatusApp}
       initialState={fixtures.createCleanState({ all: args.all })}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -86,7 +74,7 @@ export const SingleMember: Story = {
       app={StatusApp}
       initialState={fixtures.createSingleMemberState({ all: args.all })}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -99,7 +87,7 @@ export const EmptyWorkspace: Story = {
       app={StatusApp}
       initialState={fixtures.createEmptyWorkspaceState({ all: args.all })}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }

--- a/packages/@overeng/megarepo/src/cli/renderers/StatusOutput/stories/Complex.stories.tsx
+++ b/packages/@overeng/megarepo/src/cli/renderers/StatusOutput/stories/Complex.stories.tsx
@@ -5,23 +5,11 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React from 'react'
 
-import type { OutputTab } from '@overeng/tui-react/storybook'
-import { TuiStoryPreview } from '@overeng/tui-react/storybook'
+import { ALL_OUTPUT_TABS, TuiStoryPreview } from '@overeng/tui-react/storybook'
 
 import { StatusApp } from '../mod.ts'
 import { StatusView } from '../view.tsx'
 import * as fixtures from './_fixtures.ts'
-
-const ALL_TABS: OutputTab[] = [
-  'tty',
-  'alt-screen',
-  'ci',
-  'ci-plain',
-  'pipe',
-  'log',
-  'json',
-  'ndjson',
-]
 
 type StoryArgs = {
   height: number
@@ -65,7 +53,7 @@ export const NestedMegarepos: Story = {
       app={StatusApp}
       initialState={fixtures.createNestedMegareposState({ all: args.all })}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -79,7 +67,7 @@ export const DeeplyNested: Story = {
       app={StatusApp}
       initialState={fixtures.createDeeplyNestedState({ all: args.all })}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -93,7 +81,7 @@ export const CurrentLocation: Story = {
       app={StatusApp}
       initialState={fixtures.createCurrentLocationState({ all: args.all })}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -110,7 +98,7 @@ export const PinnedMembers: Story = {
       app={StatusApp}
       initialState={fixtures.createPinnedMembersState({ all: args.all })}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -123,7 +111,7 @@ export const LocalPathMembers: Story = {
       app={StatusApp}
       initialState={fixtures.createLocalPathMembersState({ all: args.all })}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -136,7 +124,7 @@ export const ManyMembers: Story = {
       app={StatusApp}
       initialState={fixtures.createManyMembersState({ all: args.all })}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -153,7 +141,7 @@ export const MultipleProblems: Story = {
       app={StatusApp}
       initialState={fixtures.createMultipleProblemsState({ all: args.all })}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }

--- a/packages/@overeng/megarepo/src/cli/renderers/StatusOutput/stories/LockIssues.stories.tsx
+++ b/packages/@overeng/megarepo/src/cli/renderers/StatusOutput/stories/LockIssues.stories.tsx
@@ -5,23 +5,11 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React from 'react'
 
-import type { OutputTab } from '@overeng/tui-react/storybook'
-import { TuiStoryPreview } from '@overeng/tui-react/storybook'
+import { ALL_OUTPUT_TABS, TuiStoryPreview } from '@overeng/tui-react/storybook'
 
 import { StatusApp } from '../mod.ts'
 import { StatusView } from '../view.tsx'
 import * as fixtures from './_fixtures.ts'
-
-const ALL_TABS: OutputTab[] = [
-  'tty',
-  'alt-screen',
-  'ci',
-  'ci-plain',
-  'pipe',
-  'log',
-  'json',
-  'ndjson',
-]
 
 type StoryArgs = {
   height: number
@@ -60,7 +48,7 @@ export const LockMissing: Story = {
       app={StatusApp}
       initialState={fixtures.createLockMissingState({ all: args.all })}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -73,7 +61,7 @@ export const LockStale: Story = {
       app={StatusApp}
       initialState={fixtures.createLockStaleState({ all: args.all })}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -86,7 +74,7 @@ export const StaleLockRef: Story = {
       app={StatusApp}
       initialState={fixtures.createStaleLockState({ all: args.all })}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -99,7 +87,7 @@ export const CommitDrift: Story = {
       app={StatusApp}
       initialState={fixtures.createCommitDriftState({ all: args.all })}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }

--- a/packages/@overeng/megarepo/src/cli/renderers/StatusOutput/stories/RefIssues.stories.tsx
+++ b/packages/@overeng/megarepo/src/cli/renderers/StatusOutput/stories/RefIssues.stories.tsx
@@ -5,23 +5,11 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React from 'react'
 
-import type { OutputTab } from '@overeng/tui-react/storybook'
-import { TuiStoryPreview } from '@overeng/tui-react/storybook'
+import { ALL_OUTPUT_TABS, TuiStoryPreview } from '@overeng/tui-react/storybook'
 
 import { StatusApp } from '../mod.ts'
 import { StatusView } from '../view.tsx'
 import * as fixtures from './_fixtures.ts'
-
-const ALL_TABS: OutputTab[] = [
-  'tty',
-  'alt-screen',
-  'ci',
-  'ci-plain',
-  'pipe',
-  'log',
-  'json',
-  'ndjson',
-]
 
 type StoryArgs = {
   height: number
@@ -60,7 +48,7 @@ export const SymlinkDrift: Story = {
       app={StatusApp}
       initialState={fixtures.createSymlinkDriftState({ all: args.all })}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -73,7 +61,7 @@ export const MultipleSymlinkDrift: Story = {
       app={StatusApp}
       initialState={fixtures.createMultipleSymlinkDriftState({ all: args.all })}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -86,7 +74,7 @@ export const RefMismatch: Story = {
       app={StatusApp}
       initialState={fixtures.createRefMismatchState({ all: args.all })}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }

--- a/packages/@overeng/megarepo/src/cli/renderers/StatusOutput/stories/WorktreeIssues.stories.tsx
+++ b/packages/@overeng/megarepo/src/cli/renderers/StatusOutput/stories/WorktreeIssues.stories.tsx
@@ -5,23 +5,11 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React from 'react'
 
-import type { OutputTab } from '@overeng/tui-react/storybook'
-import { TuiStoryPreview } from '@overeng/tui-react/storybook'
+import { ALL_OUTPUT_TABS, TuiStoryPreview } from '@overeng/tui-react/storybook'
 
 import { StatusApp } from '../mod.ts'
 import { StatusView } from '../view.tsx'
 import * as fixtures from './_fixtures.ts'
-
-const ALL_TABS: OutputTab[] = [
-  'tty',
-  'alt-screen',
-  'ci',
-  'ci-plain',
-  'pipe',
-  'log',
-  'json',
-  'ndjson',
-]
 
 type StoryArgs = {
   height: number
@@ -60,7 +48,7 @@ export const AllDirty: Story = {
       app={StatusApp}
       initialState={fixtures.createAllDirtyState({ all: args.all })}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -73,7 +61,7 @@ export const AllNotSynced: Story = {
       app={StatusApp}
       initialState={fixtures.createAllNotSyncedState({ all: args.all })}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -86,7 +74,7 @@ export const WithWarnings: Story = {
       app={StatusApp}
       initialState={fixtures.createWarningsState({ all: args.all })}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }

--- a/packages/@overeng/megarepo/src/cli/renderers/StoreOutput/stories/Add.stories.tsx
+++ b/packages/@overeng/megarepo/src/cli/renderers/StoreOutput/stories/Add.stories.tsx
@@ -5,22 +5,10 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React from 'react'
 
-import type { OutputTab } from '@overeng/tui-react/storybook'
-import { TuiStoryPreview } from '@overeng/tui-react/storybook'
+import { ALL_OUTPUT_TABS, TuiStoryPreview } from '@overeng/tui-react/storybook'
 
 import { StoreApp, StoreView } from '../mod.ts'
 import * as fixtures from './_fixtures.ts'
-
-const ALL_TABS: OutputTab[] = [
-  'tty',
-  'alt-screen',
-  'ci',
-  'ci-plain',
-  'pipe',
-  'log',
-  'json',
-  'ndjson',
-]
 
 type StoryArgs = {
   height: number
@@ -82,7 +70,7 @@ export const InvalidSource: Story = {
         source: 'not-a-valid-source',
       })}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -97,7 +85,7 @@ export const LocalPath: Story = {
         message: 'Local paths are not supported. Use a remote URL or owner/repo format.',
       })}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -112,7 +100,7 @@ export const NoUrl: Story = {
         message: 'No URL provided',
       })}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -134,7 +122,7 @@ export const SuccessNew: Story = {
         path: '/Users/me/.megarepo/store/github.com/effect-ts/effect/refs/main',
       })}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -152,7 +140,7 @@ export const SuccessExisting: Story = {
         path: '/Users/me/.megarepo/store/github.com/effect-ts/effect/refs/main',
       })}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -170,7 +158,7 @@ export const SuccessWithRef: Story = {
         path: '/Users/me/.megarepo/store/github.com/effect-ts/effect/refs/feat/new-feature',
       })}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -187,7 +175,7 @@ export const SuccessNoCommit: Story = {
         path: '/Users/me/.megarepo/store/github.com/effect-ts/effect/refs/v3.0.0',
       })}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }

--- a/packages/@overeng/megarepo/src/cli/renderers/StoreOutput/stories/Fetch.stories.tsx
+++ b/packages/@overeng/megarepo/src/cli/renderers/StoreOutput/stories/Fetch.stories.tsx
@@ -5,7 +5,12 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React, { useMemo } from 'react'
 
-import { ALL_OUTPUT_TABS, commonArgTypes, defaultStoryArgs, TuiStoryPreview } from '@overeng/tui-react/storybook'
+import {
+  ALL_OUTPUT_TABS,
+  commonArgTypes,
+  defaultStoryArgs,
+  TuiStoryPreview,
+} from '@overeng/tui-react/storybook'
 
 import { StoreApp, StoreView } from '../mod.ts'
 import * as fixtures from './_fixtures.ts'

--- a/packages/@overeng/megarepo/src/cli/renderers/StoreOutput/stories/Fetch.stories.tsx
+++ b/packages/@overeng/megarepo/src/cli/renderers/StoreOutput/stories/Fetch.stories.tsx
@@ -5,22 +5,10 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React, { useMemo } from 'react'
 
-import type { OutputTab } from '@overeng/tui-react/storybook'
-import { TuiStoryPreview } from '@overeng/tui-react/storybook'
+import { ALL_OUTPUT_TABS, commonArgTypes, defaultStoryArgs, TuiStoryPreview } from '@overeng/tui-react/storybook'
 
 import { StoreApp, StoreView } from '../mod.ts'
 import * as fixtures from './_fixtures.ts'
-
-const ALL_TABS: OutputTab[] = [
-  'tty',
-  'alt-screen',
-  'ci',
-  'ci-plain',
-  'pipe',
-  'log',
-  'json',
-  'ndjson',
-]
 
 type StoryArgs = {
   height: number
@@ -45,24 +33,10 @@ export default {
     },
   },
   args: {
-    height: 400,
-    interactive: false,
-    playbackSpeed: 1,
+    ...defaultStoryArgs,
   },
   argTypes: {
-    height: {
-      description: 'Terminal height in pixels',
-      control: { type: 'range', min: 200, max: 600, step: 50 },
-    },
-    interactive: {
-      description: 'Enable animated timeline playback',
-      control: { type: 'boolean' },
-    },
-    playbackSpeed: {
-      description: 'Playback speed multiplier (when interactive)',
-      control: { type: 'range', min: 0.5, max: 3, step: 0.5 },
-      if: { arg: 'interactive' },
-    },
+    ...commonArgTypes,
   },
 } satisfies Meta
 
@@ -97,7 +71,7 @@ export const Success: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createFetchTimeline(stateConfig) } : {})}
       />
     )
@@ -125,7 +99,7 @@ export const WithErrors: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createFetchTimeline(stateConfig) } : {})}
       />
     )
@@ -164,7 +138,7 @@ export const AllErrors: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createFetchTimeline(stateConfig) } : {})}
       />
     )

--- a/packages/@overeng/megarepo/src/cli/renderers/StoreOutput/stories/GC.stories.tsx
+++ b/packages/@overeng/megarepo/src/cli/renderers/StoreOutput/stories/GC.stories.tsx
@@ -5,7 +5,12 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React, { useMemo } from 'react'
 
-import { ALL_OUTPUT_TABS, commonArgTypes, defaultStoryArgs, TuiStoryPreview } from '@overeng/tui-react/storybook'
+import {
+  ALL_OUTPUT_TABS,
+  commonArgTypes,
+  defaultStoryArgs,
+  TuiStoryPreview,
+} from '@overeng/tui-react/storybook'
 
 import { StoreApp, StoreView } from '../mod.ts'
 import * as fixtures from './_fixtures.ts'

--- a/packages/@overeng/megarepo/src/cli/renderers/StoreOutput/stories/GC.stories.tsx
+++ b/packages/@overeng/megarepo/src/cli/renderers/StoreOutput/stories/GC.stories.tsx
@@ -5,8 +5,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React, { useMemo } from 'react'
 
-import type { OutputTab } from '@overeng/tui-react/storybook'
-import { TuiStoryPreview } from '@overeng/tui-react/storybook'
+import { ALL_OUTPUT_TABS, commonArgTypes, defaultStoryArgs, TuiStoryPreview } from '@overeng/tui-react/storybook'
 
 import { StoreApp, StoreView } from '../mod.ts'
 import * as fixtures from './_fixtures.ts'
@@ -14,17 +13,6 @@ import * as fixtures from './_fixtures.ts'
 // =============================================================================
 // Meta
 // =============================================================================
-
-const ALL_TABS: OutputTab[] = [
-  'tty',
-  'alt-screen',
-  'ci',
-  'ci-plain',
-  'pipe',
-  'log',
-  'json',
-  'ndjson',
-]
 
 type StoryArgs = {
   height: number
@@ -42,27 +30,13 @@ export default {
     layout: 'fullscreen',
   },
   args: {
-    height: 400,
-    interactive: false,
-    playbackSpeed: 1,
+    ...defaultStoryArgs,
     dryRun: false,
     force: false,
     all: false,
   },
   argTypes: {
-    height: {
-      description: 'Terminal height in pixels',
-      control: { type: 'range', min: 200, max: 600, step: 50 },
-    },
-    interactive: {
-      description: 'Enable animated timeline playback',
-      control: { type: 'boolean' },
-    },
-    playbackSpeed: {
-      description: 'Playback speed multiplier (when interactive)',
-      control: { type: 'range', min: 0.5, max: 3, step: 0.5 },
-      if: { arg: 'interactive' },
-    },
+    ...commonArgTypes,
     dryRun: {
       description: '--dry-run flag: show what would be removed without removing',
       control: { type: 'boolean' },
@@ -106,7 +80,7 @@ export const Mixed: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createGcTimeline(stateConfig) } : {})}
       />
     )
@@ -148,7 +122,7 @@ export const DryRun: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createGcTimeline(stateConfig) } : {})}
       />
     )
@@ -178,7 +152,7 @@ export const OnlyCurrentMegarepo: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createGcTimeline(stateConfig) } : {})}
       />
     )
@@ -221,7 +195,7 @@ export const NotInMegarepo: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createGcTimeline(stateConfig) } : {})}
       />
     )
@@ -251,7 +225,7 @@ export const CustomWarning: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createGcTimeline(stateConfig) } : {})}
       />
     )
@@ -278,7 +252,7 @@ export const Empty: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createGcTimeline(stateConfig) } : {})}
       />
     )
@@ -326,7 +300,7 @@ export const AllSkipped: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createGcTimeline(stateConfig) } : {})}
       />
     )
@@ -380,7 +354,7 @@ export const AllRemoved: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createGcTimeline(stateConfig) } : {})}
       />
     )
@@ -431,7 +405,7 @@ export const AllErrors: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createGcTimeline(stateConfig) } : {})}
       />
     )
@@ -509,7 +483,7 @@ export const ManyInUse: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createGcTimeline(stateConfig) } : {})}
       />
     )
@@ -560,7 +534,7 @@ export const DirtyWithDetails: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createGcTimeline(stateConfig) } : {})}
       />
     )
@@ -602,7 +576,7 @@ export const DryRunForceMode: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createGcTimeline(stateConfig) } : {})}
       />
     )
@@ -677,7 +651,7 @@ export const LargeCleanup: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createGcTimeline(stateConfig) } : {})}
       />
     )

--- a/packages/@overeng/megarepo/src/cli/renderers/StoreOutput/stories/List.stories.tsx
+++ b/packages/@overeng/megarepo/src/cli/renderers/StoreOutput/stories/List.stories.tsx
@@ -5,22 +5,10 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React from 'react'
 
-import type { OutputTab } from '@overeng/tui-react/storybook'
-import { TuiStoryPreview } from '@overeng/tui-react/storybook'
+import { ALL_OUTPUT_TABS, TuiStoryPreview } from '@overeng/tui-react/storybook'
 
 import { StoreApp, StoreView } from '../mod.ts'
 import * as fixtures from './_fixtures.ts'
-
-const ALL_TABS: OutputTab[] = [
-  'tty',
-  'alt-screen',
-  'ci',
-  'ci-plain',
-  'pipe',
-  'log',
-  'json',
-  'ndjson',
-]
 
 type StoryArgs = {
   height: number
@@ -78,7 +66,7 @@ export const WithRepos: Story = {
       app={StoreApp}
       initialState={fixtures.createLsState(fixtures.exampleStoreRepos)}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -90,7 +78,7 @@ export const Empty: Story = {
       app={StoreApp}
       initialState={fixtures.createLsState([])}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -111,7 +99,7 @@ export const ManyRepos: Story = {
         { relativePath: 'gitlab.com/company/internal-lib' },
       ])}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }

--- a/packages/@overeng/megarepo/src/cli/renderers/StoreOutput/stories/Status.stories.tsx
+++ b/packages/@overeng/megarepo/src/cli/renderers/StoreOutput/stories/Status.stories.tsx
@@ -5,22 +5,10 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React from 'react'
 
-import type { OutputTab } from '@overeng/tui-react/storybook'
-import { TuiStoryPreview } from '@overeng/tui-react/storybook'
+import { ALL_OUTPUT_TABS, TuiStoryPreview } from '@overeng/tui-react/storybook'
 
 import { StoreApp, StoreView } from '../mod.ts'
 import * as fixtures from './_fixtures.ts'
-
-const ALL_TABS: OutputTab[] = [
-  'tty',
-  'alt-screen',
-  'ci',
-  'ci-plain',
-  'pipe',
-  'log',
-  'json',
-  'ndjson',
-]
 
 type StoryArgs = {
   height: number
@@ -83,7 +71,7 @@ export const Healthy: Story = {
         worktrees: fixtures.healthyWorktrees,
       })}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -100,7 +88,7 @@ export const HealthyWithDiskUsage: Story = {
         worktrees: fixtures.healthyWorktrees,
       })}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -116,7 +104,7 @@ export const MixedIssues: Story = {
         worktrees: fixtures.mixedIssuesWorktrees,
       })}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -159,7 +147,7 @@ export const RefMismatch: Story = {
         ],
       })}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -200,7 +188,7 @@ export const DirtyWorktrees: Story = {
         ],
       })}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -244,7 +232,7 @@ export const OrphanedWorktrees: Story = {
         ],
       })}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -279,7 +267,7 @@ export const BrokenWorktrees: Story = {
         ],
       })}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -340,7 +328,7 @@ export const AllIssueTypes: Story = {
         ],
       })}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -356,7 +344,7 @@ export const Empty: Story = {
         worktrees: [],
       })}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -394,7 +382,7 @@ export const LargeStore: Story = {
         ],
       })}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }

--- a/packages/@overeng/megarepo/src/cli/renderers/SyncOutput/stories/Issues.stories.tsx
+++ b/packages/@overeng/megarepo/src/cli/renderers/SyncOutput/stories/Issues.stories.tsx
@@ -5,24 +5,12 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React, { useMemo } from 'react'
 
-import type { OutputTab } from '@overeng/tui-react/storybook'
-import { TuiStoryPreview } from '@overeng/tui-react/storybook'
+import { ALL_OUTPUT_TABS, commonArgTypes, defaultStoryArgs, TuiStoryPreview } from '@overeng/tui-react/storybook'
 
 import type { MemberSyncResult } from '../../../../lib/sync/schema.ts'
 import { SyncApp } from '../mod.ts'
 import { SyncView } from '../view.tsx'
 import * as fixtures from './_fixtures.ts'
-
-const ALL_TABS: OutputTab[] = [
-  'tty',
-  'alt-screen',
-  'ci',
-  'ci-plain',
-  'pipe',
-  'log',
-  'json',
-  'ndjson',
-]
 
 type StoryArgs = {
   height: number
@@ -41,28 +29,14 @@ export default {
     layout: 'fullscreen',
   },
   args: {
-    height: 400,
-    interactive: false,
-    playbackSpeed: 1,
+    ...defaultStoryArgs,
     dryRun: false,
     frozen: false,
     pull: false,
     all: false,
   },
   argTypes: {
-    height: {
-      description: 'Terminal height in pixels',
-      control: { type: 'range', min: 200, max: 600, step: 50 },
-    },
-    interactive: {
-      description: 'Enable animated timeline playback',
-      control: { type: 'boolean' },
-    },
-    playbackSpeed: {
-      description: 'Playback speed multiplier (when interactive)',
-      control: { type: 'range', min: 0.5, max: 3, step: 0.5 },
-      if: { arg: 'interactive' },
-    },
+    ...commonArgTypes,
     dryRun: {
       description: '--dry-run flag: show what would happen without making changes',
       control: { type: 'boolean' },
@@ -103,7 +77,7 @@ export const WithErrors: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createTimeline(stateConfig) } : {})}
       />
     )
@@ -134,7 +108,7 @@ export const AllErrors: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createTimeline(stateConfig) } : {})}
       />
     )
@@ -165,7 +139,7 @@ export const SkippedMembers: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createTimeline(stateConfig) } : {})}
       />
     )
@@ -197,7 +171,7 @@ export const MixedSkipped: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createTimeline(stateConfig) } : {})}
       />
     )
@@ -245,7 +219,7 @@ export const RefMismatchDetected: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createTimeline(stateConfig) } : {})}
       />
     )
@@ -275,7 +249,7 @@ export const Interrupted: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createTimeline(stateConfig) } : {})}
       />
     )

--- a/packages/@overeng/megarepo/src/cli/renderers/SyncOutput/stories/Issues.stories.tsx
+++ b/packages/@overeng/megarepo/src/cli/renderers/SyncOutput/stories/Issues.stories.tsx
@@ -5,7 +5,12 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React, { useMemo } from 'react'
 
-import { ALL_OUTPUT_TABS, commonArgTypes, defaultStoryArgs, TuiStoryPreview } from '@overeng/tui-react/storybook'
+import {
+  ALL_OUTPUT_TABS,
+  commonArgTypes,
+  defaultStoryArgs,
+  TuiStoryPreview,
+} from '@overeng/tui-react/storybook'
 
 import type { MemberSyncResult } from '../../../../lib/sync/schema.ts'
 import { SyncApp } from '../mod.ts'

--- a/packages/@overeng/megarepo/src/cli/renderers/SyncOutput/stories/Success.stories.tsx
+++ b/packages/@overeng/megarepo/src/cli/renderers/SyncOutput/stories/Success.stories.tsx
@@ -5,7 +5,12 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React, { useMemo } from 'react'
 
-import { ALL_OUTPUT_TABS, commonArgTypes, defaultStoryArgs, TuiStoryPreview } from '@overeng/tui-react/storybook'
+import {
+  ALL_OUTPUT_TABS,
+  commonArgTypes,
+  defaultStoryArgs,
+  TuiStoryPreview,
+} from '@overeng/tui-react/storybook'
 
 import { SyncApp } from '../mod.ts'
 import { SyncView } from '../view.tsx'

--- a/packages/@overeng/megarepo/src/cli/renderers/SyncOutput/stories/Success.stories.tsx
+++ b/packages/@overeng/megarepo/src/cli/renderers/SyncOutput/stories/Success.stories.tsx
@@ -5,23 +5,11 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React, { useMemo } from 'react'
 
-import type { OutputTab } from '@overeng/tui-react/storybook'
-import { TuiStoryPreview } from '@overeng/tui-react/storybook'
+import { ALL_OUTPUT_TABS, commonArgTypes, defaultStoryArgs, TuiStoryPreview } from '@overeng/tui-react/storybook'
 
 import { SyncApp } from '../mod.ts'
 import { SyncView } from '../view.tsx'
 import * as fixtures from './_fixtures.ts'
-
-const ALL_TABS: OutputTab[] = [
-  'tty',
-  'alt-screen',
-  'ci',
-  'ci-plain',
-  'pipe',
-  'log',
-  'json',
-  'ndjson',
-]
 
 type StoryArgs = {
   height: number
@@ -40,28 +28,14 @@ export default {
     layout: 'fullscreen',
   },
   args: {
-    height: 400,
-    interactive: false,
-    playbackSpeed: 1,
+    ...defaultStoryArgs,
     dryRun: false,
     frozen: false,
     pull: false,
     all: false,
   },
   argTypes: {
-    height: {
-      description: 'Terminal height in pixels',
-      control: { type: 'range', min: 200, max: 600, step: 50 },
-    },
-    interactive: {
-      description: 'Enable animated timeline playback',
-      control: { type: 'boolean' },
-    },
-    playbackSpeed: {
-      description: 'Playback speed multiplier (when interactive)',
-      control: { type: 'range', min: 0.5, max: 3, step: 0.5 },
-      if: { arg: 'interactive' },
-    },
+    ...commonArgTypes,
     dryRun: {
       description: '--dry-run flag: show what would happen without making changes',
       control: { type: 'boolean' },
@@ -104,7 +78,7 @@ export const MixedResults: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createTimeline(stateConfig) } : {})}
       />
     )
@@ -131,7 +105,7 @@ export const AllSynced: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createTimeline(stateConfig) } : {})}
       />
     )
@@ -164,7 +138,7 @@ export const FirstSync: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createTimeline(stateConfig) } : {})}
       />
     )
@@ -204,7 +178,7 @@ export const LockUpdates: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createTimeline(stateConfig) } : {})}
       />
     )
@@ -242,7 +216,7 @@ export const RemovedMembers: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createTimeline(stateConfig) } : {})}
       />
     )
@@ -274,7 +248,7 @@ export const WithGenerators: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createTimeline(stateConfig) } : {})}
       />
     )
@@ -300,7 +274,7 @@ export const SingleMember: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createTimeline(stateConfig) } : {})}
       />
     )
@@ -333,7 +307,7 @@ export const ManyMembers: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createTimeline(stateConfig) } : {})}
       />
     )
@@ -364,7 +338,7 @@ export const NestedMegarepos: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createTimeline(stateConfig) } : {})}
       />
     )

--- a/packages/@overeng/megarepo/src/cli/renderers/SyncOutput/stories/Success.stories.tsx
+++ b/packages/@overeng/megarepo/src/cli/renderers/SyncOutput/stories/Success.stories.tsx
@@ -403,7 +403,7 @@ export const NestedMegarepos: Story = {
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
-        tabs={ALL_TABS}
+        tabs={ALL_OUTPUT_TABS}
         {...(args.interactive ? { timeline: fixtures.createTimeline(stateConfig) } : {})}
       />
     )

--- a/packages/@overeng/notion-cli/src/renderers/DumpOutput.stories.tsx
+++ b/packages/@overeng/notion-cli/src/renderers/DumpOutput.stories.tsx
@@ -59,30 +59,57 @@ export const Demo: Story = {
 
 export const Loading: Story = {
   render: () => (
-    <TuiStoryPreview View={DumpView} app={DumpApp} initialState={fixtures.createLoadingState()} autoRun={false} />
+    <TuiStoryPreview
+      View={DumpView}
+      app={DumpApp}
+      initialState={fixtures.createLoadingState()}
+      autoRun={false}
+    />
   ),
 }
 
 export const Introspecting: Story = {
   render: () => (
-    <TuiStoryPreview View={DumpView} app={DumpApp} initialState={fixtures.createIntrospectingState()} autoRun={false} />
+    <TuiStoryPreview
+      View={DumpView}
+      app={DumpApp}
+      initialState={fixtures.createIntrospectingState()}
+      autoRun={false}
+    />
   ),
 }
 
 export const Fetching: Story = {
   render: () => (
-    <TuiStoryPreview View={DumpView} app={DumpApp} initialState={fixtures.createFetchingState(42)} autoRun={false} />
+    <TuiStoryPreview
+      View={DumpView}
+      app={DumpApp}
+      initialState={fixtures.createFetchingState(42)}
+      autoRun={false}
+    />
   ),
 }
 
 export const FetchingMany: Story = {
   render: () => (
-    <TuiStoryPreview View={DumpView} app={DumpApp} initialState={fixtures.createFetchingState(1500)} autoRun={false} />
+    <TuiStoryPreview
+      View={DumpView}
+      app={DumpApp}
+      initialState={fixtures.createFetchingState(1500)}
+      autoRun={false}
+    />
   ),
 }
 
 export const DoneSimple: Story = {
-  render: () => <TuiStoryPreview View={DumpView} app={DumpApp} initialState={fixtures.createDoneState()} autoRun={false} />,
+  render: () => (
+    <TuiStoryPreview
+      View={DumpView}
+      app={DumpApp}
+      initialState={fixtures.createDoneState()}
+      autoRun={false}
+    />
+  ),
 }
 
 export const DoneWithAssets: Story = {
@@ -135,5 +162,12 @@ export const DoneFullStats: Story = {
 }
 
 export const ErrorState: Story = {
-  render: () => <TuiStoryPreview View={DumpView} app={DumpApp} initialState={fixtures.createErrorState()} autoRun={false} />,
+  render: () => (
+    <TuiStoryPreview
+      View={DumpView}
+      app={DumpApp}
+      initialState={fixtures.createErrorState()}
+      autoRun={false}
+    />
+  ),
 }

--- a/packages/@overeng/notion-cli/src/renderers/DumpOutput.stories.tsx
+++ b/packages/@overeng/notion-cli/src/renderers/DumpOutput.stories.tsx
@@ -3,14 +3,15 @@ import React from 'react'
 
 import { TuiStoryPreview } from '@overeng/tui-react/storybook'
 
+import * as fixtures from './DumpOutput/_fixtures.ts'
 import { DumpApp } from './DumpOutput/mod.ts'
-import type { DumpAction, DumpState } from './DumpOutput/schema.ts'
+import type { DumpAction } from './DumpOutput/schema.ts'
 import { DumpView } from './DumpOutput/view.tsx'
 
 export default {
   title: 'NotionCLI/Dump Output',
   component: DumpView,
-  parameters: { layout: 'padded' },
+  parameters: { layout: 'fullscreen' },
 } satisfies Meta<typeof DumpView>
 
 type Story = StoryObj<{ autoRun: boolean; playbackSpeed: number; height: number }>
@@ -47,7 +48,7 @@ export const Demo: Story = {
     <TuiStoryPreview
       View={DumpView}
       app={DumpApp}
-      initialState={createLoadingState()}
+      initialState={fixtures.createLoadingState()}
       timeline={dumpTimeline}
       autoRun={args.autoRun}
       playbackSpeed={args.playbackSpeed}
@@ -56,68 +57,32 @@ export const Demo: Story = {
   ),
 }
 
-const createLoadingState = (): DumpState => ({
-  _tag: 'Loading',
-  databaseId: 'abc123',
-})
-
-const createIntrospectingState = (): DumpState => ({
-  _tag: 'Introspecting',
-  databaseId: 'abc123',
-})
-
-const createFetchingState = (pageCount: number): DumpState => ({
-  _tag: 'Fetching',
-  databaseId: 'abc123',
-  dbName: 'Tasks',
-  pageCount,
-  outputPath: './dump/tasks.json',
-})
-
-const createDoneState = (
-  overrides: Partial<Extract<DumpState, { _tag: 'Done' }>> = {},
-): Extract<DumpState, { _tag: 'Done' }> => ({
-  _tag: 'Done',
-  pageCount: 150,
-  assetsDownloaded: 0,
-  assetBytes: 0,
-  assetsSkipped: 0,
-  failures: 0,
-  outputPath: './dump/tasks.json',
-  ...overrides,
-})
-
-const createErrorState = (): DumpState => ({
-  _tag: 'Error',
-  message: 'Rate limited by Notion API',
-})
-
 export const Loading: Story = {
   render: () => (
-    <TuiStoryPreview View={DumpView} app={DumpApp} initialState={createLoadingState()} />
+    <TuiStoryPreview View={DumpView} app={DumpApp} initialState={fixtures.createLoadingState()} autoRun={false} />
   ),
 }
 
 export const Introspecting: Story = {
   render: () => (
-    <TuiStoryPreview View={DumpView} app={DumpApp} initialState={createIntrospectingState()} />
+    <TuiStoryPreview View={DumpView} app={DumpApp} initialState={fixtures.createIntrospectingState()} autoRun={false} />
   ),
 }
 
 export const Fetching: Story = {
   render: () => (
-    <TuiStoryPreview View={DumpView} app={DumpApp} initialState={createFetchingState(42)} />
+    <TuiStoryPreview View={DumpView} app={DumpApp} initialState={fixtures.createFetchingState(42)} autoRun={false} />
   ),
 }
 
 export const FetchingMany: Story = {
   render: () => (
-    <TuiStoryPreview View={DumpView} app={DumpApp} initialState={createFetchingState(1500)} />
+    <TuiStoryPreview View={DumpView} app={DumpApp} initialState={fixtures.createFetchingState(1500)} autoRun={false} />
   ),
 }
 
 export const DoneSimple: Story = {
-  render: () => <TuiStoryPreview View={DumpView} app={DumpApp} initialState={createDoneState()} />,
+  render: () => <TuiStoryPreview View={DumpView} app={DumpApp} initialState={fixtures.createDoneState()} autoRun={false} />,
 }
 
 export const DoneWithAssets: Story = {
@@ -125,7 +90,8 @@ export const DoneWithAssets: Story = {
     <TuiStoryPreview
       View={DumpView}
       app={DumpApp}
-      initialState={createDoneState({ assetsDownloaded: 25, assetBytes: 15_728_640 })}
+      initialState={fixtures.createDoneState({ assetsDownloaded: 25, assetBytes: 15_728_640 })}
+      autoRun={false}
     />
   ),
 }
@@ -135,7 +101,8 @@ export const DoneWithSkippedAssets: Story = {
     <TuiStoryPreview
       View={DumpView}
       app={DumpApp}
-      initialState={createDoneState({ assetsSkipped: 12 })}
+      initialState={fixtures.createDoneState({ assetsSkipped: 12 })}
+      autoRun={false}
     />
   ),
 }
@@ -145,7 +112,8 @@ export const DoneWithFailures: Story = {
     <TuiStoryPreview
       View={DumpView}
       app={DumpApp}
-      initialState={createDoneState({ failures: 3 })}
+      initialState={fixtures.createDoneState({ failures: 3 })}
+      autoRun={false}
     />
   ),
 }
@@ -155,16 +123,17 @@ export const DoneFullStats: Story = {
     <TuiStoryPreview
       View={DumpView}
       app={DumpApp}
-      initialState={createDoneState({
+      initialState={fixtures.createDoneState({
         assetsDownloaded: 25,
         assetBytes: 15_728_640,
         assetsSkipped: 12,
         failures: 3,
       })}
+      autoRun={false}
     />
   ),
 }
 
 export const ErrorState: Story = {
-  render: () => <TuiStoryPreview View={DumpView} app={DumpApp} initialState={createErrorState()} />,
+  render: () => <TuiStoryPreview View={DumpView} app={DumpApp} initialState={fixtures.createErrorState()} autoRun={false} />,
 }

--- a/packages/@overeng/notion-cli/src/renderers/DumpOutput/_fixtures.ts
+++ b/packages/@overeng/notion-cli/src/renderers/DumpOutput/_fixtures.ts
@@ -10,16 +10,19 @@ import type { DumpState } from './schema.ts'
 // State Factories
 // =============================================================================
 
+/** Creates a Loading state for storybook demos */
 export const createLoadingState = (): DumpState => ({
   _tag: 'Loading',
   databaseId: 'abc123',
 })
 
+/** Creates an Introspecting state for storybook demos */
 export const createIntrospectingState = (): DumpState => ({
   _tag: 'Introspecting',
   databaseId: 'abc123',
 })
 
+/** Creates a Fetching state with the given page count */
 export const createFetchingState = (pageCount: number): DumpState => ({
   _tag: 'Fetching',
   databaseId: 'abc123',
@@ -28,6 +31,7 @@ export const createFetchingState = (pageCount: number): DumpState => ({
   outputPath: './dump/tasks.json',
 })
 
+/** Creates a Done state with optional overrides */
 export const createDoneState = (
   overrides: Partial<Extract<DumpState, { _tag: 'Done' }>> = {},
 ): Extract<DumpState, { _tag: 'Done' }> => ({
@@ -41,6 +45,7 @@ export const createDoneState = (
   ...overrides,
 })
 
+/** Creates an Error state for storybook demos */
 export const createErrorState = (): DumpState => ({
   _tag: 'Error',
   message: 'Rate limited by Notion API',

--- a/packages/@overeng/notion-cli/src/renderers/DumpOutput/_fixtures.ts
+++ b/packages/@overeng/notion-cli/src/renderers/DumpOutput/_fixtures.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared fixtures for DumpOutput stories.
+ *
+ * @internal
+ */
+
+import type { DumpState } from './schema.ts'
+
+// =============================================================================
+// State Factories
+// =============================================================================
+
+export const createLoadingState = (): DumpState => ({
+  _tag: 'Loading',
+  databaseId: 'abc123',
+})
+
+export const createIntrospectingState = (): DumpState => ({
+  _tag: 'Introspecting',
+  databaseId: 'abc123',
+})
+
+export const createFetchingState = (pageCount: number): DumpState => ({
+  _tag: 'Fetching',
+  databaseId: 'abc123',
+  dbName: 'Tasks',
+  pageCount,
+  outputPath: './dump/tasks.json',
+})
+
+export const createDoneState = (
+  overrides: Partial<Extract<DumpState, { _tag: 'Done' }>> = {},
+): Extract<DumpState, { _tag: 'Done' }> => ({
+  _tag: 'Done',
+  pageCount: 150,
+  assetsDownloaded: 0,
+  assetBytes: 0,
+  assetsSkipped: 0,
+  failures: 0,
+  outputPath: './dump/tasks.json',
+  ...overrides,
+})
+
+export const createErrorState = (): DumpState => ({
+  _tag: 'Error',
+  message: 'Rate limited by Notion API',
+})

--- a/packages/@overeng/tui-react/examples/03-cli/deploy/deploy.stories.tsx
+++ b/packages/@overeng/tui-react/examples/03-cli/deploy/deploy.stories.tsx
@@ -11,7 +11,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React from 'react'
 
-import { TuiStoryPreview, type OutputTab } from '../../../src/storybook/TuiStoryPreview.tsx'
+import { ALL_OUTPUT_TABS, TuiStoryPreview } from '../../../src/storybook/TuiStoryPreview.tsx'
 import { DeployApp } from './deploy.tsx'
 import type { DeployState, DeployAction } from './schema.ts'
 import { type LogEntry } from './schema.ts'
@@ -239,17 +239,6 @@ const deployTimeline: Array<{ at: number; action: typeof DeployAction.Type }> = 
 // Story Meta
 // =============================================================================
 
-const ALL_TABS: OutputTab[] = [
-  'tty',
-  'alt-screen',
-  'ci',
-  'ci-plain',
-  'pipe',
-  'log',
-  'json',
-  'ndjson',
-]
-
 export default {
   component: DeployView,
   title: 'Examples/03 CLI/Deploy',
@@ -328,7 +317,7 @@ export const Demo: Story = {
       autoRun={args.autoRun}
       playbackSpeed={args.playbackSpeed}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -343,7 +332,7 @@ export const Progress: Story = {
       initialState={createProgressState()}
       height={args.height}
       autoRun={false}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -358,7 +347,7 @@ export const Complete: Story = {
       initialState={createCompleteState()}
       height={args.height}
       autoRun={false}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -373,7 +362,7 @@ export const Failed: Story = {
       initialState={createFailedState()}
       height={args.height}
       autoRun={false}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -388,7 +377,7 @@ export const RollingBack: Story = {
       initialState={createRollingBackState()}
       height={args.height}
       autoRun={false}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -403,7 +392,7 @@ export const Validating: Story = {
       initialState={createValidatingState()}
       height={args.height}
       autoRun={false}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -418,7 +407,7 @@ export const Idle: Story = {
       initialState={createIdleState()}
       height={args.height}
       autoRun={false}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }
@@ -642,7 +631,7 @@ export const LongLines: Story = {
       autoRun={args.autoRun}
       playbackSpeed={args.playbackSpeed}
       height={args.height}
-      tabs={ALL_TABS}
+      tabs={ALL_OUTPUT_TABS}
     />
   ),
 }

--- a/packages/@overeng/tui-react/examples/03-cli/deploy/deploy.stories.tsx
+++ b/packages/@overeng/tui-react/examples/03-cli/deploy/deploy.stories.tsx
@@ -11,7 +11,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import React from 'react'
 
-import { ALL_OUTPUT_TABS, TuiStoryPreview } from '../../../src/storybook/TuiStoryPreview.tsx'
+import { ALL_OUTPUT_TABS, TuiStoryPreview } from '../../../src/storybook/mod.tsx'
 import { DeployApp } from './deploy.tsx'
 import type { DeployState, DeployAction } from './schema.ts'
 import { type LogEntry } from './schema.ts'

--- a/packages/@overeng/tui-react/src/storybook/mod.tsx
+++ b/packages/@overeng/tui-react/src/storybook/mod.tsx
@@ -93,33 +93,32 @@ export const defaultStoryArgs = {
  *     app={MyApp}
  *     height={args.height}
  *     tabs={ALL_OUTPUT_TABS}
- *     {...createInteractiveProps(args, {
+ *     {...createInteractiveProps({
+ *       args,
  *       staticState: fixtures.createCompleteState(stateConfig),
  *       idleState: fixtures.createIdleState(),
- *       createTimeline: (state) => fixtures.createTimeline(stateConfig),
+ *       createTimeline: () => fixtures.createTimeline(stateConfig),
  *     })}
  *   />
  * )
  * ```
  */
-export const createInteractiveProps = <S, A>(
-  args: { interactive: boolean; playbackSpeed: number },
-  config: {
-    /** The final state to show in static mode */
-    staticState: S
-    /** The initial state to start from in interactive mode */
-    idleState: S
-    /** Factory to create timeline actions */
-    createTimeline: () => TimelineEvent<A>[]
-  },
-): {
+export const createInteractiveProps = <S, A>(_: {
+  args: { interactive: boolean; playbackSpeed: number }
+  /** The final state to show in static mode */
+  staticState: S
+  /** The initial state to start from in interactive mode */
+  idleState: S
+  /** Factory to create timeline actions */
+  createTimeline: () => TimelineEvent<A>[]
+}): {
   initialState: S
   autoRun: boolean
   playbackSpeed: number
   timeline?: TimelineEvent<A>[]
 } => ({
-  initialState: args.interactive ? config.idleState : config.staticState,
-  autoRun: args.interactive,
-  playbackSpeed: args.playbackSpeed,
-  ...(args.interactive ? { timeline: config.createTimeline() } : {}),
+  initialState: _.args.interactive ? _.idleState : _.staticState,
+  autoRun: _.args.interactive,
+  playbackSpeed: _.args.playbackSpeed,
+  ...(_.args.interactive ? { timeline: _.createTimeline() } : {}),
 })

--- a/packages/@overeng/tui-react/src/storybook/mod.tsx
+++ b/packages/@overeng/tui-react/src/storybook/mod.tsx
@@ -77,3 +77,51 @@ export const defaultStoryArgs = {
   interactive: false,
   playbackSpeed: 1,
 } as const
+
+import type { TimelineEvent } from './TuiStoryPreview.tsx'
+
+/**
+ * Helper to create TuiStoryPreview props for interactive timeline stories.
+ *
+ * Handles the common pattern where:
+ * - In interactive mode: starts from idle state and plays through timeline
+ * - In static mode: shows the final state directly without animation
+ *
+ * @example
+ * ```tsx
+ * render: (args) => (
+ *   <TuiStoryPreview
+ *     View={MyView}
+ *     app={MyApp}
+ *     height={args.height}
+ *     tabs={ALL_OUTPUT_TABS}
+ *     {...createInteractiveProps(args, {
+ *       staticState: fixtures.createCompleteState(stateConfig),
+ *       idleState: fixtures.createIdleState(),
+ *       createTimeline: (state) => fixtures.createTimeline(stateConfig),
+ *     })}
+ *   />
+ * )
+ * ```
+ */
+export const createInteractiveProps = <S, A>(
+  args: { interactive: boolean; playbackSpeed: number },
+  config: {
+    /** The final state to show in static mode */
+    staticState: S
+    /** The initial state to start from in interactive mode */
+    idleState: S
+    /** Factory to create timeline actions */
+    createTimeline: () => TimelineEvent<A>[]
+  },
+): {
+  initialState: S
+  autoRun: boolean
+  playbackSpeed: number
+  timeline?: TimelineEvent<A>[]
+} => ({
+  initialState: args.interactive ? config.idleState : config.staticState,
+  autoRun: args.interactive,
+  playbackSpeed: args.playbackSpeed,
+  ...(args.interactive ? { timeline: config.createTimeline() } : {}),
+})

--- a/packages/@overeng/tui-react/src/storybook/mod.tsx
+++ b/packages/@overeng/tui-react/src/storybook/mod.tsx
@@ -40,7 +40,7 @@ export { createStaticApp } from './static-app.ts'
 export { tuiPreview } from './preview.ts'
 export { xtermTheme, containerStyles, previewTextStyles } from './theme.ts'
 
-import type { OutputTab } from './TuiStoryPreview.tsx'
+import type { OutputTab, TimelineEvent } from './TuiStoryPreview.tsx'
 
 /** All available output tabs for CLI storybooks */
 export const ALL_OUTPUT_TABS: OutputTab[] = [
@@ -77,8 +77,6 @@ export const defaultStoryArgs = {
   interactive: false,
   playbackSpeed: 1,
 } as const
-
-import type { TimelineEvent } from './TuiStoryPreview.tsx'
 
 /**
  * Helper to create TuiStoryPreview props for interactive timeline stories.

--- a/packages/@overeng/tui-react/src/storybook/mod.tsx
+++ b/packages/@overeng/tui-react/src/storybook/mod.tsx
@@ -39,3 +39,41 @@ export {
 export { createStaticApp } from './static-app.ts'
 export { tuiPreview } from './preview.ts'
 export { xtermTheme, containerStyles, previewTextStyles } from './theme.ts'
+
+import type { OutputTab } from './TuiStoryPreview.tsx'
+
+/** All available output tabs for CLI storybooks */
+export const ALL_OUTPUT_TABS: OutputTab[] = [
+  'tty',
+  'alt-screen',
+  'ci',
+  'ci-plain',
+  'pipe',
+  'log',
+  'json',
+  'ndjson',
+]
+
+/** Common argTypes for CLI storybooks with interactive timeline support */
+export const commonArgTypes = {
+  height: {
+    description: 'Terminal height in pixels',
+    control: { type: 'range', min: 200, max: 600, step: 50 },
+  },
+  interactive: {
+    description: 'Enable animated timeline playback',
+    control: { type: 'boolean' },
+  },
+  playbackSpeed: {
+    description: 'Playback speed multiplier (when interactive)',
+    control: { type: 'range', min: 0.5, max: 3, step: 0.5 },
+    if: { arg: 'interactive' },
+  },
+} as const
+
+/** Default args for CLI storybooks with interactive timeline support */
+export const defaultStoryArgs = {
+  height: 400,
+  interactive: false,
+  playbackSpeed: 1,
+} as const

--- a/packages/@overeng/tui-react/src/storybook/mod.tsx
+++ b/packages/@overeng/tui-react/src/storybook/mod.tsx
@@ -116,9 +116,10 @@ export const createInteractiveProps = <S, A>(_: {
   autoRun: boolean
   playbackSpeed: number
   timeline?: TimelineEvent<A>[]
-} => ({
-  initialState: _.args.interactive ? _.idleState : _.staticState,
-  autoRun: _.args.interactive,
-  playbackSpeed: _.args.playbackSpeed,
-  ...(_.args.interactive ? { timeline: _.createTimeline() } : {}),
-})
+} =>
+  ({
+    initialState: _.args.interactive ? _.idleState : _.staticState,
+    autoRun: _.args.interactive,
+    playbackSpeed: _.args.playbackSpeed,
+    ...(_.args.interactive ? { timeline: _.createTimeline() } : {}),
+  })


### PR DESCRIPTION
## Summary
This PR refactors storybook fixtures into a shared module and standardizes layout configuration across CLI storybooks. It also introduces common argTypes and default args for interactive timeline support.

## Key Changes

- **Extracted DumpOutput fixtures**: Moved state factory functions from `DumpOutput.stories.tsx` into a new `_fixtures.ts` module for better reusability and maintainability
- **Standardized layout configuration**: Changed storybook layout from `'padded'` to `'fullscreen'` in:
  - `StatusOutput/stories/Basic.stories.tsx`
  - `DumpOutput.stories.tsx`
- **Added storybook utilities**: Exported common argTypes and default args from `@overeng/tui-react/storybook` for consistent CLI storybook configuration:
  - `ALL_OUTPUT_TABS`: Array of available output tab options
  - `commonArgTypes`: Reusable control definitions for height, interactive mode, and playback speed
  - `defaultStoryArgs`: Default values for interactive timeline stories
- **Updated story implementations**: Added `autoRun={false}` prop to all individual story renders and updated fixture references

## Implementation Details

The new `_fixtures.ts` module is marked as `@internal` to indicate it's for internal storybook use only. All state factory functions maintain their original implementation and type safety. The exported utilities from the storybook module follow a consistent naming convention and are designed to reduce boilerplate across multiple CLI storybook files.
