### PR TITLE
fix(ci): revert runDevenvTasksBefore to string, add runDevenvTasksBeforeStep

### DIFF
--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -148,21 +148,21 @@ const multiPlatformJob = (step: { name: string; run: string }) => ({
 const jobs: Record<CIJobName, ReturnType<typeof job> | ReturnType<typeof multiPlatformJob>> = {
   typecheck: job({
     name: 'Type check',
-    run: runDevenvTasksBefore('ts:check').run,
+    run: runDevenvTasksBefore('ts:check'),
   }),
   lint: job({
     name: 'Format + lint',
-    run: runDevenvTasksBefore('lint:check').run,
+    run: runDevenvTasksBefore('lint:check'),
   }),
   test: multiPlatformJob({
     name: 'Unit tests',
-    run: runDevenvTasksBefore('test:run').run,
+    run: runDevenvTasksBefore('test:run'),
   }),
   // Verify Nix hashes are up-to-date (pnpmDepsHash + localDeps)
   // This catches stale hashes before they break downstream consumers
   'nix-check': multiPlatformJob({
     name: 'Nix hash check',
-    run: runDevenvTasksBefore('nix:check').run,
+    run: runDevenvTasksBefore('nix:check'),
   }),
 }
 

--- a/genie/ci-workflow.ts
+++ b/genie/ci-workflow.ts
@@ -166,18 +166,15 @@ const withGcRaceRetry = (command: string) => {
 }; __nix_gc_retry ${quoted}`
 }
 
-/**
- * Build a workflow step for running devenv tasks with `--mode before` and GC race retry.
- *
- * Returns `{ name, run }` — use as a step directly or spread into a step with a custom name:
- * - As step: `runDevenvTasksBefore('test:unit')` → `{ name: 'devenv: test:unit', run: '...' }`
- * - Custom name: `{ name: 'My step', run: runDevenvTasksBefore('test:unit').run }`
- * - In template string: `${runDevenvTasksBefore('deploy')}` (uses `toString()` → the run command)
- */
-export const runDevenvTasksBefore = (...args: [string, ...string[]]) => {
-  const run = withGcRaceRetry(runDevenvTasksBeforeWithOptions({ unrestrictedEval: true }, ...args))
-  return Object.assign({ name: `devenv: ${args.join(' ')}`, run }, { toString: () => run })
-}
+/** Build a command string that runs devenv tasks with `--mode before` and GC race retry. */
+export const runDevenvTasksBefore = (...args: [string, ...string[]]) =>
+  withGcRaceRetry(runDevenvTasksBeforeWithOptions({ unrestrictedEval: true }, ...args))
+
+/** Build a workflow step `{ name, run }` for running devenv tasks. Derives the step name from the task args. */
+export const runDevenvTasksBeforeStep = (...args: [string, ...string[]]) => ({
+  name: `devenv: ${args.join(' ')}`,
+  run: runDevenvTasksBefore(...args),
+})
 
 /** Evict cached pnpm-deps fixed-output outputs so CI re-derives them fresh. */
 export const evictCachedPnpmDepsStep = ({

--- a/genie/external.ts
+++ b/genie/external.ts
@@ -589,6 +589,7 @@ export {
   namespaceRunner,
   nixDiagnosticsArtifactStep,
   runDevenvTasksBefore,
+  runDevenvTasksBeforeStep,
   validateNixStoreStep,
   standardCIEnv,
   syncMegarepoWorkspaceStep,


### PR DESCRIPTION
## Problem

PR #454 changed `runDevenvTasksBefore` to return `{ name, run, toString() }`. While `toString()` works in JS template strings, genie's YAML serializer doesn't call `toString()` — it serializes the full object, producing invalid YAML:

```yaml
- run:
    name: 'devenv: lint'
    run: |
      __nix_gc_retry() { ... }
```

This broke all downstream `ci.yml` files (livestore #1118 shows "A mapping was not expected").

## Fix

- Revert `runDevenvTasksBefore` to return a plain string (backward compatible)
- Add `runDevenvTasksBeforeStep` that returns `{ name, run }` for callers that want auto-generated step names
- Export `runDevenvTasksBeforeStep` from `external.ts`

Downstream repos can migrate to `runDevenvTasksBeforeStep` at their own pace.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) on behalf of @schickling