### PR TITLE
fix(ci): remove toString from runDevenvTasksBefore return

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,9 +145,9 @@ jobs:
             local __max=${NIX_GC_RACE_MAX_RETRIES:-10} __n=1 __log __rc __path
             while [ "$__n" -le "$__max" ]; do
               __log=$(mktemp)
-              set +e; eval "$1" 2> >(tee "$__log" >&2); __rc=$?; set -e
+              set +e; eval "$1" 2>&1 | tee "$__log"; __rc=${PIPESTATUS[0]}; set -e
               [ $__rc -eq 0 ] && { rm -f "$__log"; return 0; }
-              __path=$(grep -oP "path '\K/nix/store/[^']*" "$__log" 2>/dev/null | head -1 || true)
+              __path=$(sed -n "s/.*path '\(\/nix\/store\/[^']*\)'.*/\1/p" "$__log" | head -1)
               rm -f "$__log"
               [ -z "$__path" ] && return $__rc
               echo "::warning::Nix GC race detected (attempt $__n/$__max): $__path"
@@ -332,9 +332,9 @@ jobs:
             local __max=${NIX_GC_RACE_MAX_RETRIES:-10} __n=1 __log __rc __path
             while [ "$__n" -le "$__max" ]; do
               __log=$(mktemp)
-              set +e; eval "$1" 2> >(tee "$__log" >&2); __rc=$?; set -e
+              set +e; eval "$1" 2>&1 | tee "$__log"; __rc=${PIPESTATUS[0]}; set -e
               [ $__rc -eq 0 ] && { rm -f "$__log"; return 0; }
-              __path=$(grep -oP "path '\K/nix/store/[^']*" "$__log" 2>/dev/null | head -1 || true)
+              __path=$(sed -n "s/.*path '\(\/nix\/store\/[^']*\)'.*/\1/p" "$__log" | head -1)
               rm -f "$__log"
               [ -z "$__path" ] && return $__rc
               echo "::warning::Nix GC race detected (attempt $__n/$__max): $__path"
@@ -522,9 +522,9 @@ jobs:
             local __max=${NIX_GC_RACE_MAX_RETRIES:-10} __n=1 __log __rc __path
             while [ "$__n" -le "$__max" ]; do
               __log=$(mktemp)
-              set +e; eval "$1" 2> >(tee "$__log" >&2); __rc=$?; set -e
+              set +e; eval "$1" 2>&1 | tee "$__log"; __rc=${PIPESTATUS[0]}; set -e
               [ $__rc -eq 0 ] && { rm -f "$__log"; return 0; }
-              __path=$(grep -oP "path '\K/nix/store/[^']*" "$__log" 2>/dev/null | head -1 || true)
+              __path=$(sed -n "s/.*path '\(\/nix\/store\/[^']*\)'.*/\1/p" "$__log" | head -1)
               rm -f "$__log"
               [ -z "$__path" ] && return $__rc
               echo "::warning::Nix GC race detected (attempt $__n/$__max): $__path"
@@ -712,9 +712,9 @@ jobs:
             local __max=${NIX_GC_RACE_MAX_RETRIES:-10} __n=1 __log __rc __path
             while [ "$__n" -le "$__max" ]; do
               __log=$(mktemp)
-              set +e; eval "$1" 2> >(tee "$__log" >&2); __rc=$?; set -e
+              set +e; eval "$1" 2>&1 | tee "$__log"; __rc=${PIPESTATUS[0]}; set -e
               [ $__rc -eq 0 ] && { rm -f "$__log"; return 0; }
-              __path=$(grep -oP "path '\K/nix/store/[^']*" "$__log" 2>/dev/null | head -1 || true)
+              __path=$(sed -n "s/.*path '\(\/nix\/store\/[^']*\)'.*/\1/p" "$__log" | head -1)
               rm -f "$__log"
               [ -z "$__path" ] && return $__rc
               echo "::warning::Nix GC race detected (attempt $__n/$__max): $__path"
