### PR TITLE
fix(otel): compact JSONL spans to single-line format

### DIFF
--- a/nix/devenv-modules/otel.nix
+++ b/nix/devenv-modules/otel.nix
@@ -499,9 +499,10 @@ let
     }'
 
     # Write span to spool file for collector to pick up (near-zero overhead)
+    # Compact to single-line JSONL — otlpjsonfilereceiver reads one JSON object per line
     _spool_dir="''${OTEL_SPAN_SPOOL_DIR:-}"
     if [ -n "$_spool_dir" ] && [ -d "$_spool_dir" ]; then
-      printf '%s\n' "$payload" >> "$_spool_dir/spans.jsonl"
+      printf '%s\n' "$payload" | ${pkgs.jq}/bin/jq -c . >> "$_spool_dir/spans.jsonl"
     else
       # Fallback to HTTP if spool dir not available
       ${pkgs.curl}/bin/curl -s -X POST \

--- a/nix/devenv-modules/tasks/shared/ts.nix
+++ b/nix/devenv-modules/tasks/shared/ts.nix
@@ -150,7 +150,7 @@ let
           }'
           _tsc_spool="''${OTEL_SPAN_SPOOL_DIR:-}"
           if [ -n "$_tsc_spool" ] && [ -d "$_tsc_spool" ]; then
-            printf '%s\n' "$_tsc_payload" >> "$_tsc_spool/spans.jsonl"
+            printf '%s\n' "$_tsc_payload" | ${pkgs.jq}/bin/jq -c . >> "$_tsc_spool/spans.jsonl"
           else
             ${pkgs.curl}/bin/curl -s -X POST \
               "$OTEL_EXPORTER_OTLP_ENDPOINT/v1/traces" \


### PR DESCRIPTION
## Summary
- Pipes OTLP span payloads through `jq -c` before writing to spool files to ensure single-line JSONL format
- Fixes `otlpjsonfilereceiver` parsing which expects one JSON object per line
- Applies the fix in both `otel.nix` (shell tracing helper) and `tasks/shared/ts.nix` (tsc tracing)

Follow-up to #174 where these files were missed.

## Test plan
- [ ] Verify spans are written as single-line JSONL in the spool directory
- [ ] Confirm `otlpjsonfilereceiver` correctly picks up and parses the spans

🤖 Generated with [Claude Code](https://claude.com/claude-code)