### PR TITLE
fix(nix): share prepared pnpm workspaces

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -130,6 +130,10 @@
       # Builder function for external repos to create their own Bun CLIs
       lib.mkBunCli = { pkgs }: import ./nix/workspace-tools/lib/mk-bun-cli.nix { inherit pkgs; };
 
+      # Helper to assemble a canonical prepared pnpm workspace plus fingerprints.
+      lib.mkPreparedPnpmWorkspace =
+        { pkgs }: import ./nix/workspace-tools/lib/mk-prepared-pnpm-workspace.nix { inherit pkgs; };
+
       # Shell helper for runtime CLI build stamps.
       lib.cliBuildStamp =
         { pkgs }: import ./nix/workspace-tools/lib/cli-build-stamp.nix { inherit pkgs; };

--- a/nix/devenv-modules/tasks/shared/nix-cli.nix
+++ b/nix/devenv-modules/tasks/shared/nix-cli.nix
@@ -39,6 +39,49 @@
 { pkgs, lib, ... }:
 let
   trace = import ../lib/trace.nix { inherit lib; };
+  fingerprintHelpers = ''
+    preparedLockfileHash=""
+    preparedPackageJsonDepsHash=""
+
+    load_prepared_fingerprints() {
+      local flakeRef="$1"
+      local flakeSource="''${flakeRef%%#*}"
+      local fingerprintRef=""
+      local outPath=""
+
+      preparedLockfileHash=""
+      preparedPackageJsonDepsHash=""
+
+      if [ -z "$flakeSource" ]; then
+        flakeSource="$flakeRef"
+      fi
+
+      fingerprintRef="$flakeSource#fingerprint"
+
+      set +e
+      outPath=$(${pkgs.nix}/bin/nix build "$fingerprintRef" --no-link --print-out-paths 2>/dev/null)
+      local status=$?
+      set -e
+
+      if [ $status -ne 0 ] || [ -z "$outPath" ]; then
+        return 1
+      fi
+
+      if [ -f "$outPath/lockfileHash" ]; then
+        preparedLockfileHash="$(cat "$outPath/lockfileHash")"
+      fi
+
+      if [ -f "$outPath/packageJsonDepsHash" ]; then
+        preparedPackageJsonDepsHash="$(cat "$outPath/packageJsonDepsHash")"
+      fi
+
+      if [ -z "$preparedLockfileHash" ] && [ -z "$preparedPackageJsonDepsHash" ]; then
+        return 1
+      fi
+
+      return 0
+    }
+  '';
   # Script to update all hashes in a build.nix file
   # Handles pnpmDepsHash/bunDepsHash, lockfileHash, and packageJsonDepsHash
   # Iteratively updates hashes until build succeeds
@@ -52,6 +95,8 @@ let
 
     FAKE_HASH="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
     MAX_ITERATIONS=20
+
+    ${fingerprintHelpers}
 
     # Helper function to update a hash value in build.nix
     # Handles both simple hashes and platform-specific (if isDarwin then/else) patterns
