### PR TITLE
fix: prune phantom packages from pnpm store FOD for deterministic hashes

### DIFF
--- a/context/nix-devenv/ci.md
+++ b/context/nix-devenv/ci.md
@@ -22,23 +22,20 @@ Repos that depend on effect-utils via megarepo need to run `mr sync --frozen` in
   shell: bash
 ```
 
-### Issue: pnpm Deps Hash Mismatch
+### Issue: pnpm Deps Hash Mismatch (Root-Caused & Fixed)
 
-The megarepo Nix build uses `pnpmDepsHash` for reproducible builds. However, pnpm resolves slightly different content based on:
+The Nix build uses `pnpmDepsHash` for reproducible dependency fetching via fixed-output
+derivations (FODs). `pnpm install --force` can non-deterministically fetch "phantom" packages
+not listed in the lockfile — extra versions pulled from npm registry metadata during
+resolution (e.g., `@types/node@25.0.3` alongside the lockfile's `@types/node@25.3.3`).
 
-- pnpm version differences
-- npm registry state at fetch time
-- Platform/architecture differences
+This produces different FOD output hashes between builds even with identical inputs (same
+lockfile, same pnpm version, same platform). Confirmed by observing 3 different hashes for
+the same source fingerprint.
 
-This causes hash mismatches in CI:
-
-```
-error: hash mismatch in fixed-output derivation 'megarepo-pnpm-deps.drv':
-         specified: sha256-ABC...
-            got:    sha256-XYZ...
-```
-
-The hash keeps changing between local builds and CI environments, making the flake-based approach unreliable.
+**Fix**: `mk-pnpm-deps.nix` now prunes phantom packages by parsing the lockfile's `packages:`
+section as the source of truth and removing any store index file not in that set. See the
+store normalization pipeline docs in `context/workarounds/pnpm-issues.md`.
 
 ### Options
 

--- a/context/workarounds/pnpm-issues.md
+++ b/context/workarounds/pnpm-issues.md
@@ -160,6 +160,25 @@ pnpmDeps = pkgs.stdenvNoCC.mkDerivation {
 };
 ```
 
+### Store Normalization Pipeline
+
+After `pnpm install`, the FOD runs a normalization pipeline (`mk-pnpm-deps.nix`) to ensure
+the archived store is deterministic across different build environments:
+
+1. **Phase 0 — Phantom package pruning**: `pnpm install --force` can non-deterministically
+   fetch packages not listed in the lockfile (e.g., older `@types/node` versions from
+   registry metadata). These "phantom" packages are pruned by parsing the lockfile's
+   `packages:` section and removing any store index file whose `pkg@version` doesn't match.
+2. **Phase 1 — CAS file inventory**: Builds a set of all content-addressable storage files
+   (source of truth for executable status via `-exec` filename suffix).
+3. **Phase 2 — Index JSON canonicalization**: Normalizes `mode` fields (derived from CAS
+   filename, not the non-deterministic index value), sorts keys, strips `sideEffects`/
+   `requiresBuild`, and zeroes `checkedAt` timestamps.
+4. **Phase 3 — Orphan CAS cleanup**: Removes CAS files not referenced by any remaining index.
+5. **Directory/permission normalization**: Removes empty dirs, non-essential store dirs
+   (`projects/`, `tmp/`), and normalizes permissions (dirs 755, files 444, exec files 555).
+6. **Deterministic tarball**: GNU tar with sorted names, epoch mtime, root ownership.
+
 ### Platform-Independent Hashes via supportedArchitectures
 
 To avoid needing separate hashes for Linux and macOS, we configure pnpm to download

--- a/nix/workspace-tools/README.md
+++ b/nix/workspace-tools/README.md
@@ -7,6 +7,9 @@ pure and designed to work in both megarepo workspaces and standalone repos.
 
 - `lib/`
   - `mk-bun-cli.nix` — Bun binary builder (deterministic, local file deps).
