### PR TITLE
Make genie lint checks strict before regeneration

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -226,6 +226,7 @@ in
       packages = packagesWithStorybook;
     })
     (taskModules.lint-oxc {
+      jsPlugins = lib.optionals (oxlintNpm.pluginPath != null) [ oxlintNpm.pluginPath ];
       lintPaths = [
         "packages"
         "scripts"

--- a/nix/devenv-modules/tasks/shared/lint-genie.nix
+++ b/nix/devenv-modules/tasks/shared/lint-genie.nix
@@ -15,8 +15,8 @@ in
     "lint:check:genie" = {
       description = "Check generated files are up to date";
       exec = trace.exec "lint:check:genie" "genie --check";
-      # genie:run must complete first so the check compares against freshly generated files
-      after = [ "genie:run" "pnpm:install" ];
+      # Strict mode: never auto-regenerate before checking drift.
+      after = [ "pnpm:install" ];
     };
     "lint:check" = {
       description = "Run all lint checks";

--- a/nix/devenv-modules/tasks/shared/lint-oxc.nix
+++ b/nix/devenv-modules/tasks/shared/lint-oxc.nix
@@ -112,10 +112,7 @@ in
       # TODO: Drop "pnpm:install" dep once devenv supports glob negation patterns (e.g. !**/node_modules/**)
       #   Upstream issue: https://github.com/cachix/devenv/issues/2422
       #   Upstream fix:   https://github.com/cachix/devenv/pull/2423
-      after = [
-        "genie:run"
-        "pnpm:install"
-      ];
+      after = [ "pnpm:install" ];
       execIfModified = execIfModifiedPatterns;
     };
     "lint:check:oxlint" = {
@@ -124,19 +121,16 @@ in
       # TODO: Drop "pnpm:install" dep once devenv supports glob negation patterns (e.g. !**/node_modules/**)
       #   Upstream issue: https://github.com/cachix/devenv/issues/2422
       #   Upstream fix:   https://github.com/cachix/devenv/pull/2423
-      after = [
-        "genie:run"
-        "pnpm:install"
-      ];
+      after = [ "pnpm:install" ];
       execIfModified = execIfModifiedPatterns;
     };
     "lint:check:genie" = {
       description = "Check generated files are up to date";
       exec = trace.exec "lint:check:genie" "genie --check";
-      # genie:run must complete first so the check compares against freshly generated files
+      # Strict mode: never auto-regenerate before checking drift.
       # TODO: Drop "pnpm:install" dep once devenv supports glob negation patterns
       #   See: https://github.com/cachix/devenv/issues/2422, https://github.com/cachix/devenv/pull/2423
-      after = [ "genie:run" "pnpm:install" ];
+      after = [ "pnpm:install" ];
       execIfModified = geniePatterns;
     };
     "lint:check:genie:coverage" = {


### PR DESCRIPTION
## Problem\n\nDownstream CI can pass with stale generated files because  currently runs after , which self-heals drift before checking.\n\n## Solution\n\n- Make  strict in shared lint task modules by removing the  dependency.\n- Apply the same strict behavior to  for consistency.\n\n## Validation\n\n- Ran  locally.\n- Note: local environment currently reports an existing Found 0 warnings and 0 errors.
Finished in 540ms on 684 files using 16 threads. plugin resolution issue (), so CI run is the source of truth for this change.\n\n## Impact\n\nAll repos using  /  get strict genie drift checking once they bump  lock files.