### PR TITLE
feat(genie): add programmatic TS SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- **genie**: Add programmatic TS SDK (`@overeng/genie/sdk`) for calling genie's generate/check
+  logic from TypeScript without the CLI. Core orchestration extracted into shared `core.ts` using
+  PubSub + Stream event bus pattern, consumed by both CLI (TUI progress) and SDK (silent).
+
 - **devenv/tasks/shared/worktree-guard.nix**: Git hook to enforce worktree workflow
   - Refuses commits on the default branch (detected via `refs/remotes/<remote>/HEAD` with fallback)
   - Optionally refuses commits from the primary worktree

--- a/megarepo.lock
+++ b/megarepo.lock
@@ -4,16 +4,16 @@
     "effect": {
       "url": "https://github.com/effect-ts/effect",
       "ref": "main",
-      "commit": "8e2286271a982b1cc34c78fca8b9f59de71fc790",
+      "commit": "d67c7089ba8616b2d48ef7324312267a2a6f310a",
       "pinned": false,
-      "lockedAt": "2026-02-10T14:09:16.907Z"
+      "lockedAt": "2026-02-11T15:08:22.831Z"
     },
     "overeng-beads-public": {
       "url": "https://github.com/overengineeringstudio/overeng-beads-public",
       "ref": "main",
-      "commit": "629e251bd2d4c314367622291155159cfbbfb807",
+      "commit": "268231d1664abf25ef82fd7aa4d83e9f77e2f9c5",
       "pinned": false,
-      "lockedAt": "2026-02-10T14:09:16.907Z"
+      "lockedAt": "2026-02-11T15:08:22.831Z"
     }
   }
 }

