### PR TITLE
fix(tasks): expose vercel deploy URL via task outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ All notable changes to this project will be documented in this file.
   - Writes `VERCEL_DEPLOY_URL` and `VERCEL_DEPLOY_URL_<DEPLOYMENT_NAME>` via `DEVENV_TASK_OUTPUT_FILE`
   - Enables CI callers to consume deploy URLs from structured task output instead of brittle log scraping
 
+### Changed
+
+- **devenv/tasks/shared/vercel.nix**: Switch to prebuilt deploy mode (`vercel pull` -> `vercel build` -> `vercel deploy --prebuilt`)
+  - Replaces direct `vercel deploy <dir>` with local prebuilt workflow for deterministic deploys
+  - Replaces `path`/`outputDir` deployment config with `cwd` (defaults to `"."`)
+  - Adds `vercel pull` step to fetch project settings and env for the target environment
+  - Adds `vercel build` step to produce `.vercel/output` locally before deploying
+
 ### Added
 
 - **@overeng/genie**: Added `githubAction` runtime generator for type-safe `action.yml` generation

--- a/nix/devenv-modules/tasks/shared/vercel.nix
+++ b/nix/devenv-modules/tasks/shared/vercel.nix
@@ -1,4 +1,4 @@
-# Vercel deploy tasks for prebuilt directories
+# Vercel deploy tasks using local prebuilt artifacts
 #
 # Deploy context is passed via DEVENV_TASK_INPUT (devenv --input flag).
 #
@@ -8,8 +8,6 @@
 #       deployments = [
 #         {
 #           name = "web";
-#           path = "apps/web";
-#           outputDir = "dist";
 #           projectIdEnv = "VERCEL_PROJECT_ID_WEB";
 #         }
 #       ];
@@ -24,7 +22,7 @@
 #
 # Provides:
 #   Tasks:
-#     - vercel:deploy:<name> - Deploy specific prebuilt directory to Vercel
+#     - vercel:deploy:<name> - Prebuild + deploy specific target to Vercel
 #     - vercel:deploy        - Aggregate: deploy all configured targets
 {
   deployments ? [ ],
@@ -39,7 +37,7 @@ let
     let
       orgIdEnv = deployment.orgIdEnv or "VERCEL_ORG_ID";
       projectIdEnv = deployment.projectIdEnv or "VERCEL_PROJECT_ID";
-      outputDir = deployment.outputDir or "dist";
+      cwd = deployment.cwd or ".";
       buildDeps = if buildTaskPrefix == null then [ ] else [ "${buildTaskPrefix}:${deployment.name}" ];
     in
     {
@@ -67,13 +65,6 @@ let
             exit 1
           fi
 
-          deploy_dir="${deployment.path}/${outputDir}"
-          if [ ! -d "$deploy_dir" ]; then
-            echo "Error: deploy directory not found: $deploy_dir" >&2
-            echo "Run the build task first or configure outputDir correctly." >&2
-            exit 1
-          fi
-
           input="''${DEVENV_TASK_INPUT:-"{}"}"
           deploy_type="$(echo "$input" | ${pkgs.jq}/bin/jq -r '.type // "preview"')"
 
@@ -82,22 +73,52 @@ let
 
           case "$deploy_type" in
             prod)
-              echo "Deploying ${deployment.name} to production..."
+              pull_env="production"
+              build_flag="--prod"
+              ;;
+            pr|preview)
+              pull_env="preview"
+              build_flag=""
+              ;;
+            *)
+              echo "Error: Unknown deploy type '$deploy_type'. Use: prod, pr, preview" >&2
+              exit 1
+              ;;
+          esac
+
+          echo "Pulling Vercel project settings and env for ${deployment.name} ($pull_env)..."
+          ${pkgs.bun}/bin/bunx vercel pull --cwd "${cwd}" --yes --environment "$pull_env" --token "$VERCEL_TOKEN"
+
+          echo "Building ${deployment.name} locally with vercel build..."
+          if [ -n "$build_flag" ]; then
+            ${pkgs.bun}/bin/bunx vercel build --cwd "${cwd}" --yes $build_flag --token "$VERCEL_TOKEN"
+          else
+            ${pkgs.bun}/bin/bunx vercel build --cwd "${cwd}" --yes --token "$VERCEL_TOKEN"
+          fi
+
+          if [ ! -d "${cwd}/.vercel/output" ]; then
+            echo "Error: Missing prebuilt output directory: ${cwd}/.vercel/output" >&2
+            exit 1
+          fi
+
+          case "$deploy_type" in
+            prod)
+              echo "Deploying ${deployment.name} prebuilt output to production..."
               deploy_log="$(mktemp)"
               trap 'rm -f "$deploy_log"' EXIT
-              ${pkgs.bun}/bin/bunx vercel deploy "$deploy_dir" --yes --prod --token "$VERCEL_TOKEN" 2>&1 | tee "$deploy_log"
+              ${pkgs.bun}/bin/bunx vercel deploy --cwd "${cwd}" --prebuilt --yes --prod --token "$VERCEL_TOKEN" 2>&1 | tee "$deploy_log"
               deploy_exit=''${PIPESTATUS[0]}
               ;;
             pr|preview)
               pr_number="$(echo "$input" | ${pkgs.jq}/bin/jq -r '.pr // empty')"
               if [ -n "$pr_number" ]; then
-                echo "Deploying ${deployment.name} preview for PR #$pr_number..."
+                echo "Deploying ${deployment.name} prebuilt preview for PR #$pr_number..."
               else
-                echo "Deploying ${deployment.name} preview..."
+                echo "Deploying ${deployment.name} prebuilt preview..."
               fi
               deploy_log="$(mktemp)"
               trap 'rm -f "$deploy_log"' EXIT
-              ${pkgs.bun}/bin/bunx vercel deploy "$deploy_dir" --yes --token "$VERCEL_TOKEN" 2>&1 | tee "$deploy_log"
+              ${pkgs.bun}/bin/bunx vercel deploy --cwd "${cwd}" --prebuilt --yes --token "$VERCEL_TOKEN" 2>&1 | tee "$deploy_log"
               deploy_exit=''${PIPESTATUS[0]}
               ;;
             *)


### PR DESCRIPTION
## Summary
- capture `vercel deploy` output inside `tasks.shared.vercel` and extract the deployed URL deterministically
- write deploy URLs to `DEVENV_TASK_OUTPUT_FILE` as `VERCEL_DEPLOY_URL` and `VERCEL_DEPLOY_URL_<DEPLOYMENT_NAME>`
- fail fast when deploy succeeds but URL extraction fails, so CI callers don't silently miss deploy links

## Why
Several repos depend on deploy URLs for CI summaries/PR comments. Devenv task logs are not always a reliable source of command output, so exposing URL data through task outputs gives a stable machine-readable contract.

## Notes
- attempted `dt check:quick` locally, but evaluation is currently blocked by an unrelated `beads` binary build failure in this environment.