### PR TITLE
fix(nix-lock): strip revCount when converting git to github scheme

### DIFF
--- a/packages/@overeng/megarepo/src/lib/nix-lock/schema.ts
+++ b/packages/@overeng/megarepo/src/lib/nix-lock/schema.ts
@@ -246,8 +246,8 @@ export const convertLockedInputToGitHub = (
       result['owner'] = match[1]
       result['repo'] = match[2]
       ownerRepoInserted = true
-    } else if (key === 'shallow' || key === 'submodules') {
-      // Drop git-specific fields
+    } else if (key === 'shallow' || key === 'submodules' || key === 'revCount') {
+      // Drop git-specific fields not supported by github scheme
     } else {
       result[key] = input[key]
     }

--- a/packages/@overeng/megarepo/src/lib/nix-lock/schema.unit.test.ts
+++ b/packages/@overeng/megarepo/src/lib/nix-lock/schema.unit.test.ts
@@ -86,6 +86,28 @@ describe('convertLockedInputToGitHub', () => {
     ).toBeUndefined()
   })
 
+  it('should strip revCount when converting git to github', () => {
+    const result = convertLockedInputToGitHub({
+      type: 'git',
+      url: 'https://github.com/livestorejs/livestore',
+      rev: 'abc123',
+      ref: 'dev',
+      revCount: 3081,
+    })
+    expect(result).toBeDefined()
+    expect(result!['type']).toBe('github')
+    expect(result).not.toHaveProperty('revCount')
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "owner": "livestorejs",
+        "ref": "dev",
+        "repo": "livestore",
+        "rev": "abc123",
+        "type": "github",
+      }
+    `)
+  })
+
   it('should preserve dir param from URL query string', () => {
     const result = convertLockedInputToGitHub({
       type: 'git',


### PR DESCRIPTION
## Problem

`convertLockedInputToGitHub` converts `git` type flake lock inputs to `github` type. It stripped `shallow` and `submodules` (git-specific fields) but not `revCount` — which is also git-specific and invalid for the `github` scheme.

This caused dotfiles alignment PRs to fail with:
```
error: input attribute 'revCount' not supported by scheme 'github'
```

The issue surfaces when a `flake.nix` declares an input as `git+https://github.com/...` (which Nix locks with `type: "git"` + `revCount`), and `mr apply` converts it to `type: "github"` while preserving the incompatible `revCount` field.

## Fix

Add `revCount` to the list of git-specific fields stripped during conversion.

## Test plan

- [x] New test: verifies `revCount` is stripped during git→github conversion
- [x] All 9 schema unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)