### PR TITLE
fix(alignment): unset CI for devenv tasks + provide perl

### DIFF
--- a/genie/alignment.ts
+++ b/genie/alignment.ts
@@ -117,6 +117,10 @@ const memberTasksStep = (
     shell: 'bash',
     run: `set -euo pipefail
 
+# Provide perl for nix:hash tasks (update-all-hashes script needs it)
+PERL_BIN=$(nix build nixpkgs#perl --no-link --print-out-paths)/bin
+export PATH="$PERL_BIN:$PATH"
+
 run_devenv_tasks() {
   local member_name="$1"; shift
   local member_dir="repos/$member_name"
@@ -142,7 +146,7 @@ run_devenv_tasks() {
     cd "$member_dir"
     for task in "$@"; do
       echo "  Running: $task"
-      NIX_CONFIG="restrict-eval = false" "$devenv_bin" tasks run "$task" --mode before || \\
+      CI= NIX_CONFIG="restrict-eval = false" "$devenv_bin" tasks run "$task" --mode before || \\
         echo "::warning::Task $task failed in $member_name"
     done
   )


### PR DESCRIPTION
## Summary

- Unset `CI` env var when running devenv tasks so `pnpm:install` doesn't use `--frozen-lockfile` (the coordinator needs to generate lockfile changes, not validate them)
- Build `perl` via nix and add to `PATH` for `nix:hash` tasks (`update-all-hashes` script requires it)

## Context

The alignment coordinator runs devenv tasks to regenerate derived files after syncing members. Two issues:
1. `CI=true` makes `pnpm:install` use `--frozen-lockfile`, which fails after `genie:run` updates `package.json`
2. `devenv tasks run` doesn't provide the full devenv shell environment, so `perl` (needed by `nix:hash`) is missing from `PATH`

---
*Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>*