### PR TITLE
fix: adopt pure pty client api

### DIFF
--- a/genie/external.ts
+++ b/genie/external.ts
@@ -148,7 +148,7 @@ export const catalog = defineCatalog({
   // Tracking: https://github.com/myobie/pty/blob/main/package.json (currently
   // shows 0.5.0 but only 0.4.1 is on npm). Pinning to a fork branch with
   // dist/ pre-committed so pnpm git-dep installs work without a build step.
-  '@myobie/pty': 'github:schickling/pty#schickling/2026-04-08-prepare-build',
+  '@myobie/pty': 'github:schickling/pty#ad76c4211b6a7707ba711366b2ff0eb3fbdaed27',
 
   // Type definitions
   '@types/react': '19.2.7',
@@ -260,10 +260,10 @@ export const commonPnpmPolicySettings = {
   allowBuilds: {
     '@parcel/watcher': true,
     '@myobie/pty': true,
-    'esbuild': true,
+    esbuild: true,
     'msgpackr-extract': true,
     'node-pty': true,
-    'sharp': true,
+    sharp: true,
     'unix-dgram': true,
   },
 }

--- a/nix/oxc-config-plugin.nix
+++ b/nix/oxc-config-plugin.nix
@@ -28,7 +28,7 @@ let
     pnpm = pinnedPnpm;
   };
   packageDir = "packages/@overeng/oxc-config";
-  pnpmDepsHash = "sha256-ohDmNWmPUQ80aCAeItEpK/QiHTPC6vEl29TTuwiWb7M=";
+  pnpmDepsHash = "sha256-f2u4rJx+EpcBGOQQxeSzkcLXjKkBVYCvk2f3kXGQhOw=";
 
   srcPath =
     if builtins.isAttrs src && builtins.hasAttr "outPath" src then

--- a/packages/@overeng/genie/nix/build.nix
+++ b/packages/@overeng/genie/nix/build.nix
@@ -24,7 +24,7 @@ let
     # Managed by `dt nix:hash:genie` — do not edit manually.
     depsBuilds = {
       "." = {
-        hash = "sha256-IQXVg6fVP5AtBNDmGRTScFFiXZdxwoSSqSpXcfu6oqs=";
+        hash = "sha256-IzieAcInOsIyPswVkclTFmu6t6ZjtdTTxgs+tQaaS5E=";
       };
     };
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/megarepo/nix/build.nix
+++ b/packages/@overeng/megarepo/nix/build.nix
@@ -23,7 +23,7 @@ let
     # Managed by `dt nix:hash:megarepo` — do not edit manually.
     depsBuilds = {
       "." = {
-        hash = "sha256-Ux+52SfppxC458h2SiZxHp9wJBceQlw0ZwpAFOPSD2k=";
+        hash = "sha256-oefTb77J8DqXm/XIViMhggllTTN3wQ8nIuCXtxA0zJc=";
       };
     };
     smokeTestArgs = [ "--help" ];

--- a/packages/@overeng/pty-effect/package.json
+++ b/packages/@overeng/pty-effect/package.json
@@ -15,7 +15,7 @@
     }
   },
   "dependencies": {
-    "@myobie/pty": "github:schickling/pty#schickling/2026-04-08-prepare-build"
+    "@myobie/pty": "github:schickling/pty#ad76c4211b6a7707ba711366b2ff0eb3fbdaed27"
   },
   "devDependencies": {
     "@effect/vitest": "0.29.0",

--- a/packages/@overeng/pty-effect/src/client.test.ts
+++ b/packages/@overeng/pty-effect/src/client.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process'
 import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
@@ -27,6 +28,19 @@ const withIsolatedDir = <A, E, R>(eff: Effect.Effect<A, E, R>) =>
     }
   })
 
