### PR TITLE
Fix external beads store resolution

### DIFF
--- a/nix/beads.nix
+++ b/nix/beads.nix
@@ -91,6 +91,9 @@ pkgs.stdenv.mkDerivation {
       esac
     done
 
+    # TODO: Drop this detached-worktree normalization once beads#2439 is merged
+    # and released. Upstream beads should then resolve refs/commits/*/.beads to a
+    # stable same-commit branch worktree on its own.
     resolve_beads_dir() {
       local beads_dir="$1"
       local resolved_dir
@@ -128,6 +131,10 @@ pkgs.stdenv.mkDerivation {
         cd "''${BEADS_DIR%/.beads}"
       fi
 
+      # TODO: Re-check this explicit --db pin after beads#2439 is merged. The
+      # upstream PR fixes path identity, but external-store server-mode
+      # resolution still needs validation before this wrapper can collapse to a
+      # plain bd passthrough.
       if [ "''${has_explicit_db}" = false ] && [ -d "$BEADS_DIR/dolt" ] && should_pin_db "$BEADS_DIR"; then
         exec "$bd_real" --db "$BEADS_DIR/dolt" "$@"
       fi

--- a/nix/devenv-modules/tasks/shared/beads.nix
+++ b/nix/devenv-modules/tasks/shared/beads.nix
@@ -15,6 +15,9 @@ let
 in
 {
   env.BEADS_DIR = "${config.devenv.root}/${beadsRepoRelPath}/.beads";
+  # TODO: Remove BEADS_PRIMARY_REF after beads#2439 is merged and adopted.
+  # It is only threaded through today so the wrapper can rewrite detached
+  # refs/commits worktrees back to a stable branch worktree.
   env.BEADS_PRIMARY_REF = beadsRepoRef;
 
   tasks."beads:push" = {


### PR DESCRIPTION
## Why
`bd` was resolving centralized `BEADS_DIR` stores through unstable megarepo commit worktrees, which broke Dolt server reuse and caused repo identity mismatches in schickling megarepos.

## What
- resolve `BEADS_DIR` commit-worktree paths back to the configured primary branch worktree
- only pass `--db` for Dolt-backed metadata layouts that actually expect it
- thread the configured primary beads ref through the shared devenv beads module
- add TODOs pointing at upstream cleanup work in steveyegge/beads#2439

## Validation
- `dt ts:check`
- `oxfmt --check .`
- `nix build .#beads`
- rebuilt wrapper verified with `bd where` against dotfiles/schickling.dev/schickling-stiftung and `bd doctor` against the migrated public beads repo
- `dt check:all` still hits the existing unrelated `test:op-proxy` failure from the op-proxy Playwright dist suite

_Acting on behalf of the repository owner._