### PR TITLE
feat(otel): add extraDashboards + buildOtelDashboards

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -135,6 +135,12 @@
       lib.cliBuildStamp =
         { pkgs }: import ./nix/workspace-tools/lib/cli-build-stamp.nix { inherit pkgs; };
 
+      # Build Grafonnet dashboards against the shared OTEL dashboard library.
+      # Returns a linkFarm (Nix store path) containing compiled JSON files.
+      lib.buildOtelDashboards =
+        { pkgs, src, dashboardNames }:
+        import ./nix/devenv-modules/otel/build-dashboards.nix { inherit pkgs src dashboardNames; };
+
       # Convenience helper for bundling the common genie/megarepo CLIs.
       # Use this for releases/CI where hermetic Nix builds are needed.
       lib.mkCliPackages = import ./nix/workspace-tools/lib/mk-cli-packages.nix;

--- a/nix/devenv-modules/otel/build-dashboards.nix
+++ b/nix/devenv-modules/otel/build-dashboards.nix
@@ -1,0 +1,83 @@
+# Standalone build helper for compiling Grafonnet dashboards.
+#
+# Projects import this to compile their Jsonnet sources against Grafonnet
+# and the shared effect-utils dashboard library (lib.libsonnet, g.libsonnet).
+#
+# Usage:
+#   let
+#     dashboards = effectUtils.lib.buildOtelDashboards {
+#       inherit pkgs;
+#       src = ./nix/otel-dashboards;
+#       dashboardNames = [ "my-overview" "my-traces" ];
+#     };
+#   in
+#   # dashboards is a Nix store path (linkFarm) containing compiled JSON files
+#   (effectUtils.devenvModules.otel {
+#     extraDashboards = [{ name = "my-project"; path = dashboards; }];
+#   })
+{
+  pkgs,
+  # Directory containing *.jsonnet source files and any project-local libsonnet
+  src,
+  # List of dashboard names to compile (each must have a corresponding .jsonnet file in src)
+  dashboardNames,
+}:
+let
+  grafonnetSrc = pkgs.fetchFromGitHub {
+    owner = "grafana";
+    repo = "grafonnet";
+    rev = "7380c9c64fb973f34c3ec46265621a2b0dee0058";
+    sha256 = "sha256-WS3Z/k9fDSleK6RVPTFQ9Um26GRFv/kxZhARXpGkS10=";
+  };
+
+  xtdSrc = pkgs.fetchFromGitHub {
+    owner = "jsonnet-libs";
+    repo = "xtd";
+    rev = "4d7f8cb24d613430799f9d56809cc6964f35cea9";
+    sha256 = "sha256-MWinI7gX39UIDVh9kzkHFH6jsKZoI294paQUWd/4+ag=";
+  };
+
+  docsonnetSrc = pkgs.fetchFromGitHub {
+    owner = "jsonnet-libs";
+    repo = "docsonnet";
+    rev = "6ac6c69685b8c29c54515448eaca583da2d88150";
+    sha256 = "sha256-Uy86lIQbFjebNiAAp0dJ8rAtv16j4V4pXMPcl+llwBA=";
+  };
+
+  builtinDashboardsSrcDir = ./dashboards;
+
+  grafonnetJpath = pkgs.linkFarm "grafonnet-jpath" [
+    {
+      name = "github.com/grafana/grafonnet";
+      path = grafonnetSrc;
+    }
+    {
+      name = "github.com/jsonnet-libs/xtd";
+      path = xtdSrc;
+    }
+    {
+      name = "github.com/jsonnet-libs/docsonnet";
+      path = docsonnetSrc;
+    }
+  ];
+
+  buildDashboard = name:
+    pkgs.runCommand "grafana-dashboard-${name}"
+      { nativeBuildInputs = [ pkgs.go-jsonnet ]; }
+      ''
+        mkdir -p $out
+        jsonnet \
+          -J ${grafonnetJpath} \
+          -J ${grafonnetSrc} \
+          -J ${builtinDashboardsSrcDir} \
+          -J ${src} \
+          ${src}/${name}.jsonnet \
+          -o $out/${name}.json
+      '';
+in
+pkgs.linkFarm "otel-dashboards-extra" (
+  map (name: {
+    name = "${name}.json";
+    path = "${buildDashboard name}/${name}.json";
+  }) dashboardNames
+)


### PR DESCRIPTION
## Summary

- Add `lib.buildOtelDashboards` — standalone build helper that compiles Jsonnet dashboards against Grafonnet and the shared `lib.libsonnet`/`g.libsonnet`
- Add `extraDashboards` parameter to the OTEL module — accepts pre-compiled dashboard dirs as `[{ name, path }]` for provisioning
- Separates compilation (build helper) from provisioning (module) so projects control their own build step

## API

```nix
# In consuming project's devenv.nix:
let
  dashboards = effectUtils.lib.buildOtelDashboards {
    inherit pkgs;
    src = ./nix/otel-dashboards;
    dashboardNames = [ "my-overview" "my-traces" ];
  };
in
(effectUtils.devenvModules.otel {
  extraDashboards = [{ name = "my-project"; path = dashboards; }];
})
```

## Test plan

- [ ] Verify built-in dashboards still compile and provision (no regression)
- [ ] Verify `buildOtelDashboards` compiles project Jsonnet against shared libs
- [ ] Verify system-mode copies extra dashboards to `$OTEL_STATE_DIR/dashboards/<name>/`
- [ ] Verify local-mode Grafana provisioning includes extra dashboard providers

---

*This PR was authored by @schickling with assistance from Claude Code.*