+const withTempDir = <A>(prefix: string, f: (dir: string) => A) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix))
+  try {
+    return f(dir)
+  } finally {
+    try {
+      fs.rmSync(dir, { recursive: true, force: true })
+    } catch {
+      // best effort
+    }
+  }
+}
+
 const decodeName = (s: string) => Schema.decodeUnknownSync(PtyName)(s) as PtyName
 
 /** Keep names short — macOS Unix sockets cap at 104 bytes including the
@@ -36,6 +50,29 @@ const uniqueName = (label: string): PtyName =>
   decodeName(`t${label}${(Date.now() % 100000).toString(36)}`)
 
 describe('PtyClient', () => {
+  it('keeps @overeng/pty-effect/client compile-safe for Bun-built CLIs', () => {
+    withTempDir('pty-effect-bun-compile-', (dir) => {
+      const entryPath = path.join(dir, 'main.ts')
+      const outPath = path.join(dir, 'main')
+      const clientModulePath = new URL('./client.ts', import.meta.url).pathname
+
+      fs.writeFileSync(
+        entryPath,
+        [`import ${JSON.stringify(clientModulePath)}`, `console.log('client-module-ok')`, ''].join(
+          '\n',
+        ),
+      )
+
+      execFileSync('bun', ['build', entryPath, '--compile', '--outfile', outPath], {
+        cwd: dir,
+        stdio: 'pipe',
+      })
+
+      const stdout = execFileSync(outPath, [], { encoding: 'utf8' })
+      expect(stdout.trim()).toBe('client-module-ok')
+    })
+  })
+
   it.scopedLive('spawns a daemon, lists it, attaches, reads bytes, exits cleanly', () =>
     withIsolatedDir(
       Effect.gen(function* () {

--- a/packages/@overeng/tui-stories/nix/build.nix
+++ b/packages/@overeng/tui-stories/nix/build.nix
@@ -20,7 +20,7 @@ let
     # Managed by `dt nix:hash:tui-stories` — do not edit manually.
     depsBuilds = {
       "." = {
-        hash = "sha256-0NYG3MKGQ+Ib3f+3nv3X+CwDzcmcQ3IZMhSAQA6KtC0=";
+        hash = "sha256-ue6ohMCHcZJBnm4aITwjTsIWNchdaejc9zQc1Ounrq8=";
       };
     };
     inherit gitRev commitTs dirty;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1042,8 +1042,8 @@ importers:
   packages/@overeng/pty-effect:
     dependencies:
       '@myobie/pty':
-        specifier: github:schickling/pty#schickling/2026-04-08-prepare-build
-        version: https://codeload.github.com/schickling/pty/tar.gz/fa13c3fbd6941300479a3f22ab748b6a96c7091c
+        specifier: github:schickling/pty#ad76c4211b6a7707ba711366b2ff0eb3fbdaed27
+        version: https://codeload.github.com/schickling/pty/tar.gz/ad76c4211b6a7707ba711366b2ff0eb3fbdaed27
     devDependencies:
       '@effect/vitest':
         specifier: 0.29.0
@@ -2119,8 +2119,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@myobie/pty@https://codeload.github.com/schickling/pty/tar.gz/fa13c3fbd6941300479a3f22ab748b6a96c7091c':
-    resolution: {tarball: https://codeload.github.com/schickling/pty/tar.gz/fa13c3fbd6941300479a3f22ab748b6a96c7091c}
+  '@myobie/pty@https://codeload.github.com/schickling/pty/tar.gz/ad76c4211b6a7707ba711366b2ff0eb3fbdaed27':
+    resolution: {tarball: https://codeload.github.com/schickling/pty/tar.gz/ad76c4211b6a7707ba711366b2ff0eb3fbdaed27}
     version: 0.5.0
     hasBin: true
 
@@ -5916,7 +5916,7 @@ snapshots:
   '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
     optional: true
 
-  '@myobie/pty@https://codeload.github.com/schickling/pty/tar.gz/fa13c3fbd6941300479a3f22ab748b6a96c7091c':
+  '@myobie/pty@https://codeload.github.com/schickling/pty/tar.gz/ad76c4211b6a7707ba711366b2ff0eb3fbdaed27':
     dependencies:
       '@preact/signals-core': 1.14.1
       '@xterm/addon-serialize': 0.14.0


### PR DESCRIPTION
## Why
The current  surface eagerly loads the native PTY runtime, which breaks Bun-compiled downstream CLIs that only need the client API during help/load-time paths.

## What
- pin  to the fork commit that splits  from the daemon runtime
- add a Bun compile regression test for 

## Validation
- packages/@overeng/pty-effect/src/client.test.ts(1,30): error TS2591: Cannot find name 'node:child_process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.
packages/@overeng/pty-effect/src/client.test.ts(2,21): error TS2591: Cannot find name 'node:fs'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.
packages/@overeng/pty-effect/src/client.test.ts(3,21): error TS2591: Cannot find name 'node:os'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.
packages/@overeng/pty-effect/src/client.test.ts(4,23): error TS2591: Cannot find name 'node:path'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.
packages/@overeng/pty-effect/src/client.test.ts(6,38): error TS2307: Cannot find module '@effect/vitest' or its corresponding type declarations.
packages/@overeng/pty-effect/src/client.test.ts(7,47): error TS2307: Cannot find module 'effect' or its corresponding type declarations.
packages/@overeng/pty-effect/src/client.test.ts(16,18): error TS2591: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.
packages/@overeng/pty-effect/src/client.test.ts(17,5): error TS2591: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.
packages/@overeng/pty-effect/src/client.test.ts(21,38): error TS2591: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.
packages/@overeng/pty-effect/src/client.test.ts(22,12): error TS2591: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.
packages/@overeng/pty-effect/src/client.test.ts(57,36): error TS2304: Cannot find name 'URL'.
packages/@overeng/pty-effect/src/client.test.ts(57,67): error TS2339: Property 'url' does not exist on type 'ImportMeta'.
packages/@overeng/pty-effect/src/client.test.ts(79,31): error TS2488: Type 'typeof PtyClient' must have a '[Symbol.iterator]()' method that returns an iterator.
packages/@overeng/pty-effect/src/client.test.ts(90,31): error TS7006: Parameter 's' implicitly has an 'any' type.
packages/@overeng/pty-effect/src/client.test.ts(115,31): error TS2488: Type 'typeof PtyClient' must have a '[Symbol.iterator]()' method that returns an iterator.
packages/@overeng/pty-effect/src/client.test.ts(142,31): error TS2488: Type 'typeof PtyClient' must have a '[Symbol.iterator]()' method that returns an iterator.
packages/@overeng/pty-effect/src/client.test.ts(163,31): error TS2488: Type 'typeof PtyClient' must have a '[Symbol.iterator]()' method that returns an iterator.
packages/@overeng/pty-effect/src/client.test.ts(166,13): error TS2578: Unused '@ts-expect-error' directive.
packages/@overeng/pty-effect/src/client.ts(24,8): error TS2307: Cannot find module '@myobie/pty/client' or its corresponding type declarations.
packages/@overeng/pty-effect/src/client.ts(37,8): error TS2307: Cannot find module 'effect' or its corresponding type declarations.
packages/@overeng/pty-effect/src/client.ts(38,28): error TS2307: Cannot find module 'effect' or its corresponding type declarations.
packages/@overeng/pty-effect/src/client.ts(170,30): error TS2339: Property 'reason' does not exist on type 'PtyError'.
packages/@overeng/pty-effect/src/client.ts(176,13): error TS7006: Parameter 'cause' implicitly has an 'any' type.
packages/@overeng/pty-effect/src/client.ts(177,20): error TS2554: Expected 0 arguments, but got 1.
packages/@overeng/pty-effect/src/client.ts(187,30): error TS2339: Property 'reason' does not exist on type 'PtyError'.
packages/@overeng/pty-effect/src/client.ts(193,13): error TS7006: Parameter 'cause' implicitly has an 'any' type.
packages/@overeng/pty-effect/src/client.ts(194,20): error TS2554: Expected 0 arguments, but got 1.
packages/@overeng/pty-effect/src/client.ts(218,81): error TS2345: Argument of type 'string | RegExp' is not assignable to parameter of type 'string'.
  Type 'RegExp' is not assignable to type 'string'.
packages/@overeng/pty-effect/src/client.ts(219,38): error TS2339: Property 'source' does not exist on type 'string | RegExp'.
  Property 'source' does not exist on type 'string'.
packages/@overeng/pty-effect/src/client.ts(219,59): error TS2339: Property 'flags' does not exist on type 'string | RegExp'.
  Property 'flags' does not exist on type 'string'.
packages/@overeng/pty-effect/src/client.ts(236,13): error TS7006: Parameter 'cause' implicitly has an 'any' type.
packages/@overeng/pty-effect/src/client.ts(237,20): error TS2554: Expected 0 arguments, but got 1.
packages/@overeng/pty-effect/src/client.ts(249,49): error TS2591: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.
packages/@overeng/pty-effect/src/client.ts(250,40): error TS2591: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.
packages/@overeng/pty-effect/src/client.ts(260,40): error TS2591: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.
packages/@overeng/pty-effect/src/client.ts(261,14): error TS2591: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.
packages/@overeng/pty-effect/src/client.ts(286,17): error TS7006: Parameter 'sessions' implicitly has an 'any' type.
packages/@overeng/pty-effect/src/client.ts(286,45): error TS7006: Parameter 's' implicitly has an 'any' type.
packages/@overeng/pty-effect/src/client.ts(292,36): error TS7006: Parameter 's' implicitly has an 'any' type.
packages/@overeng/pty-effect/src/client.ts(294,21): error TS2488: Type 'PtyError' must have a '[Symbol.iterator]()' method that returns an iterator.
packages/@overeng/pty-effect/src/client.ts(294,34): error TS2554: Expected 0 arguments, but got 1.
packages/@overeng/pty-effect/src/client.ts(303,20): error TS2591: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.
packages/@overeng/pty-effect/src/client.ts(326,21): error TS2304: Cannot find name 'TextEncoder'.
packages/@overeng/pty-effect/src/client.ts(353,24): error TS2554: Expected 0 arguments, but got 1.
packages/@overeng/pty-effect/src/client.ts(366,24): error TS2554: Expected 0 arguments, but got 1.
packages/@overeng/pty-effect/src/client.ts(410,27): error TS7006: Parameter 'ss' implicitly has an 'any' type.
packages/@overeng/pty-effect/src/client.ts(418,30): error TS2554: Expected 0 arguments, but got 1.
packages/@overeng/pty-effect/src/client.ts(436,27): error TS7006: Parameter 'ss' implicitly has an 'any' type.
packages/@overeng/pty-effect/src/client.ts(444,30): error TS2554: Expected 0 arguments, but got 1.
packages/@overeng/pty-effect/src/client.ts(479,13): error TS2339: Property 'of' does not exist on type 'typeof PtyClient'.
packages/@overeng/pty-effect/src/client.ts(491,34): error TS2307: Cannot find module '@myobie/pty/client' or its corresponding type declarations.
packages/@overeng/pty-effect/src/PtyError.ts(1,24): error TS2307: Cannot find module 'effect' or its corresponding type declarations.
packages/@overeng/pty-effect/src/PtyError.ts(40,16): error TS4112: This member cannot have an 'override' modifier because its containing class 'PtyError' does not extend another class.
packages/@overeng/pty-effect/src/PtyError.ts(41,35): error TS2339: Property 'reason' does not exist on type 'PtyError'.
packages/@overeng/pty-effect/src/PtyError.ts(42,14): error TS2339: Property 'name' does not exist on type 'PtyError'.
packages/@overeng/pty-effect/src/PtyError.ts(42,54): error TS2339: Property 'name' does not exist on type 'PtyError'.
packages/@overeng/pty-effect/src/PtyError.ts(43,25): error TS2339: Property 'method' does not exist on type 'PtyError'.
packages/@overeng/pty-effect/src/PtyError.ts(44,14): error TS2339: Property 'cause' does not exist on type 'PtyError'.
packages/@overeng/pty-effect/src/PtyError.ts(44,59): error TS2339: Property 'cause' does not exist on type 'PtyError'.
packages/@overeng/pty-effect/src/PtyError.ts(45,19): error TS2339: Property 'cause' does not exist on type 'PtyError'.
packages/@overeng/pty-effect/src/PtyError.ts(45,68): error TS2339: Property 'cause' does not exist on type 'PtyError'.
packages/@overeng/pty-effect/src/PtyEvent.ts(1,24): error TS2307: Cannot find module 'effect' or its corresponding type declarations.
packages/@overeng/pty-effect/src/PtyKey.ts(1,24): error TS2307: Cannot find module 'effect' or its corresponding type declarations.
packages/@overeng/pty-effect/src/PtySession.test.ts(1,21): error TS2591: Cannot find name 'node:fs'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.
packages/@overeng/pty-effect/src/PtySession.test.ts(2,21): error TS2591: Cannot find name 'node:os'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.
packages/@overeng/pty-effect/src/PtySession.test.ts(3,23): error TS2591: Cannot find name 'node:path'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.
packages/@overeng/pty-effect/src/PtySession.test.ts(5,38): error TS2307: Cannot find module '@effect/vitest' or its corresponding type declarations.
packages/@overeng/pty-effect/src/PtySession.test.ts(6,71): error TS2307: Cannot find module 'effect' or its corresponding type declarations.
packages/@overeng/pty-effect/src/PtySession.test.ts(20,18): error TS2591: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.
packages/@overeng/pty-effect/src/PtySession.test.ts(21,5): error TS2591: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.
packages/@overeng/pty-effect/src/PtySession.test.ts(25,38): error TS2591: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.
packages/@overeng/pty-effect/src/PtySession.test.ts(26,12): error TS2591: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.
packages/@overeng/pty-effect/src/PtySession.test.ts(162,23): error TS7006: Parameter 'ss' implicitly has an 'any' type.
packages/@overeng/pty-effect/src/PtySession.test.ts(268,30): error TS2554: Expected 0 arguments, but got 1.
packages/@overeng/pty-effect/src/PtySession.test.ts(269,16): error TS2339: Property '_tag' does not exist on type 'PtyError'.
packages/@overeng/pty-effect/src/PtySession.test.ts(270,16): error TS2339: Property 'reason' does not exist on type 'PtyError'.
packages/@overeng/pty-effect/src/PtySession.ts(1,44): error TS2307: Cannot find module '@myobie/pty/testing' or its corresponding type declarations.
packages/@overeng/pty-effect/src/PtySession.ts(2,67): error TS2307: Cannot find module 'effect' or its corresponding type declarations.
packages/@overeng/pty-effect/src/PtySession.ts(3,28): error TS2307: Cannot find module 'effect' or its corresponding type declarations.
packages/@overeng/pty-effect/src/PtySession.ts(66,30): error TS2339: Property 'reason' does not exist on type 'PtyError'.
packages/@overeng/pty-effect/src/PtySession.ts(73,13): error TS7006: Parameter 'cause' implicitly has an 'any' type.
packages/@overeng/pty-effect/src/PtySession.ts(74,20): error TS2554: Expected 0 arguments, but got 1.
packages/@overeng/pty-effect/src/PtySession.ts(83,30): error TS2339: Property 'reason' does not exist on type 'PtyError'.
packages/@overeng/pty-effect/src/PtySession.ts(90,13): error TS7006: Parameter 'cause' implicitly has an 'any' type.
packages/@overeng/pty-effect/src/PtySession.ts(91,20): error TS2554: Expected 0 arguments, but got 1.
packages/@overeng/pty-effect/src/PtySession.ts(99,81): error TS2345: Argument of type 'string | RegExp' is not assignable to parameter of type 'string'.
  Type 'RegExp' is not assignable to type 'string'.
packages/@overeng/pty-effect/src/PtySession.ts(105,38): error TS2339: Property 'source' does not exist on type 'string | RegExp'.
  Property 'source' does not exist on type 'string'.
packages/@overeng/pty-effect/src/PtySession.ts(105,59): error TS2339: Property 'flags' does not exist on type 'string | RegExp'.
  Property 'flags' does not exist on type 'string'.
packages/@overeng/pty-effect/src/PtySession.ts(228,30): error TS2554: Expected 0 arguments, but got 1.
packages/@overeng/pty-effect/src/PtySpawner.ts(1,40): error TS2307: Cannot find module 'effect' or its corresponding type declarations.
packages/@overeng/pty-effect/src/PtySpawner.ts(2,28): error TS2307: Cannot find module 'effect' or its corresponding type declarations.
packages/@overeng/pty-effect/src/PtySpawner.ts(33,14): error TS2339: Property 'of' does not exist on type 'typeof PtySpawner'.
packages/@overeng/pty-effect/src/PtySpawner.ts(34,13): error TS7006: Parameter 'spec' implicitly has an 'any' type.
packages/@overeng/pty-effect/src/PtySpawner.ts(39,69): error TS7006: Parameter 's' implicitly has an 'any' type.
packages/@overeng/pty-effect/src/PtySpec.ts(1,24): error TS2307: Cannot find module 'effect' or its corresponding type declarations.
packages/@overeng/pty-effect/src/Screenshot.ts(1,24): error TS2307: Cannot find module 'effect' or its corresponding type declarations.
- 
- Found 0 warnings and 0 errors.
Finished in 27ms on 2 files with 166 rules using 16 threads.
- Checking formatting...

All matched files use the correct format.
Finished in 33ms on 2 files using 16 threads.

## Rationale
This keeps downstream CLI packaging simple and fixes the boundary at the PTY layer where the problem originates.

_Acting on behalf of the user._