### PR TITLE
feat(beads): upgrade to v0.57.0 with self-managing dolt server

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -351,10 +351,6 @@ in
     description = "Apply .github/repo-settings.json to GitHub ruleset";
   };
 
-  # Wire beads:ensure directly to shell entry (not via optionalTasks)
-  # because the setup module's gitHashStatus cache isn't the right gate here.
-  tasks."devenv:enterShell".after = lib.mkAfter [ "beads:ensure" ];
-
   # Keep git-hook installation out of the shell-entry path.
   # If needed, install with `devenv tasks run devenv:git-hooks:install`.
   # TODO(cachix/git-hooks.nix#688): remove this once the upstream git-hooks.nix issue

--- a/nix/beads.nix
+++ b/nix/beads.nix
@@ -1,27 +1,26 @@
 # Beads (bd) — pre-built binary package from GitHub releases.
-# v0.56+ removed embedded Dolt entirely (CGO_ENABLED=0, pure-Go MySQL protocol).
-# Requires an external `dolt sql-server` for database operations.
+# v0.57+ self-manages dolt sql-server per project (deterministic port from FNV hash of BEADS_DIR).
 { pkgs }:
 let
-  version = "0.56.1";
+  version = "0.57.0";
   tag = "v${version}";
 
   sources = {
     x86_64-linux = {
       url = "https://github.com/steveyegge/beads/releases/download/${tag}/beads_${version}_linux_amd64.tar.gz";
-      sha256 = "0p512lhdmv5h0bh1a77rn7343y5a3s80k42jzw9id8b58k26r7sg";
+      sha256 = "0jy0blh895iask2hi7gdkagnf78pvjnk88zr0rgx5mxy4xb9sqpq";
     };
     aarch64-linux = {
       url = "https://github.com/steveyegge/beads/releases/download/${tag}/beads_${version}_linux_arm64.tar.gz";
-      sha256 = "1l4v9cwnpksk1p9v0i0vj27x7drppkcacq1q8lfxj6988c7md656";
+      sha256 = "1a5gn5kn8gf8a1923z19h4wz8vc483vy51q71q591wyvd5dnpk44";
     };
     x86_64-darwin = {
       url = "https://github.com/steveyegge/beads/releases/download/${tag}/beads_${version}_darwin_amd64.tar.gz";
-      sha256 = "06w5rky4qdpiqvjxqyddjxj54yg0ajdknqfj4kmq91z9fwb911y9";
+      sha256 = "0x72ylyv0n8riy9d9kxylfrdcpdydsm589i5xkr9i8pag4ns76i8";
     };
     aarch64-darwin = {
       url = "https://github.com/steveyegge/beads/releases/download/${tag}/beads_${version}_darwin_arm64.tar.gz";
-      sha256 = "04h85wydl1hhi1jwv52w1a44afn5xln6afy0j1xc5f1avq4l72ma";
+      sha256 = "1vcc6dm85in4hb8ik6c863l76p9hhp14r7ckpqpzfafsckzvvg7v";
     };
   };
 
@@ -40,7 +39,7 @@ pkgs.stdenv.mkDerivation {
     inherit (platformInfo) url sha256;
   };
 
-  # v0.56+ is dynamically linked on Linux (needs libc.so.6) —
+  # Dynamically linked on Linux (needs libc.so.6) —
   # autoPatchelfHook resolves the interpreter and rpath automatically.
   nativeBuildInputs = [ pkgs.gnutar pkgs.installShellFiles pkgs.makeWrapper ]
     ++ pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.autoPatchelfHook ];

--- a/nix/devenv-modules/otel/dashboards/dt-duration-trends.jsonnet
+++ b/nix/devenv-modules/otel/dashboards/dt-duration-trends.jsonnet
@@ -335,7 +335,7 @@ g.dashboard.new('dt Task Duration Trends')
   at(
     taskDurationPanel(
       'Shell entry sub-tasks (p50 / p95)',
-      'setup:gate|pnpm:install|genie:run|megarepo:sync|ts:patch-lsp|ts:emit|setup:completions|beads:ensure|devenv:.*',
+      'setup:gate|pnpm:install|genie:run|megarepo:sync|ts:patch-lsp|ts:emit|setup:completions|devenv:.*',
     ),
     12, y.shellContent, 12, 8,
   ),

--- a/nix/devenv-modules/tasks/shared/beads.nix
+++ b/nix/devenv-modules/tasks/shared/beads.nix
@@ -1,84 +1,17 @@
 # Beads devenv module — integrates beads issue tracking with devenv.
 #
