### PR TITLE
feat(nix): model per-install-root deps hashes

### DIFF
--- a/nix/workspace-tools/README.md
+++ b/nix/workspace-tools/README.md
@@ -39,3 +39,15 @@ When a downstream repo consumes `effect-utils` packages or pnpm-based builders,
 its root `nixpkgs` and `flake-utils` should follow `effect-utils/nixpkgs` and
 `effect-utils/flake-utils`. That keeps prepared pnpm trees content-addressed
 against one canonical build graph across standalone and composed views.
+
+For `mk-pnpm-cli`, the deps-hash contract now matches the actual prepared-artifact
+shape:
+
+- single-root CLIs use one `pnpmDepsHash`
+- composed CLIs use `pnpmDepsHashes = [{ dir, hash }, ...]`, one entry per
+  authoritative install root
+
+The helper exposes the resulting install-root metadata via `passthru.installRoots`,
+`passthru.pnpmDepsByInstallRoot`, and `passthru.pnpmDepsHashEntries` so downstream
+hash-refresh tooling can target the direct prepared dependency boundary for each
+root.

--- a/nix/workspace-tools/lib/mk-pnpm-cli.nix
+++ b/nix/workspace-tools/lib/mk-pnpm-cli.nix
@@ -6,7 +6,8 @@
   packageDir,
   workspaceRoot,
   workspaceSources ? { },
-  pnpmDepsHash,
+  pnpmDepsHash ? null,
+  pnpmDepsHashes ? null,
   lockfileHash ? null,
   binaryName ? name,
   gitRev ? "unknown",
@@ -290,6 +291,43 @@ let
   installRootDerivationName =
     installDir:
     if installDir == "." then name else "${name}-${lib.replaceStrings [ "/" ] [ "-" ] installDir}";
+  installRootHashEntries =
+    if pnpmDepsHashes == null then
+      [ ]
+    else
+      map (
+        entry:
+        if !(entry ? dir && entry ? hash) then
+          throw "mk-pnpm-cli: pnpmDepsHashes entries must be { dir, hash }"
+        else
+          {
+            dir = entry.dir;
+            hash = entry.hash;
+          }
+      ) pnpmDepsHashes;
+
+  /**
+    Resolve the fixed-output hash for one authoritative install root.
+
+    Single-root CLIs can keep using `pnpmDepsHash`, because there is only one
+    prepared dependency artifact. Composed CLIs must provide `pnpmDepsHashes`
+    with one entry per install root so hash refresh can track each prepared
+    tree independently.
+  */
+  pnpmDepsHashForInstallRoot =
+    installDir:
+    let
+      matches = builtins.filter (entry: entry.dir == installDir) installRootHashEntries;
+    in
+    if pnpmDepsHashes != null then
+      if matches == [ ] then
+        throw "mk-pnpm-cli: pnpmDepsHashes is missing an entry for install root ${installDir}"
+      else if builtins.length matches > 1 then
+        throw "mk-pnpm-cli: pnpmDepsHashes has multiple entries for install root ${installDir}"
+      else
+        (builtins.head matches).hash
+    else
+      pnpmDepsHash;
 
   copyFileCmd =
     relPath:
@@ -497,7 +535,7 @@ let
         preInstall = ''
           chmod -R +w .
         '';
-        inherit pnpmDepsHash;
+        pnpmDepsHash = pnpmDepsHashForInstallRoot root.installDir;
       };
     in
     root
@@ -516,7 +554,8 @@ let
     lockfilePath = "pnpm-lock.yaml";
     depsSrc = rootDepsSrc;
     pnpmDeps = pnpmDepsHelper.mkDeps {
-      inherit name pnpmDepsHash;
+      inherit name;
+      pnpmDepsHash = pnpmDepsHashForInstallRoot ".";
       src = rootDepsSrc;
       sourceRoot = ".";
       lockfilePaths = [ "pnpm-lock.yaml" ];
@@ -526,6 +565,31 @@ let
     };
   };
   pnpmDepsInstallRoots = [ rootInstallRoot ] ++ externalInstallRootDeps;
+  installRootDirs = map (root: root.installDir) pnpmDepsInstallRoots;
+  unusedInstallRootHashEntries = builtins.filter (
+    entry: !(lib.elem entry.dir installRootDirs)
+  ) installRootHashEntries;
+  _validateInstallRootHashContract =
+    if pnpmDepsHash != null && pnpmDepsHashes != null then
+      throw "mk-pnpm-cli: pass either pnpmDepsHash or pnpmDepsHashes, not both"
+    else if builtins.length pnpmDepsInstallRoots == 1 then
+      if pnpmDepsHash == null && pnpmDepsHashes == null then
+        throw "mk-pnpm-cli: single-root builds require pnpmDepsHash"
+      else if pnpmDepsHashes != null && unusedInstallRootHashEntries != [ ] then
+        throw "mk-pnpm-cli: pnpmDepsHashes contains unknown install roots"
+      else
+        true
+    else if pnpmDepsHashes == null then
+      throw ''
+        mk-pnpm-cli: composed builds require pnpmDepsHashes = [
+          { dir = "."; hash = "..."; }
+          ...
+        ]
+      ''
+    else if unusedInstallRootHashEntries != [ ] then
+      throw "mk-pnpm-cli: pnpmDepsHashes contains unknown install roots"
+    else
+      true;
   pnpmDepsByInstallRoot = builtins.listToAttrs (
     map (root: {
       name = root.attrName;
@@ -628,6 +692,7 @@ let
   smokeTestArgsStr = lib.escapeShellArgs smokeTestArgs;
 
 in
+assert _validateInstallRootHashContract;
 pkgs.stdenv.mkDerivation {
   inherit name;
 
@@ -646,6 +711,11 @@ pkgs.stdenv.mkDerivation {
     inherit depsSrcByInstallRoot pnpmDepsByInstallRoot;
     installRoots = map (root: {
       inherit (root) attrName installDir lockfilePath;
+    }) pnpmDepsInstallRoots;
+    pnpmDepsHashEntries = map (root: {
+      dir = root.installDir;
+      attrName = root.attrName;
+      hash = pnpmDepsHashForInstallRoot root.installDir;
     }) pnpmDepsInstallRoots;
   }
   // lib.optionalAttrs (builtins.length pnpmDepsInstallRoots == 1) {


### PR DESCRIPTION
## Why
Composed pnpm CLI builds now restore one prepared dependency artifact per authoritative install root. A single `pnpmDepsHash` is no longer sufficient for those builds, which blocks downstream adoption across `megarepo-all`.

## What
- add `pnpmDepsHashes = [{ dir, hash }, ...]` for composed `mkPnpmCli` builds
- keep `pnpmDepsHash` for single-root builds
- validate the hash contract explicitly and fail fast for mismatches
- expose install-root hash metadata in `passthru` for downstream hash-refresh tooling
- document the new contract in the workspace-tools README

## How
`mk-pnpm-cli` now resolves the prepared deps hash per install root and requires composed callers to provide one entry per root. Downstream tooling can use the exported install-root metadata to measure and reconcile each prepared artifact independently.

## Rationale
This matches the real artifact graph from the split-root dependency work instead of preserving a misleading single-hash abstraction for composed workspaces.