### PR TITLE
feat(beads): upgrade to v0.55.4 with Dolt-native backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,12 +39,13 @@ jobs:
         shell: bash
       - name: Validate Nix store
         run: |
-          if devenv version > /dev/null 2>&1; then
+          if devenv shell -- true > /dev/null 2>&1; then
             echo "Nix store OK"
           else
-            echo "::warning::Nix store validation failed, running repair..."
-            nix-store --verify --repair 2>&1 | tail -20
-            devenv version
+            echo "::warning::Nix store validation failed, repairing..."
+            nix-store --verify --check-contents --repair 2>&1 | tail -20
+            rm -rf ~/.cache/nix/eval-cache-*
+            devenv shell -- true
           fi
         shell: bash
       - name: Type check
@@ -84,12 +85,13 @@ jobs:
         shell: bash
       - name: Validate Nix store
         run: |
-          if devenv version > /dev/null 2>&1; then
+          if devenv shell -- true > /dev/null 2>&1; then
             echo "Nix store OK"
           else
-            echo "::warning::Nix store validation failed, running repair..."
-            nix-store --verify --repair 2>&1 | tail -20
-            devenv version
+            echo "::warning::Nix store validation failed, repairing..."
+            nix-store --verify --check-contents --repair 2>&1 | tail -20
+            rm -rf ~/.cache/nix/eval-cache-*
+            devenv shell -- true
           fi
         shell: bash
       - name: Format + lint
@@ -132,12 +134,13 @@ jobs:
         shell: bash
       - name: Validate Nix store
         run: |
-          if devenv version > /dev/null 2>&1; then
+          if devenv shell -- true > /dev/null 2>&1; then
             echo "Nix store OK"
           else
-            echo "::warning::Nix store validation failed, running repair..."
-            nix-store --verify --repair 2>&1 | tail -20
-            devenv version
+            echo "::warning::Nix store validation failed, repairing..."
+            nix-store --verify --check-contents --repair 2>&1 | tail -20
+            rm -rf ~/.cache/nix/eval-cache-*
+            devenv shell -- true
           fi
         shell: bash
       - name: Unit tests
@@ -180,12 +183,13 @@ jobs:
         shell: bash
       - name: Validate Nix store
         run: |
-          if devenv version > /dev/null 2>&1; then
+          if devenv shell -- true > /dev/null 2>&1; then
             echo "Nix store OK"
           else
-            echo "::warning::Nix store validation failed, running repair..."
-            nix-store --verify --repair 2>&1 | tail -20
-            devenv version
+            echo "::warning::Nix store validation failed, repairing..."
+            nix-store --verify --check-contents --repair 2>&1 | tail -20
+            rm -rf ~/.cache/nix/eval-cache-*
+            devenv shell -- true
           fi
         shell: bash
       - name: Nix hash check
@@ -229,12 +233,13 @@ jobs:
         shell: bash
       - name: Validate Nix store
         run: |
-          if devenv version > /dev/null 2>&1; then
+          if devenv shell -- true > /dev/null 2>&1; then
             echo "Nix store OK"
           else
-            echo "::warning::Nix store validation failed, running repair..."
-            nix-store --verify --repair 2>&1 | tail -20
-            devenv version
+            echo "::warning::Nix store validation failed, repairing..."
+            nix-store --verify --check-contents --repair 2>&1 | tail -20
+            rm -rf ~/.cache/nix/eval-cache-*
+            devenv shell -- true
           fi
         shell: bash
       - name: Deploy storybooks to Netlify

