### PR TITLE
fix(tui-stories): cache story discovery to fix flaky CI timeouts

### DIFF
--- a/packages/@overeng/tui-stories/test/StoryCapture.test.ts
+++ b/packages/@overeng/tui-stories/test/StoryCapture.test.ts
@@ -10,13 +10,18 @@ import { findStory } from '../src/StoryModule.ts'
 const WORKSPACE_ROOT = resolve(import.meta.dirname, '../../../..')
 const MEGAREPO_DIR = resolve(WORKSPACE_ROOT, 'packages/@overeng/megarepo')
 
+/* Eagerly kick off discovery once at module load and share the promise across all tests.
+   Without this, each test calls discoverStories() independently — the first call per file
+   pays the full glob + sequential-import cost (sequential due to the Bun TDZ workaround),
+   which on CI exceeds the default 5s vitest timeout. */
+const discoveryResult = Effect.runPromise(discoverStories({ packageDirs: [MEGAREPO_DIR] }))
+
 /** Helper to discover + find a story, skipping the test if not found */
 const findOrSkip = (query: string) =>
   Effect.gen(function* () {
-    const { modules } = yield* discoverStories({ packageDirs: [MEGAREPO_DIR] })
+    const { modules } = yield* Effect.promise(() => discoveryResult)
     const story = findStory({ modules, query })
     if (story === undefined) {
-      // Story may not load in vitest context due to missing browser deps
       console.warn(`Skipping: story "${query}" not found (may be an import issue)`)
       return undefined
     }

--- a/packages/@overeng/tui-stories/test/StoryRenderer.test.ts
+++ b/packages/@overeng/tui-stories/test/StoryRenderer.test.ts
@@ -11,10 +11,16 @@ import { renderStory } from '../src/StoryRenderer.ts'
 const WORKSPACE_ROOT = resolve(import.meta.dirname, '../../../..')
 const MEGAREPO_DIR = resolve(WORKSPACE_ROOT, 'packages/@overeng/megarepo')
 
+/* Eagerly kick off discovery once at module load and share the promise across all tests.
+   Without this, each test calls discoverStories() independently — the first call per file
+   pays the full glob + sequential-import cost (sequential due to the Bun TDZ workaround),
+   which on CI exceeds the default 5s vitest timeout. */
+const discoveryResult = Effect.runPromise(discoverStories({ packageDirs: [MEGAREPO_DIR] }))
+
 /** Helper to discover + find + capture a story */
 const captureOrSkip = (query: string, overrides?: Record<string, unknown>) =>
   Effect.gen(function* () {
-    const { modules } = yield* discoverStories({ packageDirs: [MEGAREPO_DIR] })
+    const { modules } = yield* Effect.promise(() => discoveryResult)
     const story = findStory({ modules, query })
     if (story === undefined) {
       console.warn(`Skipping: story "${query}" not found`)


### PR DESCRIPTION
## Summary

- Cache `discoverStories()` result at module level in `StoryCapture.test.ts` and `StoryRenderer.test.ts` so it runs once per file instead of once per test
- Eliminates redundant glob + sequential dynamic imports that caused the first test in each file to timeout on CI

## Rationale

Both `StoryCapture` and `StoryRenderer` tests called `discoverStories()` in every test via helpers (`findOrSkip`/`captureOrSkip`). On CI (Linux x86), the cold-start cost of glob discovery + sequential dynamic imports (required to avoid the [Bun TDZ race](https://github.com/oven-sh/bun/issues/20489)) exceeded the default 5s vitest timeout for the first test in each file — but only intermittently depending on machine load.

The fix eagerly kicks off discovery at module load time and shares the resulting promise across all tests. This is safe because discovery is read-only.

Ref: https://github.com/overengineeringstudio/effect-utils/actions/runs/23735802812/job/69140072691?pr=485

## Benchmark (local, Apple Silicon — CI improvement will be more dramatic)

| Metric | Before | After |
|---|---|---|
| Total duration | 2.84s | 2.38s |
| Collect phase | 3.47s | 2.69s |
| Subsequent test avg | ~27ms | ~12ms |

## Test plan

- [x] All 29 tui-stories tests pass locally
- [x] No lint errors on changed files
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)