### PR TITLE
fix(genie): empty files array and missing error details in JSON output

### DIFF
--- a/packages/@overeng/genie/src/build/errors.ts
+++ b/packages/@overeng/genie/src/build/errors.ts
@@ -1,5 +1,7 @@
 import { Schema } from 'effect'
 
+import { GenieFile } from './schema.ts'
+
 /**
  * Error when importing a .genie.ts file fails.
  *
@@ -29,6 +31,8 @@ export class GenieGenerationFailedError extends Schema.TaggedError<GenieGenerati
   {
     failedCount: Schema.Number,
     message: Schema.String,
+    /** Per-file details including error messages for failed files */
+    files: Schema.Array(GenieFile),
   },
 ) {}
 

--- a/packages/@overeng/genie/src/build/mod.tsx
+++ b/packages/@overeng/genie/src/build/mod.tsx
@@ -234,6 +234,7 @@ export const genieCommand: Cli.Command.Command<
                 return yield* new GenieGenerationFailedError({
                   failedCount: failed,
                   message: `${failed} file(s) are out of date`,
+                  files: tui.getState().files,
                 })
               }
 
@@ -249,6 +250,7 @@ export const genieCommand: Cli.Command.Command<
                 return yield* new GenieGenerationFailedError({
                   failedCount: 1,
                   message,
+                  files: tui.getState().files,
                 })
               }
 
@@ -364,6 +366,7 @@ export const genieCommand: Cli.Command.Command<
               return yield* new GenieGenerationFailedError({
                 failedCount: revalidateErrors.length,
                 message: `${rootCauses.length} root cause error(s), ${dependentCount} dependent failure(s)`,
+                files: tui.getState().files,
               })
             }
 
@@ -383,6 +386,7 @@ export const genieCommand: Cli.Command.Command<
               return yield* new GenieGenerationFailedError({
                 failedCount: summary.failed,
                 message: `${summary.failed} file(s) failed to generate`,
+                files: tui.getState().files,
               })
             }
 


### PR DESCRIPTION
## Summary

Fixes #135

- **Bug 1**: `--output json` mode returned empty `state.files` and blank `state.cwd`. Root cause: effect-atom Registry garbage-collects atom nodes with no subscribers via microtask. JSON mode never subscribes to `stateAtom`, so the node was GC'd between async operations. Fix: `registry.mount(stateAtom)` in `run_()` to prevent GC, with cleanup in scope finalizer.
- **Bug 2**: `GenieGenerationFailedError` only carried `{message, failedCount}` with no per-file details. Fix: Added `files: Schema.Array(GenieFile)` field and populated it at all 4 construction sites.
- Added integration tests for both `--output json` and `--output ndjson` failure scenarios.

## Test plan

- [x] `dt check:quick` passes (ts:check + lint)
- [x] `dt test:genie` passes (including new integration tests)
- [x] `dt test:tui-react` passes
- [x] Integration test: `--output json` includes non-empty files array and cwd on failure
- [x] Integration test: `--output ndjson` final line includes files and cwd on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)