### PR TITLE
fix(megarepo): use in-memory backing for store-lock unit test

### DIFF
--- a/packages/@overeng/megarepo/src/lib/store-lock.ts
+++ b/packages/@overeng/megarepo/src/lib/store-lock.ts
@@ -96,6 +96,25 @@ const makeKeyedLock = ({
   })
 
 /**
+ * Create the StoreLock layer from an arbitrary DistributedSemaphoreBacking layer.
+ * Useful for testing with an in-memory backing.
+ */
+export const makeStoreLockLayerFromBacking = (
+  backingLayer: Layer.Layer<DistributedSemaphoreBacking>,
+) =>
+  Layer.scoped(
+    StoreLock,
+    Effect.gen(function* () {
+      const backingContext = yield* Layer.build(backingLayer)
+
+      return {
+        withRepoLock: yield* makeKeyedLock({ backingContext, namespace: 'repo' }),
+        withWorktreeLock: yield* makeKeyedLock({ backingContext, namespace: 'worktree' }),
+      } as const
+    }),
+  )
+
+/**
  * Create the StoreLock layer backed by file-system locks at the given path.
  * Lock files stored in {basePath}.locks/ directory.
  */

--- a/packages/@overeng/megarepo/src/lib/store-lock.unit.test.ts
+++ b/packages/@overeng/megarepo/src/lib/store-lock.unit.test.ts
@@ -1,19 +1,14 @@
-import { NodeContext } from '@effect/platform-node'
 import { it } from '@effect/vitest'
 import { Effect, Ref } from 'effect'
 import { describe, expect } from 'vitest'
 
-import { EffectPath } from '@overeng/effect-path'
+import { InMemoryBacking } from '@overeng/utils'
 
-import { makeStoreLockLayer, StoreLock } from './store-lock.ts'
+import { makeStoreLockLayerFromBacking, StoreLock } from './store-lock.ts'
 
-/** Provide StoreLock backed by a temp directory */
+/** Provide StoreLock backed by an in-memory distributed semaphore */
 const withStoreLock = <A, E>(effect: Effect.Effect<A, E, StoreLock>): Effect.Effect<A, E, never> =>
