### PR TITLE
Remove IFD from CLI package evaluation

### DIFF
--- a/context/effect/socket/package.json
+++ b/context/effect/socket/package.json
@@ -13,6 +13,9 @@
   },
   "$genie": {
     "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten"
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "context/effect/socket"
+    ]
   }
 }

--- a/context/opentui/package.json
+++ b/context/opentui/package.json
@@ -24,6 +24,9 @@
   },
   "$genie": {
     "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten"
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "context/opentui"
+    ]
   }
 }

--- a/nix/workspace-tools/lib/mk-pnpm-cli.nix
+++ b/nix/workspace-tools/lib/mk-pnpm-cli.nix
@@ -52,66 +52,6 @@ let
   ) (builtins.attrNames workspaceSourceRoots);
   workspaceSourcePrefixesByLengthDesc = lib.reverseList workspaceSourcePrefixesByLengthAsc;
 
-  overlayWorkspaceSourceCmd =
-    prefix:
-    let
-      sourceRoot = workspaceSourceRoots.${prefix};
-      sourceRootArg = lib.escapeShellArg (toString sourceRoot);
-      targetRelPathArg = lib.escapeShellArg prefix;
-    in
-    if prefix == "." || prefix == "" then
-      ''
-        source_root=${sourceRootArg}
-        find "$out" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
-        cp -R "$source_root"/. "$out"
-        chmod -R +w "$out"
-      ''
-    else
-      ''
-        source_root=${sourceRootArg}
-        target_rel_path=${targetRelPathArg}
-        rm -rf "$out/$target_rel_path"
-        mkdir -p "$out/$target_rel_path"
-        cp -R "$source_root"/. "$out/$target_rel_path"
-        chmod -R +w "$out/$target_rel_path"
-      '';
-
-  repoLevelPrefixes = builtins.filter
-    (prefix:
-      let parts = lib.splitString "/" prefix;
-      in builtins.length parts == 2 && builtins.head parts == "repos")
-    workspaceSourcePrefixesByLengthAsc;
-
-  crossRepoSymlinkCmds =
-    if builtins.length repoLevelPrefixes < 2 then ""
-    else
-      lib.concatMapStrings (outer:
-        lib.concatMapStrings (inner:
-          if outer == inner then ""
-          else
-            let innerName = lib.removePrefix "repos/" inner;
-            in ''
-              mkdir -p "$out/${outer}/repos"
-              ln -s "../../${innerName}" "$out/${outer}/repos/${innerName}"
-            ''
-        ) repoLevelPrefixes
-      ) repoLevelPrefixes;
-
-  workspaceEvalRootPath =
-    if workspaceSourcePrefixesByLengthAsc == [ ] then
-      workspaceRootPath
-    else
-      pkgs.runCommand "workspace-eval-root" { } (
-        ''
-          set -euo pipefail
-          mkdir -p "$out"
-          cp -R ${lib.escapeShellArg (toString workspaceRootPath)}/. "$out"
-          chmod -R +w "$out"
-        ''
-        + builtins.concatStringsSep "\n" (map overlayWorkspaceSourceCmd workspaceSourcePrefixesByLengthAsc)
-        + crossRepoSymlinkCmds
-      );
-
   hasInstallRoot =
     sourceRoot:
     builtins.pathExists (sourceRoot + "/package.json")
@@ -153,45 +93,15 @@ let
     else
       resolved.sourceRoot + "/${resolved.sourceRelPath}";
 
-  genieRelPath = "packages/@overeng/genie/src/runtime/pnpm-workspace/mod.ts";
-  geniePrefix =
-    if builtins.pathExists (workspaceRootPath + "/${genieRelPath}") then
-      ""
-    else
-      let
-        found = lib.findFirst
-          (prefix: builtins.pathExists (absoluteSourcePathFor "${prefix}/${genieRelPath}"))
-          null
-          workspaceSourcePrefixesByLengthAsc;
-      in
-      if found == null then
-        throw "mk-pnpm-cli: Cannot find genie runtime (${genieRelPath}) in workspace root or workspace sources"
-      else
-        "${found}/";
+  # Read workspace closure dirs from the generated package.json ($genie.workspaceClosureDirs).
+  # Pre-computed by genie at generation time, avoiding import-from-derivation (IFD).
+  # Future alternative: NixOS/nix#15380 (builtins.wasm) could compute this natively at eval time.
+  packageJsonPath = absoluteSourcePathFor "${packageDir}/package.json";
+  packageJson = builtins.fromJSON (builtins.readFile packageJsonPath);
+  packageVersion = packageJson.version or "0.0.0";
 
   rootPnpmWorkspaceYamlPath = workspaceRootPath + "/pnpm-workspace.yaml";
   rootPnpmWorkspaceYaml = builtins.readFile rootPnpmWorkspaceYamlPath;
