### PR TITLE
feat(genie): add shared CI workflow building blocks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
+        uses: DeterminateSystems/determinate-nix-action@v3
         with:
-          extra_nix_config: |
-            extra-substituters = https://cache.nixos.org
-            extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+          extra-conf: |
+            extra-substituters = https://devenv.cachix.org
+            extra-trusted-public-keys = devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
       - name: Enable Cachix cache
         uses: cachix/cachix-action@v16
         with:
@@ -58,11 +58,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
+        uses: DeterminateSystems/determinate-nix-action@v3
         with:
-          extra_nix_config: |
-            extra-substituters = https://cache.nixos.org
-            extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+          extra-conf: |
+            extra-substituters = https://devenv.cachix.org
+            extra-trusted-public-keys = devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
       - name: Enable Cachix cache
         uses: cachix/cachix-action@v16
         with:
@@ -97,11 +97,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
+        uses: DeterminateSystems/determinate-nix-action@v3
         with:
-          extra_nix_config: |
-            extra-substituters = https://cache.nixos.org
-            extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+          extra-conf: |
+            extra-substituters = https://devenv.cachix.org
+            extra-trusted-public-keys = devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
       - name: Enable Cachix cache
         uses: cachix/cachix-action@v16
         with:
@@ -136,11 +136,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
+        uses: DeterminateSystems/determinate-nix-action@v3
         with:
-          extra_nix_config: |
-            extra-substituters = https://cache.nixos.org
-            extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+          extra-conf: |
+            extra-substituters = https://devenv.cachix.org
+            extra-trusted-public-keys = devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
       - name: Enable Cachix cache
         uses: cachix/cachix-action@v16
         with:
@@ -176,11 +176,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
+        uses: DeterminateSystems/determinate-nix-action@v3
         with:
-          extra_nix_config: |
-            extra-substituters = https://cache.nixos.org
-            extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+          extra-conf: |
+            extra-substituters = https://devenv.cachix.org
+            extra-trusted-public-keys = devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
       - name: Enable Cachix cache
         uses: cachix/cachix-action@v16
         with:

--- a/genie/ci-workflow.ts
+++ b/genie/ci-workflow.ts
@@ -1,0 +1,125 @@
+/**
+ * Shared CI workflow building blocks for GitHub Actions.
+ *
+ * Provides composable step atoms and job configuration helpers
+ * that peer repos import to avoid CI template duplication.
+ *
+ * @example
+ * ```ts
+ * import {
+ *   checkoutStep, installNixStep, cachixStep,
+ *   installDevenvFromLockStep, devenvShellDefaults, standardCIEnv,
+ * } from '../../repos/effect-utils/genie/ci-workflow.ts'
+ *
+ * const baseSteps = [
+ *   checkoutStep(),
+ *   installNixStep(),
+ *   cachixStep({ name: 'my-cache' }),
+ *   installDevenvFromLockStep,
+ * ]
+ * ```
+ */
+
+import { RUNNER_PROFILES, type RunnerProfile } from './ci.ts'
+
+export { RUNNER_PROFILES, type RunnerProfile }
+
+// =============================================================================
+// Shared Config
+// =============================================================================
+
+/** Standard devenv shell for CI job defaults */
+export const devenvShellDefaults = {
+  run: { shell: 'devenv shell bash -- -e {0}' },
+} as const
+
+/** Standard CI environment variables */
+export const standardCIEnv = {
+  FORCE_SETUP: '1',
+  CI: 'true',
+} as const
+
+/**
+ * Namespace runner with run ID-based affinity to prevent queue jumping.
+ * Adds a run ID label so runners spawned for one workflow run
+ * don't steal jobs from other runs.
+ */
+export const namespaceRunner = (profile: RunnerProfile | (string & {}), runId: string) =>
+  [profile, `namespace-features:github.run-id=${runId}`] as const
+
+// =============================================================================
+// Step Atoms
+// =============================================================================
+
+/** Checkout repository via actions/checkout@v4 */
+export const checkoutStep = (opts?: { repository?: string; ref?: string; path?: string }) => ({
+  uses: 'actions/checkout@v4' as const,
+  ...(opts && Object.keys(opts).length > 0 ? { with: opts } : {}),
+})
+
+/**
+ * Install Nix via DeterminateSystems/determinate-nix-action@v3.
+ * Includes devenv.cachix.org as extra substituter by default
+ * for pre-built devenv binaries.
+ */
+export const installNixStep = (opts?: { extraConf?: string }) => ({
+  name: 'Install Nix',
+  uses: 'DeterminateSystems/determinate-nix-action@v3' as const,
+  with: {
+    'extra-conf': [
+      'extra-substituters = https://devenv.cachix.org',
+      'extra-trusted-public-keys = devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=',
+      ...(opts?.extraConf ? [opts.extraConf] : []),
+    ].join('\n'),
+  },
+})
+
+/** Enable a Cachix binary cache */
+export const cachixStep = (opts: { name: string; authToken?: string }) => ({
+  name: 'Enable Cachix cache',
+  uses: 'cachix/cachix-action@v16' as const,
+  with: {
+    name: opts.name,
+    ...(opts.authToken ? { authToken: opts.authToken } : {}),
+  },
+})
+
+/**
+ * Install devenv pinned to the exact rev from devenv.lock.
+ * Ensures version consistency between local dev and CI.
+ */
+export const installDevenvFromLockStep = {
+  name: 'Install devenv',
+  run: 'nix profile install github:cachix/devenv/$(jq -r ".nodes.devenv.locked.rev" devenv.lock)',
+  shell: 'bash',
+} as const
+
+/** Install megarepo CLI from effect-utils */
+export const installMegarepoStep = {
+  name: 'Install megarepo CLI',
+  run: 'nix profile install github:overengineeringstudio/effect-utils#megarepo',
+  shell: 'bash',
+} as const
+
+/** Sync megarepo dependencies */
+export const syncMegarepoStep = (opts?: { frozen?: boolean; skip?: string[] }) => {
+  const args = ['mr', 'sync']
+  if (opts?.frozen !== false) args.push('--frozen')
+  if (opts?.skip) for (const s of opts.skip) args.push('--skip', s)
+  return {
+    name: 'Sync megarepo dependencies',
+    run: args.join(' '),
+    shell: 'bash',
+  }
+}
+
+/**
+ * Repair Nix store on namespace runners.
+ * Removes invalid DB entries so nix re-fetches from substituters on demand.
+ * @see https://github.com/overengineeringstudio/effect-utils/issues/201
+ */
+export const repairNixStoreStep = {
+  name: 'Repair Nix store',
+  run: 'nix-store --verify --repair',
+  shell: 'bash',
+} as const

