### PR TITLE
fix(dt): use --build --noEmit for ts:check to match ts:build strictness

### DIFF
--- a/nix/devenv-modules/tasks/shared/ts.nix
+++ b/nix/devenv-modules/tasks/shared/ts.nix
@@ -182,8 +182,8 @@ in
 
   tasks = {
     "ts:check" = {
-      description = "Type check the whole workspace (tsc -p; emits by design with project references)";
-      exec = trace.exec "ts:check" (tscWithDiagnostics "-p ${tsconfigFile}" "--noEmit");
+      description = "Type check the whole workspace (tsc --build --noEmit)";
+      exec = trace.exec "ts:check" (tscWithDiagnostics "--build ${tsconfigFile}" "--noEmit");
       after = [
         "genie:run"
         "pnpm:install"


### PR DESCRIPTION
## Problem

PR #218 switched `ts:check` from `tsc --build` to `tsc -p --noEmit`. While this preserved the no-emit intent, it inadvertently weakened type checking:

- `tsc -p` compiles everything in a single context where types can leak across project boundaries
- `tsc --build` enforces strict project-reference isolation, compiling each project independently

This caused `ts:check` to pass while `ts:build` failed on the same codebase (observed in [livestore CI](https://github.com/livestorejs/livestore/pull/1026) where the `type-check` job was green but all `ts:build`-dependent jobs failed).

## Approach

Switch `ts:check` to `tsc --build --noEmit` (supported since TS 5.x), which preserves both:
- The `--build` project isolation semantics (same strictness as `ts:build`)
- The no-emit behavior (faster than `ts:build` since it skips output generation)

## Validation

- Verified the `--build --noEmit` invocation matches the `tscInvocation` guard (`== --build*`) so OTEL diagnostics still work correctly
- Confirmed TS 5.x supports `--build --noEmit`

## Tradeoffs

None — this is strictly better than the `-p --noEmit` approach since it catches the same errors as `ts:build`.