### PR TITLE
perf(ci): lazy nix store repair instead of eager validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
           echo "DEVENV_REV=$DEVENV_REV" >> "$GITHUB_ENV"
           echo "Pinned devenv rev: $DEVENV_REV"
         shell: bash
-      - name: Validate Nix store
+      - name: Resolve devenv
         run: |
           if [ -z "${DEVENV_REV:-}" ]; then
             DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -65,14 +65,7 @@ jobs:
             nix build --no-link --print-out-paths "github:cachix/devenv/$DEVENV_REV#devenv"
           }
 
-          # Always append restrict-eval=false so caller-provided NIX_CONFIG keeps its settings.
-          if [ -n "${NIX_CONFIG:-}" ]; then
-            NIX_CONFIG_WITH_UNRESTRICTED_EVAL="$NIX_CONFIG"$'\n''restrict-eval = false'
-          else
-            NIX_CONFIG_WITH_UNRESTRICTED_EVAL='restrict-eval = false'
-          fi
-
-          # Temporary: capture complete diagnostics for #272 root-cause analysis.
+          # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
           mkdir -p "$DIAG_ROOT"
           echo "NIX_STORE_DIAGNOSTICS_DIR=$DIAG_ROOT" >> "$GITHUB_ENV"
@@ -84,42 +77,21 @@ jobs:
             echo "runner_arch=${RUNNER_ARCH:-unknown}"
             echo "github_job=${GITHUB_JOB:-unknown}"
             echo "github_run_id=${GITHUB_RUN_ID:-unknown}"
-            echo "github_run_attempt=${GITHUB_RUN_ATTEMPT:-unknown}"
             echo "nix_user_conf_files=${NIX_USER_CONF_FILES:-}"
-            echo ""
-            echo "== uname -a =="
-            uname -a || true
-            if command -v sw_vers > /dev/null 2>&1; then
-              echo ""
-              echo "== sw_vers =="
-              sw_vers || true
-            fi
-            echo ""
-            echo "== nix --version =="
             nix --version || true
           } > "$DIAG_ROOT/environment.txt" 2>&1
 
-          pre_resolve_log="$DIAG_ROOT/resolve-devenv-pre-repair.log"
-          pre_info_log="$DIAG_ROOT/devenv-info-pre-repair.log"
-          verify_log="$DIAG_ROOT/nix-store-verify-pre-repair.log"
-          repair_log="$DIAG_ROOT/nix-store-verify-repair.log"
-          post_resolve_log="$DIAG_ROOT/resolve-devenv-post-repair.log"
-          post_info_log="$DIAG_ROOT/devenv-info-post-repair.log"
+          DEVENV_OUT=$(resolve_devenv 2>"$DIAG_ROOT/resolve-devenv.log")
+          DEVENV_BIN="$DEVENV_OUT/bin/devenv"
 
-          if DEVENV_OUT=$(resolve_devenv 2>"$pre_resolve_log") && DEVENV_BIN="$DEVENV_OUT/bin/devenv" && NIX_CONFIG="$NIX_CONFIG_WITH_UNRESTRICTED_EVAL" "$DEVENV_BIN" info > "$pre_info_log" 2>&1; then
-            echo "Nix store OK"
-          else
-            echo "::warning::Nix store validation failed, collecting diagnostics and repairing..."
-            if ! nix-store --verify --check-contents > "$verify_log" 2>&1; then
-              echo "::warning::nix-store --verify --check-contents reported issues (see diagnostics artifact)"
-            fi
-            if ! nix-store --verify --check-contents --repair > "$repair_log" 2>&1; then
-              echo "::warning::nix-store --verify --check-contents --repair reported issues (see diagnostics artifact)"
-            fi
+          # Fast validity check on the devenv store path (~1-2s vs ~25s for devenv info).
+          # Deeper transitive-dep corruption is caught lazily at task time via retry wrapper.
+          if ! nix-store --check-validity "$DEVENV_OUT" 2>/dev/null; then
+            echo "::warning::devenv store path invalid, repairing..."
+            nix-store --verify --check-contents --repair > "$DIAG_ROOT/nix-store-verify-repair.log" 2>&1 || true
             rm -rf ~/.cache/nix/eval-cache-*
-            DEVENV_OUT=$(resolve_devenv 2>"$post_resolve_log")
+            DEVENV_OUT=$(resolve_devenv 2>"$DIAG_ROOT/resolve-devenv-post-repair.log")
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
-            NIX_CONFIG="$NIX_CONFIG_WITH_UNRESTRICTED_EVAL" "$DEVENV_BIN" info > "$post_info_log" 2>&1
           fi
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
@@ -139,7 +111,7 @@ jobs:
           echo "::warning::Intentional failure for diagnostics validation (#272)"
           exit 1
       - name: Type check
