### PR TITLE
fix(cli-guard): inject DT_PASSTHROUGH=1 directly into guarded task scripts

### DIFF
--- a/nix/devenv-modules/dt.nix
+++ b/nix/devenv-modules/dt.nix
@@ -16,8 +16,10 @@
 # TODO: Remove once devenv supports defaultMode for tasks (https://github.com/cachix/devenv/issues/2417)
 { pkgs, ... }:
 {
-  # cli-guard passthrough: DT_PASSTHROUGH=1 lets task exec scripts call
-  # guarded CLIs. enterShell unsets it so interactive shell usage hits guards.
+  # cli-guard passthrough (belt-and-suspenders): guarded tasks now inject
+  # DT_PASSTHROUGH=1 into their exec scripts directly, but we also set it
+  # via env for any non-guarded scripts that may call guarded CLIs.
+  # enterShell unsets it so interactive shell usage hits guards.
   env.DT_PASSTHROUGH = "1";
 
   # Wrapper that runs tasks with --mode before so dependencies run automatically.

--- a/nix/devenv-modules/tasks/lib/cli-guard.nix
+++ b/nix/devenv-modules/tasks/lib/cli-guard.nix
@@ -6,20 +6,23 @@
 # dt wrapper, and CI).
 #
 # How passthrough works:
-#   - devenv sets env.DT_PASSTHROUGH=1 (active during task execution)
+#   - stripGuards sets per-task env.DT_PASSTHROUGH=1 on all tasks
 #   - enterShell unsets it (so interactive shell usage hits guards)
 #   - dt wrapper re-sets it before calling devenv tasks run
 #   - CI helper (runDevenvTasksBefore) sets it
 #
-# Usage in task modules (Option A — derive guards from task defs):
+# Usage in task modules:
 #
 #   let cliGuard = import ../lib/cli-guard.nix { inherit pkgs; };
 #   in {
-#     packages = cliGuard.fromTasks tasks;
-#     tasks = cliGuard.stripGuards tasks;
+#     packages = cliGuard.fromTasks guardedTasks;
+#     tasks = cliGuard.stripGuards (guardedTasks // otherTasks);
 #   }
 #
-#   where tasks have a `guard = "cli-name"` attribute on guarded entries.
+#   guardedTasks have a `guard = "cli-name"` attribute on entries that
+#   should appear in the guard's help message. otherTasks may also call
+#   guarded CLIs. stripGuards removes guard attrs and sets DT_PASSTHROUGH=1
+#   on all tasks so they can call guarded CLIs during task execution.
 #
 # Low-level API (for cases where tasks aren't a plain attrset):
 #
@@ -123,9 +126,14 @@ let
     in
     map mkGuardForCli cliNames;
 
-  # Strip the `guard` attribute from all tasks in an attrset.
-  # Use this before passing tasks to devenv (which doesn't know about `guard`).
-  stripGuards = builtins.mapAttrs (_: def: builtins.removeAttrs def [ "guard" ]);
+  # Strip the `guard` attribute and set DT_PASSTHROUGH=1 via per-task env.
+  # devenv's module-level `env` attributes are not propagated to task
+  # subprocesses, but per-task `env` is. Pass all tasks (guarded + other)
+  # so every task can call guarded CLIs during task execution.
+  stripGuards = builtins.mapAttrs (_: def:
+    let stripped = builtins.removeAttrs def [ "guard" ];
+    in stripped // { env = (stripped.env or { }) // { DT_PASSTHROUGH = "1"; }; }
+  );
 
 in
 {

--- a/nix/devenv-modules/tasks/shared/lint-genie.nix
+++ b/nix/devenv-modules/tasks/shared/lint-genie.nix
@@ -6,12 +6,13 @@
 #   ];
 #
 # Provides: lint:check, lint:check:genie, lint:fix
-{ lib, ... }:
+{ lib, pkgs, ... }:
 let
   trace = import ../lib/trace.nix { inherit lib; };
+  cliGuard = import ../lib/cli-guard.nix { inherit pkgs; };
 in
 {
-  tasks = {
+  tasks = cliGuard.stripGuards {
     "lint:check:genie" = {
       description = "Check generated files are up to date";
       exec = trace.exec "lint:check:genie" "genie --check";

--- a/nix/devenv-modules/tasks/shared/lint-oxc.nix
+++ b/nix/devenv-modules/tasks/shared/lint-oxc.nix
@@ -188,5 +188,5 @@ in
   # Provide tsgolint when type-aware linting is enabled
   packages = lib.optionals (tsconfig != null) [ pkgs.tsgolint ] ++ cliGuard.fromTasks guardedTasks;
 
-  tasks = (cliGuard.stripGuards guardedTasks) // otherTasks;
+  tasks = cliGuard.stripGuards (guardedTasks // otherTasks);
 }

--- a/nix/devenv-modules/tasks/shared/netlify.nix
+++ b/nix/devenv-modules/tasks/shared/netlify.nix
@@ -32,6 +32,7 @@
 }:
 { lib, pkgs, ... }:
 let
+  cliGuard = import ../lib/cli-guard.nix { inherit pkgs; };
   git = "${pkgs.git}/bin/git";
   hasPackages = packages != [];
 
@@ -113,8 +114,8 @@ let
 
 in {
   tasks = lib.mkMerge (
-    (if hasPackages then map mkDeployTask packages else [])
-    ++ [{
+    (if hasPackages then map (pkg: cliGuard.stripGuards (mkDeployTask pkg)) packages else [])
+    ++ [(cliGuard.stripGuards {
       "netlify:deploy" = {
         description = "Deploy all storybooks to Netlify";
         exec = null;
@@ -122,6 +123,6 @@ in {
           then map (pkg: "netlify:deploy:${pkg.name}") packages
           else [];
       };
-    }]
+    })]
   );
 }

--- a/nix/devenv-modules/tasks/shared/setup.nix
+++ b/nix/devenv-modules/tasks/shared/setup.nix
@@ -39,6 +39,7 @@
   ...
 }:
 let
+  cliGuard = import ../lib/cli-guard.nix { inherit pkgs; };
   git = "${pkgs.git}/bin/git";
   userRequiredTasks = requiredTasks;
   userOptionalTasks = optionalTasks;
@@ -146,7 +147,7 @@ let
   allSetupTasks = setupTasks;
 in
 {
-  tasks =
+  tasks = cliGuard.stripGuards (
     lib.optionalAttrs completionsEnabled {
       "${completionsTaskName}" = {
         description = "Install shell completions for CLI tools";
@@ -231,5 +232,6 @@ in
           done
         '';
       };
-    };
+    }
+  );
 }

--- a/nix/devenv-modules/tasks/shared/storybook.nix
+++ b/nix/devenv-modules/tasks/shared/storybook.nix
@@ -28,9 +28,10 @@
   packages ? [ ],
   installTask ? "pnpm:install",
 }:
-{ lib, config, ... }:
+{ lib, config, pkgs, ... }:
 let
   trace = import ../lib/trace.nix { inherit lib; };
+  cliGuard = import ../lib/cli-guard.nix { inherit pkgs; };
   hasPackages = packages != [ ];
 
   mkBuildTask = pkg: {
@@ -71,15 +72,15 @@ let
 in
 {
   tasks = lib.mkMerge (
-    (if hasPackages then map mkBuildTask packages else [ ])
+    (if hasPackages then map (pkg: cliGuard.stripGuards (mkBuildTask pkg)) packages else [ ])
     ++ [
-      {
+      (cliGuard.stripGuards {
         "storybook:build" = {
           description = "Build all storybooks";
           exec = null;
           after = if hasPackages then map (pkg: "storybook:build:${pkg.name}") packages else [ ];
         };
-      }
+      })
     ]
   );
 

--- a/nix/devenv-modules/tasks/shared/test-playwright.nix
+++ b/nix/devenv-modules/tasks/shared/test-playwright.nix
@@ -47,7 +47,7 @@ in {
   packages = cliGuard.fromTasks guardedTasks;
 
   tasks = lib.mkMerge (
-    map mkTestTask packages
+    map (pkg: cliGuard.stripGuards (mkTestTask pkg)) packages
     ++ [ (cliGuard.stripGuards guardedTasks) ]
   );
 }

--- a/nix/devenv-modules/tasks/shared/test.nix
+++ b/nix/devenv-modules/tasks/shared/test.nix
@@ -80,7 +80,7 @@ in {
   packages = cliGuard.fromTasks guardedTasks;
 
   tasks = lib.mkMerge (
-    (if hasPackages then map mkTestTask packages else [])
+    (if hasPackages then map (pkg: cliGuard.stripGuards (mkTestTask pkg)) packages else [])
     ++ [ (cliGuard.stripGuards guardedTasks) ]
   );
 }

--- a/nix/devenv-modules/tasks/shared/ts-effect-lsp.nix
+++ b/nix/devenv-modules/tasks/shared/ts-effect-lsp.nix
@@ -27,12 +27,13 @@
     "pnpm:install"
   ],
 }:
-{ lib, ... }:
+{ lib, pkgs, ... }:
 let
   trace = import ../lib/trace.nix { inherit lib; };
+  cliGuard = import ../lib/cli-guard.nix { inherit pkgs; };
 in
 {
-  tasks = {
+  tasks = cliGuard.stripGuards {
     # TODO(effect-utils#377): this should become part of the normal tsgo-backed
     # `ts:check` flow once we stop using `tsc --build` for the main workspace
     # type check.

--- a/nix/devenv-modules/tasks/shared/ts.nix
+++ b/nix/devenv-modules/tasks/shared/ts.nix
@@ -208,5 +208,5 @@ in
     pkgs.bc
   ] ++ cliGuard.fromTasks guardedTasks;
 
-  tasks = (cliGuard.stripGuards guardedTasks) // otherTasks;
+  tasks = cliGuard.stripGuards (guardedTasks // otherTasks);
 }


### PR DESCRIPTION
## Summary

devenv's module-level `env` attributes are not propagated to task subprocesses, so `env.DT_PASSTHROUGH = "1"` from `dt.nix` never reached guarded CLI wrappers during task execution. This caused all tasks calling guarded CLIs to fail with the "use devenv task(s) instead" message.

## Approach

`stripGuards` now does two things in a single pass:
1. Strips `guard` attributes (existing behavior)
2. Sets per-task `env.DT_PASSTHROUGH = "1"` (new — uses devenv's per-task env which IS propagated to subprocesses)

Modules pass all tasks (guarded + other) through `stripGuards`:

```nix
tasks = cliGuard.stripGuards (guardedTasks // otherTasks);
```

Updated all 12 task modules. No new API surface — just `stripGuards` doing the right thing.

## Test plan

- [ ] `devenv tasks run genie:run --mode before --no-tui` succeeds
- [ ] `devenv tasks run ts:emit --mode before --no-tui` succeeds
- [ ] `devenv tasks run lint:check:genie --mode before --no-tui` succeeds
- [ ] `devenv shell` completes without task failures
- [ ] Interactive shell still shows guard when running `genie` directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)