### PR TITLE
fix(devenv/lint): simplify oxfmt to direct invocation with pnpm:install dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **devenv/lint**: Simplify `lint:check:format` by reverting to direct `oxfmt --check` invocation (#157)
+  - Removed `git ls-files` complexity — oxfmt's directory walker already excludes `node_modules`
+  - Added `pnpm:install` dependency to ensure stable `node_modules` state during formatting
+  - Investigation confirmed `experimentalSortImports` uses string-based classification (no filesystem reads)
+
 - **CI/storybook**: Fix storybook builds used by Netlify preview deploys
   - Stub `@opentui/*` in `@overeng/genie` Storybook build (OpenTUI requires Bun runtime)
   - Fix `@overeng/tui-react` examples importing `src/mod.ts` (actual entry is `src/mod.tsx`)

--- a/nix/devenv-modules/tasks/shared/lint-oxc.nix
+++ b/nix/devenv-modules/tasks/shared/lint-oxc.nix
@@ -62,53 +62,6 @@ let
   scanDirsArg = builtins.concatStringsSep " " genieCoverageDirs;
   lintPathsArg = builtins.concatStringsSep " " lintPaths;
 
-  # oxfmt should never enumerate node_modules.
-  #
-  # Why this exists (CI flake prevention):
-  # - lint:check:format historically ran `oxfmt --check <dir>...`, which makes
-  #   oxfmt walk directory trees.
-  # - In this repo, pnpm creates node_modules entries that are *symlinks* into
-  #   workspace packages (e.g. node_modules/@overeng/utils -> ../../../../../utils).
-  # - When installs are running (or cached tasks are interleaving), directory
-  #   traversal can observe transient filesystem states under node_modules and
-  #   fail with "File not found: .../node_modules/...". Ignore patterns help with
-  #   what gets formatted, but they don't fully eliminate traversal/stat races.
-  #
-  # Fix: format only an explicit file list (git-tracked files via pathspec globs),
-  # which avoids directory walking entirely and guarantees node_modules is never
-  # touched.
-  #
-  # Trade-off: untracked files aren't checked until they are added to git.
-  #
-  # Note: We intentionally limit to common source/config docs that oxfmt supports.
-  formatExtensions = [
-    "ts"
-    "tsx"
-    "js"
-    "jsx"
-    "mts"
-    "cts"
-    "mjs"
-    "cjs"
-    "json"
-    "md"
-  ];
-  formatPathspecs =
-    lib.concatMap
-      (p:
-        map
-          (ext:
-            let
-              glob = "**/*.${ext}";
-              prefix = if p == "." then "" else "${p}/";
-            in
-            ":(glob)${prefix}${glob}"
-          )
-          formatExtensions
-      )
-      lintPaths;
-  formatPathspecArg = builtins.concatStringsSep " " (map lib.escapeShellArg formatPathspecs);
-
   # Type-aware linting flags (enabled when tsconfig is provided)
   typeAwareFlags = if tsconfig != null then "--type-aware --tsconfig ${tsconfig}" else "";
 in
@@ -121,18 +74,8 @@ in
     # Uses default config files (.oxfmtrc.json, .oxlintrc.json) - no -c flags needed
     "lint:check:format" = {
       description = "Check code formatting with oxfmt";
-      exec = ''
-        set -euo pipefail
-
-        bytes="$(git ls-files -z -- ${formatPathspecArg} | wc -c)"
-        if [ "''${bytes}" -eq 0 ]; then
-          echo "[oxfmt] No tracked files found for formatting."
-          exit 0
-        fi
-
-        git ls-files -z -- ${formatPathspecArg} | xargs -0 -n 200 oxfmt --check
-      '';
-      after = [ "genie:run" ];
+      exec = "oxfmt --check ${lintPathsArg}";
+      after = [ "genie:run" "pnpm:install" ];
       execIfModified = execIfModifiedPatterns;
     };
     "lint:check:oxlint" = {
@@ -174,17 +117,8 @@ in
     # Lint fix tasks
     "lint:fix:format" = {
       description = "Fix code formatting with oxfmt";
-      exec = ''
-        set -euo pipefail
-
-        bytes="$(git ls-files -z -- ${formatPathspecArg} | wc -c)"
-        if [ "''${bytes}" -eq 0 ]; then
-          echo "[oxfmt] No tracked files found for formatting."
-          exit 0
-        fi
-
-        git ls-files -z -- ${formatPathspecArg} | xargs -0 -n 200 oxfmt
-      '';
+      exec = "oxfmt ${lintPathsArg}";
+      after = [ "pnpm:install" ];
     };
     "lint:fix:oxlint" = {
       description = "Fix lint issues with oxlint";


### PR DESCRIPTION
## Summary

Closes #157.

- Reverts `lint:check:format` from complex `git ls-files | xargs oxfmt` to simple `oxfmt --check .`
- Adds `pnpm:install` as a dependency for format tasks to ensure stable `node_modules` state
- Removes ~60 lines of `git ls-files` plumbing (formatExtensions, formatPathspecs, etc.)

## Root cause (not oxfmt!)

The CI flake is caused by **devenv's `execIfModified` glob expansion** following symlinks into `node_modules` (known upstream issue: cachix/devenv#2422, fix in progress: cachix/devenv#2423).

1. `execIfModified` patterns with `**` follow pnpm workspace symlinks into `node_modules`
2. After oxfmt finishes, devenv expands globs and calls `std::fs::metadata()` for each match
3. Concurrent `pnpm:install:*` tasks modify symlink targets between glob expansion and metadata read
4. `metadata()` → `CacheError::FileNotFound` → "Task failed"

**Minimal repro**: https://github.com/schickling-repros/devenv-execifmodified-glob-symlink (reproduces on attempt 1)

## Investigation findings

Parallel investigation (strace + source code analysis of oxfmt/oxc) confirmed:
- `experimentalSortImports` does NOT read `node_modules` — purely string-based classification
- `experimentalSortPackageJson` does NOT read `node_modules` — in-memory JSON reordering
- oxfmt's directory walker already excludes `node_modules` via the `ignore` crate

## Trade-off

Adding `pnpm:install` as a dependency serializes format after installs. This is the correct workaround until devenv adds negation pattern support upstream (cachix/devenv#2423).

## Test plan

- [x] `dt lint:check` passes
- [x] `dt check:quick` passes
- [x] Repro script verified locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)