-  Effect.gen(function* () {
-    const tmpDir = yield* Effect.sync(() => require('node:os').tmpdir())
-    const basePath = EffectPath.unsafe.absoluteDir(`${tmpDir}/store-lock-test-${Date.now()}/`)
-    return yield* effect.pipe(Effect.provide(makeStoreLockLayer(basePath)))
-  }).pipe(Effect.scoped, Effect.provide(NodeContext.layer))
+  effect.pipe(Effect.provide(makeStoreLockLayerFromBacking(InMemoryBacking.layer)), Effect.scoped)
 
 describe('StoreLock', () => {
   it.effect(

--- a/packages/@overeng/tui-react/src/effect/TerminalInput.ts
+++ b/packages/@overeng/tui-react/src/effect/TerminalInput.ts
@@ -509,7 +509,7 @@ export const createTerminalInput = (
   options: TerminalInputOptions = {},
 ): Effect.Effect<TerminalInput, never, Scope.Scope> =>
   Effect.gen(function* () {
-    const input = options.input ?? process.stdin
+    const input: Readable = options.input ?? process.stdin
     const output = options.output ?? process.stdout
     const rawMode = options.rawMode ?? true
     const handleCtrlC = options.handleCtrlC ?? false

--- a/packages/@overeng/utils/src/isomorphic/in-memory-backing.ts
+++ b/packages/@overeng/utils/src/isomorphic/in-memory-backing.ts
@@ -1,0 +1,89 @@
+import { Duration, Effect, Layer } from 'effect'
+import { DistributedSemaphoreBacking } from 'effect-distributed-lock'
+
+/**
+ * In-memory DistributedSemaphoreBacking — useful for tests where filesystem
+ * or Redis backings introduce non-determinism (e.g. flaky fs.watch on CI).
+ * Does not implement onPermitsReleased; the DistributedSemaphore falls back
+ * to its default polling schedule.
+ */
+export const make = (): DistributedSemaphoreBacking => {
+  /** Map of key -> Map of holderId -> { permits, expiresAt } */
+  const store = new Map<string, Map<string, { permits: number; expiresAt: number }>>()
+
+  const getKeyStore = (key: string) => {
+    let keyStore = store.get(key)
+    if (keyStore === undefined) {
+      keyStore = new Map()
+      store.set(key, keyStore)
+    }
+    return keyStore
+  }
+
+  const activeCount = (key: string): number => {
+    const keyStore = store.get(key)
+    if (keyStore === undefined) return 0
+    const now = Date.now()
+    let count = 0
+    for (const [holderId, entry] of keyStore) {
+      if (entry.expiresAt <= now) {
+        keyStore.delete(holderId)
+      } else {
+        count += entry.permits
+      }
+    }
+    return count
+  }
+
+  return {
+    // oxlint-disable-next-line overeng/named-args -- implements DistributedSemaphoreBacking interface
+    tryAcquire: (key, holderId, ttl, limit, permits) =>
+      Effect.sync(() => {
+        const current = activeCount(key)
+        if (current + permits > limit) return false
+        const keyStore = getKeyStore(key)
+        const existing = keyStore.get(holderId)
+        keyStore.set(holderId, {
+          permits: (existing?.permits ?? 0) + permits,
+          expiresAt: Date.now() + Duration.toMillis(ttl),
+        })
+        return true
+      }),
+
+    // oxlint-disable-next-line overeng/named-args -- implements DistributedSemaphoreBacking interface
+    release: (key, holderId, permits) =>
+      Effect.sync(() => {
+        const keyStore = store.get(key)
+        if (keyStore === undefined) return 0
+        const entry = keyStore.get(holderId)
+        if (entry === undefined) return 0
+        const released = Math.min(permits, entry.permits)
+        if (released >= entry.permits) {
+          keyStore.delete(holderId)
+        } else {
+          keyStore.set(holderId, { ...entry, permits: entry.permits - released })
+        }
+        return released
+      }),
+
+    // oxlint-disable-next-line overeng/named-args -- implements DistributedSemaphoreBacking interface
+    refresh: (key, holderId, ttl, _limit, _permits) =>
+      Effect.sync(() => {
+        const keyStore = store.get(key)
+        if (keyStore === undefined) return false
+        const entry = keyStore.get(holderId)
+        if (entry === undefined) return false
+        keyStore.set(holderId, { ...entry, expiresAt: Date.now() + Duration.toMillis(ttl) })
+        return true
+      }),
+
+    // oxlint-disable-next-line overeng/named-args -- implements DistributedSemaphoreBacking interface
+    getCount: (key, _ttl) => Effect.sync(() => activeCount(key)),
+  }
+}
+
+/** Layer providing an in-memory DistributedSemaphoreBacking */
+export const layer: Layer.Layer<DistributedSemaphoreBacking> = Layer.sync(
+  DistributedSemaphoreBacking,
+  make,
+)

--- a/packages/@overeng/utils/src/isomorphic/mod.ts
+++ b/packages/@overeng/utils/src/isomorphic/mod.ts
@@ -7,6 +7,9 @@ export {
   SemaphoreBackingError,
 } from 'effect-distributed-lock'
 
+/** In-memory backing for distributed semaphore (useful for tests) */
+export * as InMemoryBacking from './in-memory-backing.ts'
+
 /** Debug utilities for tracing scope and finalizer lifecycle */
 export * from './ScopeDebugger.ts'
 


### PR DESCRIPTION
## Summary

- Replace `FileSystemBacking` with a new `InMemoryBacking` in `store-lock.unit.test.ts` to fix flaky timeout on macOS CI ([failed run](https://github.com/overengineeringstudio/effect-utils/actions/runs/23432340758/job/68161589451?pr=441))
- Extract `InMemoryBacking` into `@overeng/utils` (exported as `InMemoryBacking` from the isomorphic module) for reuse across tests
- Add `makeStoreLockLayerFromBacking()` to `store-lock.ts` so tests can inject a custom backing without filesystem dependencies
- Fix pre-existing TS error in `tui-react/TerminalInput.ts` — narrowed `input` to `Readable` to resolve union type incompatibility on `.off()`

## Rationale

The unit test only needs to verify in-process fiber serialization logic, not cross-process filesystem locking. The `fs.watch`-based `onPermitsReleased` notification was unreliable on macOS CI runners, causing deadlocks. Using an in-memory backing eliminates this non-determinism while still exercising the full `DistributedSemaphore` acquire/release/polling path. Tests now complete in ~35ms deterministically.

## Test plan

- [x] All 4 store-lock unit tests pass locally (5/5 consecutive runs, ~35ms)
- [x] TypeScript compilation passes (all packages including tui-react fix)
- [x] Lint + format checks pass
- [ ] CI passes on macOS runner