### PR TITLE
fix(tasks): keep genie install wiring repo-local

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -345,6 +345,7 @@ in
   tasks."genie:run".after = [ "pnpm:install:genie" ];
   tasks."genie:watch".after = [ "pnpm:install:genie" ];
   tasks."genie:check".after = [ "pnpm:install:genie" ];
+  tasks."lint:check:genie".after = [ "pnpm:install:genie" ];
   tasks."megarepo:sync".after = [ "pnpm:install:megarepo" ];
 
   tasks."gh:apply-settings" = {

--- a/nix/devenv-modules/tasks/shared/lint-genie.nix
+++ b/nix/devenv-modules/tasks/shared/lint-genie.nix
@@ -15,8 +15,6 @@ in
     "lint:check:genie" = {
       description = "Check generated files are up to date";
       exec = trace.exec "lint:check:genie" "genie --check";
-      # Strict mode: never auto-regenerate before checking drift.
-      after = [ "pnpm:install" ];
     };
     "lint:check" = {
       description = "Run all lint checks";

--- a/nix/devenv-modules/tasks/shared/lint-oxc.nix
+++ b/nix/devenv-modules/tasks/shared/lint-oxc.nix
@@ -120,9 +120,6 @@ in
     "lint:check:genie" = {
       description = "Check generated files are up to date";
       exec = trace.exec "lint:check:genie" "genie --check";
-      # genie is a source-mode CLI in this repo, so a fresh checkout needs its
-      # package-local workspace install before running the check.
-      after = [ "pnpm:install:genie" ];
       execIfModified = geniePatterns;
     };
     "lint:check:genie:coverage" = {


### PR DESCRIPTION
Why
- `effect-utils` runs `genie` from source in its own `devenv`, so the install dependency belongs in the repo config, not in the shared lint modules
- shared task modules should stay install-agnostic for downstream consumers

What
- add `tasks."lint:check:genie".after = [ "pnpm:install:genie" ];` in `effect-utils/devenv.nix`
- remove source-mode install assumptions from the shared lint modules

How
- update `devenv.nix`
- keep `nix/devenv-modules/tasks/shared/lint-oxc.nix` pure
- keep `nix/devenv-modules/tasks/shared/lint-genie.nix` pure

Validation
- `git diff --check`
- verified the final diff only moves the dependency to repo-local config

_Acting on behalf of @schickling._