-  packageClosureProjectionFile = pkgs.runCommand "${name}-pnpm-package-closure.json" {
-    nativeBuildInputs = [ pkgs.bun ];
-  } ''
-    set -euo pipefail
-    cd ${lib.escapeShellArg (toString workspaceEvalRootPath)}
-    bun --eval '
-      const pkg = (await import(${builtins.toJSON "./${packageDir}/package.json.genie.ts"})).default
-      const { projectPnpmPackageClosure } = await import(${builtins.toJSON "./${geniePrefix}${genieRelPath}"})
-
-      if (pkg?.meta?.workspace?.memberPath !== ${builtins.toJSON packageDir}) {
-        throw new Error(
-          "package.json.genie.ts default export has unexpected memberPath: "
-          + (pkg?.meta?.workspace?.memberPath ?? "<missing>")
-          + " (expected: " + ${builtins.toJSON packageDir} + ")"
-        )
-      }
-
-      process.stdout.write(JSON.stringify(projectPnpmPackageClosure({ pkg })))
-    ' > "$out"
-  '';
-  packageClosureProjection = builtins.fromJSON (builtins.readFile packageClosureProjectionFile);
 
   workspaceSuffixLines =
     workspaceYaml:
@@ -224,19 +134,23 @@ let
   formatWorkspaceYaml =
     packageDirs: suffixLines:
     let
-      packagesBlock = builtins.concatStringsSep "\n" ([ "packages:" ] ++ map (dir: "  - ${dir}") packageDirs);
+      packagesBlock = builtins.concatStringsSep "\n" (
+        [ "packages:" ] ++ map (dir: "  - ${dir}") packageDirs
+      );
       suffix = builtins.concatStringsSep "\n" suffixLines;
     in
-    if suffix == "" then
-      "${packagesBlock}\n"
-    else
-      "${packagesBlock}\n\n${suffix}\n";
+    if suffix == "" then "${packagesBlock}\n" else "${packagesBlock}\n\n${suffix}\n";
 
   workspaceClosureDirs =
-    if packageClosureProjection.packageDir != packageDir then
-      throw "mk-pnpm-cli: projected packageDir does not match requested packageDir"
+    let
+      genieData = packageJson."$genie" or { };
+    in
+    if !(genieData ? workspaceClosureDirs) then
+      throw "mk-pnpm-cli: ${packageDir}/package.json missing $genie.workspaceClosureDirs (run: dt genie:run)"
+    else if !(lib.elem packageDir genieData.workspaceClosureDirs) then
+      throw "mk-pnpm-cli: $genie.workspaceClosureDirs does not contain packageDir (${packageDir})"
     else
-      packageClosureProjection.workspaceClosureDirs;
+      genieData.workspaceClosureDirs;
   workspaceMembers = builtins.filter (dir: dir != packageDir) workspaceClosureDirs;
 
   resolvedWorkspaceMembers = map (
@@ -254,42 +168,38 @@ let
           resolved.sourceRoot + "/${resolved.sourceRelPath}";
     }
   ) workspaceMembers;
-  externalInstallRootItems =
-    builtins.filter (item: item != null) (
-      map
-        (
-          item:
-          let
-            prefixRootHasWorkspace =
-              item.resolved.prefix != null
-              && builtins.pathExists (item.resolved.sourceRoot + "/pnpm-workspace.yaml")
-              && hasInstallRoot item.resolved.sourceRoot;
-            memberHasInstallRoot = hasInstallRoot item.sourcePath;
-          in
-          if item.resolved.prefix == null then
-            null
-          else if prefixRootHasWorkspace then
-            {
-              installDir = item.resolved.prefix;
-              installSourceRoot = item.resolved.sourceRoot;
-              memberDir = item.dir;
-              sourceRelMemberDir = item.resolved.sourceRelPath;
-            }
-          else if memberHasInstallRoot then
-            {
-              installDir = item.dir;
-              installSourceRoot = item.sourcePath;
-              memberDir = item.dir;
-              sourceRelMemberDir = ".";
-            }
-          else
-            null
-        )
-        resolvedWorkspaceMembers
-    );
+  externalInstallRootItems = builtins.filter (item: item != null) (
+    map (
+      item:
+      let
+        prefixRootHasWorkspace =
+          item.resolved.prefix != null
+          && builtins.pathExists (item.resolved.sourceRoot + "/pnpm-workspace.yaml")
+          && hasInstallRoot item.resolved.sourceRoot;
+        memberHasInstallRoot = hasInstallRoot item.sourcePath;
+      in
+      if item.resolved.prefix == null then
+        null
+      else if prefixRootHasWorkspace then
+        {
+          installDir = item.resolved.prefix;
+          installSourceRoot = item.resolved.sourceRoot;
+          memberDir = item.dir;
+          sourceRelMemberDir = item.resolved.sourceRelPath;
+        }
+      else if memberHasInstallRoot then
+        {
+          installDir = item.dir;
+          installSourceRoot = item.sourcePath;
+          memberDir = item.dir;
+          sourceRelMemberDir = ".";
+        }
+      else
+        null
+    ) resolvedWorkspaceMembers
+  );
 
