### PR TITLE
fix: bump @myobie/pty for xterm namespace import fix

### DIFF
--- a/nix/oxc-config-plugin.nix
+++ b/nix/oxc-config-plugin.nix
@@ -28,7 +28,7 @@ let
     pnpm = pinnedPnpm;
   };
   packageDir = "packages/@overeng/oxc-config";
-  pnpmDepsHash = "sha256-wB37ZfgGboWNcmgbNwJ8CDmBsIr/rYbPZH/yUknWEqo=";
+  pnpmDepsHash = "sha256-ohDmNWmPUQ80aCAeItEpK/QiHTPC6vEl29TTuwiWb7M=";
 
   srcPath =
     if builtins.isAttrs src && builtins.hasAttr "outPath" src then

--- a/nix/oxc-config-plugin.nix
+++ b/nix/oxc-config-plugin.nix
@@ -28,7 +28,7 @@ let
     pnpm = pinnedPnpm;
   };
   packageDir = "packages/@overeng/oxc-config";
-  pnpmDepsHash = "sha256-L6KbFKMGG1Kdp1TKliykJevxCH5f1NRV65u69VeH3zM=";
+  pnpmDepsHash = "sha256-wB37ZfgGboWNcmgbNwJ8CDmBsIr/rYbPZH/yUknWEqo=";
 
   srcPath =
     if builtins.isAttrs src && builtins.hasAttr "outPath" src then

--- a/packages/@overeng/genie/nix/build.nix
+++ b/packages/@overeng/genie/nix/build.nix
@@ -24,7 +24,7 @@ let
     # Managed by `dt nix:hash:genie` — do not edit manually.
     depsBuilds = {
       "." = {
-        hash = "sha256-q9gMpVlO3SmOmxydlF21+LUWSxlDZ/IlM2nnBG3Abis=";
+        hash = "sha256-IQXVg6fVP5AtBNDmGRTScFFiXZdxwoSSqSpXcfu6oqs=";
       };
     };
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/genie/nix/build.nix
+++ b/packages/@overeng/genie/nix/build.nix
@@ -24,7 +24,7 @@ let
     # Managed by `dt nix:hash:genie` — do not edit manually.
     depsBuilds = {
       "." = {
-        hash = "sha256-CdSu76W4BlPWdtcdkqweJT9qkKtW9EulkgNFnBRM1TY=";
+        hash = "sha256-q9gMpVlO3SmOmxydlF21+LUWSxlDZ/IlM2nnBG3Abis=";
       };
     };
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/megarepo/nix/build.nix
+++ b/packages/@overeng/megarepo/nix/build.nix
@@ -23,7 +23,7 @@ let
     # Managed by `dt nix:hash:megarepo` — do not edit manually.
     depsBuilds = {
       "." = {
-        hash = "sha256-vNZQUAzJ9Eg+UozWuylFqO+UxjrB3n6OiHbKFT1+UOU=";
+        hash = "sha256-hKZU+F6E74FdIGB3Cqo1MYwiNPtXtzexMbK4FzGUEMw=";
       };
     };
     smokeTestArgs = [ "--help" ];

--- a/packages/@overeng/megarepo/nix/build.nix
+++ b/packages/@overeng/megarepo/nix/build.nix
@@ -23,7 +23,7 @@ let
     # Managed by `dt nix:hash:megarepo` — do not edit manually.
     depsBuilds = {
       "." = {
-        hash = "sha256-hKZU+F6E74FdIGB3Cqo1MYwiNPtXtzexMbK4FzGUEMw=";
+        hash = "sha256-Ux+52SfppxC458h2SiZxHp9wJBceQlw0ZwpAFOPSD2k=";
       };
     };
     smokeTestArgs = [ "--help" ];

--- a/packages/@overeng/tui-stories/nix/build.nix
+++ b/packages/@overeng/tui-stories/nix/build.nix
@@ -20,7 +20,7 @@ let
     # Managed by `dt nix:hash:tui-stories` — do not edit manually.
     depsBuilds = {
       "." = {
-        hash = "sha256-XDFXDUj1c9w2fTyH+kgDIV8NKR2kRvnBbl1cp7eNNkU=";
+        hash = "sha256-sww2NylF7vo7df/R9H1wrJbjKJzVzulofE3ExAiRuwU=";
       };
     };
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/tui-stories/nix/build.nix
+++ b/packages/@overeng/tui-stories/nix/build.nix
@@ -20,7 +20,7 @@ let
     # Managed by `dt nix:hash:tui-stories` — do not edit manually.
     depsBuilds = {
       "." = {
-        hash = "sha256-sww2NylF7vo7df/R9H1wrJbjKJzVzulofE3ExAiRuwU=";
+        hash = "sha256-0NYG3MKGQ+Ib3f+3nv3X+CwDzcmcQ3IZMhSAQA6KtC0=";
       };
     };
     inherit gitRev commitTs dirty;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1043,7 +1043,7 @@ importers:
     dependencies:
       '@myobie/pty':
         specifier: github:schickling/pty#schickling/2026-04-08-prepare-build
