### PR TITLE
fix(megarepo): use .value.members path in mr:check jq filter

### DIFF
--- a/nix/devenv-modules/tasks/shared/megarepo.nix
+++ b/nix/devenv-modules/tasks/shared/megarepo.nix
@@ -106,7 +106,7 @@ let
         fi
 
         # Verify all configured members have symlinks in repos/
-        members=$(mr ls --output json | ${pkgs.jq}/bin/jq -r 'select(._tag == "Success") | .members[].name') || exit 1
+        members=$(mr ls --output json | ${pkgs.jq}/bin/jq -r 'select(._tag == "Success") | .value.members[].name') || exit 1
         for member in $members; do
           if [ ! -L "./repos/$member" ] && [ ! -d "./repos/$member" ]; then
             exit 1
@@ -129,7 +129,7 @@ let
 
         # Check for missing member symlinks
         missing=""
-        members=$(mr ls --output json | ${pkgs.jq}/bin/jq -r 'select(._tag == "Success") | .members[].name') || exit 1
+        members=$(mr ls --output json | ${pkgs.jq}/bin/jq -r 'select(._tag == "Success") | .value.members[].name') || exit 1
         for member in $members; do
           if [ ! -L "./repos/$member" ] && [ ! -d "./repos/$member" ]; then
             missing="$missing $member"


### PR DESCRIPTION
## Summary
- Fix `mr:check` devenv task jq filter to use `.value.members[].name` instead of `.members[].name`

## Rationale
`LsState` is a `Schema.Union` (Success | Error), not a `TypeLiteral`. `deriveOutputSchema` in TuiApp wraps non-struct schemas in `{ _tag: "Success", value: <state> }` (line 252-254 of TuiApp.tsx). The jq filter was accessing `.members` directly on the outer envelope (which is null), instead of navigating through `.value.members`.

This causes `mr:check` to fail in all downstream repos with: `jq: error (at <stdin>:1): Cannot iterate over null (null)`

## Test plan
- [ ] CI passes
- [ ] `mr:check` task succeeds in downstream repos (livestore, overeng, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)