-        run: "if [ -n \"${NIX_CONFIG:-}\" ]; then NIX_CONFIG_WITH_APPEND=$(printf '%s\\n%s' \"$NIX_CONFIG\" 'restrict-eval = false'); else NIX_CONFIG_WITH_APPEND='restrict-eval = false'; fi; NIX_CONFIG=\"$NIX_CONFIG_WITH_APPEND\" \"${DEVENV_BIN:?DEVENV_BIN not set}\" tasks run ts:check --mode before"
+        run: "(if [ -n \"${NIX_CONFIG:-}\" ]; then NIX_CONFIG_WITH_APPEND=$(printf '%s\\n%s' \"$NIX_CONFIG\" 'restrict-eval = false'); else NIX_CONFIG_WITH_APPEND='restrict-eval = false'; fi; NIX_CONFIG=\"$NIX_CONFIG_WITH_APPEND\" \"${DEVENV_BIN:?DEVENV_BIN not set}\" tasks run ts:check --mode before) || { echo \"::warning::Task failed, attempting Nix store repair and retry...\"; DIAG_DIR=\"${NIX_STORE_DIAGNOSTICS_DIR:-${RUNNER_TEMP:-/tmp}}\"; nix-store --verify --check-contents --repair > \"$DIAG_DIR/nix-store-verify-repair.log\" 2>&1 || true; rm -rf ~/.cache/nix/eval-cache-*; (if [ -n \"${NIX_CONFIG:-}\" ]; then NIX_CONFIG_WITH_APPEND=$(printf '%s\\n%s' \"$NIX_CONFIG\" 'restrict-eval = false'); else NIX_CONFIG_WITH_APPEND='restrict-eval = false'; fi; NIX_CONFIG=\"$NIX_CONFIG_WITH_APPEND\" \"${DEVENV_BIN:?DEVENV_BIN not set}\" tasks run ts:check --mode before); }"
       - name: Nix diagnostics summary
         if: failure()
         shell: bash
@@ -224,7 +196,7 @@ jobs:
           echo "DEVENV_REV=$DEVENV_REV" >> "$GITHUB_ENV"
           echo "Pinned devenv rev: $DEVENV_REV"
         shell: bash
-      - name: Validate Nix store
+      - name: Resolve devenv
         run: |
           if [ -z "${DEVENV_REV:-}" ]; then
             DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -238,14 +210,7 @@ jobs:
             nix build --no-link --print-out-paths "github:cachix/devenv/$DEVENV_REV#devenv"
           }
 
-          # Always append restrict-eval=false so caller-provided NIX_CONFIG keeps its settings.
-          if [ -n "${NIX_CONFIG:-}" ]; then
-            NIX_CONFIG_WITH_UNRESTRICTED_EVAL="$NIX_CONFIG"$'\n''restrict-eval = false'
-          else
-            NIX_CONFIG_WITH_UNRESTRICTED_EVAL='restrict-eval = false'
-          fi
-
-          # Temporary: capture complete diagnostics for #272 root-cause analysis.
+          # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
           mkdir -p "$DIAG_ROOT"
           echo "NIX_STORE_DIAGNOSTICS_DIR=$DIAG_ROOT" >> "$GITHUB_ENV"
@@ -257,42 +222,21 @@ jobs:
             echo "runner_arch=${RUNNER_ARCH:-unknown}"
             echo "github_job=${GITHUB_JOB:-unknown}"
             echo "github_run_id=${GITHUB_RUN_ID:-unknown}"
-            echo "github_run_attempt=${GITHUB_RUN_ATTEMPT:-unknown}"
             echo "nix_user_conf_files=${NIX_USER_CONF_FILES:-}"
-            echo ""
-            echo "== uname -a =="
-            uname -a || true
-            if command -v sw_vers > /dev/null 2>&1; then
-              echo ""
-              echo "== sw_vers =="
-              sw_vers || true
-            fi
-            echo ""
-            echo "== nix --version =="
             nix --version || true
           } > "$DIAG_ROOT/environment.txt" 2>&1
 
-          pre_resolve_log="$DIAG_ROOT/resolve-devenv-pre-repair.log"
-          pre_info_log="$DIAG_ROOT/devenv-info-pre-repair.log"
-          verify_log="$DIAG_ROOT/nix-store-verify-pre-repair.log"
-          repair_log="$DIAG_ROOT/nix-store-verify-repair.log"
-          post_resolve_log="$DIAG_ROOT/resolve-devenv-post-repair.log"
-          post_info_log="$DIAG_ROOT/devenv-info-post-repair.log"
+          DEVENV_OUT=$(resolve_devenv 2>"$DIAG_ROOT/resolve-devenv.log")
+          DEVENV_BIN="$DEVENV_OUT/bin/devenv"
 
-          if DEVENV_OUT=$(resolve_devenv 2>"$pre_resolve_log") && DEVENV_BIN="$DEVENV_OUT/bin/devenv" && NIX_CONFIG="$NIX_CONFIG_WITH_UNRESTRICTED_EVAL" "$DEVENV_BIN" info > "$pre_info_log" 2>&1; then
-            echo "Nix store OK"
-          else
-            echo "::warning::Nix store validation failed, collecting diagnostics and repairing..."
-            if ! nix-store --verify --check-contents > "$verify_log" 2>&1; then
-              echo "::warning::nix-store --verify --check-contents reported issues (see diagnostics artifact)"
-            fi
-            if ! nix-store --verify --check-contents --repair > "$repair_log" 2>&1; then
-              echo "::warning::nix-store --verify --check-contents --repair reported issues (see diagnostics artifact)"
-            fi
+          # Fast validity check on the devenv store path (~1-2s vs ~25s for devenv info).
+          # Deeper transitive-dep corruption is caught lazily at task time via retry wrapper.
+          if ! nix-store --check-validity "$DEVENV_OUT" 2>/dev/null; then
+            echo "::warning::devenv store path invalid, repairing..."
+            nix-store --verify --check-contents --repair > "$DIAG_ROOT/nix-store-verify-repair.log" 2>&1 || true
             rm -rf ~/.cache/nix/eval-cache-*
