### PR TITLE
fix(nix-lock): strip ref from locked inputs when converting git to github

### DIFF
--- a/packages/@overeng/megarepo/src/lib/nix-lock/schema.ts
+++ b/packages/@overeng/megarepo/src/lib/nix-lock/schema.ts
@@ -248,6 +248,8 @@ export const convertLockedInputToGitHub = (
       ownerRepoInserted = true
     } else if (key === 'shallow' || key === 'submodules' || key === 'revCount') {
       // Drop git-specific fields not supported by github scheme
+    } else if (key === 'ref' && input['rev'] !== undefined) {
+      // Drop ref when rev is present — github locked inputs reject both simultaneously
     } else {
       result[key] = input[key]
     }

--- a/packages/@overeng/megarepo/src/lib/nix-lock/schema.unit.test.ts
+++ b/packages/@overeng/megarepo/src/lib/nix-lock/schema.unit.test.ts
@@ -17,7 +17,6 @@ describe('convertLockedInputToGitHub', () => {
         "lastModified": 1234567890,
         "narHash": "sha256-xxx",
         "owner": "owner",
-        "ref": "main",
         "repo": "repo",
         "rev": "abc123",
         "type": "github",
@@ -86,7 +85,7 @@ describe('convertLockedInputToGitHub', () => {
     ).toBeUndefined()
   })
 
-  it('should strip revCount when converting git to github', () => {
+  it('should strip revCount and ref (when rev is present) when converting git to github', () => {
     const result = convertLockedInputToGitHub({
       type: 'git',
       url: 'https://github.com/livestorejs/livestore',
@@ -97,15 +96,26 @@ describe('convertLockedInputToGitHub', () => {
     expect(result).toBeDefined()
     expect(result!['type']).toBe('github')
     expect(result).not.toHaveProperty('revCount')
+    expect(result).not.toHaveProperty('ref')
     expect(result).toMatchInlineSnapshot(`
       {
         "owner": "livestorejs",
-        "ref": "dev",
         "repo": "livestore",
         "rev": "abc123",
         "type": "github",
       }
     `)
+  })
+
+  it('should preserve ref in original sections (no rev)', () => {
+    const result = convertLockedInputToGitHub({
+      type: 'git',
+      url: 'https://github.com/livestorejs/livestore',
+      ref: 'dev',
+    })
+    expect(result).toBeDefined()
+    expect(result).toHaveProperty('ref', 'dev')
+    expect(result!['type']).toBe('github')
   })
 
   it('should preserve dir param from URL query string', () => {


### PR DESCRIPTION
## Problem

Follow-up to #439. After stripping `revCount`, dotfiles alignment PRs still fail with:

```
error: input {...,"type":"github"} contains both a commit hash and a branch/tag name ('dev')
```

`convertLockedInputToGitHub` converts `git` type inputs to `github` type. The `git` scheme allows both `rev` and `ref` in locked inputs, but `github` scheme rejects this combination.

## Fix

Strip `ref` from the converted output when `rev` is also present (i.e., in locked inputs). Preserve `ref` when `rev` is absent (i.e., in original sections where it tracks the branch).

## Test plan

- [x] Updated test: verifies both `revCount` and `ref` are stripped from locked inputs
- [x] New test: verifies `ref` is preserved in original sections (no rev)
- [x] All 10 schema unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)