### PR TITLE
fix(pnpm): handle megarepo peer repo paths in toName

### DIFF
--- a/nix/devenv-modules/tasks/shared/pnpm.nix
+++ b/nix/devenv-modules/tasks/shared/pnpm.nix
@@ -90,11 +90,15 @@ let
   # "apps/example.com" -> "example-com"
   # "tests/wa-sqlite" -> "tests-wa-sqlite"
   # "scripts" -> "scripts"
+  # "repos/effect-utils/packages/@overeng/oxc-config" -> "oxc-config"
   toName = path:
     let
       sanitize = s: builtins.replaceStrings ["/" "."] ["-" "-"] s;
+      # Strip "repos/*/packages/" prefix for megarepo peer repo paths
+      repoStripped = let m = builtins.match "repos/[^/]+/packages/(.*)" path;
+        in if m != null then builtins.head m else path;
       # Only strip "packages/" or "apps/" prefix, keep others like "tests/"
-      stripped = lib.removePrefix "apps/" (lib.removePrefix "packages/" path);
+      stripped = lib.removePrefix "apps/" (lib.removePrefix "packages/" repoStripped);
       # Strip @scope/ pattern (e.g., "@overeng/foo" -> "foo")
       m = builtins.match "@[^/]+/(.*)" stripped;
       final = if m != null then builtins.head m else stripped;


### PR DESCRIPTION
## Summary
- Fix `toName` in `pnpm.nix` to handle `repos/*/packages/` paths from megarepo peer repos
- Without this, paths like `repos/effect-utils/packages/@overeng/oxc-config` produce `InvalidTaskName` because the `@` character isn't stripped

## Context
Peer repos need to install effect-utils packages via `pnpmPackages` (e.g., `oxc-config` for `eslint-plugin-storybook` resolution). The `toName` function strips `packages/` and `@scope/` prefixes but didn't handle the `repos/*/packages/` prefix that megarepo paths use.

### Before
```
"repos/effect-utils/packages/@overeng/oxc-config"
→ sanitize("repos/effect-utils/packages/@overeng/oxc-config")
→ "repos-effect-utils-packages-@overeng-oxc-config"  ← InvalidTaskName (@ is invalid)
```

### After
```
"repos/effect-utils/packages/@overeng/oxc-config"
→ strip "repos/*/packages/" → "@overeng/oxc-config"
→ strip "@scope/" → "oxc-config"
→ "oxc-config" ✅
```