-            DEVENV_OUT=$(resolve_devenv 2>"$post_resolve_log")
+            DEVENV_OUT=$(resolve_devenv 2>"$DIAG_ROOT/resolve-devenv-post-repair.log")
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
-            NIX_CONFIG="$NIX_CONFIG_WITH_UNRESTRICTED_EVAL" "$DEVENV_BIN" info > "$post_info_log" 2>&1
           fi
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
@@ -312,7 +256,7 @@ jobs:
           echo "::warning::Intentional failure for diagnostics validation (#272)"
           exit 1
       - name: Format + lint
-        run: "if [ -n \"${NIX_CONFIG:-}\" ]; then NIX_CONFIG_WITH_APPEND=$(printf '%s\\n%s' \"$NIX_CONFIG\" 'restrict-eval = false'); else NIX_CONFIG_WITH_APPEND='restrict-eval = false'; fi; NIX_CONFIG=\"$NIX_CONFIG_WITH_APPEND\" \"${DEVENV_BIN:?DEVENV_BIN not set}\" tasks run lint:check --mode before"
+        run: "(if [ -n \"${NIX_CONFIG:-}\" ]; then NIX_CONFIG_WITH_APPEND=$(printf '%s\\n%s' \"$NIX_CONFIG\" 'restrict-eval = false'); else NIX_CONFIG_WITH_APPEND='restrict-eval = false'; fi; NIX_CONFIG=\"$NIX_CONFIG_WITH_APPEND\" \"${DEVENV_BIN:?DEVENV_BIN not set}\" tasks run lint:check --mode before) || { echo \"::warning::Task failed, attempting Nix store repair and retry...\"; DIAG_DIR=\"${NIX_STORE_DIAGNOSTICS_DIR:-${RUNNER_TEMP:-/tmp}}\"; nix-store --verify --check-contents --repair > \"$DIAG_DIR/nix-store-verify-repair.log\" 2>&1 || true; rm -rf ~/.cache/nix/eval-cache-*; (if [ -n \"${NIX_CONFIG:-}\" ]; then NIX_CONFIG_WITH_APPEND=$(printf '%s\\n%s' \"$NIX_CONFIG\" 'restrict-eval = false'); else NIX_CONFIG_WITH_APPEND='restrict-eval = false'; fi; NIX_CONFIG=\"$NIX_CONFIG_WITH_APPEND\" \"${DEVENV_BIN:?DEVENV_BIN not set}\" tasks run lint:check --mode before); }"
       - name: Nix diagnostics summary
         if: failure()
         shell: bash
@@ -400,7 +344,7 @@ jobs:
           echo "DEVENV_REV=$DEVENV_REV" >> "$GITHUB_ENV"
           echo "Pinned devenv rev: $DEVENV_REV"
         shell: bash
-      - name: Validate Nix store
+      - name: Resolve devenv
         run: |
           if [ -z "${DEVENV_REV:-}" ]; then
             DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -414,14 +358,7 @@ jobs:
             nix build --no-link --print-out-paths "github:cachix/devenv/$DEVENV_REV#devenv"
           }
 
-          # Always append restrict-eval=false so caller-provided NIX_CONFIG keeps its settings.
-          if [ -n "${NIX_CONFIG:-}" ]; then
-            NIX_CONFIG_WITH_UNRESTRICTED_EVAL="$NIX_CONFIG"$'\n''restrict-eval = false'
-          else
-            NIX_CONFIG_WITH_UNRESTRICTED_EVAL='restrict-eval = false'
-          fi
-
-          # Temporary: capture complete diagnostics for #272 root-cause analysis.
+          # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
           mkdir -p "$DIAG_ROOT"
           echo "NIX_STORE_DIAGNOSTICS_DIR=$DIAG_ROOT" >> "$GITHUB_ENV"
@@ -433,42 +370,21 @@ jobs:
             echo "runner_arch=${RUNNER_ARCH:-unknown}"
             echo "github_job=${GITHUB_JOB:-unknown}"
             echo "github_run_id=${GITHUB_RUN_ID:-unknown}"
-            echo "github_run_attempt=${GITHUB_RUN_ATTEMPT:-unknown}"
             echo "nix_user_conf_files=${NIX_USER_CONF_FILES:-}"
-            echo ""
-            echo "== uname -a =="
-            uname -a || true
-            if command -v sw_vers > /dev/null 2>&1; then
-              echo ""
-              echo "== sw_vers =="
-              sw_vers || true
-            fi
-            echo ""
-            echo "== nix --version =="
             nix --version || true
           } > "$DIAG_ROOT/environment.txt" 2>&1
 
-          pre_resolve_log="$DIAG_ROOT/resolve-devenv-pre-repair.log"
-          pre_info_log="$DIAG_ROOT/devenv-info-pre-repair.log"
-          verify_log="$DIAG_ROOT/nix-store-verify-pre-repair.log"
-          repair_log="$DIAG_ROOT/nix-store-verify-repair.log"
-          post_resolve_log="$DIAG_ROOT/resolve-devenv-post-repair.log"
-          post_info_log="$DIAG_ROOT/devenv-info-post-repair.log"
+          DEVENV_OUT=$(resolve_devenv 2>"$DIAG_ROOT/resolve-devenv.log")
+          DEVENV_BIN="$DEVENV_OUT/bin/devenv"
 
