### PR TITLE
refactor(tui-react): make main entry point browser-safe for Storybook

### DIFF
--- a/megarepo.lock
+++ b/megarepo.lock
@@ -4,9 +4,9 @@
     "effect": {
       "url": "https://github.com/effect-ts/effect",
       "ref": "main",
-      "commit": "22d9d27bc007db86d9e4748c17324fab5f950c7d",
+      "commit": "8e2286271a982b1cc34c78fca8b9f59de71fc790",
       "pinned": false,
-      "lockedAt": "2026-02-05T10:02:54.883Z"
+      "lockedAt": "2026-02-06T13:28:08.524Z"
     },
     "overeng-beads-public": {
       "url": "https://github.com/overengineeringstudio/overeng-beads-public",

--- a/packages/@overeng/genie/bin/genie.tsx
+++ b/packages/@overeng/genie/bin/genie.tsx
@@ -4,7 +4,7 @@ import * as Cli from '@effect/cli'
 import { NodeContext, NodeRuntime } from '@effect/platform-node'
 import { Effect, Layer } from 'effect'
 
-import { runTuiMain } from '@overeng/tui-react'
+import { runTuiMain } from '@overeng/tui-react/node'
 import { CurrentWorkingDirectory } from '@overeng/utils/node'
 import { resolveCliVersion } from '@overeng/utils/node/cli-version'
 

--- a/packages/@overeng/genie/src/build/mod.tsx
+++ b/packages/@overeng/genie/src/build/mod.tsx
@@ -5,7 +5,8 @@ import { type Error as PlatformError, FileSystem } from '@effect/platform'
 import { Effect, Either, Option, pipe, Stream } from 'effect'
 import React from 'react'
 
-import { outputOption, outputModeLayer, run } from '@overeng/tui-react'
+import { run } from '@overeng/tui-react'
+import { outputOption, outputModeLayer } from '@overeng/tui-react/node'
 import { assertNever } from '@overeng/utils'
 import { CurrentWorkingDirectory } from '@overeng/utils/node'
 

--- a/packages/@overeng/genie/src/build/types.ts
+++ b/packages/@overeng/genie/src/build/types.ts
@@ -2,7 +2,7 @@ import type { Error as PlatformError, FileSystem, Path } from '@effect/platform'
 import type * as CommandExecutor from '@effect/platform/CommandExecutor'
 import type { Option } from 'effect'
 
-import type { OutputModeValue } from '@overeng/tui-react'
+import type { OutputModeValue } from '@overeng/tui-react/node'
 import type { CurrentWorkingDirectory } from '@overeng/utils/node'
 
 import type { GenieCheckError, GenieGenerationFailedError, GenieImportError } from './errors.ts'

--- a/packages/@overeng/megarepo/bin/mr.ts
+++ b/packages/@overeng/megarepo/bin/mr.ts
@@ -4,7 +4,7 @@ import * as Cli from '@effect/cli'
 import { NodeContext, NodeRuntime } from '@effect/platform-node'
 import { Effect } from 'effect'
 
-import { runTuiMain } from '@overeng/tui-react'
+import { runTuiMain } from '@overeng/tui-react/node'
 import { resolveCliVersion } from '@overeng/utils/node/cli-version'
 
 import { mrCommand } from '../src/cli/mod.ts'

--- a/packages/@overeng/megarepo/src/cli/context.ts
+++ b/packages/@overeng/megarepo/src/cli/context.ts
@@ -116,7 +116,7 @@ export {
   outputModeLayer,
   type OutputModeValue,
   resolveOutputMode,
-} from '@overeng/tui-react'
+} from '@overeng/tui-react/node'
 
 // =============================================================================
 // Filesystem Helpers

--- a/packages/@overeng/notion-cli/src/commands/db/mod.ts
+++ b/packages/@overeng/notion-cli/src/commands/db/mod.ts
@@ -10,7 +10,8 @@ import type { NodeInspectSymbol } from 'effect/Inspectable'
 import React from 'react'
 
 import { EffectPath, type AbsoluteDirPath } from '@overeng/effect-path'
-import { outputOption as tuiOutputOption, outputModeLayer, run } from '@overeng/tui-react'
+import { run } from '@overeng/tui-react'
+import { outputOption as tuiOutputOption, outputModeLayer } from '@overeng/tui-react/node'
 
 import { DumpApp } from '../../renderers/DumpOutput/app.ts'
 import { DumpView } from '../../renderers/DumpOutput/view.tsx'

