### PR TITLE
fix(ci): auto-retry devenv tasks on Nix GC race condition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,24 @@ jobs:
           echo "::warning::Intentional failure for diagnostics validation (#272)"
           exit 1
       - name: Type check
-        run: "if [ -n \"${NIX_CONFIG:-}\" ]; then NIX_CONFIG_WITH_APPEND=$(printf '%s\\n%s' \"$NIX_CONFIG\" 'restrict-eval = false'); else NIX_CONFIG_WITH_APPEND='restrict-eval = false'; fi; NIX_CONFIG=\"$NIX_CONFIG_WITH_APPEND\" DT_PASSTHROUGH=1 \"${DEVENV_BIN:?DEVENV_BIN not set}\" tasks run ts:check --mode before"
+        run: |
+          __nix_gc_retry() {
+            local __max=${NIX_GC_RACE_MAX_RETRIES:-10} __n=1 __log __rc __path
+            while [ "$__n" -le "$__max" ]; do
+              __log=$(mktemp)
+              set +e; eval "$1" 2> >(tee "$__log" >&2); __rc=$?; set -e
+              [ $__rc -eq 0 ] && { rm -f "$__log"; return 0; }
+              __path=$(grep -oP "path '\K/nix/store/[^']*" "$__log" 2>/dev/null | head -1 || true)
+              rm -f "$__log"
+              [ -z "$__path" ] && return $__rc
+              echo "::warning::Nix GC race detected (attempt $__n/$__max): $__path"
+              nix-store --realise "$__path" 2>/dev/null || true
+              rm -rf ~/.cache/nix/eval-cache-*
+              __n=$((__n + 1))
+            done
+            echo "::error::Nix GC race retry exhausted ($__max attempts)"
+            return 1
+          }; __nix_gc_retry 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run ts:check --mode before'
       - name: Nix diagnostics summary
         if: failure()
         shell: bash
@@ -310,7 +327,24 @@ jobs:
           echo "::warning::Intentional failure for diagnostics validation (#272)"
           exit 1
       - name: Format + lint
-        run: "if [ -n \"${NIX_CONFIG:-}\" ]; then NIX_CONFIG_WITH_APPEND=$(printf '%s\\n%s' \"$NIX_CONFIG\" 'restrict-eval = false'); else NIX_CONFIG_WITH_APPEND='restrict-eval = false'; fi; NIX_CONFIG=\"$NIX_CONFIG_WITH_APPEND\" DT_PASSTHROUGH=1 \"${DEVENV_BIN:?DEVENV_BIN not set}\" tasks run lint:check --mode before"
+        run: |
+          __nix_gc_retry() {
+            local __max=${NIX_GC_RACE_MAX_RETRIES:-10} __n=1 __log __rc __path
+            while [ "$__n" -le "$__max" ]; do
+              __log=$(mktemp)
+              set +e; eval "$1" 2> >(tee "$__log" >&2); __rc=$?; set -e
+              [ $__rc -eq 0 ] && { rm -f "$__log"; return 0; }
+              __path=$(grep -oP "path '\K/nix/store/[^']*" "$__log" 2>/dev/null | head -1 || true)
+              rm -f "$__log"
+              [ -z "$__path" ] && return $__rc
+              echo "::warning::Nix GC race detected (attempt $__n/$__max): $__path"
+              nix-store --realise "$__path" 2>/dev/null || true
+              rm -rf ~/.cache/nix/eval-cache-*
+              __n=$((__n + 1))
+            done
+            echo "::error::Nix GC race retry exhausted ($__max attempts)"
+            return 1
+          }; __nix_gc_retry 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run lint:check --mode before'
       - name: Nix diagnostics summary
         if: failure()
         shell: bash
@@ -483,7 +517,24 @@ jobs:
           echo "::warning::Intentional failure for diagnostics validation (#272)"
           exit 1
       - name: Unit tests
