### PR TITLE
feat(notion-schema): add Option variants for single relation transforms

### DIFF
--- a/packages/@overeng/notion-cli/src/codegen.ts
+++ b/packages/@overeng/notion-cli/src/codegen.ts
@@ -69,7 +69,7 @@ export const PROPERTY_TRANSFORMS: Record<NotionPropertyType, readonly string[]> 
   email: ['raw', 'asString', 'asOption'],
   phone_number: ['raw', 'asString', 'asOption'],
   formula: ['raw', 'asBoolean', 'asDate', 'asNumber', 'asString'],
-  relation: ['raw', 'asIds', 'asSingle', 'asSingleId'],
+  relation: ['raw', 'asIds', 'asSingle', 'asSingleOption', 'asSingleId', 'asSingleIdOption'],
   rollup: ['raw', 'asArray', 'asBoolean', 'asDate', 'asNumber', 'asString'],
   created_time: ['raw', 'asDate'],
   created_by: ['raw'],
@@ -155,7 +155,9 @@ export const NOTION_SCHEMA_TRANSFORM_KEYS: Partial<
     raw: 'relationProperty',
     asIds: 'relationIds',
     asSingle: 'relationSingle',
+    asSingleOption: 'relationSingleOption',
     asSingleId: 'relationSingleId',
