### PR TITLE
ci: source syncMegarepoFromLockStep from megarepo.lock

### DIFF
--- a/genie/ci-workflow.ts
+++ b/genie/ci-workflow.ts
@@ -128,15 +128,20 @@ export const syncMegarepoStep = (opts?: { frozen?: boolean; skip?: string[] }) =
 }
 
 /**
- * Sync megarepo dependencies using the locked effect-utils rev from devenv.lock.
- * Resolves the rev inline and uses `nix run` to avoid `nix profile install`
+ * Sync megarepo dependencies using the locked effect-utils commit from megarepo.lock.
+ * Resolves the commit inline and uses `nix run` to avoid `nix profile install`
  * (which can conflict on self-hosted).
  */
 export const syncMegarepoFromLockStep = (opts?: { skip?: string[] }) => {
   const skipArgs = opts?.skip?.flatMap((s) => ['--skip', s]).join(' ') ?? ''
   return {
     name: 'Sync megarepo dependencies',
-    run: `EU_REV=$(jq -r '.nodes["effect-utils"].locked.rev' devenv.lock)\nnix run "github:overengineeringstudio/effect-utils/$EU_REV#megarepo" -- sync --frozen${skipArgs ? ` ${skipArgs}` : ''}`,
+    run: `EU_REV=$(jq -r '.members["effect-utils"].commit' megarepo.lock)
+if [ -z "$EU_REV" ] || [ "$EU_REV" = "null" ]; then
+  echo '::error::megarepo.lock missing members["effect-utils"].commit'
+  exit 1
+fi
+nix run "github:overengineeringstudio/effect-utils/$EU_REV#megarepo" -- sync --frozen${skipArgs ? ` ${skipArgs}` : ''}`,
     shell: 'bash',
   }
 }


### PR DESCRIPTION
## Summary
- update `syncMegarepoFromLockStep` to resolve effect-utils commit from `megarepo.lock`
- fail fast with a clear error when `members["effect-utils"].commit` is missing

## Why
`devenv.lock` shape differs across repos (`effect-utils` can be path-locked or absent), while `megarepo.lock` is the canonical source of pinned member commits for megarepo sync.