### PR TITLE
fix(megarepo): harden store against broken worktree remnants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **@overeng/megarepo**: Harden store against broken worktree remnants (#423)
+  - `hasWorktree` now checks for `.git` file existence instead of just directory existence, so broken partial worktrees are properly detected and recreated
+  - Lock-protected worktree creation cleans up broken directory remnants and prunes stale git worktree bookkeeping before recreating
+  - Fix semaphore creation race in `StoreLock` using `SynchronizedRef` for atomic get-or-create
+
 - **devenv/tasks/shared/nix-cli**: Update multiple stale Nix FOD hashes per `dt nix:hash:*` iteration
   - Adds `nix build --keep-going` to surface all fixed-output hash mismatches from one build
   - Parses and applies multiple reported hash updates in one pass instead of only the first mismatch

--- a/packages/@overeng/megarepo/src/lib/git.ts
+++ b/packages/@overeng/megarepo/src/lib/git.ts
@@ -265,6 +265,13 @@ export const removeWorktree = (args: { repoPath: string; worktreePath: string; f
     yield* runGitCommand({ args: cmdArgs, cwd: args.repoPath })
   })
 
+/** Prune stale worktree bookkeeping entries from a bare repo */
+export const pruneWorktrees = (repoPath: string) =>
+  runGitCommand({ args: ['worktree', 'prune'], cwd: repoPath }).pipe(
+    Effect.asVoid,
+    Effect.withSpan('git/worktree-prune', { attributes: { 'span.label': repoPath, repoPath } }),
+  )
+
 /**
  * Move a git worktree to a new path.
  */

--- a/packages/@overeng/megarepo/src/lib/store-lock.ts
+++ b/packages/@overeng/megarepo/src/lib/store-lock.ts
@@ -5,13 +5,17 @@
  * store resources — both within a single process (concurrent fibers) and
  * across separate mr processes.
  *
- * Uses effect-distributed-lock with a file-system backing stored in
+ * Uses DistributedSemaphore with a file-system backing stored in
  * $MEGAREPO_STORE/.locks/. TTL-based permits auto-expire if a process crashes.
+ *
+ * Per-key semaphores are cached in-memory via SynchronizedRef for performance
+ * (avoids repeated file-system holderId allocation). The file-system backing
+ * handles cross-process and cross-fiber serialization.
  */
 
 import { createHash } from 'node:crypto'
 
-import { Context, Duration, Effect, Layer, Ref } from 'effect'
+import { Context, Duration, Effect, Layer, SynchronizedRef } from 'effect'
 
 import type { AbsoluteDirPath } from '@overeng/effect-path'
 import { DistributedSemaphore, type DistributedSemaphoreBacking } from '@overeng/utils'
@@ -38,37 +42,37 @@ export interface StoreLockService {
 /** Distributed semaphore service for serializing concurrent access to shared store resources */
 export class StoreLock extends Context.Tag('megarepo/StoreLock')<StoreLock, StoreLockService>() {}
 
-/**
- * Keyed distributed semaphore registry — lazily creates one DistributedSemaphore per key.
- * Takes an eagerly-built backing context so withLock has no extra deps.
- * Keys are hashed to avoid filesystem NAME_MAX limits.
- */
-const makeKeyedDistributedRegistry = (
-  backingContext: Context.Context<DistributedSemaphoreBacking>,
-) =>
-  Effect.gen(function* () {
-    type Semaphore = Effect.Effect.Success<ReturnType<typeof DistributedSemaphore.make>>
-    const mapRef = yield* Ref.make(new Map<string, Semaphore>())
+type Semaphore = Effect.Effect.Success<ReturnType<typeof DistributedSemaphore.make>>
 
-    const withLock =
-      (key: string) =>
+/**
+ * Create a keyed lock function backed by distributed semaphores.
+ * Keys are hashed to avoid filesystem NAME_MAX limits.
+ * A namespace prefix separates independent lock registries (e.g. repo vs worktree).
+ * Semaphores are cached per-key via SynchronizedRef (atomic get-or-create).
+ */
+const makeKeyedLock = ({
+  backingContext,
+  namespace,
+}: {
+  backingContext: Context.Context<DistributedSemaphoreBacking>
+  namespace: string
+}) =>
+  Effect.gen(function* () {
+    const cache = yield* SynchronizedRef.make(new Map<string, Semaphore>())
+
+    return (key: string) =>
       <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
         Effect.gen(function* () {
-          const hashedKey = hashKey(key)
+          const hashedKey = `${namespace}/${hashKey(key)}`
 
-          let semaphore = yield* Ref.modify(mapRef, (map) => {
+          const semaphore = yield* SynchronizedRef.modifyEffect(cache, (map) => {
             const existing = map.get(hashedKey)
-            if (existing !== undefined) return [existing, map] as const
-            return [undefined, map] as const
+            if (existing !== undefined) return Effect.succeed([existing, map] as const)
+            return DistributedSemaphore.make(hashedKey, { limit: 1, ttl: LOCK_TTL }).pipe(
+              Effect.provide(backingContext),
+              Effect.map((sem) => [sem, new Map(map).set(hashedKey, sem)] as const),
+            )
           })
-
-          if (semaphore === undefined) {
-            semaphore = yield* DistributedSemaphore.make(hashedKey, {
-              limit: 1,
-              ttl: LOCK_TTL,
-            }).pipe(Effect.provide(backingContext))
-            yield* Ref.update(mapRef, (map) => new Map(map).set(hashedKey, semaphore!))
-          }
 
           return yield* semaphore
             .withPermits(1)(effect)
@@ -79,8 +83,6 @@ const makeKeyedDistributedRegistry = (
               ),
             ) as Effect.Effect<A, E, R>
         })
-
-    return { withLock } as const
   })
 
 /**
@@ -95,12 +97,9 @@ export const makeStoreLockLayer = (basePath: AbsoluteDirPath) =>
       const lockLayer = FileSystemBacking.layer({ lockDir })
       const backingContext = yield* Layer.build(lockLayer)
 
-      const repoLocks = yield* makeKeyedDistributedRegistry(backingContext)
-      const worktreeLocks = yield* makeKeyedDistributedRegistry(backingContext)
-
       return {
-        withRepoLock: repoLocks.withLock,
-        withWorktreeLock: worktreeLocks.withLock,
+        withRepoLock: yield* makeKeyedLock({ backingContext, namespace: 'repo' }),
+        withWorktreeLock: yield* makeKeyedLock({ backingContext, namespace: 'worktree' }),
       } as const
     }),
   )

--- a/packages/@overeng/megarepo/src/lib/store-lock.unit.test.ts
+++ b/packages/@overeng/megarepo/src/lib/store-lock.unit.test.ts
@@ -82,4 +82,32 @@ describe('StoreLock', () => {
       }),
     ),
   )
+
+  it.effect('worktree lock serializes concurrent creation for same path (issue #423)', () =>
+    withStoreLock(
+      Effect.gen(function* () {
+        const { withWorktreeLock } = yield* StoreLock
+        const creationOrder: number[] = []
+
+        /** Simulates two nested megarepos trying to create the same worktree */
+        yield* Effect.all(
+          Array.from(
+            { length: 5 },
+            (_, i) => () =>
+              withWorktreeLock('/store/github.com/org/shared-member/refs/heads/main/')(
+                Effect.gen(function* () {
+                  yield* Effect.yieldNow()
+                  creationOrder.push(i)
+                }),
+              ),
+          ).map((f) => f()),
+          { concurrency: 'unbounded' },
+        )
+
+        // All 5 ran exactly once, serialized (no duplicates, no drops)
+        expect(creationOrder).toHaveLength(5)
+        expect(new Set(creationOrder).size).toBe(5)
+      }),
+    ),
+  )
 })

