### PR TITLE
Add cache.nixos.org as fallback Nix substituter in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Nix
         uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            extra-substituters = https://cache.nixos.org
+            extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
       - name: Enable Cachix cache
         uses: cachix/cachix-action@v16
         with:
@@ -46,6 +50,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Nix
         uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            extra-substituters = https://cache.nixos.org
+            extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
       - name: Enable Cachix cache
         uses: cachix/cachix-action@v16
         with:
@@ -72,6 +80,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Nix
         uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            extra-substituters = https://cache.nixos.org
+            extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
       - name: Enable Cachix cache
         uses: cachix/cachix-action@v16
         with:
@@ -98,6 +110,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Nix
         uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            extra-substituters = https://cache.nixos.org
+            extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
       - name: Enable Cachix cache
         uses: cachix/cachix-action@v16
         with:

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -19,6 +19,15 @@ const baseSteps = [
   {
     name: 'Install Nix',
     uses: 'cachix/install-nix-action@v31',
+    with: {
+      // Ensure cache.nixos.org is available as a fallback substituter.
+      // Without this, macOS ARM64 runners can fail with "path is not valid"
+      // during Darwin stdenv bootstrap when low-level store paths get GC'd
+      // and aren't in our Cachix cache.
+      // See: https://github.com/NixOS/nix/issues/9052
+      //      https://github.com/cachix/cachix-action/issues/44
+      extra_nix_config: 'extra-substituters = https://cache.nixos.org\nextra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=',
+    },
   },
   {
     name: 'Enable Cachix cache',


### PR DESCRIPTION
## Summary

- Add `cache.nixos.org` as an explicit fallback substituter in all CI jobs
- Prevents transient "path is not valid" failures on macOS ARM64 runners when Darwin stdenv bootstrap store paths get GC'd and aren't in our Cachix cache

See [NixOS/nix#9052](https://github.com/NixOS/nix/issues/9052), [cachix/cachix-action#44](https://github.com/cachix/cachix-action/issues/44)

## Test plan

- [ ] CI passes on macOS ARM64 runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)