### PR TITLE
feat(genie): add Vercel deploy helpers for CI workflows

### DIFF
--- a/genie/ci-workflow.ts
+++ b/genie/ci-workflow.ts
@@ -375,6 +375,15 @@ export type VercelProject = {
   projectId: string
 }
 
+/** Configure git author so Vercel associates the deploy with a team member. */
+export const vercelGitAuthorStep = (opts: { name: string; email: string }) => ({
+  name: 'Configure git author for Vercel',
+  run: [
+    `git config user.name "${opts.name}"`,
+    `git config user.email "${opts.email}"`,
+  ].join('\n'),
+})
+
 /** Validate the Vercel token works for the given org. Fails fast before attempting a deploy. */
 export const vercelTokenValidationStep = (orgId: string) => ({
   name: 'Validate Vercel token',
@@ -403,13 +412,17 @@ export const vercelDeployStep = (project: VercelProject, orgId: string) => ({
   },
 })
 
-/** Create a complete Vercel deploy job for a project. */
-export const vercelDeployJob = (opts: {
+type VercelDeployOpts = {
   project: VercelProject
   orgId: string
   /** CI job names that must succeed before deploying */
   needs: readonly string[]
-}) => ({
+  /** Git author for Vercel team association (Vercel checks git author email) */
+  gitAuthor: { name: string; email: string }
+}
+
+/** Create a complete Vercel deploy job for a project. */
+export const vercelDeployJob = (opts: VercelDeployOpts) => ({
   needs: [...opts.needs],
   if: [
     'always()',
@@ -418,6 +431,7 @@ export const vercelDeployJob = (opts: {
   'runs-on': 'ubuntu-latest',
   steps: [
     checkoutStep(),
+    vercelGitAuthorStep(opts.gitAuthor),
     vercelTokenValidationStep(opts.orgId),
     vercelDeployStep(opts.project, opts.orgId),
   ],
@@ -428,9 +442,10 @@ export const vercelDeployJobs = (opts: {
   projects: readonly VercelProject[]
   orgId: string
   needs: readonly string[]
+  gitAuthor: { name: string; email: string }
 }) =>
   Object.fromEntries(
-    opts.projects.map((p) => [p.key, vercelDeployJob({ project: p, orgId: opts.orgId, needs: opts.needs })]),
+    opts.projects.map((p) => [p.key, vercelDeployJob({ ...opts, project: p })]),
   )
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- Add composable Vercel deploy step atoms to `genie/ci-workflow.ts`, following the same pattern as the existing Netlify helpers
- `vercelTokenValidationStep` — validates token before deploy (fail-fast)
- `vercelDeployStep` — prod on main/schedule/dispatch, preview on PRs
- `vercelDeployJob` / `vercelDeployJobs` — complete job factory with checkout + validation + deploy

## Context

This complements the existing `vercel.nix` devenv task module (which handles local prebuilt deploys via `vercel build` + `deploy --prebuilt`) with a simpler CI-focused approach where Vercel does the build remotely. The two approaches serve different use cases:

- **`vercel.nix`**: Full control, local build, requires Nix runner
- **CI genie helpers**: Simple remote build on `ubuntu-latest`, less setup

Intended consumers: schickling-stiftung (3 Vercel projects), schickling.dev (2 Vercel projects).

## Test plan

- [ ] Verify helpers are used successfully in schickling-stiftung PR #58
- [ ] Verify types are correct (no TS errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Note: PR created on behalf of @schickling_