### PR TITLE
fix: default local pnpm tasks to a workspace pnpm home

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
           path: |
             ${{ github.workspace }}/.pnpm-home
             ${{ runner.temp }}/pnpm-store/${{ github.job }}
-          key: "pnpm-home-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
+          key: "pnpm-home-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
       - name: Resolve devenv
         run: |
           if [ -z "${DEVENV_REV:-}" ]; then
@@ -301,7 +301,7 @@ jobs:
           path: |
             ${{ github.workspace }}/.pnpm-home
             ${{ runner.temp }}/pnpm-store/${{ github.job }}
-          key: "pnpm-home-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
+          key: "pnpm-home-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
       - name: Nix diagnostics summary
         if: failure()
         shell: bash
@@ -401,7 +401,7 @@ jobs:
           path: |
             ${{ github.workspace }}/.pnpm-home
             ${{ runner.temp }}/pnpm-store/${{ github.job }}
-          key: "pnpm-home-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
+          key: "pnpm-home-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
       - name: Resolve devenv
         run: |
           if [ -z "${DEVENV_REV:-}" ]; then
@@ -632,7 +632,7 @@ jobs:
           path: |
             ${{ github.workspace }}/.pnpm-home
             ${{ runner.temp }}/pnpm-store/${{ github.job }}
-          key: "pnpm-home-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
+          key: "pnpm-home-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
       - name: Nix diagnostics summary
         if: failure()
         shell: bash
@@ -735,7 +735,7 @@ jobs:
           path: |
             ${{ github.workspace }}/.pnpm-home
             ${{ runner.temp }}/pnpm-store/${{ github.job }}
-          key: "pnpm-home-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
+          key: "pnpm-home-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
       - name: Resolve devenv
         run: |
           if [ -z "${DEVENV_REV:-}" ]; then
@@ -966,7 +966,7 @@ jobs:
           path: |
             ${{ github.workspace }}/.pnpm-home
             ${{ runner.temp }}/pnpm-store/${{ github.job }}
-          key: "pnpm-home-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
+          key: "pnpm-home-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
       - name: Nix diagnostics summary
         if: failure()
         shell: bash
@@ -1069,7 +1069,7 @@ jobs:
           path: |
             ${{ github.workspace }}/.pnpm-home
             ${{ runner.temp }}/pnpm-store/${{ github.job }}
-          key: "pnpm-home-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
+          key: "pnpm-home-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
       - name: Resolve devenv
         run: |
           if [ -z "${DEVENV_REV:-}" ]; then
@@ -1300,7 +1300,7 @@ jobs:
           path: |
             ${{ github.workspace }}/.pnpm-home
             ${{ runner.temp }}/pnpm-store/${{ github.job }}
-          key: "pnpm-home-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
+          key: "pnpm-home-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
       - name: Nix diagnostics summary
         if: failure()
         shell: bash
@@ -1546,7 +1546,7 @@ jobs:
           path: |
             ${{ github.workspace }}/.pnpm-home
             ${{ runner.temp }}/pnpm-store/${{ github.job }}
-          key: "pnpm-home-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
+          key: "pnpm-home-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
       - name: Resolve devenv
         run: |
           if [ -z "${DEVENV_REV:-}" ]; then
@@ -1694,7 +1694,7 @@ jobs:
           path: |
             ${{ github.workspace }}/.pnpm-home
             ${{ runner.temp }}/pnpm-store/${{ github.job }}
-          key: "pnpm-home-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
+          key: "pnpm-home-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
       - name: Nix diagnostics summary
         if: failure()
         shell: bash
@@ -1794,7 +1794,7 @@ jobs:
           path: |
             ${{ github.workspace }}/.pnpm-home
             ${{ runner.temp }}/pnpm-store/${{ github.job }}
-          key: "pnpm-home-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
+          key: "pnpm-home-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
       - name: Resolve devenv
         run: |
           if [ -z "${DEVENV_REV:-}" ]; then
@@ -1919,7 +1919,7 @@ jobs:
           path: |
             ${{ github.workspace }}/.pnpm-home
             ${{ runner.temp }}/pnpm-store/${{ github.job }}
-          key: "pnpm-home-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
+          key: "pnpm-home-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
       - name: Nix diagnostics summary
         if: failure()
         shell: bash
@@ -2020,7 +2020,7 @@ jobs:
           path: |
             ${{ github.workspace }}/.pnpm-home
             ${{ runner.temp }}/pnpm-store/${{ github.job }}
-          key: "pnpm-home-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
+          key: "pnpm-home-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
       - name: Resolve devenv
         run: |
           if [ -z "${DEVENV_REV:-}" ]; then
@@ -2251,7 +2251,7 @@ jobs:
           path: |
             ${{ github.workspace }}/.pnpm-home
             ${{ runner.temp }}/pnpm-store/${{ github.job }}
-          key: "pnpm-home-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
+          key: "pnpm-home-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
       - name: Nix diagnostics summary
         if: failure()
         shell: bash
@@ -2355,7 +2355,7 @@ jobs:
           path: |
             ${{ github.workspace }}/.pnpm-home
             ${{ runner.temp }}/pnpm-store/${{ github.job }}
-          key: "pnpm-home-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
+          key: "pnpm-home-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
       - name: Resolve devenv
         run: |
           if [ -z "${DEVENV_REV:-}" ]; then
@@ -2756,7 +2756,7 @@ jobs:
           path: |
             ${{ github.workspace }}/.pnpm-home
             ${{ runner.temp }}/pnpm-store/${{ github.job }}
-          key: "pnpm-home-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
+          key: "pnpm-home-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
       - name: Nix diagnostics summary
         if: failure()
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,12 +64,13 @@ jobs:
           echo "PNPM_STORE_DIR=${{ runner.temp }}/pnpm-store/${{ github.job }}" >> "$GITHUB_ENV"
           echo "PNPM_HOME=${{ github.workspace }}/.pnpm-home" >> "$GITHUB_ENV"
       - id: restore-pnpm-store
-        name: Restore pnpm home
+        name: Restore pnpm state
         uses: actions/cache/restore@v4
         with:
-          path: '${{ github.workspace }}/.pnpm-home'
+          path: |
+            ${{ github.workspace }}/.pnpm-home
+            ${{ runner.temp }}/pnpm-store/${{ github.job }}
           key: "pnpm-home-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
-          restore-keys: 'pnpm-home-${{ runner.os }}-${{ runner.arch }}-'
       - name: Resolve devenv
         run: |
           if [ -z "${DEVENV_REV:-}" ]; then
@@ -293,11 +294,13 @@ jobs:
           . "$__nix_gc_retry_helper"
           rm -f "$__nix_gc_retry_helper"
           run_nix_gc_race_retry 'devenv tasks run ts:check:strict --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run ts:check:strict --mode before'
-      - name: Save pnpm home
+      - name: Save pnpm state
         if: "${{ always() && !cancelled() && steps.restore-pnpm-store.outputs.cache-hit != 'true' }}"
         uses: actions/cache/save@v4
         with:
-          path: '${{ github.workspace }}/.pnpm-home'
+          path: |
+            ${{ github.workspace }}/.pnpm-home
+            ${{ runner.temp }}/pnpm-store/${{ github.job }}
           key: "pnpm-home-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
       - name: Nix diagnostics summary
         if: failure()
@@ -392,12 +395,13 @@ jobs:
           echo "PNPM_STORE_DIR=${{ runner.temp }}/pnpm-store/${{ github.job }}" >> "$GITHUB_ENV"
           echo "PNPM_HOME=${{ github.workspace }}/.pnpm-home" >> "$GITHUB_ENV"
       - id: restore-pnpm-store