-          if DEVENV_OUT=$(resolve_devenv 2>"$pre_resolve_log") && DEVENV_BIN="$DEVENV_OUT/bin/devenv" && NIX_CONFIG="$NIX_CONFIG_WITH_UNRESTRICTED_EVAL" "$DEVENV_BIN" info > "$pre_info_log" 2>&1; then
-            echo "Nix store OK"
-          else
-            echo "::warning::Nix store validation failed, collecting diagnostics and repairing..."
-            if ! nix-store --verify --check-contents > "$verify_log" 2>&1; then
-              echo "::warning::nix-store --verify --check-contents reported issues (see diagnostics artifact)"
-            fi
-            if ! nix-store --verify --check-contents --repair > "$repair_log" 2>&1; then
-              echo "::warning::nix-store --verify --check-contents --repair reported issues (see diagnostics artifact)"
-            fi
+          # Fast validity check on the devenv store path (~1-2s vs ~25s for devenv info).
+          # Deeper transitive-dep corruption is caught lazily at task time via retry wrapper.
+          if ! nix-store --check-validity "$DEVENV_OUT" 2>/dev/null; then
+            echo "::warning::devenv store path invalid, repairing..."
+            nix-store --verify --check-contents --repair > "$DIAG_ROOT/nix-store-verify-repair.log" 2>&1 || true
             rm -rf ~/.cache/nix/eval-cache-*
-            DEVENV_OUT=$(resolve_devenv 2>"$post_resolve_log")
+            DEVENV_OUT=$(resolve_devenv 2>"$DIAG_ROOT/resolve-devenv-post-repair.log")
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
-            NIX_CONFIG="$NIX_CONFIG_WITH_UNRESTRICTED_EVAL" "$DEVENV_BIN" info > "$post_info_log" 2>&1
           fi
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
@@ -488,7 +404,7 @@ jobs:
           echo "::warning::Intentional failure for diagnostics validation (#272)"
           exit 1
       - name: Unit tests
-        run: "if [ -n \"${NIX_CONFIG:-}\" ]; then NIX_CONFIG_WITH_APPEND=$(printf '%s\\n%s' \"$NIX_CONFIG\" 'restrict-eval = false'); else NIX_CONFIG_WITH_APPEND='restrict-eval = false'; fi; NIX_CONFIG=\"$NIX_CONFIG_WITH_APPEND\" \"${DEVENV_BIN:?DEVENV_BIN not set}\" tasks run test:run --mode before"
+        run: "(if [ -n \"${NIX_CONFIG:-}\" ]; then NIX_CONFIG_WITH_APPEND=$(printf '%s\\n%s' \"$NIX_CONFIG\" 'restrict-eval = false'); else NIX_CONFIG_WITH_APPEND='restrict-eval = false'; fi; NIX_CONFIG=\"$NIX_CONFIG_WITH_APPEND\" \"${DEVENV_BIN:?DEVENV_BIN not set}\" tasks run test:run --mode before) || { echo \"::warning::Task failed, attempting Nix store repair and retry...\"; DIAG_DIR=\"${NIX_STORE_DIAGNOSTICS_DIR:-${RUNNER_TEMP:-/tmp}}\"; nix-store --verify --check-contents --repair > \"$DIAG_DIR/nix-store-verify-repair.log\" 2>&1 || true; rm -rf ~/.cache/nix/eval-cache-*; (if [ -n \"${NIX_CONFIG:-}\" ]; then NIX_CONFIG_WITH_APPEND=$(printf '%s\\n%s' \"$NIX_CONFIG\" 'restrict-eval = false'); else NIX_CONFIG_WITH_APPEND='restrict-eval = false'; fi; NIX_CONFIG=\"$NIX_CONFIG_WITH_APPEND\" \"${DEVENV_BIN:?DEVENV_BIN not set}\" tasks run test:run --mode before); }"
       - name: Nix diagnostics summary
         if: failure()
         shell: bash
@@ -576,7 +492,7 @@ jobs:
           echo "DEVENV_REV=$DEVENV_REV" >> "$GITHUB_ENV"
           echo "Pinned devenv rev: $DEVENV_REV"
         shell: bash
-      - name: Validate Nix store
+      - name: Resolve devenv
         run: |
           if [ -z "${DEVENV_REV:-}" ]; then
             DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -590,14 +506,7 @@ jobs:
             nix build --no-link --print-out-paths "github:cachix/devenv/$DEVENV_REV#devenv"
           }
 
-          # Always append restrict-eval=false so caller-provided NIX_CONFIG keeps its settings.
-          if [ -n "${NIX_CONFIG:-}" ]; then
-            NIX_CONFIG_WITH_UNRESTRICTED_EVAL="$NIX_CONFIG"$'\n''restrict-eval = false'
-          else
-            NIX_CONFIG_WITH_UNRESTRICTED_EVAL='restrict-eval = false'
-          fi
-
-          # Temporary: capture complete diagnostics for #272 root-cause analysis.
+          # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
           mkdir -p "$DIAG_ROOT"
           echo "NIX_STORE_DIAGNOSTICS_DIR=$DIAG_ROOT" >> "$GITHUB_ENV"
@@ -609,42 +518,21 @@ jobs:
             echo "runner_arch=${RUNNER_ARCH:-unknown}"
             echo "github_job=${GITHUB_JOB:-unknown}"
             echo "github_run_id=${GITHUB_RUN_ID:-unknown}"
-            echo "github_run_attempt=${GITHUB_RUN_ATTEMPT:-unknown}"
             echo "nix_user_conf_files=${NIX_USER_CONF_FILES:-}"
