### PR TITLE
chore(devenv/lint): add TODO for dropping pnpm:install workaround

### DIFF
--- a/nix/devenv-modules/tasks/shared/lint-oxc.nix
+++ b/nix/devenv-modules/tasks/shared/lint-oxc.nix
@@ -75,18 +75,26 @@ in
     "lint:check:format" = {
       description = "Check code formatting with oxfmt";
       exec = "oxfmt --check ${lintPathsArg}";
+      # TODO: Drop "pnpm:install" dep once devenv supports glob negation patterns (e.g. !**/node_modules/**)
+      #   Upstream issue: https://github.com/cachix/devenv/issues/2422
+      #   Upstream fix:   https://github.com/cachix/devenv/pull/2423
       after = [ "genie:run" "pnpm:install" ];
       execIfModified = execIfModifiedPatterns;
     };
     "lint:check:oxlint" = {
       description = "Run oxlint linter";
       exec = "oxlint --import-plugin --deny-warnings ${typeAwareFlags} ${lintPathsArg}";
+      # TODO: Drop "pnpm:install" dep once devenv supports glob negation patterns (e.g. !**/node_modules/**)
+      #   Upstream issue: https://github.com/cachix/devenv/issues/2422
+      #   Upstream fix:   https://github.com/cachix/devenv/pull/2423
       after = [ "genie:run" "pnpm:install" ];
       execIfModified = execIfModifiedPatterns;
     };
     "lint:check:genie" = {
       description = "Check generated files are up to date";
       exec = "genie --check";
+      # TODO: Drop "pnpm:install" dep once devenv supports glob negation patterns
+      #   See: https://github.com/cachix/devenv/issues/2422, https://github.com/cachix/devenv/pull/2423
       after = [ "pnpm:install" ];
       execIfModified = geniePatterns;
     };
@@ -118,6 +126,8 @@ in
     "lint:fix:format" = {
       description = "Fix code formatting with oxfmt";
       exec = "oxfmt ${lintPathsArg}";
+      # TODO: Drop "pnpm:install" dep once devenv supports glob negation patterns
+      #   See: https://github.com/cachix/devenv/issues/2422, https://github.com/cachix/devenv/pull/2423
       after = [ "pnpm:install" ];
     };
     "lint:fix:oxlint" = {


### PR DESCRIPTION
## Summary

- Adds TODO comments to lint task `pnpm:install` dependencies linking to upstream devenv issues
- The `pnpm:install` dep was added in #158 as a workaround for devenv's `execIfModified` glob following symlinks into `node_modules`
- Once [cachix/devenv#2422](https://github.com/cachix/devenv/issues/2422) lands (via [PR #2423](https://github.com/cachix/devenv/pull/2423) — glob negation pattern support), we can drop the `pnpm:install` dependency and restore full parallelism

## Test plan

- [ ] No functional changes — only comments added

🤖 Generated with [Claude Code](https://claude.com/claude-code)