### PR TITLE
Document Bun nested workspace patch blocker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ All notable changes to this project will be documented in this file.
 - **genie/ci-workflow**: Add shared `nixExtraConf` and `runDevenvTasksBeforeWithWasmBuiltin` helpers
   - Lets downstream workflows enable `wasm-builtin` without repo-local `NIX_CONFIG` string assembly
 - **@overeng/genie**: Added `githubAction` runtime generator for type-safe `action.yml` generation
+- **docs/bun**: Document the upstream nested-workspace `patchedDependencies` blocker and link the Bun issue
 
 ### Removed
 

--- a/context/workarounds/bun-issues.md
+++ b/context/workarounds/bun-issues.md
@@ -54,11 +54,20 @@ This aligns with our pnpm pattern - see "Bun Workspace Pattern" section below.
 
 ---
 
-## Other Issues (non-blocking)
+## Additional Blocking Issues
 
 ### BUN-03: Bun patchedDependencies bug
 
 - [Patching falls over when using local path dependencies](https://github.com/oven-sh/bun/issues/13531)
+- [Nested workspace package patchedDependencies break root install](https://github.com/oven-sh/bun/issues/27894)
+
+Validated on Bun `1.3.10`:
+
+- A workspace app root can install successfully when only the install root carries top-level `patchedDependencies`
+- The same install fails as soon as a nested workspace package also carries its own top-level `patchedDependencies`
+- A package like `@overeng/utils` still needs top-level `patchedDependencies` when it is installed as its own Bun root
+
+That means the remaining patch blocker is not just missing `workspaces` generation. Bun currently requires contradictory static manifest shapes depending on whether the same package is the install root or a nested workspace member.
 
 ---
 
@@ -117,7 +126,7 @@ Use these as concrete cleanup tasks once the corresponding Bun issues are resolv
 
 - **BUN-01**: Revert mk-bun-cli to bun-only installs (remove `depsManager`, `pnpmDepsHash`, pnpm install path).
 - **BUN-02**: Switch to `workspace:*` with per-package workspaces in `package.json`.
-- **BUN-03**: Re-enable bun patchedDependencies flow; remove postinstall patch workaround.
+- **BUN-03**: Re-enable bun patchedDependencies flow once Bun fixes both local path patching and nested workspace patch handling.
 - **All BUN issues resolved**:
   - Remove pnpm-specific code paths in `mk-bun-cli` and `mk-bun-cli/bun-deps.nix`.
   - Update genie to generate `workspaces` field in `package.json` instead of `pnpm-workspace.yaml`.


### PR DESCRIPTION
## Why

We validated a Bun blocker that was more specific than the existing patched-deps note: packages like `@overeng/utils` need top-level `patchedDependencies` when installed as their own Bun root, but the same field breaks when that package is a nested workspace member under another Bun root.

## What

- add the new upstream Bun issue link
- document the validated root-vs-nested `patchedDependencies` conflict
- mark the patched-deps issue as a blocking issue in the workaround doc
- add a changelog note for the documentation update

## How

This updates `context/workarounds/bun-issues.md` with the exact behavior we reproduced on Bun `1.3.10` and links the new upstream tracker.

---
<sub>Created by an AI assistant on behalf of @schickling</sub>