@@ -909,9 +909,9 @@ jobs:
             local __max=${NIX_GC_RACE_MAX_RETRIES:-10} __n=1 __log __rc __path
             while [ "$__n" -le "$__max" ]; do
               __log=$(mktemp)
-              set +e; eval "$1" 2> >(tee "$__log" >&2); __rc=$?; set -e
+              set +e; eval "$1" 2>&1 | tee "$__log"; __rc=${PIPESTATUS[0]}; set -e
               [ $__rc -eq 0 ] && { rm -f "$__log"; return 0; }
-              __path=$(grep -oP "path '\K/nix/store/[^']*" "$__log" 2>/dev/null | head -1 || true)
+              __path=$(sed -n "s/.*path '\(\/nix\/store\/[^']*\)'.*/\1/p" "$__log" | head -1)
               rm -f "$__log"
               [ -z "$__path" ] && return $__rc
               echo "::warning::Nix GC race detected (attempt $__n/$__max): $__path"
@@ -927,9 +927,9 @@ jobs:
             local __max=${NIX_GC_RACE_MAX_RETRIES:-10} __n=1 __log __rc __path
             while [ "$__n" -le "$__max" ]; do
               __log=$(mktemp)
-              set +e; eval "$1" 2> >(tee "$__log" >&2); __rc=$?; set -e
+              set +e; eval "$1" 2>&1 | tee "$__log"; __rc=${PIPESTATUS[0]}; set -e
               [ $__rc -eq 0 ] && { rm -f "$__log"; return 0; }
-              __path=$(grep -oP "path '\K/nix/store/[^']*" "$__log" 2>/dev/null | head -1 || true)
+              __path=$(sed -n "s/.*path '\(\/nix\/store\/[^']*\)'.*/\1/p" "$__log" | head -1)
               rm -f "$__log"
               [ -z "$__path" ] && return $__rc
               echo "::warning::Nix GC race detected (attempt $__n/$__max): $__path"

--- a/genie/ci-workflow.ts
+++ b/genie/ci-workflow.ts
@@ -151,9 +151,9 @@ const withGcRaceRetry = (command: string) => {
   local __max=${'${NIX_GC_RACE_MAX_RETRIES:-10}'} __n=1 __log __rc __path
   while [ "$__n" -le "$__max" ]; do
     __log=$(mktemp)
-    set +e; eval "$1" 2> >(tee "$__log" >&2); __rc=$?; set -e
+    set +e; eval "$1" 2>&1 | tee "$__log"; __rc=${'${PIPESTATUS[0]}'}; set -e
     [ $__rc -eq 0 ] && { rm -f "$__log"; return 0; }
-    __path=$(grep -oP "path '\\K/nix/store/[^']*" "$__log" 2>/dev/null | head -1 || true)
+    __path=$(sed -n "s/.*path '\\(\\/nix\\/store\\/[^']*\\)'.*/\\1/p" "$__log" | head -1)
     rm -f "$__log"
     [ -z "$__path" ] && return $__rc
     echo "::warning::Nix GC race detected (attempt $__n/$__max): $__path"


### PR DESCRIPTION
## Problem

`runDevenvTasksBefore` returns `Object.assign({ name, run }, { toString: () => run })`. Genie's YAML serializer outputs `toString` as a literal key, producing invalid GitHub Actions YAML:

```yaml
- name: 'devenv: lint:check'
  run: |
    __nix_gc_retry() { ... }
  toString: () => run   # ← invalid
```

This breaks CI on all downstream repos.

## Fix

- Remove `toString` — return plain `{ name, run }`
- Fix 4 vercel/netlify callers that used template string coercion: `${runDevenvTasksBefore(...)}` → `${runDevenvTasksBefore(...).run}`

## Downstream impact

None — all downstream repos already use `.run` for string access and the object directly for steps.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) on behalf of @schickling