### PR TITLE
feat(ruleset): enable merge queue for auto-rebasing

### DIFF
--- a/.github/repo-settings.json
+++ b/.github/repo-settings.json
@@ -24,7 +24,7 @@
       "type": "required_status_checks",
       "parameters": {
         "do_not_enforce_on_create": true,
-        "strict_required_status_checks_policy": true,
+        "strict_required_status_checks_policy": false,
         "required_status_checks": [
           {
             "context": "typecheck"
@@ -39,6 +39,18 @@
             "context": "nix-check"
           }
         ]
+      }
+    },
+    {
+      "type": "merge_queue",
+      "parameters": {
+        "merge_method": "SQUASH",
+        "min_entries_to_merge": 1,
+        "max_entries_to_merge": 5,
+        "min_entries_to_merge_wait_minutes": 1,
+        "max_entries_to_build": 5,
+        "check_response_timeout_minutes": 30,
+        "grouping_strategy": "ALLGREEN"
       }
     },
     {

--- a/.github/repo-settings.json.genie.ts
+++ b/.github/repo-settings.json.genie.ts
@@ -41,13 +41,26 @@ export default githubRuleset({
       type: 'required_status_checks',
       parameters: {
         do_not_enforce_on_create: true, // Allow first push
-        strict_required_status_checks_policy: true,
+        strict_required_status_checks_policy: false, // Merge queue handles this
         required_status_checks: [
           { context: 'typecheck' },
           { context: 'lint' },
           { context: 'test' },
           { context: 'nix-check' },
         ],
+      },
+    },
+    // Use merge queue for automatic rebasing and batched CI
+    {
+      type: 'merge_queue',
+      parameters: {
+        merge_method: 'SQUASH',
+        min_entries_to_merge: 1,
+        max_entries_to_merge: 5,
+        min_entries_to_merge_wait_minutes: 1,
+        max_entries_to_build: 5,
+        check_response_timeout_minutes: 30,
+        grouping_strategy: 'ALLGREEN',
       },
     },
     // Prevent force push


### PR DESCRIPTION
## Summary
- Disable `strict_required_status_checks_policy` (merge queue handles this)
- Add `merge_queue` rule with SQUASH merge method
- Allows PRs to auto-merge without manual rebase when main changes

## Configuration
- Merge method: SQUASH
- Min entries to merge: 1 (no waiting for batching)
- Max entries to merge: 5
- Wait time: 1 minute
- Grouping: ALLGREEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)