### PR TITLE
perf(lint): implement git-based genie coverage

### DIFF
--- a/nix/devenv-modules/tasks/shared/lint-oxc.nix
+++ b/nix/devenv-modules/tasks/shared/lint-oxc.nix
@@ -165,7 +165,7 @@ in
             ${git} ls-files --others --exclude-standard -- ${scanDirsArg}
           } | sort -u | while IFS= read -r f; do
             case "$f" in
-              */package.json|*/tsconfig.json) echo "$f" ;;
+              package.json|tsconfig.json|*/package.json|*/tsconfig.json) echo "$f" ;;
             esac
           done
         )


### PR DESCRIPTION
## Why
`lint:check:genie:coverage` enforces that config files (currently `package.json` + `tsconfig.json`) are owned by Genie (have a sibling `.genie.ts` source). The previous implementation used `find` which:
- still traverses excluded trees (e.g. `node_modules`) because it filtered with `-not -path` instead of pruning
- was cached based only on `*.genie.ts` patterns, which can miss the exact violation we care about (new unmanaged config file)

## Change
- Enumerate candidate config files using git:
  - tracked: `git ls-files`
  - untracked but not ignored: `git ls-files --others --exclude-standard`
- Then require `"$file.genie.ts"` to exist.
- Remove `execIfModified = geniePatterns` so the check can't be skipped when new unmanaged config files are added.

## Validation
- `dt lint:check:genie:coverage --no-tui`
- `dt check:quick --no-tui`
- `CI=1 dt test:run --no-tui`