+    asSingleIdOption: 'relationSingleIdOption',
   },
   rollup: {
     raw: 'rollupRaw',
@@ -211,7 +213,7 @@ const inferRollupTransform = (property: PropertyInfo): string | undefined => {
 
 const inferDefaultTransform = (property: PropertyInfo): string => {
   if (property.type === 'relation' && property.relation?.type === 'single_property') {
-    return 'asSingle'
+    return 'asSingleOption'
   }
 
   if (property.type === 'rollup') {

--- a/packages/@overeng/notion-cli/src/codegen.unit.test.ts
+++ b/packages/@overeng/notion-cli/src/codegen.unit.test.ts
@@ -516,7 +516,7 @@ describe('codegen', () => {
       }
 
       const code = generateSchemaCode({ dbInfo, schemaName: 'Test' })
-      expect(code).toContain('Owner: NotionSchema.relationSingle')
+      expect(code).toContain('Owner: NotionSchema.relationSingleOption')
       expect(code).toContain('Total: NotionSchema.rollupNumber')
     })
 

--- a/packages/@overeng/notion-effect-schema/src/mod.ts
+++ b/packages/@overeng/notion-effect-schema/src/mod.ts
@@ -143,6 +143,8 @@ export const NotionSchema = {
   relationIds: Relation.asIds,
   relationSingle: Relation.asSingle,
   relationSingleId: Relation.asSingleId,
+  relationSingleOption: Relation.asSingleOption,
+  relationSingleIdOption: Relation.asSingleIdOption,
   relationProperty: Relation.Property,
   peopleIds: People.asIds,
   peopleRaw: People.raw,

--- a/packages/@overeng/notion-effect-schema/src/properties.unit.test.ts
+++ b/packages/@overeng/notion-effect-schema/src/properties.unit.test.ts
@@ -1308,6 +1308,70 @@ Vitest.describe('Relation Property', () => {
     )
   })
 
+  Vitest.describe('NotionSchema.relationSingleOption', () => {
+    Vitest.it.effect('returns Some for single relation', () =>
+      Effect.gen(function* () {
+        const result = yield* Schema.decodeUnknown(NotionSchema.relationSingleOption)(
+          singleRelationProperty,
+        )
+        expect(Option.isSome(result)).toBe(true)
+        expect(Option.getOrThrow(result)).toEqual({ id: 'page-1' })
+      }),
+    )
+
+    Vitest.it.effect('returns None for empty relation', () =>
+      Effect.gen(function* () {
+        const result = yield* Schema.decodeUnknown(NotionSchema.relationSingleOption)({
+          id: 'relation',
+          type: 'relation' as const,
+          relation: [],
+        })
+        expect(Option.isNone(result)).toBe(true)
+      }),
+    )
+
+    Vitest.it.effect('fails for multiple relations', () =>
+      Effect.gen(function* () {
+        const result = yield* Schema.decodeUnknown(NotionSchema.relationSingleOption)(
+          relationProperty,
+        ).pipe(Effect.either)
+        expect(result._tag).toBe('Left')
+      }),
+    )
+  })
+
+  Vitest.describe('NotionSchema.relationSingleIdOption', () => {
+    Vitest.it.effect('returns Some for single relation', () =>
+      Effect.gen(function* () {
+        const result = yield* Schema.decodeUnknown(NotionSchema.relationSingleIdOption)(
+          singleRelationProperty,
+        )
+        expect(Option.isSome(result)).toBe(true)
+        expect(Option.getOrThrow(result)).toBe('page-1')
+      }),
+    )
+
+    Vitest.it.effect('returns None for empty relation', () =>
+      Effect.gen(function* () {
+        const result = yield* Schema.decodeUnknown(NotionSchema.relationSingleIdOption)({
+          id: 'relation',
+          type: 'relation' as const,
+          relation: [],
+        })
+        expect(Option.isNone(result)).toBe(true)
+      }),
+    )
+
+    Vitest.it.effect('fails for multiple relations', () =>
+      Effect.gen(function* () {
+        const result = yield* Schema.decodeUnknown(NotionSchema.relationSingleIdOption)(
+          relationProperty,
+        ).pipe(Effect.either)
+        expect(result._tag).toBe('Left')
+      }),
+    )
+  })
+
   Vitest.describe('NotionSchema.relationWriteFromIds', () => {
     Vitest.it.effect('encodes page IDs to write payload', () =>
       Effect.gen(function* () {

--- a/packages/@overeng/notion-effect-schema/src/properties/reference.ts
+++ b/packages/@overeng/notion-effect-schema/src/properties/reference.ts
@@ -1,4 +1,4 @@
-import { Schema } from 'effect'
+import { Option, Schema } from 'effect'
 
 import { docsPath, NotionUUID, shouldNeverHappen } from '../common.ts'
 import { User } from '../users.ts'
@@ -222,6 +222,42 @@ export const Relation = {
       encode: () =>
         shouldNeverHappen(
           'Relation.asSingleId encode is not supported. Use RelationWrite / RelationWriteFromIds.',
+        ),
+    },
+  ),
+
+  /** Transform to an optional single relation object (allows 0 or 1 items). */
+  asSingleOption: Schema.transform(
+    RelationProperty.pipe(
+      Schema.filter((p) => p.relation.length <= 1, {
+        message: () => 'Relation must have at most one item',
+      }),
+    ),
+    Schema.OptionFromSelf(Schema.Struct({ id: NotionUUID })),
+    {
+      strict: false,
+      decode: (prop) => Option.fromNullable(prop.relation[0]),
+      encode: () =>
+        shouldNeverHappen(
+          'Relation.asSingleOption encode is not supported. Use RelationWrite / RelationWriteFromIds.',
+        ),
+    },
+  ),
+
+  /** Transform to an optional single related page ID (allows 0 or 1 items). */
+  asSingleIdOption: Schema.transform(
+    RelationProperty.pipe(
+      Schema.filter((p) => p.relation.length <= 1, {
+        message: () => 'Relation must have at most one item',
+      }),
+    ),
+    Schema.OptionFromSelf(NotionUUID),
+    {
+      strict: false,
+      decode: (prop) => Option.fromNullable(prop.relation[0]?.id),
+      encode: () =>
+        shouldNeverHappen(
+          'Relation.asSingleIdOption encode is not supported. Use RelationWrite / RelationWriteFromIds.',
         ),
     },
   ),


### PR DESCRIPTION
## Summary

- Add `relationSingleOption` and `relationSingleIdOption` transforms to `NotionSchema` that return `Option<{id}>` / `Option<string>` for 0-or-1 relation properties
- Change the schema generator default for `single_property` relations from `asSingle` (requires exactly 1) to `asSingleOption` (allows 0 or 1)
- Fixes `PageDecodeError` when Notion `single_property` relations are empty, which is valid and common in practice

## Context

Notion's `single_property` relation type means the UI shows a single-select picker, but the field can be empty (0 items). The current `asSingle` transform uses `Schema.filter(p => p.relation.length === 1)` which fails on empty relations. This caused runtime decode failures in downstream apps (e.g. schickling-stiftung-app "Error loading artwork").

## Design

Follows the existing `*Option` naming convention (`number`/`numberOption`, `richText`/`richTextOption`, etc.):

| Transform | Type | Use case |
|---|---|---|
| `relationSingle` (unchanged) | `{ id: string }` | Opt-in strict, for schema overlays when the relation is always populated |
| `relationSingleOption` (new, generator default) | `Option<{ id: string }>` | Safe default for `single_property` relations |
| `relationSingleId` (unchanged) | `string` | Opt-in strict, ID only |
| `relationSingleIdOption` (new) | `Option<string>` | Optional single ID |

## Test plan

- [x] Added tests for `relationSingleOption`: returns `Some` for single, `None` for empty, fails for multiple
- [x] Added tests for `relationSingleIdOption`: same behavior pattern
- [x] Updated codegen test to expect `relationSingleOption` as default for `single_property`
- [x] All pre-commit checks pass (`ts:check`, `lint:check`, `check:quick`)

> [!NOTE]
> This is a breaking change for generated schemas: regenerated files will use `relationSingleOption` instead of `relationSingle` for single-property relations, changing the decoded type from `{ id: string }` to `Option<{ id: string }>`. Manual overlay schemas using `NotionSchema.relationSingle` are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)