-# v0.56+ requires an external `dolt sql-server` (embedded mode removed).
-# This module manages the server lifecycle: auto-starts on shell entry,
-# stops on exit. Sets BEADS_DIR so `bd` works from anywhere.
+# v0.57+ self-manages dolt sql-server (auto-start with deterministic port).
+# This module sets BEADS_DIR and provides push/pull convenience tasks.
 { beadsPrefix, beadsRepoName, beadsRepoPath ? "repos/${beadsRepoName}" }:
 { pkgs, config, ... }:
 let
   git = "${pkgs.git}/bin/git";
-  dolt = "${pkgs.dolt}/bin/dolt";
   bdPackage = import ../../../beads.nix { inherit pkgs; };
   bd = "${bdPackage}/bin/bd";
   beadsRepoRelPath = beadsRepoPath;
 in
 {
   env.BEADS_DIR = "${config.devenv.root}/${beadsRepoRelPath}/.beads";
-
-  tasks."beads:ensure" = {
-    description = "Ensure beads Dolt server is running and database is initialized";
-    after = [ "megarepo:sync" ];
-    exec = ''
-      if [ ! -d "$BEADS_DIR" ]; then
-        echo "[beads] Beads repo not materialized, skipping."
-        exit 0
-      fi
-
-      cd "''${BEADS_DIR%/.beads}"
-
-      DOLT_DIR="$BEADS_DIR/dolt"
-      PID_FILE="$DOLT_DIR/sql-server.pid"
-      LOG_FILE="$DOLT_DIR/sql-server.log"
-
-      # Start dolt sql-server if not already running
-      # Uses --data-dir so dolt serves all databases under $BEADS_DIR/dolt/
-      # (bd creates the database directory structure, e.g. dolt/<db-name>/.dolt/)
-      if [ -f "$PID_FILE" ] && kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
-        echo "[beads] Dolt server already running (PID $(cat "$PID_FILE"))"
-      else
-        rm -f "$PID_FILE"
-        echo "[beads] Starting Dolt sql-server on port 3307..."
-        ${dolt} sql-server --port 3307 --host 127.0.0.1 --data-dir "$DOLT_DIR" >> "$LOG_FILE" 2>&1 &
-        echo $! > "$PID_FILE"
-
-        # Wait for server to be ready
-        for i in $(seq 1 30); do
-          if ${bd} dolt test --quiet 2>/dev/null; then
-            echo "[beads] Dolt server ready."
-            break
-          fi
-          sleep 0.2
-        done
-      fi
-
-      # Bootstrap DB from JSONL on fresh checkout
-      if [ -f "$BEADS_DIR/issues.jsonl" ]; then
-        ${bd} list --quiet >/dev/null 2>&1 || true
-      fi
-    '';
-    status = ''
-      [ ! -d "$BEADS_DIR" ] && exit 0
-      PID_FILE="$BEADS_DIR/dolt/sql-server.pid"
-      [ -f "$PID_FILE" ] && kill -0 "$(cat "$PID_FILE")" 2>/dev/null
-    '';
-  };
-
-  tasks."beads:stop" = {
-    description = "Stop beads Dolt server";
-    exec = ''
-      PID_FILE="$BEADS_DIR/dolt/sql-server.pid"
-      if [ -f "$PID_FILE" ]; then
-        PID=$(cat "$PID_FILE")
-        if kill -0 "$PID" 2>/dev/null; then
-          echo "[beads] Stopping Dolt server (PID $PID)..."
-          kill "$PID" 2>/dev/null || true
-          rm -f "$PID_FILE"
-        fi
-      else
-        echo "[beads] Dolt server not running."
-      fi
-    '';
-  };
 
   tasks."beads:push" = {
     description = "Push beads changes to Dolt remote";


### PR DESCRIPTION
## Summary

- Upgrade beads from v0.56.1 to v0.57.0 which self-manages dolt sql-server per project (deterministic port from FNV hash of BEADS_DIR, range 13307-14307)
- Remove all manual dolt lifecycle management from devenv module (`beads:ensure`, `beads:stop`, shell entry wiring, PID files, port 3307)
- Net -72 lines — keep only what's needed: `BEADS_DIR` env var, `beads:push`/`beads:pull`, git hook

## Context

v0.56 required us to manage the dolt sql-server lifecycle externally (start on shell entry, stop on exit, hardcoded port 3307). This caused port conflicts when running beads across multiple repos simultaneously.

v0.57.0 has bd self-manage the dolt server: auto-starts on first command, deterministic port per project via FNV hash, 30min idle shutdown, crash watchdog. Our devenv module's dolt management becomes redundant and counterproductive.

## Test plan

- [x] `nix build` succeeds for beads v0.57.0 (darwin)
- [x] `bd version` → v0.57.0
- [x] `bd list` auto-starts dolt server on derived port
- [x] `bd init --from-jsonl` imports issues from JSONL
- [ ] CI: Linux builds pass (autoPatchelfHook)
- [ ] Shell entry works without `beads:ensure`

🤖 Generated with [Claude Code](https://claude.com/claude-code)