### PR TITLE
fix(megarepo/sync): include nested errors in sync output

### DIFF
--- a/packages/@overeng/megarepo/docs/commands.md
+++ b/packages/@overeng/megarepo/docs/commands.md
@@ -21,7 +21,7 @@ mr init
 Ensure worktrees exist and symlinks are correct.
 
 ```bash
-mr sync [--pull] [--force] [--frozen] [--deep] [--only <members>] [--skip <members>] [--dry-run]
+mr sync [--pull] [--force] [--frozen] [--all] [--only <members>] [--skip <members>] [--dry-run]
 ```
 
 **Options:**
@@ -31,7 +31,7 @@ mr sync [--pull] [--force] [--frozen] [--deep] [--only <members>] [--skip <membe
 | `--pull`    | Fetch from remote and update to latest commits |
 | `--force`   | Override dirty worktree checks                 |
 | `--frozen`  | CI mode: fail if lock is missing or stale      |
-| `--deep`    | Recursively sync nested megarepos              |
+| `--all`     | Recursively sync nested megarepos              |
 | `--only`    | Only sync specified members (comma-separated)  |
 | `--skip`    | Skip specified members (comma-separated)       |
 | `--dry-run` | Show what would be done without making changes |
@@ -53,6 +53,18 @@ mr sync [--pull] [--force] [--frozen] [--deep] [--only <members>] [--skip <membe
 - Lock MUST cover all config members
 - Uses locked commits exactly
 - Fails if config has members not in lock
+
+**JSON output (`--output json` / `--output ndjson`):**
+
+The sync command emits a machine-readable state object.
+
+- `_tag`: one of `Syncing` | `Success` | `Error` | `Interrupted`
+- `results`: root megarepo member results (direct members only)
+- `syncErrors`: flattened list of all errors across the full nested tree (includes nested megarepos)
+- `syncErrorCount`: total number of errors across the full nested tree
+- `syncTree`: full recursive tree for `--all` runs (root + nested results)
+
+This means `mr sync --all` can fail because of nested errors even if all root-level members succeeded; the nested failures are discoverable via `syncErrors` and `syncTree`.
 
 ### `mr add`
 

--- a/packages/@overeng/megarepo/docs/workflows.md
+++ b/packages/@overeng/megarepo/docs/workflows.md
@@ -227,10 +227,10 @@ mr sync
 
 # Note about nested megarepos will be shown
 # Note: 1 member(s) contain nested megarepos (member-name)
-#       Run 'mr sync --deep' to sync them, or 'cd repos/<member> && mr sync'
+#       Run 'mr sync --all' to sync them, or 'cd repos/<member> && mr sync'
 
 # Sync recursively
-mr sync --deep
+mr sync --all
 ```
 
 ## Store Management

--- a/packages/@overeng/megarepo/src/cli/renderers/SyncOutput/app.ts
+++ b/packages/@overeng/megarepo/src/cli/renderers/SyncOutput/app.ts
@@ -16,6 +16,7 @@ export const createInitialSyncState = (params: {
   workspaceName: string
   workspaceRoot: string
 }): typeof SyncState.Type => ({
+  _tag: 'Syncing',
   workspace: {
     name: params.workspaceName,
     root: params.workspaceRoot,
@@ -26,13 +27,22 @@ export const createInitialSyncState = (params: {
     pull: false,
     all: false,
   },
-  phase: 'idle',
   members: [],
+  activeMember: null,
   results: [],
   logs: [],
+  startedAt: null,
   nestedMegarepos: [],
   generatedFiles: [],
   lockSyncResults: [],
+  syncTree: {
+    root: params.workspaceRoot,
+    results: [],
+    nestedMegarepos: [],
+    nestedResults: [],
+  },
+  syncErrors: [],
+  syncErrorCount: 0,
 })
 
 /**
@@ -57,9 +67,8 @@ export const SyncApp = createTuiApp({
   initial: createInitialSyncState({ workspaceName: '', workspaceRoot: '' }),
   reducer: syncReducer,
   exitCode: (state) => {
-    if (state.phase === 'interrupted') return 130 // SIGINT
-    const hasErrors = state.results.some((r) => r.status === 'error')
-    if (hasErrors) return 1
+    if (state._tag === 'Interrupted') return 130 // SIGINT
+    if (state._tag === 'Error') return 1
     return 0
   },
 })

--- a/packages/@overeng/megarepo/src/cli/renderers/SyncOutput/stories/Issues.stories.tsx
+++ b/packages/@overeng/megarepo/src/cli/renderers/SyncOutput/stories/Issues.stories.tsx
@@ -78,7 +78,9 @@ export const WithErrors: Story = {
       <TuiStoryPreview
         View={SyncView}
         app={SyncApp}
-        initialState={fixtures.createBaseState(args.interactive ? { phase: 'idle' } : stateConfig)}
+        initialState={fixtures.createBaseState(
+          args.interactive ? { _tag: 'Success' } : stateConfig,
+        )}
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
@@ -109,7 +111,9 @@ export const AllErrors: Story = {
       <TuiStoryPreview
         View={SyncView}
         app={SyncApp}
-        initialState={fixtures.createBaseState(args.interactive ? { phase: 'idle' } : stateConfig)}
+        initialState={fixtures.createBaseState(
+          args.interactive ? { _tag: 'Success' } : stateConfig,
+        )}
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
@@ -140,7 +144,9 @@ export const SkippedMembers: Story = {
       <TuiStoryPreview
         View={SyncView}
         app={SyncApp}
-        initialState={fixtures.createBaseState(args.interactive ? { phase: 'idle' } : stateConfig)}
+        initialState={fixtures.createBaseState(
+          args.interactive ? { _tag: 'Success' } : stateConfig,
+        )}
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
@@ -172,7 +178,9 @@ export const MixedSkipped: Story = {
       <TuiStoryPreview
         View={SyncView}
         app={SyncApp}
-        initialState={fixtures.createBaseState(args.interactive ? { phase: 'idle' } : stateConfig)}
+        initialState={fixtures.createBaseState(
+          args.interactive ? { _tag: 'Success' } : stateConfig,
+        )}
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
@@ -220,7 +228,9 @@ export const RefMismatchDetected: Story = {
       <TuiStoryPreview
         View={SyncView}
         app={SyncApp}
-        initialState={fixtures.createBaseState(args.interactive ? { phase: 'idle' } : stateConfig)}
+        initialState={fixtures.createBaseState(
+          args.interactive ? { _tag: 'Success' } : stateConfig,
+        )}
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
@@ -237,7 +247,7 @@ export const Interrupted: Story = {
     const stateConfig = useMemo(
       () => ({
         options: { dryRun: args.dryRun, frozen: args.frozen, pull: args.pull, all: args.all },
-        phase: 'interrupted' as const,
+        _tag: 'Interrupted' as const,
         members: ['effect', 'effect-utils', 'livestore', 'dotfiles'],
         results: [
           { name: 'effect', status: 'synced' as const, ref: 'main' },
@@ -250,7 +260,9 @@ export const Interrupted: Story = {
       <TuiStoryPreview
         View={SyncView}
         app={SyncApp}
-        initialState={fixtures.createBaseState(args.interactive ? { phase: 'idle' } : stateConfig)}
+        initialState={fixtures.createBaseState(
+          args.interactive ? { _tag: 'Success' } : stateConfig,
+        )}
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}

--- a/packages/@overeng/megarepo/src/cli/renderers/SyncOutput/stories/Success.stories.tsx
+++ b/packages/@overeng/megarepo/src/cli/renderers/SyncOutput/stories/Success.stories.tsx
@@ -91,7 +91,9 @@ export const MixedResults: Story = {
       <TuiStoryPreview
         View={SyncView}
         app={SyncApp}
-        initialState={fixtures.createBaseState(args.interactive ? { phase: 'idle' } : stateConfig)}
+        initialState={fixtures.createBaseState(
+          args.interactive ? { _tag: 'Success' } : stateConfig,
+        )}
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
@@ -124,7 +126,9 @@ export const AllSynced: Story = {
       <TuiStoryPreview
         View={SyncView}
         app={SyncApp}
-        initialState={fixtures.createBaseState(args.interactive ? { phase: 'idle' } : stateConfig)}
+        initialState={fixtures.createBaseState(
+          args.interactive ? { _tag: 'Success' } : stateConfig,
+        )}
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
@@ -163,7 +167,9 @@ export const FirstSync: Story = {
       <TuiStoryPreview
         View={SyncView}
         app={SyncApp}
-        initialState={fixtures.createBaseState(args.interactive ? { phase: 'idle' } : stateConfig)}
+        initialState={fixtures.createBaseState(
+          args.interactive ? { _tag: 'Success' } : stateConfig,
+        )}
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
@@ -209,7 +215,9 @@ export const LockUpdates: Story = {
       <TuiStoryPreview
         View={SyncView}
         app={SyncApp}
-        initialState={fixtures.createBaseState(args.interactive ? { phase: 'idle' } : stateConfig)}
+        initialState={fixtures.createBaseState(
+          args.interactive ? { _tag: 'Success' } : stateConfig,
+        )}
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
@@ -253,7 +261,9 @@ export const RemovedMembers: Story = {
       <TuiStoryPreview
         View={SyncView}
         app={SyncApp}
-        initialState={fixtures.createBaseState(args.interactive ? { phase: 'idle' } : stateConfig)}
+        initialState={fixtures.createBaseState(
+          args.interactive ? { _tag: 'Success' } : stateConfig,
+        )}
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
@@ -291,7 +301,9 @@ export const WithGenerators: Story = {
       <TuiStoryPreview
         View={SyncView}
         app={SyncApp}
-        initialState={fixtures.createBaseState(args.interactive ? { phase: 'idle' } : stateConfig)}
+        initialState={fixtures.createBaseState(
+          args.interactive ? { _tag: 'Success' } : stateConfig,
+        )}
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
@@ -323,7 +335,9 @@ export const SingleMember: Story = {
       <TuiStoryPreview
         View={SyncView}
         app={SyncApp}
-        initialState={fixtures.createBaseState(args.interactive ? { phase: 'idle' } : stateConfig)}
+        initialState={fixtures.createBaseState(
+          args.interactive ? { _tag: 'Success' } : stateConfig,
+        )}
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
@@ -362,7 +376,9 @@ export const ManyMembers: Story = {
       <TuiStoryPreview
         View={SyncView}
         app={SyncApp}
-        initialState={fixtures.createBaseState(args.interactive ? { phase: 'idle' } : stateConfig)}
+        initialState={fixtures.createBaseState(
+          args.interactive ? { _tag: 'Success' } : stateConfig,
+        )}
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
@@ -399,7 +415,9 @@ export const NestedMegarepos: Story = {
       <TuiStoryPreview
         View={SyncView}
         app={SyncApp}
-        initialState={fixtures.createBaseState(args.interactive ? { phase: 'idle' } : stateConfig)}
+        initialState={fixtures.createBaseState(
+          args.interactive ? { _tag: 'Success' } : stateConfig,
+        )}
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}
@@ -440,7 +458,9 @@ export const WithLockSync: Story = {
       <TuiStoryPreview
         View={SyncView}
         app={SyncApp}
-        initialState={fixtures.createBaseState(args.interactive ? { phase: 'idle' } : stateConfig)}
+        initialState={fixtures.createBaseState(
+          args.interactive ? { _tag: 'Success' } : stateConfig,
+        )}
         height={args.height}
         autoRun={args.interactive}
         playbackSpeed={args.playbackSpeed}

--- a/packages/@overeng/megarepo/src/cli/renderers/SyncOutput/ui.ts
+++ b/packages/@overeng/megarepo/src/cli/renderers/SyncOutput/ui.ts
@@ -147,6 +147,7 @@ export const startSyncUI = (options: {
     tui.dispatch({
       _tag: 'SetState',
       state: {
+        _tag: 'Syncing',
         workspace: { name: workspaceName, root: workspaceRoot },
         options: {
           dryRun: dryRun ?? false,
@@ -158,13 +159,22 @@ export const startSyncUI = (options: {
           skippedMembers:
             skippedMembers && skippedMembers.length > 0 ? [...skippedMembers] : undefined,
         },
-        phase: 'syncing',
         members: [...memberNames],
+        activeMember: null,
         results: [],
         logs: [],
+        startedAt: Date.now(),
         nestedMegarepos: [],
         generatedFiles: [],
         lockSyncResults: [],
+        syncTree: {
+          root: workspaceRoot,
+          results: [],
+          nestedMegarepos: [],
+          nestedResults: [],
+        },
+        syncErrors: [],
+        syncErrorCount: 0,
       },
     })
 

--- a/packages/@overeng/megarepo/src/lib/sync/mod.ts
+++ b/packages/@overeng/megarepo/src/lib/sync/mod.ts
@@ -18,9 +18,12 @@ export {
 } from './member.ts'
 export {
   countSyncResults,
+  collectAllMemberResults,
+  collectSyncErrors,
   flattenSyncResults,
   type MegarepoSyncResult,
   type MemberSyncResult,
   type MemberSyncStatus,
+  type SyncMemberError,
   type SyncOptions,
 } from './types.ts'

--- a/packages/@overeng/megarepo/src/lib/sync/schema.ts
+++ b/packages/@overeng/megarepo/src/lib/sync/schema.ts
@@ -90,6 +90,38 @@ export const SyncSummary = Schema.Struct({
 /** Inferred type for aggregated sync summary counts. */
 export type SyncSummary = Schema.Schema.Type<typeof SyncSummary>
 
+// =============================================================================
+// Nested Sync Tree (for --all)
+// =============================================================================
+
+/** Recursive schema for nested megarepo sync results. */
+export type MegarepoSyncTree = {
+  readonly root: string
+  readonly results: readonly MemberSyncResult[]
+  readonly nestedMegarepos: readonly string[]
+  readonly nestedResults: readonly MegarepoSyncTree[]
+}
+
+/** Recursive schema for nested megarepo sync results. */
+export const MegarepoSyncTree: Schema.Schema<MegarepoSyncTree> = Schema.suspend(() =>
+  Schema.Struct({
+    root: Schema.String,
+    results: Schema.Array(MemberSyncResult),
+    nestedMegarepos: Schema.Array(Schema.String),
+    nestedResults: Schema.Array(MegarepoSyncTree),
+  }),
+)
+
+/** Flattened error item (includes nested megarepo root). */
+export const SyncErrorItem = Schema.Struct({
+  megarepoRoot: Schema.String,
+  memberName: Schema.String,
+  message: Schema.NullOr(Schema.String),
+})
+
+/** Inferred type for a flattened sync error item. */
+export type SyncErrorItem = Schema.Schema.Type<typeof SyncErrorItem>
+
 /** Compute summary from results */
 export const computeSyncSummary = (results: readonly MemberSyncResult[]): SyncSummary => {
   let cloned = 0


### PR DESCRIPTION
## Why
`mr sync --all` can fail due to nested megarepo member sync errors, but the output previously only reflected root-level member results. This produced confusing JSON like `_tag: \"Success\"` while exiting non-zero, and provided no way to identify which nested member failed.

Fixes #176.

## What Changed
- Make nested failures first-class in sync output:
  - `syncTree`: full recursive sync result tree (root + nested)
  - `syncErrors` / `syncErrorCount`: flattened nested + root error reporting with megarepo root context
- Treat the final sync output as the source of truth for exit status (`_tag: 'Error'` -> exit code 1), instead of throwing after rendering.
- Update TTY output to show nested errors in the final view.
- Update docs to describe the new/breaking sync JSON schema.

## Breaking Change
`mr sync --output json` schema changed:
- Removed `phase`
- Added `_tag: Syncing | Success | Error | Interrupted`
- Added required fields: `syncTree`, `syncErrors`, `syncErrorCount` (and `activeMember`/`startedAt` are now always present as `null` when unset)

## Tests
- `dt ts:check`
- `dt lint:check`
- `dt test:megarepo`