### PR TITLE
fix(tui-stories): move discovery to beforeAll to fix flaky CI timeouts

### DIFF
--- a/packages/@overeng/tui-stories/test/StoryCapture.test.ts
+++ b/packages/@overeng/tui-stories/test/StoryCapture.test.ts
@@ -1,25 +1,29 @@
 import { resolve } from 'node:path'
 
-import { describe, it, expect } from '@effect/vitest'
-import { Effect } from 'effect'
+import { expect, layer } from '@effect/vitest'
+import { Context, Effect, Layer } from 'effect'
 
 import { captureStoryProps } from '../src/StoryCapture.ts'
-import { discoverStories } from '../src/StoryDiscovery.ts'
+import { discoverStories, type DiscoverStoriesResult } from '../src/StoryDiscovery.ts'
 import { findStory } from '../src/StoryModule.ts'
 
 const WORKSPACE_ROOT = resolve(import.meta.dirname, '../../../..')
 const MEGAREPO_DIR = resolve(WORKSPACE_ROOT, 'packages/@overeng/megarepo')
 
-/* Eagerly kick off discovery once at module load and share the promise across all tests.
-   Without this, each test calls discoverStories() independently — the first call per file
-   pays the full glob + sequential-import cost (sequential due to the Bun TDZ workaround),
-   which on CI exceeds the default 5s vitest timeout. */
-const discoveryResult = Effect.runPromise(discoverStories({ packageDirs: [MEGAREPO_DIR] }))
+/* Story discovery is slow on CI (glob + sequential imports due to Bun TDZ workaround
+   can take >5s). Provide it as a layer so it runs once in beforeAll — independent of
+   per-test timeouts — and is shared across all tests via dependency injection. */
+class TestStories extends Context.Tag('TestStories')<TestStories, DiscoverStoriesResult>() {
+  static readonly layer = Layer.effect(
+    TestStories,
+    discoverStories({ packageDirs: [MEGAREPO_DIR] }),
+  )
+}
 
-/** Helper to discover + find a story, skipping the test if not found */
+/** Helper to find a story, skipping the test if not found */
 const findOrSkip = (query: string) =>
   Effect.gen(function* () {
-    const { modules } = yield* Effect.promise(() => discoveryResult)
+    const { modules } = yield* TestStories
     const story = findStory({ modules, query })
     if (story === undefined) {
       console.warn(`Skipping: story "${query}" not found (may be an import issue)`)
@@ -28,7 +32,7 @@ const findOrSkip = (query: string) =>
     return story
   })
 
-describe('StoryCapture', () => {
+layer(TestStories.layer, { timeout: '30 seconds' })('StoryCapture', (it) => {
   it.effect('captures props from a status story', () =>
     Effect.gen(function* () {
       const story = yield* findOrSkip('CLI/Status/Basic')

--- a/packages/@overeng/tui-stories/test/StoryRenderer.test.ts
+++ b/packages/@overeng/tui-stories/test/StoryRenderer.test.ts
@@ -1,26 +1,30 @@
 import { resolve } from 'node:path'
 
-import { describe, it, expect } from '@effect/vitest'
-import { Effect } from 'effect'
+import { expect, layer } from '@effect/vitest'
+import { Context, Effect, Layer } from 'effect'
 
 import { captureStoryProps } from '../src/StoryCapture.ts'
-import { discoverStories } from '../src/StoryDiscovery.ts'
+import { discoverStories, type DiscoverStoriesResult } from '../src/StoryDiscovery.ts'
 import { findStory } from '../src/StoryModule.ts'
 import { renderStory } from '../src/StoryRenderer.ts'
 
 const WORKSPACE_ROOT = resolve(import.meta.dirname, '../../../..')
 const MEGAREPO_DIR = resolve(WORKSPACE_ROOT, 'packages/@overeng/megarepo')
 
-/* Eagerly kick off discovery once at module load and share the promise across all tests.
-   Without this, each test calls discoverStories() independently — the first call per file
-   pays the full glob + sequential-import cost (sequential due to the Bun TDZ workaround),
-   which on CI exceeds the default 5s vitest timeout. */
-const discoveryResult = Effect.runPromise(discoverStories({ packageDirs: [MEGAREPO_DIR] }))
+/* Story discovery is slow on CI (glob + sequential imports due to Bun TDZ workaround
+   can take >5s). Provide it as a layer so it runs once in beforeAll — independent of
+   per-test timeouts — and is shared across all tests via dependency injection. */
+class TestStories extends Context.Tag('TestStories')<TestStories, DiscoverStoriesResult>() {
+  static readonly layer = Layer.effect(
+    TestStories,
+    discoverStories({ packageDirs: [MEGAREPO_DIR] }),
+  )
+}
 
 /** Helper to discover + find + capture a story */
 const captureOrSkip = (query: string, overrides?: Record<string, unknown>) =>
   Effect.gen(function* () {
-    const { modules } = yield* Effect.promise(() => discoveryResult)
+    const { modules } = yield* TestStories
     const story = findStory({ modules, query })
     if (story === undefined) {
       console.warn(`Skipping: story "${query}" not found`)
@@ -29,7 +33,7 @@ const captureOrSkip = (query: string, overrides?: Record<string, unknown>) =>
     return yield* Effect.promise(() => captureStoryProps({ story, argOverrides: overrides }))
   })
 
-describe('StoryRenderer', () => {
+layer(TestStories.layer, { timeout: '30 seconds' })('StoryRenderer', (it) => {
   it.effect('renders log mode (no colors, no ANSI)', () =>
     Effect.gen(function* () {
       const captured = yield* captureOrSkip('CLI/Status/Basic')


### PR DESCRIPTION
## Summary

- Use `@effect/vitest`'s `layer()` pattern to run `discoverStories()` once per test file in `beforeAll` with its own 30s timeout
- Discovery result is shared across all tests via Effect dependency injection (`Context.Tag` + `Layer.effect`)
- Individual tests access modules via `yield* TestStories` — no mutable `let`, no manual `beforeAll`

## Rationale

Story discovery is slow on CI (~6.7s) due to glob + sequential dynamic imports (sequential to avoid the [Bun TDZ race](https://github.com/oven-sh/bun/issues/20489)). Previously, discovery either ran per-test (original, ~12 redundant calls) or as a module-level promise (#487, but still awaited within the 5s test timeout).

`layer()` is the idiomatic `@effect/vitest` pattern for expensive shared setup — it wraps `beforeAll`/`afterAll` with proper memoization and scope management, keeping discovery cost entirely outside per-test timeouts.

Failed CI run (pre-fix): https://github.com/overengineeringstudio/effect-utils/actions/runs/23745565165/job/69173198817

## Benchmark (local)

| Test | Before (CI) | After |
|---|---|---|
| StoryCapture first test | 5013ms (timeout) | 7ms |
| StoryRenderer first test | 5023ms (timeout) | 15ms |
| Total duration | 11.33s | 1.39s |

## Test plan

- [x] All 29 tui-stories tests pass locally
- [x] No lint errors
- [ ] CI passes (especially `test (namespace-profile-linux-x86-64)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)