### PR TITLE
feat(lint): exclude import.meta.main from explicit-boolean-compare rule

### DIFF
--- a/packages/@overeng/oxc-config/src/explicit-boolean-compare.ts
+++ b/packages/@overeng/oxc-config/src/explicit-boolean-compare.ts
@@ -136,6 +136,15 @@ const collectImplicit = (node: any): any[] => {
     return [node]
   }
 
+  // import.meta.main — idiomatic Bun/Deno entry-point guard, always boolean
+  if (
+    node.type === 'MemberExpression' &&
+    node.property?.name === 'main' &&
+    node.object?.type === 'MetaProperty'
+  ) {
+    return []
+  }
+
   // Everything else (identifier, call, member, etc.) — implicit
   return [node]
 }

--- a/packages/@overeng/oxc-config/src/explicit-boolean-compare.unit.test.ts
+++ b/packages/@overeng/oxc-config/src/explicit-boolean-compare.unit.test.ts
@@ -88,6 +88,15 @@ ruleTester.run('explicit-boolean-compare: valid other condition positions', rule
 })
 
 // ---------------------------------------------------------------------------
+// Valid: import.meta.main is allowed implicitly
+// ---------------------------------------------------------------------------
+
+ruleTester.run('explicit-boolean-compare: import.meta.main allowed', rule, {
+  valid: [{ code: `if (import.meta.main) {}` }, { code: `if (import.meta.main && x === true) {}` }],
+  invalid: [],
+})
+
+// ---------------------------------------------------------------------------
 // Valid: non-condition positions are not checked
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Allow `if (import.meta.main)` without requiring explicit comparison since it's the idiomatic entry-point guard in Bun/Deno and always evaluates to boolean. Adds test cases to verify the pattern is properly recognized.