### PR TITLE
chore(nix): bump beads to 0.55.4

### DIFF
--- a/nix/beads.nix
+++ b/nix/beads.nix
@@ -3,25 +3,25 @@
 # Go version mismatch in nixpkgs, so we fetch the pre-built binary instead.
 { pkgs }:
 let
-  version = "0.49.6";
+  version = "0.55.4";
   tag = "v${version}";
 
   sources = {
     x86_64-linux = {
       url = "https://github.com/steveyegge/beads/releases/download/${tag}/beads_${version}_linux_amd64.tar.gz";
-      sha256 = "1f3xpczha8r6nv5k42c5j5g9g466m4j056mwq8dc67g18yddqil5";
+      sha256 = "0jazd9189vf5j6z692670i8rkgx090s6a5zg1qir0a6qdm2jbyp0";
     };
     aarch64-linux = {
       url = "https://github.com/steveyegge/beads/releases/download/${tag}/beads_${version}_linux_arm64.tar.gz";
-      sha256 = "05iyf86mhc102vim8fcvcmn15gd3rblncpbh3hn212r62jbxmms3";
+      sha256 = "1bxydkk3qqr8wbh5j64wi8h4l0dfskw9q4g7chvqyxqh7r32lg17";
     };
     x86_64-darwin = {
       url = "https://github.com/steveyegge/beads/releases/download/${tag}/beads_${version}_darwin_amd64.tar.gz";
-      sha256 = "0qmwcc722xbd461dmscwvbmy3dghd5aj49sxb2axy0lsbay8m9xr";
+      sha256 = "11427xlz86l1aq8qcmxczaiakmqfz5a4zj2vxca2wqjfidl738rr";
     };
     aarch64-darwin = {
       url = "https://github.com/steveyegge/beads/releases/download/${tag}/beads_${version}_darwin_arm64.tar.gz";
-      sha256 = "0zdbv5inmzfjcf0kmi02vq1yj17g0p9smdpcl2ilib7f37csqz80";
+      sha256 = "1ff001pigbwwlyj7dcb1sglawl3pqaayvxxjhwbaf8r3ar7xzbqq";
     };
   };
 


### PR DESCRIPTION
## Why
beads in effect-utils is pinned to 0.49.6, while upstream latest is 0.55.4.

## What
- bump `nix/beads.nix` version from `0.49.6` to `0.55.4`
- update platform tarball sha256 values for:
  - linux amd64
  - linux arm64
  - darwin amd64
  - darwin arm64

## Verification
- `nix flake check --no-build`
- `nix build .#beads`


_Opened by Codex on behalf of @schickling._