-  externalInstallRoots =
-    lib.sort (left: right: left.installDir < right.installDir) (
+  externalInstallRoots = lib.sort (left: right: left.installDir < right.installDir) (
     map
       (
         installDir:
@@ -306,31 +216,47 @@ let
           sourceRelMemberDirs = lib.unique (map (item: item.sourceRelMemberDir) items);
           filteredPnpmWorkspaceYaml =
             if hasWorkspaceYaml then
-              formatWorkspaceYaml
-                (lib.unique (map (item: item.sourceRelMemberDir) items))
-                (workspaceSuffixLines sourcePnpmWorkspaceYaml)
+              formatWorkspaceYaml (lib.unique (map (item: item.sourceRelMemberDir) items)) (
+                workspaceSuffixLines sourcePnpmWorkspaceYaml
+              )
             else
               formatWorkspaceYaml [ "." ] [ ];
         }
       )
-      (lib.sort (left: right: left < right) (lib.unique (map (item: item.installDir) externalInstallRootItems))));
+      (
+        lib.sort (left: right: left < right) (
+          lib.unique (map (item: item.installDir) externalInstallRootItems)
+        )
+      )
+  );
 
   stagedWorkspaceMembers =
     let
       externallyOwnedDirs = lib.concatMap (root: root.memberDirs) externalInstallRoots;
     in
-    lib.unique ([ packageDir ] ++ builtins.filter (dir: !(lib.elem dir externallyOwnedDirs)) workspaceMembers);
+    lib.unique (
+      [ packageDir ] ++ builtins.filter (dir: !(lib.elem dir externallyOwnedDirs)) workspaceMembers
+    );
   allExternallyOwnedDirs =
     (map (root: root.installDir) externalInstallRoots)
     ++ (lib.concatMap (root: root.memberDirs) externalInstallRoots);
-  aggregateOwnedWorkspaceClosureDirs =
-    builtins.filter (dir: !(lib.elem dir allExternallyOwnedDirs)) workspaceClosureDirs;
+  aggregateOwnedWorkspaceClosureDirs = builtins.filter (
+    dir: !(lib.elem dir allExternallyOwnedDirs)
+  ) workspaceClosureDirs;
 
-  filteredRootPnpmWorkspaceYaml = formatWorkspaceYaml stagedWorkspaceMembers (workspaceSuffixLines rootPnpmWorkspaceYaml);
+  filteredRootPnpmWorkspaceYaml = formatWorkspaceYaml stagedWorkspaceMembers (
+    workspaceSuffixLines rootPnpmWorkspaceYaml
+  );
 
   rootLockfileContent = builtins.readFile (absoluteSourcePathFor "pnpm-lock.yaml");
-  rootWorkspaceFiles = [ "package.json" "pnpm-lock.yaml" ];
-  optionalRootWorkspaceFiles = [ ".npmrc" "tsconfig.base.json" ];
+  rootWorkspaceFiles = [
+    "package.json"
+    "pnpm-lock.yaml"
+  ];
+  optionalRootWorkspaceFiles = [
+    ".npmrc"
+    "tsconfig.base.json"
+  ];
 
   copyFileCmd =
     relPath:
@@ -364,7 +290,9 @@ let
       fi
     '';
 
-  /** Parse patchedDependencies path: entries from a pnpm-lock.yaml string (pure Nix). */
+  /**
+    Parse patchedDependencies path: entries from a pnpm-lock.yaml string (pure Nix).
+  */
   parsePatchPaths =
     lockfileContent:
     let
