### PR TITLE
refactor(tasks): remove pnpm exec from shared package runners

### DIFF
--- a/nix/devenv-modules/tasks/shared/pnpm-task-helpers.sh
+++ b/nix/devenv-modules/tasks/shared/pnpm-task-helpers.sh
@@ -87,3 +87,70 @@ purge_node_modules() {
     rm -rf "$node_modules_dir"
   done
 }
+
+resolve_package_bin() {
+  local package_name="$1"
+  local bin_name="${2:-$1}"
+  local cwd="${3:-$PWD}"
+  local node_bin="${NODE_BIN:-node}"
+  local shim_path="$cwd/node_modules/.bin/$bin_name"
+
+  if [ -x "$shim_path" ]; then
+    printf '%s\n' "$shim_path"
+    return 0
+  fi
+
+  "$node_bin" - "$package_name" "$bin_name" "$cwd" <<'EOF'
+const fs = require('node:fs')
+const path = require('node:path')
+
+const [packageName, binName, cwd] = process.argv.slice(2)
+
+const manifestPath = require.resolve(`${packageName}/package.json`, { paths: [cwd] })
+const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
+const packageDir = path.dirname(manifestPath)
+
+const candidates = []
+if (typeof manifest.bin === 'string') {
+  candidates.push(manifest.bin)
+} else if (manifest.bin && typeof manifest.bin === 'object') {
+  if (typeof manifest.bin[binName] === 'string') {
+    candidates.push(manifest.bin[binName])
+  }
+  if (typeof manifest.bin[packageName] === 'string' && manifest.bin[packageName] !== manifest.bin[binName]) {
+    candidates.push(manifest.bin[packageName])
+  }
+  for (const value of Object.values(manifest.bin)) {
+    if (typeof value === 'string' && !candidates.includes(value)) {
+      candidates.push(value)
+    }
+  }
+}
+
+if (candidates.length === 0) {
+  console.error(`[pnpm] Package '${packageName}' does not declare a usable bin entry for '${binName}'`)
+  process.exit(1)
+}
+
+for (const candidate of candidates) {
+  const resolved = path.resolve(packageDir, candidate)
+  if (fs.existsSync(resolved)) {
+    process.stdout.write(`${resolved}\n`)
+    process.exit(0)
+  }
+}
+
+console.error(`[pnpm] Could not resolve an existing bin path for '${packageName}' from ${manifestPath}`)
+process.exit(1)
+EOF
+}
+
+run_package_bin() {
+  local package_name="$1"
+  local bin_name="${2:-$1}"
+  shift 2
+
+  local bin_path
+  bin_path="$(resolve_package_bin "$package_name" "$bin_name")"
+  "$bin_path" "$@"
+}

--- a/nix/devenv-modules/tasks/shared/storybook.nix
+++ b/nix/devenv-modules/tasks/shared/storybook.nix
@@ -28,16 +28,28 @@
   packages ? [ ],
   installTask ? "pnpm:install",
 }:
-{ lib, config, pkgs, ... }:
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
 let
   trace = import ../lib/trace.nix { inherit lib; };
   cliGuard = import ../lib/cli-guard.nix { inherit pkgs; };
+  pnpmTaskHelpersScript = pkgs.writeText "pnpm-task-helpers.sh" (
+    builtins.readFile ./pnpm-task-helpers.sh
+  );
   hasPackages = packages != [ ];
 
   mkBuildTask = pkg: {
     "storybook:build:${pkg.name}" = {
       description = "Build storybook for ${pkg.name}";
-      exec = trace.exec "storybook:build:${pkg.name}" "pnpm exec storybook build";
+      exec = trace.exec "storybook:build:${pkg.name}" ''
+        set -euo pipefail
+        source ${lib.escapeShellArg pnpmTaskHelpersScript}
+        run_package_bin storybook storybook build
+      '';
       cwd = pkg.path;
       after = [ installTask ];
     };
@@ -63,7 +75,8 @@ let
         export DT_PASSTHROUGH=1
         _host="''${TS_HOSTNAME:-localhost}"
         echo "[storybook] ${pkg.name}: http://$_host:${toString (getAllocatedPort pkg)}"
-        pnpm exec storybook dev -p ${toString (getAllocatedPort pkg)} --host 0.0.0.0 --no-open --ci --exact-port
+        source ${lib.escapeShellArg pnpmTaskHelpersScript}
+        run_package_bin storybook storybook dev -p ${toString (getAllocatedPort pkg)} --host 0.0.0.0 --no-open --ci --exact-port
       '';
       cwd = pkg.path;
     };

