### PR TITLE
feat(nix): expose notion-cli as Nix binary via flake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- **@overeng/notion-cli**: Expose `notion` binary via Nix flake (`packages.${system}.notion-cli`) so consuming repos can add it to their `$PATH` without managing JS module resolution themselves
+
 - **@overeng/notion-effect-schema**: Add `NamedIcon` (type: `"icon"`) variant to `Icon` union for native Notion icons (noticons) (#543)
 - **@overeng/notion-effect-schema**: Add `NoticonColor` schema for named icon color palette
 - **@overeng/notion-effect-schema**: Add `heading_4`, `tab`, and `meeting_notes` block types to `BlockType`

--- a/devenv.nix
+++ b/devenv.nix
@@ -75,6 +75,13 @@ let
       lockfile = "pnpm-lock.yaml";
       packageJson = "packages/@overeng/oxc-config/package.json";
     }
+    {
+      name = "notion-cli";
+      flakeRef = ".#notion-cli";
+      hashSource = "packages/@overeng/notion-cli/nix/build.nix";
+      lockfile = "pnpm-lock.yaml";
+      packageJson = "packages/@overeng/notion-cli/package.json";
+    }
   ];
 
   # Explicit workspace members for the repo-root pnpm workspace.

--- a/flake.nix
+++ b/flake.nix
@@ -70,6 +70,15 @@
               ;
             src = self;
           };
+          notion-cli = import (rootPath + "/packages/@overeng/notion-cli/nix/build.nix") {
+            inherit
+              pkgs
+              gitRev
+              commitTs
+              dirty
+              ;
+            src = self;
+          };
         };
         cliPackagesDirty = {
           genie = import (rootPath + "/packages/@overeng/genie/nix/build.nix") {
@@ -83,6 +92,11 @@
             dirty = true;
           };
           tui-stories = import (rootPath + "/packages/@overeng/tui-stories/nix/build.nix") {
+            inherit pkgs gitRev commitTs;
+            src = self;
+            dirty = true;
+          };
+          notion-cli = import (rootPath + "/packages/@overeng/notion-cli/nix/build.nix") {
             inherit pkgs gitRev commitTs;
             src = self;
             dirty = true;
@@ -103,6 +117,9 @@
           "megarepo-pnpm-deps" = cliPackages.megarepo.passthru.depsBuildsByInstallRoot.root;
           tui-stories-dirty = cliPackagesDirty.tui-stories;
           "tui-stories-pnpm-deps" = cliPackages.tui-stories.passthru.depsBuildsByInstallRoot.root;
+          notion-cli = cliPackages.notion-cli;
+          notion-cli-dirty = cliPackagesDirty.notion-cli;
+          "notion-cli-pnpm-deps" = cliPackages.notion-cli.passthru.depsBuildsByInstallRoot.root;
           "oxc-config-plugin-pnpm-deps" = oxlintNpm.pluginBundle.passthru.pnpmDeps;
           # npm oxlint with NAPI bindings + pre-bundled @overeng/oxc-config plugin
           oxlint-npm = oxlintNpm;
@@ -117,11 +134,13 @@
           genie = cliPackages.genie.outPath;
           megarepo = cliPackages.megarepo.outPath;
           tui-stories = cliPackages.tui-stories.outPath;
+          notion-cli = cliPackages.notion-cli.outPath;
         };
         cliOutPathsDirty = {
           genie = cliPackagesDirty.genie.outPath;
           megarepo = cliPackagesDirty.megarepo.outPath;
           tui-stories = cliPackagesDirty.tui-stories.outPath;
+          notion-cli = cliPackagesDirty.notion-cli.outPath;
         };
 
         apps.update-bun-hashes = flake-utils.lib.mkApp {

--- a/packages/@overeng/notion-cli/nix/build.nix
+++ b/packages/@overeng/notion-cli/nix/build.nix
@@ -1,0 +1,40 @@
+# Nix derivation that builds notion CLI binary.
+# Uses bun build --compile for native platform.
+{
+  pkgs,
+  src,
+  gitRev ? "unknown",
+  commitTs ? 0,
+  dirty ? false,
+}:
+
+let
+  pnpm = import ../../../../nix/pnpm.nix { inherit pkgs; };
+  mkPnpmCli = import ../../../../nix/workspace-tools/lib/mk-pnpm-cli.nix { inherit pkgs pnpm; };
+  unwrapped = mkPnpmCli {
+    name = "notion-cli-unwrapped";
+    entry = "packages/@overeng/notion-cli/src/cli.ts";
+    binaryName = "notion";
+    packageDir = "packages/@overeng/notion-cli";
+    workspaceRoot = src;
+    # Managed by `dt nix:hash:notion-cli` — do not edit manually.
+    depsBuilds = {
+      "." = {
+        hash = "sha256-+1tZX9Pi1aLVdSq+u+AOvPw9y33FIUZUS+0uTEYwxj0=";
+      };
+    };
+    inherit gitRev commitTs dirty;
+  };
+in
+pkgs.runCommand "notion-cli"
+  {
+    nativeBuildInputs = [ pkgs.makeWrapper ];
+    meta.mainProgram = "notion";
+    passthru = {
+      inherit (unwrapped.passthru) depsBuildEntries depsBuildsByInstallRoot installRoots;
+    };
+  }
+  ''
+    mkdir -p $out/bin
+    makeWrapper ${unwrapped}/bin/notion $out/bin/notion
+  ''


### PR DESCRIPTION
## Summary

- Adds `packages/@overeng/notion-cli/nix/build.nix` using the same `mkPnpmCli` pattern as genie, megarepo, and tui-stories
- Registers `notion-cli` in `flake.nix` (`cliPackages`, `cliPackagesDirty`, `packages`, `cliOutPaths`)
- Registers `notion-cli` in `devenv.nix` `nixCliPackages` for hash management via `dt nix:hash:notion-cli`

The resulting `notion` binary is available as `effectUtils.packages.${system}.notion-cli` so consuming repos (e.g. schickling-stiftung) can add it to their `$PATH` via devenv without managing JS module resolution.

## Rationale

The previous approach of running `bun packages/@overeng/notion-cli/src/cli.ts ...` from the effect-utils checkout root is fragile: it requires GVS links to be intact and can't be invoked from external repos. A Nix-built binary sidesteps these issues by bundling all deps at build time via `bun build --compile`.

## Test plan

- [x] `nix build .#notion-cli` succeeds
- [x] `nix build .#notion-cli-pnpm-deps` succeeds with correct FOD hash
- [x] `notion --help` output is correct (shows subcommands: schema, db)
- [ ] CI passes

Closes schickling/megarepo-all#73

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
*Acting on behalf of @schickling*