### PR TITLE
fix(tui-stories): sequential imports to avoid Bun TDZ race

### DIFF
--- a/packages/@overeng/tui-stories/src/StoryDiscovery.ts
+++ b/packages/@overeng/tui-stories/src/StoryDiscovery.ts
@@ -89,7 +89,7 @@ export const discoverStories = (options: {
        module's bindings uninitialized for other importers. With the shared
        @overeng/tui-react/storybook dependency this caused ~100% TDZ failure rate.
        Performance is unaffected — shared modules are cached after first evaluation.
-       See: https://github.com/overengineeringstudio/effect-utils/issues/470 */
+       See: https://github.com/oven-sh/bun/issues/20489 */
     const results = yield* Effect.all(
       filePaths.map((fp) => importStoryFile(fp)),
       { concurrency: 1 },


### PR DESCRIPTION
## Summary

- Switches story file loading from `concurrency: 10` to `concurrency: 1` to avoid Bun's ESM TDZ bug where concurrent `import()` calls poison shared module bindings when one import chain fails

## Rationale

Bun's ESM loader has a bug ([oven-sh/bun#20489](https://github.com/oven-sh/bun/issues/20489)) where concurrent dynamic imports that share a dependency module can leave that module's exports in TDZ (Temporal Dead Zone) when one import chain fails. In our case:

1. `RenderOutput/Errors.stories.tsx` imports `@overeng/tui-react/storybook` + transitively `@megarepo-internal/...` (Vite-only alias)
2. The `@megarepo-internal` resolution fails in Bun, leaving `@overeng/tui-react/storybook` partially initialized
3. Concurrent `ListOutput/Results.stories.tsx` then gets `Cannot access 'defaultStoryArgs' before initialization`

This was **100% reproducible** with `concurrency: 10` and **0% with `concurrency: 1`** across 20 runs each.

No performance impact — shared modules are cached after first evaluation, so sequential imports of files with overlapping dependency graphs take the same time as concurrent ones.

## Test plan

- [x] Verified 5/5 consecutive `tui-stories list --path . --output log` runs produce `7 stories · 2 groups · 2 skipped` (no TDZ)
- [x] Pre-commit hooks pass (check-quick)

Closes #470

🤖 Generated with [Claude Code](https://claude.com/claude-code)