### PR TITLE
fix(devenv): prevent Storybook port drifting

### DIFF
--- a/context/workarounds/devenv-issues.md
+++ b/context/workarounds/devenv-issues.md
@@ -74,6 +74,33 @@ Example trace event:
 
 ---
 
+### DEVENV-03: Automatic port allocation (`ports.<name>.allocate`) does not pick a free port
+
+**Issue:** https://github.com/cachix/devenv/issues/2484
+
+**Repro:** https://github.com/schickling-repros/2026-02-devenv-port-allocation-ignored
+
+**Affected repos:** Any repo that runs multiple concurrent dev servers across multiple devenv instances
+
+**Symptoms:**
+
+- `config.processes.<name>.ports.<port>.value` stays equal to the base port even when that port is already in use
+- Downstream servers fail with `EADDRINUSE`, or (worse) tools like Storybook auto-select a different port and collide with other servers
+
+**Impact on Storybook:**
+
+- Storybook with `--ci` will silently choose another port when the requested port is taken, which can drift into other storybook ports (e.g. base `6009` drifts into `6014`) and cause cascading failures
+
+**Workaround (recommended):**
+
+- Force deterministic failure instead of port drifting by using Storybook `--exact-port` for all Storybook dev processes.
+
+**Additional mitigation:**
+
+- If base ports are contiguous (e.g. `6006..6013`), consider spacing them out to reduce the blast radius when any tool auto-selects ports.
+
+---
+
 ## Platform Compatibility Issues
 
 ### COMPAT-01: Web coding agents have limited Nix/devenv support


### PR DESCRIPTION
## Why
When running multiple Storybook dev servers concurrently under `devenv` + `--ci`, Storybook will silently pick a different port if the requested one is taken. With contiguous base ports this can drift into another Storybook's intended port and cause cascading `EADDRINUSE` failures.

This is especially painful given `ports.<name>.allocate` currently appears to not pick a free port when the base is occupied (tracked upstream).

## What
- Run Storybook with `--exact-port` in the shared Storybook devenv process module so it fails fast instead of drifting.
- Document the upstream devenv port allocation issue and the workaround.

## References
- Upstream devenv issue: https://github.com/cachix/devenv/issues/2484
- Repro repo: https://github.com/schickling-repros/2026-02-devenv-port-allocation-ignored