### PR TITLE
fix: add GH_REPO env to deploy comment step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -857,6 +857,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: '${{ github.token }}'
+          GH_REPO: '${{ github.repository }}'
         run: |
           site="overeng-utils"
           if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ]; then

--- a/genie/ci-workflow.ts
+++ b/genie/ci-workflow.ts
@@ -291,6 +291,7 @@ export const deployCommentStep = (opts: {
   shell: 'bash' as const,
   env: {
     GH_TOKEN: '${{ github.token }}',
+    GH_REPO: '${{ github.repository }}',
   },
   run: [
     opts.modeScript,


### PR DESCRIPTION
## Summary

- The nix-provided `gh` CLI (via `nix run nixpkgs#gh`) doesn't infer the repo from git remotes on self-hosted runners
- Adding `GH_REPO: ${{ github.repository }}` to the `deployCommentStep` env fixes this
- Follow-up to #337

## Test plan

- CI on this PR should pass (genie check + lint)
- After merging, downstream repos consuming this helper will get working PR deploy comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)