### PR TITLE
feat(alignment): add memberTasks for devenv task execution

### DIFF
--- a/genie/alignment.ts
+++ b/genie/alignment.ts
@@ -42,15 +42,22 @@ export const dispatchAlignmentStep = (opts: {
  * Coordinator workflow factory for megarepo-all.
  *
  * Triggers on `repository_dispatch` (upstream-changed) and `workflow_dispatch` (manual testing).
- * Runs `mr sync --pull --all`, detects dirty lock files in member worktrees,
- * and for each dirty member pushes an alignment branch + creates/updates a PR.
+ * Runs `mr sync --pull --all`, optionally runs devenv tasks per member (e.g. pnpm:install,
+ * nix:hash), detects dirty files in member worktrees, and for each dirty member pushes an
+ * alignment branch + creates/updates a PR.
  *
- * Auto-merges only when the diff is exclusively lock files. Non-lock changes
- * are labeled `alignment-needs-review` for manual handling.
+ * Auto-merges only when the diff is exclusively safe files (lock files, pnpm-lock.yaml,
+ * build.nix). Non-safe changes are labeled `alignment-needs-review` for manual handling.
  */
 export const alignmentCoordinatorWorkflow = (opts?: {
   /** Members to exclude from alignment (e.g. beads repos, reference repos) */
   excludeMembers?: string[]
+  /**
+   * Devenv tasks to run per member after sync.
+   * Each member's tasks are run in order via the member's pinned devenv from devenv.lock.
+   * Members not listed here skip devenv entirely (no overhead).
+   */
+  memberTasks?: Record<string, [string, ...string[]]>
 }) =>
   githubWorkflow({
     name: 'Alignment Coordinator',
@@ -81,11 +88,70 @@ export const alignmentCoordinatorWorkflow = (opts?: {
             run: 'mr sync --pull --all',
             shell: 'bash',
           },
+          ...(opts?.memberTasks && Object.keys(opts.memberTasks).length > 0
+            ? [memberTasksStep(opts.memberTasks)]
+            : []),
           coordinatorScript(opts?.excludeMembers ?? []),
         ],
       },
     },
   } satisfies GitHubWorkflowArgs)
+
+/**
+ * Generate a step that runs devenv tasks for configured members.
+ * Each member's pinned devenv is resolved from its devenv.lock.
+ * Task failures are logged as warnings but don't abort the coordinator.
+ */
+const memberTasksStep = (
+  memberTasks: Record<string, [string, ...string[]]>,
+) => {
+  const calls = Object.entries(memberTasks)
+    .map(
+      ([member, tasks]) =>
+        `run_devenv_tasks "${member}" ${tasks.map((t) => `"${t}"`).join(' ')}`,
+    )
+    .join('\n')
+
+  return {
+    name: 'Run devenv tasks per member',
+    shell: 'bash',
+    run: `set -euo pipefail
+
+run_devenv_tasks() {
+  local member_name="$1"; shift
+  local member_dir="repos/$member_name"
+  [ -d "$member_dir" ] || return 0
+
+  if [ ! -f "$member_dir/devenv.lock" ]; then
+    echo "::warning::$member_name has no devenv.lock — skipping devenv tasks"
+    return 0
+  fi
+
+  local devenv_rev
+  devenv_rev=$(jq -r .nodes.devenv.locked.rev "$member_dir/devenv.lock")
+  if [ -z "$devenv_rev" ] || [ "$devenv_rev" = "null" ]; then
+    echo "::warning::$member_name devenv.lock missing devenv rev — skipping"
+    return 0
+  fi
+
+  echo "::group::devenv tasks for $member_name"
+  local devenv_bin
+  devenv_bin=$(nix build --no-link --print-out-paths "github:cachix/devenv/$devenv_rev#devenv")/bin/devenv
+
+  (
+    cd "$member_dir"
+    for task in "$@"; do
+      echo "  Running: $task"
+      NIX_CONFIG="restrict-eval = false" "$devenv_bin" tasks run "$task" --mode before || \\
+        echo "::warning::Task $task failed in $member_name"
+    done
+  )
+  echo "::endgroup::"
+}
+
+${calls}`,
+  }
+}
 
 const coordinatorScript = (excludeMembers: string[]) => ({
   name: 'Create alignment PRs for dirty members',
@@ -111,36 +177,36 @@ while IFS=' ' read -r member_name member_url; do
   member_dir="repos/$member_name"
   [ -d "$member_dir" ] || continue
 
-  # Check for dirty lock files after sync
-  lock_files_changed=$(cd "$member_dir" && git diff --name-only -- '*.lock' 2>/dev/null || true)
-  [ -z "$lock_files_changed" ] && continue
+  # Check for any dirty files after sync + devenv tasks
+  files_changed=$(cd "$member_dir" && git diff --name-only 2>/dev/null || true)
+  [ -z "$files_changed" ] && continue
 
-  # Determine if diff is lock-files-only
-  all_files_changed=$(cd "$member_dir" && git diff --name-only 2>/dev/null || true)
-  lock_only=true
+  # Determine if all changed files are safe for auto-merge
+  safe_only=true
   while IFS= read -r f; do
     case "$f" in
-      *.lock) ;;
-      *) lock_only=false; break ;;
+      *.lock|pnpm-lock.yaml|*/pnpm-lock.yaml|nix/build.nix|*/nix/build.nix) ;;
+      *) safe_only=false; break ;;
     esac