+  - `mk-pnpm-cli.nix` — pnpm + bun compile builder for workspace CLIs.
+  - `mk-pnpm-deps.nix` — FOD helper for fetching pnpm deps with store normalization (phantom package pruning, CAS/index canonicalization).
+  - `pnpm-platform.nix` — pnpm `supportedArchitectures` setup for cross-platform hashes.
   - `cli-build-stamp.nix` — build stamp helper for CLIs.
   - `update-bun-hashes.nix` — helper to refresh bunDeps hashes.
 - `docs/`

--- a/nix/workspace-tools/lib/mk-pnpm-deps.nix
+++ b/nix/workspace-tools/lib/mk-pnpm-deps.nix
@@ -99,22 +99,30 @@ in
 
         pnpm install --frozen-lockfile --ignore-scripts ${installFlags}
 
+        export LOCKFILE_DIR="$NIX_BUILD_TOP"
+
         # Normalize pnpm store for cross-platform/cross-run determinism.
         # See: https://github.com/NixOS/nixpkgs/issues/422889
         #
-        # Key insight: the CAS file name (-exec suffix or not) is set during
-        # initial fetch from the tarball and is deterministic. But the index
-        # JSON mode field can change non-deterministically due to cross-partition
-        # hardlink behavior (pnpm flips exec bits on bin entries via hardlinks;
-        # on same-partition this propagates to the CAS file's mode, on cross-
-        # partition it doesn't). So we derive exec status from the CAS file
-        # name (deterministic source of truth), not the index mode.
+        # Pipeline overview:
+        #   Phase 0: Prune phantom index files not in lockfile (fixes --force non-determinism)
+        #   Phase 1: Build CAS file existence set (source of truth for exec status)
+        #   Phase 2: Canonicalize index JSON (deterministic mode from CAS filename)
+        #   Phase 3: Remove orphan CAS files (not referenced by any index)
+        #
+        # Phase 0 context: pnpm install --force can non-deterministically fetch
+        # "phantom" packages not listed in the lockfile (e.g., older @types/node
+        # versions from registry metadata). These phantom packages have valid
+        # index+CAS entries so the existing orphan cleanup doesn't remove them.
+        # We prune by parsing ALL lockfiles in the workspace (the root lockfile
+        # plus any workspace member lockfiles) as the source of truth for which
+        # pkg@version pairs should exist in the store.
 
-        # 1. Canonicalize index JSON and remove orphan CAS files.
         node -e '
           const fs = require("fs");
           const p = require("path");
           const sp = process.env.STORE_PATH;