-        version: https://codeload.github.com/schickling/pty/tar.gz/3725304ad9829912a1b44e84d95ceb65cc6522bb
+        version: https://codeload.github.com/schickling/pty/tar.gz/48785789a2e8d9eeb81f45e7ccb20b390fe18214
     devDependencies:
       '@effect/vitest':
         specifier: 0.29.0
@@ -2119,8 +2119,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@myobie/pty@https://codeload.github.com/schickling/pty/tar.gz/3725304ad9829912a1b44e84d95ceb65cc6522bb':
-    resolution: {tarball: https://codeload.github.com/schickling/pty/tar.gz/3725304ad9829912a1b44e84d95ceb65cc6522bb}
+  '@myobie/pty@https://codeload.github.com/schickling/pty/tar.gz/48785789a2e8d9eeb81f45e7ccb20b390fe18214':
+    resolution: {tarball: https://codeload.github.com/schickling/pty/tar.gz/48785789a2e8d9eeb81f45e7ccb20b390fe18214}
     version: 0.5.0
     hasBin: true
 
@@ -5916,7 +5916,7 @@ snapshots:
   '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
     optional: true
 
-  '@myobie/pty@https://codeload.github.com/schickling/pty/tar.gz/3725304ad9829912a1b44e84d95ceb65cc6522bb':
+  '@myobie/pty@https://codeload.github.com/schickling/pty/tar.gz/48785789a2e8d9eeb81f45e7ccb20b390fe18214':
     dependencies:
       '@preact/signals-core': 1.14.1
       '@xterm/addon-serialize': 0.14.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1043,7 +1043,7 @@ importers:
     dependencies:
       '@myobie/pty':
         specifier: github:schickling/pty#schickling/2026-04-08-prepare-build
-        version: https://codeload.github.com/schickling/pty/tar.gz/48785789a2e8d9eeb81f45e7ccb20b390fe18214
+        version: https://codeload.github.com/schickling/pty/tar.gz/fa13c3fbd6941300479a3f22ab748b6a96c7091c
     devDependencies:
       '@effect/vitest':
         specifier: 0.29.0
@@ -2119,8 +2119,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@myobie/pty@https://codeload.github.com/schickling/pty/tar.gz/48785789a2e8d9eeb81f45e7ccb20b390fe18214':
-    resolution: {tarball: https://codeload.github.com/schickling/pty/tar.gz/48785789a2e8d9eeb81f45e7ccb20b390fe18214}
+  '@myobie/pty@https://codeload.github.com/schickling/pty/tar.gz/fa13c3fbd6941300479a3f22ab748b6a96c7091c':
+    resolution: {tarball: https://codeload.github.com/schickling/pty/tar.gz/fa13c3fbd6941300479a3f22ab748b6a96c7091c}
     version: 0.5.0
     hasBin: true
 
@@ -5916,7 +5916,7 @@ snapshots:
   '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
     optional: true
 
-  '@myobie/pty@https://codeload.github.com/schickling/pty/tar.gz/48785789a2e8d9eeb81f45e7ccb20b390fe18214':
+  '@myobie/pty@https://codeload.github.com/schickling/pty/tar.gz/fa13c3fbd6941300479a3f22ab748b6a96c7091c':
     dependencies:
       '@preact/signals-core': 1.14.1
       '@xterm/addon-serialize': 0.14.0


### PR DESCRIPTION
## Summary

- Updates `pnpm-lock.yaml` to pick up the new `@myobie/pty` commit (`4878578`) from `schickling/pty#schickling/2026-04-08-prepare-build`
- The previous commit (`3725304`) used default imports for `@xterm/addon-serialize` and `@xterm/headless`, which broke when bundlers (vite/bun) resolved the `.mjs` entry with named-only exports
- The fix in the pty fork switches to namespace imports (`import * as`) which work in both Node ESM and bundler contexts

## Test plan

- [x] Verified `dist/server.js` in installed `@myobie/pty` uses `import * as xtermSerialize`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_This PR was created by schickling-assistant on behalf of @schickling_