### PR TITLE
fix(beads): avoid emulated Go builds by using patched release binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ All notable changes to this project will be documented in this file.
 - **devenv/tasks/shared/ts.nix**: Fix `ts:emit` missing `--build` flag
   - `tscWithDiagnostics` was called without `--build`, causing tsc to treat `tsconfig.all.json` as a source file
   - Previously masked by `setup:opt:*` wrappers silently swallowing the failure
+- **beads packaging**: Avoid long emulated builds by using patched prebuilt `bd` release binaries (v0.55.4)
+  - `nix/beads.nix` now fetches release tarballs instead of compiling Go sources under QEMU
+  - Linux binaries are patched with Nix loader/RPATH (`icu74`) so Dolt-enabled `bd` runs correctly
 - **@overeng/genie**: `genie --check` now fails fast on fatal `.genie.ts` import/build errors and marks interrupted sibling checks as canceled
   - Prevents indefinite stalls when a sibling check remains in-flight after a fatal import/build failure
   - Final JSON/TUI failure state is reconciled from `GenieGenerationFailedError.files` to avoid stale `active` entries


### PR DESCRIPTION
## Summary
Switch `nix/beads.nix` from source-based `buildGo126Module` packaging back to release tarballs for v0.55.4, while patching Linux binaries to run correctly in Nix (Dolt support preserved).

## Why
The source build path was compiling `cmd/bd` under `qemu-aarch64` in some environments, causing very long CPU-heavy builds.

## What changed
- Fetch prebuilt beads release tarballs per platform (v0.55.4).
- On Linux, patch `bd` with:
  - Nix dynamic loader (interpreter)
  - RPATH to `stdenv.cc.cc.lib` + `icu74`
- Keep `beads` symlink and shell completion installation.
- Add changelog entry under `[Unreleased]`.

## Verification
- Built x86_64 package from this branch successfully:
  - `nix build --impure --expr 'let pkgs = import <nixpkgs> {}; in import ./nix/beads.nix { inherit pkgs; }' --no-link -L`
- Built aarch64-linux package successfully with no Go compile step:
  - `nix build --impure --expr 'let pkgs = import <nixpkgs> { system = "aarch64-linux"; }; in import ./nix/beads.nix { inherit pkgs; }' --no-link -L --option max-jobs 1 --cores 2`
- Runtime smoke test (x86_64):
  - `bd --version` -> `bd version 0.55.4 (21f49ddb)`
