### PR TITLE
Remove pnpm store caching from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,12 +31,6 @@ jobs:
       - name: Install devenv
         run: 'nix profile install github:cachix/devenv/$(jq -r ".nodes.devenv.locked.rev" devenv.lock)'
         shell: bash
-      - name: Cache pnpm store
-        uses: actions/cache@v4
-        with:
-          path: ~/.local/share/pnpm/store
-          key: "pnpm-store-v2-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
-          restore-keys: 'pnpm-store-v2-${{ runner.os }}-'
       - name: Type check
         run: 'dt ts:check'
   lint:
@@ -60,12 +54,6 @@ jobs:
       - name: Install devenv
         run: 'nix profile install github:cachix/devenv/$(jq -r ".nodes.devenv.locked.rev" devenv.lock)'
         shell: bash
-      - name: Cache pnpm store
-        uses: actions/cache@v4
-        with:
-          path: ~/.local/share/pnpm/store
-          key: "pnpm-store-v2-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
-          restore-keys: 'pnpm-store-v2-${{ runner.os }}-'
       - name: Format + lint
         run: 'dt lint:check'
   test:
@@ -92,12 +80,6 @@ jobs:
       - name: Install devenv
         run: 'nix profile install github:cachix/devenv/$(jq -r ".nodes.devenv.locked.rev" devenv.lock)'
         shell: bash
-      - name: Cache pnpm store
-        uses: actions/cache@v4
-        with:
-          path: ~/.local/share/pnpm/store
-          key: "pnpm-store-v2-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
-          restore-keys: 'pnpm-store-v2-${{ runner.os }}-'
       - name: Unit tests
         run: 'dt test:run'
   nix-check:
@@ -124,11 +106,5 @@ jobs:
       - name: Install devenv
         run: 'nix profile install github:cachix/devenv/$(jq -r ".nodes.devenv.locked.rev" devenv.lock)'
         shell: bash
-      - name: Cache pnpm store
-        uses: actions/cache@v4
-        with:
-          path: ~/.local/share/pnpm/store
-          key: "pnpm-store-v2-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
-          restore-keys: 'pnpm-store-v2-${{ runner.os }}-'
       - name: Nix hash check
         run: 'dt nix:check'

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -34,15 +34,6 @@ const baseSteps = [
     run: 'nix profile install github:cachix/devenv/$(jq -r ".nodes.devenv.locked.rev" devenv.lock)',
     shell: 'bash',
   },
-  {
-    name: 'Cache pnpm store',
-    uses: 'actions/cache@v4',
-    with: {
-      path: '~/.local/share/pnpm/store',
-      key: "pnpm-store-v2-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}",
-      'restore-keys': 'pnpm-store-v2-${{ runner.os }}-',
-    },
-  },
 ] as const
 
 const job = (step: { name: string; run: string }) => ({


### PR DESCRIPTION
## Summary
- Removes the `actions/cache@v4` step that cached `~/.local/share/pnpm/store` in all CI jobs
- Removes it from the genie source file and regenerates the workflow

## Test plan
- [ ] CI passes without the pnpm cache step

🤖 Generated with [Claude Code](https://claude.com/claude-code)