### PR TITLE
nix: add workspace bin helper for mk-pnpm-cli

### DIFF
--- a/nix/workspace-tools/lib/mk-pnpm-cli.nix
+++ b/nix/workspace-tools/lib/mk-pnpm-cli.nix
@@ -601,11 +601,22 @@ pkgs.stdenv.mkDerivation {
     # shared wrapper for already-installed workspace binaries in postBuild hooks.
     export HOME=$(mktemp -d "$NIX_BUILD_TOP/pnpm-home.XXXXXX")
     export PNPM_HOME="$HOME/.local/share/pnpm"
-    export WORKSPACE_BIN_DIR="$NIX_BUILD_TOP/workspace/node_modules/.bin"
+    export WORKSPACE_ROOT_BIN_DIR="$NIX_BUILD_TOP/workspace/node_modules/.bin"
     mkdir -p "$PNPM_HOME"
     printf '\nmanage-package-manager-versions=false\n' >> .npmrc
     run_workspace_bin() {
-      "$WORKSPACE_BIN_DIR/$1" "''${@:2}"
+      local bin_name="$1"
+      shift
+      local package_bin_dir="$PWD/node_modules/.bin"
+
+      if [ -x "$package_bin_dir/$bin_name" ]; then
+        "$package_bin_dir/$bin_name" "$@"
+      elif [ -x "$WORKSPACE_ROOT_BIN_DIR/$bin_name" ]; then
+        "$WORKSPACE_ROOT_BIN_DIR/$bin_name" "$@"
+      else
+        echo "error: workspace binary '$bin_name' not found in $package_bin_dir or $WORKSPACE_ROOT_BIN_DIR" >&2
+        exit 127
+      fi
     }
 
     cd ${packageDir}


### PR DESCRIPTION
Why

Nix CLI derivations prepare a pnpm workspace up front, but some postBuild hooks still need to run workspace-installed JS binaries such as vite. Calling `pnpm exec` inside the sandbox is the wrong layer and can fall back to registry/tooling resolution.

What

- add `run_workspace_bin` to `mk-pnpm-cli`
- prefer package-local `.bin` first and fall back to the workspace root `.bin`
- fail explicitly if the binary is missing

Rationale

This keeps package-manager work in workspace prep and makes postBuild hooks use already-installed binaries directly. The package-local-first lookup is needed because `mk-pnpm-cli` runs postBuild from inside `packageDir`, so not every workspace binary is guaranteed to exist in the root `.bin`.

Acting on behalf of the user.