### PR TITLE
chore: bump @types/bun 1.3.5 → 1.3.10

### DIFF
--- a/genie/external.ts
+++ b/genie/external.ts
@@ -191,7 +191,7 @@ export const catalog = defineCatalog({
   '@types/react': '19.2.7',
   '@types/react-dom': '19.2.3',
   '@types/node': '25.3.3',
-  '@types/bun': '1.3.5',
+  '@types/bun': '1.3.10',
   '@types/eslint': '9.6.1',
   '@types/is-dom': '1.1.2',
 

--- a/packages/@overeng/genie/nix/build.nix
+++ b/packages/@overeng/genie/nix/build.nix
@@ -16,9 +16,9 @@ let
     workspaceRoot = src;
     extraExcludedSourceNames = [ "context" "scripts" ];
     # Managed by `dt nix:hash:genie` — do not edit manually.
-    pnpmDepsHash = "sha256-IjXvo+rox3eylWYLlt/5kOYkHB4zqkqZkeMs+Iep2d4=";
-    lockfileHash = "sha256-X4TrzvCtLNAGV+LaNB+ps3HiCr6ip7mzwkMPmmEdk64=";
-    packageJsonDepsHash = "sha256-mCUgw8hk6ZZJDfqdc2uqC49gvg8MMlfsOQJ8pa/b9HU=";
+    pnpmDepsHash = "sha256-0OSGcThI7Q9YhYLhNmTpobn7/2IYnDg0ejmisZcaoSQ=";
+    lockfileHash = "sha256-wz/rAU1352qbOZJ0twlReP1tdGDuUEwqqcIZR28PEYU=";
+    packageJsonDepsHash = "sha256-tMch41qH+GilQSbIGitAHjKtPH2tb4h9uSwDW1peQDc=";
     inherit gitRev commitTs dirty;
   };
 in

--- a/packages/@overeng/genie/package.json
+++ b/packages/@overeng/genie/package.json
@@ -44,7 +44,7 @@
     "@playwright/test": "^1.58.2",
     "@storybook/react": "10.2.3",
     "@storybook/react-vite": "10.2.3",
-    "@types/bun": "1.3.5",
+    "@types/bun": "1.3.10",
     "@types/node": "25.3.3",
     "@types/react": "19.2.7",
     "@types/react-reconciler": "0.28.9",

--- a/packages/@overeng/genie/pnpm-lock.yaml
+++ b/packages/@overeng/genie/pnpm-lock.yaml
@@ -78,8 +78,8 @@ importers:
         specifier: 10.2.3
         version: 10.2.3(esbuild@0.27.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.57.1)(storybook@10.2.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.3)(yaml@2.8.2))
       '@types/bun':
-        specifier: 1.3.5
-        version: 1.3.5
+        specifier: 1.3.10
+        version: 1.3.10
       '@types/node':
         specifier: 25.3.3
         version: 25.3.3