-  done <<< "$all_files_changed"
+  done <<< "$files_changed"
 
   # Extract owner/repo from URL
   repo_slug=$(echo "$member_url" | sed -E 's|https://github.com/||; s|\\.git$||')
   branch_name="$BRANCH_PREFIX/$SOURCE_REPO"
 
   echo "::group::$member_name ($repo_slug)"
-  echo "Changed: $lock_files_changed"
-  echo "Lock-only: $lock_only"
+  echo "Changed files:"
+  echo "$files_changed" | sed 's/^/  /'
+  echo "Safe-only: $safe_only"
 
-  # Stage lock files, commit, push
+  # Stage all changes, commit, push
   (
     cd "$member_dir"
     git checkout -B "$branch_name"
-    git add -- *.lock */*.lock 2>/dev/null || git add -- *.lock
+    git add -A
     git -c user.name="schickling-assistant" \\
         -c user.email="schickling-assistant@users.noreply.github.com" \\
-        commit -m "chore: align lock files (upstream update)"
+        commit -m "chore: align dependency files (upstream update)"
     git push "https://x-access-token:\${GH_TOKEN}@github.com/$repo_slug.git" \\
         "$branch_name" --force
   )
@@ -149,10 +215,10 @@ while IFS=' ' read -r member_name member_url; do
   member_ref=$(jq -r --arg m "$member_name" '.members[$m].ref' megarepo.lock)
 
   # Create or update PR
-  PR_TITLE="chore: align lock files (upstream update)"
-  PR_BODY="Automated lock file alignment.
+  PR_TITLE="chore: align dependency files (upstream update)"
+  PR_BODY="Automated dependency alignment.
 
-Updates Nix lock files to match latest upstream commits.
+Updates lock files and dependency hashes to match latest upstream commits.
 
 ---
 *Created by the megarepo alignment coordinator.*"
@@ -171,13 +237,13 @@ Updates Nix lock files to match latest upstream commits.
     existing_pr=$($GH_BIN pr list --repo "$repo_slug" --head "$branch_name" --base "$member_ref" --state open --json number -q '.[0].number' 2>/dev/null || true)
   fi
 
-  # Auto-merge gate: only if diff is exclusively lock files
-  if [ "$lock_only" = true ] && [ -n "$existing_pr" ]; then
-    echo "Lock-only diff — enabling auto-merge"
+  # Auto-merge gate: only if all changed files are safe (lock files, pnpm-lock.yaml, build.nix)
+  if [ "$safe_only" = true ] && [ -n "$existing_pr" ]; then
+    echo "Safe-only diff — enabling auto-merge"
     $GH_BIN pr merge "$existing_pr" --repo "$repo_slug" --auto --squash 2>/dev/null || \\
       echo "::warning::Could not enable auto-merge for $repo_slug#$existing_pr (may need branch protection)"
   elif [ -n "$existing_pr" ]; then
-    echo "::warning::Non-lock files changed in $member_name — skipping auto-merge"
+    echo "::warning::Non-safe files changed in $member_name — skipping auto-merge"
     $GH_BIN pr edit "$existing_pr" --repo "$repo_slug" --add-label "alignment-needs-review" 2>/dev/null || true
   fi
 


### PR DESCRIPTION
## Summary

- Add `memberTasks` option to `alignmentCoordinatorWorkflow` for running devenv tasks (pnpm:install, nix:hash) per member after sync
- Add `memberTasksStep` that resolves each member's pinned devenv from `devenv.lock` and runs configured tasks
- Broaden dirty check to all files (not just `*.lock`)
- Broaden staging to `git add -A`
- Expand auto-merge safe-file gate to include `pnpm-lock.yaml` and `*/nix/build.nix`

## Test plan

- [x] TypeScript compiles
- [x] Genie generates updated YAML correctly
- [x] `genie --check` passes
- [ ] End-to-end: trigger coordinator via `workflow_dispatch` after all three PRs merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)