### PR TITLE
Add strict TypeScript check task for CI gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,7 +292,7 @@ jobs:
           EOF
           . "$__nix_gc_retry_helper"
           rm -f "$__nix_gc_retry_helper"
-          run_nix_gc_race_retry 'devenv tasks run ts:check --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run ts:check --mode before'
+          run_nix_gc_race_retry 'devenv tasks run ts:check:strict --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run ts:check:strict --mode before'
       - name: Save pnpm home
         if: "${{ always() && !cancelled() && steps.restore-pnpm-store.outputs.cache-hit != 'true' }}"
         uses: actions/cache/save@v4

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -186,7 +186,7 @@ const multiPlatformStrictNixJob = (step: ReturnType<typeof validateColdPnpmDepsS
 const jobs: Record<CIJobName, ReturnType<typeof job> | ReturnType<typeof multiPlatformJob>> = {
   typecheck: job({
     name: 'Type check',
-    run: runDevenvTasksBefore('ts:check'),
+    run: runDevenvTasksBefore('ts:check:strict'),
   }),
   lint: job({
     name: 'Format + lint',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,8 +62,6 @@ All notable changes to this project will be documented in this file.
 - **genie/external**: Export the full shared patch registry to peer repos
   - Adds the `node-pty@1.1.0` patch to `createPnpmPatchedDependencies()` / `pnpmPatchedDependencies()`
   - Unblocks composed-root `pnpm-workspace.yaml` generation in downstream megarepos that import `@overeng/utils`
-- **genie/ci-workflow**: Restore the legacy `selfHostedRunner` export as an alias of `linuxX64Runner`
-  - Keeps older downstream workflow generators compatible while they migrate to the newer explicit runner constants
 - **@overeng/genie**: Use cwd-relative lock directory instead of shared `/tmp/genie-locks/` to fix `EACCES` errors in multi-user CI environments (#520)
 - **@overeng/tui-react**: Format timeline timestamps as human-readable durations (e.g. `6m 18s / 16m 21s`) instead of raw seconds (`377.9s / 980.6s`) in `TuiStoryPreview` (#472)
 - **@overeng/genie**: Validate GitHub Actions `runs-on` labels before emitting workflow YAML

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **devenv/tasks/shared/ts.nix**: Make `ts:check:strict` inherit repo-local `ts:check.after` dependencies
+  - Preserves consumer generators like `contentlayer:build` when strict typecheck is used as the CI gate
+  - Prevents downstream repos from regressing when they already extend `ts:check` with extra build prerequisites
 - **genie/external**: Export the shared `@effect-atom/atom` peer-version allowlist in megarepo pnpm policy
   - Keeps downstream repos on `strictPeerDependencies: true` while allowing the Effect version ranges already used inside effect-utils itself
   - Prevents consumer workspace installs from failing on the known pre-1.0 peer ranges declared by `@effect-atom/atom`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **genie/external**: Export the shared `@effect-atom/atom` peer-version allowlist in megarepo pnpm policy
+  - Keeps downstream repos on `strictPeerDependencies: true` while allowing the Effect version ranges already used inside effect-utils itself
+  - Prevents consumer workspace installs from failing on the known pre-1.0 peer ranges declared by `@effect-atom/atom`
 - **genie/external**: Export the full shared patch registry to peer repos
   - Adds the `node-pty@1.1.0` patch to `createPnpmPatchedDependencies()` / `pnpmPatchedDependencies()`
   - Unblocks composed-root `pnpm-workspace.yaml` generation in downstream megarepos that import `@overeng/utils`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,11 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **genie/external**: Export the full shared patch registry to peer repos
+  - Adds the `node-pty@1.1.0` patch to `createPnpmPatchedDependencies()` / `pnpmPatchedDependencies()`
+  - Unblocks composed-root `pnpm-workspace.yaml` generation in downstream megarepos that import `@overeng/utils`
+- **genie/ci-workflow**: Restore the legacy `selfHostedRunner` export as an alias of `linuxX64Runner`
+  - Keeps older downstream workflow generators compatible while they migrate to the newer explicit runner constants
 - **@overeng/genie**: Use cwd-relative lock directory instead of shared `/tmp/genie-locks/` to fix `EACCES` errors in multi-user CI environments (#520)
 - **@overeng/tui-react**: Format timeline timestamps as human-readable durations (e.g. `6m 18s / 16m 21s`) instead of raw seconds (`377.9s / 980.6s`) in `TuiStoryPreview` (#472)
 - **@overeng/genie**: Validate GitHub Actions `runs-on` labels before emitting workflow YAML

--- a/devenv.nix
+++ b/devenv.nix
@@ -247,6 +247,7 @@ in
         "workspace:check"
         "lint:nix"
       ];
+      checkAllTypecheckTask = "ts:check:strict";
     })
     (taskModules.clean { packages = allPackages; })
     # Repo-root pnpm install task

--- a/genie/ci-workflow.ts
+++ b/genie/ci-workflow.ts
@@ -41,9 +41,6 @@ export { RUNNER_PROFILES, type RunnerProfile }
 /** Self-hosted NixOS runner labels (x86_64-linux, e.g. dev3) */
 export const linuxX64Runner = ['sh-linux-x64', 'nix'] as const
 
-/** Backwards-compatible alias for older downstream workflow generators. */
-export const selfHostedRunner = linuxX64Runner
-
 /** Self-hosted NixOS runner labels (aarch64-linux, e.g. dev4) */
 export const linuxArm64Runner = ['sh-linux-arm64', 'nix'] as const
 

--- a/genie/ci-workflow.ts
+++ b/genie/ci-workflow.ts
@@ -41,6 +41,9 @@ export { RUNNER_PROFILES, type RunnerProfile }
 /** Self-hosted NixOS runner labels (x86_64-linux, e.g. dev3) */
 export const linuxX64Runner = ['sh-linux-x64', 'nix'] as const
 
+/** Backwards-compatible alias for older downstream workflow generators. */
+export const selfHostedRunner = linuxX64Runner
+
 /** Self-hosted NixOS runner labels (aarch64-linux, e.g. dev4) */
 export const linuxArm64Runner = ['sh-linux-arm64', 'nix'] as const
 

--- a/genie/external.ts
+++ b/genie/external.ts
@@ -248,6 +248,14 @@ export const catalog = defineCatalog({
 export const commonPnpmPolicySettings = {
   dedupePeerDependents: true as const,
   strictPeerDependencies: true as const,
+  peerDependencyRules: {
+    /** @effect-atom/atom@0.5.3 pins pre-1.0 Effect peer ranges that don't cover our versions */
+    allowedVersions: {
+      '@effect/experimental': '>=0.58.0',
+      '@effect/platform': '>=0.94.2',
+      '@effect/rpc': '>=0.73.0',
+    },
+  },
   enableGlobalVirtualStore: true as const,
   /** Disable until pnpm#10393 is resolved (install no-ops for workspace changes) */
   optimisticRepeatInstall: false as const,

--- a/nix/devenv-modules/tasks/README.md
+++ b/nix/devenv-modules/tasks/README.md
@@ -42,6 +42,7 @@ imports = [
 - `test.nix` - Test tasks
 - `test-playwright.nix` - Playwright e2e tasks
 - `ts.nix` - TypeScript tasks (`ts:check`, `ts:check:strict`, build/watch/clean helpers)
+  - `ts:check:strict` inherits repo-local `ts:check.after` hooks so strict CI stays aligned with consumer generators
 - `bun.nix` - Bun tasks (legacy)
 - `context.nix` - Context directory tasks
 - `lint-genie.nix` - Genie lint tasks

--- a/nix/devenv-modules/tasks/README.md
+++ b/nix/devenv-modules/tasks/README.md
@@ -26,7 +26,7 @@ imports = [
 
 ### Available Modules:
 
-- `check.nix` - Aggregate check tasks (check:quick, check:all)
+- `check.nix` - Aggregate check tasks (check:quick, check:all, configurable strict typecheck gate)
 - `clean.nix` - Clean tasks
 - `genie.nix` - Genie config generation tasks
 - `ts-effect-lsp.nix` - Effect LSP diagnostics via tsgo (`ts:effect-lsp`)
@@ -41,7 +41,7 @@ imports = [
 - `setup.nix` - Setup tasks
 - `test.nix` - Test tasks
 - `test-playwright.nix` - Playwright e2e tasks
-- `ts.nix` - TypeScript tasks
+- `ts.nix` - TypeScript tasks (`ts:check`, `ts:check:strict`, build/watch/clean helpers)
 - `bun.nix` - Bun tasks (legacy)
 - `context.nix` - Context directory tasks
 - `lint-genie.nix` - Genie lint tasks

--- a/nix/devenv-modules/tasks/shared/check.nix
+++ b/nix/devenv-modules/tasks/shared/check.nix
@@ -19,13 +19,16 @@
 #   # Without megarepo checks (for repos that skip members in CI):
 #   imports = [ (inputs.effect-utils.devenvModules.tasks.check { hasMegarepoCheck = false; }) ];
 #
+#   # With strict type checking in aggregate gates:
+#   imports = [ (inputs.effect-utils.devenvModules.tasks.check { checkAllTypecheckTask = "ts:check:strict"; }) ];
+#
 #   # With additional custom checks:
 #   imports = [ (inputs.effect-utils.devenvModules.tasks.check { extraChecks = [ "workspace:check" ]; }) ];
 #
 # Provides: check:quick, check:all
 #
 # check:quick - Fast local development (ts:check, mr:check*, lint, nix-fingerprint)
-# check:all   - Comprehensive pre-push validation (includes nix flake check)
+# check:all   - Comprehensive validation (defaults to ts:check, can opt into ts:check:strict)
 #               * mr:check included unless hasMegarepoCheck = false
 #
 # Note: Requires ts:check task to exist.
@@ -41,6 +44,8 @@
   hasLint ? true,
   hasNixCheck ? true,
   hasMegarepoCheck ? true,
+  checkQuickTypecheckTask ? "ts:check",
+  checkAllTypecheckTask ? checkQuickTypecheckTask,
   extraChecks ? [ ], # Additional check tasks to include (e.g., [ "workspace:check" ])
 }:
 { lib, ... }:
@@ -64,31 +69,25 @@ let
 in
 {
   tasks = {
-    # Quick: Fast feedback for development (genie, typecheck, lint, nix fingerprint only)
     "check:quick" = {
-      description = "Fast checks for development (ts:check${lib.optionalString hasLint ", lint"}${lib.optionalString hasNixCheck ", nix-fingerprint"}) without tests";
+      description = "Fast checks for development (${checkQuickTypecheckTask}${lib.optionalString hasLint ", lint"}${lib.optionalString hasNixCheck ", nix-fingerprint"}) without tests";
       exec = "true";
-      after = [
-        "ts:check"
-      ]
-      ++ megarepoTasks
-      ++ lintTask
-      ++ nixQuickTask
-      ++ extraChecks;
+      after = [ checkQuickTypecheckTask ]
+        ++ megarepoTasks
+        ++ lintTask
+        ++ nixQuickTask
+        ++ extraChecks;
     };
 
-    # All: Comprehensive pre-push validation (includes full nix flake check)
     "check:all" = {
-      description = "All checks (ts:check${extraDesc})";
+      description = "All checks (${checkAllTypecheckTask}${extraDesc})";
       exec = "true";
-      after = [
-        "ts:check"
-      ]
-      ++ megarepoTasks
-      ++ extraChecks
-      ++ lintTask
-      ++ nixFullTask
-      ++ testTasks;
+      after = [ checkAllTypecheckTask ]
+        ++ megarepoTasks
+        ++ extraChecks
+        ++ lintTask
+        ++ nixFullTask
+        ++ testTasks;
     };
   };
 }

--- a/nix/devenv-modules/tasks/shared/ts.nix
+++ b/nix/devenv-modules/tasks/shared/ts.nix
@@ -18,6 +18,8 @@
 #   results. Use `ts:check` for fast local feedback and `ts:check:strict`
 #   when correctness matters more than incremental reuse, such as CI gates or
 #   reused automation workspaces that may see dependency-only type changes.
+#   `ts:check:strict` inherits the merged `ts:check.after` graph so repo-local
+#   generators also run in strict mode.
 #   `ts:clean` remains available as a heavier escape hatch when you suspect
 #   corrupted build metadata. Ensure all packages are listed in
 #   tsconfig.all.json references.
@@ -37,10 +39,14 @@
   tsconfigFile ? "tsconfig.all.json",
   tscBin ? "tsc",
 }:
-{ lib, pkgs, ... }:
+{ lib, pkgs, config, ... }:
 let
   trace = import ../lib/trace.nix { inherit lib; };
   cliGuard = import ../lib/cli-guard.nix { inherit pkgs; };
+  inheritedCheckAfter = config.tasks."ts:check".after or [
+    "genie:run"
+    "pnpm:install"
+  ];
 
   # Script that runs tsc with --extendedDiagnostics --verbose,
   # parses per-project timing, and emits OTEL child spans.
@@ -177,7 +183,7 @@ let
       guard = tscBin;
       description = "Type check the whole workspace without incremental reuse (tsc --build --force)";
       exec = trace.exec "ts:check:strict" (tscWithDiagnostics "--build --force ${tsconfigFile}" "");
-      after = [ "genie:run" "pnpm:install" ];
+      after = inheritedCheckAfter;
     };
     "ts:build" = {
       guard = tscBin;

--- a/nix/devenv-modules/tasks/shared/ts.nix
+++ b/nix/devenv-modules/tasks/shared/ts.nix
@@ -7,7 +7,7 @@
 #     (inputs.effect-utils.devenvModules.tasks.ts { tsconfigFile = "tsconfig.dev.json"; })
 #   ];
 #
-# Provides: ts:check, ts:build-watch, ts:build, ts:emit, ts:clean
+# Provides: ts:check, ts:check:strict, ts:build-watch, ts:build, ts:emit, ts:clean
 #
 # Dependencies:
 #   - genie:run: config files must be generated before tsc can resolve paths
@@ -15,9 +15,12 @@
 #
 # Caching notes:
 #   TypeScript's incremental build (--build) uses .tsbuildinfo files to cache
-#   results. If you suspect stale cache issues (e.g., cross-package signature
-#   changes not detected), run `dt ts:clean` first to clear the cache.
-#   Ensure all packages are listed in tsconfig.all.json references.
+#   results. Use `ts:check` for fast local feedback and `ts:check:strict`
+#   when correctness matters more than incremental reuse, such as CI gates or
+#   reused automation workspaces that may see dependency-only type changes.
+#   `ts:clean` remains available as a heavier escape hatch when you suspect
+#   corrupted build metadata. Ensure all packages are listed in
+#   tsconfig.all.json references.
 #
 # tscBin:
 #   Path to the tsc binary. Defaults to "tsc".
@@ -169,6 +172,12 @@ let
         "genie:run"
         "pnpm:install"
       ];
+    };
+    "ts:check:strict" = {
+      guard = tscBin;
+      description = "Type check the whole workspace without incremental reuse (tsc --build --force)";
+      exec = trace.exec "ts:check:strict" (tscWithDiagnostics "--build --force ${tsconfigFile}" "");
+      after = [ "genie:run" "pnpm:install" ];
     };
     "ts:build" = {
       guard = tscBin;


### PR DESCRIPTION
## Summary
- add a compiler-native `ts:check:strict` task that runs `tsc --build --force`
- let shared `check:all` use a configurable typecheck task so CI can gate on strict mode while local `ts:check` stays incremental
- update shared CI wiring to use the strict typecheck gate
- export downstream pnpm policy/patch compatibility fixes surfaced during real consumer validation

## Why
Incremental `tsc --build` can miss dependency-only regressions when `.tsbuildinfo` survives and linked cross-repo packages change. The principled split is:
- `ts:check`: fast local feedback
- `ts:check:strict`: trustworthy gate check

This PR makes that split reusable across megarepos instead of having each repo hand-delete `*.tsbuildinfo` or invent its own strict CI wrapper.

## Additional downstream fixes included
While validating this against real consumers, two shared downstream-adoption gaps surfaced and are fixed here:
- export the full shared pnpm patch registry to downstream megarepos
- export the shared `@effect-atom/atom` peer-version allowlist through external pnpm policy so consumers can keep `strictPeerDependencies: true`

## Validation
- `devenv --no-tui tasks list | rg 'ts:check(:strict)?|check:all|check:quick'`
- `nix run .#genie`
- `nix run .#genie -- --check`
- downstream validation on `schickling-stiftung`
- downstream validation on `megarepo-all`