-        name: Restore pnpm home
+        name: Restore pnpm state
         uses: actions/cache/restore@v4
         with:
-          path: '${{ github.workspace }}/.pnpm-home'
+          path: |
+            ${{ github.workspace }}/.pnpm-home
+            ${{ runner.temp }}/pnpm-store/${{ github.job }}
           key: "pnpm-home-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
-          restore-keys: 'pnpm-home-${{ runner.os }}-${{ runner.arch }}-'
       - name: Resolve devenv
         run: |
           if [ -z "${DEVENV_REV:-}" ]; then
@@ -621,11 +625,13 @@ jobs:
           . "$__nix_gc_retry_helper"
           rm -f "$__nix_gc_retry_helper"
           run_nix_gc_race_retry 'devenv tasks run lint:check --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run lint:check --mode before'
-      - name: Save pnpm home
+      - name: Save pnpm state
         if: "${{ always() && !cancelled() && steps.restore-pnpm-store.outputs.cache-hit != 'true' }}"
         uses: actions/cache/save@v4
         with:
-          path: '${{ github.workspace }}/.pnpm-home'
+          path: |
+            ${{ github.workspace }}/.pnpm-home
+            ${{ runner.temp }}/pnpm-store/${{ github.job }}
           key: "pnpm-home-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
       - name: Nix diagnostics summary
         if: failure()
@@ -723,12 +729,13 @@ jobs:
           echo "PNPM_STORE_DIR=${{ runner.temp }}/pnpm-store/${{ github.job }}" >> "$GITHUB_ENV"
           echo "PNPM_HOME=${{ github.workspace }}/.pnpm-home" >> "$GITHUB_ENV"
       - id: restore-pnpm-store
-        name: Restore pnpm home
+        name: Restore pnpm state
         uses: actions/cache/restore@v4
         with:
-          path: '${{ github.workspace }}/.pnpm-home'
+          path: |
+            ${{ github.workspace }}/.pnpm-home
+            ${{ runner.temp }}/pnpm-store/${{ github.job }}
           key: "pnpm-home-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
-          restore-keys: 'pnpm-home-${{ runner.os }}-${{ runner.arch }}-'
       - name: Resolve devenv
         run: |
           if [ -z "${DEVENV_REV:-}" ]; then
@@ -952,11 +959,13 @@ jobs:
           . "$__nix_gc_retry_helper"
           rm -f "$__nix_gc_retry_helper"
           run_nix_gc_race_retry 'devenv tasks run test:run --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run test:run --mode before'
-      - name: Save pnpm home
+      - name: Save pnpm state
         if: "${{ always() && !cancelled() && steps.restore-pnpm-store.outputs.cache-hit != 'true' }}"
         uses: actions/cache/save@v4
         with:
-          path: '${{ github.workspace }}/.pnpm-home'
+          path: |
+            ${{ github.workspace }}/.pnpm-home
+            ${{ runner.temp }}/pnpm-store/${{ github.job }}
           key: "pnpm-home-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
       - name: Nix diagnostics summary
         if: failure()
@@ -1054,12 +1063,13 @@ jobs:
           echo "PNPM_STORE_DIR=${{ runner.temp }}/pnpm-store/${{ github.job }}" >> "$GITHUB_ENV"
           echo "PNPM_HOME=${{ github.workspace }}/.pnpm-home" >> "$GITHUB_ENV"
       - id: restore-pnpm-store
-        name: Restore pnpm home
+        name: Restore pnpm state
         uses: actions/cache/restore@v4
         with:
-          path: '${{ github.workspace }}/.pnpm-home'
+          path: |
+            ${{ github.workspace }}/.pnpm-home
+            ${{ runner.temp }}/pnpm-store/${{ github.job }}
           key: "pnpm-home-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
-          restore-keys: 'pnpm-home-${{ runner.os }}-${{ runner.arch }}-'
       - name: Resolve devenv
         run: |
           if [ -z "${DEVENV_REV:-}" ]; then
@@ -1283,11 +1293,13 @@ jobs:
           . "$__nix_gc_retry_helper"
           rm -f "$__nix_gc_retry_helper"
           run_nix_gc_race_retry 'devenv tasks run nix:check --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run nix:check --mode before'
-      - name: Save pnpm home
+      - name: Save pnpm state
         if: "${{ always() && !cancelled() && steps.restore-pnpm-store.outputs.cache-hit != 'true' }}"
         uses: actions/cache/save@v4
         with:
-          path: '${{ github.workspace }}/.pnpm-home'
+          path: |
+            ${{ github.workspace }}/.pnpm-home
+            ${{ runner.temp }}/pnpm-store/${{ github.job }}
           key: "pnpm-home-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
       - name: Nix diagnostics summary
         if: failure()
@@ -1528,12 +1540,13 @@ jobs:
           echo "PNPM_STORE_DIR=${{ runner.temp }}/pnpm-store/${{ github.job }}" >> "$GITHUB_ENV"
           echo "PNPM_HOME=${{ github.workspace }}/.pnpm-home" >> "$GITHUB_ENV"
       - id: restore-pnpm-store
-        name: Restore pnpm home
+        name: Restore pnpm state
         uses: actions/cache/restore@v4
         with:
-          path: '${{ github.workspace }}/.pnpm-home'
+          path: |
+            ${{ github.workspace }}/.pnpm-home
+            ${{ runner.temp }}/pnpm-store/${{ github.job }}
           key: "pnpm-home-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
-          restore-keys: 'pnpm-home-${{ runner.os }}-${{ runner.arch }}-'
       - name: Resolve devenv
         run: |
           if [ -z "${DEVENV_REV:-}" ]; then
@@ -1674,11 +1687,13 @@ jobs:
               exit 1
             fi
           done
-      - name: Save pnpm home
+      - name: Save pnpm state
         if: "${{ always() && !cancelled() && steps.restore-pnpm-store.outputs.cache-hit != 'true' }}"
         uses: actions/cache/save@v4
         with:
-          path: '${{ github.workspace }}/.pnpm-home'
+          path: |
+            ${{ github.workspace }}/.pnpm-home
+            ${{ runner.temp }}/pnpm-store/${{ github.job }}
           key: "pnpm-home-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
       - name: Nix diagnostics summary
         if: failure()
@@ -1773,12 +1788,13 @@ jobs:
           echo "PNPM_STORE_DIR=${{ runner.temp }}/pnpm-store/${{ github.job }}" >> "$GITHUB_ENV"
           echo "PNPM_HOME=${{ github.workspace }}/.pnpm-home" >> "$GITHUB_ENV"
       - id: restore-pnpm-store
-        name: Restore pnpm home
+        name: Restore pnpm state
         uses: actions/cache/restore@v4
         with:
-          path: '${{ github.workspace }}/.pnpm-home'
+          path: |
+            ${{ github.workspace }}/.pnpm-home
+            ${{ runner.temp }}/pnpm-store/${{ github.job }}
           key: "pnpm-home-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
-          restore-keys: 'pnpm-home-${{ runner.os }}-${{ runner.arch }}-'
       - name: Resolve devenv
         run: |
           if [ -z "${DEVENV_REV:-}" ]; then
@@ -1896,11 +1912,13 @@ jobs:
         run: |
           bash genie/ci-scripts/nix-gc-race-retry.test.sh
           bash nix/workspace-tools/lib/mk-pnpm-cli/tests/run.sh --skip-genie --skip-megarepo --skip-devenv-shell --skip-downstream-megarepo