--- a/packages/@overeng/megarepo/src/lib/store.ts
+++ b/packages/@overeng/megarepo/src/lib/store.ts
@@ -221,7 +221,11 @@ const make = ({
 
     hasBareRepo: (source) => fs.exists(getBareRepoPath(source)),
 
-    hasWorktree: (args) => fs.exists(getWorktreePath(args)),
+    hasWorktree: (args) => {
+      const worktreePath = getWorktreePath(args)
+      const gitFilePath = `${worktreePath}.git`.replace(/\/\.git$/, '/.git')
+      return fs.exists(gitFilePath)
+    },
 
     // Legacy compatibility
     hasRepo: (source) => fs.exists(getBareRepoPath(source)),

--- a/packages/@overeng/megarepo/src/lib/sync/member.ts
+++ b/packages/@overeng/megarepo/src/lib/sync/member.ts
@@ -750,6 +750,13 @@ export const syncMember = <R = never>({
               false
             if (stillNotExists === false) return
 
+            // Clean up broken worktree remnants (directory exists but .git is missing)
+            const dirExists = yield* fs.exists(worktreePath)
+            if (dirExists === true) {
+              yield* fs.remove(worktreePath, { recursive: true })
+              yield* Git.pruneWorktrees(bareRepoPath)
+            }
+
             // Ensure worktree parent directory exists
             const worktreeParent = EffectPath.ops.parent(worktreePath)
             if (worktreeParent !== undefined) {
@@ -807,6 +814,13 @@ export const syncMember = <R = never>({
               refType: 'commit',
             })
             if (exists === true) return
+
+            // Clean up broken worktree remnants
+            const dirExists = yield* fs.exists(commitWorktreePath)
+            if (dirExists === true) {
+              yield* fs.remove(commitWorktreePath, { recursive: true })
+              yield* Git.pruneWorktrees(bareRepoPath)
+            }
 
             const parent = EffectPath.ops.parent(commitWorktreePath)
             if (parent !== undefined) {


### PR DESCRIPTION
## Summary

Partial fix for #423. Hardens the store against broken worktree remnants.

StoreLock (#415) correctly serializes concurrent worktree creation for the same path via `withWorktreeLock`. The repro confirmed this (50 iterations, no trigger). However, three gaps remained:

- **`hasWorktree` checked directory existence, not `.git` file** — a partially-created worktree (directory exists, `.git` missing) would be treated as "existing", preventing recreation
- **Semaphore creation race in `StoreLock`** — two fibers could both create duplicate in-memory `DistributedSemaphore` instances for the same key
- **No cleanup of broken worktree remnants** — lock-protected creation would fail on `git worktree add` if a broken directory already existed

## Changes

- `store.ts`: `hasWorktree` checks `.git` file existence instead of directory existence
- `store-lock.ts`: Simplify with `SynchronizedRef.modifyEffect` for atomic get-or-create, namespace prefixes, `makeKeyedLock` helper
- `member.ts`: Inside `withWorktreeLock`, detect/remove broken directories + `git worktree prune` before recreating
- `git.ts`: Add `pruneWorktrees` helper

## Rationale

By making `hasWorktree` semantically correct (a worktree without `.git` is broken, not "existing"), the system self-heals from partial failures regardless of their cause. This is a prerequisite for #426 which makes the pre-flight check trust apply's self-healing.

## Test plan

- [x] All 453 tests pass (452 existing + 1 new lock serialization test)
- [x] TypeScript type check passes
- [x] Lint/format passes (check:quick)

🤖 Generated with [Claude Code](https://claude.com/claude-code)