--- a/nix/devenv-modules/tasks/shared/test.nix
+++ b/nix/devenv-modules/tasks/shared/test.nix
@@ -1,7 +1,7 @@
 # Test tasks (vitest)
 #
-# Self-contained test tasks that run in package cwd while using the repo-root
-# hoisted install via `pnpm exec`.
+# Self-contained test tasks that run in package cwd while resolving Vitest from
+# the installed package graph directly.
 #
 # Usage in devenv.nix:
 #   # Per-package tests (recommended):
@@ -28,23 +28,30 @@
 #   - test:watch - Run tests in watch mode
 #   - test:<name> - Run tests for specific package (when packages provided)
 {
-  packages ? [],
+  packages ? [ ],
   installTask ? "pnpm:install",
-  extraTests ? [],
+  extraTests ? [ ],
 }:
 { lib, pkgs, ... }:
 let
   trace = import ../lib/trace.nix { inherit lib; };
   cliGuard = import ../lib/cli-guard.nix { inherit pkgs; };
-  hasPackages = packages != [];
+  pnpmTaskHelpersScript = pkgs.writeText "pnpm-task-helpers.sh" (
+    builtins.readFile ./pnpm-task-helpers.sh
+  );
+  hasPackages = packages != [ ];
   # Do not force preserve-symlinks here. pnpm's projected workspace graph
   # relies on realpath-based resolution, and preserve-symlinks caused Vitest to
   # miss hoisted dependencies in CI.
   vitestExec = ''
-    pnpm exec vitest run
+    set -euo pipefail
+    source ${lib.escapeShellArg pnpmTaskHelpersScript}
+    run_package_bin vitest vitest run
   '';
   vitestWatchExec = ''
-    pnpm exec vitest
+    set -euo pipefail
+    source ${lib.escapeShellArg pnpmTaskHelpersScript}
+    run_package_bin vitest vitest
   '';
 
   # Per-package test task using the workspace-aware vitest entrypoint.
@@ -73,9 +80,8 @@ let
       guard = "vitest";
       description = "Run all tests";
       exec = if hasPackages then null else vitestExec;
-      after = if hasPackages
-        then map (pkg: "test:${pkg.name}") packages ++ extraTests
-        else [ "genie:run" ];
+      after =
+        if hasPackages then map (pkg: "test:${pkg.name}") packages ++ extraTests else [ "genie:run" ];
     };
     "test:watch" = {
       guard = "vitest";
@@ -85,11 +91,12 @@ let
     };
   };
 