--- a/packages/@overeng/notion-cli/src/commands/schema/mod.ts
+++ b/packages/@overeng/notion-cli/src/commands/schema/mod.ts
@@ -12,7 +12,8 @@ import React from 'react'
 
 import { EffectPath } from '@overeng/effect-path'
 import { NotionConfig, NotionDatabases } from '@overeng/notion-effect-client'
-import { outputOption as tuiOutputOption, outputModeLayer, run } from '@overeng/tui-react'
+import { run } from '@overeng/tui-react'
+import { outputOption as tuiOutputOption, outputModeLayer } from '@overeng/tui-react/node'
 
 import { DiffApp } from '../../renderers/DiffOutput/app.ts'
 import { DiffView } from '../../renderers/DiffOutput/view.tsx'

--- a/packages/@overeng/tui-react/examples/01-basic/hello-world.tsx
+++ b/packages/@overeng/tui-react/examples/01-basic/hello-world.tsx
@@ -19,7 +19,8 @@ import { NodeContext, NodeRuntime } from '@effect/platform-node'
 import { Effect } from 'effect'
 import React from 'react'
 
-import { createTuiApp, run, outputOption, outputModeLayer } from '../../src/mod.ts'
+import { createTuiApp, run } from '../../src/mod.ts'
+import { outputOption, outputModeLayer } from '../../src/node/mod.ts'
 // Import from shared modules
 import { AppState, AppAction, appReducer } from './schema.ts'
 import { HelloWorldView } from './view.tsx'

--- a/packages/@overeng/tui-react/examples/02-effect-integration/counter.tsx
+++ b/packages/@overeng/tui-react/examples/02-effect-integration/counter.tsx
@@ -21,7 +21,8 @@ import { NodeContext, NodeRuntime } from '@effect/platform-node'
 import { Duration, Effect } from 'effect'
 import React from 'react'
 
-import { createTuiApp, run, outputOption, outputModeLayer } from '../../src/mod.ts'
+import { createTuiApp, run } from '../../src/mod.ts'
+import { outputOption, outputModeLayer } from '../../src/node/mod.ts'
 // Import from shared modules
 import { CounterState, CounterAction, counterReducer } from './schema.ts'
 import { CounterView } from './view.tsx'

--- a/packages/@overeng/tui-react/examples/03-cli/deploy/main.ts
+++ b/packages/@overeng/tui-react/examples/03-cli/deploy/main.ts
@@ -20,7 +20,7 @@ import { Command, Options } from '@effect/cli'
 import { NodeContext, NodeRuntime } from '@effect/platform-node'
 import { Effect } from 'effect'
 
-import { outputOption, outputModeLayer } from '../../../src/mod.ts'
+import { outputOption, outputModeLayer } from '../../../src/node/mod.ts'
 import { DeployError, runDeploy } from './deploy.tsx'
 
 // =============================================================================

--- a/packages/@overeng/tui-react/examples/04-stress-tests/rapid-updates.tsx
+++ b/packages/@overeng/tui-react/examples/04-stress-tests/rapid-updates.tsx
@@ -19,7 +19,8 @@ import { NodeContext, NodeRuntime } from '@effect/platform-node'
 import { Effect, Fiber } from 'effect'
 import React from 'react'
 
-import { createTuiApp, run, outputOption, outputModeLayer } from '../../src/mod.ts'
+import { createTuiApp, run } from '../../src/mod.ts'
+import { outputOption, outputModeLayer } from '../../src/node/mod.ts'
 // Import from shared modules
 import { StressTestState, StressTestAction, createStressTestReducer } from './schema.ts'
 import { StressTestView } from './view.tsx'

--- a/packages/@overeng/tui-react/examples/05-advanced/bouncing-windows.tsx
+++ b/packages/@overeng/tui-react/examples/05-advanced/bouncing-windows.tsx
@@ -22,7 +22,8 @@ import { NodeContext, NodeRuntime } from '@effect/platform-node'
 import { Effect, Fiber } from 'effect'
 import React from 'react'
 
-import { createTuiApp, run, outputOption, outputModeLayer } from '../../src/mod.ts'
+import { createTuiApp, run } from '../../src/mod.ts'
+import { outputOption, outputModeLayer } from '../../src/node/mod.ts'
 // Import from shared modules
 import { AppState, AppAction, appReducer, createWindow } from './schema.ts'
 import { BouncingWindowsView } from './view.tsx'

--- a/packages/@overeng/tui-react/examples/06-log-capture/log-capture.tsx
+++ b/packages/@overeng/tui-react/examples/06-log-capture/log-capture.tsx
@@ -15,7 +15,8 @@ import { NodeContext, NodeRuntime } from '@effect/platform-node'
 import { Duration, Effect } from 'effect'
 import React from 'react'
 