@@ -415,13 +343,13 @@ let
     } lines;
 
   /**
-   * Copy patch files from a lockfile, resolving source paths through workspaceSources.
-   * Each patch path is resolved at Nix eval time via absoluteSourcePathFor so that
-   * patches under workspaceSources prefixes are found in the correct source root.
-   *
-   * Note: the resolved source root (via builtins.path) snapshots the whole matched
-   * source tree, so this has the same invalidation scope as other copyFileCmd calls.
-   */
+    Copy patch files from a lockfile, resolving source paths through workspaceSources.
+    Each patch path is resolved at Nix eval time via absoluteSourcePathFor so that
+    patches under workspaceSources prefixes are found in the correct source root.
+
+    Note: the resolved source root (via builtins.path) snapshots the whole matched
+    source tree, so this has the same invalidation scope as other copyFileCmd calls.
+  */
   copyResolvedPatchFilesCmd =
     {
       lockfileContent,
@@ -447,10 +375,10 @@ let
     builtins.concatStringsSep "\n" (map copyOnePatch patchPaths);
 
   /**
-   * Copy patch files from an external install root's lockfile.
-   * These are self-contained (source and target share the same root), so shell-time
-   * awk parsing is fine — no workspaceSources resolution needed.
-   */
+    Copy patch files from an external install root's lockfile.
+    These are self-contained (source and target share the same root), so shell-time
+    awk parsing is fine — no workspaceSources resolution needed.
+  */
   copyPatchedDependencyFilesCmd =
     {
       sourceRoot,
@@ -504,44 +432,42 @@ let
       + builtins.concatStringsSep "\n" (map copyFileCmd rootWorkspaceFiles)
       + builtins.concatStringsSep "\n" (map copyOptionalFileCmd optionalRootWorkspaceFiles)
       + ''
-        cat > "$out/pnpm-workspace.yaml" <<'EOF'
-${filteredRootPnpmWorkspaceYaml}
-EOF
+                cat > "$out/pnpm-workspace.yaml" <<'EOF'
+        ${filteredRootPnpmWorkspaceYaml}
+        EOF
       ''
       + builtins.concatStringsSep "\n" (
-        map
-          (
-            root:
-            builtins.concatStringsSep "\n" (
-              (
-                if manifestOnly then
-                  (map (file: copyFileCmd "${root.installDir}/${file}") rootWorkspaceFiles)
-                  ++ (map (file: copyOptionalFileCmd "${root.installDir}/${file}") optionalRootWorkspaceFiles)
-                  ++ (map (dir: copyFileCmd "${dir}/package.json") (builtins.filter (dir: dir != root.installDir) root.memberDirs))
-                else if lib.elem root.installDir root.memberDirs then
-                  [ (copyDirCmd root.installDir) ]
-                else
-                  (map (file: copyFileCmd "${root.installDir}/${file}") rootWorkspaceFiles)
-                  ++ (map (file: copyOptionalFileCmd "${root.installDir}/${file}") optionalRootWorkspaceFiles)
-                  ++ (map copyDirCmd (builtins.filter (dir: dir != root.installDir) root.memberDirs))
-              )
-              ++ [
-                ''
-                  mkdir -p "$out/${root.installDir}"
-                  cat > "$out/${root.installDir}/pnpm-workspace.yaml" <<'EOF'
-${root.filteredPnpmWorkspaceYaml}
-EOF
-                ''
-              ]
+        map (
+          root:
+          builtins.concatStringsSep "\n" (
+            (
+              if manifestOnly then
+                (map (file: copyFileCmd "${root.installDir}/${file}") rootWorkspaceFiles)
+                ++ (map (file: copyOptionalFileCmd "${root.installDir}/${file}") optionalRootWorkspaceFiles)
+                ++ (map (dir: copyFileCmd "${dir}/package.json") (
+                  builtins.filter (dir: dir != root.installDir) root.memberDirs
+                ))
+              else if lib.elem root.installDir root.memberDirs then
+                [ (copyDirCmd root.installDir) ]
+              else
+                (map (file: copyFileCmd "${root.installDir}/${file}") rootWorkspaceFiles)
+                ++ (map (file: copyOptionalFileCmd "${root.installDir}/${file}") optionalRootWorkspaceFiles)
+                ++ (map copyDirCmd (builtins.filter (dir: dir != root.installDir) root.memberDirs))
             )
+            ++ [
+              ''
+                                  mkdir -p "$out/${root.installDir}"
+                                  cat > "$out/${root.installDir}/pnpm-workspace.yaml" <<'EOF'
+                ${root.filteredPnpmWorkspaceYaml}
+                EOF
+              ''
+            ]
           )
-          externalInstallRoots
+        ) externalInstallRoots
       )
       + builtins.concatStringsSep "\n" (
         if manifestOnly then
-          map
-            (dir: copyFileCmd "${dir}/package.json")
-            aggregateOwnedWorkspaceClosureDirs
+          map (dir: copyFileCmd "${dir}/package.json") aggregateOwnedWorkspaceClosureDirs
         else
           map copyDirCmd aggregateOwnedWorkspaceClosureDirs
       )
@@ -550,14 +476,13 @@ EOF
         targetPrefix = "";
       }
       + builtins.concatStringsSep "\n" (
-        map
-          (root:
-            copyPatchedDependencyFilesCmd {
-              sourceRoot = root.installSourceRoot;
-              targetPrefix = root.installDir;
-            }
-          )
-          externalInstallRoots
+        map (
+          root:
+          copyPatchedDependencyFilesCmd {
+            sourceRoot = root.installSourceRoot;
+            targetPrefix = root.installDir;
+          }
+        ) externalInstallRoots
       )
     );
 
@@ -575,26 +500,22 @@ EOF
     inherit name pnpmDepsHash;
     src = depsSrc;
     sourceRoot = ".";
-    lockfilePaths =
-      lib.sort (left: right: left < right) (
-        [ "pnpm-lock.yaml" ] ++ map (root: "${root.installDir}/pnpm-lock.yaml") externalInstallRoots
-      );
+    lockfilePaths = lib.sort (left: right: left < right) (
+      [ "pnpm-lock.yaml" ] ++ map (root: "${root.installDir}/pnpm-lock.yaml") externalInstallRoots
+    );
     preInstall = ''
       chmod -R +w .
     '';
   };
 
-  packageJsonPath = absoluteSourcePathFor "${packageDir}/package.json";
-  packageJson = builtins.fromJSON (builtins.readFile packageJsonPath);
-  packageVersion = packageJson.version or "0.0.0";
   entryRelativeToPackage =
     if lib.hasPrefix "${packageDir}/" entry then
       lib.removePrefix "${packageDir}/" entry
     else
       throw "mk-pnpm-cli: entry must be inside packageDir (${packageDir}): ${entry}";
 
-  pnpmInstallFlags = "--offline --frozen-lockfile --ignore-scripts"
-    + lib.optionalString prodInstall " --prod";
+  pnpmInstallFlags =
+    "--offline --frozen-lockfile --ignore-scripts" + lib.optionalString prodInstall " --prod";
   dirtyStr = if dirty then "true" else "false";
   nixStampJson = ''{\"type\":\"nix\",\"version\":\"${packageVersion}\",\"rev\":\"${gitRev}\",\"commitTs\":${toString commitTs},\"dirty\":${dirtyStr}}'';
   smokeTestArgsStr = lib.escapeShellArgs smokeTestArgs;
@@ -647,18 +568,13 @@ pkgs.stdenv.mkDerivation {
     pnpm install ${pnpmInstallFlags}
 
     ${builtins.concatStringsSep "\n" (
-      map
+      map (root: ''
+        echo "Installing external workspace root: ${root.installDir}..."
         (
-          root:
-          ''
-            echo "Installing external workspace root: ${root.installDir}..."
-            (
-              cd ${lib.escapeShellArg root.installDir}
-              pnpm install ${pnpmInstallFlags}
-            )
-          ''
+          cd ${lib.escapeShellArg root.installDir}
+          pnpm install ${pnpmInstallFlags}
         )
-        externalInstallRoots
+      '') externalInstallRoots
     )}
 
     cd ${packageDir}

--- a/packages/@overeng/agent-session-ingest/package.json
+++ b/packages/@overeng/agent-session-ingest/package.json
@@ -36,6 +36,10 @@
   },
   "$genie": {
     "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten"
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/agent-session-ingest",
+      "packages/@overeng/utils-dev"
+    ]
   }
 }

