### PR TITLE
fix(tasks): use bunx vercel in shared deploy module

### DIFF
--- a/nix/devenv-modules/tasks/shared/vercel.nix
+++ b/nix/devenv-modules/tasks/shared/vercel.nix
@@ -83,7 +83,7 @@ let
           case "$deploy_type" in
             prod)
               echo "Deploying ${deployment.name} to production..."
-              ${pkgs.vercel}/bin/vercel deploy "$deploy_dir" --yes --prod --token "$VERCEL_TOKEN"
+              ${pkgs.bun}/bin/bunx vercel deploy "$deploy_dir" --yes --prod --token "$VERCEL_TOKEN"
               ;;
             pr|preview)
               pr_number="$(echo "$input" | ${pkgs.jq}/bin/jq -r '.pr // empty')"
@@ -92,7 +92,7 @@ let
               else
                 echo "Deploying ${deployment.name} preview..."
               fi
-              ${pkgs.vercel}/bin/vercel deploy "$deploy_dir" --yes --token "$VERCEL_TOKEN"
+              ${pkgs.bun}/bin/bunx vercel deploy "$deploy_dir" --yes --token "$VERCEL_TOKEN"
               ;;
             *)
               echo "Error: Unknown deploy type '$deploy_type'. Use: prod, pr, preview" >&2


### PR DESCRIPTION
## Summary
- switch shared `tasks.vercel` module from `${pkgs.vercel}/bin/vercel` to `${pkgs.bun}/bin/bunx vercel`
- keep deploy behavior unchanged for `preview|pr|prod` modes

## Why
Some downstream repos do not expose `pkgs.vercel` in their nixpkgs set, which makes evaluation fail when importing the shared module. `bunx vercel` matches the existing pattern used by the shared Netlify task module and keeps the module portable.

## Validation
- `devenv tasks run check:quick --mode before`