### PR TITLE
fix(genie-coverage): wire up genieCoverageExcludes in coverage check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,11 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- **devenv/tasks/shared/lint-oxc.nix**: Wire up `genieCoverageExcludes` in coverage check (#198)
+- **devenv/tasks/shared/lint-oxc.nix**: Wire up `genieCoverageExcludes` and add `genieCoverageFiles` (#198)
   - `genieCoverageExcludes` was accepted but never applied; now uses git pathspec exclusion
+  - New `genieCoverageFiles` parameter (default: `["package.json" "tsconfig.json"]`) makes checked file types configurable
   - Removed dead `defaultExcludes`/`excludeArgs` code from obsolete `find`-based approach
+  - Made doc examples more generic (removed `@overeng`-specific paths)
 
 ### Added
 

--- a/nix/devenv-modules/tasks/shared/lint-oxc.nix
+++ b/nix/devenv-modules/tasks/shared/lint-oxc.nix
@@ -8,25 +8,24 @@
 #     (inputs.effect-utils.devenvModules.tasks.lint-oxc {
 #       # Explicit glob patterns for execIfModified (avoids node_modules traversal)
 #       # IMPORTANT: Use patterns that don't traverse into node_modules directories
-#       # Good: "packages/@overeng/*/src/**/*.ts" (src/ never contains node_modules)
+#       # Good: "packages/*/src/**/*.ts" (src/ never contains node_modules)
 #       # Bad:  "packages/**/*.ts" (traverses into packages/*/node_modules/)
 #       execIfModifiedPatterns = [
-#         "packages/@overeng/*/src/**/*.ts"
-#         "packages/@overeng/*/src/**/*.tsx"
-#         "packages/@overeng/*/*.ts"  # root config files including *.genie.ts
-#         "scripts/*.ts"
-#         "scripts/commands/**/*.ts"
+#         "packages/*/src/**/*.ts"
+#         "packages/*/src/**/*.tsx"
+#         "packages/*/*.ts"  # root config files including *.genie.ts
 #       ];
 #       # Glob patterns for .genie.ts files (for genie check caching)
 #       # Should match all *.genie.ts files without traversing node_modules
 #       geniePatterns = [
-#         "packages/@overeng/*/*.genie.ts"
-#         "scripts/*.genie.ts"
+#         "packages/*/*.genie.ts"
 #       ];
 #       # Directories to scan for genie coverage check
-#       genieCoverageDirs = [ "packages" "scripts" ];  # required
+#       genieCoverageDirs = [ "packages" ];  # required
 #       # Path prefixes to exclude from genie coverage (git pathspec patterns)
-#       genieCoverageExcludes = [ "packages/vendored/" "packages/**/.yarn/sdks/" ];  # optional
+#       genieCoverageExcludes = [ "packages/vendored/" ];  # optional
+#       # Config file names to check for genie coverage (default: package.json + tsconfig.json)
+#       genieCoverageFiles = [ "package.json" "tsconfig.json" ];  # optional
 #       # Path to tsconfig for type-aware linting (enables typescript/no-deprecated etc)
 #       tsconfig = "tsconfig.all.json";  # optional
 #       # Pre-built JS plugin paths to inject at runtime (for repos without node_modules)
@@ -44,6 +43,7 @@
   geniePatterns,
   genieCoverageDirs,
   genieCoverageExcludes ? [ ],
+  genieCoverageFiles ? [ "package.json" "tsconfig.json" ],
   lintPaths ? [ "." ],
   # Type-aware linting: provide tsconfig to enable --type-aware flag.
   # Requires pkgs.tsgolint in devenv packages (auto-discovered on PATH by oxlint).
@@ -64,6 +64,8 @@ let
   scanDirsArg = builtins.concatStringsSep " " genieCoverageDirs;
   # Git pathspec exclusion patterns applied to coverage check (e.g. "packages/vendored/")
   excludePathspecs = builtins.concatStringsSep " " (map (p: "':(exclude)${p}'") genieCoverageExcludes);
+  # Bash case pattern matching config file names (e.g. "package.json|*/package.json|tsconfig.json|*/tsconfig.json")
+  coverageFilePattern = builtins.concatStringsSep "|" (lib.concatMap (f: [ f "*/${f}" ]) genieCoverageFiles);
   lintPathsArg = builtins.concatStringsSep " " lintPaths;
 
   # Type-aware linting flags (enabled when tsconfig is provided)
@@ -154,7 +156,7 @@ in
             ${git} ls-files --others --exclude-standard -- ${scanDirsArg} ${excludePathspecs}
           } | sort -u | while IFS= read -r f; do
             case "$f" in
-              package.json|tsconfig.json|*/package.json|*/tsconfig.json) echo "$f" ;;
+              ${coverageFilePattern}) echo "$f" ;;
             esac
           done
         )


### PR DESCRIPTION
## Summary

Closes #198

- **Wire up `genieCoverageExcludes`**: Was accepted as a parameter but never applied to the `git ls-files` enumeration — now uses git pathspec exclusion (`:(exclude)pattern`)
- **New `genieCoverageFiles` parameter**: Configurable list of file names to check (default: `["package.json" "tsconfig.json"]`), so consumer repos can extend coverage to other genie-managed config files
- **Remove dead code**: `defaultExcludes` / `allExcludes` / `excludeArgs` from the obsolete `find`-based approach (these dirs are already handled by `.gitignore` + `--exclude-standard`)
- **Generic doc examples**: Replaced `@overeng`-specific paths with generic `packages/*/...` patterns

## Usage

```nix
genieCoverageExcludes = [ "packages/vendored/" ];
genieCoverageFiles = [ "package.json" "tsconfig.json" "megarepo.json" ];
```

## Test plan

- [x] `dt lint:check:genie:coverage` passes (no regressions — this repo uses the defaults)
- [ ] Verify in a consumer repo that excludes suppress coverage errors for excluded subtrees

🤖 Generated with [Claude Code](https://claude.com/claude-code)