+          const lockfileDir = process.env.LOCKFILE_DIR;
 
           function walk(dir, out) {
             for (const e of fs.readdirSync(dir, {withFileTypes:true})) {
@@ -128,6 +136,55 @@ in
           if (!vdirs.length) { console.log("store-norm: no v* dir found"); process.exit(0); }
           const vdir = p.join(sp, vdirs[0]);
 
+          /* Phase 0: Prune phantom index files not in lockfiles.
+             Find ALL pnpm-lock.yaml files in the source tree (root + workspace members)
+             and collect their packages sections into a single allowlist. */
+          const allLockfiles = walk(lockfileDir, []).filter(
+            f => p.basename(f) === "pnpm-lock.yaml" && !f.includes("node_modules")
+          );
+
+          const Q = String.fromCharCode(39); /* single quote */
+          const pkgLineRe = new RegExp("^\\s+(" + Q + "?)(.+?)\\1:\\s*$");
+          const allowedPkgVersions = new Set();
+
+          for (const lf of allLockfiles) {
+            const lines = fs.readFileSync(lf, "utf8").split("\n");
+            let inPackages = false;
+            for (const line of lines) {
+              if (/^packages:\s*$/.test(line)) { inPackages = true; continue; }
+              if (inPackages) {
+                if (line.length > 0 && line[0] !== " " && line[0] !== "\n") break;
+                const m = pkgLineRe.exec(line);
+                if (m && m[2].includes("@")) allowedPkgVersions.add(m[2]);
+              }
+            }
+          }
+          console.log("store-norm: parsed " + allLockfiles.length + " lockfile(s), found " + allowedPkgVersions.size + " unique packages");
+
+          if (allowedPkgVersions.size === 0) {
+            console.error("store-norm: FATAL — no packages parsed from " + allLockfiles.length + " lockfile(s)");
+            process.exit(1);
+          }
+
+          const indexDir = p.join(vdir, "index");
+          const allIndex = walk(indexDir, []).filter(f => f.endsWith(".json"));
+          let pruned = 0;
+          for (const ip of allIndex) {
+            /* Extract pkg@version from filename: {hash}-{pkg}@{ver}.json
+               Scoped packages use + instead of / in filenames. */
+            const basename = p.basename(ip, ".json");
+            const dashIdx = basename.indexOf("-");
+            if (dashIdx === -1) continue;
+            const pkgAtVersion = basename.slice(dashIdx + 1).replace(/\+/g, "/");
+            if (!allowedPkgVersions.has(pkgAtVersion)) {
+              fs.unlinkSync(ip);
+              pruned++;
+            }
+          }
+          const remaining = allIndex.length - pruned;
+          if (pruned) console.log("store-norm: pruned " + pruned + " phantom index files");
+          console.log("store-norm: " + remaining + " index files remain (from " + allowedPkgVersions.size + " lockfile packages)");
+
           /* Phase 1: Build CAS file existence set (source of truth for exec status) */
           const filesDir = p.join(vdir, "files");
           const casFiles = new Set();
@@ -135,10 +192,17 @@ in
             for (const f of walk(filesDir, [])) casFiles.add(f);
           }
 
-          /* Phase 2: Normalize index JSON using CAS file names for exec detection */
+          /* Phase 2: Normalize index JSON using CAS file names for exec detection.
+             Key insight: the CAS file name (-exec suffix or not) is set during
+             initial fetch from the tarball and is deterministic. But the index
+             JSON mode field can change non-deterministically due to cross-partition
+             hardlink behavior (pnpm flips exec bits on bin entries via hardlinks;
+             on same-partition this propagates to the CAS file mode, on cross-
+             partition it does not). So we derive exec status from the CAS file
+             name (deterministic source of truth), not the index mode. */
           const referenced = new Set();
-          const indexDir = p.join(vdir, "index");
-          const indexFiles = walk(indexDir, []).filter(f => f.endsWith(".json")).sort();
+          const indexDir2 = p.join(vdir, "index");
+          const indexFiles = walk(indexDir2, []).filter(f => f.endsWith(".json")).sort();
           for (const ip of indexFiles) {
             const d = JSON.parse(fs.readFileSync(ip, "utf8"));
             if (d.files) {


### PR DESCRIPTION
## Summary

- **Root cause**: `pnpm install --force` non-deterministically fetches "phantom" packages not listed in the lockfile (e.g., older `@types/node` versions from registry metadata), causing different FOD output hashes across builds with identical inputs
- **Fix**: Add lockfile-based index pruning (Phase 0) to the store normalization pipeline in `mk-pnpm-deps.nix` — scans all `pnpm-lock.yaml` files in the workspace, removes any store index file whose `pkg@version` is not in any lockfile
- **Verified**: On dev3, the pruned FOD produces the same hash as before (phantoms only appeared in CI). Full otel-cli build + smoke test passes

## Changes

- `nix/workspace-tools/lib/mk-pnpm-deps.nix`: New Phase 0 (phantom pruning) + build-time assertion
- `context/workarounds/pnpm-issues.md`: Documented store normalization pipeline
- `context/nix-devenv/ci.md`: Updated hash mismatch section with precise root cause
- `nix/workspace-tools/README.md`: Added missing pnpm builder entries

Refs: beads sch-60n (investigation), sch-fuv (implementation)

---
*This PR was created by an AI agent on behalf of @schickling*