### PR TITLE
otel(devenv): hard-cut system dashboard sync behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,11 @@ All notable changes to this project will be documented in this file.
   - `otel-span emit` replaces `otel-emit-span` (reads OTLP JSON from stdin)
   - Breaking: subcommand is now required
 
+- **devenv/otel.nix**: Hard-cut system-mode dashboard sync compatibility
+  - `OTEL_MODE=system` now fails shell entry when `OTEL_STATE_DIR`, `OTEL_EXPORTER_OTLP_ENDPOINT`, or `otel` CLI is missing
+  - Removed `OTEL_DASHBOARDS_DIR` shell env export
+  - Removed shell-side `extraDashboards` merge logic; `extraDashboards` is now rejected in system mode
+
 - **devenv/otel.nix**: Replace `curl` with file spool (`otlpjsonfilereceiver`) in `otel-span`
   - Spans are written to `$OTEL_SPAN_SPOOL_DIR/spans.jsonl` instead of HTTP POST
   - Collector picks up spans via `otlpjsonfilereceiver` (500ms poll, delete after read)

--- a/context/otel.md
+++ b/context/otel.md
@@ -47,7 +47,7 @@ mode = "auto" (default)
   └── not set?            → "local": starts per-project Collector/Tempo/Grafana
 ```
 
-When in system mode, this module auto-syncs dashboards by invoking `otel dash sync` on shell entry (when `otel` is available), targeting `$OTEL_STATE_DIR/dashboards`. This keeps dashboard path/UID/archive behavior aligned with the otel-cli implementation instead of ad-hoc shell copies.
+When in system mode, this module requires `OTEL_STATE_DIR`, `OTEL_EXPORTER_OTLP_ENDPOINT`, and the `otel` CLI. Shell entry fails immediately if any are missing. Dashboards are synced by invoking `otel dash sync` on shell entry, targeting `$OTEL_STATE_DIR/dashboards`.
 
 ## Environment Variables
 
@@ -190,7 +190,7 @@ jsonnet -J path/to/grafonnet dt-tasks.jsonnet | jq .
 
 ### Project Dashboards (`.otel/dashboards.json`)
 
-Projects define their own dashboards in `.otel/dashboards.json`. In system mode, dashboard syncing is delegated to `otel dash sync` on shell entry.
+Projects define their own dashboards in `.otel/dashboards.json`. In system mode, dashboard syncing is delegated to `otel dash sync` on shell entry. `extraDashboards` is local-mode only and is rejected in system mode.
 
 ## Data Storage
 


### PR DESCRIPTION
## Why
`OTEL_MODE=system` still had compatibility behavior that could hide misconfiguration and reintroduce stale dashboard state.
We want a strict, explicit setup with no shell-side legacy sync logic.

## What
- Keep system-mode dashboard sync delegated to `otel dash sync`.
- Hard-fail shell entry in `OTEL_MODE=system` when any required dependency is missing:
  - `OTEL_STATE_DIR`
  - `OTEL_EXPORTER_OTLP_ENDPOINT`
  - `otel` CLI on `PATH`
- Remove `OTEL_DASHBOARDS_DIR` shell env export.
- Remove shell-side `extraDashboards` merge shim.
- Reject `extraDashboards` in system mode (local mode support remains unchanged).
- Update `context/otel.md` and `CHANGELOG.md`.

## Validation
- `CI=1 devenv tasks run lint:check --mode before`
- `CI=1 devenv tasks run check:quick --mode before`
- `CI=1 devenv tasks run otel:test --mode before`

## Breaking Change
- System mode now fails fast instead of warning/continuing when required env/CLI pieces are missing.
- `extraDashboards` is no longer accepted in system mode.

---
Created by an AI coding assistant on behalf of @schickling.