--- a/packages/@overeng/effect-ai-claude-cli/package.json
+++ b/packages/@overeng/effect-ai-claude-cli/package.json
@@ -29,6 +29,10 @@
   },
   "$genie": {
     "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten"
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/effect-ai-claude-cli",
+      "packages/@overeng/utils-dev"
+    ]
   }
 }

--- a/packages/@overeng/effect-path/package.json
+++ b/packages/@overeng/effect-path/package.json
@@ -28,6 +28,10 @@
   },
   "$genie": {
     "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten"
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/effect-path",
+      "packages/@overeng/utils-dev"
+    ]
   }
 }

--- a/packages/@overeng/effect-react/package.json
+++ b/packages/@overeng/effect-react/package.json
@@ -42,6 +42,11 @@
   },
   "$genie": {
     "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten"
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/effect-react",
+      "packages/@overeng/utils",
+      "packages/@overeng/utils-dev"
+    ]
   }
 }

--- a/packages/@overeng/effect-rpc-tanstack/examples/basic/package.json
+++ b/packages/@overeng/effect-rpc-tanstack/examples/basic/package.json
@@ -31,6 +31,11 @@
   },
   "$genie": {
     "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten"
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/effect-rpc-tanstack/examples/basic",
+      "packages/@overeng/utils",
+      "packages/@overeng/utils-dev"
+    ]
   }
 }

