### PR TITLE
Add reusable CI concurrency helper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 # Generated file - DO NOT EDIT
 # Source: ci.yml.genie.ts
 
+concurrency:
+  group: '${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}'
+  cancel-in-progress: true
+
 name: CI
 
 on:

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -9,6 +9,7 @@ import {
   installNixStep,
   runDevenvTasksBefore,
   standardCIEnv,
+  ciWorkflow,
   namespaceRunner,
   nixDiagnosticsArtifactStep,
   netlifyDeployStep,
@@ -16,10 +17,7 @@ import {
   validateNixStoreStep,
 } from '../../genie/ci-workflow.ts'
 import { type CIJobName } from '../../genie/ci.ts'
-import {
-  githubWorkflow,
-  type GitHubWorkflowArgs,
-} from '../../packages/@overeng/genie/src/runtime/mod.ts'
+import { type GitHubWorkflowArgs } from '../../packages/@overeng/genie/src/runtime/mod.ts'
 
 const baseSteps = [
   checkoutStep(),
@@ -191,7 +189,7 @@ const notifyAlignmentJob = {
   steps: [dispatchAlignmentStep({ targetRepo: 'schickling/megarepo-all' })],
 }
 
-export default githubWorkflow({
+export default ciWorkflow({
   name: 'CI',
   on: {
     push: { branches: ['main'] },

--- a/genie/ci-workflow.ts
+++ b/genie/ci-workflow.ts
@@ -23,6 +23,10 @@
  * ```
  */
 
+import {
+  githubWorkflow,
+  type GitHubWorkflowArgs,
+} from '../packages/@overeng/genie/src/runtime/mod.ts'
 import { RUNNER_PROFILES, type RunnerProfile } from './ci.ts'
 
 export { RUNNER_PROFILES, type RunnerProfile }
@@ -57,6 +61,32 @@ export const standardCIEnv = {
   CI: 'true',
   GITHUB_TOKEN: '${{ github.token }}',
 } as const
+
+/**
+ * Cancel superseded CI workflow runs for the same PR or branch.
+ *
+ * The group key intentionally does not include the job name so a new push
+ * cancels the entire older workflow run rather than letting stale sibling jobs
+ * continue consuming runner capacity.
+ */
+export const ciWorkflowConcurrency = {
+  group: '${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}',
+  'cancel-in-progress': true,
+} as const
+
+/**
+ * Standard wrapper for composed CI workflows.
+ *
+ * This keeps cancellation policy centralized in `effect-utils` instead of
+ * making each consumer remember to wire `concurrency` by hand. Repos can still
+ * override the policy by passing an explicit `concurrency` field.
+ */
+export const ciWorkflow = (args: GitHubWorkflowArgs) =>
+  (({ concurrency, ...rest }) =>
+    githubWorkflow({
+      concurrency: concurrency ?? ciWorkflowConcurrency,
+      ...rest,
+    }))(args)
 
 type NixConfigOptions = {
   unrestrictedEval?: boolean


### PR DESCRIPTION
## Summary
- add a reusable `ciWorkflowConcurrency` helper to `genie/ci-workflow.ts`
- apply it to effect-utils' own CI workflow generator
- regenerate `.github/workflows/ci.yml`

## Why
Effect-utils already supports workflow-level `concurrency` in the underlying GitHub workflow DSL, but it did not expose a shared CI helper and did not use cancellation for its own CI. This change makes the default CI behavior reusable and lets newer pushes cancel older superseded CI runs for the same PR or branch.

## Validation
- `genie --check`
- verified generated `.github/workflows/ci.yml` now includes:
  - `concurrency.group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}`
  - `cancel-in-progress: true`