-        run: "if [ -n \"${NIX_CONFIG:-}\" ]; then NIX_CONFIG_WITH_APPEND=$(printf '%s\\n%s' \"$NIX_CONFIG\" 'restrict-eval = false'); else NIX_CONFIG_WITH_APPEND='restrict-eval = false'; fi; NIX_CONFIG=\"$NIX_CONFIG_WITH_APPEND\" DT_PASSTHROUGH=1 \"${DEVENV_BIN:?DEVENV_BIN not set}\" tasks run test:run --mode before"
+        run: |
+          __nix_gc_retry() {
+            local __max=${NIX_GC_RACE_MAX_RETRIES:-10} __n=1 __log __rc __path
+            while [ "$__n" -le "$__max" ]; do
+              __log=$(mktemp)
+              set +e; eval "$1" 2> >(tee "$__log" >&2); __rc=$?; set -e
+              [ $__rc -eq 0 ] && { rm -f "$__log"; return 0; }
+              __path=$(grep -oP "path '\K/nix/store/[^']*" "$__log" 2>/dev/null | head -1 || true)
+              rm -f "$__log"
+              [ -z "$__path" ] && return $__rc
+              echo "::warning::Nix GC race detected (attempt $__n/$__max): $__path"
+              nix-store --realise "$__path" 2>/dev/null || true
+              rm -rf ~/.cache/nix/eval-cache-*
+              __n=$((__n + 1))
+            done
+            echo "::error::Nix GC race retry exhausted ($__max attempts)"
+            return 1
+          }; __nix_gc_retry 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run test:run --mode before'
       - name: Nix diagnostics summary
         if: failure()
         shell: bash
@@ -656,7 +707,24 @@ jobs:
           echo "::warning::Intentional failure for diagnostics validation (#272)"
           exit 1
       - name: Nix hash check
-        run: "if [ -n \"${NIX_CONFIG:-}\" ]; then NIX_CONFIG_WITH_APPEND=$(printf '%s\\n%s' \"$NIX_CONFIG\" 'restrict-eval = false'); else NIX_CONFIG_WITH_APPEND='restrict-eval = false'; fi; NIX_CONFIG=\"$NIX_CONFIG_WITH_APPEND\" DT_PASSTHROUGH=1 \"${DEVENV_BIN:?DEVENV_BIN not set}\" tasks run nix:check --mode before"
+        run: |
+          __nix_gc_retry() {
+            local __max=${NIX_GC_RACE_MAX_RETRIES:-10} __n=1 __log __rc __path
+            while [ "$__n" -le "$__max" ]; do
+              __log=$(mktemp)
+              set +e; eval "$1" 2> >(tee "$__log" >&2); __rc=$?; set -e
+              [ $__rc -eq 0 ] && { rm -f "$__log"; return 0; }
+              __path=$(grep -oP "path '\K/nix/store/[^']*" "$__log" 2>/dev/null | head -1 || true)
+              rm -f "$__log"
+              [ -z "$__path" ] && return $__rc
+              echo "::warning::Nix GC race detected (attempt $__n/$__max): $__path"
+              nix-store --realise "$__path" 2>/dev/null || true
+              rm -rf ~/.cache/nix/eval-cache-*
+              __n=$((__n + 1))
+            done
+            echo "::error::Nix GC race retry exhausted ($__max attempts)"
+            return 1
+          }; __nix_gc_retry 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run nix:check --mode before'
       - name: Nix diagnostics summary
         if: failure()
         shell: bash
@@ -837,9 +905,41 @@ jobs:
             exit 0
           fi
           if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '%s\n%s' "$NIX_CONFIG" 'restrict-eval = false'); else NIX_CONFIG_WITH_APPEND='restrict-eval = false'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run netlify:deploy --input type=prod --mode before
+            __nix_gc_retry() {
+            local __max=${NIX_GC_RACE_MAX_RETRIES:-10} __n=1 __log __rc __path
+            while [ "$__n" -le "$__max" ]; do
+              __log=$(mktemp)
+              set +e; eval "$1" 2> >(tee "$__log" >&2); __rc=$?; set -e
+              [ $__rc -eq 0 ] && { rm -f "$__log"; return 0; }
+              __path=$(grep -oP "path '\K/nix/store/[^']*" "$__log" 2>/dev/null | head -1 || true)
+              rm -f "$__log"
+              [ -z "$__path" ] && return $__rc
+              echo "::warning::Nix GC race detected (attempt $__n/$__max): $__path"
+              nix-store --realise "$__path" 2>/dev/null || true
+              rm -rf ~/.cache/nix/eval-cache-*
+              __n=$((__n + 1))
+            done
+            echo "::error::Nix GC race retry exhausted ($__max attempts)"
+            return 1
+          }; __nix_gc_retry 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run netlify:deploy --input type=prod --mode before'
           elif [ "${{ github.event_name }}" = "pull_request" ]; then