-      - name: Save pnpm home
+      - name: Save pnpm state
         if: "${{ always() && !cancelled() && steps.restore-pnpm-store.outputs.cache-hit != 'true' }}"
         uses: actions/cache/save@v4
         with:
-          path: '${{ github.workspace }}/.pnpm-home'
+          path: |
+            ${{ github.workspace }}/.pnpm-home
+            ${{ runner.temp }}/pnpm-store/${{ github.job }}
           key: "pnpm-home-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
       - name: Nix diagnostics summary
         if: failure()
@@ -1996,12 +2014,13 @@ jobs:
           echo "PNPM_STORE_DIR=${{ runner.temp }}/pnpm-store/${{ github.job }}" >> "$GITHUB_ENV"
           echo "PNPM_HOME=${{ github.workspace }}/.pnpm-home" >> "$GITHUB_ENV"
       - id: restore-pnpm-store
-        name: Restore pnpm home
+        name: Restore pnpm state
         uses: actions/cache/restore@v4
         with:
-          path: '${{ github.workspace }}/.pnpm-home'
+          path: |
+            ${{ github.workspace }}/.pnpm-home
+            ${{ runner.temp }}/pnpm-store/${{ github.job }}
           key: "pnpm-home-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
-          restore-keys: 'pnpm-home-${{ runner.os }}-${{ runner.arch }}-'
       - name: Resolve devenv
         run: |
           if [ -z "${DEVENV_REV:-}" ]; then
@@ -2225,11 +2244,13 @@ jobs:
           . "$__nix_gc_retry_helper"
           rm -f "$__nix_gc_retry_helper"
           run_nix_gc_race_retry 'devenv tasks run test:notion-integration --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run test:notion-integration --mode before'
-      - name: Save pnpm home
+      - name: Save pnpm state
         if: "${{ always() && !cancelled() && steps.restore-pnpm-store.outputs.cache-hit != 'true' }}"
         uses: actions/cache/save@v4
         with:
-          path: '${{ github.workspace }}/.pnpm-home'
+          path: |
+            ${{ github.workspace }}/.pnpm-home
+            ${{ runner.temp }}/pnpm-store/${{ github.job }}
           key: "pnpm-home-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
       - name: Nix diagnostics summary
         if: failure()
@@ -2328,12 +2349,13 @@ jobs:
           echo "PNPM_STORE_DIR=${{ runner.temp }}/pnpm-store/${{ github.job }}" >> "$GITHUB_ENV"
           echo "PNPM_HOME=${{ github.workspace }}/.pnpm-home" >> "$GITHUB_ENV"
       - id: restore-pnpm-store
-        name: Restore pnpm home
+        name: Restore pnpm state
         uses: actions/cache/restore@v4
         with:
-          path: '${{ github.workspace }}/.pnpm-home'
+          path: |
+            ${{ github.workspace }}/.pnpm-home
+            ${{ runner.temp }}/pnpm-store/${{ github.job }}
           key: "pnpm-home-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
-          restore-keys: 'pnpm-home-${{ runner.os }}-${{ runner.arch }}-'
       - name: Resolve devenv
         run: |
           if [ -z "${DEVENV_REV:-}" ]; then
@@ -2727,11 +2749,13 @@ jobs:
             nix run nixpkgs#gh -- pr comment "${{ github.event.pull_request.number }}" --body-file /tmp/comment.md --edit-last 2>/dev/null \
               || nix run nixpkgs#gh -- pr comment "${{ github.event.pull_request.number }}" --body-file /tmp/comment.md
           fi
-      - name: Save pnpm home
+      - name: Save pnpm state
         if: "${{ always() && !cancelled() && steps.restore-pnpm-store.outputs.cache-hit != 'true' }}"
         uses: actions/cache/save@v4
         with:
-          path: '${{ github.workspace }}/.pnpm-home'
+          path: |
+            ${{ github.workspace }}/.pnpm-home
+            ${{ runner.temp }}/pnpm-store/${{ github.job }}
           key: "pnpm-home-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
       - name: Nix diagnostics summary
         if: failure()

