### PR TITLE
feat(ci): add reusable deploy summary comment helper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -881,7 +881,7 @@ jobs:
 
           # Write job summary
           {
-            echo "## Storybook Previews (${label})"
+            echo "## Storybook Previews ($label)"
             echo ""
             echo "| Package | URL |"
             echo "| --- | --- |"

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -10,6 +10,7 @@ import {
   standardCIEnv,
   namespaceRunner,
   nixDiagnosticsArtifactStep,
+  deployCommentStep,
   validateNixStoreStep,
 } from '../../genie/ci-workflow.ts'
 import { type CIJobName } from '../../genie/ci.ts'
@@ -157,7 +158,7 @@ const jobs: Record<CIJobName, ReturnType<typeof job> | ReturnType<typeof multiPl
 const NETLIFY_SITE = 'overeng-utils'
 
 // Deploy job — NOT a required status check (separate from CIJobName)
-const deployJobs = {
+const deployJobs: Record<string, any> = {
   'deploy-storybooks': {
     'runs-on': namespaceRunner('namespace-profile-linux-x86-64', '${{ github.run_id }}'),
     // No `needs` — run in parallel with other jobs for faster feedback
@@ -182,14 +183,11 @@ const deployJobs = {
           'fi',
         ].join('\n'),
       },
-      {
-        name: 'Post deploy URLs',
-        if: 'always() && !cancelled()',
-        shell: 'bash',
-        env: {
-          GH_TOKEN: '${{ github.token }}',
-        },
-        run: [
+      deployCommentStep({
+        summaryTitle: 'Storybook Previews',
+        tableHeaders: ['Package', 'URL'],
+        noRowsMessage: 'No storybooks were deployed.',
+        modeScript: [
           `site="${NETLIFY_SITE}"`,
           'if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ]; then',
           '  suffix=""',
@@ -200,7 +198,8 @@ const deployJobs = {
           'else',
           '  exit 0',
           'fi',
-          '',
+        ].join('\n'),
+        rowsScript: [
           '# Collect deployed storybooks by checking for build output',
           'rows=""',
           'for dir in packages/@overeng/*/storybook-static; do',
@@ -210,35 +209,8 @@ const deployJobs = {
           '  url="https://${name}${suffix}--${site}.netlify.app"',
           '  rows="${rows}| ${name} | ${url} |\\n"',
           'done',
-          '',
-          'if [ -z "$rows" ]; then',
-          '  echo "No storybooks were deployed." >> "$GITHUB_STEP_SUMMARY"',
-          '  exit 0',
-          'fi',
-          '',
-          '# Write job summary',
-          '{',
-          '  echo "## Storybook Previews (${label})"',
-          '  echo ""',
-          '  echo "| Package | URL |"',
-          '  echo "| --- | --- |"',
-          '  echo -e "$rows"',
-          '} >> "$GITHUB_STEP_SUMMARY"',
-          '',
-          '# Post/update PR comment',
-          'if [ "${{ github.event_name }}" = "pull_request" ]; then',
-          '  {',
-          '    echo "## Storybook Previews"',
-          '    echo ""',
-          '    echo "| Package | URL |"',
-          '    echo "| --- | --- |"',
-          '    echo -e "$rows"',
-          '  } > /tmp/comment.md',
-          '  gh pr comment "${{ github.event.pull_request.number }}" --body-file /tmp/comment.md --edit-last 2>/dev/null \\',
-          '    || gh pr comment "${{ github.event.pull_request.number }}" --body-file /tmp/comment.md',
-          'fi',
         ].join('\n'),
-      },
+      }),
       nixDiagnosticsSummaryStep,
       nixDiagnosticsArtifactStep(),
       failureReminderStep,

--- a/genie/ci-workflow.ts
+++ b/genie/ci-workflow.ts
@@ -271,3 +271,59 @@ export const nixDiagnosticsArtifactStep = (
     'retention-days': opts?.retentionDays ?? 14,
   },
 })
+
+/**
+ * Reusable step that writes a deployment summary and upserts a PR comment.
+ *
+ * The provided scripts run in order and must:
+ * - `modeScript`: set `label` (or `exit 0` for unsupported events)
+ * - `rowsScript`: set `rows` as markdown table rows (`| a | b |\n`)
+ */
+export const deployCommentStep = (opts: {
+  summaryTitle: string
+  tableHeaders: readonly [string, string]
+  modeScript: string
+  rowsScript: string
+  noRowsMessage: string
+  commentTitle?: string
+  if?: string
+}) => ({
+  name: 'Post deploy URLs',
+  if: opts.if ?? 'always() && !cancelled()',
+  shell: 'bash' as const,
+  env: {
+    GH_TOKEN: '${{ github.token }}',
+  },
+  run: [
+    opts.modeScript,
+    '',
+    opts.rowsScript,
+    '',
+    'if [ -z "$rows" ]; then',
+    `  echo "${opts.noRowsMessage}" >> "$GITHUB_STEP_SUMMARY"`,
+    '  exit 0',
+    'fi',
+    '',
+    '# Write job summary',
+    '{',
+    `  echo "## ${opts.summaryTitle} (\$label)"`,
+    '  echo ""',
+    `  echo "| ${opts.tableHeaders[0]} | ${opts.tableHeaders[1]} |"`,
+    '  echo "| --- | --- |"',
+    '  echo -e "$rows"',
+    '} >> "$GITHUB_STEP_SUMMARY"',
+    '',
+    '# Post/update PR comment',
+    'if [ "${{ github.event_name }}" = "pull_request" ]; then',
+    '  {',
+    `    echo "## ${opts.commentTitle ?? opts.summaryTitle}"`,
+    '    echo ""',
+    `    echo "| ${opts.tableHeaders[0]} | ${opts.tableHeaders[1]} |"`,
+    '    echo "| --- | --- |"',
+    '    echo -e "$rows"',
+    '  } > /tmp/comment.md',
+    '  gh pr comment "${{ github.event.pull_request.number }}" --body-file /tmp/comment.md --edit-last 2>/dev/null \\',
+    '    || gh pr comment "${{ github.event.pull_request.number }}" --body-file /tmp/comment.md',
+    'fi',
+  ].join('\n'),
+})


### PR DESCRIPTION
## Summary
- add `deployCommentStep()` to `genie/ci-workflow.ts` as a reusable CI step for deployment summaries + PR comment upserts
- refactor `deploy-storybooks` in `.github/workflows/ci.yml.genie.ts` to use the new helper
- regenerate `.github/workflows/ci.yml`

## Why
Multiple repos need the same post-deploy UX (step summary + upserted PR comment). Centralizing this in shared CI workflow helpers avoids copy/paste drift.

## Validation
- `devenv tasks run lint:check --mode before`
- `dt ts:check`