### PR TITLE
fix(genie): validate pnpmWorkspaceYaml rejects absolute paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- **@overeng/genie**: Validate `pnpmWorkspaceYaml` rejects absolute paths in `packages` during `genie:check` (#152)
+
 - **devenv**: Netlify deploy tasks for storybook preview deployments
   - New shared `netlify.nix` task module with `netlify:deploy:<name>` per-package tasks
   - Supports prod, PR preview (alias), and local draft deploy modes via `--input` flags

--- a/devenv.lock
+++ b/devenv.lock
@@ -170,11 +170,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769819859,
-        "narHash": "sha256-18ESEN2ZCnik6X2xpMfFtOWcQq/rZrywULnSlYNUsh4=",
+        "lastModified": 1770424747,
+        "narHash": "sha256-dK/r3ieufFTebdrCp2eaphKyglWT+trRtcZAIyOQDSQ=",
         "owner": "pietdevries94",
         "repo": "playwright-web-flake",
-        "rev": "44c0226df3e14d96b27851e32458aed0cc075ae1",
+        "rev": "f6342a859e548b104b3f6024e0c99c667953ad62",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

- Add a `validate` hook to `pnpmWorkspaceYaml()` that rejects absolute paths in the `packages` array during `genie:check`
- Follows the same pattern as `packageJson()` which already has a validate hook for recomposition checking
- Catches non-portable `pnpm-workspace.yaml` output at CI time with a clear error message

Closes #152

See also #153 for a follow-up to run validation during generation too.

## Test plan

- [x] `dt ts:check` passes
- [x] `dt genie:check` passes
- [x] `dt test:genie` passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)