### PR TITLE
fix(devenv): use devenv CLI for pre-commit hook

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -270,7 +270,8 @@ in
   git-hooks.enable = true;
   git-hooks.hooks.check-quick = {
     enable = true;
-    entry = "dt check:quick";
+    # Can't use `dt` here — git hooks run outside the devenv shell where `dt` isn't on $PATH
+    entry = "devenv tasks run check:quick --mode before";
     stages = ["pre-commit"];
     always_run = true;
     pass_filenames = false;


### PR DESCRIPTION
Git hooks run outside the devenv shell where the `dt` wrapper isn't available. This change uses the globally-installed `devenv` command with `--mode before` to automatically resolve task dependencies, providing the same behavior as `dt` while remaining accessible from git hook execution contexts.

Fixes pre-commit hook failures due to missing `dt` command.