### PR TITLE
chore(devenv): remove dt TUI workaround and bump devenv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- **devenv/dt**: Remove CI/non-interactive TUI suppression workaround now that devenv auto-disables TUI in CI
+  - Dropped manual `DEVENV_TUI=false` handling and PTY stderr piping from `dt`
+  - Updated failure re-run hints to use `devenv tasks run ... --mode before` without `--no-tui`
+
 - **@overeng/genie**: Reduce duplicate check-time work by reusing loaded genie modules between content verification and validation
   - Added `loadGenieFile` / `checkFileDetailed` in core generation to return reusable module/context metadata
   - `checkAll` now passes preloaded modules into `runGenieValidation` instead of re-importing every `.genie.ts`

--- a/devenv.lock
+++ b/devenv.lock
@@ -3,11 +3,11 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1770304289,
-        "narHash": "sha256-+g+XMyB1zi50h2N38GE32l7ZONX4oW7Nw6QSXzfNiwk=",
+        "lastModified": 1771510130,
+        "narHash": "sha256-Kd/dmNOYLEBwkjT+96DFMt0Ft80ZOYRb6ZSunSXsnUE=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "fd777e39027d393346e4df672d51ad2bf44b2a12",
+        "rev": "0bcb90a82f1df250943c189545ea614a4dbeaf63",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- bump devenv.lock to the latest devenv revision that includes the upstream CI TUI fix
- remove dt wrapper logic that forced DEVENV_TUI=false and PTY stderr piping
- simplify task rerun hints to use devenv tasks run ... --mode before