-in {
+in
+{
   packages = cliGuard.fromTasks guardedTasks;
 
   tasks = lib.mkMerge (
-    (if hasPackages then map (pkg: cliGuard.stripGuards (mkTestTask pkg)) packages else [])
+    (if hasPackages then map (pkg: cliGuard.stripGuards (mkTestTask pkg)) packages else [ ])
     ++ [ (cliGuard.stripGuards guardedTasks) ]
   );
 }

--- a/nix/devenv-modules/tasks/shared/tests/pnpm-task-smoke.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/pnpm-task-smoke.test.sh
@@ -43,6 +43,48 @@ extract_task_script() {
   chmod +x "$output_path"
 }
 
+extract_shared_task_script() {
+  local module_path="$1"
+  local task_name="$2"
+  local package_path="$3"
+  local package_name="$4"
+  local output_path="$5"
+
+  nix eval --impure --raw --expr "
+    let
+      flake = builtins.getFlake (toString $ROOT);
+      pkgs = import flake.inputs.nixpkgs { system = builtins.currentSystem; };
+      pkgsForTest = pkgs // {
+        writeText = name: text: builtins.toFile name text;
+      };
+      lib = pkgs.lib;
+      evaluated = lib.evalModules {
+        modules = [
+          ({ ... }: {
+            options.tasks = lib.mkOption { type = lib.types.attrsOf lib.types.anything; default = { }; };
+            options.processes = lib.mkOption { type = lib.types.attrsOf lib.types.anything; default = { }; };
+            options.packages = lib.mkOption { type = lib.types.listOf lib.types.anything; default = [ ]; };
+          })
+          ((import $ROOT/${module_path} {
+            packages = [
+              {
+                path = \"$package_path\";
+                name = \"$package_name\";
+                port = 6006;
+              }
+            ];
+          }) {
+            pkgs = pkgsForTest;
+            lib = lib;
+            config = { };
+          })
+        ];
+      };
+    in evaluated.config.tasks.\"${task_name}\".exec
+  " > "$output_path"
+  chmod +x "$output_path"
+}
+
 rewrite_unrealized_tool_paths() {
   local script_path="$1"
 
@@ -60,7 +102,7 @@ tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
 
 workspace="$tmpdir/workspace"
-mkdir -p "$workspace/.direnv/task-cache" "$workspace/.pnpm-home-a/store/v11" "$workspace/.pnpm-home-b/store/v11" "$tmpdir/bin"
+mkdir -p "$workspace/.direnv/task-cache" "$workspace/.pnpm-home-a/store/v11" "$workspace/.pnpm-home-b/store/v11" "$tmpdir/bin" "$workspace/packages/demo/node_modules/.bin"
 
 cat > "$workspace/package.json" <<'EOF'
 {"name":"smoke-workspace","private":true}
@@ -73,6 +115,9 @@ lockfileVersion: '9.0'
 settings: {}
 importers: {}
 packages: {}
+EOF
+cat > "$workspace/packages/demo/package.json" <<'EOF'
+{"name":"demo","private":true}
 EOF
 
 cat > "$tmpdir/bin/pnpm" <<'EOF'
@@ -106,8 +151,48 @@ exit 0
 EOF
 chmod +x "$tmpdir/bin/flock"
 
+mkdir -p "$workspace/packages/demo/node_modules/vitest/bin" "$workspace/packages/demo/node_modules/storybook/bin"
+cat > "$workspace/packages/demo/node_modules/vitest/package.json" <<'EOF'
+{"name":"vitest","bin":{"vitest":"bin/vitest.js"}}
+EOF
+cat > "$workspace/packages/demo/node_modules/vitest/bin/vitest.js" <<'EOF'
+#!/usr/bin/env node
+console.log(`vitest:${process.argv.slice(2).join(' ')}`)
+EOF
+chmod +x "$workspace/packages/demo/node_modules/vitest/bin/vitest.js"
+cat > "$workspace/packages/demo/node_modules/.bin/vitest" <<'EOF'
+#!/usr/bin/env bash
+printf 'vitest-shim:%s\n' "$*"
+EOF
+chmod +x "$workspace/packages/demo/node_modules/.bin/vitest"
+cat > "$workspace/packages/demo/node_modules/storybook/package.json" <<'EOF'
+{"name":"storybook","bin":{"storybook":"bin/storybook.js"}}
+EOF
+cat > "$workspace/packages/demo/node_modules/storybook/bin/storybook.js" <<'EOF'
+#!/usr/bin/env node
+console.log(`storybook:${process.argv.slice(2).join(' ')}`)
+EOF
+chmod +x "$workspace/packages/demo/node_modules/storybook/bin/storybook.js"
+cat > "$workspace/packages/demo/node_modules/.bin/storybook" <<'EOF'
+#!/usr/bin/env bash
+printf 'storybook-shim:%s\n' "$*"
+EOF
+chmod +x "$workspace/packages/demo/node_modules/.bin/storybook"
+
 extract_task_script "$workspace" "exec" "$tmpdir/pnpm-install.exec.sh"
 extract_task_script "$workspace" "status" "$tmpdir/pnpm-install.status.sh"
+extract_shared_task_script \
+  "nix/devenv-modules/tasks/shared/test.nix" \
+  "test:demo" \
+  "packages/demo" \
+  "demo" \
+  "$tmpdir/test-demo.exec.sh"
+extract_shared_task_script \
+  "nix/devenv-modules/tasks/shared/storybook.nix" \
+  "storybook:build:demo" \
+  "packages/demo" \
+  "demo" \
+  "$tmpdir/storybook-demo.exec.sh"
 rewrite_unrealized_tool_paths "$tmpdir/pnpm-install.exec.sh"
 rewrite_unrealized_tool_paths "$tmpdir/pnpm-install.status.sh"
 
@@ -183,6 +268,20 @@ echo "Test 6: exec detaches stdin before probing pnpm version"
   assert_exit_code 0 "$exit_code" "exec should not inherit an open stdin pipe"
 )
 grep -qxF -- "--version" "$tmpdir/pnpm.log"
