### PR TITLE
fix(megarepo): reduce git process spawns in test setup to fix flaky timeouts

### DIFF
--- a/packages/@overeng/megarepo/src/test-utils/setup.ts
+++ b/packages/@overeng/megarepo/src/test-utils/setup.ts
@@ -59,12 +59,17 @@ export const runGitCommand = (cwd: AbsoluteDirPath, ...args: ReadonlyArray<strin
     return result.trim()
   })
 
-/** Initialize a new git repository */
+/** Initialize a new git repository (writes user config directly to avoid extra process spawns) */
 export const initGitRepo = (path: AbsoluteDirPath) =>
   Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem
     yield* runGitCommand(path, 'init')
-    yield* runGitCommand(path, 'config', 'user.email', 'test@example.com')
-    yield* runGitCommand(path, 'config', 'user.name', 'Test User')
+    const configPath = EffectPath.ops.join(path, EffectPath.unsafe.relativeFile('.git/config'))
+    const existing = yield* fs.readFileString(configPath)
+    yield* fs.writeFileString(
+      configPath,
+      `${existing}[user]\n\temail = test@example.com\n\tname = Test User\n`,
+    )
   })
 
 /** Add files and create a commit */

--- a/packages/@overeng/megarepo/src/test-utils/store-setup.ts
+++ b/packages/@overeng/megarepo/src/test-utils/store-setup.ts
@@ -63,12 +63,17 @@ const runGitCommand = (cwd: AbsoluteDirPath, ...args: ReadonlyArray<string>) =>
     return result.trim()
   })
 
-/** Initialize a new git repository */
+/** Initialize a new git repository (writes user config directly to avoid extra process spawns) */
 const initGitRepo = (path: AbsoluteDirPath) =>
   Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem
     yield* runGitCommand(path, 'init')
-    yield* runGitCommand(path, 'config', 'user.email', 'test@example.com')
-    yield* runGitCommand(path, 'config', 'user.name', 'Test User')
+    const configPath = EffectPath.ops.join(path, EffectPath.unsafe.relativeFile('.git/config'))
+    const existing = yield* fs.readFileString(configPath)
+    yield* fs.writeFileString(
+      configPath,
+      `${existing}[user]\n\temail = test@example.com\n\tname = Test User\n`,
+    )
   })
 
 // =============================================================================

--- a/packages/@overeng/megarepo/vitest.config.ts
+++ b/packages/@overeng/megarepo/vitest.config.ts
@@ -3,5 +3,7 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     include: ['src/**/*.test.ts'],
+    /** Integration tests spawn git subprocesses whose overhead varies across CI runners */
+    testTimeout: 15_000,
   },
 })


### PR DESCRIPTION
## Summary

- **Reduce subprocess overhead**: `initGitRepo` now writes user config directly to `.git/config` instead of spawning 2 extra `git config` processes per repo init (~400-1000ms saved per init on macOS CI)
- **Global `testTimeout: 15_000`** in vitest config prevents future integration tests from silently inheriting the 5s default — the root cause of [3 flaky timeouts in CI](https://github.com/overengineeringstudio/effect-utils/actions/runs/23707432283/job/69061587417?pr=480)

## Rationale

The 3 failing tests (`status.integration.test.ts:144`, `store.integration.test.ts:288`, `sync.integration.test.ts:177`) were simply missing the `{ timeout: N }` override that other tests in the same files had. Rather than sprinkling per-test timeouts, this sets a principled global default and reduces the actual overhead so tests complete faster.

## Test plan

- [x] Verified `store.integration.test.ts` passes locally (previously flaky test now completes in ~280ms)
- [ ] CI should pass — the status/sync tests that timed out at 5s will now have 15s budget and reduced setup cost

🤖 Generated with [Claude Code](https://claude.com/claude-code)