### PR TITLE
Fix beads CGO build and Dolt task compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ All notable changes to this project will be documented in this file.
 - **@overeng/genie**: `genie --check` now fails fast on fatal `.genie.ts` import/build errors and marks interrupted sibling checks as canceled
   - Prevents indefinite stalls when a sibling check remains in-flight after a fatal import/build failure
   - Final JSON/TUI failure state is reconciled from `GenieGenerationFailedError.files` to avoid stale `active` entries
+- **beads packaging/tasks**: Fix `bd` Dolt startup failures on macOS by building with CGO enabled and updating beads task/hook invocations for current CLI flags
+  - `nix/beads.nix` now builds `bd` from source (`buildGo126Module`) with CGO + ICU/SQLite inputs instead of prebuilt no-CGO release tarballs
+  - `nix/devenv-modules/tasks/shared/beads.nix` now exports `BEADS_DB`, uses Dolt-directory bootstrap checks, and removes deprecated `--no-daemon/--no-db` flag usage
 
 ### Changed
 

--- a/nix/beads.nix
+++ b/nix/beads.nix
@@ -1,65 +1,42 @@
-# Beads (bd) — pre-built binary package from GitHub releases.
-# Upstream flake (github:steveyegge/beads) can't build from source due to
-# Go version mismatch in nixpkgs, so we fetch the pre-built binary instead.
+# Beads (bd) — build from source with CGO enabled so Dolt embedded mode works.
 { pkgs }:
 let
   version = "0.55.4";
-  tag = "v${version}";
-
-  sources = {
-    x86_64-linux = {
-      url = "https://github.com/steveyegge/beads/releases/download/${tag}/beads_${version}_linux_amd64.tar.gz";
-      sha256 = "0jazd9189vf5j6z692670i8rkgx090s6a5zg1qir0a6qdm2jbyp0";
-    };
-    aarch64-linux = {
-      url = "https://github.com/steveyegge/beads/releases/download/${tag}/beads_${version}_linux_arm64.tar.gz";
-      sha256 = "1bxydkk3qqr8wbh5j64wi8h4l0dfskw9q4g7chvqyxqh7r32lg17";
-    };
-    x86_64-darwin = {
-      url = "https://github.com/steveyegge/beads/releases/download/${tag}/beads_${version}_darwin_amd64.tar.gz";
-      sha256 = "11427xlz86l1aq8qcmxczaiakmqfz5a4zj2vxca2wqjfidl738rr";
-    };
-    aarch64-darwin = {
-      url = "https://github.com/steveyegge/beads/releases/download/${tag}/beads_${version}_darwin_arm64.tar.gz";
-      sha256 = "1ff001pigbwwlyj7dcb1sglawl3pqaayvxxjhwbaf8r3ar7xzbqq";
-    };
-  };
-
-  system = pkgs.stdenv.hostPlatform.system;
-  platformInfo = sources.${system} or (throw "Unsupported system: ${system}");
 in
-pkgs.stdenv.mkDerivation {
+pkgs.buildGo126Module {
   pname = "beads";
   inherit version;
 
-  dontBuild = true;
-  dontStrip = true;
-
-  src = pkgs.fetchurl {
-    inherit (platformInfo) url sha256;
+  src = pkgs.fetchFromGitHub {
+    owner = "steveyegge";
+    repo = "beads";
+    rev = "v${version}";
+    hash = "sha256-HTcmGKn2NNoBEg5yRsnVIATNdte5Xw8E86D09e1X5nk=";
   };
 
-  nativeBuildInputs = [ pkgs.gnutar pkgs.installShellFiles ];
+  vendorHash = "sha256-cMvxGJBMUszIbWwBNmWe+ws4m3mfyEZgapxVYNYc5c4=";
+  subPackages = [ "cmd/bd" ];
+  doCheck = false;
 
-  unpackPhase = ''
-    mkdir -p source
-    tar -xzf "$src" -C source
-  '';
+  nativeBuildInputs = [
+    pkgs.installShellFiles
+    pkgs.pkg-config
+  ];
 
-  installPhase = ''
-    runHook preInstall
+  buildInputs = [
+    pkgs.icu
+    pkgs.sqlite
+  ];
 
-    mkdir -p $out/bin
-    cp source/bd $out/bin/bd
-    chmod +x $out/bin/bd
+  env.CGO_ENABLED = 1;
+
+  postInstall = ''
     ln -s $out/bin/bd $out/bin/beads
 
     installShellCompletion --cmd bd \
       --fish <($out/bin/bd completion fish) \
       --bash <($out/bin/bd completion bash) \
       --zsh <($out/bin/bd completion zsh)
-
-    runHook postInstall
   '';
 
   meta = with pkgs.lib; {


### PR DESCRIPTION
This updates beads packaging to build `bd` v0.55.4 from source with CGO enabled so Dolt embedded mode works on macOS.
It also updates shared beads task/hook wiring to export `BEADS_DB`, initialize from JSONL using current CLI behavior, and remove deprecated `--no-daemon/--no-db` usage.
`CHANGELOG.md` now includes an Unreleased entry describing these fixes.
Validation was run with `dt check:all --no-tui` and completed successfully.

_This PR was created by Codex acting on behalf of the user._