### PR TITLE
fix(nix): stabilize pnpm workspace projection inputs

### DIFF
--- a/genie/external.ts
+++ b/genie/external.ts
@@ -355,6 +355,14 @@ export const utilsPatches = definePatchedDependencies({
   patches: {
     'effect-distributed-lock@0.0.11': './patches/effect-distributed-lock@0.0.11.patch',
     /**
+     * The pinned `@myobie/pty` dist bundle imports `@xterm/addon-serialize`
+     * as a default export, but the published ESM module only provides named
+     * exports. This fails Forge's macOS Nix build when esbuild bundles the
+     * server entrypoint.
+     */
+    '@myobie/pty@https://codeload.github.com/schickling/pty/tar.gz/3725304ad9829912a1b44e84d95ceb65cc6522bb':
+      './patches/@myobie-pty-3725304ad9829912a1b44e84d95ceb65cc6522bb.patch',
+    /**
      * `node-pty`'s prebuilt `spawn-helper` ships with mode 0644 and node-pty's
      * own post-install never chmods it. Under pnpm GVS the upstream
      * `@myobie/pty` workaround (relative-path chmod) silently no-ops because

--- a/genie/external.ts
+++ b/genie/external.ts
@@ -357,11 +357,11 @@ export const utilsPatches = definePatchedDependencies({
     /**
      * The pinned `@myobie/pty` dist bundle imports `@xterm/addon-serialize`
      * as a default export, but the published ESM module only provides named
-     * exports. This fails Forge's macOS Nix build when esbuild bundles the
-     * server entrypoint.
+     * exports. We key this patch by the resolved package version rather than
+     * the tarball URL because pnpm 11 rejects non-semver patch selectors in
+     * regular workspace installs, while still matching the exact package here.
      */
-    '@myobie/pty@https://codeload.github.com/schickling/pty/tar.gz/3725304ad9829912a1b44e84d95ceb65cc6522bb':
-      './patches/@myobie-pty-3725304ad9829912a1b44e84d95ceb65cc6522bb.patch',
+    '@myobie/pty@0.5.0': './patches/@myobie-pty-3725304ad9829912a1b44e84d95ceb65cc6522bb.patch',
     /**
      * `node-pty`'s prebuilt `spawn-helper` ships with mode 0644 and node-pty's
      * own post-install never chmods it. Under pnpm GVS the upstream

--- a/nix/oxc-config-plugin.nix
+++ b/nix/oxc-config-plugin.nix
@@ -28,7 +28,7 @@ let
     pnpm = pinnedPnpm;
   };
   packageDir = "packages/@overeng/oxc-config";
-  pnpmDepsHash = "sha256-L6KbFKMGG1Kdp1TKliykJevxCH5f1NRV65u69VeH3zM=";
+  pnpmDepsHash = "sha256-6nnA4vGD87GqPVjLluMO22CC1P0gnA3YZc8uXoKNKHo=";
 
   srcPath =
     if builtins.isAttrs src && builtins.hasAttr "outPath" src then

--- a/nix/workspace-tools/lib/mk-pnpm-cli.nix
+++ b/nix/workspace-tools/lib/mk-pnpm-cli.nix
@@ -439,9 +439,9 @@ let
             paths
           else
             let
-              colonIdx = lib.stringLength (builtins.head (builtins.split ":" trimmed));
-              value = lib.trim (builtins.substring (colonIdx + 1) (lib.stringLength trimmed) trimmed);
-              isPatchPath = lib.hasSuffix ".patch" value;
+              match = builtins.match ".*: +(.*)" trimmed;
+              value = if match == null then "" else lib.trim (builtins.elemAt match 0);
+              isPatchPath = match != null && lib.hasSuffix ".patch" value;
             in
             if isPatchPath then
               collect {

--- a/nix/workspace-tools/lib/mk-pnpm-cli.nix
+++ b/nix/workspace-tools/lib/mk-pnpm-cli.nix
@@ -41,8 +41,22 @@ let
       name = lib.strings.sanitizeDerivationName (lib.replaceStrings [ "/" ] [ "-" ] prefix);
     };
 
-  workspaceSourceRawRoots = lib.mapAttrs (_: coerceSourceRoot) workspaceSources;
-  workspaceSourceRoots = lib.mapAttrs normalizeSourceRoot workspaceSources;
+  workspaceSourceSpecs = lib.mapAttrs (
+    _:
+    sourceRoot: {
+      sourcePath = coerceSourceRoot sourceRoot;
+      isDerived =
+        builtins.isAttrs sourceRoot
+        && builtins.hasAttr "outPath" sourceRoot
+        && (sourceRoot.type or null) == "derivation";
+    }
+  ) workspaceSources;
+  workspaceSourceRawRoots = lib.mapAttrs (_: spec: spec.sourcePath) workspaceSourceSpecs;
+  workspaceSourceRoots = lib.mapAttrs (
+    prefix:
+    spec:
+    if spec.isDerived then spec.sourcePath else normalizeSourceRoot prefix spec.sourcePath
+  ) workspaceSourceSpecs;
   workspaceSourcePrefixesByLengthAsc = lib.sort (
     left: right: lib.stringLength left < lib.stringLength right
   ) (builtins.attrNames workspaceSourceRoots);
@@ -65,6 +79,7 @@ let
       prefix = lib.findFirst matchesPrefix null workspaceSourcePrefixesByLengthDesc;
       sourceRoot = if prefix == null then workspaceRootPath else workspaceSourceRawRoots.${prefix};
       fullSourceRoot = if prefix == null then workspaceRootPath else workspaceSourceRoots.${prefix};
+      sourceRootIsDerived = if prefix == null then false else workspaceSourceSpecs.${prefix}.isDerived;
       sourceRelPath =
         if prefix == null then
           relPath
@@ -77,7 +92,7 @@ let
     in
     {
       inherit prefix;
-      inherit sourceRoot fullSourceRoot sourceRelPath;
+      inherit sourceRoot fullSourceRoot sourceRelPath sourceRootIsDerived;
     };
 
   snapshotPath =
@@ -192,11 +207,14 @@ let
     map (
       item:
       let
+        prefixRootSupportsPureEvalInstallRootProbe =
+          item.resolved.prefix != null && !item.resolved.sourceRootIsDerived;
         prefixRootHasWorkspace =
-          item.resolved.prefix != null
+          prefixRootSupportsPureEvalInstallRootProbe
           && builtins.pathExists (item.resolved.sourceRoot + "/pnpm-workspace.yaml")
           && hasInstallRoot item.resolved.sourceRoot;
-        memberHasInstallRoot = hasInstallRoot item.sourcePath;
+        memberHasInstallRoot =
+          prefixRootSupportsPureEvalInstallRootProbe && hasInstallRoot item.sourcePath;
       in
       if item.resolved.prefix == null then
         null

--- a/nix/workspace-tools/lib/mk-pnpm-cli/tests/fixtures/downstream/flake.nix
+++ b/nix/workspace-tools/lib/mk-pnpm-cli/tests/fixtures/downstream/flake.nix
@@ -26,6 +26,10 @@
           cp -R ${./fixture-workspace} "$out"
           chmod -R +w "$out"
         '';
+        derivedEffectUtilsRoot = pkgs.runCommand "mk-pnpm-cli-derived-effect-utils-root" { } ''
+          cp -R ${effectUtilsSource} "$out"
+          chmod -R +w "$out"
+        '';
         mkPnpmCliFactory = import "${effectUtilsSource}/nix/workspace-tools/lib/mk-pnpm-cli.nix";
         mkPnpmCli = mkPnpmCliFactory (
           {
@@ -72,6 +76,22 @@
             };
             "repos/effect-utils" = {
               hash = "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=";
+            };
+          };
+          smokeTestArgs = [ ];
+        };
+        pureEvalDerivedWorkspaceSourceFixture = mkPnpmCli {
+          name = "mk-pnpm-cli-pure-eval-derived-workspace-source-fixture";
+          binaryName = "mk-pnpm-cli-pure-eval-derived-workspace-source-fixture";
+          entry = "app/src/mod.ts";
+          packageDir = "app";
+          workspaceRoot = ./fixture-workspace;
+          workspaceSources = {
+            "repos/effect-utils" = derivedEffectUtilsRoot;
+          };
+          depsBuilds = {
+            "." = {
+              hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
             };
           };
           smokeTestArgs = [ ];
@@ -124,6 +144,21 @@
               expected='[".","repos/effect-utils"]'
               if [ "$actual" != "$expected" ]; then
                 echo "unexpected install roots for derived workspace root: $actual" >&2
+                exit 1
+              fi
+              printf '%s' "$actual" > "$out"
+            '';
+        checks.pure-eval-derived-workspace-source =
+          pkgs.runCommand "mk-pnpm-cli-pure-eval-derived-workspace-source" { }
+            ''
+              actual='${
+                builtins.toJSON (
+                  map (root: root.installDir) pureEvalDerivedWorkspaceSourceFixture.passthru.installRoots
+                )
+              }'
+              expected='["."]'
+              if [ "$actual" != "$expected" ]; then
+                echo "unexpected install roots for derived workspace source: $actual" >&2
                 exit 1
               fi
               printf '%s' "$actual" > "$out"

--- a/packages/@overeng/genie/nix/build.nix
+++ b/packages/@overeng/genie/nix/build.nix
@@ -24,7 +24,7 @@ let
     # Managed by `dt nix:hash:genie` — do not edit manually.
     depsBuilds = {
       "." = {
-        hash = "sha256-CdSu76W4BlPWdtcdkqweJT9qkKtW9EulkgNFnBRM1TY=";
+        hash = "sha256-JsTHgXCEewpC77PKD5ZWZIdHb7uMCZWkiS9s2zUflcU=";
       };
     };
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/megarepo/nix/build.nix
+++ b/packages/@overeng/megarepo/nix/build.nix
@@ -23,7 +23,7 @@ let
     # Managed by `dt nix:hash:megarepo` — do not edit manually.
     depsBuilds = {
       "." = {
-        hash = "sha256-vNZQUAzJ9Eg+UozWuylFqO+UxjrB3n6OiHbKFT1+UOU=";
+        hash = "sha256-2u/1OHvuizTzfnNRdjXmFePm/IahrG6QrrteFtvkbjE=";
       };
     };
     smokeTestArgs = [ "--help" ];

--- a/packages/@overeng/utils/package.json
+++ b/packages/@overeng/utils/package.json
@@ -91,6 +91,7 @@
   },
   "pnpm": {
     "patchedDependencies": {
+      "@myobie/pty@0.5.0": "patches/@myobie-pty-3725304ad9829912a1b44e84d95ceb65cc6522bb.patch",
       "effect-distributed-lock@0.0.11": "patches/effect-distributed-lock@0.0.11.patch",
       "node-pty@1.1.0": "patches/node-pty@1.1.0.patch"
     }

--- a/packages/@overeng/utils/patches/@myobie-pty-3725304ad9829912a1b44e84d95ceb65cc6522bb.patch
+++ b/packages/@overeng/utils/patches/@myobie-pty-3725304ad9829912a1b44e84d95ceb65cc6522bb.patch
@@ -1,0 +1,13 @@
+diff --git a/dist/server.js b/dist/server.js
+index dcb5ebb194e20c7d1f2724c3d45616f745310020..c7e939c04fc0dc7bf649f7b02d1671f775b1a3c7 100644
+--- a/dist/server.js
++++ b/dist/server.js
+@@ -3,7 +3,7 @@ import * as fs from "node:fs";
+ import { execFileSync } from "node:child_process";
+ import * as pty from "node-pty";
+ import xterm from "@xterm/headless";
+-import xtermSerialize from "@xterm/addon-serialize";
++import * as xtermSerialize from "@xterm/addon-serialize";
+ import { MessageType, PacketReader, encodeData, encodeExit, encodeScreen, encodeStatusResponse, decodeSize, } from "./protocol.js";
+ import { getSocketPath, getPidPath, ensureSessionDir, cleanup, cleanupAll, writeMetadata, readMetadata, } from "./sessions.js";
+ import { EventWriter, clearEvents, EventType } from "./events.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,6 +188,7 @@ settings:
 packageExtensionsChecksum: sha256-6cS8D25oV8JxyYRUXZukPZaGz7zpUutYoZpOLuoEA/g=
 
 patchedDependencies:
+  '@myobie/pty@0.5.0': a2e8c27ec6d6487d9f3c72c6def56e366d3afdd7ecdc2e20405ab79e66fe965e
   effect-distributed-lock@0.0.11: a365d5c8857e3a421ea3b83b6be483433a5a75b344072aa68c4c984b14ec5a0b
   node-pty@1.1.0: 397f76e147dd0206f215159833bf64a3ea8061da2a283ecdf9b9923933a3477e
 
@@ -1043,7 +1044,7 @@ importers:
     dependencies:
       '@myobie/pty':
         specifier: github:schickling/pty#schickling/2026-04-08-prepare-build
-        version: https://codeload.github.com/schickling/pty/tar.gz/3725304ad9829912a1b44e84d95ceb65cc6522bb
+        version: https://codeload.github.com/schickling/pty/tar.gz/3725304ad9829912a1b44e84d95ceb65cc6522bb(patch_hash=a2e8c27ec6d6487d9f3c72c6def56e366d3afdd7ecdc2e20405ab79e66fe965e)
     devDependencies:
       '@effect/vitest':
         specifier: 0.29.0
@@ -5916,7 +5917,7 @@ snapshots:
   '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
     optional: true
 
-  '@myobie/pty@https://codeload.github.com/schickling/pty/tar.gz/3725304ad9829912a1b44e84d95ceb65cc6522bb':
+  '@myobie/pty@https://codeload.github.com/schickling/pty/tar.gz/3725304ad9829912a1b44e84d95ceb65cc6522bb(patch_hash=a2e8c27ec6d6487d9f3c72c6def56e366d3afdd7ecdc2e20405ab79e66fe965e)':
     dependencies:
       '@preact/signals-core': 1.14.1
       '@xterm/addon-serialize': 0.14.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,6 +29,7 @@ packages:
   - packages/@overeng/utils-dev
 
 patchedDependencies:
+  '@myobie/pty@0.5.0': packages/@overeng/utils/patches/@myobie-pty-3725304ad9829912a1b44e84d95ceb65cc6522bb.patch
   effect-distributed-lock@0.0.11: packages/@overeng/utils/patches/effect-distributed-lock@0.0.11.patch
   node-pty@1.1.0: packages/@overeng/utils/patches/node-pty@1.1.0.patch
 


### PR DESCRIPTION
## Summary
- avoid probing derived workspace-source paths when computing pnpm install roots
- key the `@myobie/pty` patch by resolved semver (`0.5.0`) so pnpm 11 accepts it
- add downstream coverage for the derived workspace-source case

## Why
Downstream repos consuming this branch hit two concrete regressions while validating Forge:
1. `mk-pnpm-cli` tried to inspect install roots for derived `workspaceSources`, which breaks pure evaluation.
2. pnpm 11 rejects URL-keyed `patchedDependencies`, which prevented workspace commands from starting.

## Verification
- `nix build .#factory-repos-effect-utils-deps-build` with the downstream override no longer fails on the derived workspace-source probe
- `DT_PASSTHROUGH=1 pnpm --version` and `pnpm why @myobie/pty` succeed with the semver-keyed patch

Acting on behalf of the user.