-            echo ""
-            echo "== uname -a =="
-            uname -a || true
-            if command -v sw_vers > /dev/null 2>&1; then
-              echo ""
-              echo "== sw_vers =="
-              sw_vers || true
-            fi
-            echo ""
-            echo "== nix --version =="
             nix --version || true
           } > "$DIAG_ROOT/environment.txt" 2>&1
 
-          pre_resolve_log="$DIAG_ROOT/resolve-devenv-pre-repair.log"
-          pre_info_log="$DIAG_ROOT/devenv-info-pre-repair.log"
-          verify_log="$DIAG_ROOT/nix-store-verify-pre-repair.log"
-          repair_log="$DIAG_ROOT/nix-store-verify-repair.log"
-          post_resolve_log="$DIAG_ROOT/resolve-devenv-post-repair.log"
-          post_info_log="$DIAG_ROOT/devenv-info-post-repair.log"
+          DEVENV_OUT=$(resolve_devenv 2>"$DIAG_ROOT/resolve-devenv.log")
+          DEVENV_BIN="$DEVENV_OUT/bin/devenv"
 
-          if DEVENV_OUT=$(resolve_devenv 2>"$pre_resolve_log") && DEVENV_BIN="$DEVENV_OUT/bin/devenv" && NIX_CONFIG="$NIX_CONFIG_WITH_UNRESTRICTED_EVAL" "$DEVENV_BIN" info > "$pre_info_log" 2>&1; then
-            echo "Nix store OK"
-          else
-            echo "::warning::Nix store validation failed, collecting diagnostics and repairing..."
-            if ! nix-store --verify --check-contents > "$verify_log" 2>&1; then
-              echo "::warning::nix-store --verify --check-contents reported issues (see diagnostics artifact)"
-            fi
-            if ! nix-store --verify --check-contents --repair > "$repair_log" 2>&1; then
-              echo "::warning::nix-store --verify --check-contents --repair reported issues (see diagnostics artifact)"
-            fi
+          # Fast validity check on the devenv store path (~1-2s vs ~25s for devenv info).
+          # Deeper transitive-dep corruption is caught lazily at task time via retry wrapper.
+          if ! nix-store --check-validity "$DEVENV_OUT" 2>/dev/null; then
+            echo "::warning::devenv store path invalid, repairing..."
+            nix-store --verify --check-contents --repair > "$DIAG_ROOT/nix-store-verify-repair.log" 2>&1 || true
             rm -rf ~/.cache/nix/eval-cache-*
-            DEVENV_OUT=$(resolve_devenv 2>"$post_resolve_log")
+            DEVENV_OUT=$(resolve_devenv 2>"$DIAG_ROOT/resolve-devenv-post-repair.log")
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
-            NIX_CONFIG="$NIX_CONFIG_WITH_UNRESTRICTED_EVAL" "$DEVENV_BIN" info > "$post_info_log" 2>&1
           fi
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
@@ -664,7 +552,7 @@ jobs:
           echo "::warning::Intentional failure for diagnostics validation (#272)"
           exit 1
       - name: Nix hash check
-        run: "if [ -n \"${NIX_CONFIG:-}\" ]; then NIX_CONFIG_WITH_APPEND=$(printf '%s\\n%s' \"$NIX_CONFIG\" 'restrict-eval = false'); else NIX_CONFIG_WITH_APPEND='restrict-eval = false'; fi; NIX_CONFIG=\"$NIX_CONFIG_WITH_APPEND\" \"${DEVENV_BIN:?DEVENV_BIN not set}\" tasks run nix:check --mode before"
+        run: "(if [ -n \"${NIX_CONFIG:-}\" ]; then NIX_CONFIG_WITH_APPEND=$(printf '%s\\n%s' \"$NIX_CONFIG\" 'restrict-eval = false'); else NIX_CONFIG_WITH_APPEND='restrict-eval = false'; fi; NIX_CONFIG=\"$NIX_CONFIG_WITH_APPEND\" \"${DEVENV_BIN:?DEVENV_BIN not set}\" tasks run nix:check --mode before) || { echo \"::warning::Task failed, attempting Nix store repair and retry...\"; DIAG_DIR=\"${NIX_STORE_DIAGNOSTICS_DIR:-${RUNNER_TEMP:-/tmp}}\"; nix-store --verify --check-contents --repair > \"$DIAG_DIR/nix-store-verify-repair.log\" 2>&1 || true; rm -rf ~/.cache/nix/eval-cache-*; (if [ -n \"${NIX_CONFIG:-}\" ]; then NIX_CONFIG_WITH_APPEND=$(printf '%s\\n%s' \"$NIX_CONFIG\" 'restrict-eval = false'); else NIX_CONFIG_WITH_APPEND='restrict-eval = false'; fi; NIX_CONFIG=\"$NIX_CONFIG_WITH_APPEND\" \"${DEVENV_BIN:?DEVENV_BIN not set}\" tasks run nix:check --mode before); }"
       - name: Nix diagnostics summary
         if: failure()
         shell: bash
@@ -753,7 +641,7 @@ jobs:
           echo "DEVENV_REV=$DEVENV_REV" >> "$GITHUB_ENV"
           echo "Pinned devenv rev: $DEVENV_REV"
         shell: bash
-      - name: Validate Nix store
+      - name: Resolve devenv
         run: |
           if [ -z "${DEVENV_REV:-}" ]; then
             DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -767,14 +655,7 @@ jobs:
             nix build --no-link --print-out-paths "github:cachix/devenv/$DEVENV_REV#devenv"
           }
 
