### PR TITLE
feat: add preserveSymlinks to baseTsconfigCompilerOptions

### DIFF
--- a/context/effect/socket/tsconfig.json
+++ b/context/effect/socket/tsconfig.json
@@ -2,6 +2,7 @@
 // Source: tsconfig.json.genie.ts
 {
   "compilerOptions": {
+    "preserveSymlinks": true,
     "target": "ES2024",
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "NodeNext",

--- a/context/opentui/tsconfig.json
+++ b/context/opentui/tsconfig.json
@@ -2,6 +2,7 @@
 // Source: tsconfig.json.genie.ts
 {
   "compilerOptions": {
+    "preserveSymlinks": true,
     "target": "ES2024",
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "ESNext",

--- a/genie/external.ts
+++ b/genie/external.ts
@@ -458,6 +458,9 @@ export const createPatchPostinstall = (args: { basePath: string }) => {
 
 /** Base tsconfig compiler options shared across all packages */
 export const baseTsconfigCompilerOptions = {
+  /** Megarepo topology: repos/* are symlinks to the megarepo store. Without this,
+   * tsc follows the symlink to the real store path where no node_modules exists. */
+  preserveSymlinks: true,
   target: 'ES2024',
   lib: ['ES2024'],
   module: 'NodeNext',

--- a/packages/@overeng/effect-ai-claude-cli/tsconfig.json
+++ b/packages/@overeng/effect-ai-claude-cli/tsconfig.json
@@ -2,6 +2,7 @@
 // Source: tsconfig.json.genie.ts
 {
   "compilerOptions": {
+    "preserveSymlinks": true,
     "target": "ES2024",
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "NodeNext",

--- a/packages/@overeng/effect-path/tsconfig.json
+++ b/packages/@overeng/effect-path/tsconfig.json
@@ -2,6 +2,7 @@
 // Source: tsconfig.json.genie.ts
 {
   "compilerOptions": {
+    "preserveSymlinks": true,
     "target": "ES2024",
     "lib": ["ES2023"],
     "module": "NodeNext",

--- a/packages/@overeng/effect-react/tsconfig.json
+++ b/packages/@overeng/effect-react/tsconfig.json
@@ -2,6 +2,7 @@
 // Source: tsconfig.json.genie.ts
 {
   "compilerOptions": {
+    "preserveSymlinks": true,
     "target": "ES2024",
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "NodeNext",

--- a/packages/@overeng/effect-rpc-tanstack/tsconfig.json
+++ b/packages/@overeng/effect-rpc-tanstack/tsconfig.json
@@ -2,6 +2,7 @@
 // Source: tsconfig.json.genie.ts
 {
   "compilerOptions": {
+    "preserveSymlinks": true,
     "target": "ES2024",
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "NodeNext",

--- a/packages/@overeng/effect-schema-form-aria/tsconfig.json
+++ b/packages/@overeng/effect-schema-form-aria/tsconfig.json
@@ -2,6 +2,7 @@
 // Source: tsconfig.json.genie.ts
 {
   "compilerOptions": {
+    "preserveSymlinks": true,
     "target": "ES2024",
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "NodeNext",

--- a/packages/@overeng/effect-schema-form/tsconfig.json
+++ b/packages/@overeng/effect-schema-form/tsconfig.json
@@ -2,6 +2,7 @@
 // Source: tsconfig.json.genie.ts
 {
   "compilerOptions": {
+    "preserveSymlinks": true,
     "target": "ES2024",
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "NodeNext",

--- a/packages/@overeng/genie/tsconfig.json
+++ b/packages/@overeng/genie/tsconfig.json
@@ -2,6 +2,7 @@
 // Source: tsconfig.json.genie.ts
 {
   "compilerOptions": {
+    "preserveSymlinks": true,
     "target": "ES2024",
     "lib": ["ES2024"],
     "module": "NodeNext",

--- a/packages/@overeng/megarepo/tsconfig.json
+++ b/packages/@overeng/megarepo/tsconfig.json
@@ -2,6 +2,7 @@
 // Source: tsconfig.json.genie.ts
 {
   "compilerOptions": {
+    "preserveSymlinks": true,
     "target": "ES2024",
     "lib": ["ES2024"],
     "module": "NodeNext",

--- a/packages/@overeng/notion-cli/tsconfig.json
+++ b/packages/@overeng/notion-cli/tsconfig.json
@@ -2,6 +2,7 @@
 // Source: tsconfig.json.genie.ts
 {
   "compilerOptions": {
+    "preserveSymlinks": true,
     "target": "ES2024",
     "lib": ["ES2024"],
     "module": "NodeNext",

--- a/packages/@overeng/notion-effect-client/tsconfig.json
+++ b/packages/@overeng/notion-effect-client/tsconfig.json
@@ -2,6 +2,7 @@
 // Source: tsconfig.json.genie.ts
 {
   "compilerOptions": {
+    "preserveSymlinks": true,
     "target": "ES2024",
     "lib": ["ES2024"],
     "module": "NodeNext",

--- a/packages/@overeng/notion-effect-schema/tsconfig.json
+++ b/packages/@overeng/notion-effect-schema/tsconfig.json
@@ -2,6 +2,7 @@
 // Source: tsconfig.json.genie.ts
 {
   "compilerOptions": {
+    "preserveSymlinks": true,
     "target": "ES2024",
     "lib": ["ES2024"],
     "module": "NodeNext",

--- a/packages/@overeng/oxc-config/tsconfig.json
+++ b/packages/@overeng/oxc-config/tsconfig.json
@@ -2,6 +2,7 @@
 // Source: tsconfig.json.genie.ts
 {
   "compilerOptions": {
+    "preserveSymlinks": true,
     "target": "ES2024",
     "lib": ["ES2024"],
     "module": "NodeNext",

--- a/packages/@overeng/react-inspector/tsconfig.json
+++ b/packages/@overeng/react-inspector/tsconfig.json
@@ -2,6 +2,7 @@
 // Source: tsconfig.json.genie.ts
 {
   "compilerOptions": {
+    "preserveSymlinks": true,
     "target": "ES2024",
     "lib": ["ES2023", "DOM"],
     "module": "NodeNext",

--- a/packages/@overeng/tui-core/tsconfig.json
+++ b/packages/@overeng/tui-core/tsconfig.json
@@ -2,6 +2,7 @@
 // Source: tsconfig.json.genie.ts
 {
   "compilerOptions": {
+    "preserveSymlinks": true,
     "target": "ES2024",
     "lib": ["ES2024"],
     "module": "NodeNext",

--- a/packages/@overeng/tui-react/tsconfig.json
+++ b/packages/@overeng/tui-react/tsconfig.json
@@ -2,6 +2,7 @@
 // Source: tsconfig.json.genie.ts
 {
   "compilerOptions": {
+    "preserveSymlinks": true,
     "target": "ES2024",
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "NodeNext",

--- a/packages/@overeng/utils-dev/tsconfig.json
+++ b/packages/@overeng/utils-dev/tsconfig.json
@@ -2,6 +2,7 @@
 // Source: tsconfig.json.genie.ts
 {
   "compilerOptions": {
+    "preserveSymlinks": true,
     "target": "ES2024",
     "lib": ["ES2024"],
     "module": "NodeNext",

--- a/packages/@overeng/utils/tsconfig.json
+++ b/packages/@overeng/utils/tsconfig.json
@@ -2,6 +2,7 @@
 // Source: tsconfig.json.genie.ts
 {
   "compilerOptions": {
+    "preserveSymlinks": true,
     "target": "ES2024",
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "NodeNext",


### PR DESCRIPTION
## Summary

- Adds `preserveSymlinks: true` to `baseTsconfigCompilerOptions` in `genie/external.ts`
- Regenerates all 19 downstream `tsconfig.json` files via genie

## Rationale

Megarepo topology uses symlinks (`repos/*`) pointing to the megarepo store (`~/.megarepo/...`). Without `preserveSymlinks`, tsc follows the symlink to the real store path where no `node_modules` exists, causing module resolution failures for all cross-repo source files.

Previously every downstream megarepo (overeng, schickling-stiftung, megarepo-all) added `preserveSymlinks: true` independently. Moving it into the base config eliminates per-repo duplication and ensures new repos get it automatically.

Closes #384

## Test plan

- [ ] CI passes (type-check across all packages)
- [ ] Downstream repos can remove their per-package `preserveSymlinks` overrides after adopting this

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> Created on behalf of @schickling