### PR TITLE
feat(genie): add agentation to base catalog

### DIFF
--- a/genie/external.ts
+++ b/genie/external.ts
@@ -218,6 +218,9 @@ export const catalog = defineCatalog({
   'yoga-layout': '3.2.1',
   'string-width': '7.2.0',
   'cli-truncate': '5.1.1',
+
+  // AI agent tooling
+  agentation: '3.0.1',
 })
 
 /**


### PR DESCRIPTION
## Summary
- Add `agentation@3.0.1` to the shared genie catalog so downstream megarepos can reference it without maintaining their own version entry

## Rationale
`agentation` is a visual feedback tool (React component + MCP server) used across multiple projects for AI agent workflows. Centralizing the version in the base catalog keeps versions consistent and avoids duplication in downstream `dotfilesPackages`.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — acting on behalf of @schickling