### PR TITLE
refactor(ci): remove DEVENV_TUI workaround from standardCIEnv

### DIFF
--- a/genie/ci-workflow.ts
+++ b/genie/ci-workflow.ts
@@ -39,12 +39,10 @@ export const devenvShellDefaults = {
 /**
  * Standard CI environment variables.
  * GITHUB_TOKEN is exported for tools that need it as a shell env var (e.g. gh CLI, nix auth).
- * TODO: Drop DEVENV_TUI once devenv auto-disables TUI in CI (https://github.com/cachix/devenv/issues/2504)
  */
 export const standardCIEnv = {
   FORCE_SETUP: '1',
   CI: 'true',
-  DEVENV_TUI: 'false',
   GITHUB_TOKEN: '${{ github.token }}',
 } as const
 


### PR DESCRIPTION
## Summary

- Remove `DEVENV_TUI: 'false'` from `standardCIEnv` — devenv auto-disables TUI in CI now ([cachix/devenv#2504](https://github.com/cachix/devenv/issues/2504) fixed)
- Remove the associated TODO comment

## Test plan

- [ ] Verify CI workflows in consuming repos still work without explicit `DEVENV_TUI=false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)