--- a/genie/ci-workflow.ts
+++ b/genie/ci-workflow.ts
@@ -421,23 +421,30 @@ echo "Pinned devenv rev: $DEVENV_REV"`,
 } as const
 
 /**
- * Keep pnpm's hot mutable content isolated per job while still allowing cache reuse across runs.
+ * Keep pnpm's workspace-relative GVS projection isolated per job.
  *
- * In the pnpm 11 + GVS configuration we use today, the effective hot state lives
- * under `PNPM_HOME`, not `PNPM_STORE_DIR`. `PNPM_HOME` must stay
- * workspace-relative because the GVS links embed absolute paths and those need
- * to stay valid for relocatable artifacts like `vercel deploy --prebuilt`.
+ * `PNPM_HOME` must stay workspace-relative because pnpm 11 embeds absolute
+ * paths into the GVS links, and those need to stay valid for relocatable
+ * artifacts like `vercel deploy --prebuilt`.
  */
 export const jobLocalPnpmHome = '${{ github.workspace }}/.pnpm-home'
 
 /**
- * Keep pnpm's auxiliary mutable store content isolated per job.
+ * Keep pnpm's tarball / package store isolated per job.
  *
- * We still wire `PNPM_STORE_DIR` explicitly for pnpm, but the primary CI cache
- * target is `PNPM_HOME` because that is where pnpm 11 GVS keeps the reusable
- * links and metadata.
+ * Unlike `PNPM_HOME`, this lives outside the workspace so jobs do not fight
+ * over mutable store state on shared runners.
  */
 export const jobLocalPnpmStore = '${{ runner.temp }}/pnpm-store/${{ github.job }}'
+
+/**
+ * Cache the full pnpm hot state, not just the GVS home projection.
+ *
+ * `PNPM_HOME` keeps the reusable GVS links / metadata while `PNPM_STORE_DIR`
+ * keeps the fetched package tarballs. Caching both avoids re-downloading the
+ * entire workspace on each CI job when the lockfile has not changed.
+ */
+export const jobLocalPnpmCachePaths = [jobLocalPnpmHome, jobLocalPnpmStore].join('\n')
 
 /**
  * Export the canonical CI pnpm paths once so every later shell step shares the
@@ -455,11 +462,8 @@ export const pnpmStoreSetupStep = {
 const pnpmStoreCachePrimaryKey = (keyPrefix: string) =>
   `${keyPrefix}-${'${{ runner.os }}'}-${'${{ runner.arch }}'}-${"${{ hashFiles('**/pnpm-lock.yaml') }}"}`
 
-const pnpmStoreCacheRestorePrefix = (keyPrefix: string) =>
-  `${keyPrefix}-${'${{ runner.os }}'}-${'${{ runner.arch }}'}-`
-
 /**
- * Restore the job-local pnpm home snapshot before any install work runs.
+ * Restore the job-local pnpm state snapshot before any install work runs.
  *
  * This is intentionally separate from the save step so a job can still publish
  * a freshly populated store even if the main task fails later. The trade-off is
@@ -472,28 +476,27 @@ export const restorePnpmStoreStep = (opts?: {
   path?: string
 }) => {
   const keyPrefix = opts?.keyPrefix ?? 'pnpm-home'
-  const path = opts?.path ?? jobLocalPnpmHome
+  const path = opts?.path ?? jobLocalPnpmCachePaths
 
   return {
     id: opts?.stepId ?? 'restore-pnpm-store',
-    name: 'Restore pnpm home',
+    name: 'Restore pnpm state',
     uses: 'actions/cache/restore@v4' as const,
     with: {
       path,
       // The fetched store contents are platform-specific, so the cache must
       // isolate both OS and CPU architecture to avoid cross-platform corruption.
       key: pnpmStoreCachePrimaryKey(keyPrefix),
-      'restore-keys': pnpmStoreCacheRestorePrefix(keyPrefix),
     },
   }
 }
 
 /**
- * Save the job-local pnpm home after the main task graph runs.
+ * Save the job-local pnpm state after the main task graph runs.
  *
- * We only upload when the restore step missed the exact key. A restore-key hit
- * still saves the new primary key so lockfile changes warm later runs, while an
- * exact hit skips the redundant upload.
+ * We only upload when the restore step missed the exact key. Exact-key reuse
+ * keeps CI deterministic across branches that happen to share a lockfile,
+ * without restoring stale fallback state from unrelated lockfile revisions.
  */
 export const savePnpmStoreStep = (opts?: {
   keyPrefix?: string
@@ -502,10 +505,10 @@ export const savePnpmStoreStep = (opts?: {
 }) => {
   const keyPrefix = opts?.keyPrefix ?? 'pnpm-home'
   const restoreStepId = opts?.restoreStepId ?? 'restore-pnpm-store'
-  const path = opts?.path ?? jobLocalPnpmHome
+  const path = opts?.path ?? jobLocalPnpmCachePaths
 
   return {
-    name: 'Save pnpm home',
+    name: 'Save pnpm state',
     if: `\${{ always() && !cancelled() && steps.${restoreStepId}.outputs.cache-hit != 'true' }}`,
     uses: 'actions/cache/save@v4' as const,
     with: {

--- a/genie/ci-workflow.ts
+++ b/genie/ci-workflow.ts
@@ -459,8 +459,14 @@ export const pnpmStoreSetupStep = {
   ].join('\n'),
 } as const
 
+/**
+ * Bump this when the cache contents change shape so exact cache hits cannot
+ * silently restore an older layout and then skip repopulating the new paths.
+ */
+const pnpmStoreCacheSchemaVersion = 'v2'
+
 const pnpmStoreCachePrimaryKey = (keyPrefix: string) =>
-  `${keyPrefix}-${'${{ runner.os }}'}-${'${{ runner.arch }}'}-${"${{ hashFiles('**/pnpm-lock.yaml') }}"}`
+  `${keyPrefix}-${pnpmStoreCacheSchemaVersion}-${'${{ runner.os }}'}-${'${{ runner.arch }}'}-${"${{ hashFiles('**/pnpm-lock.yaml') }}"}`
 
 /**
  * Restore the job-local pnpm state snapshot before any install work runs.

--- a/nix/devenv-modules/tasks/shared/pnpm-task-helpers.sh
+++ b/nix/devenv-modules/tasks/shared/pnpm-task-helpers.sh
@@ -4,6 +4,14 @@ compute_hash() {
   sha256sum | awk '{print $1}'
 }
 
+ensure_local_pnpm_home_default() {
+  local workspace_root="$1"
+
+  if [ -z "${PNPM_HOME:-}" ]; then
+    export PNPM_HOME="${workspace_root}/.pnpm-home"
+  fi
+}
+
 emit_dir_state() {
   local dir="$1"
 

--- a/nix/devenv-modules/tasks/shared/pnpm.nix
+++ b/nix/devenv-modules/tasks/shared/pnpm.nix
@@ -86,6 +86,11 @@ let
     # tests so cleanup refactors cannot silently drift the two code paths apart.
     source ${lib.escapeShellArg pnpmTaskHelpersScript}
   '';
+  ensureLocalPnpmHomeFn = ''
+    # Keep pnpm's hot GVS projection workspace-local by default so local tasks
+    # match CI and don't inherit stale global link state from unrelated repos.
+    ensure_local_pnpm_home_default ${lib.escapeShellArg config.devenv.root}
+  '';
 
   computeWorkspaceStateHash = ''
     compute_workspace_state_hash() {
@@ -145,6 +150,7 @@ let
       exec = trace.exec "pnpm:install" ''
         set -euo pipefail
         ${loadPnpmTaskHelpersFn}
+        ${ensureLocalPnpmHomeFn}
         mkdir -p "${cacheRoot}"
         # This cache tracks the effective install state, not just workspace
         # manifests. The fingerprint also includes the active GVS projection
@@ -211,6 +217,7 @@ let
       status = trace.status "pnpm:install" "hash" ''
         set -euo pipefail
         ${loadPnpmTaskHelpersFn}
+        ${ensureLocalPnpmHomeFn}
         hash_file="${cacheRoot}/install-state.hash"
 
         if [ ! -d node_modules ] || [ ! -f pnpm-lock.yaml ] || [ ! -f "$hash_file" ]; then
@@ -237,6 +244,8 @@ let
       after = [ "genie:run" ] ++ updateAfter;
       exec = trace.exec "pnpm:update" ''
         set -euo pipefail
+        ${loadPnpmTaskHelpersFn}
+        ${ensureLocalPnpmHomeFn}
         export npm_config_manage_package_manager_versions=false
         pnpm install --fix-lockfile --config.confirmModulesPurge=false
         echo "Repo-root lockfile updated. Run 'dt nix:hash' to update Nix hashes."
@@ -250,6 +259,7 @@ let
       exec = trace.exec "pnpm:clean" ''
         set -euo pipefail
         ${loadPnpmTaskHelpersFn}
+        ${ensureLocalPnpmHomeFn}
 
         purge_node_modules node_modules ${nodeModulesPaths}
 
@@ -277,6 +287,7 @@ in
   packages = cliGuard.fromTasks allTasks;
 
   enterShell = lib.mkIf globalCache ''
+    export PNPM_HOME="''${PNPM_HOME:-${config.devenv.root}/.pnpm-home}"
     export npm_config_cache="$HOME/.cache/pnpm"
     export npm_config_manage_package_manager_versions=false
   '';

--- a/nix/devenv-modules/tasks/shared/tests/pnpm-task-smoke.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/pnpm-task-smoke.test.sh
@@ -132,6 +132,7 @@ if [ "${1:-}" = "--version" ]; then
   exit 0
 fi
 if [ "${1:-}" = "install" ]; then
+  printf 'PNPM_HOME=%s\n' "${PNPM_HOME:-}" >> "${TEST_PNPM_LOG:?}"
   mkdir -p node_modules
   touch node_modules/.install-ok
   exit 0
@@ -233,7 +234,29 @@ echo "Test 3: status hits after install with same GVS path"
   assert_exit_code 0 "$exit_code" "status should hit after install"
 )
 
-echo "Test 4: status misses after effective GVS path changes"
+echo "Test 4: exec defaults PNPM_HOME to a workspace-local projection"
+(
+  cd "$workspace"
+  export HOME="$tmpdir/home"
+  unset PNPM_HOME
+  : > "$tmpdir/pnpm.log"
+  bash "$tmpdir/pnpm-install.exec.sh"
+  grep -qxF "PNPM_HOME=$workspace/.pnpm-home" "$tmpdir/pnpm.log"
+)
+
+echo "Test 5: status hits after install with the default GVS path"
+(
+  cd "$workspace"
+  export HOME="$tmpdir/home"
+  unset PNPM_HOME
+  set +e
+  bash "$tmpdir/pnpm-install.status.sh"
+  exit_code=$?
+  set -e
+  assert_exit_code 0 "$exit_code" "status should hit after default-PNPM_HOME install"
+)
+
+echo "Test 6: status misses after effective GVS path changes"
 (
   cd "$workspace"
   export HOME="$tmpdir/home"
@@ -245,11 +268,11 @@ echo "Test 4: status misses after effective GVS path changes"
   assert_exit_code 1 "$exit_code" "status should miss when GVS path changes"
 )
 
-echo "Test 5: exec invoked pnpm version and install"
+echo "Test 7: exec invoked pnpm version and install"
 grep -qxF -- "--version" "$tmpdir/pnpm.log"
 grep -q "^install " "$tmpdir/pnpm.log"
 
-echo "Test 6: exec detaches stdin before probing pnpm version"
+echo "Test 8: exec detaches stdin before probing pnpm version"
 (
   cd "$workspace"
   export HOME="$tmpdir/home"
@@ -269,14 +292,14 @@ echo "Test 6: exec detaches stdin before probing pnpm version"
 )
 grep -qxF -- "--version" "$tmpdir/pnpm.log"
 
-echo "Test 7: generated test task runs vitest without pnpm exec"
+echo "Test 9: generated test task runs vitest without pnpm exec"
 (
   cd "$workspace/packages/demo"
   output="$(bash "$tmpdir/test-demo.exec.sh")"
   [ "$output" = "vitest-shim:run" ]
 )
 
-echo "Test 8: generated storybook task runs storybook without pnpm exec"
+echo "Test 10: generated storybook task runs storybook without pnpm exec"
 (
   cd "$workspace/packages/demo"
   output="$(bash "$tmpdir/storybook-demo.exec.sh")"

--- a/nix/devenv-modules/tasks/shared/tests/pnpm.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/pnpm.test.sh
@@ -127,7 +127,27 @@ echo "Test 2: XDG_DATA_HOME is used when PNPM_HOME is unset"
     "resolve_gvs_links_dir uses XDG_DATA_HOME"
 )
 
-echo "Test 3: Cache fingerprint changes when GVS path changes"
+echo "Test 3: ensure_local_pnpm_home_default sets a workspace-local default"
+(
+  unset PNPM_HOME
+  ensure_local_pnpm_home_default "$test_dir/workspace"
+  assert_eq \
+    "$test_dir/workspace/.pnpm-home" \
+    "$PNPM_HOME" \
+    "ensure_local_pnpm_home_default sets PNPM_HOME"
+)
+
+echo "Test 4: ensure_local_pnpm_home_default preserves an explicit PNPM_HOME"
+(
+  export PNPM_HOME="$test_dir/custom-home"
+  ensure_local_pnpm_home_default "$test_dir/workspace"
+  assert_eq \
+    "$test_dir/custom-home" \
+    "$PNPM_HOME" \
+    "ensure_local_pnpm_home_default keeps explicit PNPM_HOME"
+)
+
+echo "Test 5: Cache fingerprint changes when GVS path changes"
 fingerprint_a="$(cache_fingerprint "workspace-hash" "/tmp/a/store/v11/links")"
 fingerprint_b="$(cache_fingerprint "workspace-hash" "/tmp/b/store/v11/links")"
 if [ "$fingerprint_a" = "$fingerprint_b" ]; then
@@ -135,7 +155,7 @@ if [ "$fingerprint_a" = "$fingerprint_b" ]; then
   exit 1
 fi
 
-echo "Test 4: resolve_package_bin prefers package-local .bin shims"
+echo "Test 6: resolve_package_bin prefers package-local .bin shims"
 bin_fixture="$test_dir/bin-fixture"
 make_bin_fixture "$bin_fixture"
 resolved_bin="$(resolve_package_bin fake-tool fake-tool "$bin_fixture")"
@@ -145,14 +165,14 @@ assert_eq \
   "$resolved_bin" \
   "resolve_package_bin prefers the generated .bin shim"
 
-echo "Test 5: run_package_bin executes the .bin shim when present"
+echo "Test 7: run_package_bin executes the .bin shim when present"
 output="$(cd "$bin_fixture" && run_package_bin fake-tool fake-tool alpha beta)"
 assert_eq \
   "fake-tool-shim:alpha beta" \
   "$output" \
   "run_package_bin executes the resolved shim"
 
-echo "Test 6: resolve_package_bin falls back to the package bin file"
+echo "Test 8: resolve_package_bin falls back to the package bin file"
 fallback_fixture="$test_dir/fallback-bin-fixture"
 make_bin_fixture_without_shim "$fallback_fixture"
 resolved_fallback_bin="$(resolve_package_bin fallback-tool fallback-tool "$fallback_fixture")"
@@ -162,7 +182,7 @@ assert_eq \
   "$resolved_fallback_bin" \
   "resolve_package_bin falls back to the package bin file"
 
-echo "Test 7: Projection health passes when symlinked package can resolve deps"
+echo "Test 9: Projection health passes when symlinked package can resolve deps"
 healthy_dir="$test_dir/healthy"
 make_projection_fixture "$healthy_dir" 1
 set +e
@@ -171,7 +191,7 @@ exit_code=$?
 set -e
 assert_exit_code 0 "$exit_code" "projection health passes"
 
-echo "Test 8: Projection health ignores packages that do not export ./package.json"
+echo "Test 10: Projection health ignores packages that do not export ./package.json"
 exports_dir="$test_dir/exports"
 make_projection_fixture "$exports_dir" 1 1
 set +e
@@ -180,7 +200,7 @@ exit_code=$?
 set -e
 assert_exit_code 0 "$exit_code" "projection health should not depend on package.json exports"
 
-echo "Test 9: Projection health fails when symlinked package loses a transitive dep"
+echo "Test 11: Projection health fails when symlinked package loses a transitive dep"
 stale_dir="$test_dir/stale"
 make_projection_fixture "$stale_dir" 0
 set +e
@@ -189,7 +209,7 @@ exit_code=$?
 set -e
 assert_exit_code 1 "$exit_code" "projection health detects missing dep"
 
-echo "Test 10: Broken node_modules symlink is rejected before projection checks"
+echo "Test 12: Broken node_modules symlink is rejected before projection checks"
 broken_dir="$test_dir/broken"
 mkdir -p "$broken_dir/node_modules"
 ln -s ../missing "$broken_dir/node_modules/broken"

--- a/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
@@ -61,8 +61,12 @@ describe('ci workflow pnpm cache defaults', () => {
     )
   })
 
-  it('defaults the split cache helpers to pnpm home instead of pnpm store', () => {
-    expect(ciWorkflowSource).toContain('const path = opts?.path ?? jobLocalPnpmHome')
+  it('defaults the split cache helpers to the full pnpm hot state', () => {
+    expect(ciWorkflowSource).toContain(
+      "export const jobLocalPnpmCachePaths = [jobLocalPnpmHome, jobLocalPnpmStore].join('\\n')",
+    )
+    expect(ciWorkflowSource).toContain('const path = opts?.path ?? jobLocalPnpmCachePaths')
+    expect(ciWorkflowSource).not.toContain("'restore-keys': pnpmStoreCacheRestorePrefix(keyPrefix)")
   })
 
   it('cold-builds pnpm deps artifacts by evicting cached outputs before the second build', () => {

--- a/packages/@overeng/pty-effect/src/PtySession.test.ts
+++ b/packages/@overeng/pty-effect/src/PtySession.test.ts
@@ -212,17 +212,20 @@ describe('PtySession scope finalization', () => {
 })
 
 describe('PtySession (server mode)', () => {
-  it.scopedLive('spawns a server, attaches, reads text', () =>
-    withIsolatedDir(
-      Effect.gen(function* () {
-        const session = yield* make(
-          PtySpec_.server({ command: 'sh', args: ['-c', 'echo server-ok; sleep 5'] }),
-        )
-        yield* session.attach
-        const ss = yield* session.waitForText({ needle: 'server-ok', schedule: fastSchedule })
-        expect(ss.text).toContain('server-ok')
-      }),
-    ),
+  it.scopedLive(
+    'spawns a server, attaches, reads text',
+    () =>
+      withIsolatedDir(
+        Effect.gen(function* () {
+          const session = yield* make(
+            PtySpec_.server({ command: 'sh', args: ['-c', 'echo server-ok; sleep 5'] }),
+          )
+          yield* session.attach
+          const ss = yield* session.waitForText({ needle: 'server-ok', schedule: fastSchedule })
+          expect(ss.text).toContain('server-ok')
+        }),
+      ),
+    30_000,
   )
 
   it.scopedLive('resize works in server mode', () =>

--- a/packages/@overeng/pty-effect/src/client.test.ts
+++ b/packages/@overeng/pty-effect/src/client.test.ts
@@ -6,7 +6,7 @@ import * as path from 'node:path'
 import { describe, expect, it } from '@effect/vitest'
 import { Chunk, Effect, Schema, Stream } from 'effect'
 
-import { PtyClient, layer as ptyClientLayer } from './client.ts'
+import { makeLayer, PtyClient, layer as ptyClientLayer } from './client.ts'
 import { PtyName } from './PtySpec.ts'
 
 /** Per-test isolated `PTY_SESSION_DIR` so daemons can't collide. */
@@ -172,6 +172,35 @@ describe('PtyClient', () => {
         expect(result._tag).toBe('Left')
         if (result._tag === 'Left') expect(result.left.reason).toBe('BadName')
       }).pipe(Effect.provide(ptyClientLayer)),
+    ),
+  )
+
+  it.scopedLive('supports fixed session-dir layers without mutating the ambient env', () =>
+    withTempDir('pty-effect-client-layer-', (ptySessionDir) =>
+      withTempDir('pty-effect-client-ambient-', (ambientDir) =>
+        Effect.gen(function* () {
+          const previous = process.env.PTY_SESSION_DIR
+          process.env.PTY_SESSION_DIR = ambientDir
+
+          try {
+            const client = yield* PtyClient
+            const name = uniqueName('layer')
+
+            yield* client.spawnDaemon({
+              name,
+              command: 'sh',
+              args: ['-c', 'echo LAYER_TARGET && sleep 0.05'],
+            })
+
+            const sessions = yield* client.list
+            expect(sessions.some((session) => session.name === name)).toBe(true)
+            expect(process.env.PTY_SESSION_DIR).toBe(ambientDir)
+          } finally {
+            if (previous === undefined) delete process.env.PTY_SESSION_DIR
+            else process.env.PTY_SESSION_DIR = previous
+          }
+        }).pipe(Effect.provide(makeLayer({ ptySessionDir }))),
+      ),
     ),
   )
 })

--- a/packages/@overeng/pty-effect/src/client.ts
+++ b/packages/@overeng/pty-effect/src/client.ts
@@ -79,6 +79,10 @@ export interface PtyAttachSpec {
   readonly size: TerminalSize
 }
 
+export interface PtyClientLayerOptions {
+  readonly ptySessionDir?: string
+}
+
 /** Default polling schedule for `waitFor*` (50ms fixed). */
 export const defaultPollSchedule: Schedule.Schedule<unknown> = Schedule.spaced('50 millis')
 
@@ -199,6 +203,38 @@ const wrapSync = <A>(opts: {
       }),
   })
 
+let serializedEnvQueue = Promise.resolve()
+
+const withSerializedEnv = <A>(
+  env: Readonly<Record<string, string | undefined>>,
+  thunk: () => Promise<A> | A,
+): Promise<A> => {
+  const previous = serializedEnvQueue
+  let release!: () => void
+  serializedEnvQueue = new Promise<void>((resolve) => {
+    release = resolve
+  })
+
+  return previous.then(async () => {
+    const saved = Object.entries(env).map(([key]) => [key, process.env[key]] as const)
+
+    for (const [key, value] of Object.entries(env)) {
+      if (value === undefined) delete process.env[key]
+      else process.env[key] = value
+    }
+
+    try {
+      return await thunk()
+    } finally {
+      for (const [key, value] of saved) {
+        if (value === undefined) delete process.env[key]
+        else process.env[key] = value
+      }
+      release()
+    }
+  })
+}
+
 const buildSpawnOpts = (spec: PtyDaemonSpec): SpawnDaemonOptions => {
   const opts: SpawnDaemonOptions = {
     name: spec.name,
@@ -242,53 +278,62 @@ const validateNameOrFail = (name: string) =>
       }),
   })
 
-const spawnDaemon = (spec: PtyDaemonSpec): Effect.Effect<void, PtyError> =>
-  Effect.gen(function* () {
-    yield* validateNameOrFail(spec.name)
-    const envOverrides = spec.env !== undefined ? Object.entries(spec.env) : []
-    const saved = envOverrides.map(([k]) => [k, process.env[k]] as const)
-    for (const [k, v] of envOverrides) process.env[k] = v
-    try {
+const spawnDaemon =
+  (options: PtyClientLayerOptions) =>
+  (spec: PtyDaemonSpec): Effect.Effect<void, PtyError> =>
+    Effect.gen(function* () {
+      yield* validateNameOrFail(spec.name)
       yield* wrapPromise({
         method: 'spawnDaemon',
         reason: 'SpawnFailed',
         name: spec.name,
-        thunk: () => upstreamSpawnDaemon(buildSpawnOpts(spec)),
+        thunk: () =>
+          withSerializedEnv(
+            {
+              PTY_SESSION_DIR: options.ptySessionDir,
+              ...(spec.env ?? {}),
+            },
+            () => upstreamSpawnDaemon(buildSpawnOpts(spec)),
+          ),
       })
-    } finally {
-      for (const [k, prev] of saved) {
-        if (prev === undefined) delete process.env[k]
-        else process.env[k] = prev
-      }
-    }
-  }).pipe(Effect.withSpan('pty-client.spawnDaemon', { attributes: { 'span.label': spec.name } }))
+    }).pipe(Effect.withSpan('pty-client.spawnDaemon', { attributes: { 'span.label': spec.name } }))
 
-const peek = (input: { readonly name: PtyName; readonly plain?: boolean }) =>
+const peek =
+  (options: PtyClientLayerOptions) =>
+  (input: { readonly name: PtyName; readonly plain?: boolean }) =>
+    wrapPromise({
+      method: 'peek',
+      reason: 'ConnectFailed',
+      name: input.name,
+      thunk: () =>
+        withSerializedEnv({ PTY_SESSION_DIR: options.ptySessionDir }, () =>
+          upstreamPeekScreen(
+            input.plain !== undefined
+              ? { name: input.name, plain: input.plain }
+              : { name: input.name },
+          ),
+        ),
+    }).pipe(Effect.withSpan('pty-client.peek', { attributes: { 'span.label': input.name } }))
+
+const list = (
+  options: PtyClientLayerOptions,
+): Effect.Effect<ReadonlyArray<SessionInfo>, PtyError> =>
   wrapPromise({
-    method: 'peek',
+    method: 'list',
     reason: 'ConnectFailed',
-    name: input.name,
     thunk: () =>
-      upstreamPeekScreen(
-        input.plain !== undefined ? { name: input.name, plain: input.plain } : { name: input.name },
-      ),
-  }).pipe(Effect.withSpan('pty-client.peek', { attributes: { 'span.label': input.name } }))
+      withSerializedEnv({ PTY_SESSION_DIR: options.ptySessionDir }, () => upstreamListSessions()),
+  }).pipe(Effect.withSpan('pty-client.list'))
 
-const list: Effect.Effect<ReadonlyArray<SessionInfo>, PtyError> = wrapPromise({
-  method: 'list',
-  reason: 'ConnectFailed',
-  thunk: () => upstreamListSessions(),
-}).pipe(Effect.withSpan('pty-client.list'))
-
-const exists = (input: { readonly name: PtyName }) =>
+const exists = (options: PtyClientLayerOptions) => (input: { readonly name: PtyName }) =>
   pipe(
-    list,
+    list(options),
     Effect.map((sessions) => sessions.some((s) => s.name === input.name)),
   ).pipe(Effect.withSpan('pty-client.exists', { attributes: { 'span.label': input.name } }))
 
-const kill = (input: { readonly name: PtyName }) =>
+const kill = (options: PtyClientLayerOptions) => (input: { readonly name: PtyName }) =>
   Effect.gen(function* () {
-    const sessions = yield* list
+    const sessions = yield* list(options)
     const session = sessions.find((s) => s.name === input.name)
     if (session === undefined || session.pid === null) {
       return yield* new PtyError({
@@ -319,172 +364,179 @@ const kill = (input: { readonly name: PtyName }) =>
  * require `Effect.runtime` plumbing through the event handlers — tracked
  * as a v2 improvement.
  */
-const attach = (spec: PtyAttachSpec): Effect.Effect<PtyClientSession, PtyError, Scope.Scope> =>
-  Effect.gen(function* () {
-    const queue = yield* Queue.bounded<Uint8Array>(1024)
-    const exitDeferred = yield* Deferred.make<{ readonly code: number }, PtyError>()
-    const enc = new TextEncoder()
+const attach =
+  (options: PtyClientLayerOptions) =>
+  (spec: PtyAttachSpec): Effect.Effect<PtyClientSession, PtyError, Scope.Scope> =>
+    Effect.gen(function* () {
+      const queue = yield* Queue.bounded<Uint8Array>(1024)
+      const exitDeferred = yield* Deferred.make<{ readonly code: number }, PtyError>()
+      const enc = new TextEncoder()
 
-    const opts: SessionConnectionOptions = {
-      name: spec.name,
-      rows: spec.size.rows,
-      cols: spec.size.cols,
-    }
-
-    const conn = yield* wrapSync({
-      method: 'attach.construct',
-      reason: 'ConnectFailed',
-      name: spec.name,
-      thunk: () => new SessionConnection(opts),
-    })
-
-    conn.on('data', (chunk: string) => {
-      Effect.runFork(Queue.offer(queue, enc.encode(chunk)))
-    })
-    conn.on('exit', (code: number) => {
-      Effect.runFork(
-        Deferred.succeed(exitDeferred, { code }).pipe(Effect.andThen(Queue.shutdown(queue))),
-      )
-    })
-    conn.on('error', (err: Error) => {
-      Effect.runFork(
-        Deferred.fail(
-          exitDeferred,
-          new PtyError({
-            reason: 'ConnectFailed',
-            method: 'attach.error',
-            name: spec.name,
-            cause: err,
-          }),
-        ).pipe(Effect.andThen(Queue.shutdown(queue))),
-      )
-    })
-    conn.on('close', () => {
-      Effect.runFork(
-        Deferred.fail(
-          exitDeferred,
-          new PtyError({ reason: 'Closed', method: 'attach.close', name: spec.name }),
-        ).pipe(Effect.andThen(Queue.shutdown(queue))),
-      )
-    })
-
-    const initialScreen = yield* Effect.acquireRelease(
-      wrapPromise({
-        method: 'attach.connect',
-        reason: 'ConnectFailed',
+      const opts: SessionConnectionOptions = {
         name: spec.name,
-        thunk: () => conn.connect(),
-      }),
-      () => Effect.sync(() => conn.disconnect()),
-    )
+        rows: spec.size.rows,
+        cols: spec.size.cols,
+      }
 
-    const bytes: Stream.Stream<Uint8Array, PtyError> = Stream.fromQueue(queue)
+      let conn!: SessionConnection
 
-    const write: PtyClientSession['write'] = ({ data }) =>
-      wrapSync({ method: 'write', name: spec.name, thunk: () => conn.write(data) })
+      const initialScreen = yield* Effect.acquireRelease(
+        wrapPromise({
+          method: 'attach.connect',
+          reason: 'ConnectFailed',
+          name: spec.name,
+          thunk: () =>
+            withSerializedEnv({ PTY_SESSION_DIR: options.ptySessionDir }, async () => {
+              conn = new SessionConnection(opts)
 
-    const typeText: PtyClientSession['type'] = ({ text }) =>
-      wrapSync({ method: 'type', name: spec.name, thunk: () => conn.write(text) })
+              conn.on('data', (chunk: string) => {
+                Effect.runFork(Queue.offer(queue, enc.encode(chunk)))
+              })
+              conn.on('exit', (code: number) => {
+                Effect.runFork(
+                  Deferred.succeed(exitDeferred, { code }).pipe(
+                    Effect.andThen(Queue.shutdown(queue)),
+                  ),
+                )
+              })
+              conn.on('error', (err: Error) => {
+                Effect.runFork(
+                  Deferred.fail(
+                    exitDeferred,
+                    new PtyError({
+                      reason: 'ConnectFailed',
+                      method: 'attach.error',
+                      name: spec.name,
+                      cause: err,
+                    }),
+                  ).pipe(Effect.andThen(Queue.shutdown(queue))),
+                )
+              })
+              conn.on('close', () => {
+                Effect.runFork(
+                  Deferred.fail(
+                    exitDeferred,
+                    new PtyError({ reason: 'Closed', method: 'attach.close', name: spec.name }),
+                  ).pipe(Effect.andThen(Queue.shutdown(queue))),
+                )
+              })
 
-    const press: PtyClientSession['press'] = ({ key }) =>
-      wrapSync({ method: 'press', name: spec.name, thunk: () => conn.press(key) })
+              return await conn.connect()
+            }),
+        }),
+        () => Effect.sync(() => conn.disconnect()),
+      )
 
-    const resize: PtyClientSession['resize'] = ({ rows, cols }) =>
-      wrapSync({
-        method: 'resize',
-        reason: 'ResizeFailed',
+      const bytes: Stream.Stream<Uint8Array, PtyError> = Stream.fromQueue(queue)
+
+      const write: PtyClientSession['write'] = ({ data }) =>
+        wrapSync({ method: 'write', name: spec.name, thunk: () => conn.write(data) })
+
+      const typeText: PtyClientSession['type'] = ({ text }) =>
+        wrapSync({ method: 'type', name: spec.name, thunk: () => conn.write(text) })
+
+      const press: PtyClientSession['press'] = ({ key }) =>
+        wrapSync({ method: 'press', name: spec.name, thunk: () => conn.press(key) })
+
+      const resize: PtyClientSession['resize'] = ({ rows, cols }) =>
+        wrapSync({
+          method: 'resize',
+          reason: 'ResizeFailed',
+          name: spec.name,
+          thunk: () => conn.resize(rows, cols),
+        })
+
+      const screenshot: PtyClientSession['screenshot'] = Effect.gen(function* () {
+        const ansi = yield* peek(options)({ name: spec.name, plain: false })
+        const text = yield* peek(options)({ name: spec.name, plain: true })
+        const lines = text.split('\n')
+        return { lines, text, ansi } satisfies Screenshot
+      }).pipe(Effect.withSpan('pty-client.screenshot', { attributes: { 'span.label': spec.name } }))
+
+      const waitForText: PtyClientSession['waitForText'] = ({ needle, schedule }) =>
+        pipe(
+          Stream.repeatEffectWithSchedule(screenshot, schedule ?? defaultPollSchedule),
+          Stream.filterMap((ss) =>
+            matches({ haystack: ss.text, needle }) === true ? Option.some(ss) : Option.none(),
+          ),
+          Stream.runHead,
+          Effect.flatMap(
+            Option.match({
+              onNone: () =>
+                Effect.fail(
+                  new PtyError({
+                    reason: 'Timeout',
+                    method: `waitForText(${String(needle)})`,
+                    name: spec.name,
+                  }),
+                ),
+              onSome: Effect.succeed,
+            }),
+          ),
+        ).pipe(
+          Effect.withSpan('pty-client.waitForText', {
+            attributes: { 'span.label': `${spec.name}: ${String(needle)}` },
+          }),
+        )
+
+      const waitForAbsent: PtyClientSession['waitForAbsent'] = ({ needle, schedule }) =>
+        pipe(
+          Stream.repeatEffectWithSchedule(screenshot, schedule ?? defaultPollSchedule),
+          Stream.filterMap((ss) =>
+            matches({ haystack: ss.text, needle }) === false ? Option.some(ss) : Option.none(),
+          ),
+          Stream.runHead,
+          Effect.flatMap(
+            Option.match({
+              onNone: () =>
+                Effect.fail(
+                  new PtyError({
+                    reason: 'Timeout',
+                    method: `waitForAbsent(${String(needle)})`,
+                    name: spec.name,
+                  }),
+                ),
+              onSome: Effect.succeed,
+            }),
+          ),
+        ).pipe(
+          Effect.withSpan('pty-client.waitForAbsent', {
+            attributes: { 'span.label': `${spec.name}: ${String(needle)}` },
+          }),
+        )
+
+      return {
         name: spec.name,
-        thunk: () => conn.resize(rows, cols),
-      })
-
-    const screenshot: PtyClientSession['screenshot'] = Effect.gen(function* () {
-      const ansi = yield* peek({ name: spec.name, plain: false })
-      const text = yield* peek({ name: spec.name, plain: true })
-      const lines = text.split('\n')
-      return { lines, text, ansi } satisfies Screenshot
-    }).pipe(Effect.withSpan('pty-client.screenshot', { attributes: { 'span.label': spec.name } }))
-
-    const waitForText: PtyClientSession['waitForText'] = ({ needle, schedule }) =>
-      pipe(
-        Stream.repeatEffectWithSchedule(screenshot, schedule ?? defaultPollSchedule),
-        Stream.filterMap((ss) =>
-          matches({ haystack: ss.text, needle }) === true ? Option.some(ss) : Option.none(),
-        ),
-        Stream.runHead,
-        Effect.flatMap(
-          Option.match({
-            onNone: () =>
-              Effect.fail(
-                new PtyError({
-                  reason: 'Timeout',
-                  method: `waitForText(${String(needle)})`,
-                  name: spec.name,
-                }),
-              ),
-            onSome: Effect.succeed,
-          }),
-        ),
-      ).pipe(
-        Effect.withSpan('pty-client.waitForText', {
-          attributes: { 'span.label': `${spec.name}: ${String(needle)}` },
-        }),
-      )
-
-    const waitForAbsent: PtyClientSession['waitForAbsent'] = ({ needle, schedule }) =>
-      pipe(
-        Stream.repeatEffectWithSchedule(screenshot, schedule ?? defaultPollSchedule),
-        Stream.filterMap((ss) =>
-          matches({ haystack: ss.text, needle }) === false ? Option.some(ss) : Option.none(),
-        ),
-        Stream.runHead,
-        Effect.flatMap(
-          Option.match({
-            onNone: () =>
-              Effect.fail(
-                new PtyError({
-                  reason: 'Timeout',
-                  method: `waitForAbsent(${String(needle)})`,
-                  name: spec.name,
-                }),
-              ),
-            onSome: Effect.succeed,
-          }),
-        ),
-      ).pipe(
-        Effect.withSpan('pty-client.waitForAbsent', {
-          attributes: { 'span.label': `${spec.name}: ${String(needle)}` },
-        }),
-      )
-
-    return {
-      name: spec.name,
-      initialScreen,
-      bytes,
-      write,
-      type: typeText,
-      press,
-      resize,
-      screenshot,
-      exit: Deferred.await(exitDeferred),
-      waitForText,
-      waitForAbsent,
-    } satisfies PtyClientSession
-  }).pipe(Effect.withSpan('pty-client.attach', { attributes: { 'span.label': spec.name } }))
+        initialScreen,
+        bytes,
+        write,
+        type: typeText,
+        press,
+        resize,
+        screenshot,
+        exit: Deferred.await(exitDeferred),
+        waitForText,
+        waitForAbsent,
+      } satisfies PtyClientSession
+    }).pipe(Effect.withSpan('pty-client.attach', { attributes: { 'span.label': spec.name } }))
 
 /* ───────────────────────────── layer ────────────────────────────── */
 
-/** Default in-process layer wrapping upstream `@myobie/pty/client` functions. */
-export const layer: Layer.Layer<PtyClient> = Layer.succeed(
-  PtyClient,
+const makeClient = (options: PtyClientLayerOptions) =>
   PtyClient.of({
-    spawnDaemon,
-    attach,
-    peek,
-    list,
-    exists,
-    kill,
-  }),
-)
+    spawnDaemon: spawnDaemon(options),
+    attach: attach(options),
+    peek: peek(options),
+    list: list(options),
+    exists: exists(options),
+    kill: kill(options),
+  })
+
+export const makeLayer = (options: PtyClientLayerOptions = {}): Layer.Layer<PtyClient> =>
+  Layer.succeed(PtyClient, makeClient(options))
+
+/** Default in-process layer wrapping upstream `@myobie/pty/client` functions. */
+export const layer: Layer.Layer<PtyClient> = makeLayer()
 
 /* ───────────────────────── re-exports ────────────────────────────── */
 


### PR DESCRIPTION
## Why

Local `devenv` pnpm tasks were still inheriting the global pnpm home when `PNPM_HOME` was unset. That let stale GVS projections from unrelated repos leak into the task state and diverge from the repo-local install model we already use in CI and Nix builds.

## What

- default shared pnpm tasks to `${config.devenv.root}/.pnpm-home` when `PNPM_HOME` is unset
- apply that default consistently across install, update, clean, status, and shell entry
- extend the shell and smoke tests to verify the default and preserve explicit overrides

## How

The shared helper now sets a workspace-local `PNPM_HOME` only when callers have not configured one already. That keeps the projection path stable and local without changing explicit caller configuration.

## Rationale

This keeps the source of truth in the shared pnpm task layer instead of adding downstream workarounds in dotfiles/forge. It reduces cross-repo drift, matches the CI/runtime assumptions we already have, and gives downstream Electron packaging a reliable install boundary.

Acting on behalf of the user.