### PR TITLE
fix(ci): remove perl from retry helper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,8 +206,9 @@ jobs:
                 return 0
               }
 
-              __flattened=$(perl -0pe 's/\e\[[0-9;]*m//g; s/\n/ /g' "$__log")
-              __path=$(printf '%s' "$__flattened" | grep -oP "error:\s+path '\K/nix/store/[^']*(?='\s+is not valid)" 2>/dev/null | head -1 | tr -d '[:space:]' || true)
+              __flattened=$(tr '
+          ' ' ' < "$__log" | sed "s/$(printf '\033')\[[0-9;]*m//g")
+              __path=$(printf '%s' "$__flattened" | sed -n "s#.*error:[[:space:]]*path '\\(/nix/store/[^']*\\)'[[:space:]]*is not valid.*#\\1#p" | head -1 | tr -d '[:space:]' || true)
               __saw_invalid_path=false
               __saw_cachix_signature=false
               [ -n "$__path" ] && __saw_invalid_path=true
@@ -483,8 +484,9 @@ jobs:
                 return 0
               }
 
-              __flattened=$(perl -0pe 's/\e\[[0-9;]*m//g; s/\n/ /g' "$__log")
-              __path=$(printf '%s' "$__flattened" | grep -oP "error:\s+path '\K/nix/store/[^']*(?='\s+is not valid)" 2>/dev/null | head -1 | tr -d '[:space:]' || true)
+              __flattened=$(tr '
+          ' ' ' < "$__log" | sed "s/$(printf '\033')\[[0-9;]*m//g")
+              __path=$(printf '%s' "$__flattened" | sed -n "s#.*error:[[:space:]]*path '\\(/nix/store/[^']*\\)'[[:space:]]*is not valid.*#\\1#p" | head -1 | tr -d '[:space:]' || true)
               __saw_invalid_path=false
               __saw_cachix_signature=false
               [ -n "$__path" ] && __saw_invalid_path=true
@@ -763,8 +765,9 @@ jobs:
                 return 0
               }
 
-              __flattened=$(perl -0pe 's/\e\[[0-9;]*m//g; s/\n/ /g' "$__log")
-              __path=$(printf '%s' "$__flattened" | grep -oP "error:\s+path '\K/nix/store/[^']*(?='\s+is not valid)" 2>/dev/null | head -1 | tr -d '[:space:]' || true)
+              __flattened=$(tr '
+          ' ' ' < "$__log" | sed "s/$(printf '\033')\[[0-9;]*m//g")
+              __path=$(printf '%s' "$__flattened" | sed -n "s#.*error:[[:space:]]*path '\\(/nix/store/[^']*\\)'[[:space:]]*is not valid.*#\\1#p" | head -1 | tr -d '[:space:]' || true)
               __saw_invalid_path=false
               __saw_cachix_signature=false
               [ -n "$__path" ] && __saw_invalid_path=true
@@ -1043,8 +1046,9 @@ jobs:
                 return 0
               }
 
-              __flattened=$(perl -0pe 's/\e\[[0-9;]*m//g; s/\n/ /g' "$__log")
-              __path=$(printf '%s' "$__flattened" | grep -oP "error:\s+path '\K/nix/store/[^']*(?='\s+is not valid)" 2>/dev/null | head -1 | tr -d '[:space:]' || true)
+              __flattened=$(tr '
+          ' ' ' < "$__log" | sed "s/$(printf '\033')\[[0-9;]*m//g")
+              __path=$(printf '%s' "$__flattened" | sed -n "s#.*error:[[:space:]]*path '\\(/nix/store/[^']*\\)'[[:space:]]*is not valid.*#\\1#p" | head -1 | tr -d '[:space:]' || true)
               __saw_invalid_path=false
               __saw_cachix_signature=false
               [ -n "$__path" ] && __saw_invalid_path=true
@@ -1472,8 +1476,9 @@ jobs:
                 return 0
               }
 
