### PR TITLE
fix(nix): replace deprecated pkgs.system with stdenv.hostPlatform.system

### DIFF
--- a/nix/beads.nix
+++ b/nix/beads.nix
@@ -25,7 +25,8 @@ let
     };
   };
 
-  platformInfo = sources.${pkgs.system} or (throw "Unsupported system: ${pkgs.system}");
+  system = pkgs.stdenv.hostPlatform.system;
+  platformInfo = sources.${system} or (throw "Unsupported system: ${system}");
 in
 pkgs.stdenv.mkDerivation {
   pname = "beads";


### PR DESCRIPTION
## Summary
- Replace `pkgs.system` with `pkgs.stdenv.hostPlatform.system` in `nix/beads.nix`
- Fixes Nix evaluation warning `'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'` that appears in consumers using recent nixpkgs-unstable

🤖 Generated with [Claude Code](https://claude.com/claude-code)