@@ -99,6 +144,21 @@ let
 
     # Helper to update lockfileHash and packageJsonDepsHash in build.nix
     update_fingerprint_hashes() {
+      if load_prepared_fingerprints "$flakeRef"; then
+        if [ -n "$preparedLockfileHash" ] && grep -q "lockfileHash" "$buildNix"; then
+          export NEW_LF_HASH="$preparedLockfileHash"
+          ${pkgs.perl}/bin/perl -i -pe 's/lockfileHash\s*=\s*"sha256-[^"]+"/lockfileHash = "$ENV{NEW_LF_HASH}"/g' "$buildNix"
+          echo "Updated lockfileHash to $preparedLockfileHash"
+        fi
+
+        if [ -n "$preparedPackageJsonDepsHash" ] && grep -q "packageJsonDepsHash" "$buildNix"; then
+          export NEW_PACKAGE_JSON_DEPS_HASH="$preparedPackageJsonDepsHash"
+          ${pkgs.perl}/bin/perl -i -pe 's/packageJsonDepsHash\s*=\s*"sha256-[^"]+"/packageJsonDepsHash = "$ENV{NEW_PACKAGE_JSON_DEPS_HASH}"/g' "$buildNix"
+          echo "Updated packageJsonDepsHash to $preparedPackageJsonDepsHash"
+        fi
+        return 0
+      fi
+
       if [ -n "$lockfile" ] && [ -f "$lockfile" ]; then
         # Update lockfileHash
         newLockfileHash="sha256-$(${pkgs.nix}/bin/nix-hash --type sha256 --base64 "$lockfile")"
@@ -168,6 +228,18 @@ let
 
       newHash=$(extract_got_hash "$output")
       actualHash=$(extract_actual_hash "$output")
+
+      if echo "$output" | grep -q 'packageJsonDepsHash is stale'; then
+        update_fingerprint_hashes
+        updated_any=true
+        continue
+      fi
+
+      if echo "$output" | grep -q 'lockfileHash is stale'; then
+        update_fingerprint_hashes
+        updated_any=true
+        continue
+      fi
 
       if [ -n "$actualHash" ] && grep -q "lockfileHash" "$buildNix"; then
         export NEW_LF_HASH="$actualHash"
@@ -251,9 +323,27 @@ let
     buildNix="''${3-}"
     lockfile="''${4-}"
 
+    ${fingerprintHelpers}
+
     # Preflight: ensure lockfile/package.json fingerprints match build.nix
     # This avoids false passes on warmed Nix stores (R5: deterministic checks).
-    if [ -n "$buildNix" ] && [ -n "$lockfile" ] && [ -f "$lockfile" ]; then
+    if [ -n "$buildNix" ] && load_prepared_fingerprints "$flakeRef"; then
+      storedLockfileHash=$(grep -oE 'lockfileHash\s*=\s*"sha256-[^"]+"' "$buildNix" | grep -oE 'sha256-[^"]+' | head -1 || echo "")
+      if [ -n "$preparedLockfileHash" ] && [ -n "$storedLockfileHash" ] && [ "$preparedLockfileHash" != "$storedLockfileHash" ]; then
+        echo "✗ $name: lockfile changed (run: dt nix:hash:$name)"
+        echo "  stored:  $storedLockfileHash"
+        echo "  current: $preparedLockfileHash"
+        exit 1
+      fi
+
+      storedPackageJsonDepsHash=$(grep -oE 'packageJsonDepsHash\s*=\s*"sha256-[^"]+"' "$buildNix" | grep -oE 'sha256-[^"]+' | head -1 || echo "")
+      if [ -n "$preparedPackageJsonDepsHash" ] && [ -n "$storedPackageJsonDepsHash" ] && [ "$preparedPackageJsonDepsHash" != "$storedPackageJsonDepsHash" ]; then
+        echo "✗ $name: package.json deps changed (run: pnpm install && dt nix:hash:$name)"
+        echo "  stored:  $storedPackageJsonDepsHash"
+        echo "  current: $preparedPackageJsonDepsHash"
+        exit 1
+      fi
+    elif [ -n "$buildNix" ] && [ -n "$lockfile" ] && [ -f "$lockfile" ]; then
       packageJson="$(dirname "$lockfile")/package.json"
 
       currentLockfileHash="sha256-$(${pkgs.nix}/bin/nix-hash --type sha256 --base64 "$lockfile")"
@@ -338,6 +428,11 @@ let
       exit 1
     fi
 
+    if echo "$output" | grep -q 'packageJsonDepsHash is stale'; then
+      echo "✗ $name: packageJsonDepsHash is stale (run: pnpm install && dt nix:hash:$name)"
+      exit 1
+    fi
+
     # Check for custom bun.lock staleness
     if echo "$output" | grep -q 'deps hash is stale'; then
       echo "✗ $name: lockfile changed, deps hash is stale (run: dt nix:hash:$name)"
@@ -381,45 +476,66 @@ let
     name="$1"
     buildNix="$2"
     lockfile="$3"
+    flakeRef="$4"
+
+    ${fingerprintHelpers}
 
     # Derive package.json path from lockfile path
     packageJson="$(dirname "$lockfile")/package.json"
     failed=false
 
-    # Check 1: lockfileHash (lockfile changed without hash update)
-    currentLockfileHash=$(${pkgs.nix}/bin/nix-hash --type sha256 --base64 "$lockfile" 2>/dev/null || echo "")
-    if [ -z "$currentLockfileHash" ]; then
-      echo "⚠ $name: lockfile not found ($lockfile), skipping lockfile check"
-    else
-      currentLockfileHash="sha256-$currentLockfileHash"
+    if load_prepared_fingerprints "$flakeRef"; then
       storedLockfileHash=$(grep -oE 'lockfileHash\s*=\s*"sha256-[^"]+"' "$buildNix" | grep -oE 'sha256-[^"]+' | head -1 || echo "")
-
-      if [ -z "$storedLockfileHash" ]; then
-        echo "⚠ $name: no lockfileHash in build.nix, skipping lockfile check"
-      elif [ "$currentLockfileHash" != "$storedLockfileHash" ]; then
+      if [ -n "$preparedLockfileHash" ] && [ -n "$storedLockfileHash" ] && [ "$preparedLockfileHash" != "$storedLockfileHash" ]; then
         echo "✗ $name: lockfile changed (run: dt nix:hash:$name)"
         echo "  stored:  $storedLockfileHash"
-        echo "  current: $currentLockfileHash"
+        echo "  current: $preparedLockfileHash"
         failed=true
       fi
-    fi
-
-    # Check 2: packageJsonDepsHash (package.json deps changed without lockfile update)
-    if [ -f "$packageJson" ]; then
-      tmpDeps=$(mktemp)
-      ${pkgs.jq}/bin/jq -cS '{dependencies, devDependencies, peerDependencies}' "$packageJson" > "$tmpDeps"
-      currentPackageJsonDepsHash="sha256-$(${pkgs.nix}/bin/nix-hash --type sha256 --base64 "$tmpDeps")"
-      rm "$tmpDeps"
 
       storedPackageJsonDepsHash=$(grep -oE 'packageJsonDepsHash\s*=\s*"sha256-[^"]+"' "$buildNix" | grep -oE 'sha256-[^"]+' | head -1 || echo "")
-
-      if [ -z "$storedPackageJsonDepsHash" ]; then
-        echo "⚠ $name: no packageJsonDepsHash in build.nix, skipping deps check"
-      elif [ "$currentPackageJsonDepsHash" != "$storedPackageJsonDepsHash" ]; then
+      if [ -n "$preparedPackageJsonDepsHash" ] && [ -n "$storedPackageJsonDepsHash" ] && [ "$preparedPackageJsonDepsHash" != "$storedPackageJsonDepsHash" ]; then
         echo "✗ $name: package.json deps changed (run: pnpm install && dt nix:hash:$name)"
         echo "  stored:  $storedPackageJsonDepsHash"
-        echo "  current: $currentPackageJsonDepsHash"
+        echo "  current: $preparedPackageJsonDepsHash"
         failed=true
+      fi
+    else
+      # Check 1: lockfileHash (lockfile changed without hash update)
+      currentLockfileHash=$(${pkgs.nix}/bin/nix-hash --type sha256 --base64 "$lockfile" 2>/dev/null || echo "")
+      if [ -z "$currentLockfileHash" ]; then
+        echo "⚠ $name: lockfile not found ($lockfile), skipping lockfile check"
+      else
+        currentLockfileHash="sha256-$currentLockfileHash"
+        storedLockfileHash=$(grep -oE 'lockfileHash\s*=\s*"sha256-[^"]+"' "$buildNix" | grep -oE 'sha256-[^"]+' | head -1 || echo "")
+
+        if [ -z "$storedLockfileHash" ]; then
+          echo "⚠ $name: no lockfileHash in build.nix, skipping lockfile check"
+        elif [ "$currentLockfileHash" != "$storedLockfileHash" ]; then
+          echo "✗ $name: lockfile changed (run: dt nix:hash:$name)"
+          echo "  stored:  $storedLockfileHash"
+          echo "  current: $currentLockfileHash"
+          failed=true
+        fi
+      fi
+
+      # Check 2: packageJsonDepsHash (package.json deps changed without lockfile update)
+      if [ -f "$packageJson" ]; then
+        tmpDeps=$(mktemp)
+        ${pkgs.jq}/bin/jq -cS '{dependencies, devDependencies, peerDependencies}' "$packageJson" > "$tmpDeps"
+        currentPackageJsonDepsHash="sha256-$(${pkgs.nix}/bin/nix-hash --type sha256 --base64 "$tmpDeps")"
+        rm "$tmpDeps"
+
+        storedPackageJsonDepsHash=$(grep -oE 'packageJsonDepsHash\s*=\s*"sha256-[^"]+"' "$buildNix" | grep -oE 'sha256-[^"]+' | head -1 || echo "")
+
+        if [ -z "$storedPackageJsonDepsHash" ]; then
+          echo "⚠ $name: no packageJsonDepsHash in build.nix, skipping deps check"
+        elif [ "$currentPackageJsonDepsHash" != "$storedPackageJsonDepsHash" ]; then
+          echo "✗ $name: package.json deps changed (run: pnpm install && dt nix:hash:$name)"
+          echo "  stored:  $storedPackageJsonDepsHash"
+          echo "  current: $currentPackageJsonDepsHash"
+          failed=true
+        fi
       fi
     fi
 
@@ -485,7 +601,7 @@ let
   mkQuickCheckTask = pkg: lib.optionalAttrs (pkg ? lockfile) {
     "nix:check:quick:${pkg.name}" = {
       description = "Quick lockfile check for ${pkg.name}";
-      exec = trace.exec "nix:check:quick:${pkg.name}" "${quickCheckScript} '${pkg.name}' '${pkg.buildNix}' '${pkg.lockfile}'";
+      exec = trace.exec "nix:check:quick:${pkg.name}" "${quickCheckScript} '${pkg.name}' '${pkg.buildNix}' '${pkg.lockfile}' '${pkg.flakeRef}'";
     };
   };
 

--- a/nix/devenv-modules/tasks/shared/tests/nix-cli-hash.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/nix-cli-hash.test.sh
@@ -56,6 +56,23 @@ assert_eq "" "$(extract_got_hash "$missing_output")" "missing_got"
 
 echo "Hash extraction tests passed"
 
+fingerprint_ref_for() {
+  local flakeRef="$1"
+  local flakeSource="${flakeRef%%#*}"
+
+  if [ -z "$flakeSource" ]; then
+    flakeSource="$flakeRef"
+  fi
+
+  printf '%s#fingerprint' "$flakeSource"
+}
+
+assert_eq ".#fingerprint" "$(fingerprint_ref_for ".#genie")" "flake_ref_attr_path"
+assert_eq "./flakes/agent-exporter#fingerprint" "$(fingerprint_ref_for "./flakes/agent-exporter")" "flake_ref_path"
+assert_eq "github:example/project#fingerprint" "$(fingerprint_ref_for "github:example/project#cli")" "flake_ref_remote"
+
+echo "Fingerprint ref normalization tests passed"
+
 # ============================================================================
 # Tests for update_hash_in_file helper (platform-specific hash support)
 # ============================================================================

--- a/nix/workspace-tools/lib/mk-pnpm-cli.nix
+++ b/nix/workspace-tools/lib/mk-pnpm-cli.nix
@@ -36,9 +36,11 @@
   name,
   entry,
   packageDir,
-  workspaceRoot,
+  workspaceRoot ? null,
+  preparedWorkspace ? null,
   pnpmDepsHash,
   lockfileHash ? null,
+  packageJsonDepsHash ? null,
   patchesDir ? "patches",
   binaryName ? name,
   gitRev ? "unknown",
@@ -51,10 +53,25 @@
 
 let
   lib = pkgs.lib;
+  stripStoreHash =
+    source:
+    let
+      baseName = baseNameOf (toString source);
+      match = builtins.match "^[a-z0-9]{32}-(.*)$" baseName;
+    in
+    if match == null then baseName else builtins.head match;
+  effectivePackageDir =
+    if preparedWorkspace != null && preparedWorkspace ? packageDir then
+      preparedWorkspace.packageDir
+    else
+      packageDir;
 
-  # Convert workspaceRoot to path
-  workspaceRootPath =
-    if builtins.isAttrs workspaceRoot && builtins.hasAttr "outPath" workspaceRoot then
+  legacyWorkspaceRootPath =
+    if preparedWorkspace != null then
+      null
+    else if workspaceRoot == null then
+      builtins.throw "mk-pnpm-cli.nix requires workspaceRoot or preparedWorkspace"
+    else if builtins.isAttrs workspaceRoot && builtins.hasAttr "outPath" workspaceRoot then
       workspaceRoot.outPath
     else if builtins.isPath workspaceRoot then
       workspaceRoot
@@ -71,11 +88,12 @@ let
   #   3. Block/dash:          packages:\n  - .\n  - ../tui-core
   # Resolves relative paths to workspace-root-relative paths.
 
-  pnpmWorkspaceYamlPath = workspaceRootPath + "/${packageDir}/pnpm-workspace.yaml";
-  pnpmWorkspaceYaml = builtins.readFile pnpmWorkspaceYamlPath;
+  pnpmWorkspaceYamlPath =
+    if preparedWorkspace != null then null else legacyWorkspaceRootPath + "/${effectivePackageDir}/pnpm-workspace.yaml";
+  pnpmWorkspaceYaml = if preparedWorkspace != null then "" else builtins.readFile pnpmWorkspaceYamlPath;
 
   # Extract "packages: [...]" line
-  workspaceLines = lib.splitString "\n" pnpmWorkspaceYaml;
+  workspaceLines = if preparedWorkspace != null then [ ] else lib.splitString "\n" pnpmWorkspaceYaml;
   packagesLine = lib.findFirst (line: lib.hasPrefix "packages:" line) null workspaceLines;
 
   # Detect format from the "packages:" line content
@@ -151,9 +169,13 @@ let
       in
       parseLines lines;
 
-  workspaceMemberItems = builtins.filter builtins.isString (
-    if isPackagesInline then parsePackagesInline else parsePackagesMultiline
-  );
+  workspaceMemberItems =
+    if preparedWorkspace != null then
+      [ ]
+    else
+      builtins.filter builtins.isString (
+        if isPackagesInline then parsePackagesInline else parsePackagesMultiline
+      );
 
   # Filter out "." (main package itself)
   relativeWorkspaceMembers = builtins.filter (s: s != ".") workspaceMemberItems;
@@ -199,8 +221,12 @@ let
     lib.concatStringsSep "/" (resolvedBase ++ remainingParts);
 
   # Final workspace members list (workspace-root-relative paths)
-  workspaceMembers = map (relPath: resolveRelativePath packageDir relPath) relativeWorkspaceMembers;
-  workspaceClosureDirs = [ packageDir ] ++ workspaceMembers;
+  workspaceMembers =
+    if preparedWorkspace != null then
+      preparedWorkspace.workspaceMembers or [ ]
+    else
+      map (relPath: resolveRelativePath effectivePackageDir relPath) relativeWorkspaceMembers;
+  workspaceClosureDirs = [ effectivePackageDir ] ++ workspaceMembers;
 
   parentDirsFor =
     dir:
@@ -216,11 +242,11 @@ let
   mkPackageSource =
     pkgDir:
     lib.cleanSourceWith {
-      src = workspaceRootPath;
+      src = legacyWorkspaceRootPath;
       filter =
         path: type:
         let
-          relPath = lib.removePrefix (toString workspaceRootPath + "/") (toString path);
+          relPath = lib.removePrefix (toString legacyWorkspaceRootPath + "/") (toString path);
           baseName = baseNameOf path;
           excludedNames = [
             ".git"
@@ -296,84 +322,103 @@ let
     };
 
   # Fetch pnpm dependencies from the staged lockfile + workspace member manifests.
+  depsSource =
+    if preparedWorkspace != null then
+      preparedWorkspace.depsSource
+    else
+      mkPackageSource effectivePackageDir;
+
+  pnpmDepsWorkspaceRoot = stripStoreHash depsSource;
+  pnpmDepsSourceRoot = "${pnpmDepsWorkspaceRoot}/${effectivePackageDir}";
+
+  # The prepared workspace path already includes any external mounts and file overrides.
   pnpmDeps = pnpmDepsHelper.mkDeps {
     inherit name pnpmDepsHash;
-    src = mkPackageSource packageDir;
-    sourceRoot = "source/${packageDir}";
+    src = depsSource;
+    sourceRoot = pnpmDepsSourceRoot;
     # Make the entire source tree writable (critical for workspace members
     # whose directories are read-only in the Nix store)
     preInstall = ''
-      cd "$NIX_BUILD_TOP/source"
+      cd "$NIX_BUILD_TOP/${pnpmDepsWorkspaceRoot}"
       chmod -R +w .
-      cd "$NIX_BUILD_TOP/source/${packageDir}"
+      cd "$NIX_BUILD_TOP/${pnpmDepsSourceRoot}"
     '';
   };
 
   # Full workspace source for building
-  workspaceClosureSrc = lib.cleanSourceWith {
-    src = workspaceRootPath;
-    filter =
-      path: type:
-      let
-        relPath = lib.removePrefix (toString workspaceRootPath + "/") (toString path);
-        baseName = baseNameOf path;
-        isInWorkspaceClosure = lib.any (
-          dir: relPath == dir || lib.hasPrefix "${dir}/" relPath
-        ) workspaceClosureDirs;
-        isWorkspaceClosureParent =
-          type == "directory"
-          && lib.any (dir: lib.elem relPath (parentDirsFor dir)) workspaceClosureDirs;
-        isInPatches =
-          patchesDir != null
-          && (
-            lib.hasPrefix "${patchesDir}/" relPath
-            || relPath == patchesDir
-            || lib.any
-              (
-                memberDir:
-                lib.hasPrefix "${memberDir}/${patchesDir}/" relPath
-                || relPath == "${memberDir}/${patchesDir}"
-              )
-              workspaceMembers
-          );
-      in
-      lib.cleanSourceFilter path type
-      && !(lib.elem baseName (
-        [
-          ".git"
-          ".direnv"
-          ".devenv"
-          ".cache"
-          ".turbo"
-          ".next"
-          ".bun"
-          "node_modules"
-          "dist"
-          "result"
-          "coverage"
-          "tmp"
-          "out"
-        ]
-        ++ extraExcludedSourceNames
-      ))
-      && (isInWorkspaceClosure || isWorkspaceClosureParent || isInPatches);
-  };
-
-  # Read package.json for version
-  packageJsonPath = workspaceRootPath + "/${packageDir}/package.json";
-  packageJson = builtins.fromJSON (builtins.readFile packageJsonPath);
-  packageVersion = packageJson.version or "0.0.0";
-  entryRelativeToPackage =
-    if lib.hasPrefix "${packageDir}/" entry then
-      lib.removePrefix "${packageDir}/" entry
+  workspaceClosureSrc =
+    if preparedWorkspace != null then
+      preparedWorkspace.workspaceSource
     else
-      throw "mk-pnpm-cli: entry must be inside packageDir (${packageDir}): ${entry}";
+      lib.cleanSourceWith {
+        src = legacyWorkspaceRootPath;
+        filter =
+          path: type:
+          let
+            relPath = lib.removePrefix (toString legacyWorkspaceRootPath + "/") (toString path);
+            baseName = baseNameOf path;
+            isInWorkspaceClosure = lib.any (
+              dir: relPath == dir || lib.hasPrefix "${dir}/" relPath
+            ) workspaceClosureDirs;
+            isWorkspaceClosureParent =
+              type == "directory"
+              && lib.any (dir: lib.elem relPath (parentDirsFor dir)) workspaceClosureDirs;
+            isInPatches =
+              patchesDir != null
+              && (
+                lib.hasPrefix "${patchesDir}/" relPath
+                || relPath == patchesDir
+                || lib.any
+                  (
+                    memberDir:
+                    lib.hasPrefix "${memberDir}/${patchesDir}/" relPath
+                    || relPath == "${memberDir}/${patchesDir}"
+                  )
+                  workspaceMembers
+              );
+          in
+          lib.cleanSourceFilter path type
+          && !(lib.elem baseName (
+            [
+              ".git"
+              ".direnv"
+              ".devenv"
+              ".cache"
+              ".turbo"
+              ".next"
+              ".bun"
+              "node_modules"
+              "dist"
+              "result"
+              "coverage"
+              "tmp"
+              "out"
+            ]
+            ++ extraExcludedSourceNames
+          ))
+          && (isInWorkspaceClosure || isWorkspaceClosureParent || isInPatches);
+      };
+
+  resolvedPackageVersion =
+    if preparedWorkspace != null && preparedWorkspace ? packageVersion then
+      preparedWorkspace.packageVersion
+    else
+      let
+        packageJsonPath = legacyWorkspaceRootPath + "/${effectivePackageDir}/package.json";
+        packageJson = builtins.fromJSON (builtins.readFile packageJsonPath);
+      in
+      packageJson.version or "0.0.0";
+  entryRelativeToPackage =
+    if lib.hasPrefix "${effectivePackageDir}/" entry then
+      lib.removePrefix "${effectivePackageDir}/" entry
+    else
+      throw "mk-pnpm-cli: entry must be inside packageDir (${effectivePackageDir}): ${entry}";
 
   # Build NixStamp JSON for embedding in binary
   # Note: We manually construct the JSON to avoid escaping issues with builtins.toJSON
   # when the string is interpolated into shell scripts and substituteInPlace.
   dirtyStr = if dirty then "true" else "false";
-  nixStampJson = ''{\"type\":\"nix\",\"version\":\"${packageVersion}\",\"rev\":\"${gitRev}\",\"commitTs\":${toString commitTs},\"dirty\":${dirtyStr}}'';
+  nixStampJson = ''{\"type\":\"nix\",\"version\":\"${resolvedPackageVersion}\",\"rev\":\"${gitRev}\",\"commitTs\":${toString commitTs},\"dirty\":${dirtyStr}}'';
 
   smokeTestArgsStr = lib.escapeShellArgs smokeTestArgs;
   pnpmDepsHelper = import ./mk-pnpm-deps.nix { inherit pkgs; };
@@ -389,7 +434,8 @@ pkgs.stdenv.mkDerivation {
     pkgs.cacert
     pkgs.zstd
   ]
-  ++ lib.optionals (lockfileHash != null) [ pkgs.nix ];
+  ++ lib.optionals (lockfileHash != null || packageJsonDepsHash != null) [ pkgs.nix ]
+  ++ lib.optionals (packageJsonDepsHash != null) [ pkgs.jq ];
 
   inherit pnpmDeps;
 
@@ -404,12 +450,33 @@ pkgs.stdenv.mkDerivation {
       if lockfileHash != null then
         ''
           # Validate lockfile hash (early failure with clear message)
-          currentHash="sha256-$(nix-hash --type sha256 --base64 ${workspaceClosureSrc}/${packageDir}/pnpm-lock.yaml)"
+          currentHash="sha256-$(nix-hash --type sha256 --base64 ${workspaceClosureSrc}/${effectivePackageDir}/pnpm-lock.yaml)"
           if [ "$currentHash" != "${lockfileHash}" ]; then
             echo ""
             echo "error: lockfileHash is stale (run: dt nix:hash)"
             echo "  expected: ${lockfileHash}"
             echo "  actual:   $currentHash"
+            echo ""
+            exit 1
+          fi
+        ''
+      else
+        ""
+    }
+
+    ${
+      if packageJsonDepsHash != null then
+        ''
+          # Validate package.json dependency fingerprint against the prepared workspace.
+          tmpDeps="$(mktemp)"
+          jq -cS '{dependencies, devDependencies, peerDependencies}' ${workspaceClosureSrc}/${effectivePackageDir}/package.json > "$tmpDeps"
+          currentPackageJsonDepsHash="sha256-$(nix-hash --type sha256 --base64 "$tmpDeps")"
+          rm "$tmpDeps"
+          if [ "$currentPackageJsonDepsHash" != "${packageJsonDepsHash}" ]; then
+            echo ""
+            echo "error: packageJsonDepsHash is stale (run: pnpm install && dt nix:hash)"
+            echo "  expected: ${packageJsonDepsHash}"
+            echo "  actual:   $currentPackageJsonDepsHash"
             echo ""
             exit 1
           fi
@@ -432,7 +499,7 @@ pkgs.stdenv.mkDerivation {
     echo "Deploying package closure..."
     deploy_dir="$PWD/.pnpm-deploy"
     rm -rf "$deploy_dir"
-    cd ${packageDir}
+    cd ${effectivePackageDir}
     pnpm --config.inject-workspace-packages=true \
       --filter . \
       deploy \

--- a/nix/workspace-tools/lib/mk-prepared-pnpm-workspace.nix
+++ b/nix/workspace-tools/lib/mk-prepared-pnpm-workspace.nix
@@ -1,0 +1,154 @@
+{ pkgs }:
+
+{
+  name,
+  packageDir,
+  packageSource,
+  workspaceMembers ? [ ],
+  mounts ? { },
+  fileOverrides ? { },
+  extraDependencyPaths ? [ ],
+  extraExcludedSourceNames ? [ ],
+  packageVersion ? null,
+}:
+
+let
+  lib = pkgs.lib;
+
+  excludedSourceNames = [
+    ".git"
+    ".direnv"
+    ".devenv"
+    ".cache"
+    ".turbo"
+    ".next"
+    ".bun"
+    "node_modules"
+    "dist"
+    "result"
+    "coverage"
+    "tmp"
+    "out"
+  ] ++ extraExcludedSourceNames;
+
+  normalizePath = src:
+    if builtins.isAttrs src && builtins.hasAttr "outPath" src then
+      src.outPath
+    else if builtins.isPath src then
+      src
+    else
+      builtins.toPath src;
+
+  packageSourcePath = normalizePath packageSource;
+  normalizedMounts = lib.mapAttrs (_: normalizePath) mounts;
+
+  dependencyPaths = lib.unique (workspaceMembers ++ extraDependencyPaths);
+  dependencyMounts = lib.filterAttrs (path: _: lib.elem path dependencyPaths) normalizedMounts;
+
+  writeTextFile = path: text:
+    pkgs.writeText "prepared-pnpm-workspace-${builtins.substring 0 12 (builtins.hashString "sha256" path)}" text;
+
+  normalizedOverrides = lib.mapAttrs writeTextFile fileOverrides;
+
+  copyTreeCommands = path: source: ''
+    mkdir -p "$(dirname "$out/${path}")"
+    if [ -d ${lib.escapeShellArg (toString source)} ]; then
+      mkdir -p "$out/${path}"
+      cp -R ${lib.escapeShellArg (toString source + "/.")} "$out/${path}/"
+    else
+      cp ${lib.escapeShellArg (toString source)} "$out/${path}"
+    fi
+  '';
+
+  overrideCommands = lib.concatStringsSep "\n" (
+    lib.mapAttrsToList
+      (path: sourceFile: ''
+        mkdir -p "$(dirname "$out/${path}")"
+        cp ${lib.escapeShellArg (toString sourceFile)} "$out/${path}"
+      '')
+      normalizedOverrides
+  );
+
+  removeExcludedCommands = lib.concatStringsSep "\n" (
+    map
+      (name: ''
+        find "$out" -depth -name ${lib.escapeShellArg name} -exec rm -rf {} +
+      '')
+      excludedSourceNames
+  );
+
+  workspaceSource = pkgs.runCommand "${name}-prepared-workspace" { } ''
+    set -euo pipefail
+
+    mkdir -p "$out/${packageDir}"
+    cp -R ${lib.escapeShellArg (toString packageSourcePath + "/.")} "$out/${packageDir}/"
+
+    ${lib.concatStringsSep "\n" (lib.mapAttrsToList copyTreeCommands normalizedMounts)}
+
+    chmod -R u+w "$out"
+
+    ${overrideCommands}
+
+    ${removeExcludedCommands}
+  '';
+
+  depsRelevantFiles = [
+    "pnpm-lock.yaml"
+    "package.json"
+    "pnpm-workspace.yaml"
+    ".npmrc"
+  ];
+
+  depsSource = pkgs.runCommand "${name}-prepared-deps-source" { } ''
+    set -euo pipefail
+
+    mkdir -p "$out/${packageDir}"
+    cp -R ${lib.escapeShellArg (toString packageSourcePath + "/.")} "$out/${packageDir}/"
+    chmod -R u+w "$out/${packageDir}"
+
+    find "$out/${packageDir}" -mindepth 1 -maxdepth 1 \
+      ${lib.concatStringsSep " " (map (file: "! -name ${lib.escapeShellArg file}") depsRelevantFiles)} \
+      -exec rm -rf {} +
+
+    ${lib.concatStringsSep "\n" (lib.mapAttrsToList copyTreeCommands dependencyMounts)}
+
+    chmod -R u+w "$out"
+
+    ${overrideCommands}
+
+    ${removeExcludedCommands}
+  '';
+
+  fingerprint = pkgs.runCommand "${name}-fingerprint" {
+    nativeBuildInputs = [ pkgs.jq pkgs.nix ];
+  } ''
+    set -euo pipefail
+
+    mkdir -p "$out"
+
+    lockfileHash="sha256-$(nix-hash --type sha256 --base64 ${workspaceSource}/${packageDir}/pnpm-lock.yaml)"
+    printf '%s' "$lockfileHash" > "$out/lockfileHash"
+
+    tmpDeps="$(mktemp)"
+    jq -cS '{dependencies, devDependencies, peerDependencies}' ${workspaceSource}/${packageDir}/package.json > "$tmpDeps"
+    packageJsonDepsHash="sha256-$(nix-hash --type sha256 --base64 "$tmpDeps")"
+    rm "$tmpDeps"
+    printf '%s' "$packageJsonDepsHash" > "$out/packageJsonDepsHash"
+  '';
+
+  resolvedPackageVersion =
+    if packageVersion != null then
+      packageVersion
+    else
+      ((builtins.fromJSON (builtins.readFile (packageSourcePath + "/package.json"))).version or "0.0.0");
+in
+{
+  inherit
+    depsSource
+    fingerprint
+    packageDir
+    workspaceMembers
+    workspaceSource
+    ;
+  packageVersion = resolvedPackageVersion;
+}


### PR DESCRIPTION
## Summary
- add `lib.mkPreparedPnpmWorkspace` so consumers can describe a staged pnpm workspace once and reuse it for builds and fingerprinting
- teach `mk-pnpm-cli` and the nix hash/check tasks to consume prepared workspaces and `#fingerprint` outputs
- add regression coverage for flake ref normalization in the hash helper tests

## Why
The current flow has two competing sources of truth: builds run against a prepared workspace, while `dt nix:hash` and `dt nix:check:quick` still fingerprint raw repo files. That mismatch forces consumer-specific patching and makes stale hash failures misleading.

This change makes the prepared workspace the reusable contract, so downstream repos can stage once and keep build inputs, lockfile hashes, and package dependency hashes aligned.

## Scope
- directly addresses the prepared-workspace/build-path part of `#246`
- reduces downstream boilerplate that has been accumulating around `#244`
- does **not** attempt to solve the dev install overlap problem from `#331`

<sub>Created by Codex on behalf of @schickling</sub>