-            if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '%s\n%s' "$NIX_CONFIG" 'restrict-eval = false'); else NIX_CONFIG_WITH_APPEND='restrict-eval = false'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run netlify:deploy --input type=pr --input pr=${{ github.event.pull_request.number }} --mode before
+            __nix_gc_retry() {
+            local __max=${NIX_GC_RACE_MAX_RETRIES:-10} __n=1 __log __rc __path
+            while [ "$__n" -le "$__max" ]; do
+              __log=$(mktemp)
+              set +e; eval "$1" 2> >(tee "$__log" >&2); __rc=$?; set -e
+              [ $__rc -eq 0 ] && { rm -f "$__log"; return 0; }
+              __path=$(grep -oP "path '\K/nix/store/[^']*" "$__log" 2>/dev/null | head -1 || true)
+              rm -f "$__log"
+              [ -z "$__path" ] && return $__rc
+              echo "::warning::Nix GC race detected (attempt $__n/$__max): $__path"
+              nix-store --realise "$__path" 2>/dev/null || true
+              rm -rf ~/.cache/nix/eval-cache-*
+              __n=$((__n + 1))
+            done
+            echo "::error::Nix GC race retry exhausted ($__max attempts)"
+            return 1
+          }; __nix_gc_retry 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run netlify:deploy --input type=pr --input pr=${{ github.event.pull_request.number }} --mode before'
           fi
       - name: Post deploy URLs
         if: always() && !cancelled()

--- a/genie/ci-workflow.ts
+++ b/genie/ci-workflow.ts
@@ -136,9 +136,39 @@ const runDevenvTasksBeforeWithOptions = (opts: NixConfigOptions, ...args: [strin
     opts,
   })
 
+/**
+ * Retry wrapper for the Nix GC race condition where `derivationStrict` fails with
+ * `path '/nix/store/...' is not valid`. On each retry, fetches the missing path
+ * and clears the eval cache.
+ *
+ * TODO: Remove once NixOS/nix#15469 and DeterminateSystems/nix-src#395 are released
+ * @see https://github.com/NixOS/nix/pull/15469
+ * @see https://github.com/DeterminateSystems/nix-src/issues/395
+ */
+const withGcRaceRetry = (command: string) => {
+  const quoted = shellSingleQuote(command)
+  return `__nix_gc_retry() {
+  local __max=${'${NIX_GC_RACE_MAX_RETRIES:-10}'} __n=1 __log __rc __path
+  while [ "$__n" -le "$__max" ]; do
+    __log=$(mktemp)
+    set +e; eval "$1" 2> >(tee "$__log" >&2); __rc=$?; set -e
+    [ $__rc -eq 0 ] && { rm -f "$__log"; return 0; }
+    __path=$(grep -oP "path '\\K/nix/store/[^']*" "$__log" 2>/dev/null | head -1 || true)
+    rm -f "$__log"
+    [ -z "$__path" ] && return $__rc
+    echo "::warning::Nix GC race detected (attempt $__n/$__max): $__path"
+    nix-store --realise "$__path" 2>/dev/null || true
+    rm -rf ~/.cache/nix/eval-cache-*
+    __n=$((__n + 1))
+  done
+  echo "::error::Nix GC race retry exhausted ($__max attempts)"
+  return 1
+}; __nix_gc_retry ${quoted}`
+}
+
 /** Build a command that runs one or more devenv tasks with `--mode before`. */
 export const runDevenvTasksBefore = (...args: [string, ...string[]]) =>
-  runDevenvTasksBeforeWithOptions({ unrestrictedEval: true }, ...args)
+  withGcRaceRetry(runDevenvTasksBeforeWithOptions({ unrestrictedEval: true }, ...args))
 
 /** Evict cached pnpm-deps fixed-output outputs so CI re-derives them fresh. */
 export const evictCachedPnpmDepsStep = ({


### PR DESCRIPTION
## Summary

Wraps all `runDevenvTasksBefore` invocations with automatic retry logic that detects the Nix GC race condition and recovers.

## Problem

A GC race condition in Nix (NixOS/nix#15469, DeterminateSystems/nix-src#395) causes ~5-15% of CI runs to fail with:

```
error: path '/nix/store/...' is not valid
```

The upstream fix is open but not yet released. This PR adds a pragmatic workaround.

## How it works

The `withGcRaceRetry` wrapper:
1. Runs the devenv task command, capturing stderr to a temp file
2. On failure, checks if stderr contains `error: path '/nix/store/...' is not valid`
3. If yes: extracts the missing path, fetches it via `nix-store --realise`, clears the eval cache, and retries
4. If no (different error): fails immediately with the original exit code
5. Retries up to `$NIX_GC_RACE_MAX_RETRIES` times (default 10)

Each retry emits a `::warning::` annotation so flaky runs are visible in CI.

## Scope

All `runDevenvTasksBefore()` calls are wrapped — this propagates to all downstream repos via genie.

## TODO

Remove once the upstream fixes are released:
- https://github.com/NixOS/nix/pull/15469
- https://github.com/DeterminateSystems/nix-src/issues/395

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) on behalf of @schickling