-          # Always append restrict-eval=false so caller-provided NIX_CONFIG keeps its settings.
-          if [ -n "${NIX_CONFIG:-}" ]; then
-            NIX_CONFIG_WITH_UNRESTRICTED_EVAL="$NIX_CONFIG"$'\n''restrict-eval = false'
-          else
-            NIX_CONFIG_WITH_UNRESTRICTED_EVAL='restrict-eval = false'
-          fi
-
-          # Temporary: capture complete diagnostics for #272 root-cause analysis.
+          # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
           mkdir -p "$DIAG_ROOT"
           echo "NIX_STORE_DIAGNOSTICS_DIR=$DIAG_ROOT" >> "$GITHUB_ENV"
@@ -786,42 +667,21 @@ jobs:
             echo "runner_arch=${RUNNER_ARCH:-unknown}"
             echo "github_job=${GITHUB_JOB:-unknown}"
             echo "github_run_id=${GITHUB_RUN_ID:-unknown}"
-            echo "github_run_attempt=${GITHUB_RUN_ATTEMPT:-unknown}"
             echo "nix_user_conf_files=${NIX_USER_CONF_FILES:-}"
-            echo ""
-            echo "== uname -a =="
-            uname -a || true
-            if command -v sw_vers > /dev/null 2>&1; then
-              echo ""
-              echo "== sw_vers =="
-              sw_vers || true
-            fi
-            echo ""
-            echo "== nix --version =="
             nix --version || true
           } > "$DIAG_ROOT/environment.txt" 2>&1
 
-          pre_resolve_log="$DIAG_ROOT/resolve-devenv-pre-repair.log"
-          pre_info_log="$DIAG_ROOT/devenv-info-pre-repair.log"
-          verify_log="$DIAG_ROOT/nix-store-verify-pre-repair.log"
-          repair_log="$DIAG_ROOT/nix-store-verify-repair.log"
-          post_resolve_log="$DIAG_ROOT/resolve-devenv-post-repair.log"
-          post_info_log="$DIAG_ROOT/devenv-info-post-repair.log"
+          DEVENV_OUT=$(resolve_devenv 2>"$DIAG_ROOT/resolve-devenv.log")
+          DEVENV_BIN="$DEVENV_OUT/bin/devenv"
 
-          if DEVENV_OUT=$(resolve_devenv 2>"$pre_resolve_log") && DEVENV_BIN="$DEVENV_OUT/bin/devenv" && NIX_CONFIG="$NIX_CONFIG_WITH_UNRESTRICTED_EVAL" "$DEVENV_BIN" info > "$pre_info_log" 2>&1; then
-            echo "Nix store OK"
-          else
-            echo "::warning::Nix store validation failed, collecting diagnostics and repairing..."
-            if ! nix-store --verify --check-contents > "$verify_log" 2>&1; then
-              echo "::warning::nix-store --verify --check-contents reported issues (see diagnostics artifact)"
-            fi
-            if ! nix-store --verify --check-contents --repair > "$repair_log" 2>&1; then
-              echo "::warning::nix-store --verify --check-contents --repair reported issues (see diagnostics artifact)"
-            fi
+          # Fast validity check on the devenv store path (~1-2s vs ~25s for devenv info).
+          # Deeper transitive-dep corruption is caught lazily at task time via retry wrapper.
+          if ! nix-store --check-validity "$DEVENV_OUT" 2>/dev/null; then
+            echo "::warning::devenv store path invalid, repairing..."
+            nix-store --verify --check-contents --repair > "$DIAG_ROOT/nix-store-verify-repair.log" 2>&1 || true
             rm -rf ~/.cache/nix/eval-cache-*
-            DEVENV_OUT=$(resolve_devenv 2>"$post_resolve_log")
+            DEVENV_OUT=$(resolve_devenv 2>"$DIAG_ROOT/resolve-devenv-post-repair.log")
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
-            NIX_CONFIG="$NIX_CONFIG_WITH_UNRESTRICTED_EVAL" "$DEVENV_BIN" info > "$post_info_log" 2>&1
           fi
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
@@ -848,9 +708,9 @@ jobs:
             exit 0
           fi
           if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '%s\n%s' "$NIX_CONFIG" 'restrict-eval = false'); else NIX_CONFIG_WITH_APPEND='restrict-eval = false'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run netlify:deploy --input type=prod --mode before
+            (if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '%s\n%s' "$NIX_CONFIG" 'restrict-eval = false'); else NIX_CONFIG_WITH_APPEND='restrict-eval = false'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run netlify:deploy --input type=prod --mode before) || { echo "::warning::Task failed, attempting Nix store repair and retry..."; DIAG_DIR="${NIX_STORE_DIAGNOSTICS_DIR:-${RUNNER_TEMP:-/tmp}}"; nix-store --verify --check-contents --repair > "$DIAG_DIR/nix-store-verify-repair.log" 2>&1 || true; rm -rf ~/.cache/nix/eval-cache-*; (if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '%s\n%s' "$NIX_CONFIG" 'restrict-eval = false'); else NIX_CONFIG_WITH_APPEND='restrict-eval = false'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run netlify:deploy --input type=prod --mode before); }
           elif [ "${{ github.event_name }}" = "pull_request" ]; then
