### PR TITLE
refactor(genie): replace repairNixStoreStep with validateNixStoreStep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,15 @@ jobs:
       - name: Install devenv
         run: 'nix profile install github:cachix/devenv/$(jq -r ".nodes.devenv.locked.rev" devenv.lock)'
         shell: bash
-      - name: Repair Nix store
-        run: nix-store --verify --repair
+      - name: Validate Nix store
+        run: |
+          if devenv version > /dev/null 2>&1; then
+            echo "Nix store OK"
+          else
+            echo "::warning::Nix store validation failed, running repair..."
+            nix-store --verify --repair 2>&1 | tail -20
+            devenv version
+          fi
         shell: bash
       - name: Type check
         run: 'dt ts:check'
@@ -71,8 +78,15 @@ jobs:
       - name: Install devenv
         run: 'nix profile install github:cachix/devenv/$(jq -r ".nodes.devenv.locked.rev" devenv.lock)'
         shell: bash
-      - name: Repair Nix store
-        run: nix-store --verify --repair
+      - name: Validate Nix store
+        run: |
+          if devenv version > /dev/null 2>&1; then
+            echo "Nix store OK"
+          else
+            echo "::warning::Nix store validation failed, running repair..."
+            nix-store --verify --repair 2>&1 | tail -20
+            devenv version
+          fi
         shell: bash
       - name: Format + lint
         run: 'dt lint:check'
@@ -110,8 +124,15 @@ jobs:
       - name: Install devenv
         run: 'nix profile install github:cachix/devenv/$(jq -r ".nodes.devenv.locked.rev" devenv.lock)'
         shell: bash
-      - name: Repair Nix store
-        run: nix-store --verify --repair
+      - name: Validate Nix store
+        run: |
+          if devenv version > /dev/null 2>&1; then
+            echo "Nix store OK"
+          else
+            echo "::warning::Nix store validation failed, running repair..."
+            nix-store --verify --repair 2>&1 | tail -20
+            devenv version
+          fi
         shell: bash
       - name: Unit tests
         run: 'dt test:run'
@@ -149,8 +170,15 @@ jobs:
       - name: Install devenv
         run: 'nix profile install github:cachix/devenv/$(jq -r ".nodes.devenv.locked.rev" devenv.lock)'
         shell: bash
-      - name: Repair Nix store
-        run: nix-store --verify --repair
+      - name: Validate Nix store
+        run: |
+          if devenv version > /dev/null 2>&1; then
+            echo "Nix store OK"
+          else
+            echo "::warning::Nix store validation failed, running repair..."
+            nix-store --verify --repair 2>&1 | tail -20
+            devenv version
+          fi
         shell: bash
       - name: Nix hash check
         run: 'dt nix:check'
@@ -189,8 +217,15 @@ jobs:
       - name: Install devenv
         run: 'nix profile install github:cachix/devenv/$(jq -r ".nodes.devenv.locked.rev" devenv.lock)'
         shell: bash
-      - name: Repair Nix store
-        run: nix-store --verify --repair
+      - name: Validate Nix store
+        run: |
+          if devenv version > /dev/null 2>&1; then
+            echo "Nix store OK"
+          else
+            echo "::warning::Nix store validation failed, running repair..."
+            nix-store --verify --repair 2>&1 | tail -20
+            devenv version
+          fi
         shell: bash
       - name: Deploy storybooks to Netlify
         run: |

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -7,7 +7,7 @@ import {
   installNixStep,
   cachixStep,
   installDevenvFromLockStep,
-  repairNixStoreStep,
+  validateNixStoreStep,
   devenvShellDefaults,
   standardCIEnv,
   namespaceRunner,
@@ -18,7 +18,7 @@ const baseSteps = [
   installNixStep(),
   cachixStep({ name: 'overeng-effect-utils', authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}' }),
   installDevenvFromLockStep,
-  repairNixStoreStep,
+  validateNixStoreStep,
 ] as const
 
 const failureReminderStep = {

--- a/genie/ci-workflow.ts
+++ b/genie/ci-workflow.ts
@@ -114,12 +114,20 @@ export const syncMegarepoStep = (opts?: { frozen?: boolean; skip?: string[] }) =
 }
 
 /**
- * Repair Nix store on namespace runners.
- * Removes invalid DB entries so nix re-fetches from substituters on demand.
+ * Validate Nix store on namespace runners.
+ * A cheap `devenv version` probe catches corruption before real work starts;
+ * the expensive `--verify --repair` only runs when actually needed.
+ * @see https://github.com/namespacelabs/nscloud-setup/issues/8
  * @see https://github.com/overengineeringstudio/effect-utils/issues/201
  */
-export const repairNixStoreStep = {
-  name: 'Repair Nix store',
-  run: 'nix-store --verify --repair',
+export const validateNixStoreStep = {
+  name: 'Validate Nix store',
+  run: `if devenv version > /dev/null 2>&1; then
+  echo "Nix store OK"
+else
+  echo "::warning::Nix store validation failed, running repair..."
+  nix-store --verify --repair 2>&1 | tail -20
+  devenv version
+fi`,
   shell: 'bash',
 } as const

--- a/genie/external.ts
+++ b/genie/external.ts
@@ -632,7 +632,7 @@ export {
   installMegarepoStep,
   installNixStep,
   namespaceRunner,
-  repairNixStoreStep,
+  validateNixStoreStep,
   standardCIEnv,
   syncMegarepoStep,
   RUNNER_PROFILES,


### PR DESCRIPTION
## Summary
- Replaces the unconditional `nix-store --verify --repair` with a smarter two-stage approach: cheap `devenv version` probe first, expensive repair only when needed
- Saves ~30s on every green CI run on namespace runners
- Aligns effect-utils with the pattern already battle-tested in livestore

## Test plan
- [ ] CI passes with the new validate step
- [ ] Verify namespace runner jobs still recover from store corruption (will be validated over time)