### PR TITLE
fix: update stale beads refs in AGENTS.md and dashboard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ This repo uses [beads](../overeng-beads-public) for task tracking via the megare
 
 - Create an **epic** for larger work items and correlate it with the PR
 - Create **follow-up beads** (or a follow-up epic for larger scope) for out-of-scope work discovered during implementation
-- Run `dt beads:sync` before pushing to keep beads in sync with git
+- Run `dt beads:push` before pushing to sync beads to Dolt remote
 
 ## Landing the Plane (Session Completion)
 
@@ -54,7 +54,7 @@ This repo uses [beads](../overeng-beads-public) for task tracking via the megare
 4. **PUSH TO REMOTE** - This is MANDATORY:
    ```bash
    git pull --rebase
-   dt beads:sync    # sync beads JSONL to git (pull + commit + push)
+   dt beads:push    # push beads changes to Dolt remote
    git push
    git status  # MUST show "up to date with origin"
    ```

--- a/nix/devenv-modules/otel/dashboards/dt-duration-trends.jsonnet
+++ b/nix/devenv-modules/otel/dashboards/dt-duration-trends.jsonnet
@@ -335,7 +335,7 @@ g.dashboard.new('dt Task Duration Trends')
   at(
     taskDurationPanel(
       'Shell entry sub-tasks (p50 / p95)',
-      'setup:gate|pnpm:install|genie:run|megarepo:sync|ts:patch-lsp|ts:emit|setup:completions|beads:daemon:ensure|devenv:.*',
+      'setup:gate|pnpm:install|genie:run|megarepo:sync|ts:patch-lsp|ts:emit|setup:completions|beads:ensure|devenv:.*',
     ),
     12, y.shellContent, 12, 8,
   ),


### PR DESCRIPTION
## Summary
- AGENTS.md: `dt beads:sync` → `dt beads:push` (Dolt-native push/pull replaces old sync)
- dt-duration-trends.jsonnet: `beads:daemon:ensure` → `beads:ensure`

## Context
Follow-up to #262 — these references were missed in the initial beads v0.55.4 upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)