### PR TITLE
fix(megarepo): configure fetch refspec for bare repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,11 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **@overeng/megarepo**: Configure fetch refspec when cloning bare repos (#111)
+  - `git clone --bare` doesn't set `remote.origin.fetch`, breaking `git push --force-with-lease`
+  - Now `cloneBare` configures `+refs/heads/*:refs/remotes/origin/*` after clone
+  - Ensures remote tracking refs are created on fetch for proper git workflows
+
 - **nix/devenv-modules/tasks/shared/test.nix**: Self-contained test tasks - each package uses its own vitest
   - Previously test tasks shared a vitest binary from `@overeng/utils`, violating self-contained packages requirements (R1-R5)
   - Now each package runs tests using `node_modules/.bin/vitest` from its own dependencies

--- a/packages/@overeng/megarepo/src/lib/git.ts
+++ b/packages/@overeng/megarepo/src/lib/git.ts
@@ -300,10 +300,18 @@ export const listWorktrees = (repoPath: string) =>
 // =============================================================================
 
 /**
- * Clone a repository as a bare repo
+ * Clone a repository as a bare repo.
+ * Configures fetch refspec so remote tracking refs are created on fetch.
+ * (git clone --bare doesn't set this up by default)
  */
 export const cloneBare = (args: { url: string; targetPath: string }) =>
-  clone({ url: args.url, targetPath: args.targetPath, bare: true })
+  Effect.gen(function* () {
+    yield* clone({ url: args.url, targetPath: args.targetPath, bare: true })
+    yield* runGitCommand({
+      args: ['config', 'remote.origin.fetch', '+refs/heads/*:refs/remotes/origin/*'],
+      cwd: args.targetPath,
+    })
+  })
 
 /**
  * Fetch all refs from remote in a bare repo


### PR DESCRIPTION
## Summary

- Fixes `git push --force-with-lease` failing with "stale info" in megarepo worktrees
- `git clone --bare` doesn't set `remote.origin.fetch`, so `git fetch` doesn't create remote tracking refs
- Now `cloneBare` configures `+refs/heads/*:refs/remotes/origin/*` after clone

Closes #111

## Test plan

- [x] Type check passes
- [x] Verified fix on existing repos (ran migration script on local + dev3)
- [ ] Test fresh `mr sync` creates bare repo with correct refspec

🤖 Generated with [Claude Code](https://claude.com/claude-code)