-              __flattened=$(perl -0pe 's/\e\[[0-9;]*m//g; s/\n/ /g' "$__log")
-              __path=$(printf '%s' "$__flattened" | grep -oP "error:\s+path '\K/nix/store/[^']*(?='\s+is not valid)" 2>/dev/null | head -1 | tr -d '[:space:]' || true)
+              __flattened=$(tr '
+          ' ' ' < "$__log" | sed "s/$(printf '\033')\[[0-9;]*m//g")
+              __path=$(printf '%s' "$__flattened" | sed -n "s#.*error:[[:space:]]*path '\\(/nix/store/[^']*\\)'[[:space:]]*is not valid.*#\\1#p" | head -1 | tr -d '[:space:]' || true)
               __saw_invalid_path=false
               __saw_cachix_signature=false
               [ -n "$__path" ] && __saw_invalid_path=true
@@ -1562,8 +1567,9 @@ jobs:
                 return 0
               }
 
-              __flattened=$(perl -0pe 's/\e\[[0-9;]*m//g; s/\n/ /g' "$__log")
-              __path=$(printf '%s' "$__flattened" | grep -oP "error:\s+path '\K/nix/store/[^']*(?='\s+is not valid)" 2>/dev/null | head -1 | tr -d '[:space:]' || true)
+              __flattened=$(tr '
+          ' ' ' < "$__log" | sed "s/$(printf '\033')\[[0-9;]*m//g")
+              __path=$(printf '%s' "$__flattened" | sed -n "s#.*error:[[:space:]]*path '\\(/nix/store/[^']*\\)'[[:space:]]*is not valid.*#\\1#p" | head -1 | tr -d '[:space:]' || true)
               __saw_invalid_path=false
               __saw_cachix_signature=false
               [ -n "$__path" ] && __saw_invalid_path=true

--- a/genie/ci-workflow.ts
+++ b/genie/ci-workflow.ts
@@ -216,8 +216,8 @@ const withGcRaceRetry = ({ command, label }: { command: string; label: string })
       return 0
     }
 
-    __flattened=$(perl -0pe 's/\\e\\[[0-9;]*m//g; s/\\n/ /g' "$__log")
-    __path=$(printf '%s' "$__flattened" | grep -oP "error:\\s+path '\\K/nix/store/[^']*(?='\\s+is not valid)" 2>/dev/null | head -1 | tr -d '[:space:]' || true)
+    __flattened=$(tr '\n' ' ' < "$__log" | sed "s/$(printf '\\033')\\[[0-9;]*m//g")
+    __path=$(printf '%s' "$__flattened" | sed -n "s#.*error:[[:space:]]*path '\\\\(/nix/store/[^']*\\\\)'[[:space:]]*is not valid.*#\\\\1#p" | head -1 | tr -d '[:space:]' || true)
     __saw_invalid_path=false
     __saw_cachix_signature=false
     [ -n "$__path" ] && __saw_invalid_path=true

--- a/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
@@ -27,6 +27,13 @@ describe('ci workflow retry helpers', () => {
     )
   })
 
+  it('avoids non-portable perl and grep -P usage in the retry helper', () => {
+    expect(ciWorkflowSource).not.toContain('perl -0pe')
+    expect(ciWorkflowSource).not.toContain('grep -oP')
+    expect(ciWorkflowSource).toContain("tr '\\n' ' ' < \"$__log\"")
+    expect(ciWorkflowSource).toContain('sed -n "s#.*error:[[:space:]]*path')
+  })
+
   it('retries cachix wrapper failures even when the invalid store path was not extracted', () => {
     expect(ciWorkflowSource).toContain(
       'if [ "$__saw_invalid_path" != true ] && [ "$__saw_cachix_signature" != true ]; then',


### PR DESCRIPTION
Why
The shared GitHub Actions retry helper still assumes host-level `perl` and `grep -P`. Our self-hosted runners are intentionally lean, so older generated workflows can fail before the actual task body runs with `perl: command not found`.

What
- replace the `perl -0pe` log flattening with portable `tr` + `sed`
- replace the `grep -oP` path extraction with POSIX-compatible `sed -n`
- add a regression test that asserts the helper source no longer contains `perl -0pe` or `grep -oP`
- regenerate `.github/workflows/ci.yml` from the updated helper source

How
This keeps the retry helper behavior the same while removing non-portable shell dependencies from the generated workflow path.

Rationale
Installing `perl` on runners would only mask the portability bug. The correct fix is to make the shared helper itself portable so downstream repos regenerate clean workflows without hidden host assumptions.

Validation
- `oxlint genie/ci-workflow.ts packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts`
- `oxfmt --check genie/ci-workflow.ts packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts .github/workflows/ci.yml`
- `genie --check`

Acting on behalf of the user.