--- a/packages/@overeng/effect-rpc-tanstack/package.json
+++ b/packages/@overeng/effect-rpc-tanstack/package.json
@@ -47,6 +47,12 @@
   },
   "$genie": {
     "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten"
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/effect-rpc-tanstack",
+      "packages/@overeng/effect-rpc-tanstack/examples/basic",
+      "packages/@overeng/utils",
+      "packages/@overeng/utils-dev"
+    ]
   }
 }

--- a/packages/@overeng/effect-schema-form-aria/package.json
+++ b/packages/@overeng/effect-schema-form-aria/package.json
@@ -44,6 +44,12 @@
   },
   "$genie": {
     "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten"
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/effect-schema-form",
+      "packages/@overeng/effect-schema-form-aria",
+      "packages/@overeng/utils",
+      "packages/@overeng/utils-dev"
+    ]
   }
 }

--- a/packages/@overeng/effect-schema-form/package.json
+++ b/packages/@overeng/effect-schema-form/package.json
@@ -25,6 +25,9 @@
   },
   "$genie": {
     "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten"
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/effect-schema-form"
+    ]
   }
 }

--- a/packages/@overeng/genie/package.json
+++ b/packages/@overeng/genie/package.json
@@ -94,6 +94,13 @@
   },
   "$genie": {
     "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten"
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/genie",
+      "packages/@overeng/tui-core",
+      "packages/@overeng/tui-react",
+      "packages/@overeng/utils",
+      "packages/@overeng/utils-dev"
+    ]
   }
 }