-import { createTuiApp, run, outputOption, outputModeLayer } from '../../src/mod.ts'
+import { createTuiApp, run } from '../../src/mod.ts'
+import { outputOption, outputModeLayer } from '../../src/node/mod.ts'
 import { TaskRunnerState, TaskRunnerAction, taskRunnerReducer } from './schema.ts'
 import { TaskRunnerView } from './view.tsx'
 

--- a/packages/@overeng/tui-react/examples/viewport-overflow-stress.tsx
+++ b/packages/@overeng/tui-react/examples/viewport-overflow-stress.tsx
@@ -20,16 +20,8 @@ import { NodeContext, NodeRuntime } from '@effect/platform-node'
 import { Effect, Schema } from 'effect'
 import React, { useMemo } from 'react'
 
-import {
-  createTuiApp,
-  run,
-  outputModeLayer,
-  Box,
-  Text,
-  Spinner,
-  useViewport,
-  useTuiAtomValue,
-} from '../src/mod.tsx'
+import { createTuiApp, run, Box, Text, Spinner, useViewport, useTuiAtomValue } from '../src/mod.tsx'
+import { outputModeLayer } from '../src/node/mod.ts'
 
 // =============================================================================
 // State & Actions

--- a/packages/@overeng/tui-react/package.json
+++ b/packages/@overeng/tui-react/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "exports": {
     ".": "./src/mod.tsx",
+    "./node": "./src/node/mod.ts",
     "./opentui": "./src/effect/opentui/mod.tsx",
     "./storybook": "./src/storybook/mod.tsx"
   },
@@ -12,6 +13,7 @@
     "access": "public",
     "exports": {
       ".": "./dist/mod.js",
+      "./node": "./dist/node/mod.js",
       "./storybook": "./dist/storybook/mod.js",
       "./opentui": "./dist/effect/opentui/mod.js"
     }

