### PR TITLE
Validate inherited peer installs use explicit versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **@overeng/genie**: Fail `genie --check` when inherited peer deps use ranged local install versions
+  - Allows ranged `peerDependencies`
+  - Requires explicit local install versions in `dependencies` / `devDependencies` / `optionalDependencies`
 - **@overeng/megarepo**: Handle stale locked commits during `mr sync --pull`
   - Prevents recursive sync from aborting when nested pinned members reference commits that no longer exist
   - Allows `mr sync --pull --force` to recover pinned branch members by resolving the tracked ref head

--- a/packages/@overeng/genie/src/runtime/package-json/mod.ts
+++ b/packages/@overeng/genie/src/runtime/package-json/mod.ts
@@ -611,6 +611,8 @@ const buildPackageJson = <T extends PackageJsonData>({
  *   peerDependencies: {
  *     ...utilsPkg.data.peerDependencies,  // Inherit peer deps
  *   },
+ *   // If the app also installs those peers locally, use catalog versions
+ *   // in dependencies/devDependencies instead of copying peer ranges.
  * })
  * ```
  */

--- a/packages/@overeng/genie/src/runtime/package-json/validators/recompose.ts
+++ b/packages/@overeng/genie/src/runtime/package-json/validators/recompose.ts
@@ -5,6 +5,14 @@ import type { ValidationIssue } from '../validation.ts'
 const isWorkspaceSpec = (spec: string): boolean =>
   spec.startsWith('workspace:') || spec.startsWith('file:') || spec.startsWith('link:')
 
+const hasVersionRangeSyntax = (spec: string): boolean =>
+  spec.startsWith('^') ||
+  spec.startsWith('~') ||
+  spec.startsWith('>') ||
+  spec.startsWith('<') ||
+  spec.includes('||') ||
+  /\s-\s/.test(spec)
+
 const hasOptionalPeer = ({
   meta,
   name,
@@ -53,6 +61,24 @@ const validatePackageRecomposition = (args: {
         continue
       }
 
+      const localInstallSpec =
+        args.pkg.dependencies?.[peer] ??
+        args.pkg.devDependencies?.[peer] ??
+        args.pkg.optionalDependencies?.[peer]
+      if (
+        localInstallSpec !== undefined &&
+        isWorkspaceSpec(localInstallSpec) === false &&
+        hasVersionRangeSyntax(localInstallSpec) === true
+      ) {
+        issues.push({
+          severity: 'error',
+          packageName: args.pkg.name,
+          dependency: peer,
+          message: `Inherited peer "${peer}" from "${depName}" uses ranged local install spec "${localInstallSpec}". Use an explicit install version and keep the range only in peerDependencies.`,
+          rule: 'recompose-local-peer-range',
+        })
+      }
+
       /** Only check peerDependenciesMeta when the dep is actually in peerDependencies */
       const isInPeerDeps =
         args.pkg.peerDependencies !== undefined && peer in args.pkg.peerDependencies
@@ -94,6 +120,7 @@ const validatePackageRecomposition = (args: {
  *
  * For non-private (library) packages: upstream peer deps must appear in peerDependencies (delta pattern).
  * For private (app) packages: upstream peer deps must appear in dependencies, devDependencies, or peerDependencies.
+ * If they are installed locally via dependencies/devDependencies/optionalDependencies, their local install spec must be explicit.
  */
 export const validatePackageRecompositionForPackage = ({
   ctx,

--- a/packages/@overeng/genie/src/runtime/package-json/validators/recompose.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/package-json/validators/recompose.unit.test.ts
@@ -110,7 +110,7 @@ describe('validatePackageRecompositionForPackage', () => {
       name: '@test/example',
       path: 'examples/my-example',
       private: true,
-      dependencies: { '@test/utils': 'workspace:*', react: '^19.0.0' },
+      dependencies: { '@test/utils': 'workspace:*', react: '19.0.0' },
       // no peerDependencies or peerDependenciesMeta — should be fine for private packages
     })
     const ctx = makeContext([upstream, downstream])
@@ -150,7 +150,7 @@ describe('validatePackageRecompositionForPackage', () => {
       name: '@test/example',
       path: 'examples/my-example',
       private: true,
-      dependencies: { '@test/utils': 'workspace:*', effect: '^3.0.0' },
+      dependencies: { '@test/utils': 'workspace:*', effect: '3.0.0' },
     })
     const ctx = makeContext([upstream, downstream])
 
@@ -169,7 +169,79 @@ describe('validatePackageRecompositionForPackage', () => {
       path: 'examples/my-example',
       private: true,
       dependencies: { '@test/utils': 'workspace:*' },
+      devDependencies: { effect: '3.0.0' },
+    })
+    const ctx = makeContext([upstream, downstream])
+
+    const issues = validatePackageRecompositionForPackage({ ctx, pkgName: '@test/example' })
+    expect(issues).toEqual([])
+  })
+
+  it('private package: reports ranged devDependency for inherited peer install', () => {
+    const upstream = makePackage({
+      name: '@test/utils',
+      path: 'packages/utils',
+      peerDependencies: { effect: '^3.0.0' },
+    })
+    const downstream = makePackage({
+      name: '@test/example',
+      path: 'examples/my-example',
+      private: true,
+      dependencies: { '@test/utils': 'workspace:*' },
       devDependencies: { effect: '^3.0.0' },
+    })
+    const ctx = makeContext([upstream, downstream])
+
+    const issues = validatePackageRecompositionForPackage({ ctx, pkgName: '@test/example' })
+    expect(issues).toHaveLength(1)
+    expect(issues[0]).toMatchObject({
+      severity: 'error',
+      packageName: '@test/example',
+      dependency: 'effect',
+      rule: 'recompose-local-peer-range',
+      message:
+        'Inherited peer "effect" from "@test/utils" uses ranged local install spec "^3.0.0". Use an explicit install version and keep the range only in peerDependencies.',
+    })
+  })
+
+  it('private package: reports ranged dependency for inherited peer install', () => {
+    const upstream = makePackage({
+      name: '@test/utils',
+      path: 'packages/utils',
+      peerDependencies: { effect: '^3.0.0' },
+    })
+    const downstream = makePackage({
+      name: '@test/example',
+      path: 'examples/my-example',
+      private: true,
+      dependencies: {
+        '@test/utils': 'workspace:*',
+        effect: '^3.0.0',
+      },
+    })
+    const ctx = makeContext([upstream, downstream])
+
+    const issues = validatePackageRecompositionForPackage({ ctx, pkgName: '@test/example' })
+    expect(issues).toHaveLength(1)
+    expect(issues[0]).toMatchObject({
+      dependency: 'effect',
+      rule: 'recompose-local-peer-range',
+    })
+  })
+
+  it('private package: allows exact local install with ranged peerDependencies', () => {
+    const upstream = makePackage({
+      name: '@test/utils',
+      path: 'packages/utils',
+      peerDependencies: { effect: '^3.0.0' },
+    })
+    const downstream = makePackage({
+      name: '@test/example',
+      path: 'examples/my-example',
+      private: true,
+      dependencies: { '@test/utils': 'workspace:*' },
+      devDependencies: { effect: '3.0.0' },
+      peerDependencies: { effect: '^3.0.0' },
     })
     const ctx = makeContext([upstream, downstream])
 


### PR DESCRIPTION
## Why

`#343` made the Genie catalog the source of truth for concrete local install-time versions in the affected packages.

This PR turns that into an enforced rule instead of a convention.

## Policy

For peer dependencies inherited from workspace dependencies:

1. local installs in `dependencies`, `devDependencies`, or `optionalDependencies` must use an explicit version
2. ranged `peerDependencies` are still allowed
3. this does not ban version ranges globally for all `devDependencies`

## What

- extend the existing package recomposition validator to error on ranged local install specs for inherited peer names
- keep the existing peer recomposition behavior unchanged
- add unit tests for the new rule
- add a small package-json API note so the intended pattern is documented

## Validation

- `CI=1 dt test:genie --no-tui`
- `CI=1 dt genie:check --no-tui`
- `CI=1 dt check:all --no-tui`

_Automated on behalf of the user._