-            if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '%s\n%s' "$NIX_CONFIG" 'restrict-eval = false'); else NIX_CONFIG_WITH_APPEND='restrict-eval = false'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run netlify:deploy --input type=pr --input pr=${{ github.event.pull_request.number }} --mode before
+            (if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '%s\n%s' "$NIX_CONFIG" 'restrict-eval = false'); else NIX_CONFIG_WITH_APPEND='restrict-eval = false'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run netlify:deploy --input type=pr --input pr=${{ github.event.pull_request.number }} --mode before) || { echo "::warning::Task failed, attempting Nix store repair and retry..."; DIAG_DIR="${NIX_STORE_DIAGNOSTICS_DIR:-${RUNNER_TEMP:-/tmp}}"; nix-store --verify --check-contents --repair > "$DIAG_DIR/nix-store-verify-repair.log" 2>&1 || true; rm -rf ~/.cache/nix/eval-cache-*; (if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '%s\n%s' "$NIX_CONFIG" 'restrict-eval = false'); else NIX_CONFIG_WITH_APPEND='restrict-eval = false'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run netlify:deploy --input type=pr --input pr=${{ github.event.pull_request.number }} --mode before); }
           fi
       - name: Post deploy URLs
         if: always() && !cancelled()

--- a/genie/ci-workflow.ts
+++ b/genie/ci-workflow.ts
@@ -73,10 +73,9 @@ const shellSingleQuote = (value: string) => `'${value.replaceAll("'", `'"'"'`)}'
 
 /** Build extra-conf / NIX_CONFIG content for common Nix feature flags. */
 export const nixExtraConf = (opts: NixConfigOptions = {}) =>
