### PR TITLE
Add syncAll option to megarepo task module

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -22,7 +22,7 @@ let
     lint-oxc = import ./nix/devenv-modules/tasks/shared/lint-oxc.nix;
     bun = import ./nix/devenv-modules/tasks/shared/bun.nix;
     pnpm = import ./nix/devenv-modules/tasks/shared/pnpm.nix;
-    megarepo = ./nix/devenv-modules/tasks/shared/megarepo.nix;
+    megarepo = import ./nix/devenv-modules/tasks/shared/megarepo.nix;
     nix-cli = import ./nix/devenv-modules/tasks/shared/nix-cli.nix;
     context = ./nix/devenv-modules/tasks/shared/context.nix;
     beads = import ./nix/devenv-modules/tasks/shared/beads.nix;
@@ -119,7 +119,7 @@ in
       # Depend only on utils package install (not full pnpm:install) for faster parallel startup
       lspPatchAfter = [ "pnpm:install:utils" ];
     })
-    taskModules.megarepo
+    (taskModules.megarepo {})
     (taskModules.check { extraChecks = [ "workspace:check" ]; })
     (taskModules.clean { packages = allPackages; })
     # Per-package pnpm install tasks

--- a/flake.nix
+++ b/flake.nix
@@ -121,8 +121,8 @@
           # Simple tasks (no config needed)
           genie = ./nix/devenv-modules/tasks/shared/genie.nix;
           lint-genie = ./nix/devenv-modules/tasks/shared/lint-genie.nix;
-          megarepo = ./nix/devenv-modules/tasks/shared/megarepo.nix;
           # Parameterized tasks (pass config)
+          megarepo = import ./nix/devenv-modules/tasks/shared/megarepo.nix;
           ts = import ./nix/devenv-modules/tasks/shared/ts.nix;
           setup = import ./nix/devenv-modules/tasks/shared/setup.nix;
           check = import ./nix/devenv-modules/tasks/shared/check.nix;

--- a/nix/devenv-modules/tasks/shared/megarepo.nix
+++ b/nix/devenv-modules/tasks/shared/megarepo.nix
@@ -6,10 +6,16 @@
 # - megarepo:sync - Clone/update member repos and create symlinks
 # - megarepo:check - Verify megarepo setup is complete
 #
+# Options:
+# - syncAll: Whether to use `--all` (recursive nested sync). Default: true.
+#   Set to false in CI where root members are already synced and nested sync
+#   may fail due to credential scoping or version mismatches.
+#
 # NOTE: No pnpm:install:megarepo dependency here — this shared module is used by
 # repos where megarepo may be a Nix package (no pnpm install needed). Repos that
 # use source-mode megarepo via pnpm should add the dependency in their devenv.nix:
 #   tasks."megarepo:sync".after = [ "pnpm:install:megarepo" ];
+{ syncAll ? true }:
 { lib, pkgs, ... }:
 let
   trace = import ../lib/trace.nix { inherit lib; };
@@ -24,7 +30,7 @@ in
         exit 0
       fi
 
-      mr sync --all
+      mr sync${if syncAll then " --all" else ""}
     '';
     # Status: use `mr status --output json` to detect if sync is needed.
     # The CLI computes syncNeeded based on: missing symlinks/worktrees, symlink drift, lock staleness.


### PR DESCRIPTION
## Summary

- Adds a `syncAll` parameter (default: `true`) to the megarepo task module
- When `false`, `mr sync` runs without `--all`, skipping recursive nested megarepo sync
- Moves megarepo from "simple tasks" to "parameterized tasks" in the flake exports
- Updates effect-utils `devenv.nix` callsite to `(taskModules.megarepo {})`

## Context

In CI, root members are already synced by an initial `mr sync --frozen` step before devenv starts. The devenv `megarepo:sync` task then redundantly re-syncs with `--all`, which recursively enters nested megarepos. This can fail due to git credential scoping (GitHub Actions token is repo-scoped) or version mismatches between the CI-installed `mr` and the devenv-pinned `mr`.

Consumer repos can now use `(taskModules.megarepo { syncAll = false; })` in CI to avoid the nested sync.

**Breaking change:** `taskModules.megarepo` is now a function — bare references must change to `(taskModules.megarepo {})`.

Relates to #176

## Test plan

- [x] Nix evaluation: the module signature matches existing parameterized task patterns (ts, setup, check, etc.)
- [ ] CI validation after consumer repo (livestore) adopts `syncAll = false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)