+
+echo "Test 7: generated test task runs vitest without pnpm exec"
+(
+  cd "$workspace/packages/demo"
+  output="$(bash "$tmpdir/test-demo.exec.sh")"
+  [ "$output" = "vitest-shim:run" ]
+)
+
+echo "Test 8: generated storybook task runs storybook without pnpm exec"
+(
+  cd "$workspace/packages/demo"
+  output="$(bash "$tmpdir/storybook-demo.exec.sh")"
+  [ "$output" = "storybook-shim:build" ]
+)
 
 echo ""
 echo "pnpm task smoke test passed"

--- a/nix/devenv-modules/tasks/shared/tests/pnpm.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/pnpm.test.sh
@@ -65,6 +65,39 @@ EOF
   fi
 }
 
+make_bin_fixture() {
+  local root="$1"
+
+  mkdir -p "$root/node_modules/fake-tool/bin" "$root/node_modules/.bin"
+  cat > "$root/node_modules/fake-tool/package.json" <<'EOF'
+{"name":"fake-tool","bin":{"fake-tool":"bin/fake-tool.js","alt-tool":"bin/fake-tool.js"}}
+EOF
+  cat > "$root/node_modules/fake-tool/bin/fake-tool.js" <<'EOF'
+#!/usr/bin/env node
+process.stdout.write(`fake-tool-direct:${process.argv.slice(2).join(',')}\n`)
+EOF
+  chmod +x "$root/node_modules/fake-tool/bin/fake-tool.js"
+  cat > "$root/node_modules/.bin/fake-tool" <<'EOF'
+#!/usr/bin/env bash
+printf 'fake-tool-shim:%s\n' "$*"
+EOF
+  chmod +x "$root/node_modules/.bin/fake-tool"
+}
+
+make_bin_fixture_without_shim() {
+  local root="$1"
+
+  mkdir -p "$root/node_modules/fallback-tool/bin"
+  cat > "$root/node_modules/fallback-tool/package.json" <<'EOF'
+{"name":"fallback-tool","bin":{"fallback-tool":"bin/fallback-tool.js"}}
+EOF
+  cat > "$root/node_modules/fallback-tool/bin/fallback-tool.js" <<'EOF'
+#!/usr/bin/env node
+process.stdout.write(`fallback-tool-direct:${process.argv.slice(2).join(',')}\n`)
+EOF
+  chmod +x "$root/node_modules/fallback-tool/bin/fallback-tool.js"
+}
+
 echo "Running pnpm task helper tests..."
 echo ""
 
@@ -102,7 +135,34 @@ if [ "$fingerprint_a" = "$fingerprint_b" ]; then
   exit 1
 fi
 
-echo "Test 4: Projection health passes when symlinked package can resolve deps"
+echo "Test 4: resolve_package_bin prefers package-local .bin shims"
+bin_fixture="$test_dir/bin-fixture"
+make_bin_fixture "$bin_fixture"
+resolved_bin="$(resolve_package_bin fake-tool fake-tool "$bin_fixture")"
+expected_bin="$bin_fixture/node_modules/.bin/fake-tool"
+assert_eq \
+  "$expected_bin" \
+  "$resolved_bin" \
+  "resolve_package_bin prefers the generated .bin shim"
+
+echo "Test 5: run_package_bin executes the .bin shim when present"
+output="$(cd "$bin_fixture" && run_package_bin fake-tool fake-tool alpha beta)"
+assert_eq \
+  "fake-tool-shim:alpha beta" \
+  "$output" \
+  "run_package_bin executes the resolved shim"
+
+echo "Test 6: resolve_package_bin falls back to the package bin file"
+fallback_fixture="$test_dir/fallback-bin-fixture"
+make_bin_fixture_without_shim "$fallback_fixture"
+resolved_fallback_bin="$(resolve_package_bin fallback-tool fallback-tool "$fallback_fixture")"
+expected_fallback_bin="$(cd "$fallback_fixture/node_modules/fallback-tool/bin" && pwd -P)/fallback-tool.js"
+assert_eq \
+  "$expected_fallback_bin" \
+  "$resolved_fallback_bin" \
+  "resolve_package_bin falls back to the package bin file"
+
+echo "Test 7: Projection health passes when symlinked package can resolve deps"
 healthy_dir="$test_dir/healthy"
 make_projection_fixture "$healthy_dir" 1
 set +e
