### PR TITLE
feat(ci): add deploy-storybooks as required check

### DIFF
--- a/.github/repo-settings.json
+++ b/.github/repo-settings.json
@@ -43,6 +43,9 @@
           },
           {
             "context": "nix-check (namespace-profile-macos-arm64)"
+          },
+          {
+            "context": "deploy-storybooks"
           }
         ]
       }

--- a/genie/ci.ts
+++ b/genie/ci.ts
@@ -23,4 +23,5 @@ export const requiredCIJobs = [
   // Matrix jobs - GitHub reports these with the matrix value in parentheses
   ...RUNNER_PROFILES.map((runner) => `test (${runner})`),
   ...RUNNER_PROFILES.map((runner) => `nix-check (${runner})`),
+  'deploy-storybooks',
 ] as const


### PR DESCRIPTION
## Summary
- Adds `deploy-storybooks` to the required status checks in branch protection ruleset
- Ruleset already applied to the repo via GitHub API

## Test plan
- [x] `dt check:quick` passes
- [x] Ruleset updated via `gh api` PUT

🤖 Generated with [Claude Code](https://claude.com/claude-code)