### PR TITLE
feat: CLI guard wrappers for devenv task enforcement

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -136,6 +136,9 @@
         };
       };
 
+      # CLI guard helpers: .mkCliGuard for single guards, .fromTasks/.stripGuards for task-driven guards
+      lib.cliGuard = { pkgs }: import ./nix/devenv-modules/tasks/lib/cli-guard.nix { inherit pkgs; };
+
       # Builder function for external repos to create their own Bun CLIs
       lib.mkBunCli = { pkgs }: import ./nix/workspace-tools/lib/mk-bun-cli.nix { inherit pkgs; };
 

--- a/nix/devenv-modules/dt.nix
+++ b/nix/devenv-modules/dt.nix
@@ -16,6 +16,10 @@
 # TODO: Remove once devenv supports defaultMode for tasks (https://github.com/cachix/devenv/issues/2417)
 { pkgs, ... }:
 {
+  # cli-guard passthrough: DT_PASSTHROUGH=1 lets task exec scripts call
+  # guarded CLIs. enterShell unsets it so interactive shell usage hits guards.
+  env.DT_PASSTHROUGH = "1";
+
   # Wrapper that runs tasks with --mode before so dependencies run automatically.
   # When OTEL is configured (otel-span on PATH + OTEL_EXPORTER_OTLP_ENDPOINT set),
   # wraps execution in an OTLP trace span for observability.
@@ -49,14 +53,16 @@
       # Clear TRACEPARENT to avoid inheriting stale context from devenv shell
       # re-evaluations. otel-span reads OTEL_TASK_TRACEPARENT instead (which
       # survives re-evaluations) and exports both for child processes.
-      if ! TRACEPARENT="" otel-span run "dt" "$task_name" --log-url $_eval_attr --attr "dt.args=$*" \
+      # DT_PASSTHROUGH=1 bypasses cli-guard wrappers so tasks can call real binaries
+      if ! TRACEPARENT="" DT_PASSTHROUGH=1 otel-span run "dt" "$task_name" --log-url $_eval_attr --attr "dt.args=$*" \
         -- devenv tasks run "$@" --mode before $_dt_extra_args; then
         echo "dt: task failed. Re-run with: devenv tasks run $* --mode before" >&2
         exit 1
       fi
     else
       # No OTEL: run directly
-      if ! devenv tasks run "$@" --mode before $_dt_extra_args; then
+      # DT_PASSTHROUGH=1 bypasses cli-guard wrappers so tasks can call real binaries
+      if ! DT_PASSTHROUGH=1 devenv tasks run "$@" --mode before $_dt_extra_args; then
         echo "dt: task failed. Re-run with: devenv tasks run $* --mode before" >&2
         exit 1
       fi
@@ -67,6 +73,11 @@
 
   # Shell completions for bash/zsh with descriptions
   enterShell = ''
+    # Activate cli-guard wrappers for interactive shell usage.
+    # DT_PASSTHROUGH=1 was set via env (for task execution); unset it now
+    # so that direct CLI calls (e.g. `pnpm install`) show the guard message.
+    unset DT_PASSTHROUGH
+
     : "''${ZSH_VERSION:=}"
     # Shell completions for `dt` command (cached for performance)
     # Uses task config JSON for names and descriptions

--- a/nix/devenv-modules/tasks/lib/cli-guard.nix
+++ b/nix/devenv-modules/tasks/lib/cli-guard.nix
@@ -1,0 +1,119 @@
+# CLI guard wrapper builder
+#
+# Creates shell scripts that intercept direct CLI invocations and
+# print the canonical devenv task(s) instead. The real binary is
+# reachable via DT_PASSTHROUGH=1 (set automatically by devenv env,
+# dt wrapper, and CI).
+#
+# How passthrough works:
+#   - devenv sets env.DT_PASSTHROUGH=1 (active during task execution)
+#   - enterShell unsets it (so interactive shell usage hits guards)
+#   - dt wrapper re-sets it before calling devenv tasks run
+#   - CI helper (runDevenvTasksBefore) sets it
+#
+# Usage in task modules (Option A — derive guards from task defs):
+#
+#   let cliGuard = import ../lib/cli-guard.nix { inherit pkgs; };
+#   in {
+#     packages = cliGuard.fromTasks tasks;
+#     tasks = cliGuard.stripGuards tasks;
+#   }
+#
+#   where tasks have a `guard = "cli-name"` attribute on guarded entries.
+#
+# Low-level API (for cases where tasks aren't a plain attrset):
+#
+#   packages = [
+#     (cliGuard.mkCliGuard {
+#       cli = "oxlint";
+#       tasks = [
+#         { task = "lint:check:oxlint"; description = "Check lint"; }
+#       ];
+#     })
+#   ];
+{ pkgs }:
+let
+  # Build a single guard wrapper script for one CLI
+  mkCliGuard = { cli, tasks }:
+    let
+      taskLines = builtins.concatStringsSep "\n" (
+        map (t:
+          let desc = if t ? description && t.description != null
+            then "# ${t.description}\\n"
+            else "";
+          in ''printf "  ${desc}  devenv tasks run ${t.task} --mode before --no-tui\n\n" >&2'')
+        tasks
+      );
+    in
+    pkgs.writeShellScriptBin cli ''
+      set -euo pipefail
+
+      if [ "''${DT_PASSTHROUGH:-}" = "1" ]; then
+        _self="$(cd "''${0%/*}" && pwd -P)"
+        _real=""
+        IFS=: read -ra _dirs <<< "$PATH"
+        for _d in "''${_dirs[@]}"; do
+          [ -z "$_d" ] && continue
+          _resolved="$(cd "$_d" 2>/dev/null && pwd -P)" || continue
+          [ "$_resolved" = "$_self" ] && continue
+          if [ -x "$_d/${cli}" ]; then
+            _real="$_d/${cli}"
+            break
+          fi
+        done
+        if [ -z "$_real" ]; then
+          echo "cli-guard: '${cli}' not found on PATH (after removing guard)" >&2
+          exit 127
+        fi
+        exec "$_real" "$@"
+      fi
+
+      echo "" >&2
+      echo "Instead of running '${cli}' directly, use the devenv task(s):" >&2
+      echo "" >&2
+      ${taskLines}
+      echo "Run 'devenv tasks list' to see all available tasks." >&2
+      echo "" >&2
+      echo "Bypass (not recommended):" >&2
+      echo "  DT_PASSTHROUGH=1 ${cli} $*" >&2
+      echo "" >&2
+      exit 1
+    '';
+
+  # Extract guard packages from a tasks attrset.
+  # Tasks with a `guard = "cli-name"` attribute are grouped by CLI name
+  # and a guard wrapper is generated for each group.
+  fromTasks = tasks:
+    let
+      # Collect { cli, task, description } from tasks that have a guard attr
+      guardEntries = builtins.filter (e: e != null) (
+        builtins.attrValues (builtins.mapAttrs (name: def:
+          if def ? guard then {
+            cli = def.guard;
+            task = name;
+            description = def.description or null;
+          } else null
+        ) tasks)
+      );
+
+      # Group by CLI name
+      cliNames = builtins.attrNames (builtins.groupBy (e: e.cli) guardEntries);
+
+      mkGuardForCli = cli:
+        let
+          entries = builtins.filter (e: e.cli == cli) guardEntries;
+        in
+        mkCliGuard {
+          inherit cli;
+          tasks = map (e: { inherit (e) task description; }) entries;
+        };
+    in
+    map mkGuardForCli cliNames;
+
+  # Strip the `guard` attribute from all tasks in an attrset.
+  # Use this before passing tasks to devenv (which doesn't know about `guard`).
+  stripGuards = builtins.mapAttrs (_: def: builtins.removeAttrs def [ "guard" ]);
+
+in {
+  inherit mkCliGuard fromTasks stripGuards;
+}

--- a/nix/devenv-modules/tasks/shared/genie.nix
+++ b/nix/devenv-modules/tasks/shared/genie.nix
@@ -11,13 +11,14 @@
 #   tasks."genie:run".after = [ "pnpm:install:genie" ];
 #   tasks."genie:watch".after = [ "pnpm:install:genie" ];
 #   tasks."genie:check".after = [ "pnpm:install:genie" ];
-{ lib, ... }:
+{ lib, pkgs, ... }:
 let
   trace = import ../lib/trace.nix { inherit lib; };
-in
-{
+  cliGuard = import ../lib/cli-guard.nix { inherit pkgs; };
+
   tasks = {
     "genie:run" = {
+      guard = "genie";
       description = "Generate config files from .genie.ts sources";
       exec = trace.exec "genie:run" "genie";
       status = trace.status "genie:run" "binary" ''
@@ -28,12 +29,18 @@ in
       '';
     };
     "genie:watch" = {
+      guard = "genie";
       description = "Watch and regenerate config files";
       exec = "genie --watch";
     };
     "genie:check" = {
+      guard = "genie";
       description = "Check if generated files are up to date (CI)";
       exec = trace.exec "genie:check" "genie --check";
     };
   };
+in
+{
+  packages = cliGuard.fromTasks tasks;
+  tasks = cliGuard.stripGuards tasks;
 }

--- a/nix/devenv-modules/tasks/shared/lint-oxc.nix
+++ b/nix/devenv-modules/tasks/shared/lint-oxc.nix
@@ -55,6 +55,7 @@
 { lib, pkgs, ... }:
 let
   trace = import ../lib/trace.nix { inherit lib; };
+  cliGuard = import ../lib/cli-guard.nix { inherit pkgs; };
   git = "${pkgs.git}/bin/git";
   scanDirsArg = builtins.concatStringsSep " " genieCoverageDirs;
   # Git pathspec exclusion patterns applied to coverage check (e.g. "packages/vendored/")
@@ -83,26 +84,35 @@ let
       flags = "${warningsFlag} ${extraFlags}";
     in
     "oxlint --import-plugin ${flags} ${typeAwareFlags} ${lintPathsArg}";
-in
-{
-  # Provide tsgolint when type-aware linting is enabled
-  packages = lib.optionals (tsconfig != null) [ pkgs.tsgolint ];
 
-  tasks = {
-    # Lint check tasks
-    # Uses default config files (.oxfmtrc.json, .oxlintrc.json) - no -c flags needed
+  guardedTasks = {
     "lint:check:format" = {
+      guard = "oxfmt";
       description = "Check code formatting with oxfmt";
       exec = trace.exec "lint:check:format" "oxfmt --check ${lintPathsArg}";
       execIfModified = execIfModifiedPatterns;
     };
     "lint:check:oxlint" = {
+      guard = "oxlint";
       description = "Run oxlint linter";
       exec = trace.exec "lint:check:oxlint" (mkOxlintCmd "");
       execIfModified = execIfModifiedPatterns;
     } // lib.optionalAttrs (tsconfig != null) {
       after = [ "pnpm:install" ];
     };
+    "lint:fix:format" = {
+      guard = "oxfmt";
+      description = "Fix code formatting with oxfmt";
+      exec = trace.exec "lint:fix:format" "oxfmt ${lintPathsArg}";
+    };
+    "lint:fix:oxlint" = {
+      guard = "oxlint";
+      description = "Fix lint issues with oxlint";
+      exec = trace.exec "lint:fix:oxlint" (mkOxlintCmd "--fix");
+    };
+  };
+
+  otherTasks = {
     "lint:check:genie" = {
       description = "Check generated files are up to date";
       exec = trace.exec "lint:check:genie" "genie --check";
@@ -154,16 +164,6 @@ in
         "lint:check:genie:coverage"
       ];
     };
-
-    # Lint fix tasks
-    "lint:fix:format" = {
-      description = "Fix code formatting with oxfmt";
-      exec = trace.exec "lint:fix:format" "oxfmt ${lintPathsArg}";
-    };
-    "lint:fix:oxlint" = {
-      description = "Fix lint issues with oxlint";
-      exec = trace.exec "lint:fix:oxlint" (mkOxlintCmd "--fix");
-    };
     "lint:fix" = {
       description = "Fix all lint issues";
       after = [
@@ -172,4 +172,11 @@ in
       ];
     };
   };
+in
+{
+  # Provide tsgolint when type-aware linting is enabled
+  packages = lib.optionals (tsconfig != null) [ pkgs.tsgolint ]
+    ++ cliGuard.fromTasks guardedTasks;
+
+  tasks = (cliGuard.stripGuards guardedTasks) // otherTasks;
 }

--- a/nix/devenv-modules/tasks/shared/megarepo.nix
+++ b/nix/devenv-modules/tasks/shared/megarepo.nix
@@ -23,122 +23,132 @@
 { lib, pkgs, ... }:
 let
   trace = import ../lib/trace.nix { inherit lib; };
+  cliGuard = import ../lib/cli-guard.nix { inherit pkgs; };
+
+  tasks = {
+    "megarepo:sync" = {
+      guard = "mr";
+      description = "Fetch latest refs and apply to workspace";
+      exec = trace.exec "megarepo:sync" ''
+        if [ ! -f ./megarepo.json ]; then
+          exit 0
+        fi
+
+        mr fetch --apply${if syncAll then " --all" else ""}
+      '';
+      # Status: use `mr status --output json` to detect if workspace reconciliation is needed.
+      status = trace.status "megarepo:sync" "binary" ''
+        if [ ! -f ./megarepo.json ]; then
+          exit 0
+        fi
+
+        # Fast check: if repos/ doesn't exist, definitely need sync
+        if [ ! -d ./repos ]; then
+          exit 1
+        fi
+
+        # Use mr status to check the workspace-specific boolean
+        status_json=$(nix run "git+file:$PWD#megarepo" -- status --output json 2>/dev/null) || exit 1
+
+        echo "$status_json" | ${pkgs.jq}/bin/jq -e '(.workspaceSyncNeeded // false) == false' >/dev/null 2>&1
+      '';
+    };
+
+    "megarepo:lock" = {
+      guard = "mr";
+      description = "Record current workspace state into megarepo.lock";
+      exec = trace.exec "megarepo:lock" ''
+        if [ ! -f ./megarepo.json ]; then
+          exit 0
+        fi
+
+        mr lock${if syncAll then " --all" else ""}
+      '';
+    };
+
+    "megarepo:fetch-apply" = {
+      description = "Fetch latest refs and apply to workspace";
+      exec = trace.exec "megarepo:fetch-apply" ''
+        if [ ! -f ./megarepo.json ]; then
+          exit 0
+        fi
+
+        mr fetch --apply${if syncAll then " --all" else ""}
+      '';
+    };
+
+    "megarepo:apply" = {
+      guard = "mr";
+      description = "Apply megarepo.lock to workspace";
+      exec = trace.exec "megarepo:apply" ''
+        if [ ! -f ./megarepo.json ]; then
+          exit 0
+        fi
+
+        mr apply${if syncAll then " --all" else ""}
+      '';
+    };
+
+    "megarepo:check" = {
+      guard = "mr";
+      description = "Verify megarepo setup is complete";
+      after = [ "megarepo:sync" ];
+      # Check that repos dir exists and all members have symlinks
+      status = trace.status "megarepo:check" "path" ''
+        if [ ! -f ./megarepo.json ]; then
+          exit 0
+        fi
+
+        # Check that repos directory exists
+        if [ ! -d ./repos ]; then
+          exit 1
+        fi
+
+        # Verify all configured members have symlinks in repos/
+        members=$(${pkgs.jq}/bin/jq -r '.members | keys[]' ./megarepo.json 2>/dev/null) || exit 1
+        for member in $members; do
+          if [ ! -L "./repos/$member" ] && [ ! -d "./repos/$member" ]; then
+            exit 1
+          fi
+        done
+
+        exit 0
+      '';
+      exec = trace.exec "megarepo:check" ''
+        if [ ! -f ./megarepo.json ]; then
+          exit 0
+        fi
+
+        if [ ! -d ./repos ]; then
+          echo "[devenv] Missing repos/ directory." >&2
+          echo "[devenv] Fix: devenv tasks run megarepo:sync" >&2
+          exit 1
+        fi
+
+        # Check for missing member symlinks
+        missing=""
+        members=$(${pkgs.jq}/bin/jq -r '.members | keys[]' ./megarepo.json 2>/dev/null) || exit 1
+        for member in $members; do
+          if [ ! -L "./repos/$member" ] && [ ! -d "./repos/$member" ]; then
+            missing="$missing $member"
+          fi
+        done
+
+        if [ -n "$missing" ]; then
+          echo "[devenv] Missing member symlinks:$missing" >&2
+          echo "[devenv] Fix: devenv tasks run megarepo:sync" >&2
+          exit 1
+        fi
+      '';
+    };
+  };
 in
 {
   # mr shells out to git for clone/fetch/worktree operations
   packages = [
     pkgs.git
     pkgs.openssh
-  ];
-  tasks."megarepo:sync" = {
-    description = "Fetch latest refs and apply to workspace";
-    exec = trace.exec "megarepo:sync" ''
-      if [ ! -f ./megarepo.json ]; then
-        exit 0
-      fi
+  ] ++ cliGuard.fromTasks tasks;
 
-      mr fetch --apply${if syncAll then " --all" else ""}
-    '';
-    # Status: use `mr status --output json` to detect if workspace reconciliation is needed.
-    status = trace.status "megarepo:sync" "binary" ''
-      if [ ! -f ./megarepo.json ]; then
-        exit 0
-      fi
-
-      # Fast check: if repos/ doesn't exist, definitely need sync
-      if [ ! -d ./repos ]; then
-        exit 1
-      fi
-
-      # Use mr status to check the workspace-specific boolean
-      status_json=$(nix run "git+file:$PWD#megarepo" -- status --output json 2>/dev/null) || exit 1
-
-      echo "$status_json" | ${pkgs.jq}/bin/jq -e '(.workspaceSyncNeeded // false) == false' >/dev/null 2>&1
-    '';
-  };
-
-  tasks."megarepo:lock" = {
-    description = "Record current workspace state into megarepo.lock";
-    exec = trace.exec "megarepo:lock" ''
-      if [ ! -f ./megarepo.json ]; then
-        exit 0
-      fi
-
-      mr lock${if syncAll then " --all" else ""}
-    '';
-  };
-
-  tasks."megarepo:fetch-apply" = {
-    description = "Fetch latest refs and apply to workspace";
-    exec = trace.exec "megarepo:fetch-apply" ''
-      if [ ! -f ./megarepo.json ]; then
-        exit 0
-      fi
-
-      mr fetch --apply${if syncAll then " --all" else ""}
-    '';
-  };
-
-  tasks."megarepo:apply" = {
-    description = "Apply megarepo.lock to workspace";
-    exec = trace.exec "megarepo:apply" ''
-      if [ ! -f ./megarepo.json ]; then
-        exit 0
-      fi
-
-      mr apply${if syncAll then " --all" else ""}
-    '';
-  };
-
-  tasks."megarepo:check" = {
-    description = "Verify megarepo setup is complete";
-    after = [ "megarepo:sync" ];
-    # Check that repos dir exists and all members have symlinks
-    status = trace.status "megarepo:check" "path" ''
-      if [ ! -f ./megarepo.json ]; then
-        exit 0
-      fi
-
-      # Check that repos directory exists
-      if [ ! -d ./repos ]; then
-        exit 1
-      fi
-
-      # Verify all configured members have symlinks in repos/
-      members=$(${pkgs.jq}/bin/jq -r '.members | keys[]' ./megarepo.json 2>/dev/null) || exit 1
-      for member in $members; do
-        if [ ! -L "./repos/$member" ] && [ ! -d "./repos/$member" ]; then
-          exit 1
-        fi
-      done
-
-      exit 0
-    '';
-    exec = trace.exec "megarepo:check" ''
-      if [ ! -f ./megarepo.json ]; then
-        exit 0
-      fi
-
-      if [ ! -d ./repos ]; then
-        echo "[devenv] Missing repos/ directory." >&2
-        echo "[devenv] Fix: devenv tasks run megarepo:sync" >&2
-        exit 1
-      fi
-
-      # Check for missing member symlinks
-      missing=""
-      members=$(${pkgs.jq}/bin/jq -r '.members | keys[]' ./megarepo.json 2>/dev/null) || exit 1
-      for member in $members; do
-        if [ ! -L "./repos/$member" ] && [ ! -d "./repos/$member" ]; then
-          missing="$missing $member"
-        fi
-      done
-
-      if [ -n "$missing" ]; then
-        echo "[devenv] Missing member symlinks:$missing" >&2
-        echo "[devenv] Fix: devenv tasks run megarepo:sync" >&2
-        exit 1
-      fi
-    '';
-  };
+  tasks = cliGuard.stripGuards tasks;
 }

--- a/nix/devenv-modules/tasks/shared/pnpm.nix
+++ b/nix/devenv-modules/tasks/shared/pnpm.nix
@@ -26,6 +26,7 @@
 }:
 let
   trace = import ../lib/trace.nix { inherit lib; };
+  cliGuard = import ../lib/cli-guard.nix { inherit pkgs; };
   cache = import ../lib/cache.nix { inherit config; };
   cacheRoot = cache.mkCachePath "pnpm-install";
 
@@ -130,15 +131,9 @@ let
     }
   '';
 
-in
-{
-  enterShell = lib.mkIf globalCache ''
-    export npm_config_cache="$HOME/.cache/pnpm"
-    export npm_config_manage_package_manager_versions=false
-  '';
-
-  tasks = {
+  allTasks = {
     "pnpm:install" = {
+      guard = "pnpm";
       description = "Install the repo-root pnpm workspace from the authoritative root lockfile";
       after = installAfter;
       exec = trace.exec "pnpm:install" ''
@@ -191,6 +186,7 @@ in
     };
 
     "pnpm:update" = {
+      guard = "pnpm";
       description = "Update the authoritative repo-root pnpm lockfile";
       after = [ "genie:run" ] ++ updateAfter;
       exec = trace.exec "pnpm:update" ''
@@ -202,6 +198,7 @@ in
     };
 
     "pnpm:clean" = {
+      guard = "pnpm";
       description = "Remove repo-root and package-level node_modules";
       after = cleanAfter;
       exec = trace.exec "pnpm:clean" ''
@@ -217,4 +214,15 @@ in
       '';
     };
   };
+
+in
+{
+  packages = cliGuard.fromTasks allTasks;
+
+  enterShell = lib.mkIf globalCache ''
+    export npm_config_cache="$HOME/.cache/pnpm"
+    export npm_config_manage_package_manager_versions=false
+  '';
+
+  tasks = cliGuard.stripGuards allTasks;
 }

--- a/nix/devenv-modules/tasks/shared/test-playwright.nix
+++ b/nix/devenv-modules/tasks/shared/test-playwright.nix
@@ -21,9 +21,11 @@
   installTask ? "pnpm:install",
   playwrightBin ? "playwright",
 }:
-{ lib, ... }:
+{ lib, pkgs, ... }:
 let
   trace = import ../lib/trace.nix { inherit lib; };
+  cliGuard = import ../lib/cli-guard.nix { inherit pkgs; };
+
   mkTestTask = pkg: {
     "test:pw:${pkg.name}" = {
       description = "Run playwright tests for ${pkg.name}";
@@ -33,14 +35,19 @@ let
     };
   };
 
+  guardedTasks = {
+    "test:pw:run" = {
+      guard = playwrightBin;
+      description = "Run all playwright e2e tests";
+      after = map (pkg: "test:pw:${pkg.name}") packages;
+    };
+  };
+
 in {
+  packages = cliGuard.fromTasks guardedTasks;
+
   tasks = lib.mkMerge (
     map mkTestTask packages
-    ++ [{
-      "test:pw:run" = {
-        description = "Run all playwright e2e tests";
-        after = map (pkg: "test:pw:${pkg.name}") packages;
-      };
-    }]
+    ++ [ (cliGuard.stripGuards guardedTasks) ]
   );
 }

--- a/nix/devenv-modules/tasks/shared/test.nix
+++ b/nix/devenv-modules/tasks/shared/test.nix
@@ -32,9 +32,10 @@
   installTask ? "pnpm:install",
   extraTests ? [],
 }:
-{ lib, ... }:
+{ lib, pkgs, ... }:
 let
   trace = import ../lib/trace.nix { inherit lib; };
+  cliGuard = import ../lib/cli-guard.nix { inherit pkgs; };
   hasPackages = packages != [];
 
   # Per-package test task using the workspace-aware vitest entrypoint.
@@ -58,23 +59,28 @@ let
     };
   };
 
+  guardedTasks = {
+    "test:run" = {
+      guard = "vitest";
+      description = "Run all tests";
+      exec = if hasPackages then null else "pnpm exec vitest run";
+      after = if hasPackages
+        then map (pkg: "test:${pkg.name}") packages ++ extraTests
+        else [ "genie:run" ];
+    };
+    "test:watch" = {
+      guard = "vitest";
+      description = "Run tests in watch mode";
+      exec = "pnpm exec vitest";
+      after = [ "genie:run" ];
+    };
+  };
+
 in {
+  packages = cliGuard.fromTasks guardedTasks;
+
   tasks = lib.mkMerge (
     (if hasPackages then map mkTestTask packages else [])
-    ++ [{
-      "test:run" = {
-        description = "Run all tests";
-        exec = if hasPackages then null else "pnpm exec vitest run";
-        after = if hasPackages
-          then map (pkg: "test:${pkg.name}") packages ++ extraTests
-          else [ "genie:run" ];
-      };
-
-      "test:watch" = {
-        description = "Run tests in watch mode";
-        exec = "pnpm exec vitest";
-        after = [ "genie:run" ];
-      };
-    }]
+    ++ [ (cliGuard.stripGuards guardedTasks) ]
   );
 }

--- a/nix/devenv-modules/tasks/shared/ts.nix
+++ b/nix/devenv-modules/tasks/shared/ts.nix
@@ -37,6 +37,7 @@
 { lib, pkgs, ... }:
 let
   trace = import ../lib/trace.nix { inherit lib; };
+  cliGuard = import ../lib/cli-guard.nix { inherit pkgs; };
 
   # Script that runs tsc with --extendedDiagnostics --verbose,
   # parses per-project timing, and emits OTEL child spans.
@@ -158,34 +159,27 @@ let
       ${tscBin} ${tscInvocation} ${extraArgs}
     fi
   '';
-in
-{
-  packages = [ pkgs.bc ];
 
-  tasks = {
+  guardedTasks = {
     "ts:check" = {
+      guard = tscBin;
       description = "Type check the whole workspace (tsc --build)";
       exec = trace.exec "ts:check" (tscWithDiagnostics "--build ${tsconfigFile}" "");
-      after = [
-        "genie:run"
-        "pnpm:install"
-      ];
+      after = [ "genie:run" "pnpm:install" ];
     };
+    "ts:build" = {
+      guard = tscBin;
+      description = "Build all packages with type checking (tsc --build)";
+      exec = trace.exec "ts:build" (tscWithDiagnostics "--build ${tsconfigFile}" "");
+      after = [ "genie:run" "pnpm:install" ];
+    };
+  };
+
+  otherTasks = {
     "ts:build-watch" = {
       description = "Build all packages in watch mode (tsc --build --watch)";
       exec = "${tscBin} --build --watch ${tsconfigFile}";
-      after = [
-        "genie:run"
-        "pnpm:install"
-      ];
-    };
-    "ts:build" = {
-      description = "Build all packages with type checking (tsc --build)";
-      exec = trace.exec "ts:build" (tscWithDiagnostics "--build ${tsconfigFile}" "");
-      after = [
-        "genie:run"
-        "pnpm:install"
-      ];
+      after = [ "genie:run" "pnpm:install" ];
     };
     "ts:emit" = trace.withStatus "ts:emit" "binary" {
       description = "Emit build outputs without full type checking (tsc --build --noCheck)";
@@ -201,14 +195,18 @@ in
         echo "$_out" | grep -q "A non-dry build would" && exit 1
         exit 0
       '';
-      after = [
-        "genie:run"
-        "pnpm:install"
-      ];
+      after = [ "genie:run" "pnpm:install" ];
     };
     "ts:clean" = {
       description = "Remove TypeScript build artifacts";
       exec = trace.exec "ts:clean" "tsc --build --clean ${tsconfigFile}";
     };
   };
+in
+{
+  packages = [
+    pkgs.bc
+  ] ++ cliGuard.fromTasks guardedTasks;
+
+  tasks = (cliGuard.stripGuards guardedTasks) // otherTasks;
 }


### PR DESCRIPTION
## Summary

- Add CLI guard wrappers that intercept direct tool invocations (`tsc`, `oxlint`, `oxfmt`, `pnpm`, `genie`, `vitest`, `mr`, `playwright`) and show the canonical devenv task(s) instead
- Guards are derived from task definitions via `guard = "cli-name"` attr on task defs — no duplication between guard and task metadata
- `DT_PASSTHROUGH=1` env var mechanism ensures tasks, `dt` wrapper, and CI can still call real binaries

## Design

```
Interactive shell → CLI blocked, shows devenv tasks
Task execution   → DT_PASSTHROUGH=1 (set via env), CLI passes through to real binary
dt wrapper       → Re-sets DT_PASSTHROUGH=1 before calling devenv tasks run
CI               → runDevenvTasksBefore() already sets DT_PASSTHROUGH=1
```

### New files

- `nix/devenv-modules/tasks/lib/cli-guard.nix` — Core helper exposing `mkCliGuard`, `fromTasks`, `stripGuards`

### Modified files

- `dt.nix` — `env.DT_PASSTHROUGH = "1"` for task execution, `unset` in `enterShell`
- `flake.nix` — Export `lib.cliGuard` for external repos
- 7 shared task modules — Added `guard` attr to task defs, use `fromTasks`/`stripGuards`

## Rationale

Developers running `pnpm install`, `tsc`, `oxlint` etc. directly bypass the devenv task dependency graph (genie codegen, install caching, OTEL tracing). Guards enforce the canonical workflow while remaining transparent to task execution and CI.

## Test plan

- [x] Guard blocks direct CLI invocation with helpful task suggestions
- [x] Passthrough works with `DT_PASSTHROUGH=1` (full PATH, restricted PATH, missing binary)
- [x] All modules evaluate correctly (`nix-instantiate --eval --strict`)
- [x] Multi-CLI modules (lint-oxc: oxlint + oxfmt) produce separate guards
- [x] `stripGuards` removes `guard` attr from task defs
- [ ] CI workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)