--- a/devenv.nix
+++ b/devenv.nix
@@ -184,7 +184,7 @@ let
 in
 {
   imports = [
-    # Beads integration: Dolt-native, push/pull, commit correlation hook
+    # Beads integration
     (taskModules.beads {
       beadsPrefix = "oep";
       beadsRepoName = "overeng-beads-public";
@@ -351,10 +351,8 @@ in
     description = "Apply .github/repo-settings.json to GitHub ruleset";
   };
 
-  # Wire beads:ensure directly to shell entry (not via optionalTasks).
-  # The setup module's gitHashStatus cache would prevent re-checking the DB
-  # state without a new commit. The beads module's own status check
-  # (does dolt/ dir exist?) is the correct gate for this task.
+  # Wire beads:ensure directly to shell entry (not via optionalTasks)
+  # because the setup module's gitHashStatus cache isn't the right gate here.
   tasks."devenv:enterShell".after = lib.mkAfter [ "beads:ensure" ];
 
   # Keep git-hook installation out of the shell-entry path.

--- a/flake.nix
+++ b/flake.nix
@@ -161,7 +161,6 @@
         }:
         import ./nix/oxlint-npm.nix { inherit pkgs bun src; };
 
-      # Beads (bd) package built from source with CGO (Dolt support).
       # Usage: effectUtils.lib.mkBeads { inherit pkgs; }
       lib.mkBeads = { pkgs }: import ./nix/beads.nix { inherit pkgs; };
 

--- a/nix/beads.nix
+++ b/nix/beads.nix
@@ -1,5 +1,4 @@
-# Beads (bd) — built from source with CGO for Dolt support.
-# CGO is required for go-icu-regex; non-CGO builds lack `bd dolt push/pull/commit`.
+# Beads (bd) — built from source with CGO (required for go-icu-regex / Dolt support).
 { pkgs }:
 let
   version = "0.55.4";

--- a/nix/devenv-modules/tasks/shared/beads.nix
+++ b/nix/devenv-modules/tasks/shared/beads.nix
@@ -1,23 +1,10 @@
 # Beads devenv module — integrates beads issue tracking with devenv.
 #
-# Since beads v0.51, the daemon and SQLite backend have been removed.
-# Beads now uses Dolt as the sole backend. In embedded mode (default),
-# bd manages the database directly — no server needed. In server mode,
-# `bd dolt start` runs a Dolt SQL server for multi-writer concurrency.
+# Uses Dolt as backend. In embedded mode (default), bd manages the
+# database directly. In server mode, `bd dolt start` runs a Dolt SQL
+# server for multi-writer concurrency.
 #
-# Sync is handled via `bd dolt push/pull` (JSONL sync layer was removed).
-# JSONL is still maintained for git portability via `bd hooks install`,
-# but Dolt is the source of truth.
-#
-# Exported env var:
-# - BEADS_DIR: upstream bd env var for .beads discovery
-# With this set, `bd` works from anywhere without wrapper scripts.
-#
-# Provides:
-# - beads:ensure task — bootstraps Dolt DB on cold start
-# - beads:push task — push via `bd dolt push`
-# - beads:pull task — pull via `bd dolt pull`
-# - beads-commit-correlation git hook — cross-references commits with beads issues
+# Sets BEADS_DIR so `bd` works from anywhere without wrapper scripts.
 { beadsPrefix, beadsRepoName, beadsRepoPath ? "repos/${beadsRepoName}" }:
 { pkgs, config, ... }:
 let
@@ -40,8 +27,8 @@ in
 
       cd "''${BEADS_DIR%/.beads}"
 
-      # Cold-start: bootstrap Dolt DB from JSONL on fresh checkout.
-      # `bd list` auto-creates the DB from JSONL as a side effect.
+      # Bootstrap Dolt DB from JSONL on fresh checkout
+      # (`bd list` auto-creates the DB from JSONL as a side effect)
       if [ ! -d "$BEADS_DIR/dolt" ] && [ -f "$BEADS_DIR/issues.jsonl" ]; then
         echo "[beads] No database found, bootstrapping from JSONL..."
         ${bd} list --quiet >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary

- Upgrades beads from pre-built binary v0.49.6 to source build v0.55.4 with CGO for full Dolt support
- Replaces daemon-based tasks (`beads:daemon:ensure`, `beads:daemon:stop`, `beads:sync`) with Dolt-native tasks (`beads:ensure`, `beads:push`, `beads:pull`)
- Removes obsolete `--no-daemon --no-db` flags from commit correlation hook (these flags no longer exist in v0.55+)

### What changed upstream (v0.49 → v0.55)

Beads v0.51 "Dolt-native cleanup" removed the entire daemon + SQLite + JSONL sync layer in an 8-phase refactoring. Dolt is now the sole backend. Key changes:

- **Daemon removed**: No more `bd daemon start/stop/status`. Dolt runs in embedded mode (single-process) or server mode (multi-writer)
- **SQLite removed**: Dolt replaced SQLite as the database engine
- **JSONL sync removed**: `bd sync` is now a deprecated no-op. Sync is handled via `bd dolt push/pull`
- **New commands**: `bd dolt start/stop/push/pull/commit/set/show/test`

### Build changes

- Pre-built binaries are non-CGO and lack `bd dolt push/pull/commit`
- Source build with `buildGo126Module` + ICU provides full Dolt functionality
- SQLite is NOT needed in buildInputs (only ICU for go-icu-regex)

### Known limitation

Dolt's noms storage engine crashes with a nil pointer dereference when the working directory path contains `%2F` (URL-encoded `/`). This affects megarepo feature branches with `/` in the name (e.g. `schickling/my-feature` → store path `schickling%2Fmy-feature`). Works correctly from `main` and branches without `/`. Tracking upstream: steveyegge/beads#1161

### Companion PR

- overengineeringstudio/overeng-beads-public — removes obsolete config options

## Test plan

- [x] `nix build .#beads` succeeds
- [x] Built binary reports v0.55.4 and full `bd dolt` commands
- [x] `bd list`, `bd ready`, `bd dolt show` work from main worktree
- [ ] Verify `dt beads:ensure` works in devenv shell
- [ ] Verify `dt beads:push` / `dt beads:pull` work

🤖 Generated with [Claude Code](https://claude.com/claude-code)