### PR TITLE
feat(genie): bump pnpm to 11.0.0-beta.2 for GVS-in-CI support

### DIFF
--- a/genie/external.ts
+++ b/genie/external.ts
@@ -236,6 +236,9 @@ export const commonPnpmPolicySettings = {
   dedupePeerDependents: true as const,
   strictPeerDependencies: true as const,
   enableGlobalVirtualStore: true as const,
+  /** Disable until pnpm#10393 is resolved (install no-ops for workspace changes) */
+  optimisticRepeatInstall: false as const,
+  verifyDepsBeforeRun: false as const,
   supportedArchitectures: {
     os: ['linux', 'darwin'],
     cpu: ['x64', 'arm64'],

--- a/nix/oxc-config-plugin.nix
+++ b/nix/oxc-config-plugin.nix
@@ -24,7 +24,7 @@ let
   lib = pkgs.lib;
   pnpmDepsHelper = import ./workspace-tools/lib/mk-pnpm-deps.nix { inherit pkgs; };
   packageDir = "packages/@overeng/oxc-config";
-  pnpmDepsHash = "sha256-0Y2V4RL6kWk3IS5BIK2qVwe+wPl+VHK1hSo5ONI1Gus=";
+  pnpmDepsHash = "sha256-rWD/Zj9F+XBiE+shlRZqeVof9uykchskGpRYTgPBiqY=";
 
   srcPath =
     if builtins.isAttrs src && builtins.hasAttr "outPath" src then

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "packages/@overeng/utils",
     "packages/@overeng/utils-dev"
   ],
-  "packageManager": "pnpm@10.29.2",
+  "packageManager": "pnpm@11.0.0-beta.2",
   "$genie": {
     "source": "package.json.genie.ts",
     "warning": "DO NOT EDIT - changes will be overwritten"

--- a/packages/@overeng/genie/nix/build.nix
+++ b/packages/@overeng/genie/nix/build.nix
@@ -17,7 +17,7 @@ let
     packageDir = "packages/@overeng/genie";
     workspaceRoot = src;
     # Managed by `dt nix:hash:genie` — do not edit manually.
-    pnpmDepsHash = "sha256-eCslLXYQk476E4XoRVNyeUO/pdZ6dEvT4k6mkMbPmvE=";
+    pnpmDepsHash = "sha256-muLH+QL4tjdyfPA2z5kkFwoceA3B/L7M8vi4AbkdPZ0=";
     inherit lockfileHash gitRev commitTs dirty;
   };
 in

--- a/packages/@overeng/genie/src/runtime/package-json/mod.ts
+++ b/packages/@overeng/genie/src/runtime/package-json/mod.ts
@@ -780,7 +780,7 @@ function createPackageJson<const T extends PackageJsonData, const TMeta>(
  * Aggregates are repository coordination files, not package-level authoring
  * surfaces, so this stays centralized instead of being repeated by callers.
  */
-const DEFAULT_AGGREGATE_PACKAGE_MANAGER = 'pnpm@10.29.2'
+const DEFAULT_AGGREGATE_PACKAGE_MANAGER = 'pnpm@11.0.0-beta.2'
 
 /**
  * Project an aggregate manifest from package metadata for an explicit repo view.

--- a/packages/@overeng/genie/src/runtime/package-json/package-json.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/package-json/package-json.unit.test.ts
@@ -546,7 +546,7 @@ describe('packageJson.aggregateFromPackages', () => {
     expect(result.data).toEqual({
       name: 'my-monorepo',
       private: true,
-      packageManager: 'pnpm@10.29.2',
+      packageManager: 'pnpm@11.0.0-beta.2',
       workspaces: ['packages/app', 'packages/utils'],
     })
     expect(typeof result.stringify).toBe('function')
@@ -568,7 +568,7 @@ describe('packageJson.aggregateFromPackages', () => {
     })
     expect(parsed.name).toBe('my-monorepo')
     expect(parsed.private).toBe(true)
-    expect(parsed.packageManager).toBe('pnpm@10.29.2')
+    expect(parsed.packageManager).toBe('pnpm@11.0.0-beta.2')
     expect(parsed.workspaces).toEqual(['packages/app', 'packages/utils'])
   })
 

--- a/packages/@overeng/megarepo/nix/build.nix
+++ b/packages/@overeng/megarepo/nix/build.nix
@@ -16,7 +16,7 @@ let
     packageDir = "packages/@overeng/megarepo";
     workspaceRoot = src;
     # Managed by `dt nix:hash:megarepo` — do not edit manually.
-    pnpmDepsHash = "sha256-hskeU+pRsiy6afyjVxNNzZObce5yqOJ5aRDAA0SDkos=";
+    pnpmDepsHash = "sha256-xKmcAblFZpaWUdjSHiJNLK4Ij15HEHWzCp448of+AP8=";
     smokeTestArgs = [ "--help" ];
     inherit lockfileHash gitRev commitTs dirty;
   };


### PR DESCRIPTION
## Summary

- Bumps `DEFAULT_AGGREGATE_PACKAGE_MANAGER` from `pnpm@10.29.2` to `pnpm@11.0.0-beta.2`
- Adds `optimisticRepeatInstall: false` and `verifyDepsBeforeRun: false` to `commonPnpmPolicySettings`

## Rationale

pnpm 10.x hard-disables `enableGlobalVirtualStore` in CI environments (`CI=true`), breaking identity convergence for cross-repo `link:` dependencies. This causes duplicate singleton packages (e.g. React) in bundled apps when composed members have separate `pnpm install` commands.

pnpm 11 (pnpm/pnpm#10836) respects explicit `enableGlobalVirtualStore: true` even in CI.

## Test plan

- [ ] effect-utils CI green
- [ ] Downstream genie regeneration clean
- [ ] TV museum app single React instance in CI build

🤖 Generated with [Claude Code](https://claude.com/claude-code)