### PR TITLE
feat(dt): add gh:apply-settings task

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -339,6 +339,17 @@ in
   tasks."genie:check".after = [ "pnpm:install:genie" ];
   tasks."megarepo:sync".after = [ "pnpm:install:megarepo" ];
 
+  tasks."gh:apply-settings" = {
+    after = [ "genie:run" ];
+    exec = ''
+      set -euo pipefail
+      ruleset_id=$(gh api repos/overengineeringstudio/effect-utils/rulesets --jq '.[0].id')
+      gh api "repos/overengineeringstudio/effect-utils/rulesets/$ruleset_id" --method PUT --input .github/repo-settings.json
+      echo "Applied repo-settings.json to ruleset $ruleset_id"
+    '';
+    description = "Apply .github/repo-settings.json to GitHub ruleset";
+  };
+
   # Wire beads:daemon:ensure directly to shell entry (not via optionalTasks).
   # The setup module's gitHashStatus cache would prevent re-checking the daemon
   # after it stops without a new commit. The beads module's own status check

--- a/megarepo.lock
+++ b/megarepo.lock
@@ -4,16 +4,16 @@
     "effect": {
       "url": "https://github.com/effect-ts/effect",
       "ref": "main",
-      "commit": "d67c7089ba8616b2d48ef7324312267a2a6f310a",
+      "commit": "52cd53115fe14e2b9c36dd0d51eb490aead74ee6",
       "pinned": false,
-      "lockedAt": "2026-02-11T15:08:22.831Z"
+      "lockedAt": "2026-02-13T11:55:55.605Z"
     },
     "overeng-beads-public": {
       "url": "https://github.com/overengineeringstudio/overeng-beads-public",
       "ref": "main",
-      "commit": "268231d1664abf25ef82fd7aa4d83e9f77e2f9c5",
+      "commit": "6b910598ccbe27ac98ded98c9cdd98c16cae36e7",
       "pinned": false,
-      "lockedAt": "2026-02-11T15:08:22.831Z"
+      "lockedAt": "2026-02-13T11:55:55.605Z"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Adds `dt gh:apply-settings` devenv task that applies `.github/repo-settings.json` to the GitHub repository ruleset via the `gh` CLI
- Depends on `genie:run` to ensure the settings JSON is up to date before applying

🤖 Generated with [Claude Code](https://claude.com/claude-code)