### PR TITLE
feat(megarepo): auto-sync after mr add

### DIFF
--- a/megarepo.lock
+++ b/megarepo.lock
@@ -4,9 +4,9 @@
     "effect": {
       "url": "https://github.com/effect-ts/effect",
       "ref": "main",
-      "commit": "f4972eda6c3179070d0167a30985b760afa0a9f9",
+      "commit": "cc2e49ac8d94a2c00fd8dfe47be9487748407ae8",
       "pinned": false,
-      "lockedAt": "2026-02-04T17:57:30.094Z"
+      "lockedAt": "2026-02-04T23:09:47.492Z"
     },
     "overeng-beads-public": {
       "url": "https://github.com/overengineeringstudio/overeng-beads-public",

--- a/packages/@overeng/megarepo/src/cli/commands/add.ts
+++ b/packages/@overeng/megarepo/src/cli/commands/add.ts
@@ -69,7 +69,7 @@ export const addCommand = Cli.Command.make(
     sync: Cli.Options.boolean('sync').pipe(
       Cli.Options.withAlias('s'),
       Cli.Options.withDescription('Sync the added repo immediately'),
-      Cli.Options.withDefault(false),
+      Cli.Options.withDefault(true),
     ),
     output: outputOption,
   },

--- a/packages/@overeng/megarepo/src/cli/renderers/AddOutput/stories/Success.stories.tsx
+++ b/packages/@overeng/megarepo/src/cli/renderers/AddOutput/stories/Success.stories.tsx
@@ -40,14 +40,14 @@ export default {
   },
   args: {
     ...defaultStoryArgs,
-    sync: false,
+    sync: true,
     name: 'effect',
     source: 'effect-ts/effect',
   },
   argTypes: {
     ...commonArgTypes,
     sync: {
-      description: '--sync flag: sync the added repo immediately',
+      description: '--sync/--no-sync flag: sync the added repo immediately (default: true)',
       control: { type: 'boolean' },
     },
     name: {
@@ -63,8 +63,8 @@ export default {
 
 type Story = StoryObj<StoryArgs>
 
-/** Simple add without sync */
-export const AddSimple: Story = {
+/** Default add behavior - adds and syncs (clones) the member */
+export const AddDefault: Story = {
   render: (args) => {
     const stateConfig = useMemo(
       () => ({
@@ -92,8 +92,37 @@ export const AddSimple: Story = {
   },
 }
 
-/** Add with sync - member cloned */
-export const AddWithSync: Story = {
+/** Add with --no-sync flag - skips syncing */
+export const AddNoSync: Story = {
+  args: { sync: false },
+  render: (args) => {
+    const stateConfig = useMemo(
+      () => ({
+        member: args.name,
+        source: args.source,
+        synced: false,
+      }),
+      [args.name, args.source],
+    )
+    return (
+      <TuiStoryPreview
+        View={AddView}
+        app={AddApp}
+        initialState={
+          args.interactive ? fixtures.createIdleState() : fixtures.createSuccessState(stateConfig)
+        }
+        height={args.height}
+        autoRun={args.interactive}
+        playbackSpeed={args.playbackSpeed}
+        tabs={ALL_OUTPUT_TABS}
+        {...(args.interactive ? { timeline: fixtures.createTimeline(stateConfig) } : {})}
+      />
+    )
+  },
+}
+
+/** Add with sync - member cloned (explicit --sync flag) */
+export const AddWithSyncCloned: Story = {
   args: { sync: true },
   render: (args) => {
     const stateConfig = useMemo(

--- a/packages/@overeng/megarepo/src/cli/renderers/AddOutput/view.tsx
+++ b/packages/@overeng/megarepo/src/cli/renderers/AddOutput/view.tsx
@@ -7,6 +7,7 @@ import React from 'react'
 
 import { Box, Text, useTuiAtomValue, useSymbols } from '@overeng/tui-react'
 
+import { StatusIcon } from '../../components/mod.ts'
 import type { AddState } from './schema.ts'
 
 /** Props for the AddView component that renders add command progress and results. */
@@ -58,20 +59,26 @@ export const AddView = ({ stateAtom }: AddViewProps) => {
             <Text color="green">{symbols.status.check}</Text>
             <Text> Added </Text>
             <Text bold>{state.member}</Text>
+            {!state.synced && <Text dim> (sync skipped)</Text>}
           </Box>
 
           {state.synced && state.syncStatus && (
-            <>
-              <Text dim>Syncing...</Text>
-              <Box flexDirection="row">
-                <Text color={state.syncStatus === 'error' ? 'red' : 'green'}>
-                  {state.syncStatus === 'error' ? symbols.status.cross : symbols.status.check}
-                </Text>
-                <Text> </Text>
-                <Text bold>{state.member}</Text>
-                <Text dim> ({state.syncStatus === 'cloned' ? 'cloned' : state.syncStatus})</Text>
-              </Box>
-            </>
+            <Box flexDirection="row">
+              <StatusIcon
+                status={
+                  state.syncStatus === 'cloned'
+                    ? 'cloned'
+                    : state.syncStatus === 'synced'
+                      ? 'synced'
+                      : 'error'
+                }
+                variant="sync"
+              />
+              <Text> </Text>
+              <Text bold>{state.member}</Text>
+              <Text> </Text>
+              <Text color={state.syncStatus === 'error' ? 'red' : 'green'}>{state.syncStatus}</Text>
+            </Box>
           )}
         </Box>
       )


### PR DESCRIPTION
Closes #69

Make `mr add` automatically sync the added member by default, matching the behavior of `yarn add`. Users can opt out with `--no-sync`. Updated terminal output to match sync command style and clearly indicate when sync is skipped.

## Changes
- Changed sync default from `false` → `true` in add command
- Updated terminal output to show sync status matching sync command style
- Added "(sync skipped)" indicator when `--no-sync` is used
- Updated storybook stories and descriptions

## Testing
- All TypeScript checks pass
- All tests pass
- Pre-commit hooks pass