--- a/genie/external.ts
+++ b/genie/external.ts
@@ -619,3 +619,22 @@ export const testFilesOxlintOverride = {
 
 /** Re-export oxlint ignore patterns from oxlint-base */
 export { baseOxlintIgnorePatterns } from './oxlint-base.ts'
+
+// =============================================================================
+// CI Workflow Helpers
+// =============================================================================
+
+export {
+  checkoutStep,
+  cachixStep,
+  devenvShellDefaults,
+  installDevenvFromLockStep,
+  installMegarepoStep,
+  installNixStep,
+  namespaceRunner,
+  repairNixStoreStep,
+  standardCIEnv,
+  syncMegarepoStep,
+  RUNNER_PROFILES,
+  type RunnerProfile,
+} from './ci-workflow.ts'


### PR DESCRIPTION
## Summary
- Extract reusable CI step atoms into `genie/ci-workflow.ts` so peer repos can import instead of duplicating setup logic
- Migrate Nix installer from `cachix/install-nix-action` to `DeterminateSystems/determinate-nix-action@v3`
- Dogfood shared blocks in effect-utils' own CI
- Re-export CI helpers from `genie/external.ts`

### Shared building blocks
| Export | Description |
|---|---|
| `devenvShellDefaults` | `{ run: { shell: 'devenv shell bash -- -e {0}' } }` |
| `standardCIEnv` | `{ FORCE_SETUP: '1', CI: 'true' }` |
| `namespaceRunner(profile, runId)` | Runner affinity labels |
| `checkoutStep(opts?)` | `actions/checkout@v4` |
| `installNixStep(opts?)` | `DeterminateSystems/determinate-nix-action@v3` + devenv.cachix.org |
| `cachixStep({ name, authToken? })` | `cachix/cachix-action@v16` |
| `installDevenvFromLockStep` | Pinned from `devenv.lock` rev |
| `installMegarepoStep` | `nix profile install ...#megarepo` |
| `syncMegarepoStep(opts?)` | `mr sync --frozen [--skip ...]` |
| `repairNixStoreStep` | `nix-store --verify --repair` |

### Downstream adoption
Peer repos will adopt these shared blocks in follow-up PRs (lock bump + import shared steps).

## Test plan
- [x] Genie regenerates `ci.yml` correctly with Determinate Nix
- [ ] CI passes with new Nix installer

🤖 Generated with [Claude Code](https://claude.com/claude-code)