### PR TITLE
fix(devenv): use absolute nix paths for git and coreutils in task modules

### DIFF
--- a/nix/devenv-modules/tasks/shared/beads.nix
+++ b/nix/devenv-modules/tasks/shared/beads.nix
@@ -32,6 +32,7 @@
 { beadsPrefix, beadsRepoName, beadsRepoPath ? "repos/${beadsRepoName}" }:
 { pkgs, config, ... }:
 let
+  git = "${pkgs.git}/bin/git";
   beadsRepoRelPath = beadsRepoPath;
 in
 {
@@ -98,13 +99,13 @@ in
       cd "''${BEADS_DIR%/.beads}"
 
       # Safety: commit any uncommitted changes (in case daemon wasn't running)
-      if ! git diff --quiet .beads/ 2>/dev/null || ! git diff --cached --quiet .beads/ 2>/dev/null; then
-        git add .beads/
-        git commit -m "beads: sync issues" 2>&1
+      if ! ${git} diff --quiet .beads/ 2>/dev/null || ! ${git} diff --cached --quiet .beads/ 2>/dev/null; then
+        ${git} add .beads/
+        ${git} commit -m "beads: sync issues" 2>&1
       fi
 
       echo "[beads] Pushing..."
-      git push 2>&1
+      ${git} push 2>&1
       echo "[beads] Sync complete."
     '';
   };
@@ -117,15 +118,15 @@ in
     entry = "${pkgs.writeShellScript "beads-post-commit" ''
       set -euo pipefail
 
-      GIT_ROOT="$(git rev-parse --show-toplevel)"
+      GIT_ROOT="$(${git} rev-parse --show-toplevel)"
       BEADS_REPO="''${GIT_ROOT}/${beadsRepoRelPath}"
 
       # Skip if beads repo doesn't exist
       [ ! -d "$BEADS_REPO/.beads" ] && exit 0
 
       # Get commit info
-      COMMIT_SHORT=$(git rev-parse --short HEAD)
-      COMMIT_MSG=$(git log -1 --format=%B)
+      COMMIT_SHORT=$(${git} rev-parse --short HEAD)
+      COMMIT_MSG=$(${git} log -1 --format=%B)
       REPO_NAME=$(basename "$GIT_ROOT")
 
       # Extract issue references matching (prefix-xxx) pattern

--- a/nix/devenv-modules/tasks/shared/git-hooks-fix.nix
+++ b/nix/devenv-modules/tasks/shared/git-hooks-fix.nix
@@ -10,6 +10,7 @@
 { config, lib, pkgs, ... }:
 
 let
+  git = "${pkgs.git}/bin/git";
   # Get the list of hook stages from git-hooks config
   # We need to check if the actual hook files exist for each configured stage
   configuredStages = lib.pipe config.git-hooks.hooks [
@@ -27,7 +28,7 @@ in
     description = "Ensure git hooks are actually installed (workaround for cachix/devenv#2455)";
     exec = ''
       # Skip if not in a git repo
-      if ! git rev-parse --git-dir &>/dev/null; then
+      if ! ${git} rev-parse --git-dir &>/dev/null; then
         exit 0
       fi
 
@@ -36,23 +37,23 @@ in
         exit 0
       fi
 
-      HOOKS_DIR=$(git rev-parse --git-common-dir)/hooks
+      HOOKS_DIR=$(${git} rev-parse --git-common-dir)/hooks
       INSTALLED_ANY=0
 
       for stage in ${stagesStr}; do
         if [ ! -f "$HOOKS_DIR/$stage" ]; then
           echo "[git-hooks:ensure] Installing missing hook: $stage"
           # Clear core.hooksPath temporarily so prek doesn't refuse
-          HOOKS_PATH=$(git config --local core.hooksPath 2>/dev/null || true)
+          HOOKS_PATH=$(${git} config --local core.hooksPath 2>/dev/null || true)
           if [ -n "$HOOKS_PATH" ]; then
-            git config --local --unset core.hooksPath
+            ${git} config --local --unset core.hooksPath
           fi
 
           ${prek}/bin/prek install -c .pre-commit-config.yaml -t "$stage" 2>/dev/null || true
 
           # Restore core.hooksPath
           if [ -n "$HOOKS_PATH" ]; then
-            git config --local core.hooksPath "$HOOKS_PATH"
+            ${git} config --local core.hooksPath "$HOOKS_PATH"
           fi
 
           INSTALLED_ANY=1

--- a/nix/devenv-modules/tasks/shared/megarepo.nix
+++ b/nix/devenv-modules/tasks/shared/megarepo.nix
@@ -15,6 +15,8 @@ let
   trace = import ../lib/trace.nix { inherit lib; };
 in
 {
+  # mr shells out to git for clone/fetch/worktree operations
+  packages = [ pkgs.git pkgs.openssh ];
   tasks."megarepo:sync" = {
     description = "Sync megarepo members (clone repos, create symlinks)";
     exec = trace.exec "megarepo:sync" ''

--- a/nix/devenv-modules/tasks/shared/netlify.nix
+++ b/nix/devenv-modules/tasks/shared/netlify.nix
@@ -32,6 +32,7 @@
 }:
 { lib, pkgs, ... }:
 let
+  git = "${pkgs.git}/bin/git";
   hasPackages = packages != [];
 
   mkDeployTask = pkg: {
@@ -60,7 +61,7 @@ let
         # Parse deploy context from DEVENV_TASK_INPUT (set by devenv --input flag)
         input="''${DEVENV_TASK_INPUT:-"{}"}"
         deploy_type="$(echo "$input" | ${pkgs.jq}/bin/jq -r '.type // "draft"')"
-        short_sha="$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")"
+        short_sha="$(${git} rev-parse --short HEAD 2>/dev/null || echo "unknown")"
 
         alias_flag=""
         message="${pkg.name}"

--- a/nix/devenv-modules/tasks/shared/pnpm.nix
+++ b/nix/devenv-modules/tasks/shared/pnpm.nix
@@ -78,7 +78,7 @@
 # Set globalCache = false to disable (not recommended for megarepo setups).
 #
 { packages, globalCache ? true }:
-{ lib, config, ... }:
+{ lib, config, pkgs, ... }:
 let
   trace = import ../lib/trace.nix { inherit lib; };
   cache = import ../lib/cache.nix { inherit config; };
@@ -156,13 +156,10 @@ let
   # =============================================================================
   #
   # Hash function that works on both Linux (sha256sum) and macOS (shasum)
+  sha256sum = "${pkgs.coreutils}/bin/sha256sum";
   computeHashFn = ''
     compute_hash() {
-      if command -v sha256sum >/dev/null 2>&1; then
-        sha256sum | awk '{print $1}'
-      else
-        shasum -a 256 | awk '{print $1}'
-      fi
+      ${sha256sum} | awk '{print $1}'
     }
   '';
 


### PR DESCRIPTION
## Summary
- Replace bare `git` calls with `${pkgs.git}/bin/git` absolute nix paths in beads.nix, git-hooks-fix.nix, and netlify.nix — ensures tasks work even when git isn't on the devenv PATH
- Add `pkgs.git` and `pkgs.openssh` to megarepo.nix `packages` — the `mr` binary shells out to git internally, so it needs git on PATH from the module itself
- Replace platform-sniffing `sha256sum`/`shasum` fallback in pnpm.nix with `${pkgs.coreutils}/bin/sha256sum`

Follow-up to #165 which fixed the same issue in setup.nix.

## Test plan
- [ ] CI passes
- [ ] `devenv shell` works in a consumer repo without `pkgs.git` in its packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)