### PR TITLE
fix(tasks): disambiguate pnpm task names

### DIFF
--- a/nix/devenv-modules/tasks/shared/pnpm.nix
+++ b/nix/devenv-modules/tasks/shared/pnpm.nix
@@ -119,6 +119,9 @@ let
 
   # Collision fallback name:
   # include enough stable context (repo + scope + relative path) to avoid conflicts.
+  # Example:
+  #   repos/repo-a/packages/@scope/utils -> repo-a-scope-utils
+  #   packages/@other/utils -> other-utils
   disambiguatedName =
     path:
     let


### PR DESCRIPTION
## Why
pnpm task names were derived from package basename only. In megarepo setups this collides (for example multiple utils packages), causing task definition conflicts during eval.

## What
- keep short names when unique
- auto-disambiguate only colliding names using stable context (repo, scope, relative path)
- assert final task-name uniqueness

## Validation
- CI=1 FORCE_SETUP=1 devenv tasks list in effect-utils evaluates and lists pnpm install tasks
- deterministic check on root package list shows previous duplicate utils resolves to unique names

---
Created on behalf of @schickling via Codex.