### PR TITLE
fix(nix): restrict pnpm deps source filter to deps-relevant files

### DIFF
--- a/nix/workspace-tools/lib/mk-pnpm-cli.nix
+++ b/nix/workspace-tools/lib/mk-pnpm-cli.nix
@@ -157,8 +157,11 @@ let
             "out"
           ];
           isExcluded = lib.elem baseName excludedNames;
-          # Include everything under the main package directory
-          isInPackage = lib.hasPrefix "${pkgDir}/" relPath || relPath == pkgDir;
+          # For deps fetching, only include deps-relevant files from the main package
+          # (source files are only needed in workspaceSrc for the build phase)
+          depsRelevantFiles = [ "pnpm-lock.yaml" "package.json" "pnpm-workspace.yaml" ".npmrc" ];
+          isPackageDir = relPath == pkgDir && type == "directory";
+          isPackageDepsFile = lib.any (fname: relPath == "${pkgDir}/${fname}") depsRelevantFiles;
           # Include parent directories needed for structure
           parts = lib.splitString "/" pkgDir;
           isParentDir = lib.any (n: relPath == lib.concatStringsSep "/" (lib.take n parts)) (
@@ -190,7 +193,8 @@ let
         in
         !isExcluded
         && (
-          isInPackage
+          isPackageDir
+          || isPackageDepsFile
           || isInPatches
           || isParentDir
           || isWorkspaceMemberPackageJson
@@ -201,8 +205,7 @@ let
     };
 
   # Fetch pnpm dependencies using the shared helper.
-  # Uses --force --recursive because workspace member directories only contain
-  # package.json files (not full sources), and pnpm needs to handle them.
+  # Uses --force --recursive for workspace member handling.
   pnpmDeps = pnpmDepsHelper.mkDeps {
     inherit name pnpmDepsHash;
     src = mkPackageSource packageDir;


### PR DESCRIPTION
## Summary
- Restrict `mkPackageSource` filter to only include deps-relevant files (lockfile, package.json, workspace config) from the main package directory
- Source files (.ts, etc.) are excluded from the deps FOD source, so editing them no longer triggers a full pnpm re-download
- No hash updates needed: existing `pnpmDepsHash` values remain valid since the deps-relevant files are unchanged

## Problem
The `isInPackage` check in `mkPackageSource` included ALL files under the main package directory. Any `.ts` file edit changed the filtered source → changed `srcFingerprint` → changed FOD derivation name → cache miss → full pnpm re-download (~15 min).

## Fix
Replace `isInPackage` with `isPackageDir || isPackageDepsFile` that only matches:
- `pnpm-lock.yaml`
- `package.json`
- `pnpm-workspace.yaml`
- `.npmrc`

Patches are already handled by `isInPatches`. Workspace members are handled by separate checks.

## Test plan
- [x] Build genie and megarepo — both pass with existing hashes
- [ ] Verify: edit a .ts file → FOD is cached (no re-download)
- [ ] Verify: edit pnpm-lock.yaml → FOD correctly re-fetches

🤖 Generated with [Claude Code](https://claude.com/claude-code)