### PR TITLE
feat: add cmdCollect() utility

### DIFF
--- a/packages/@overeng/utils/src/node/cmd.ts
+++ b/packages/@overeng/utils/src/node/cmd.ts
@@ -298,75 +298,71 @@ export interface CmdCollectResult {
  * Errors:
  * - Propagates `PlatformError` for execution failures.
  */
-export const cmdCollect: <R = never>(
-  commandInput: string | (string | undefined)[],
-  options?: {
-    onOutput?: (stream: 'stdout' | 'stderr', line: string) => Effect.Effect<void, never, R>
-    env?: Record<string, string | undefined>
-    shell?: boolean
-    workingDirectory?: string
-  },
-) => Effect.Effect<
+export const cmdCollect = <R = never>(opts: {
+  readonly commandInput: string | (string | undefined)[]
+  readonly onOutput?: (stream: 'stdout' | 'stderr', line: string) => Effect.Effect<void, never, R>
+  readonly env?: Record<string, string | undefined>
+  readonly shell?: boolean
+  readonly workingDirectory?: string
+}): Effect.Effect<
   CmdCollectResult,
   PlatformError,
   CommandExecutor.CommandExecutor | CurrentWorkingDirectory | R
-> = Effect.fn('cmdCollect')(function* (commandInput, options) {
-  const cwd = options?.workingDirectory ?? (yield* CurrentWorkingDirectory)
+> =>
+  Effect.gen(function* () {
+    const cwd = opts.workingDirectory ?? (yield* CurrentWorkingDirectory)
 
-  const useShell = !!options?.shell
+    const useShell = !!opts.shell
 
-  // Preserve raw string input for buildCommand's shell-mode path (avoids
-  // splitting on spaces, which would break leading-whitespace commands).
-  const normalizedInput: string | string[] = Array.isArray(commandInput)
-    ? (commandInput as (string | undefined)[]).filter(isNotUndefined)
-    : useShell
-      ? (commandInput as string)
-      : (commandInput as string).split(' ')
+    // Preserve raw string input for buildCommand's shell-mode path (avoids
+    // splitting on spaces, which would break leading-whitespace commands).
+    const normalizedInput: string | string[] = Array.isArray(opts.commandInput)
+      ? (opts.commandInput as (string | undefined)[]).filter(isNotUndefined)
+      : useShell
+        ? (opts.commandInput as string)
+        : (opts.commandInput as string).split(' ')
 
-  const debugStr = Array.isArray(normalizedInput) ? normalizedInput.join(' ') : normalizedInput
+    const debugStr = Array.isArray(normalizedInput) ? normalizedInput.join(' ') : normalizedInput
 
-  yield* Effect.logDebug(`Collecting '${debugStr}' in '${cwd}'`)
+    yield* Effect.logDebug(`Collecting '${debugStr}' in '${cwd}'`)
 
-  const cmd = buildCommand({ input: normalizedInput, useShell }).pipe(
-    Command.stdout('pipe'),
-    Command.stderr('pipe'),
-    Command.workingDirectory(cwd),
-    useShell ? Command.runInShell(true) : identity,
-    Command.env(options?.env ?? {}),
-  )
+    const cmd = buildCommand({ input: normalizedInput, useShell }).pipe(
+      Command.stdout('pipe'),
+      Command.stderr('pipe'),
+      Command.workingDirectory(cwd),
+      useShell ? Command.runInShell(true) : identity,
+      Command.env(opts.env ?? {}),
+    )
 
-  const safeOnOutput = (stream: 'stdout' | 'stderr', line: string) =>
-    options?.onOutput
-      ? options.onOutput(stream, line).pipe(Effect.catchAll(() => Effect.void))
-      : Effect.void
+    const { onOutput } = opts
 
-  return yield* Effect.scoped(
-    Command.start(cmd).pipe(
-      Effect.flatMap((proc) =>
-        Effect.all(
-          {
-            stdout: proc.stdout.pipe(
-              Stream.decodeText('utf8'),
-              Stream.splitLines,
-              Stream.tap((line) => safeOnOutput('stdout', line)),
-              Stream.runCollect,
-              Effect.map(Chunk.toReadonlyArray),
-            ),
-            stderr: proc.stderr.pipe(
-              Stream.decodeText('utf8'),
-              Stream.splitLines,
-              Stream.tap((line) => safeOnOutput('stderr', line)),
-              Stream.runCollect,
-              Effect.map(Chunk.toReadonlyArray),
-            ),
-            exitCode: proc.exitCode,
-          },
-          { concurrency: 'unbounded' },
+    return yield* Effect.scoped(
+      Command.start(cmd).pipe(
+        Effect.flatMap((proc) =>
+          Effect.all(
+            {
+              stdout: proc.stdout.pipe(
+                Stream.decodeText('utf8'),
+                Stream.splitLines,
+                Stream.tap((line) => (onOutput ? onOutput('stdout', line) : Effect.void)),
+                Stream.runCollect,
+                Effect.map(Chunk.toReadonlyArray),
+              ),
+              stderr: proc.stderr.pipe(
+                Stream.decodeText('utf8'),
+                Stream.splitLines,
+                Stream.tap((line) => (onOutput ? onOutput('stderr', line) : Effect.void)),
+                Stream.runCollect,
+                Effect.map(Chunk.toReadonlyArray),
+              ),
+              exitCode: proc.exitCode,
+            },
+            { concurrency: 'unbounded' },
+          ),
         ),
       ),
-    ),
-  )
-}) as any
+    )
+  }).pipe(Effect.withSpan('cmdCollect'))
 
 /** Internal error for process signal operations */
 class ProcessSignalError extends Schema.TaggedError<ProcessSignalError>()('ProcessSignalError', {

--- a/packages/@overeng/utils/src/node/cmd.unit.test.ts
+++ b/packages/@overeng/utils/src/node/cmd.unit.test.ts
@@ -151,7 +151,7 @@ Vitest.describe('cmdCollect', () => {
     'collects stdout lines',
     Effect.fnUntraced(
       function* () {
-        const result = yield* cmdCollect(['echo', 'hello'])
+        const result = yield* cmdCollect({ commandInput: ['echo', 'hello'] })
         expect(result.stdout).toEqual(['hello'])
         expect(result.exitCode).toBe(0)
       },
@@ -164,7 +164,7 @@ Vitest.describe('cmdCollect', () => {
     'collects stderr lines',
     Effect.fnUntraced(
       function* () {
-        const result = yield* cmdCollect(['bun', '-e', "console.error('oops')"])
+        const result = yield* cmdCollect({ commandInput: ['bun', '-e', "console.error('oops')"] })
         expect(result.stderr).toEqual(['oops'])
         expect(result.exitCode).toBe(0)
       },
@@ -178,15 +178,17 @@ Vitest.describe('cmdCollect', () => {
     Effect.fnUntraced(
       function* () {
         const lines: Array<{ stream: string; line: string }> = []
-        const result = yield* cmdCollect(
-          ['bun', '-e', "console.log('out1'); console.log('out2'); console.error('err1')"],
-          {
-            onOutput: (stream, line) =>
-              Effect.sync(() => {
-                lines.push({ stream, line })
-              }),
-          },
-        )
+        const result = yield* cmdCollect({
+          commandInput: [
+            'bun',
+            '-e',
+            "console.log('out1'); console.log('out2'); console.error('err1')",
+          ],
+          onOutput: (stream, line) =>
+            Effect.sync(() => {
+              lines.push({ stream, line })
+            }),
+        })
         expect(result.stdout).toEqual(['out1', 'out2'])
         expect(result.stderr).toEqual(['err1'])
         expect(result.exitCode).toBe(0)
@@ -203,7 +205,7 @@ Vitest.describe('cmdCollect', () => {
     'returns non-zero exit code without failing',
     Effect.fnUntraced(
       function* () {
-        const result = yield* cmdCollect(['bun', '-e', 'process.exit(42)'])
+        const result = yield* cmdCollect({ commandInput: ['bun', '-e', 'process.exit(42)'] })
         expect(result.exitCode).toBe(42)
       },
       Effect.provide(TestLayer),


### PR DESCRIPTION
## Summary
- Adds `cmdCollect()` to `@overeng/utils/node` for running a command and collecting stdout/stderr as `readonly string[]` with an optional per-line `onOutput` callback
- Generic `R` parameter on `onOutput` propagates context requirements to the return type automatically
- Includes 4 unit tests covering basic collection, stderr, onOutput callback, and exit code passthrough

## Test plan
- [x] `vitest run src/node/cmd.unit.test.ts` — all 4 new tests pass
- [ ] Downstream consumer (pimuseum-cli) uses `cmdCollect()` to replace manual stream handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)