-  [
-    ...(opts.unrestrictedEval ? ['restrict-eval = false'] : []),
-    ...(opts.extraLines ?? []),
-  ].join('\n')
+  [...(opts.unrestrictedEval ? ['restrict-eval = false'] : []), ...(opts.extraLines ?? [])].join(
+    '\n',
+  )
 
 const withAppendedNixConfig = (command: string, opts: NixConfigOptions = {}) => {
   const extraConf = nixExtraConf(opts)
@@ -91,9 +90,27 @@ const withAppendedNixConfig = (command: string, opts: NixConfigOptions = {}) => 
 const runDevenvTasksBeforeWithOptions = (opts: NixConfigOptions, ...args: [string, ...string[]]) =>
   withAppendedNixConfig(`${devenvBinRef} tasks run ${args.join(' ')} --mode before`, opts)
 
+/**
+ * Shell snippet that wraps a compound command with lazy Nix store repair on failure.
+ * On first failure, runs `nix-store --verify --check-contents --repair`,
+ * clears eval cache, and retries once. Uses subshells so multi-statement
+ * commands (like withAppendedNixConfig output) are treated as a single unit.
+ *
+ * Tradeoff: genuine task failures (e.g. type errors, test failures) pay a one-time
+ * ~30-60s penalty for the unnecessary repair attempt before re-failing. This is
+ * acceptable because store corruption is the rarer failure mode and saving ~25s on
+ * every successful run across all jobs outweighs the occasional false retry.
+ *
+ * Safe to embed in if/elif branches.
+ *
+ * @see https://github.com/overengineeringstudio/effect-utils/issues/201
+ */
+const withStoreRepairRetry = (command: string) =>
+  `(${command}) || { echo "::warning::Task failed, attempting Nix store repair and retry..."; DIAG_DIR="${'${NIX_STORE_DIAGNOSTICS_DIR:-${RUNNER_TEMP:-/tmp}}'}"; nix-store --verify --check-contents --repair > "$DIAG_DIR/nix-store-verify-repair.log" 2>&1 || true; rm -rf ~/.cache/nix/eval-cache-*; (${command}); }`
+
 /** Build a command that runs one or more devenv tasks with `--mode before`. */
 export const runDevenvTasksBefore = (...args: [string, ...string[]]) =>
-  runDevenvTasksBeforeWithOptions({ unrestrictedEval: true }, ...args)
+  withStoreRepairRetry(runDevenvTasksBeforeWithOptions({ unrestrictedEval: true }, ...args))
 
 /**
  * Namespace runner with run ID-based affinity to prevent queue jumping.
@@ -193,40 +210,29 @@ nix run "github:overengineeringstudio/effect-utils/$EU_REV#megarepo" -- sync --f
 }
 
 /**
- * Validate Nix store on namespace runners.
- * Runs `${devenvBinRef} info` to evaluate the devenv expression without entering shell hooks.
- * On failure, repairs the store AND clears the Nix eval cache (which may
- * reference GC'd paths), then retries.
+ * Resolve the devenv binary and do a fast store-path validity check.
  *
- * Temporary diagnostics instrumentation for #272:
- * - Captures full verify/repair/eval logs and runner fingerprint into a temp directory.
- * - Exports `NIX_STORE_DIAGNOSTICS_DIR` for failure-only summary/artifact steps.
+ * Previously ran `devenv info` (~25s) as an eager canary to detect any store
+ * corruption before tasks run. Now uses `nix-store --check-validity` (~1-2s)
+ * which only verifies the devenv store path itself — not its full transitive
+ * closure. Corruption in deeper deps is caught lazily at task time by
+ * `withStoreRepairRetry`, which retries after repair.
  *
- * Cleanup plan:
- * - Once #201/#272 root cause is confirmed and flake rate is stable near zero,
- *   remove the diagnostics capture + upload wiring and keep only the minimal
- *   validation/repair flow for a simpler CI setup again.
+ * Still captures diagnostics dir + runner fingerprint for #272 instrumentation.
  *
  * @see https://github.com/namespacelabs/nscloud-setup/issues/8
  * @see https://github.com/overengineeringstudio/effect-utils/issues/201
  * @see https://github.com/overengineeringstudio/effect-utils/issues/272
  */
 export const validateNixStoreStep = {
-  name: 'Validate Nix store',
+  name: 'Resolve devenv',
   run: `if [ -z "${'${DEVENV_REV:-}'}" ]; then
   ${resolveDevenvRevScript}
 fi
 
 ${resolveDevenvFnScript}
 
-# Always append restrict-eval=false so caller-provided NIX_CONFIG keeps its settings.
-if [ -n "${'${NIX_CONFIG:-}'}" ]; then
-  NIX_CONFIG_WITH_UNRESTRICTED_EVAL="$NIX_CONFIG"$'\\n''restrict-eval = false'
-else
-  NIX_CONFIG_WITH_UNRESTRICTED_EVAL='restrict-eval = false'
-fi
-
-# Temporary: capture complete diagnostics for #272 root-cause analysis.
+# Temporary: capture diagnostics dir for #272 root-cause analysis.
 DIAG_ROOT="${'${RUNNER_TEMP:-/tmp}'}/nix-store-diagnostics-${'${GITHUB_JOB:-job}'}-${'${RUNNER_OS:-unknown}'}-${'${GITHUB_RUN_ATTEMPT:-0}'}"
 mkdir -p "$DIAG_ROOT"
 echo "NIX_STORE_DIAGNOSTICS_DIR=$DIAG_ROOT" >> "$GITHUB_ENV"
@@ -238,42 +244,21 @@ echo "NIX_STORE_DIAGNOSTICS_DIR=$DIAG_ROOT" >> "$GITHUB_ENV"
   echo "runner_arch=${'${RUNNER_ARCH:-unknown}'}"
   echo "github_job=${'${GITHUB_JOB:-unknown}'}"
   echo "github_run_id=${'${GITHUB_RUN_ID:-unknown}'}"
-  echo "github_run_attempt=${'${GITHUB_RUN_ATTEMPT:-unknown}'}"
   echo "nix_user_conf_files=${'${NIX_USER_CONF_FILES:-}'}"
-  echo ""
-  echo "== uname -a =="
-  uname -a || true
-  if command -v sw_vers > /dev/null 2>&1; then
-    echo ""
-    echo "== sw_vers =="
-    sw_vers || true
-  fi
-  echo ""
-  echo "== nix --version =="
   nix --version || true
 } > "$DIAG_ROOT/environment.txt" 2>&1
 
-pre_resolve_log="$DIAG_ROOT/resolve-devenv-pre-repair.log"
-pre_info_log="$DIAG_ROOT/devenv-info-pre-repair.log"
-verify_log="$DIAG_ROOT/nix-store-verify-pre-repair.log"
-repair_log="$DIAG_ROOT/nix-store-verify-repair.log"
-post_resolve_log="$DIAG_ROOT/resolve-devenv-post-repair.log"
-post_info_log="$DIAG_ROOT/devenv-info-post-repair.log"
+DEVENV_OUT=$(resolve_devenv 2>"$DIAG_ROOT/resolve-devenv.log")
+DEVENV_BIN="$DEVENV_OUT/bin/devenv"
 
-if DEVENV_OUT=$(resolve_devenv 2>"$pre_resolve_log") && DEVENV_BIN="$DEVENV_OUT/bin/devenv" && NIX_CONFIG="$NIX_CONFIG_WITH_UNRESTRICTED_EVAL" "$DEVENV_BIN" info > "$pre_info_log" 2>&1; then
-  echo "Nix store OK"
-else
-  echo "::warning::Nix store validation failed, collecting diagnostics and repairing..."
-  if ! nix-store --verify --check-contents > "$verify_log" 2>&1; then
-    echo "::warning::nix-store --verify --check-contents reported issues (see diagnostics artifact)"
-  fi
-  if ! nix-store --verify --check-contents --repair > "$repair_log" 2>&1; then
-    echo "::warning::nix-store --verify --check-contents --repair reported issues (see diagnostics artifact)"
-  fi
+# Fast validity check on the devenv store path (~1-2s vs ~25s for devenv info).
+# Deeper transitive-dep corruption is caught lazily at task time via retry wrapper.
+if ! nix-store --check-validity "$DEVENV_OUT" 2>/dev/null; then
+  echo "::warning::devenv store path invalid, repairing..."
+  nix-store --verify --check-contents --repair > "$DIAG_ROOT/nix-store-verify-repair.log" 2>&1 || true
   rm -rf ~/.cache/nix/eval-cache-*
-  DEVENV_OUT=$(resolve_devenv 2>"$post_resolve_log")
+  DEVENV_OUT=$(resolve_devenv 2>"$DIAG_ROOT/resolve-devenv-post-repair.log")
   DEVENV_BIN="$DEVENV_OUT/bin/devenv"
-  NIX_CONFIG="$NIX_CONFIG_WITH_UNRESTRICTED_EVAL" "$DEVENV_BIN" info > "$post_info_log" 2>&1
 fi
 
 echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary

Eliminates ~30s of eager nix store validation per CI job by moving from `devenv info` canary checks to lightweight `nix-store --check-validity` (~1-2s). Actual store corruption is now caught at task execution time with automatic repair+retry. Saves ~3 minutes per CI run on the happy path (~30s × 6 jobs).

Trade-off: genuine task failures (type errors, test failures) incur a one-time ~30-60s repair attempt penalty, but this is acceptable since store corruption is the rarer failure mode.

Refs: #201 #272

🤖 Generated with Claude Code