@@ -1393,8 +1393,8 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
-  '@types/bun@1.3.5':
-    resolution: {integrity: sha512-RnygCqNrd3srIPEWBd5LFeUYG7plCoH2Yw9WaZGyNmdTEei+gWaHqydbaIRkIkcbXwhBT94q78QljxN0Sk838w==}
+  '@types/bun@1.3.10':
+    resolution: {integrity: sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -1546,8 +1546,8 @@ packages:
     peerDependencies:
       typescript: ^5
 
-  bun-types@1.3.5:
-    resolution: {integrity: sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw==}
+  bun-types@1.3.10:
+    resolution: {integrity: sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg==}
 
   bun-webgpu-darwin-arm64@0.1.4:
     resolution: {integrity: sha512-eDgLN9teKTfmvrCqgwwmWNsNszxYs7IZdCqk0S1DCarvMhr4wcajoSBlA/nQA0/owwLduPTS8xxCnQp4/N/gDg==}
@@ -3557,9 +3557,9 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
-  '@types/bun@1.3.5':
+  '@types/bun@1.3.10':
     dependencies:
-      bun-types: 1.3.5
+      bun-types: 1.3.10
 
   '@types/chai@5.2.3':
     dependencies:
@@ -3708,7 +3708,7 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  bun-types@1.3.5:
+  bun-types@1.3.10:
     dependencies:
       '@types/node': 25.3.3
 

--- a/packages/@overeng/megarepo/nix/build.nix
+++ b/packages/@overeng/megarepo/nix/build.nix
@@ -16,9 +16,9 @@ let
     # Patches are in packages/@overeng/utils/patches/ (referenced by pnpm-lock.yaml)
     patchesDir = "packages/@overeng/utils/patches";
     # Managed by `dt nix:hash:megarepo` — do not edit manually.
-    pnpmDepsHash = "sha256-mFeSPMytBN2UvKfESApNYoykZeArg0VoD74WYH8mJlM=";
-    lockfileHash = "sha256-SqNadhOX4qTPcKcvZrlGN7NXJcoENtd6ZiEz0Mphx9g=";
-    packageJsonDepsHash = "sha256-zUWAUGqNRz64xtczNuazTw/6fjeAgrdyhsd8AzHYXBc=";
+    pnpmDepsHash = "sha256-Dk+XgTDM73qoHBAL90T2UNuEcUHb2iObo9FwC2jTfTE=";
+    lockfileHash = "sha256-cqXk41aoTk8DZOStnCOLp5LjgvhP5D0k7DZTCU2btrk=";
+    packageJsonDepsHash = "sha256-dhrqTHhoUUk753oIk61dMTbxJ1ivA9UYEu6h9jM51qA=";
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;
   };

--- a/packages/@overeng/megarepo/package.json
+++ b/packages/@overeng/megarepo/package.json
@@ -38,7 +38,7 @@
     "@opentui/react": "0.1.74",
     "@storybook/react": "10.2.3",
     "@storybook/react-vite": "10.2.3",
-    "@types/bun": "1.3.5",
+    "@types/bun": "1.3.10",
     "@types/node": "25.3.3",
     "@types/react": "19.2.7",
     "@types/react-reconciler": "0.28.9",

--- a/packages/@overeng/megarepo/pnpm-lock.yaml
+++ b/packages/@overeng/megarepo/pnpm-lock.yaml
@@ -87,8 +87,8 @@ importers:
         specifier: 10.2.3
         version: 10.2.3(esbuild@0.27.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.57.1)(storybook@10.2.3(@testing-library/dom@10.4.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.3)(yaml@2.8.2))
       '@types/bun':
-        specifier: 1.3.5
-        version: 1.3.5
+        specifier: 1.3.10
+        version: 1.3.10
       '@types/node':
         specifier: 25.3.3
         version: 25.3.3
@@ -1395,8 +1395,8 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
-  '@types/bun@1.3.5':
-    resolution: {integrity: sha512-RnygCqNrd3srIPEWBd5LFeUYG7plCoH2Yw9WaZGyNmdTEei+gWaHqydbaIRkIkcbXwhBT94q78QljxN0Sk838w==}
+  '@types/bun@1.3.10':
+    resolution: {integrity: sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -1548,8 +1548,8 @@ packages:
     peerDependencies:
       typescript: ^5
 
-  bun-types@1.3.5:
-    resolution: {integrity: sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw==}
+  bun-types@1.3.10:
+    resolution: {integrity: sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg==}
 
   bun-webgpu-darwin-arm64@0.1.4:
     resolution: {integrity: sha512-eDgLN9teKTfmvrCqgwwmWNsNszxYs7IZdCqk0S1DCarvMhr4wcajoSBlA/nQA0/owwLduPTS8xxCnQp4/N/gDg==}
@@ -3521,9 +3521,9 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
-  '@types/bun@1.3.5':
+  '@types/bun@1.3.10':
     dependencies:
-      bun-types: 1.3.5
+      bun-types: 1.3.10
 
   '@types/chai@5.2.3':
     dependencies:
@@ -3672,7 +3672,7 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  bun-types@1.3.5:
+  bun-types@1.3.10:
     dependencies:
       '@types/node': 25.3.3
 


### PR DESCRIPTION
## Summary
- Bump `@types/bun` from 1.3.5 to 1.3.10 (devDependency, type definitions only)

## Why
E2E test for alignment coordinator — this upstream change should propagate lockfile + nix hash updates to downstream repos (overeng, livestore, schickling.dev, etc.) via the coordinator workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> ℹ️ PR created on behalf of @schickling