### PR TITLE
feat(dt): disable TUI for coding agents

### DIFF
--- a/nix/devenv-modules/dt.nix
+++ b/nix/devenv-modules/dt.nix
@@ -35,9 +35,26 @@
     done
     set -- "''${_dt_args[@]}"
 
-    # Auto-detect non-interactive environments (CI, piped output, git hooks)
+    # Detect coding agent environments (mirrors isAgentEnv from tui-react)
+    _dt_is_agent_env() {
+      # AGENT: generic convention (OpenCode: AGENT=1, Amp: AGENT=amp)
+      if [ -n "''${AGENT:-}" ] && [ "''${AGENT}" != "0" ] && [ "''${AGENT}" != "false" ]; then return 0; fi
+      # Claude Code
+      [ -n "''${CLAUDE_PROJECT_DIR:-}" ] && return 0
+      # Amp
+      [ -n "''${CLAUDECODE:-}" ] && return 0
+      # OpenCode
+      [ -n "''${OPENCODE:-}" ] && return 0
+      # Cline (VS Code extension)
+      [ -n "''${CLINE_ACTIVE:-}" ] && return 0
+      # OpenAI Codex CLI
+      [ -n "''${CODEX_SANDBOX:-}" ] && return 0
+      return 1
+    }
+
+    # Auto-detect non-interactive environments (CI, piped output, git hooks, coding agents)
     _dt_tui_flag=""
-    if [ -n "''${CI:-}" ] || ! [ -t 1 ]; then
+    if [ -n "''${CI:-}" ] || ! [ -t 1 ] || _dt_is_agent_env; then
       _dt_tui_flag="--no-tui"
     fi
 


### PR DESCRIPTION
## Summary

Add detection for coding agent environments (Claude Code, Amp, OpenCode, Cline, Codex) and automatically disable TUI output in these contexts, matching the behavior in tui-react. This ensures coding agents receive structured, non-interactive output from devenv tasks.

## Changes

- Adds `_dt_is_agent_env()` helper function that detects coding agent environment variables
- Extends `--no-tui` flag logic to disable TUI when running in a coding agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)