### PR TITLE
Make megarepo sync frozen and add explicit update task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,9 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- **devenv/tasks/shared/megarepo.nix**: Add `syncFrozen` option to `taskModules.megarepo`
-  - Allows repos to opt into `mr sync --frozen` for deterministic shell-entry sync
-  - Keeps default behavior unchanged (`syncFrozen = false`)
+- **devenv/tasks/shared/megarepo.nix**: Make `megarepo:sync` always run with `--frozen`
+  - Prevents shell-entry and routine task runs from rewriting `megarepo.lock`
+  - Adds `megarepo:sync:update` for intentional non-frozen lockfile updates
 
 - **devenv/dt**: Remove CI/non-interactive TUI suppression workaround now that devenv auto-disables TUI in CI
   - Dropped manual `DEVENV_TUI=false` handling and PTY stderr piping from `dt`


### PR DESCRIPTION
## Summary
- make `megarepo:sync` always run `mr sync --frozen` (still honoring `--all` via `syncAll`)
- add `megarepo:sync:update` for intentional non-frozen lockfile/member ref updates
- update changelog with the new default behavior and explicit update path

## Problem
`megarepo:sync` is frequently wired into shell-entry task chains. Non-frozen sync rewrites `megarepo.lock`, which creates unwanted working-tree diffs during normal development.

## Solution
Use frozen sync as the safe default for routine task execution, and provide a dedicated opt-in task when lock updates are intentional.

## Validation
- `devenv tasks list`

---
Acting on behalf of @schickling.