### PR TITLE
feat: add lint:check:lockfile to catch specifier mismatches

### DIFF
--- a/nix/devenv-modules/tasks/shared/lint-genie.nix
+++ b/nix/devenv-modules/tasks/shared/lint-genie.nix
@@ -16,9 +16,21 @@ in
       description = "Check generated files are up to date";
       exec = trace.exec "lint:check:genie" "genie --check";
     };
+    "lint:check:lockfile" = {
+      description = "Verify pnpm-lock.yaml matches package.json specifiers";
+      after = [ "pnpm:install" ];
+      exec = trace.exec "lint:check:lockfile" ''
+        set -euo pipefail
+        export npm_config_manage_package_manager_versions=false
+        pnpm install --frozen-lockfile --ignore-scripts --config.confirmModulesPurge=false
+      '';
+    };
     "lint:check" = {
       description = "Run all lint checks";
-      after = [ "lint:check:genie" ];
+      after = [
+        "lint:check:genie"
+        "lint:check:lockfile"
+      ];
     };
     "lint:fix" = {
       description = "Fix all lint issues (no formatter configured)";

--- a/nix/devenv-modules/tasks/shared/lint-oxc.nix
+++ b/nix/devenv-modules/tasks/shared/lint-oxc.nix
@@ -97,7 +97,8 @@ let
       description = "Run oxlint linter";
       exec = trace.exec "lint:check:oxlint" (mkOxlintCmd "");
       execIfModified = execIfModifiedPatterns;
-    } // lib.optionalAttrs (tsconfig != null) {
+    }
+    // lib.optionalAttrs (tsconfig != null) {
       after = [ "pnpm:install" ];
     };
     "lint:fix:format" = {
@@ -155,6 +156,15 @@ let
       # Intentionally no execIfModified caching: new unmanaged config files are exactly
       # what this task exists to detect.
     };
+    "lint:check:lockfile" = {
+      description = "Verify pnpm-lock.yaml matches package.json specifiers";
+      after = [ "pnpm:install" ];
+      exec = trace.exec "lint:check:lockfile" ''
+        set -euo pipefail
+        export npm_config_manage_package_manager_versions=false
+        pnpm install --frozen-lockfile --ignore-scripts --config.confirmModulesPurge=false
+      '';
+    };
     "lint:check" = {
       description = "Run all lint checks";
       after = [
@@ -162,6 +172,7 @@ let
         "lint:check:oxlint"
         "lint:check:genie"
         "lint:check:genie:coverage"
+        "lint:check:lockfile"
       ];
     };
     "lint:fix" = {
@@ -175,8 +186,7 @@ let
 in
 {
   # Provide tsgolint when type-aware linting is enabled
-  packages = lib.optionals (tsconfig != null) [ pkgs.tsgolint ]
-    ++ cliGuard.fromTasks guardedTasks;
+  packages = lib.optionals (tsconfig != null) [ pkgs.tsgolint ] ++ cliGuard.fromTasks guardedTasks;
 
   tasks = (cliGuard.stripGuards guardedTasks) // otherTasks;
 }

--- a/nix/devenv-modules/tasks/shared/pnpm.nix
+++ b/nix/devenv-modules/tasks/shared/pnpm.nix
@@ -13,10 +13,10 @@
   packages,
   globalCache ? true,
   frozenInCi ? true,
-  installAfter ? [],
-  updateAfter ? [],
-  cleanAfter ? [],
-  resetLockFilesAfter ? [],
+  installAfter ? [ ],
+  updateAfter ? [ ],
+  cleanAfter ? [ ],
+  resetLockFilesAfter ? [ ],
 }:
 {
   lib,


### PR DESCRIPTION
## Summary

Add a `lint:check:lockfile` task to both `lint-oxc.nix` and `lint-genie.nix` that verifies `pnpm-lock.yaml` is consistent with `package.json` specifiers.

## Design

- **Task name**: `lint:check:lockfile` — follows the `lint:check:*` pattern alongside `lint:check:genie`, `lint:check:format`, etc.
- **Location**: Defined in both lint modules (not `pnpm.nix`) since it's a consistency check, not a pnpm operation
- **CI integration**: Automatically runs via `lint:check --mode before` which CI already executes
- **Flags**: `--frozen-lockfile --ignore-scripts` — only validates specifier consistency, doesn't run lifecycle hooks

## Rationale

There was a gap where genie catalog bumps could change `package.json` specifiers without updating `pnpm-lock.yaml`, and this went undetected because:

1. `pnpm:install`'s status check sees existing `node_modules` (from devenv shell setup) and skips the actual install
2. The skipped install means `--frozen-lockfile` never runs
3. The mismatch only surfaces in downstream repos or fresh CI builds

## Verification

Tested locally:
- Mismatch (`0.1.99` in package.json vs `0.1.88` in lockfile): exit 1 with `ERR_PNPM_OUTDATED_LOCKFILE`
- In sync: exit 0

Follow-up from discussion in #399.

---
Acting on behalf of the user.