--- a/packages/@overeng/genie/package.json
+++ b/packages/@overeng/genie/package.json
@@ -5,13 +5,15 @@
   "type": "module",
   "exports": {
     ".": "./src/runtime/mod.ts",
-    "./cli": "./src/build/mod.tsx"
+    "./cli": "./src/build/mod.tsx",
+    "./sdk": "./src/build/sdk.ts"
   },
   "publishConfig": {
     "access": "public",
     "exports": {
       ".": "./dist/src/runtime/mod.js",
-      "./cli": "./dist/src/build/mod.js"
+      "./cli": "./dist/src/build/mod.js",
+      "./sdk": "./dist/src/build/sdk.js"
     }
   },
   "scripts": {

--- a/packages/@overeng/genie/package.json.genie.ts
+++ b/packages/@overeng/genie/package.json.genie.ts
@@ -18,12 +18,14 @@ export default packageJson({
   exports: {
     '.': './src/runtime/mod.ts',
     './cli': './src/build/mod.tsx',
+    './sdk': './src/build/sdk.ts',
   },
   publishConfig: {
     access: 'public',
     exports: {
       '.': './dist/src/runtime/mod.js',
       './cli': './dist/src/build/mod.js',
+      './sdk': './dist/src/build/sdk.js',
     },
   },
   // Genie must not use any runtime dependencies (only bundled/dev dependencies)

--- a/packages/@overeng/genie/src/build/core.ts
+++ b/packages/@overeng/genie/src/build/core.ts
@@ -1,0 +1,375 @@
+import path from 'node:path'
+
+import { type Error as PlatformError, FileSystem } from '@effect/platform'
+import type * as CommandExecutor from '@effect/platform/CommandExecutor'
+import type { Path } from '@effect/platform/Path'
+import { Effect, Either, Option } from 'effect'
+
+import { assertNever } from '@overeng/utils'
+
+import { findGenieFiles } from './discovery.ts'
+import { GenieFileError, GenieGenerationFailedError } from './errors.ts'
+import { type GenieEvent, type GenieEventBus, emit } from './events.ts'
+import { checkFile, errorOriginatesInFile, generateFile, isTdzError } from './generation.ts'
+import type { GenieFileStatus, GenieSummary } from './schema.ts'
+import type { GenerateSuccess } from './types.ts'
+import { runGenieValidation } from './validation.ts'
+
+// ---------------------------------------------------------------------------
+// Shared helpers (used by both core and CLI watch mode)
+// ---------------------------------------------------------------------------
+
+/** Convention paths for oxfmt config relative to workspace root (checked in order) */
+export const OXFMT_CONFIG_CONVENTION_PATHS = ['.oxfmtrc.json', 'oxfmt.json']
+
+/** Resolve the oxfmt config path: explicit option → convention paths → none */
+export const resolveOxfmtConfigPath = Effect.fn('resolveOxfmtConfigPath')(function* ({
+  explicitPath,
+  cwd,
+}: {
+  explicitPath: Option.Option<string>
+  cwd: string
+}) {
+  if (Option.isSome(explicitPath)) return explicitPath
+  const fs = yield* FileSystem.FileSystem
+  for (const conventionPath of OXFMT_CONFIG_CONVENTION_PATHS) {
+    const fullPath = path.join(cwd, conventionPath)
+    if (yield* fs.exists(fullPath)) return Option.some(fullPath)
+  }
+  return Option.none()
+})
+
+/** Map generation result tag to file status */
+export const mapResultToStatus = (result: { _tag: string }): GenieFileStatus => {
+  switch (result._tag) {
+    case 'created':
+      return 'created'
+    case 'updated':
+      return 'updated'
+    case 'unchanged':
+      return 'unchanged'
+    case 'skipped':
+      return 'skipped'
+    default:
+      return 'error'
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Core types
+// ---------------------------------------------------------------------------
+
+export type CoreGenerateOptions = {
+  cwd: string
+  readOnly: boolean
+  dryRun: boolean
+  oxfmtConfigPath: Option.Option<string>
+}
+
+export type CoreCheckOptions = {
+  cwd: string
+  oxfmtConfigPath: Option.Option<string>
+}
+
+export type GenieGenerateResult = {
+  summary: GenieSummary
+  files: Array<GenerateSuccess>
+}
+
+// ---------------------------------------------------------------------------
+// Shared orchestration
+// ---------------------------------------------------------------------------
+
+/** Discover genie files and assert no duplicate targets. */
+const discoverAndValidate = Effect.fn('genie/discoverAndValidate')(function* (cwd: string) {
+  const genieFiles = yield* findGenieFiles(cwd)
+
+  const targetCounts = new Map<string, number>()
+  for (const genieFilePath of genieFiles) {
+    const targetFilePath = genieFilePath.replace('.genie.ts', '')
+    targetCounts.set(targetFilePath, (targetCounts.get(targetFilePath) ?? 0) + 1)
+  }
+  const duplicateTargets = Array.from(targetCounts.entries()).filter(([, count]) => count > 1)
+  assertNever({
+    condition: duplicateTargets.length === 0,
+    msg: () =>
+      `Duplicate genie targets detected: ${duplicateTargets
+        .map(([target, count]) => `${target} (${count}x)`)
+        .join(', ')}`,
+  })
+
+  return genieFiles
+})
+
+/** Compute summary counts from a list of successes and a failure count. */
+const computeSummary = (successes: Array<GenerateSuccess>, failedCount: number): GenieSummary => ({
+  created: successes.filter((s) => s._tag === 'created').length,
+  updated: successes.filter((s) => s._tag === 'updated').length,
+  unchanged: successes.filter((s) => s._tag === 'unchanged').length,
+  skipped: successes.filter((s) => s._tag === 'skipped').length,
+  failed: failedCount,
+})
+
+/** Run validation and emit error event on failure. Returns the error effect if validation fails. */
+const runValidationOrFail = Effect.fn('genie/runValidationOrFail')(function* (cwd: string) {
+  const validationResult = yield* runGenieValidation({ cwd }).pipe(Effect.either)
+  if (Either.isLeft(validationResult)) {
+    const error = validationResult.left
+    const message = error instanceof Error ? error.message : String(error)
+    yield* emit({ _tag: 'Error', message })
+    return yield* new GenieGenerationFailedError({
+      failedCount: 1,
+      message,
+      files: [],
+    })
+  }
+})
+
+/** Generate files from all discovered .genie.ts sources. */
+export const generateAll = ({
+  cwd,
+  readOnly,
+  dryRun,
+  oxfmtConfigPath,
+}: CoreGenerateOptions): Effect.Effect<
+  GenieGenerateResult,
+  GenieGenerationFailedError | PlatformError.PlatformError,
+  FileSystem.FileSystem | Path | CommandExecutor.CommandExecutor | GenieEventBus
+> =>
+  Effect.gen(function* () {
+    const genieFiles = yield* discoverAndValidate(cwd)
+
+    if (genieFiles.length === 0) {
+      const summary = computeSummary([], 0)
+      yield* emit({ _tag: 'Complete', summary })
+      return { summary, files: [] }
+    }
+
+    yield* emit({
+      _tag: 'FilesDiscovered',
+      files: genieFiles.map((fp) => ({
+        path: fp,
+        relativePath: path.relative(cwd, fp.replace('.genie.ts', '')),
+      })),
+    })
+
+    // Generate all files concurrently
+    const results = yield* Effect.all(
+      genieFiles.map((genieFilePath) =>
+        Effect.gen(function* () {
+          yield* emit({ _tag: 'FileStarted', path: genieFilePath })
+
+          const result = yield* generateFile({
+            genieFilePath,
+            cwd,
+            readOnly,
+            dryRun,
+            oxfmtConfigPath,
+          }).pipe(Effect.either)
+
+          if (Either.isRight(result)) {
+            const status = mapResultToStatus(result.right)
+            yield* emit({
+              _tag: 'FileCompleted',
+              path: genieFilePath,
+              status,
+              ...(result.right._tag === 'updated' && result.right.diffSummary
+                ? { message: result.right.diffSummary }
+                : {}),
+            })
+          } else {
+            yield* emit({
+              _tag: 'FileCompleted',
+              path: genieFilePath,
+              status: 'error',
+              message: result.left.message,
+            })
+          }
+
+          return result
+        }),
+      ),
+      { concurrency: 'unbounded' },
+    )
+
+    const successes = results.filter(Either.isRight).map((r) => r.right)
+    const failures = results.filter(Either.isLeft).map((r) => r.left)
+
+    // Handle TDZ errors with sequential re-validation
+    const hasTdzErrors = failures.some((f) => isTdzError(f.cause))
+
+    if (failures.length > 0 && hasTdzErrors) {
+      const revalidateErrors: Array<{
+        genieFilePath: string
+        error: ReturnType<typeof checkFile> extends Effect.Effect<any, infer E, any> ? E : never
+        isRootCause: boolean
+      }> = []
+
+      for (const genieFilePath of genieFiles) {
+        const result = yield* checkFile({ genieFilePath, cwd, oxfmtConfigPath }).pipe(Effect.either)
+
+        if (Either.isLeft(result)) {
+          revalidateErrors.push({
+            genieFilePath,
+            error: result.left,
+            isRootCause: errorOriginatesInFile({ error: result.left, filePath: genieFilePath }),
+          })
+        }
+      }
+
+      const rootCauses = revalidateErrors.filter((e) => e.isRootCause)
+      const dependentCount = revalidateErrors.length - rootCauses.length
+
+      // Update state with revalidated errors
+      for (const { genieFilePath, error, isRootCause } of revalidateErrors) {
+        yield* emit({
+          _tag: 'FileCompleted',
+          path: genieFilePath,
+          status: 'error',
+          message: isRootCause ? error.message : 'Failed due to dependency error',
+        })
+      }
+
+      const summary = computeSummary(successes, revalidateErrors.length)
+      yield* emit({ _tag: 'Complete', summary })
+
+      return yield* new GenieGenerationFailedError({
+        failedCount: revalidateErrors.length,
+        message: `${rootCauses.length} root cause error(s), ${dependentCount} dependent failure(s)`,
+        files: genieFiles.map((p) => {
+          const reErr = revalidateErrors.find((e) => e.genieFilePath === p)
+          return {
+            path: p,
+            relativePath: path.relative(cwd, p.replace('.genie.ts', '')),
+            status: (reErr ? 'error' : 'unchanged') as GenieFileStatus,
+            message: reErr
+              ? reErr.isRootCause
+                ? reErr.error.message
+                : 'Failed due to dependency error'
+              : undefined,
+          }
+        }),
+      })
+    }
+
+    // No TDZ errors
+    const summary = computeSummary(successes, failures.length)
+
+    if (summary.failed > 0) {
+      yield* emit({ _tag: 'Complete', summary })
+      return yield* new GenieGenerationFailedError({
+        failedCount: summary.failed,
+        message: `${summary.failed} file(s) failed to generate`,
+        files: genieFiles.map((p, i) => {
+          const resultEither = results[i]!
+          if (Either.isRight(resultEither)) {
+            return {
+              path: p,
+              relativePath: path.relative(cwd, p.replace('.genie.ts', '')),
+              status: mapResultToStatus(resultEither.right),
+            }
+          }
+          return {
+            path: p,
+            relativePath: path.relative(cwd, p.replace('.genie.ts', '')),
+            status: 'error' as GenieFileStatus,
+            message: resultEither.left.message,
+          }
+        }),
+      })
+    }
+
+    // Run validation hooks after successful generation
+    if (!dryRun) {
+      yield* runValidationOrFail(cwd)
+    }
+
+    yield* emit({ _tag: 'Complete', summary })
+    return { summary, files: successes }
+  }).pipe(Effect.withSpan('genie/generateAll'))
+
+/** Check that all generated files are up to date. */
+export const checkAll = ({
+  cwd,
+  oxfmtConfigPath,
+}: CoreCheckOptions): Effect.Effect<
+  void,
+  GenieGenerationFailedError | PlatformError.PlatformError,
+  FileSystem.FileSystem | Path | CommandExecutor.CommandExecutor | GenieEventBus
+> =>
+  Effect.gen(function* () {
+    const genieFiles = yield* discoverAndValidate(cwd)
+
+    if (genieFiles.length === 0) {
+      yield* emit({ _tag: 'Complete', summary: computeSummary([], 0) })
+      return
+    }
+
+    yield* emit({
+      _tag: 'FilesDiscovered',
+      files: genieFiles.map((fp) => ({
+        path: fp,
+        relativePath: path.relative(cwd, fp.replace('.genie.ts', '')),
+      })),
+    })
+
+    const results = yield* Effect.all(
+      genieFiles.map((genieFilePath) =>
+        Effect.gen(function* () {
+          yield* emit({ _tag: 'FileStarted', path: genieFilePath })
+
+          const result = yield* checkFile({ genieFilePath, cwd, oxfmtConfigPath }).pipe(
+            Effect.map(() => ({ success: true as const })),
+            Effect.catchAll((error) => Effect.succeed({ success: false as const, error })),
+          )
+
+          yield* emit({
+            _tag: 'FileCompleted',
+            path: genieFilePath,
+            status: result.success ? ('unchanged' as const) : ('error' as const),
+            ...(result.success ? {} : { message: result.error.message }),
+          })
+
+          return result
+        }),
+      ),
+      { concurrency: 'unbounded' },
+    )
+
+    const failed = results.filter((r) => !r.success).length
+
+    if (failed > 0) {
+      const summary: GenieSummary = {
+        created: 0,
+        updated: 0,
+        unchanged: results.filter((r) => r.success).length,
+        skipped: 0,
+        failed,
+      }
+      yield* emit({ _tag: 'Complete', summary })
+      return yield* new GenieGenerationFailedError({
+        failedCount: failed,
+        message: `${failed} file(s) are out of date`,
+        files: genieFiles.map((p, i) => {
+          const r = results[i]!
+          return {
+            path: p,
+            relativePath: path.relative(cwd, p.replace('.genie.ts', '')),
+            status: (r.success ? 'unchanged' : 'error') as GenieFileStatus,
+            message: r.success ? undefined : r.error.message,
+          }
+        }),
+      })
+    }
+
+    yield* runValidationOrFail(cwd)
+
+    const summary: GenieSummary = {
+      created: 0,
+      updated: 0,
+      unchanged: results.filter((r) => r.success).length,
+      skipped: 0,
+      failed: 0,
+    }
+    yield* emit({ _tag: 'Complete', summary })
+  }).pipe(Effect.withSpan('genie/checkAll'))

--- a/packages/@overeng/genie/src/build/events.ts
+++ b/packages/@overeng/genie/src/build/events.ts
@@ -1,0 +1,38 @@
+import { Context, Effect, PubSub, Schema } from 'effect'
+
+import { GenieFileStatus, GenieSummary } from './schema.ts'
+
+/** Schema for events emitted during genie generation/check. */
+export const GenieEvent = Schema.Union(
+  Schema.TaggedStruct('FilesDiscovered', {
+    files: Schema.Array(
+      Schema.Struct({
+        path: Schema.String,
+        relativePath: Schema.String,
+      }),
+    ),
+  }),
+
+  Schema.TaggedStruct('FileStarted', { path: Schema.String }),
+
+  Schema.TaggedStruct('FileCompleted', {
+    path: Schema.String,
+    status: GenieFileStatus,
+    message: Schema.optional(Schema.String),
+  }),
+
+  Schema.TaggedStruct('Complete', { summary: GenieSummary }),
+
+  Schema.TaggedStruct('Error', { message: Schema.String }),
+)
+export type GenieEvent = Schema.Schema.Type<typeof GenieEvent>
+
+/** PubSub for genie progress events, injected via Context. */
+export class GenieEventBus extends Context.Tag('@overeng/genie/EventBus')<
+  GenieEventBus,
+  PubSub.PubSub<GenieEvent>
+>() {}
+
+/** Publish a GenieEvent to the bus from Context. */
+export const emit = (event: GenieEvent): Effect.Effect<boolean, never, GenieEventBus> =>
+  Effect.flatMap(GenieEventBus, (bus) => PubSub.publish(bus, event))

--- a/packages/@overeng/genie/src/build/mod.tsx
+++ b/packages/@overeng/genie/src/build/mod.tsx
@@ -1,28 +1,28 @@
 import path from 'node:path'
 
 import * as Cli from '@effect/cli'
-import { type Error as PlatformError, FileSystem } from '@effect/platform'
-import { Effect, Either, Option, pipe, Stream } from 'effect'
+import { FileSystem } from '@effect/platform'
+import { Effect, Either, pipe, PubSub, Queue, Stream } from 'effect'
 import React from 'react'
 
 import { run } from '@overeng/tui-react'
 import { outputOption, outputModeLayer } from '@overeng/tui-react/node'
-import { assertNever } from '@overeng/utils'
 import { CurrentWorkingDirectory } from '@overeng/utils/node'
 
 import { GenieApp } from './app.ts'
-import { findGenieFiles } from './discovery.ts'
-import { GenieFileError, type GenieCheckError, type GenieImportError } from './errors.ts'
-import { GenieGenerationFailedError } from './errors.ts'
-import { checkFile, errorOriginatesInFile, generateFile, isTdzError } from './generation.ts'
 import {
-  createInitialGenieState,
-  type GenieFileStatus,
-  type GenieSummary,
-  type GenieMode,
-} from './schema.ts'
+  checkAll,
+  generateAll,
+  mapResultToStatus,
+  OXFMT_CONFIG_CONVENTION_PATHS,
+  resolveOxfmtConfigPath,
+} from './core.ts'
+import { findGenieFiles } from './discovery.ts'
+import { GenieGenerationFailedError } from './errors.ts'
+import { type GenieEvent, GenieEventBus } from './events.ts'
+import { generateFile } from './generation.ts'
+import { createInitialGenieState, type GenieSummary, type GenieMode } from './schema.ts'
 import type { GenieCommandConfig, GenieCommandEnv, GenieCommandError } from './types.ts'
-import { runGenieValidation } from './validation.ts'
 import { GenieView } from './view.tsx'
 
 export {
@@ -32,46 +32,29 @@ export {
   GenieImportError,
 } from './errors.ts'
 
-/** Convention paths for oxfmt config relative to workspace root (checked in order) */
-const OXFMT_CONFIG_CONVENTION_PATHS = ['.oxfmtrc.json', 'oxfmt.json']
-
-/** Resolve the oxfmt config path: explicit option → convention paths → none */
-const resolveOxfmtConfigPath = Effect.fn('resolveOxfmtConfigPath')(function* ({
-  explicitPath,
-  cwd,
-}: {
-  explicitPath: Option.Option<string>
-  cwd: string
-}) {
-  // Use explicit path if provided
-  if (Option.isSome(explicitPath)) {
-    return explicitPath
-  }
-  // Check convention paths in order
-  const fs = yield* FileSystem.FileSystem
-  for (const conventionPath of OXFMT_CONFIG_CONVENTION_PATHS) {
-    const fullPath = path.join(cwd, conventionPath)
-    const exists = yield* fs.exists(fullPath)
-    if (exists) {
-      return Option.some(fullPath)
-    }
-  }
-  return Option.none()
-})
-
-/** Map generation result tag to file status */
-const mapResultToStatus = (result: { _tag: string }): GenieFileStatus => {
-  switch (result._tag) {
-    case 'created':
-      return 'created'
-    case 'updated':
-      return 'updated'
-    case 'unchanged':
-      return 'unchanged'
-    case 'skipped':
-      return 'skipped'
-    default:
-      return 'error'
+/** Bridge GenieEvent stream to TUI dispatch. */
+const dispatchEvent = (tui: { dispatch: (action: any) => void }, event: GenieEvent): void => {
+  switch (event._tag) {
+    case 'FilesDiscovered':
+      tui.dispatch({ _tag: 'FilesDiscovered', files: event.files })
+      break
+    case 'FileStarted':
+      tui.dispatch({ _tag: 'FileStarted', path: event.path })
+      break
+    case 'FileCompleted':
+      tui.dispatch({
+        _tag: 'FileCompleted',
+        path: event.path,
+        status: event.status,
+        message: event.message,
+      })
+      break
+    case 'Complete':
+      tui.dispatch({ _tag: 'Complete', summary: event.summary })
+      break
+    case 'Error':
+      tui.dispatch({ _tag: 'Error', message: event.message })
+      break
   }
 }
 
@@ -139,364 +122,128 @@ export const genieCommand: Cli.Command.Command<
       yield* run(
         GenieApp,
         (tui) =>
-          Effect.gen(function* () {
-            // Set initial state
-            tui.dispatch({
-              _tag: 'SetState',
-              state: createInitialGenieState({ cwd: resolvedCwd, mode }),
-            })
-
-            // Discover genie files
-            const genieFiles = yield* findGenieFiles(resolvedCwd)
-
-            const targetCounts = new Map<string, number>()
-            for (const genieFilePath of genieFiles) {
-              const targetFilePath = genieFilePath.replace('.genie.ts', '')
-              targetCounts.set(targetFilePath, (targetCounts.get(targetFilePath) ?? 0) + 1)
-            }
-            const duplicateTargets = Array.from(targetCounts.entries()).filter(
-              ([, count]) => count > 1,
-            )
-            assertNever({
-              condition: duplicateTargets.length === 0,
-              msg: () =>
-                `Duplicate genie targets detected: ${duplicateTargets
-                  .map(([target, count]) => `${target} (${count}x)`)
-                  .join(', ')}`,
-            })
-
-            if (genieFiles.length === 0) {
+          Effect.scoped(
+            Effect.gen(function* () {
+              // Set initial state
               tui.dispatch({
-                _tag: 'Complete',
-                summary: { created: 0, updated: 0, unchanged: 0, skipped: 0, failed: 0 },
+                _tag: 'SetState',
+                state: createInitialGenieState({ cwd: resolvedCwd, mode }),
               })
-              return
-            }
 
-            // Dispatch files discovered
-            tui.dispatch({
-              _tag: 'FilesDiscovered',
-              files: genieFiles.map((filePath) => ({
-                path: filePath,
-                relativePath: path.relative(resolvedCwd, filePath.replace('.genie.ts', '')),
-              })),
-            })
-
-            if (check) {
-              // Check mode - verify all files are up to date
-              const results = yield* Effect.all(
-                genieFiles.map((genieFilePath) =>
-                  Effect.gen(function* () {
-                    const targetFilePath = genieFilePath.replace('.genie.ts', '')
-                    tui.dispatch({ _tag: 'FileStarted', path: genieFilePath })
-
-                    const result = yield* checkFile({
-                      genieFilePath,
-                      cwd: resolvedCwd,
-                      oxfmtConfigPath,
-                    }).pipe(
-                      Effect.map(() => ({ success: true as const })),
-                      Effect.catchAll((error) =>
-                        Effect.succeed({ success: false as const, error }),
-                      ),
-                    )
-
-                    if (result.success) {
-                      tui.dispatch({
-                        _tag: 'FileCompleted',
-                        path: genieFilePath,
-                        status: 'unchanged',
-                      })
-                    } else {
-                      tui.dispatch({
-                        _tag: 'FileCompleted',
-                        path: genieFilePath,
-                        status: 'error',
-                        message: result.error.message,
-                      })
-                    }
-
-                    return result
-                  }),
-                ),
-                { concurrency: 'unbounded' },
+              // Create event bus and subscribe for TUI progress
+              const bus = yield* PubSub.unbounded<GenieEvent>()
+              const sub = yield* PubSub.subscribe(bus)
+              yield* Queue.take(sub).pipe(
+                Effect.tap((event) => Effect.sync(() => dispatchEvent(tui, event))),
+                Effect.forever,
+                Effect.forkScoped,
               )
 
-              const failed = results.filter((r) => !r.success).length
-
-              if (failed > 0) {
-                const summary: GenieSummary = {
-                  created: 0,
-                  updated: 0,
-                  unchanged: results.filter((r) => r.success).length,
-                  skipped: 0,
-                  failed,
-                }
-                tui.dispatch({ _tag: 'Complete', summary })
-                return yield* new GenieGenerationFailedError({
-                  failedCount: failed,
-                  message: `${failed} file(s) are out of date`,
-                  files: tui.getState().files,
-                })
-              }
-
-              // Run validation before completing — ensures UI reflects validation failures
-              const validationResult = yield* runGenieValidation({ cwd: resolvedCwd }).pipe(
-                Effect.either,
-              )
-
-              if (Either.isLeft(validationResult)) {
-                const error = validationResult.left
-                const message = error instanceof Error ? error.message : String(error)
-                tui.dispatch({ _tag: 'Error', message })
-                return yield* new GenieGenerationFailedError({
-                  failedCount: 1,
-                  message,
-                  files: tui.getState().files,
-                })
-              }
-
-              const summary: GenieSummary = {
-                created: 0,
-                updated: 0,
-                unchanged: results.filter((r) => r.success).length,
-                skipped: 0,
-                failed: 0,
-              }
-              tui.dispatch({ _tag: 'Complete', summary })
-
-              return
-            }
-
-            // Generate mode (including dry-run)
-            const results = yield* Effect.all(
-              genieFiles.map((genieFilePath) =>
-                Effect.gen(function* () {
-                  tui.dispatch({ _tag: 'FileStarted', path: genieFilePath })
-
-                  const result = yield* generateFile({
-                    genieFilePath,
-                    cwd: resolvedCwd,
-                    readOnly,
-                    dryRun,
-                    oxfmtConfigPath,
-                  }).pipe(Effect.either)
-
-                  if (Either.isRight(result)) {
-                    const status = mapResultToStatus(result.right)
-                    const message =
-                      result.right._tag === 'updated' ? result.right.diffSummary : undefined
-                    tui.dispatch({
-                      _tag: 'FileCompleted',
-                      path: genieFilePath,
-                      status,
-                      message,
-                    })
-                    return result
-                  } else {
-                    tui.dispatch({
-                      _tag: 'FileCompleted',
-                      path: genieFilePath,
-                      status: 'error',
-                      message: result.left.message,
-                    })
-                    return result
-                  }
-                }),
-              ),
-              { concurrency: 'unbounded' },
-            )
-
-            // Partition results
-            const successes = results.filter(Either.isRight).map((r) => r.right)
-            const failures = results.filter(Either.isLeft).map((r) => r.left)
-
-            // Check for TDZ errors
-            const hasTdzErrors = failures.some((f) => isTdzError(f.cause))
-
-            if (failures.length > 0 && hasTdzErrors) {
-              // Re-validate sequentially to identify root causes
-              const revalidateErrors: Array<{
-                genieFilePath: string
-                error: GenieCheckError | GenieImportError | PlatformError.PlatformError
-                isRootCause: boolean
-              }> = []
-
-              for (const genieFilePath of genieFiles) {
-                const result = yield* checkFile({
-                  genieFilePath,
+              if (check) {
+                yield* checkAll({ cwd: resolvedCwd, oxfmtConfigPath }).pipe(
+                  Effect.provideService(GenieEventBus, bus),
+                )
+              } else {
+                yield* generateAll({
                   cwd: resolvedCwd,
+                  readOnly,
+                  dryRun,
                   oxfmtConfigPath,
-                }).pipe(Effect.either)
-
-                if (Either.isLeft(result)) {
-                  const error = result.left
-                  revalidateErrors.push({
-                    genieFilePath,
-                    error,
-                    isRootCause: errorOriginatesInFile({
-                      error,
-                      filePath: genieFilePath,
-                    }),
-                  })
-                }
+                }).pipe(Effect.provideService(GenieEventBus, bus))
               }
 
-              const rootCauses = revalidateErrors.filter((e) => e.isRootCause)
-              const dependentCount = revalidateErrors.length - rootCauses.length
+              if (watch && !check && !dryRun) {
+                // Watch mode - uses low-level APIs directly (CLI-specific)
+                yield* pipe(
+                  fs.watch(resolvedCwd),
+                  Stream.filter(({ path: p }) => p.endsWith('.genie.ts')),
+                  Stream.tap(({ path: p }) => {
+                    const genieFilePath = path.join(resolvedCwd, p)
 
-              // Update state with revalidated errors
-              for (const { genieFilePath, error, isRootCause } of revalidateErrors) {
-                tui.dispatch({
-                  _tag: 'FileCompleted',
-                  path: genieFilePath,
-                  status: 'error',
-                  message: isRootCause ? error.message : 'Failed due to dependency error',
-                })
-              }
+                    // Reset for new watch cycle
+                    tui.dispatch({ _tag: 'WatchReset' })
 
-              const summary: GenieSummary = {
-                created: successes.filter((s) => s._tag === 'created').length,
-                updated: successes.filter((s) => s._tag === 'updated').length,
-                unchanged: successes.filter((s) => s._tag === 'unchanged').length,
-                skipped: successes.filter((s) => s._tag === 'skipped').length,
-                failed: revalidateErrors.length,
-              }
+                    return Effect.gen(function* () {
+                      // Re-discover files (in case new ones were added)
+                      const newGenieFiles = yield* findGenieFiles(resolvedCwd)
 
-              tui.dispatch({ _tag: 'Complete', summary })
-
-              return yield* new GenieGenerationFailedError({
-                failedCount: revalidateErrors.length,
-                message: `${rootCauses.length} root cause error(s), ${dependentCount} dependent failure(s)`,
-                files: tui.getState().files,
-              })
-            }
-
-            // No TDZ errors - compute summary
-            const summary: GenieSummary = {
-              created: successes.filter((s) => s._tag === 'created').length,
-              updated: successes.filter((s) => s._tag === 'updated').length,
-              unchanged: successes.filter((s) => s._tag === 'unchanged').length,
-              skipped: successes.filter((s) => s._tag === 'skipped').length,
-              failed: failures.length,
-            }
-
-            // Exit with error code if any files failed
-            if (summary.failed > 0) {
-              tui.dispatch({ _tag: 'Complete', summary })
-              return yield* new GenieGenerationFailedError({
-                failedCount: summary.failed,
-                message: `${summary.failed} file(s) failed to generate`,
-                files: tui.getState().files,
-              })
-            }
-
-            // Run validation hooks after successful generation
-            if (!dryRun) {
-              const validationResult = yield* runGenieValidation({ cwd: resolvedCwd }).pipe(
-                Effect.either,
-              )
-
-              if (Either.isLeft(validationResult)) {
-                const error = validationResult.left
-                const message = error instanceof Error ? error.message : String(error)
-                tui.dispatch({ _tag: 'Error', message })
-                return yield* new GenieGenerationFailedError({
-                  failedCount: 1,
-                  message,
-                  files: tui.getState().files,
-                })
-              }
-            }
-
-            tui.dispatch({ _tag: 'Complete', summary })
-
-            if (watch && !dryRun) {
-              // Watch mode
-              yield* pipe(
-                fs.watch(resolvedCwd),
-                Stream.filter(({ path: p }) => p.endsWith('.genie.ts')),
-                Stream.tap(({ path: p }) => {
-                  const genieFilePath = path.join(resolvedCwd, p)
-
-                  // Reset for new watch cycle
-                  tui.dispatch({ _tag: 'WatchReset' })
-
-                  return Effect.gen(function* () {
-                    // Re-discover files (in case new ones were added)
-                    const newGenieFiles = yield* findGenieFiles(resolvedCwd)
-
-                    tui.dispatch({
-                      _tag: 'FilesDiscovered',
-                      files: newGenieFiles.map((filePath) => ({
-                        path: filePath,
-                        relativePath: path.relative(resolvedCwd, filePath.replace('.genie.ts', '')),
-                      })),
-                    })
-
-                    // Regenerate the changed file
-                    tui.dispatch({ _tag: 'FileStarted', path: genieFilePath })
-
-                    const result = yield* generateFile({
-                      genieFilePath,
-                      cwd: resolvedCwd,
-                      readOnly,
-                      oxfmtConfigPath,
-                    }).pipe(Effect.either)
-
-                    if (Either.isRight(result)) {
-                      const message =
-                        result.right._tag === 'updated' ? result.right.diffSummary : undefined
                       tui.dispatch({
-                        _tag: 'FileCompleted',
-                        path: genieFilePath,
-                        status: mapResultToStatus(result.right),
-                        message,
+                        _tag: 'FilesDiscovered',
+                        files: newGenieFiles.map((filePath) => ({
+                          path: filePath,
+                          relativePath: path.relative(
+                            resolvedCwd,
+                            filePath.replace('.genie.ts', ''),
+                          ),
+                        })),
                       })
-                    } else {
-                      tui.dispatch({
-                        _tag: 'FileCompleted',
-                        path: genieFilePath,
-                        status: 'error',
-                        message: result.left.message,
-                      })
-                    }
 
-                    // Mark all other files as unchanged
-                    for (const otherFile of newGenieFiles) {
-                      if (otherFile !== genieFilePath) {
+                      // Regenerate the changed file
+                      tui.dispatch({ _tag: 'FileStarted', path: genieFilePath })
+
+                      const result = yield* generateFile({
+                        genieFilePath,
+                        cwd: resolvedCwd,
+                        readOnly,
+                        oxfmtConfigPath,
+                      }).pipe(Effect.either)
+
+                      if (Either.isRight(result)) {
+                        const message =
+                          result.right._tag === 'updated' ? result.right.diffSummary : undefined
                         tui.dispatch({
                           _tag: 'FileCompleted',
-                          path: otherFile,
-                          status: 'unchanged',
+                          path: genieFilePath,
+                          status: mapResultToStatus(result.right),
+                          message,
+                        })
+                      } else {
+                        tui.dispatch({
+                          _tag: 'FileCompleted',
+                          path: genieFilePath,
+                          status: 'error',
+                          message: result.left.message,
                         })
                       }
-                    }
 
-                    const watchSummary: GenieSummary = Either.isRight(result)
-                      ? {
-                          created: result.right._tag === 'created' ? 1 : 0,
-                          updated: result.right._tag === 'updated' ? 1 : 0,
-                          unchanged:
-                            newGenieFiles.length - 1 + (result.right._tag === 'unchanged' ? 1 : 0),
-                          skipped: result.right._tag === 'skipped' ? 1 : 0,
-                          failed: 0,
+                      // Mark all other files as unchanged
+                      for (const otherFile of newGenieFiles) {
+                        if (otherFile !== genieFilePath) {
+                          tui.dispatch({
+                            _tag: 'FileCompleted',
+                            path: otherFile,
+                            status: 'unchanged',
+                          })
                         }
-                      : {
-                          created: 0,
-                          updated: 0,
-                          unchanged: newGenieFiles.length - 1,
-                          skipped: 0,
-                          failed: 1,
-                        }
+                      }
 
-                    tui.dispatch({ _tag: 'Complete', summary: watchSummary })
-                  })
-                }),
-                Stream.runDrain,
-              )
-            }
-          }),
+                      const watchSummary: GenieSummary = Either.isRight(result)
+                        ? {
+                            created: result.right._tag === 'created' ? 1 : 0,
+                            updated: result.right._tag === 'updated' ? 1 : 0,
+                            unchanged:
+                              newGenieFiles.length -
+                              1 +
+                              (result.right._tag === 'unchanged' ? 1 : 0),
+                            skipped: result.right._tag === 'skipped' ? 1 : 0,
+                            failed: 0,
+                          }
+                        : {
+                            created: 0,
+                            updated: 0,
+                            unchanged: newGenieFiles.length - 1,
+                            skipped: 0,
+                            failed: 1,
+                          }
+
+                      tui.dispatch({ _tag: 'Complete', summary: watchSummary })
+                    })
+                  }),
+                  Stream.runDrain,
+                )
+              }
+            }),
+          ),
         { view: <GenieView stateAtom={GenieApp.stateAtom} /> },
       )
     }).pipe(

--- a/packages/@overeng/genie/src/build/sdk.ts
+++ b/packages/@overeng/genie/src/build/sdk.ts
@@ -1,0 +1,134 @@
+import path from 'node:path'
+
+import { type Error as PlatformError, FileSystem } from '@effect/platform'
+import type * as CommandExecutor from '@effect/platform/CommandExecutor'
+import type { Path } from '@effect/platform/Path'
+import { Effect, Layer, Option, PubSub } from 'effect'
+
+import { type GenieGenerateResult, checkAll, generateAll, resolveOxfmtConfigPath } from './core.ts'
+import type { GenieGenerationFailedError } from './errors.ts'
+import { type GenieEvent, GenieEventBus } from './events.ts'
+
+export type { GenieGenerateResult } from './core.ts'
+export type { GenieSummary } from './schema.ts'
+export type { GenerateSuccess } from './types.ts'
+export { GenieCheckError, GenieGenerationFailedError, GenieImportError } from './errors.ts'
+export { type GenieEvent, GenieEventBus } from './events.ts'
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export type GenieGenerateOptions = {
+  cwd: string
+  writeable?: boolean
+  dryRun?: boolean
+  env?: Record<string, string>
+  oxfmtConfigPath?: string
+}
+
+export type GenieCheckOptions = {
+  cwd: string
+  env?: Record<string, string>
+  oxfmtConfigPath?: string
+}
+
+/** Temporarily set env vars, run an effect, then restore original values. */
+const withEnv = <A, E, R>(
+  env: Record<string, string>,
+  effect: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R> =>
+  Effect.acquireUseRelease(
+    Effect.sync(() => {
+      const saved: Record<string, string | undefined> = {}
+      for (const [key, value] of Object.entries(env)) {
+        saved[key] = process.env[key]
+        process.env[key] = value
+      }
+      return saved
+    }),
+    () => effect,
+    (saved) =>
+      Effect.sync(() => {
+        for (const [key, value] of Object.entries(saved)) {
+          if (value === undefined) {
+            delete process.env[key]
+          } else {
+            process.env[key] = value
+          }
+        }
+      }),
+  )
+
+/** Resolve cwd to a real path, normalizing symlinks. */
+const resolveCwd = (inputCwd: string) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem
+    const absoluteCwd = path.isAbsolute(inputCwd) ? inputCwd : path.resolve(inputCwd)
+    return yield* fs.realPath(absoluteCwd).pipe(Effect.catchAll(() => Effect.succeed(absoluteCwd)))
+  })
+
+/** Provide a no-subscriber event bus (events are silently dropped). */
+const withSilentEventBus = <A, E, R>(
+  effect: Effect.Effect<A, E, R | GenieEventBus>,
+): Effect.Effect<A, E, Exclude<R, GenieEventBus>> =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const bus = yield* PubSub.unbounded<GenieEvent>()
+      return yield* effect.pipe(Effect.provideService(GenieEventBus, bus))
+    }),
+  ) as Effect.Effect<A, E, Exclude<R, GenieEventBus>>
+
+/** Generate files from all discovered .genie.ts sources. */
+export const generate = ({
+  cwd: inputCwd,
+  writeable = false,
+  dryRun = false,
+  env,
+  oxfmtConfigPath: explicitOxfmtPath,
+}: GenieGenerateOptions): Effect.Effect<
+  GenieGenerateResult,
+  GenieGenerationFailedError | PlatformError.PlatformError,
+  FileSystem.FileSystem | Path | CommandExecutor.CommandExecutor
+> => {
+  const core = Effect.gen(function* () {
+    const cwd = yield* resolveCwd(inputCwd)
+    const oxfmtConfigPath = yield* resolveOxfmtConfigPath({
+      explicitPath: explicitOxfmtPath ? Option.some(explicitOxfmtPath) : Option.none(),
+      cwd,
+    })
+    return yield* withSilentEventBus(
+      generateAll({ cwd, readOnly: !writeable, dryRun, oxfmtConfigPath }),
+    )
+  })
+
+  if (env && Object.keys(env).length > 0) {
+    return withEnv(env, core)
+  }
+  return core
+}
+
+/** Check that all generated files are up to date. */
+export const check = ({
+  cwd: inputCwd,
+  env,
+  oxfmtConfigPath: explicitOxfmtPath,
+}: GenieCheckOptions): Effect.Effect<
+  void,
+  GenieGenerationFailedError | PlatformError.PlatformError,
+  FileSystem.FileSystem | Path | CommandExecutor.CommandExecutor
+> => {
+  const core = Effect.gen(function* () {
+    const cwd = yield* resolveCwd(inputCwd)
+    const oxfmtConfigPath = yield* resolveOxfmtConfigPath({
+      explicitPath: explicitOxfmtPath ? Option.some(explicitOxfmtPath) : Option.none(),
+      cwd,
+    })
+    return yield* withSilentEventBus(checkAll({ cwd, oxfmtConfigPath }))
+  })
+
+  if (env && Object.keys(env).length > 0) {
+    return withEnv(env, core)
+  }
+  return core
+}


### PR DESCRIPTION
## Summary

- Adds `@overeng/genie/sdk` export with programmatic `generate` and `check` functions
- Extracts core orchestration from `mod.tsx` into shared `core.ts` using PubSub + Stream event bus pattern
- CLI subscribes to the event stream for TUI progress; SDK provides a silent (no-subscriber) bus
- Supports `env` option for setting process env vars during generation (e.g. release version)

Closes #191

## Architecture

```
events.ts  → GenieEvent type + GenieEventBus Context.Tag
core.ts    → generateAll / checkAll (single source of truth)
sdk.ts     → thin wrapper: env handling, silent bus, cwd resolution
mod.tsx    → thin wrapper: PubSub.subscribe → TUI dispatch, delegates to core
```

## Test plan

- [x] `dt ts:check` passes
- [x] `dt lint:check` passes  
- [x] `dt genie:check` passes
- [x] `dt test:genie` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)