@@ -111,7 +171,7 @@ exit_code=$?
 set -e
 assert_exit_code 0 "$exit_code" "projection health passes"
 
-echo "Test 5: Projection health ignores packages that do not export ./package.json"
+echo "Test 8: Projection health ignores packages that do not export ./package.json"
 exports_dir="$test_dir/exports"
 make_projection_fixture "$exports_dir" 1 1
 set +e
@@ -120,7 +180,7 @@ exit_code=$?
 set -e
 assert_exit_code 0 "$exit_code" "projection health should not depend on package.json exports"
 
-echo "Test 6: Projection health fails when symlinked package loses a transitive dep"
+echo "Test 9: Projection health fails when symlinked package loses a transitive dep"
 stale_dir="$test_dir/stale"
 make_projection_fixture "$stale_dir" 0
 set +e
@@ -129,7 +189,7 @@ exit_code=$?
 set -e
 assert_exit_code 1 "$exit_code" "projection health detects missing dep"
 
-echo "Test 7: Broken node_modules symlink is rejected before projection checks"
+echo "Test 10: Broken node_modules symlink is rejected before projection checks"
 broken_dir="$test_dir/broken"
 mkdir -p "$broken_dir/node_modules"
 ln -s ../missing "$broken_dir/node_modules/broken"


### PR DESCRIPTION
## Why

We want one pnpm dependency contract that works the same way in local dev and CI.

The shared `test` and `storybook` task modules were still relying on `pnpm exec`, which made those tasks depend on pnpm's runtime command resolution instead of the installed package graph itself.

The first production slice here is to remove that overlap without introducing CI-only task variants.

## What

- add a shared helper to resolve package-local CLI runners from installed dependencies
- prefer pnpm's generated `node_modules/.bin/<cmd>` shim when present, and fall back to the package `bin` entry only when no shim exists
- switch shared `test` tasks away from `pnpm exec vitest`
- switch shared `storybook` tasks away from `pnpm exec storybook`
- extend the shell tests so they cover both shim-first and direct-bin fallback behavior
- verify the generated `test` and `storybook` task scripts no longer use `pnpm exec`

## Root Cause

Storybook specifically needs pnpm's generated `.bin/storybook` shim, because that shim injects `NODE_PATH` entries that let Storybook resolve consumer-side packages like `@storybook/react-vite`.

Running Storybook's raw package bin file directly skipped that shim layer and reproduced the CI failure locally.

## Validation

- `bash nix/devenv-modules/tasks/shared/tests/pnpm.test.sh`
- `bash nix/devenv-modules/tasks/shared/tests/pnpm-task-smoke.test.sh`
- `nixfmt --check nix/devenv-modules/tasks/shared/test.nix nix/devenv-modules/tasks/shared/storybook.nix`
- `bash -n nix/devenv-modules/tasks/shared/pnpm-task-helpers.sh nix/devenv-modules/tasks/shared/tests/pnpm.test.sh nix/devenv-modules/tasks/shared/tests/pnpm-task-smoke.test.sh`
- `git diff --check`
- local reproduction: `packages/@overeng/effect-react && source ../../../nix/devenv-modules/tasks/shared/pnpm-task-helpers.sh && run_package_bin storybook storybook build`

## Rationale

This stays intentionally narrow:
- it removes overlapping task execution semantics now
- it does not introduce CI-only task variants
- it keeps `pnpm:install` as the single dependency materializer
- it leaves the larger setup/fan-out and cache-boundary rollout to follow-up work in `schickling/megarepo-all#59`

_Acting on behalf of @schickling._
