### PR TITLE
fix: use pkgs.flock for cross-platform setup locking

### DIFF
--- a/nix/devenv-modules/tasks/shared/setup.nix
+++ b/nix/devenv-modules/tasks/shared/setup.nix
@@ -75,8 +75,9 @@
   # Set to [] for non-pnpm setups to use git-hash-only caching.
   innerCacheDirs ? [ "pnpm-install" ],
 }:
-{ lib, config, ... }:
+{ lib, config, pkgs, ... }:
 let
+  flock = "${pkgs.flock}/bin/flock";
   cache = import ../lib/cache.nix { inherit config; };
   cacheRoot = cache.cacheRoot;
   hashFile = cache.mkCachePath "setup-git-hash";
@@ -216,7 +217,7 @@ let
         lockfile="${cacheRoot}/setup-${sanitizeForLockfile t}.lock"
         mkdir -p "$(dirname "$lockfile")"
         exec 200>"$lockfile"
-        if ! flock -w 30 200; then
+        if ! ${flock} -w 30 200; then
           echo "[devenv] ${t} lock timeout after 30s - another process may be stuck" >&2
           echo "[devenv] Try: FORCE_SETUP=1 dt setup:run" >&2
           exit 0


### PR DESCRIPTION
## Summary

- Fix all optional setup tasks silently skipping on macOS due to missing `flock` command
- Use `${pkgs.flock}/bin/flock` (discoteq/flock from nixpkgs) inline instead of bare `flock`

## Problem

The setup wrapper tasks use `flock` for cross-process locking, but `flock` (from `util-linux`) is not available on macOS. When the command is missing, bash returns non-zero, and the wrapper misinterprets this as a lock timeout:

```
[setup:opt:megarepo:sync]! flock: command not found
[setup:opt:megarepo:sync]! [devenv] megarepo:sync lock timeout after 30s
```

This causes **all** optional setup tasks (`megarepo:sync`, `pnpm:install`, `genie:run`, `setup:completions`) to silently exit 0 without running.

## Fix

Use `${pkgs.flock}/bin/flock` — the [discoteq/flock](https://github.com/discoteq/flock) nixpkgs package which provides a cross-platform flock(1) that works on `lib.platforms.all`. The dependency is declared inline where it's used (Nix-idiomatic), not as a global package.

## Test plan

- [x] Verified `pkgs.flock` builds on aarch64-darwin
- [x] Verified fd-based locking pattern works (`exec 200>; flock -w 30 200`)
- [x] Verified lock contention + timeout works correctly
- [x] Clean end-to-end test: removed repos/ + cache → `devenv shell` → all 5 repos synced automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)