### PR TITLE
feat(genie): validate hooks during generation (#153)

### DIFF
--- a/megarepo.lock
+++ b/megarepo.lock
@@ -4,16 +4,16 @@
     "effect": {
       "url": "https://github.com/effect-ts/effect",
       "ref": "main",
-      "commit": "f47c8fa0809cbdfe5665e109dc24a8e0c63b284f",
+      "commit": "6a2c2778021e06181d8704e68af7cce0d96d527e",
       "pinned": false,
-      "lockedAt": "2026-02-06T20:04:10.036Z"
+      "lockedAt": "2026-02-07T10:30:16.889Z"
     },
     "overeng-beads-public": {
       "url": "https://github.com/overengineeringstudio/overeng-beads-public",
       "ref": "main",
-      "commit": "ba138d8f442da625de73e3e7c68be0e83c577a57",
+      "commit": "6a2c2778021e06181d8704e68af7cce0d96d527e",
       "pinned": false,
-      "lockedAt": "2026-02-06T20:04:10.036Z"
+      "lockedAt": "2026-02-07T10:30:16.889Z"
     }
   }
 }

--- a/packages/@overeng/genie/src/build/GenieOutput/stories/Errors.stories.tsx
+++ b/packages/@overeng/genie/src/build/GenieOutput/stories/Errors.stories.tsx
@@ -455,6 +455,39 @@ export const ValidationFailed: Story = {
   },
 }
 
+/** Validation failed during generation (Issue #153) */
+export const ValidationFailedDuringGeneration: Story = {
+  args: {
+    mode: 'generate',
+    interactive: false,
+  },
+  argTypes: {
+    interactive: {
+      control: false,
+    },
+    playbackSpeed: {
+      control: false,
+    },
+  },
+  render: (args) => {
+    const stateConfig = useMemo(
+      () => fixtures.createValidationFailedState({ mode: args.mode }),
+      [args.mode],
+    )
+
+    return (
+      <TuiStoryPreview
+        View={GenieView}
+        app={GenieApp}
+        initialState={stateConfig}
+        height={args.height}
+        autoRun={false}
+        tabs={ALL_OUTPUT_TABS}
+      />
+    )
+  },
+}
+
 /** Files skipped (parent directory missing, etc.) */
 export const WithSkipped: Story = {
   render: (args) => {

--- a/packages/@overeng/genie/src/runtime/mod.ts
+++ b/packages/@overeng/genie/src/runtime/mod.ts
@@ -59,7 +59,7 @@ export type GenieOutput<T> = {
   data: T
   /** Serialize the data to a string for file output */
   stringify: (ctx: GenieContext) => string
-  /** Optional validation hook for genie --check */
+  /** Optional validation hook — runs during both generation and check */
   validate?: (ctx: GenieContext) => GenieValidationIssue[]
 }
 


### PR DESCRIPTION
## Summary
Run `validate()` hooks after successful file generation, not just during `genie --check`. If validation fails, the command now fails immediately instead of silently writing invalid files.

## Changes
- Validation runs after successful generation in `mod.tsx` (before dispatching Complete)
- Updated JSDoc to reflect hooks run during both generation and check modes
- Added integration test for validation failure during generate mode  
- Added Storybook story documenting validation failure in generate mode

## Test Plan
- Existing tests pass (ts:check, genie:run)
- New integration test covers validation failure during generation
- Storybook story displays validation errors in generate mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)