### PR TITLE
fix(beads): Nix-provided bd binary + auto-init DB from JSONL

### DIFF
--- a/context/workflows/beads.md
+++ b/context/workflows/beads.md
@@ -109,8 +109,9 @@ tasks."devenv:enterShell".after = lib.mkAfter [ "beads:daemon:ensure" ];
 
 This provides:
 
+- `bd` binary via Nix (hermetic, available in CI)
 - `BEADS_DIR` env var (upstream `bd` env var for database discovery, works with direnv)
-- `dt beads:daemon:ensure` task (starts daemon if not running, idempotent)
+- `dt beads:daemon:ensure` task (starts daemon if not running, auto-inits DB from JSONL on fresh checkout)
 - `dt beads:daemon:stop` task (stops daemon)
 - `dt beads:sync` task (push JSONL changes to remote)
 - Commit correlation git hook (cross-references commits with beads issues)

--- a/flake.nix
+++ b/flake.nix
@@ -80,6 +80,7 @@
       in
       {
         packages = cliPackages // {
+          beads = import ./nix/beads.nix { inherit pkgs; };
           cli-build-stamp = cliBuildStamp.package;
           genie-dirty = cliPackagesDirty.genie;
           megarepo-dirty = cliPackagesDirty.megarepo;
@@ -164,6 +165,10 @@
           src ? null,
         }:
         import ./nix/oxlint-npm.nix { inherit pkgs bun src; };
+
+      # Beads (bd) pre-built binary package from GitHub releases.
+      # Usage: effectUtils.lib.mkBeads { inherit pkgs; }
+      lib.mkBeads = { pkgs }: import ./nix/beads.nix { inherit pkgs; };
 
       # Note: mkSourceCli is internal-only (not exported).
       # For consuming CLIs from other repos, use:

--- a/megarepo.lock
+++ b/megarepo.lock
@@ -4,16 +4,16 @@
     "effect": {
       "url": "https://github.com/effect-ts/effect",
       "ref": "main",
-      "commit": "f4972eda6c3179070d0167a30985b760afa0a9f9",
+      "commit": "a8c436f7004cc2a8ce2daec589ea7256b91c324f",
       "pinned": false,
-      "lockedAt": "2026-02-09T16:50:43.542Z"
+      "lockedAt": "2026-02-10T10:29:50.200Z"
     },
     "overeng-beads-public": {
       "url": "https://github.com/overengineeringstudio/overeng-beads-public",
       "ref": "main",
-      "commit": "77b7393b635add74bc9020059b0a259c02ba508e",
+      "commit": "ba596d3a1ffb4f07d8d7cfd9e972be08cfc08c6a",
       "pinned": false,
-      "lockedAt": "2026-02-09T16:50:43.542Z"
+      "lockedAt": "2026-02-10T10:29:50.200Z"
     }
   }
 }

--- a/nix/beads.nix
+++ b/nix/beads.nix
@@ -1,0 +1,70 @@
+# Beads (bd) — pre-built binary package from GitHub releases.
+# Upstream flake (github:steveyegge/beads) can't build from source due to
+# Go version mismatch in nixpkgs, so we fetch the pre-built binary instead.
+{ pkgs }:
+let
+  version = "0.49.6";
+  tag = "v${version}";
+
+  sources = {
+    x86_64-linux = {
+      url = "https://github.com/steveyegge/beads/releases/download/${tag}/beads_${version}_linux_amd64.tar.gz";
+      sha256 = "1f3xpczha8r6nv5k42c5j5g9g466m4j056mwq8dc67g18yddqil5";
+    };
+    aarch64-linux = {
+      url = "https://github.com/steveyegge/beads/releases/download/${tag}/beads_${version}_linux_arm64.tar.gz";
+      sha256 = "05iyf86mhc102vim8fcvcmn15gd3rblncpbh3hn212r62jbxmms3";
+    };
+    x86_64-darwin = {
+      url = "https://github.com/steveyegge/beads/releases/download/${tag}/beads_${version}_darwin_amd64.tar.gz";
+      sha256 = "0qmwcc722xbd461dmscwvbmy3dghd5aj49sxb2axy0lsbay8m9xr";
+    };
+    aarch64-darwin = {
+      url = "https://github.com/steveyegge/beads/releases/download/${tag}/beads_${version}_darwin_arm64.tar.gz";
+      sha256 = "0zdbv5inmzfjcf0kmi02vq1yj17g0p9smdpcl2ilib7f37csqz80";
+    };
+  };
+
+  platformInfo = sources.${pkgs.system} or (throw "Unsupported system: ${pkgs.system}");
+in
+pkgs.stdenv.mkDerivation {
+  pname = "beads";
+  inherit version;
+
+  dontBuild = true;
+  dontStrip = true;
+
+  src = pkgs.fetchurl {
+    inherit (platformInfo) url sha256;
+  };
+
+  nativeBuildInputs = [ pkgs.gnutar pkgs.installShellFiles ];
+
+  unpackPhase = ''
+    mkdir -p source
+    tar -xzf "$src" -C source
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp source/bd $out/bin/bd
+    chmod +x $out/bin/bd
+    ln -s $out/bin/bd $out/bin/beads
+
+    installShellCompletion --cmd bd \
+      --fish <($out/bin/bd completion fish) \
+      --bash <($out/bin/bd completion bash) \
+      --zsh <($out/bin/bd completion zsh)
+
+    runHook postInstall
+  '';
+
+  meta = with pkgs.lib; {
+    description = "beads (bd) - An issue tracker for AI-supervised coding workflows";
+    homepage = "https://github.com/steveyegge/beads";
+    license = licenses.mit;
+    mainProgram = "bd";
+  };
+}


### PR DESCRIPTION
## Summary

- Add `nix/beads.nix` — a plain Nix derivation that fetches pre-built `bd` binaries from GitHub releases (upstream flake can't build from source due to Go version mismatch in nixpkgs)
- Export via `flake.nix` as `packages.${system}.beads` and `lib.mkBeads` so other repos (e.g. dotfiles) can reuse it
- The beads devenv module now takes a `bdPackage` parameter and uses absolute Nix store paths for all `bd` invocations instead of relying on PATH — making `bd` available hermetically in all environments including CI
- Auto-initialize SQLite DB from JSONL on fresh checkouts — `bd daemon start` can't cold-start without a DB, so `beads:daemon:ensure` now runs `bd init --from-jsonl` when the DB is missing but JSONL exists
- Updated `context/workflows/beads.md` setup docs

Closes #143, closes #144

## Test plan

- [x] `devenv shell` builds successfully with beads from `nix/beads.nix`
- [x] `bd` available inside devenv shell (v0.49.6)
- [x] `nix build .#beads` succeeds
- [x] `genie:check` passes
- [x] Pre-commit hooks pass
- [x] Verified cold-start: `bd daemon start` fails without DB (isolated temp dir test)
- [x] Verified `bd init --from-jsonl` + `bd daemon start` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)