--- a/packages/@overeng/genie/src/core/generation.ts
+++ b/packages/@overeng/genie/src/core/generation.ts
@@ -377,32 +377,6 @@ export const loadGenieFile = Effect.fn('loadGenieFile')(function* ({
   return { genieFilePath, output: exported as GenieOutput<unknown>, ctx }
 })
 
-/**
- * For package.json files, enrich the $genie marker with source file information.
- * This transforms the simple string marker into an object with structured metadata.
- */
-const enrichPackageJsonMarker = ({
-  content,
-  sourceFile,
-}: {
-  content: string
-  sourceFile: string
-}): string => {
-  try {
-    const parsed = JSON.parse(content)
-    if (typeof parsed === 'object' && parsed !== null && '$genie' in parsed) {
-      parsed.$genie = {
-        source: sourceFile,
-        warning: 'DO NOT EDIT - changes will be overwritten',
-      }
-      return JSON.stringify(parsed, null, 2)
-    }
-  } catch {
-    // Not valid JSON or parsing failed, return original
-  }
-  return content
-}
-
 /** Generate expected content for a genie file (shared between generate and dry-run) */
 export const getExpectedContent = Effect.fn('getExpectedContent')(function* ({
   genieFilePath,
@@ -419,12 +393,7 @@ export const getExpectedContent = Effect.fn('getExpectedContent')(function* ({
   const sourceFile = path.basename(genieFilePath)
   const loaded =
     loadedGenieFile === undefined ? yield* loadGenieFile({ genieFilePath, cwd }) : loadedGenieFile
-  let rawContent = loaded.output.stringify(loaded.ctx)
-
-  // For package.json files, enrich the $genie marker with source info
-  if (path.basename(targetFilePath) === 'package.json') {
-    rawContent = enrichPackageJsonMarker({ content: rawContent, sourceFile })
-  }
+  const rawContent = loaded.output.stringify(loaded.ctx)
 
   const header = getHeaderComment({ targetFilePath, sourceFile })
   const formattedContent = yield* formatWithOxfmt({

--- a/packages/@overeng/genie/src/runtime/package-json/mod.ts
+++ b/packages/@overeng/genie/src/runtime/package-json/mod.ts
@@ -10,6 +10,7 @@
 import { createGenieOutput } from '../core.ts'
 import type { GenieContext, GenieOutput, Strict } from '../core.ts'
 import type { PnpmPackageClosureConfig } from '../pnpm-workspace/mod.ts'
+import { projectPnpmPackageClosure } from '../pnpm-workspace/mod.ts'
 import { relativeRepoPath, rootWorkspaceMemberPathsFromPackages } from '../workspace-graph.ts'
 import { PackageJsonCompositionBrand, type PackageJsonComposition } from './catalog.ts'
 import {
@@ -500,13 +501,16 @@ const resolveScripts = ({
  * Build the final package.json object with sorting, resolution, and $genie marker.
  * @param data - Package data
  * @param location - Current package's repo-relative location (for resolving internal deps)
+ * @param genieMarker - Structured $genie metadata object (defaults to `true` for backwards compat)
  */
 const buildPackageJson = <T extends PackageJsonData>({
   data,
   location,
+  genieMarker,
 }: {
   data: T
   location: string
+  genieMarker?: Record<string, unknown>
 }): Record<string, unknown> => {
   const sorted = {
     ...data,
@@ -553,7 +557,7 @@ const buildPackageJson = <T extends PackageJsonData>({
 
   return sortObjectKeys({
     obj: {
-      $genie: true,
+      $genie: genieMarker ?? true,
       ...sorted,
     },
     order: FIELD_ORDER,
@@ -688,9 +692,32 @@ function createPackageJson<const T extends PackageJsonData, const TMeta>(
 
   return createGenieOutput({
     data: effectiveData,
-    stringify: (ctx: GenieContext) =>
-      JSON.stringify(buildPackageJson({ data: effectiveData, location: ctx.location }), null, 2) +
-      '\n',
+    stringify: (ctx: GenieContext) => {
+      const genieMarker: Record<string, unknown> = {
+        source: 'package.json.genie.ts',
+        warning: 'DO NOT EDIT - changes will be overwritten',
+      }
+
+      /**
+       * Embed the workspace closure so Nix can read it from the generated package.json
+       * at eval time without import-from-derivation (IFD).
+       * Future alternative: NixOS/nix#15380 (builtins.wasm) could compute this natively.
+       */
+      if (effectiveWorkspaceMeta !== undefined) {
+        const closure = projectPnpmPackageClosure({
+          pkg: { data: effectiveData, meta: { workspace: effectiveWorkspaceMeta } },
+        })
+        genieMarker.workspaceClosureDirs = closure.workspaceClosureDirs
+      }
+
+      return (
+        JSON.stringify(
+          buildPackageJson({ data: effectiveData, location: ctx.location, genieMarker }),
+          null,
+          2,
+        ) + '\n'
+      )
+    },
     validate: (ctx: GenieContext) => [
       ...(effectiveData.name !== undefined
         ? validatePackageRecompositionForPackage({ ctx, pkgName: effectiveData.name })
@@ -794,7 +821,18 @@ const aggregatePackageJsonFromPackages = ({
   return createGenieOutput({
     data: aggregate,
     stringify: (ctx: GenieContext) =>
-      JSON.stringify(buildPackageJson({ data: aggregate, location: ctx.location }), null, 2) + '\n',
+      JSON.stringify(
+        buildPackageJson({
+          data: aggregate,
+          location: ctx.location,
+          genieMarker: {
+            source: 'package.json.genie.ts',
+            warning: 'DO NOT EDIT - changes will be overwritten',
+          },
+        }),
+        null,
+        2,
+      ) + '\n',
   })
 }
 

--- a/packages/@overeng/genie/src/runtime/package-json/package-json.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/package-json/package-json.unit.test.ts
@@ -69,9 +69,29 @@ describe('packageJson', () => {
     const json = result.stringify(mockGenieContext)
     const parsed = JSON.parse(json)
 
-    expect(parsed.$genie).toBe(true)
+    expect(parsed.$genie).toEqual({
+      source: 'package.json.genie.ts',
+      warning: 'DO NOT EDIT - changes will be overwritten',
+    })
     expect(parsed.name).toBe('@test/package')
     expect(parsed.version).toBe('1.0.0')
+  })
+
+  it('includes workspaceClosureDirs in $genie when workspace composition is used', () => {
+    const repo = createTempRepo('packages/app', 'packages/lib')
+    const libComposition = testCatalog.compose({
+      workspace: workspace({ repoName: repo.repoName, memberPath: 'packages/lib' }),
+    })
+    const libPkg = packageJson({ name: '@test/lib', version: '1.0.0' }, libComposition)
+    const appComposition = testCatalog.compose({
+      workspace: workspace({ repoName: repo.repoName, memberPath: 'packages/app' }),
+      dependencies: { workspace: [libPkg] },
+    })
+    const result = packageJson({ name: '@test/app', version: '1.0.0' }, appComposition)
+
+    const parsed = JSON.parse(result.stringify(mockGenieContext))
+
+    expect(parsed.$genie.workspaceClosureDirs).toEqual(['packages/app', 'packages/lib'])
   })
 
   it('sorts dependencies alphabetically', () => {
@@ -542,7 +562,10 @@ describe('packageJson.aggregateFromPackages', () => {
     const json = result.stringify(mockWorkspaceRootContext)
     const parsed = JSON.parse(json)
 
-    expect(parsed.$genie).toBe(true)
+    expect(parsed.$genie).toEqual({
+      source: 'package.json.genie.ts',
+      warning: 'DO NOT EDIT - changes will be overwritten',
+    })
     expect(parsed.name).toBe('my-monorepo')
     expect(parsed.private).toBe(true)
     expect(parsed.packageManager).toBe('pnpm@10.29.2')

--- a/packages/@overeng/megarepo/package.json
+++ b/packages/@overeng/megarepo/package.json
@@ -98,6 +98,14 @@
   },
   "$genie": {
     "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten"
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/effect-path",
+      "packages/@overeng/megarepo",
+      "packages/@overeng/tui-core",
+      "packages/@overeng/tui-react",
+      "packages/@overeng/utils",
+      "packages/@overeng/utils-dev"
+    ]
   }
 }

--- a/packages/@overeng/notion-cli/package.json
+++ b/packages/@overeng/notion-cli/package.json
@@ -95,6 +95,16 @@
   },
   "$genie": {
     "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten"
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/effect-path",
+      "packages/@overeng/notion-cli",
+      "packages/@overeng/notion-effect-client",
+      "packages/@overeng/notion-effect-schema",
+      "packages/@overeng/tui-core",
+      "packages/@overeng/tui-react",
+      "packages/@overeng/utils",
+      "packages/@overeng/utils-dev"
+    ]
   }
 }

--- a/packages/@overeng/notion-effect-client/package.json
+++ b/packages/@overeng/notion-effect-client/package.json
@@ -39,6 +39,12 @@
   },
   "$genie": {
     "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten"
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/notion-effect-client",
+      "packages/@overeng/notion-effect-schema",
+      "packages/@overeng/utils",
+      "packages/@overeng/utils-dev"
+    ]
   }
 }

--- a/packages/@overeng/notion-effect-schema/package.json
+++ b/packages/@overeng/notion-effect-schema/package.json
@@ -25,6 +25,10 @@
   },
   "$genie": {
     "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten"
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/notion-effect-schema",
+      "packages/@overeng/utils-dev"
+    ]
   }
 }

--- a/packages/@overeng/oxc-config/package.json
+++ b/packages/@overeng/oxc-config/package.json
@@ -21,6 +21,9 @@
   },
   "$genie": {
     "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten"
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/oxc-config"
+    ]
   }
 }

--- a/packages/@overeng/react-inspector/package.json
+++ b/packages/@overeng/react-inspector/package.json
@@ -52,6 +52,11 @@
   },
   "$genie": {
     "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten"
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/react-inspector",
+      "packages/@overeng/utils",
+      "packages/@overeng/utils-dev"
+    ]
   }
 }

--- a/packages/@overeng/tui-core/package.json
+++ b/packages/@overeng/tui-core/package.json
@@ -19,6 +19,9 @@
   },
   "$genie": {
     "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten"
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/tui-core"
+    ]
   }
 }

--- a/packages/@overeng/tui-react/package.json
+++ b/packages/@overeng/tui-react/package.json
@@ -88,6 +88,12 @@
   },
   "$genie": {
     "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten"
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/tui-core",
+      "packages/@overeng/tui-react",
+      "packages/@overeng/utils",
+      "packages/@overeng/utils-dev"
+    ]
   }
 }

--- a/packages/@overeng/utils-dev/package.json
+++ b/packages/@overeng/utils-dev/package.json
@@ -32,6 +32,9 @@
   },
   "$genie": {
     "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten"
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/utils-dev"
+    ]
   }
 }

--- a/packages/@overeng/utils/package.json
+++ b/packages/@overeng/utils/package.json
@@ -96,6 +96,10 @@
   },
   "$genie": {
     "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten"
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/utils",
+      "packages/@overeng/utils-dev"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

- Embed `workspaceClosureDirs` in generated `package.json` via genie's `$genie` property, eliminating import-from-derivation (IFD) during `nix eval`
- Move `$genie` enrichment from `core/generation.ts` into `runtime/package-json` (single-phase assembly)
- Remove ~84 lines of IFD infrastructure from `mk-pnpm-cli.nix`

## Rationale

Top-level `homeConfigurations` / `darwinConfigurations` evaluation is slow because `mk-pnpm-cli` builds `*-pnpm-package-closure.json.drv` during eval for each CLI package. This PR removes that IFD by pre-computing workspace closure data at genie generation time and embedding it in the committed `package.json`.

Future alternative: [NixOS/nix#15380](https://github.com/NixOS/nix/pull/15380) (`builtins.wasm`) could compute workspace closures natively at eval time.

## Verification

```bash
nix eval .#packages.aarch64-darwin.genie.drvPath --option allow-import-from-derivation false   # ✅
nix eval .#packages.aarch64-darwin.megarepo.drvPath --option allow-import-from-derivation false # ✅
```

All 129 genie unit tests pass.

## Downstream

Companion PR: schickling/dotfiles#454 (regenerate package.json files + update docs)

---
Acting on behalf of the user.