### PR TITLE
fix(pnpm): default local tasks to workspace pnpm home

### DIFF
--- a/nix/devenv-modules/tasks/shared/pnpm-task-helpers.sh
+++ b/nix/devenv-modules/tasks/shared/pnpm-task-helpers.sh
@@ -4,6 +4,14 @@ compute_hash() {
   sha256sum | awk '{print $1}'
 }
 
+ensure_local_pnpm_home_default() {
+  local workspace_root="$1"
+
+  if [ -z "${PNPM_HOME:-}" ]; then
+    export PNPM_HOME="${workspace_root}/.pnpm-home"
+  fi
+}
+
 emit_dir_state() {
   local dir="$1"
 

--- a/nix/devenv-modules/tasks/shared/pnpm.nix
+++ b/nix/devenv-modules/tasks/shared/pnpm.nix
@@ -86,6 +86,11 @@ let
     # tests so cleanup refactors cannot silently drift the two code paths apart.
     source ${lib.escapeShellArg pnpmTaskHelpersScript}
   '';
+  ensureLocalPnpmHomeFn = ''
+    # Keep pnpm's hot GVS projection workspace-local by default so local tasks
+    # match CI and don't inherit stale global link state from unrelated repos.
+    ensure_local_pnpm_home_default ${lib.escapeShellArg config.devenv.root}
+  '';
 
   computeWorkspaceStateHash = ''
     compute_workspace_state_hash() {
@@ -145,6 +150,7 @@ let
       exec = trace.exec "pnpm:install" ''
         set -euo pipefail
         ${loadPnpmTaskHelpersFn}
+        ${ensureLocalPnpmHomeFn}
         mkdir -p "${cacheRoot}"
         # This cache tracks the effective install state, not just workspace
         # manifests. The fingerprint also includes the active GVS projection
@@ -211,6 +217,7 @@ let
       status = trace.status "pnpm:install" "hash" ''
         set -euo pipefail
         ${loadPnpmTaskHelpersFn}
+        ${ensureLocalPnpmHomeFn}
         hash_file="${cacheRoot}/install-state.hash"
 
         if [ ! -d node_modules ] || [ ! -f pnpm-lock.yaml ] || [ ! -f "$hash_file" ]; then
@@ -237,6 +244,8 @@ let
       after = [ "genie:run" ] ++ updateAfter;
       exec = trace.exec "pnpm:update" ''
         set -euo pipefail
+        ${loadPnpmTaskHelpersFn}
+        ${ensureLocalPnpmHomeFn}
         export npm_config_manage_package_manager_versions=false
         pnpm install --fix-lockfile --config.confirmModulesPurge=false
         echo "Repo-root lockfile updated. Run 'dt nix:hash' to update Nix hashes."
@@ -250,6 +259,7 @@ let
       exec = trace.exec "pnpm:clean" ''
         set -euo pipefail
         ${loadPnpmTaskHelpersFn}
+        ${ensureLocalPnpmHomeFn}
 
         purge_node_modules node_modules ${nodeModulesPaths}
 
@@ -277,6 +287,7 @@ in
   packages = cliGuard.fromTasks allTasks;
 
   enterShell = lib.mkIf globalCache ''
+    export PNPM_HOME="''${PNPM_HOME:-${config.devenv.root}/.pnpm-home}"
     export npm_config_cache="$HOME/.cache/pnpm"
     export npm_config_manage_package_manager_versions=false
   '';

--- a/nix/devenv-modules/tasks/shared/tests/pnpm-task-smoke.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/pnpm-task-smoke.test.sh
@@ -132,6 +132,7 @@ if [ "${1:-}" = "--version" ]; then
   exit 0
 fi
 if [ "${1:-}" = "install" ]; then
+  printf 'PNPM_HOME=%s\n' "${PNPM_HOME:-}" >> "${TEST_PNPM_LOG:?}"
   mkdir -p node_modules
   touch node_modules/.install-ok
   exit 0
@@ -233,7 +234,29 @@ echo "Test 3: status hits after install with same GVS path"
   assert_exit_code 0 "$exit_code" "status should hit after install"
 )
 
-echo "Test 4: status misses after effective GVS path changes"
+echo "Test 4: exec defaults PNPM_HOME to a workspace-local projection"
+(
+  cd "$workspace"
+  export HOME="$tmpdir/home"
+  unset PNPM_HOME
+  : > "$tmpdir/pnpm.log"
+  bash "$tmpdir/pnpm-install.exec.sh"
+  grep -qxF "PNPM_HOME=$workspace/.pnpm-home" "$tmpdir/pnpm.log"
+)
+
+echo "Test 5: status hits after install with the default GVS path"
+(
+  cd "$workspace"
+  export HOME="$tmpdir/home"
+  unset PNPM_HOME
+  set +e
+  bash "$tmpdir/pnpm-install.status.sh"
+  exit_code=$?
+  set -e
+  assert_exit_code 0 "$exit_code" "status should hit after default-PNPM_HOME install"
+)
+
+echo "Test 6: status misses after effective GVS path changes"
 (
   cd "$workspace"
   export HOME="$tmpdir/home"
@@ -245,11 +268,11 @@ echo "Test 4: status misses after effective GVS path changes"
   assert_exit_code 1 "$exit_code" "status should miss when GVS path changes"
 )
 
-echo "Test 5: exec invoked pnpm version and install"
+echo "Test 7: exec invoked pnpm version and install"
 grep -qxF -- "--version" "$tmpdir/pnpm.log"
 grep -q "^install " "$tmpdir/pnpm.log"
 
-echo "Test 6: exec detaches stdin before probing pnpm version"
+echo "Test 8: exec detaches stdin before probing pnpm version"
 (
   cd "$workspace"
   export HOME="$tmpdir/home"
@@ -269,14 +292,14 @@ echo "Test 6: exec detaches stdin before probing pnpm version"
 )
 grep -qxF -- "--version" "$tmpdir/pnpm.log"
 
-echo "Test 7: generated test task runs vitest without pnpm exec"
+echo "Test 9: generated test task runs vitest without pnpm exec"
 (
   cd "$workspace/packages/demo"
   output="$(bash "$tmpdir/test-demo.exec.sh")"
   [ "$output" = "vitest-shim:run" ]
 )
 
-echo "Test 8: generated storybook task runs storybook without pnpm exec"
+echo "Test 10: generated storybook task runs storybook without pnpm exec"
 (
   cd "$workspace/packages/demo"
   output="$(bash "$tmpdir/storybook-demo.exec.sh")"

--- a/nix/devenv-modules/tasks/shared/tests/pnpm.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/pnpm.test.sh
@@ -127,7 +127,27 @@ echo "Test 2: XDG_DATA_HOME is used when PNPM_HOME is unset"
     "resolve_gvs_links_dir uses XDG_DATA_HOME"
 )
 
-echo "Test 3: Cache fingerprint changes when GVS path changes"
+echo "Test 3: ensure_local_pnpm_home_default sets a workspace-local default"
+(
+  unset PNPM_HOME
+  ensure_local_pnpm_home_default "$test_dir/workspace"
+  assert_eq \
+    "$test_dir/workspace/.pnpm-home" \
+    "$PNPM_HOME" \
+    "ensure_local_pnpm_home_default sets PNPM_HOME"
+)
+
+echo "Test 4: ensure_local_pnpm_home_default preserves an explicit PNPM_HOME"
+(
+  export PNPM_HOME="$test_dir/custom-home"
+  ensure_local_pnpm_home_default "$test_dir/workspace"
+  assert_eq \
+    "$test_dir/custom-home" \
+    "$PNPM_HOME" \
+    "ensure_local_pnpm_home_default keeps explicit PNPM_HOME"
+)
+
+echo "Test 5: Cache fingerprint changes when GVS path changes"
 fingerprint_a="$(cache_fingerprint "workspace-hash" "/tmp/a/store/v11/links")"
 fingerprint_b="$(cache_fingerprint "workspace-hash" "/tmp/b/store/v11/links")"
 if [ "$fingerprint_a" = "$fingerprint_b" ]; then
@@ -135,7 +155,7 @@ if [ "$fingerprint_a" = "$fingerprint_b" ]; then
   exit 1
 fi
 
-echo "Test 4: resolve_package_bin prefers package-local .bin shims"
+echo "Test 6: resolve_package_bin prefers package-local .bin shims"
 bin_fixture="$test_dir/bin-fixture"
 make_bin_fixture "$bin_fixture"
 resolved_bin="$(resolve_package_bin fake-tool fake-tool "$bin_fixture")"
@@ -145,14 +165,14 @@ assert_eq \
   "$resolved_bin" \
   "resolve_package_bin prefers the generated .bin shim"
 
-echo "Test 5: run_package_bin executes the .bin shim when present"
+echo "Test 7: run_package_bin executes the .bin shim when present"
 output="$(cd "$bin_fixture" && run_package_bin fake-tool fake-tool alpha beta)"
 assert_eq \
   "fake-tool-shim:alpha beta" \
   "$output" \
   "run_package_bin executes the resolved shim"
 
-echo "Test 6: resolve_package_bin falls back to the package bin file"
+echo "Test 8: resolve_package_bin falls back to the package bin file"
 fallback_fixture="$test_dir/fallback-bin-fixture"
 make_bin_fixture_without_shim "$fallback_fixture"
 resolved_fallback_bin="$(resolve_package_bin fallback-tool fallback-tool "$fallback_fixture")"
@@ -162,7 +182,7 @@ assert_eq \
   "$resolved_fallback_bin" \
   "resolve_package_bin falls back to the package bin file"
 
-echo "Test 7: Projection health passes when symlinked package can resolve deps"
+echo "Test 9: Projection health passes when symlinked package can resolve deps"
 healthy_dir="$test_dir/healthy"
 make_projection_fixture "$healthy_dir" 1
 set +e
@@ -171,7 +191,7 @@ exit_code=$?
 set -e
 assert_exit_code 0 "$exit_code" "projection health passes"
 
-echo "Test 8: Projection health ignores packages that do not export ./package.json"
+echo "Test 10: Projection health ignores packages that do not export ./package.json"
 exports_dir="$test_dir/exports"
 make_projection_fixture "$exports_dir" 1 1
 set +e
@@ -180,7 +200,7 @@ exit_code=$?
 set -e
 assert_exit_code 0 "$exit_code" "projection health should not depend on package.json exports"
 
-echo "Test 9: Projection health fails when symlinked package loses a transitive dep"
+echo "Test 11: Projection health fails when symlinked package loses a transitive dep"
 stale_dir="$test_dir/stale"
 make_projection_fixture "$stale_dir" 0
 set +e
@@ -189,7 +209,7 @@ exit_code=$?
 set -e
 assert_exit_code 1 "$exit_code" "projection health detects missing dep"
 
-echo "Test 10: Broken node_modules symlink is rejected before projection checks"
+echo "Test 12: Broken node_modules symlink is rejected before projection checks"
 broken_dir="$test_dir/broken"
 mkdir -p "$broken_dir/node_modules"
 ln -s ../missing "$broken_dir/node_modules/broken"


### PR DESCRIPTION
## Summary
- default local pnpm tasks to `$WORKSPACE_ROOT/.pnpm-home` when `PNPM_HOME` is unset
- keep the behavior override-friendly by only setting the default when `PNPM_HOME` is missing
- add helper and smoke tests for the defaulted local install path

## Why
Local devenv pnpm tasks still fell back to ambient host-global pnpm state when `PNPM_HOME` was unset. That lets the hot GVS projection depend on unrelated repos on the same machine, while CI intentionally isolates that state.

## Rationale
This keeps the fix at the shared pnpm task boundary, which is the real source of truth for local and CI installs. It avoids pushing repo-specific exports downstream and preserves an explicit escape hatch for callers that really do want a different `PNPM_HOME`.

_Acting on behalf of the user._