--- a/packages/@overeng/tui-react/package.json.genie.ts
+++ b/packages/@overeng/tui-react/package.json.genie.ts
@@ -22,6 +22,7 @@ export default packageJson({
   ...privatePackageDefaults,
   exports: {
     '.': './src/mod.tsx',
+    './node': './src/node/mod.ts',
     './storybook': './src/storybook/mod.tsx',
     './opentui': './src/effect/opentui/mod.tsx',
   },
@@ -35,6 +36,7 @@ export default packageJson({
     access: 'public',
     exports: {
       '.': './dist/mod.js',
+      './node': './dist/node/mod.js',
       './storybook': './dist/storybook/mod.js',
       './opentui': './dist/effect/opentui/mod.js',
     },

--- a/packages/@overeng/tui-react/src/effect/LogCapture.ts
+++ b/packages/@overeng/tui-react/src/effect/LogCapture.ts
@@ -30,10 +30,17 @@
  * @module
  */
 
-import { formatWithOptions } from 'node:util'
-
 import type { Layer, Scope } from 'effect'
-import { Effect, Fiber, FiberId, Logger, Runtime, Stream, SubscriptionRef } from 'effect'
+import {
+  Effect,
+  Fiber,
+  FiberId,
+  Inspectable,
+  Logger,
+  Runtime,
+  Stream,
+  SubscriptionRef,
+} from 'effect'
 import React, { createContext, type ReactNode } from 'react'
 
 import { useContext, useSyncExternalStore } from './hooks.tsx'
@@ -218,7 +225,7 @@ export const createLogCapture = (options?: {
         const entry: TuiLogEntry = {
           id: ++logCaptureEntryId,
           level,
-          message: formatWithOptions({ depth: 4 }, ...args),
+          message: args.map((a) => Inspectable.toStringUnknown(a)).join(' '),
           timestamp: new Date(),
           fiberId: 'console',
           annotations: {},

--- a/packages/@overeng/tui-react/src/effect/OutputMode.node.ts
+++ b/packages/@overeng/tui-react/src/effect/OutputMode.node.ts
@@ -1,0 +1,194 @@
+/**
+ * OutputMode Node.js detection utilities.
+ *
+ * Contains functions that require `node:fs` for detecting pipe/file redirect
+ * status of stdout. These are separated from `OutputMode.tsx` to keep the
+ * main module browser-safe for Storybook and other browser environments.
+ *
+ * @module
+ */
+
+import * as fs from 'node:fs'
+
+import { Layer } from 'effect'
+
+import { type OutputMode, OutputModeTag, tty, ci, pipe, json, isTTY } from './OutputMode.tsx'
+
+// =============================================================================
+// Node.js Detection Helpers
+// =============================================================================
+
+/**
+ * Check if visual mode is forced via env var.
+ */
+const isVisualEnvSet = (): boolean =>
+  typeof process !== 'undefined' && process.env?.TUI_VISUAL === '1'
+
+/**
+ * Check if NO_COLOR env var is set.
+ */
+const isNoColorSet = (): boolean =>
+  typeof process !== 'undefined' && process.env?.NO_COLOR !== undefined
+
+/**
+ * Check if NO_UNICODE env var is set.
+ */
+const isNoUnicodeSet = (): boolean =>
+  typeof process !== 'undefined' && process.env?.NO_UNICODE !== undefined
+
+/**
+ * Check if running in a CI environment.
+ */
+const isCIEnv = (): boolean => typeof process !== 'undefined' && process.env?.CI !== undefined
+
+/**
+ * Check if TUI_PIPE_MODE=visual env var is set to force visual output in pipes.
+ */
+const isPipeModeVisual = (): boolean =>
+  typeof process !== 'undefined' && process.env?.TUI_PIPE_MODE === 'visual'
+
+/**
+ * Check if stdout is piped to another process (FIFO).
+ *
+ * Uses `fs.fstatSync(1).isFIFO()` to detect if stdout (fd 1) is a pipe/FIFO.
+ * This is true when the command is piped to another process (e.g., `cmd | cat`).
+ *
+ * @returns `true` if stdout is a FIFO (pipe to process), `false` otherwise
+ */
+export const isPiped = (): boolean => {
+  if (typeof process === 'undefined') return false
+  try {
+    const stat = fs.fstatSync(1)
+    return stat.isFIFO()
+  } catch {
+    // If fstat fails (e.g., fd not available), assume not piped
+    return false
+  }
+}
+
+/**
+ * Check if stdout is redirected to a file.
+ *
+ * Uses `fs.fstatSync(1).isFile()` to detect if stdout (fd 1) is a regular file.
+ * This is true when the command output is redirected to a file (e.g., `cmd > file.txt`).
+ *
+ * @returns `true` if stdout is a file, `false` otherwise
+ */
+export const isRedirectedToFile = (): boolean => {
+  if (typeof process === 'undefined') return false
+  try {
+    const stat = fs.fstatSync(1)
+    return stat.isFile()
+  } catch {
+    // If fstat fails (e.g., fd not available), assume not redirected
+    return false
+  }
+}
+
+/**
+ * Check if running inside a coding agent's shell environment.
+ *
+ * Detects known coding agents by their environment variables:
+ * - `AGENT` (generic convention): OpenCode sets `AGENT=1`, Amp sets `AGENT=amp`
+ * - `CLAUDE_PROJECT_DIR`: Claude Code (https://docs.anthropic.com/en/docs/claude-code/cli-reference)
+ * - `CLAUDECODE`: Amp compatibility (https://ampcode.com/manual/appendix#toolboxes-reference)
+ * - `OPENCODE`: OpenCode (verified empirically)
+ * - `CLINE_ACTIVE`: Cline VS Code extension (https://github.com/cline/cline/blob/main/src/hosts/vscode/terminal/VscodeTerminalRegistry.ts)
+ * - `CODEX_SANDBOX`: OpenAI Codex CLI (https://github.com/openai/codex/blob/main/codex-rs/core/src/spawn.rs)
+ *
+ * Note: Some agents (Cursor, Windsurf, Aider) don't set identifiable env vars.
+ * Use `--output=json` or `TUI_VISUAL=1` for those.
+ */
+export const isAgentEnv = (): boolean => {
+  if (typeof process === 'undefined') return false
+  const env = process.env
+  return (
+    // Generic agent convention (OpenCode: AGENT=1, Amp: AGENT=amp)
+    (env?.AGENT !== undefined && env.AGENT !== '' && env.AGENT !== '0' && env.AGENT !== 'false') ||
+    // Claude Code
+    env?.CLAUDE_PROJECT_DIR !== undefined ||
+    // Amp (also sets AGENT, but CLAUDECODE is a secondary signal)
+    env?.CLAUDECODE !== undefined ||
+    // OpenCode (also sets AGENT, but OPENCODE is a secondary signal)
+    env?.OPENCODE !== undefined ||
+    // Cline (VS Code extension)
+    env?.CLINE_ACTIVE !== undefined ||
+    // OpenAI Codex CLI
+    env?.CODEX_SANDBOX !== undefined
+  )
+}
+
+/**
+ * Auto-detect the appropriate OutputMode based on environment.
+ *
+ * Detection logic:
+ * 1. `TUI_VISUAL=1` env → forces React mode (tty or ci based on TTY)
+ * 2. Agent environment detected → `json` (structured output for coding agents)
+ * 3. TTY + not CI → `tty` (animated terminal)
+ * 4. TTY + CI → `ci` (static terminal)
+ * 5. Non-TTY + piped → `json` (machine-readable for downstream tools)
+ * 6. Non-TTY + file redirect → `pipe` (visual output for file storage)
+ *
+ * Respects `NO_COLOR`, `NO_UNICODE`, and `TUI_PIPE_MODE` environment variables.
+ *
+ * @returns Detected OutputMode
+ *
+ * @example
+ * ```typescript
+ * const mode = detectOutputMode()
+ * // Returns appropriate mode based on environment
+ * ```
+ */
+export const detectOutputMode = (): OutputMode => {
+  // Check environment
+  const forceVisual = isVisualEnvSet()
+  const ttyEnv = isTTY()
+  const ciEnv = isCIEnv()
+  const agentEnv = isAgentEnv()
+  const noColor = isNoColorSet()
+  const noUnicode = isNoUnicodeSet()
+  const pipedEnv = isPiped()
+  const forcePipeVisual = isPipeModeVisual()
+
+  // Helper to apply noColor and noUnicode
+  const withEnvOverrides = (mode: OutputMode): OutputMode => {
+    if (mode._tag !== 'react') return mode
+    let render = mode.render
+    if (noColor) render = { ...render, colors: false }
+    if (noUnicode) render = { ...render, unicode: false }
+    return render === mode.render ? mode : { ...mode, render }
+  }
+
+  if (forceVisual) {
+    // Forced visual: use tty if actually TTY, otherwise ci mode
+    return withEnvOverrides(ttyEnv && !ciEnv ? tty : ci)
+  }
+
+  // Agent environment → JSON output for structured consumption
+  if (agentEnv) {
+    return json
+  }
+
+  // Auto-detect based on environment
+  if (ttyEnv) {
+    return withEnvOverrides(ciEnv ? ci : tty)
+  }
+
+  // Non-TTY: distinguish between pipe and file redirect
+  // Piped to another process (cmd | cat) → JSON for machine consumption
+  // Unless TUI_PIPE_MODE=visual is set
+  if (pipedEnv && !forcePipeVisual) {
+    return json
+  }
+
+  // File redirect or TUI_PIPE_MODE=visual → pipe mode (final React output)
+  return withEnvOverrides(pipe)
+}
+
+/** @deprecated Use `detectOutputMode()` instead */
+export const detect = detectOutputMode
+
+/**
+ * Layer that auto-detects mode from environment.
+ */
+export const detectLayer: Layer.Layer<OutputModeTag> = Layer.sync(OutputModeTag, detectOutputMode)

--- a/packages/@overeng/tui-react/src/effect/OutputMode.tsx
+++ b/packages/@overeng/tui-react/src/effect/OutputMode.tsx
@@ -44,8 +44,6 @@
  * @module
  */
 
-import * as fs from 'node:fs'
-
 import { Context, Layer } from 'effect'
 import React, { createContext, useContext, type ReactNode } from 'react'
 
@@ -297,31 +295,8 @@ export const fullscreenRenderConfig = altScreenRenderConfig
 export class OutputModeTag extends Context.Tag('OutputMode')<OutputModeTag, OutputMode>() {}
 
 // =============================================================================
-// Detection & Factory
+// Environment Helpers (browser-safe — use typeof process guards)
 // =============================================================================
-
-/**
- * Check if visual mode is forced via env var.
- */
-const isVisualEnvSet = (): boolean =>
-  typeof process !== 'undefined' && process.env?.TUI_VISUAL === '1'
-
-/**
- * Check if NO_COLOR env var is set.
- */
-const isNoColorSet = (): boolean =>
-  typeof process !== 'undefined' && process.env?.NO_COLOR !== undefined
-
-/**
- * Check if NO_UNICODE env var is set.
- */
-const isNoUnicodeSet = (): boolean =>
-  typeof process !== 'undefined' && process.env?.NO_UNICODE !== undefined
-
-/**
- * Check if running in a CI environment.
- */
-const isCIEnv = (): boolean => typeof process !== 'undefined' && process.env?.CI !== undefined
 
 /**
  * Check if running in a TTY environment.
@@ -332,152 +307,6 @@ export const isTTY = (): boolean => typeof process !== 'undefined' && process.st
  * Check if running in a non-TTY environment.
  */
 export const isNonTTY = (): boolean => !isTTY()
-
-/**
- * Check if stdout is piped to another process (FIFO).
- *
- * Uses `fs.fstatSync(1).isFIFO()` to detect if stdout (fd 1) is a pipe/FIFO.
- * This is true when the command is piped to another process (e.g., `cmd | cat`).
- *
- * @returns `true` if stdout is a FIFO (pipe to process), `false` otherwise
- */
-export const isPiped = (): boolean => {
-  if (typeof process === 'undefined') return false
-  try {
-    const stat = fs.fstatSync(1)
-    return stat.isFIFO()
-  } catch {
-    // If fstat fails (e.g., fd not available), assume not piped
-    return false
-  }
-}
-
-/**
- * Check if stdout is redirected to a file.
- *
- * Uses `fs.fstatSync(1).isFile()` to detect if stdout (fd 1) is a regular file.
- * This is true when the command output is redirected to a file (e.g., `cmd > file.txt`).
- *
- * @returns `true` if stdout is a file, `false` otherwise
- */
-export const isRedirectedToFile = (): boolean => {
-  if (typeof process === 'undefined') return false
-  try {
-    const stat = fs.fstatSync(1)
-    return stat.isFile()
-  } catch {
-    // If fstat fails (e.g., fd not available), assume not redirected
-    return false
-  }
-}
-
-/**
- * Check if TUI_PIPE_MODE=visual env var is set to force visual output in pipes.
- */
-const isPipeModeVisual = (): boolean =>
-  typeof process !== 'undefined' && process.env?.TUI_PIPE_MODE === 'visual'
-
-/**
- * Check if running inside a coding agent's shell environment.
- *
- * Detects known coding agents by their environment variables:
- * - `AGENT` (generic convention): OpenCode sets `AGENT=1`, Amp sets `AGENT=amp`
- * - `CLAUDE_PROJECT_DIR`: Claude Code (https://docs.anthropic.com/en/docs/claude-code/cli-reference)
- * - `CLAUDECODE`: Amp compatibility (https://ampcode.com/manual/appendix#toolboxes-reference)
- * - `OPENCODE`: OpenCode (verified empirically)
- * - `CLINE_ACTIVE`: Cline VS Code extension (https://github.com/cline/cline/blob/main/src/hosts/vscode/terminal/VscodeTerminalRegistry.ts)
- * - `CODEX_SANDBOX`: OpenAI Codex CLI (https://github.com/openai/codex/blob/main/codex-rs/core/src/spawn.rs)
- *
- * Note: Some agents (Cursor, Windsurf, Aider) don't set identifiable env vars.
- * Use `--output=json` or `TUI_VISUAL=1` for those.
- */
-export const isAgentEnv = (): boolean => {
-  if (typeof process === 'undefined') return false
-  const env = process.env
-  return (
-    // Generic agent convention (OpenCode: AGENT=1, Amp: AGENT=amp)
-    (env?.AGENT !== undefined && env.AGENT !== '' && env.AGENT !== '0' && env.AGENT !== 'false') ||
-    // Claude Code
-    env?.CLAUDE_PROJECT_DIR !== undefined ||
-    // Amp (also sets AGENT, but CLAUDECODE is a secondary signal)
-    env?.CLAUDECODE !== undefined ||
-    // OpenCode (also sets AGENT, but OPENCODE is a secondary signal)
-    env?.OPENCODE !== undefined ||
-    // Cline (VS Code extension)
-    env?.CLINE_ACTIVE !== undefined ||
-    // OpenAI Codex CLI
-    env?.CODEX_SANDBOX !== undefined
-  )
-}
-
-/**
- * Auto-detect the appropriate OutputMode based on environment.
- *
- * Detection logic:
- * 1. `TUI_VISUAL=1` env → forces React mode (tty or ci based on TTY)
- * 2. Agent environment detected → `json` (structured output for coding agents)
- * 3. TTY + not CI → `tty` (animated terminal)
- * 4. TTY + CI → `ci` (static terminal)
- * 5. Non-TTY + piped → `json` (machine-readable for downstream tools)
- * 6. Non-TTY + file redirect → `pipe` (visual output for file storage)
- *
- * Respects `NO_COLOR`, `NO_UNICODE`, and `TUI_PIPE_MODE` environment variables.
- *
- * @returns Detected OutputMode
- *
- * @example
- * ```typescript
- * const mode = detectOutputMode()
- * // Returns appropriate mode based on environment
- * ```
- */
-export const detectOutputMode = (): OutputMode => {
-  // Check environment
-  const forceVisual = isVisualEnvSet()
-  const ttyEnv = isTTY()
-  const ciEnv = isCIEnv()
-  const agentEnv = isAgentEnv()
-  const noColor = isNoColorSet()
-  const noUnicode = isNoUnicodeSet()
-  const pipedEnv = isPiped()
-  const forcePipeVisual = isPipeModeVisual()
-
-  // Helper to apply noColor and noUnicode
-  const withEnvOverrides = (mode: ReactOutputMode): OutputMode => {
-    let render = mode.render
-    if (noColor) render = { ...render, colors: false }
-    if (noUnicode) render = { ...render, unicode: false }
-    return render === mode.render ? mode : { ...mode, render }
-  }
-
-  if (forceVisual) {
-    // Forced visual: use tty if actually TTY, otherwise ci mode
-    return withEnvOverrides(ttyEnv && !ciEnv ? tty : ci)
-  }
-
-  // Agent environment → JSON output for structured consumption
-  if (agentEnv) {
-    return json
-  }
-
-  // Auto-detect based on environment
-  if (ttyEnv) {
-    return withEnvOverrides(ciEnv ? ci : tty)
-  }
-
-  // Non-TTY: distinguish between pipe and file redirect
-  // Piped to another process (cmd | cat) → JSON for machine consumption
-  // Unless TUI_PIPE_MODE=visual is set
-  if (pipedEnv && !forcePipeVisual) {
-    return json
-  }
-
-  // File redirect or TUI_PIPE_MODE=visual → pipe mode (final React output)
-  return withEnvOverrides(pipe)
-}
-
-/** @deprecated Use `detectOutputMode()` instead */
-export const detect = detectOutputMode
 
 // =============================================================================
 // Type Guards
@@ -649,8 +478,3 @@ export const jsonLayer: Layer.Layer<OutputModeTag> = layer(json)
 
 /** Layer for ndjson mode */
 export const ndjsonLayer: Layer.Layer<OutputModeTag> = layer(ndjson)
-
-/**
- * Layer that auto-detects mode from environment.
- */
-export const detectLayer: Layer.Layer<OutputModeTag> = Layer.sync(OutputModeTag, detectOutputMode)

--- a/packages/@overeng/tui-react/src/effect/cli.tsx
+++ b/packages/@overeng/tui-react/src/effect/cli.tsx
@@ -27,6 +27,7 @@ import { Options } from '@effect/cli'
 import { Cause, Effect, Layer, Logger } from 'effect'
 
 import { createLogCapture } from './LogCapture.ts'
+import { detectOutputMode } from './OutputMode.node.ts'
 import type { OutputModeTag } from './OutputMode.tsx'
 import {
   type OutputMode,
@@ -38,7 +39,6 @@ import {
   altScreen,
   json,
   ndjson,
-  detectOutputMode,
   layer,
   isJson,
   isReact,

--- a/packages/@overeng/tui-react/src/mod.tsx
+++ b/packages/@overeng/tui-react/src/mod.tsx
@@ -152,9 +152,7 @@ export {
   altScreen,
   json,
   ndjson,
-  // Detection
-  detectOutputMode,
-  // Environment helpers
+  // Environment helpers (browser-safe)
   isTTY,
   isNonTTY,
   // Type guards
@@ -174,7 +172,6 @@ export {
   altScreenLayer,
   jsonLayer,
   ndjsonLayer,
-  detectLayer,
 } from './effect/OutputMode.tsx'
 
 // =============================================================================
@@ -357,14 +354,6 @@ export {
 // =============================================================================
 // Effect CLI Integration
 // =============================================================================
-
-export {
-  outputOption,
-  outputModeLayer,
-  resolveOutputMode,
-  runTuiMain,
-  OUTPUT_MODE_VALUES,
-  type OutputModeValue,
-  type RunTuiMainOptions,
-  type TuiRuntime,
-} from './effect/cli.tsx'
+// Node.js-specific CLI exports (outputOption, outputModeLayer, runTuiMain, etc.)
+// have been moved to '@overeng/tui-react/node' to keep this entry point
+// browser-safe for Storybook and other browser environments.

--- a/packages/@overeng/tui-react/src/node/mod.ts
+++ b/packages/@overeng/tui-react/src/node/mod.ts
@@ -1,0 +1,38 @@
+/**
+ * @overeng/tui-react/node
+ *
+ * Node.js-specific exports for TUI React CLI integration.
+ *
+ * This entry point contains code that depends on Node.js built-in modules
+ * (`node:fs`, etc.) and should NOT be imported in browser/Storybook contexts.
+ *
+ * For browser-safe exports, use `@overeng/tui-react` instead.
+ *
+ * @example
+ * ```typescript
+ * import { outputOption, outputModeLayer, runTuiMain } from '@overeng/tui-react/node'
+ * ```
+ *
+ * @module
+ */
+
+// Node.js environment detection (requires node:fs)
+export {
+  isPiped,
+  isRedirectedToFile,
+  isAgentEnv,
+  detectOutputMode,
+  detectLayer,
+} from '../effect/OutputMode.node.ts'
+
+// Effect CLI integration (requires node:fs transitively via detectOutputMode)
+export {
+  outputOption,
+  outputModeLayer,
+  resolveOutputMode,
+  runTuiMain,
+  OUTPUT_MODE_VALUES,
+  type OutputModeValue,
+  type RunTuiMainOptions,
+  type TuiRuntime,
+} from '../effect/cli.tsx'

--- a/packages/@overeng/tui-react/test/integration/cli-integration.test.tsx
+++ b/packages/@overeng/tui-react/test/integration/cli-integration.test.tsx
@@ -9,15 +9,8 @@ import { Effect, Duration, Schema } from 'effect'
 import React from 'react'
 import { describe, expect, beforeEach, afterEach } from 'vitest'
 
-import {
-  createTuiApp,
-  run,
-  useTuiAtomValue,
-  detectOutputMode,
-  Box,
-  Text,
-  testModeLayer,
-} from '../../src/mod.tsx'
+import { detectOutputMode } from '../../src/effect/OutputMode.node.ts'
+import { createTuiApp, run, useTuiAtomValue, Box, Text, testModeLayer } from '../../src/mod.tsx'
 
 const parseJson = (json: string) =>
   Schema.decodeSync(

--- a/packages/@overeng/tui-react/test/unit/OutputMode.test.ts
+++ b/packages/@overeng/tui-react/test/unit/OutputMode.test.ts
@@ -15,11 +15,6 @@ import {
   altScreen,
   json,
   ndjson,
-  // Detection
-  detectOutputMode,
-  isAgentEnv,
-  isPiped,
-  isRedirectedToFile,
   // Type guards
   isReact,
   isJson,
@@ -33,6 +28,13 @@ import {
   ttyLayer,
   jsonLayer,
 } from '../../src/effect/OutputMode.tsx'
+import {
+  // Detection (Node-only)
+  detectOutputMode,
+  isAgentEnv,
+  isPiped,
+  isRedirectedToFile,
+} from '../../src/effect/OutputMode.node.ts'
 
 import { resolveOutputMode } from '../../src/effect/cli.tsx'
 


### PR DESCRIPTION
## Summary

- **Remove Node.js built-in imports (`node:util`, `node:fs`) from `@overeng/tui-react`'s main `.` entry point** to fix Storybook/Vite builds that externalize Node built-ins for browser compatibility
- **Add new `@overeng/tui-react/node` export path** for Node-only consumers (CLI tools, detection functions)
- **Update all consumers** (genie, megarepo, notion-cli, examples, tests) to import Node-only symbols from the `/node` subpath

## Problem

Storybook builds were failing with:
```
Module "node:util" has been externalized for browser compatibility. Cannot access "node:util.formatWithOptions" in client code.
```

The root cause was that `mod.tsx` (the `.` barrel) transitively imported `node:util` (via `LogCapture.ts`) and `node:fs` (via `OutputMode.tsx`) at the top level.

## Changes

1. **`LogCapture.ts`**: Replaced `import { formatWithOptions } from 'node:util'` with Effect's `Inspectable.toStringUnknown()` (browser-safe)
2. **`OutputMode.tsx` → `OutputMode.node.ts`**: Moved Node-only functions (`isPiped`, `isRedirectedToFile`, `isAgentEnv`, `detectOutputMode`, `detectLayer`) into new `OutputMode.node.ts`
3. **New `src/node/mod.ts`**: Barrel for `@overeng/tui-react/node` that re-exports Node-only symbols including `cli.tsx` exports (`outputOption`, `outputModeLayer`, `runTuiMain`, etc.)
4. **`src/mod.tsx`**: Removed Node-only re-exports (now only in `/node`)
5. **All consumers updated**: Import split between `.` (browser-safe) and `/node` (Node-only)