### PR TITLE
feat: add shared auto-review workflow for assistant PRs

### DIFF
--- a/.github/workflows/auto-review.yml
+++ b/.github/workflows/auto-review.yml
@@ -1,0 +1,21 @@
+# Generated file - DO NOT EDIT
+# Source: auto-review.yml.genie.ts
+
+name: Auto-request review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  request-review:
+    if: github.event.pull_request.user.login == 'schickling-assistant' && github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Request review from schickling
+        env:
+          GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+        run: 'gh pr edit ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --add-reviewer schickling'

--- a/.github/workflows/auto-review.yml.genie.ts
+++ b/.github/workflows/auto-review.yml.genie.ts
@@ -1,0 +1,3 @@
+import { autoReviewWorkflow } from '../../genie/auto-review.ts'
+
+export default autoReviewWorkflow()

--- a/genie/auto-review.ts
+++ b/genie/auto-review.ts
@@ -1,0 +1,32 @@
+/** Shared auto-review workflow: requests review from a human when an assistant opens a PR */
+
+import { githubWorkflow } from '../packages/@overeng/genie/src/runtime/mod.ts'
+
+export const autoReviewWorkflow = ({
+  author = 'schickling-assistant',
+  reviewer = 'schickling',
+} = {}) =>
+  githubWorkflow({
+    name: 'Auto-request review',
+    on: {
+      pull_request: {
+        types: ['opened', 'ready_for_review'],
+      },
+    },
+    permissions: {
+      'pull-requests': 'write',
+    },
+    jobs: {
+      'request-review': {
+        if: `github.event.pull_request.user.login == '${author}' && github.event.pull_request.draft == false`,
+        'runs-on': 'ubuntu-latest',
+        steps: [
+          {
+            name: `Request review from ${reviewer}`,
+            env: { GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}' },
+            run: `gh pr edit \${{ github.event.pull_request.number }} --repo \${{ github.repository }} --add-reviewer ${reviewer}`,
+          },
+        ],
+      },
+    },
+  })


### PR DESCRIPTION
## Summary
- Adds `genie/auto-review.ts` — reusable helper that generates a GitHub Actions workflow to auto-request review from `schickling` when `schickling-assistant` opens a PR
- Adds `auto-review.yml.genie.ts` + generated `auto-review.yml` for this repo
- Consumer repos (dotfiles, livestore, schickling-stiftung, etc.) will add their own genie files importing this helper in follow-up PRs

## How it works
- Triggers on `pull_request: [opened, ready_for_review]`
- Checks if author is `schickling-assistant` and PR is not a draft
- Uses `gh pr edit --add-reviewer` to request review from `schickling`

🤖 Generated with [Claude Code](https://claude.com/claude-code)