### PR TITLE
fix: isolate pty daemon env and make attach acquisition interruptible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ All notable changes to this project will be documented in this file.
 
 - **devenv/tasks/shared/vercel.nix**: Preserve dotfiles when packaging static prebuilt output for Vercel deploys
   - Copies `staticDir/.` into `.vercel/output/static/` instead of globbing `staticDir/*`, so hidden assets and config files are not silently dropped
+- **@overeng/notion-effect-client**: Raise user integration-test timeouts to tolerate current Notion API latency in CI
 - **@overeng/notion-cli**: Fix introspection pipeline to read properties from data source (API 2026-03-11 no longer returns properties on `GET /databases/:id`)
 - **@overeng/pty-effect**: Remove parent `process.env` mutation from daemon spawning, pass env per call, and add interruption/shutdown coverage for pending spawn and attach operations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ All notable changes to this project will be documented in this file.
 - **@overeng/notion-effect-client**: Raise user integration-test timeouts to tolerate current Notion API latency in CI
 - **@overeng/notion-cli**: Fix introspection pipeline to read properties from data source (API 2026-03-11 no longer returns properties on `GET /databases/:id`)
 - **@overeng/pty-effect**: Remove parent `process.env` mutation from daemon spawning, pass env per call, and add interruption/shutdown coverage for pending spawn and attach operations
+- **@overeng/pty-effect**: Align client lifecycles with Effect conventions by using `Effect.fn` spans, preserving the caller runtime in attach callbacks, and reporting expected startup failures as `PtyError`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ All notable changes to this project will be documented in this file.
 - **devenv/tasks/shared/vercel.nix**: Preserve dotfiles when packaging static prebuilt output for Vercel deploys
   - Copies `staticDir/.` into `.vercel/output/static/` instead of globbing `staticDir/*`, so hidden assets and config files are not silently dropped
 - **@overeng/notion-cli**: Fix introspection pipeline to read properties from data source (API 2026-03-11 no longer returns properties on `GET /databases/:id`)
+- **@overeng/pty-effect**: Remove parent `process.env` mutation from daemon spawning, pass env per call, and add interruption/shutdown coverage for pending spawn and attach operations
 
 ### Changed
 

--- a/packages/@overeng/notion-effect-client/src/test/integration/users.integration.test.ts
+++ b/packages/@overeng/notion-effect-client/src/test/integration/users.integration.test.ts
@@ -6,15 +6,21 @@ import { Vitest } from '@overeng/utils-dev/node-vitest'
 import { NotionUsers } from '../../users.ts'
 import { IntegrationTestLayer, SKIP_INTEGRATION } from './setup.ts'
 
+const USER_REQUEST_TIMEOUT = 30_000
+const USER_STREAM_TIMEOUT = 60_000
+
 Vitest.describe.skipIf(SKIP_INTEGRATION)('NotionUsers (integration)', () => {
   Vitest.describe('me', () => {
-    Vitest.it.effect('fetches the bot user', () =>
-      Effect.gen(function* () {
-        const user = yield* NotionUsers.me()
+    Vitest.it.effect(
+      'fetches the bot user',
+      () =>
+        Effect.gen(function* () {
+          const user = yield* NotionUsers.me()
 
-        expect(user.object).toBe('user')
-        expect(user.id).toBeDefined()
-      }).pipe(Effect.provide(IntegrationTestLayer)),
+          expect(user.object).toBe('user')
+          expect(user.id).toBeDefined()
+        }).pipe(Effect.provide(IntegrationTestLayer)),
+      { timeout: USER_REQUEST_TIMEOUT },
     )
   })
 
@@ -28,7 +34,7 @@ Vitest.describe.skipIf(SKIP_INTEGRATION)('NotionUsers (integration)', () => {
           expect(result.results.length).toBeGreaterThanOrEqual(1)
           expect(result.results[0]?.object).toBe('user')
         }).pipe(Effect.provide(IntegrationTestLayer)),
-      { timeout: 30000 },
+      { timeout: USER_REQUEST_TIMEOUT },
     )
 
     Vitest.it.effect(
@@ -39,7 +45,7 @@ Vitest.describe.skipIf(SKIP_INTEGRATION)('NotionUsers (integration)', () => {
 
           expect(result.results.length).toBe(1)
         }).pipe(Effect.provide(IntegrationTestLayer)),
-      { timeout: 30000 },
+      { timeout: USER_REQUEST_TIMEOUT },
     )
   })
 
@@ -57,7 +63,7 @@ Vitest.describe.skipIf(SKIP_INTEGRATION)('NotionUsers (integration)', () => {
             expect(item.object).toBe('user')
           }
         }).pipe(Effect.provide(IntegrationTestLayer)),
-      { timeout: 30000 },
+      { timeout: USER_STREAM_TIMEOUT },
     )
   })
 
@@ -75,7 +81,7 @@ Vitest.describe.skipIf(SKIP_INTEGRATION)('NotionUsers (integration)', () => {
           expect(user.object).toBe('user')
           expect(user.id).toBe(bot.id)
         }).pipe(Effect.provide(IntegrationTestLayer)),
-      { timeout: 30000 },
+      { timeout: USER_REQUEST_TIMEOUT },
     )
   })
 })

--- a/packages/@overeng/pty-effect/src/client.test.ts
+++ b/packages/@overeng/pty-effect/src/client.test.ts
@@ -157,6 +157,40 @@ describe('PtyClient', () => {
     ),
   )
 
+  it.scopedLive('passes env overrides to the daemon without mutating the parent env', () =>
+    withIsolatedDir(
+      Effect.gen(function* () {
+        const client = yield* PtyClient
+        const name = uniqueName('env')
+        const marker = `marker-${Date.now().toString(36)}`
+        const previous = process.env.PTY_EFFECT_TEST_VALUE
+
+        try {
+          delete process.env.PTY_EFFECT_TEST_VALUE
+
+          yield* client.spawnDaemon({
+            name,
+            command: 'sh',
+            args: ['-c', 'echo "ENV:$PTY_EFFECT_TEST_VALUE" && sleep 0.05'],
+            env: { PTY_EFFECT_TEST_VALUE: marker },
+          })
+
+          expect(process.env.PTY_EFFECT_TEST_VALUE).toBeUndefined()
+
+          const session = yield* client.attach({
+            name,
+            size: { rows: 24, cols: 80 },
+          })
+
+          expect(session.initialScreen).toContain(`ENV:${marker}`)
+        } finally {
+          if (previous === undefined) delete process.env.PTY_EFFECT_TEST_VALUE
+          else process.env.PTY_EFFECT_TEST_VALUE = previous
+        }
+      }).pipe(Effect.provide(ptyClientLayer)),
+    ),
+  )
+
   it.scopedLive('rejects invalid session names with BadName', () =>
     withIsolatedDir(
       Effect.gen(function* () {

--- a/packages/@overeng/pty-effect/src/client.ts
+++ b/packages/@overeng/pty-effect/src/client.ts
@@ -12,14 +12,19 @@
  * process restarts (forge, dev shells, persistent agent runners).
  */
 
+import { spawn as spawnChild } from 'node:child_process'
+import * as fs from 'node:fs'
+import { createRequire } from 'node:module'
+import * as path from 'node:path'
+import type { WriteStream } from 'node:tty'
+
 import {
   type SessionConnectionOptions,
   type SessionInfo,
-  type SpawnDaemonOptions,
   SessionConnection,
+  getSocketPath,
   listSessions as upstreamListSessions,
   peekScreen as upstreamPeekScreen,
-  spawnDaemon as upstreamSpawnDaemon,
   validateName,
 } from '@myobie/pty/client'
 import {
@@ -63,9 +68,8 @@ export const PtyDaemonSpec = Schema.Struct({
       cols: Schema.Number.pipe(Schema.int(), Schema.positive()),
     }),
   ),
-  /** Extra environment variables to set for the spawned daemon process.
-   *  Applied via `process.env` mutation before calling upstream `spawnDaemon`
-   *  (which inherits parent env) and restored after the call returns. */
+  /** Extra environment variables to merge into the daemon process env.
+   *  Applied per call without mutating the parent `process.env`. */
   env: Schema.optional(Schema.Record({ key: Schema.String, value: Schema.String })),
 })
 export type PtyDaemonSpec = typeof PtyDaemonSpec.Type
@@ -169,7 +173,7 @@ const wrapPromise = <A>(opts: {
   readonly method: string
   readonly reason?: PtyError['reason']
   readonly name?: string
-  readonly thunk: () => Promise<A>
+  readonly thunk: (signal: AbortSignal) => Promise<A>
 }) =>
   Effect.tryPromise({
     try: opts.thunk,
@@ -199,19 +203,182 @@ const wrapSync = <A>(opts: {
       }),
   })
 
-const buildSpawnOpts = (spec: PtyDaemonSpec): SpawnDaemonOptions => {
-  const opts: SpawnDaemonOptions = {
+const require = createRequire(import.meta.url)
+
+const resolveDaemonBin = () =>
+  process.env.PTY_DAEMON_BIN ??
+  path.join(path.dirname(require.resolve('@myobie/pty/client')), '..', 'bin', 'pty-daemon')
+
+const getDefaultRows = () => ((process.stdout as WriteStream | undefined)?.rows ?? 24)
+
+const getDefaultCols = () => ((process.stdout as WriteStream | undefined)?.columns ?? 80)
+
+const buildDaemonConfig = (spec: PtyDaemonSpec) => {
+  const opts = {
     name: spec.name,
     command: spec.command,
     args: spec.args !== undefined ? [...spec.args] : [],
     displayCommand: spec.displayCommand ?? spec.command,
+    cwd: spec.cwd ?? process.cwd(),
+    rows: spec.size?.rows ?? getDefaultRows(),
+    cols: spec.size?.cols ?? getDefaultCols(),
+    ephemeral: spec.ephemeral ?? false,
   }
-  if (spec.cwd !== undefined) opts.cwd = spec.cwd
-  if (spec.ephemeral !== undefined) opts.ephemeral = spec.ephemeral
-  if (spec.size?.rows !== undefined) opts.rows = spec.size.rows
-  if (spec.size?.cols !== undefined) opts.cols = spec.size.cols
   return opts
 }
+
+const waitForSocket = (opts: {
+  readonly name: string
+  readonly signal: AbortSignal
+  readonly timeoutMs: number
+  readonly earlyCheck?: () => void
+}) =>
+  new Promise<void>((resolve, reject) => {
+    const start = Date.now()
+    let pollTimer: NodeJS.Timeout | undefined
+    let settleTimer: NodeJS.Timeout | undefined
+    let settled = false
+
+    const finish = (effect: () => void) => {
+      if (settled === true) return
+      settled = true
+      if (pollTimer !== undefined) clearTimeout(pollTimer)
+      if (settleTimer !== undefined) clearTimeout(settleTimer)
+      opts.signal.removeEventListener('abort', onAbort)
+      effect()
+    }
+
+    const onAbort = () => finish(() => reject(opts.signal.reason))
+
+    const check = () => {
+      try {
+        opts.earlyCheck?.()
+      } catch (cause) {
+        finish(() => reject(cause))
+        return
+      }
+
+      if (Date.now() - start > opts.timeoutMs) {
+        finish(() => reject(new Error(`Timeout waiting for session "${opts.name}" to start`)))
+        return
+      }
+
+      try {
+        fs.statSync(getSocketPath(opts.name))
+        settleTimer = setTimeout(() => finish(resolve), 100)
+        return
+      } catch {
+        pollTimer = setTimeout(check, 50)
+      }
+    }
+
+    if (opts.signal.aborted === true) {
+      onAbort()
+      return
+    }
+
+    opts.signal.addEventListener('abort', onAbort, { once: true })
+    check()
+  })
+
+const spawnDaemonPromise = (spec: PtyDaemonSpec, signal: AbortSignal) =>
+  new Promise<void>((resolve, reject) => {
+    const child = spawnChild(resolveDaemonBin(), [], {
+      detached: true,
+      stdio: ['ignore', 'ignore', 'pipe'],
+      env: {
+        ...process.env,
+        ...spec.env,
+        PTY_SERVER_CONFIG: JSON.stringify(buildDaemonConfig(spec)),
+      },
+    })
+
+    let stderrOutput = ''
+    let earlyExit = false
+    let earlyExitCode: number | null = null
+    let settled = false
+
+    const finish = (effect: () => void) => {
+      if (settled === true) return
+      settled = true
+      signal.removeEventListener('abort', onAbort)
+      child.removeListener('exit', onExit)
+      child.stderr?.removeListener('data', onStderr)
+      effect()
+    }
+
+    const onStderr = (data: Buffer) => {
+      stderrOutput += data.toString()
+    }
+
+    const onExit = (code: number | null) => {
+      earlyExit = true
+      earlyExitCode = code
+    }
+
+    const onAbort = () => {
+      try {
+        child.kill('SIGTERM')
+      } catch {
+        // best effort: detached daemon might already be gone
+      }
+    }
+
+    if (signal.aborted === true) {
+      onAbort()
+      finish(() => reject(signal.reason))
+      return
+    }
+
+    child.stderr?.on('data', onStderr)
+    child.on('exit', onExit)
+    ;(child.stderr as { unref?: () => void } | null)?.unref?.()
+    child.unref()
+    signal.addEventListener('abort', onAbort, { once: true })
+
+    waitForSocket({
+      name: spec.name,
+      signal,
+      timeoutMs: 3_000,
+      earlyCheck: () => {
+        if (earlyExit === false) return
+        const details = stderrOutput.trim()
+        const msg = `Daemon process exited immediately (code ${earlyExitCode ?? 'unknown'}).`
+        throw new Error(details.length > 0 ? `${msg}\n${details}` : `${msg} Is the command valid?`)
+      },
+    }).then(
+      () => finish(resolve),
+      (cause) => finish(() => reject(cause)),
+    )
+  })
+
+const connectSessionConnection = (opts: {
+  readonly conn: SessionConnection
+  readonly signal: AbortSignal
+}) =>
+  new Promise<string>((resolve, reject) => {
+    const onAbort = () => {
+      opts.conn.disconnect()
+      reject(opts.signal.reason)
+    }
+
+    if (opts.signal.aborted === true) {
+      onAbort()
+      return
+    }
+
+    opts.signal.addEventListener('abort', onAbort, { once: true })
+    opts.conn.connect().then(
+      (screen) => {
+        opts.signal.removeEventListener('abort', onAbort)
+        resolve(screen)
+      },
+      (cause) => {
+        opts.signal.removeEventListener('abort', onAbort)
+        reject(cause)
+      },
+    )
+  })
 
 /** Regex matching helper — clones RegExp to avoid stateful `lastIndex`. */
 const matches = (input: { readonly haystack: string; readonly needle: string | RegExp }) => {
@@ -245,22 +412,12 @@ const validateNameOrFail = (name: string) =>
 const spawnDaemon = (spec: PtyDaemonSpec): Effect.Effect<void, PtyError> =>
   Effect.gen(function* () {
     yield* validateNameOrFail(spec.name)
-    const envOverrides = spec.env !== undefined ? Object.entries(spec.env) : []
-    const saved = envOverrides.map(([k]) => [k, process.env[k]] as const)
-    for (const [k, v] of envOverrides) process.env[k] = v
-    try {
-      yield* wrapPromise({
-        method: 'spawnDaemon',
-        reason: 'SpawnFailed',
-        name: spec.name,
-        thunk: () => upstreamSpawnDaemon(buildSpawnOpts(spec)),
-      })
-    } finally {
-      for (const [k, prev] of saved) {
-        if (prev === undefined) delete process.env[k]
-        else process.env[k] = prev
-      }
-    }
+    yield* wrapPromise({
+      method: 'spawnDaemon',
+      reason: 'SpawnFailed',
+      name: spec.name,
+      thunk: (signal) => spawnDaemonPromise(spec, signal),
+    })
   }).pipe(Effect.withSpan('pty-client.spawnDaemon', { attributes: { 'span.label': spec.name } }))
 
 const peek = (input: { readonly name: PtyName; readonly plain?: boolean }) =>
@@ -368,12 +525,12 @@ const attach = (spec: PtyAttachSpec): Effect.Effect<PtyClientSession, PtyError, 
       )
     })
 
-    const initialScreen = yield* Effect.acquireRelease(
+    const initialScreen = yield* Effect.acquireReleaseInterruptible(
       wrapPromise({
         method: 'attach.connect',
         reason: 'ConnectFailed',
         name: spec.name,
-        thunk: () => conn.connect(),
+        thunk: (signal) => connectSessionConnection({ conn, signal }),
       }),
       () => Effect.sync(() => conn.disconnect()),
     )

--- a/packages/@overeng/pty-effect/src/client.ts
+++ b/packages/@overeng/pty-effect/src/client.ts
@@ -35,6 +35,7 @@ import {
   Option,
   Predicate,
   Queue,
+  Runtime,
   Schedule,
   Schema,
   Stream,
@@ -233,12 +234,34 @@ const isSocketNotReadyError = (cause: unknown) =>
   Predicate.hasProperty(cause, 'code') === true &&
   (cause as { readonly code?: unknown }).code === 'ENOENT'
 
-const waitForSocket = (opts: {
+const socketStartTimeout = (name: string) =>
+  new PtyError({
+    reason: 'Timeout',
+    method: 'waitForSocket',
+    name,
+    cause: `Timed out waiting for session "${name}" to start`,
+  })
+
+const daemonExitedEarly = (opts: {
+  readonly name: string
+  readonly code: number | null
+  readonly stderr: string
+}) =>
+  new PtyError({
+    reason: 'UnexpectedExit',
+    method: `spawnDaemon.waitForSocket: Daemon process exited immediately (code ${opts.code ?? 'unknown'})`,
+    name: opts.name,
+    ...(opts.stderr.length > 0 ? { cause: opts.stderr } : {}),
+  })
+
+const waitForSocket = Effect.fn('pty-client.waitForSocket')(function* (opts: {
   readonly name: string
   readonly timeoutMs: number
   readonly earlyCheck?: () => void
-}) =>
-  Effect.try({
+}) {
+  yield* Effect.annotateCurrentSpan({ 'span.label': opts.name })
+
+  return yield* Effect.try({
     try: () => {
       opts.earlyCheck?.()
       fs.statSync(getSocketPath(opts.name))
@@ -247,17 +270,22 @@ const waitForSocket = (opts: {
   }).pipe(
     Effect.retry({
       while: (cause) => cause === socketNotReady,
-      schedule: Schedule.spaced('50 millis'),
+      schedule: defaultPollSchedule,
     }),
     Effect.timeoutFail({
       duration: `${opts.timeoutMs} millis`,
-      onTimeout: () => new Error(`Timeout waiting for session "${opts.name}" to start`),
+      onTimeout: () => socketStartTimeout(opts.name),
     }),
     Effect.andThen(Effect.sleep('100 millis')),
   )
+})
 
-const spawnDaemonEffect = (spec: PtyDaemonSpec) =>
-  Effect.async<void, unknown>((resume, signal) => {
+const spawnDaemonEffect = Effect.fn('pty-client.spawnDaemonEffect')(function* (
+  spec: PtyDaemonSpec,
+) {
+  yield* Effect.annotateCurrentSpan({ 'span.label': spec.name })
+
+  return yield* Effect.async<void, unknown>((resume, signal) => {
     const child = spawnChild(resolveDaemonBin(), [], {
       detached: true,
       stdio: ['ignore', 'ignore', 'pipe'],
@@ -308,47 +336,50 @@ const spawnDaemonEffect = (spec: PtyDaemonSpec) =>
         timeoutMs: 3_000,
         earlyCheck: () => {
           if (earlyExit === false) return
-          const details = stderrOutput.trim()
-          const msg = `Daemon process exited immediately (code ${earlyExitCode ?? 'unknown'}).`
-          throw new Error(
-            details.length > 0 ? `${msg}\n${details}` : `${msg} Is the command valid?`,
-          )
+          throw daemonExitedEarly({
+            name: spec.name,
+            code: earlyExitCode,
+            stderr: stderrOutput.trim(),
+          })
         },
       }).pipe(Effect.ensuring(Effect.sync(cleanupListeners))),
     )
 
     return Effect.sync(onAbort)
   })
+})
 
-const connectSessionConnection = (conn: SessionConnection) =>
-  Effect.async<string, unknown>((resume, signal) => {
-    const onAbort = () => {
-      conn.disconnect()
-    }
+const connectSessionConnection = Effect.fn('pty-client.connectSessionConnection')(
+  (conn: SessionConnection) =>
+    Effect.async<string, unknown>((resume, signal) => {
+      const onAbort = () => {
+        conn.disconnect()
+      }
 
-    if (signal.aborted === true) {
-      onAbort()
-      resume(Effect.fail(signal.reason))
-      return
-    }
+      if (signal.aborted === true) {
+        onAbort()
+        resume(Effect.fail(signal.reason))
+        return
+      }
 
-    signal.addEventListener('abort', onAbort, { once: true })
-    conn.connect().then(
-      (screen) => {
+      signal.addEventListener('abort', onAbort, { once: true })
+      conn.connect().then(
+        (screen) => {
+          signal.removeEventListener('abort', onAbort)
+          resume(Effect.succeed(screen))
+        },
+        (cause) => {
+          signal.removeEventListener('abort', onAbort)
+          resume(Effect.fail(cause))
+        },
+      )
+
+      return Effect.sync(() => {
         signal.removeEventListener('abort', onAbort)
-        resume(Effect.succeed(screen))
-      },
-      (cause) => {
-        signal.removeEventListener('abort', onAbort)
-        resume(Effect.fail(cause))
-      },
-    )
-
-    return Effect.sync(() => {
-      signal.removeEventListener('abort', onAbort)
-      onAbort()
-    })
-  })
+        onAbort()
+      })
+    }),
+)
 
 /** Regex matching helper — clones RegExp to avoid stateful `lastIndex`. */
 const matches = (input: { readonly haystack: string; readonly needle: string | RegExp }) => {
@@ -364,7 +395,7 @@ export const decodePtyName = Schema.decodeUnknown(PtyName)
 
 /** Runtime defense-in-depth: validates even branded names to produce clean
  *  `BadName` errors when brands are bypassed via `@ts-expect-error` / casts. */
-const validateNameOrFail = (name: string) =>
+const validateNameOrFail = Effect.fn('pty-client.validateNameOrFail')((name: string) =>
   Effect.try({
     try: () => {
       validateName(name)
@@ -377,26 +408,33 @@ const validateNameOrFail = (name: string) =>
         name,
         cause,
       }),
-  })
+  }),
+)
 
-const spawnDaemon = (spec: PtyDaemonSpec): Effect.Effect<void, PtyError> =>
-  Effect.gen(function* () {
-    yield* validateNameOrFail(spec.name)
-    yield* spawnDaemonEffect(spec).pipe(
-      Effect.mapError(
-        (cause) =>
-          new PtyError({
-            reason: 'SpawnFailed',
-            method: 'spawnDaemon',
-            name: spec.name,
-            cause,
-          }),
-      ),
-    )
-  }).pipe(Effect.withSpan('pty-client.spawnDaemon', { attributes: { 'span.label': spec.name } }))
+const spawnDaemon: (spec: PtyDaemonSpec) => Effect.Effect<void, PtyError> = Effect.fn(
+  'pty-client.spawnDaemon',
+)(function* (spec: PtyDaemonSpec) {
+  yield* Effect.annotateCurrentSpan({ 'span.label': spec.name })
+  yield* validateNameOrFail(spec.name)
+  yield* spawnDaemonEffect(spec).pipe(
+    Effect.mapError(
+      (cause) =>
+        new PtyError({
+          reason: 'SpawnFailed',
+          method: 'spawnDaemon',
+          name: spec.name,
+          cause,
+        }),
+    ),
+  )
+})
 
-const peek = (input: { readonly name: PtyName; readonly plain?: boolean }) =>
-  wrapPromise({
+const peek = Effect.fn('pty-client.peek')(function* (input: {
+  readonly name: PtyName
+  readonly plain?: boolean
+}) {
+  yield* Effect.annotateCurrentSpan({ 'span.label': input.name })
+  return yield* wrapPromise({
     method: 'peek',
     reason: 'ConnectFailed',
     name: input.name,
@@ -404,7 +442,8 @@ const peek = (input: { readonly name: PtyName; readonly plain?: boolean }) =>
       upstreamPeekScreen(
         input.plain !== undefined ? { name: input.name, plain: input.plain } : { name: input.name },
       ),
-  }).pipe(Effect.withSpan('pty-client.peek', { attributes: { 'span.label': input.name } }))
+  })
+})
 
 const list: Effect.Effect<ReadonlyArray<SessionInfo>, PtyError> = wrapPromise({
   method: 'list',
@@ -412,29 +451,29 @@ const list: Effect.Effect<ReadonlyArray<SessionInfo>, PtyError> = wrapPromise({
   thunk: () => upstreamListSessions(),
 }).pipe(Effect.withSpan('pty-client.list'))
 
-const exists = (input: { readonly name: PtyName }) =>
-  pipe(
-    list,
-    Effect.map((sessions) => sessions.some((s) => s.name === input.name)),
-  ).pipe(Effect.withSpan('pty-client.exists', { attributes: { 'span.label': input.name } }))
+const exists = Effect.fn('pty-client.exists')(function* (input: { readonly name: PtyName }) {
+  yield* Effect.annotateCurrentSpan({ 'span.label': input.name })
+  const sessions = yield* list
+  return sessions.some((s) => s.name === input.name)
+})
 
-const kill = (input: { readonly name: PtyName }) =>
-  Effect.gen(function* () {
-    const sessions = yield* list
-    const session = sessions.find((s) => s.name === input.name)
-    if (session === undefined || session.pid === null) {
-      return yield* new PtyError({
-        reason: 'ConnectFailed',
-        method: 'kill',
-        name: input.name,
-      })
-    }
-    yield* wrapSync({
+const kill = Effect.fn('pty-client.kill')(function* (input: { readonly name: PtyName }) {
+  yield* Effect.annotateCurrentSpan({ 'span.label': input.name })
+  const sessions = yield* list
+  const session = sessions.find((s) => s.name === input.name)
+  if (session === undefined || session.pid === null) {
+    return yield* new PtyError({
+      reason: 'ConnectFailed',
       method: 'kill',
       name: input.name,
-      thunk: () => process.kill(session.pid!, 'SIGTERM'),
     })
-  }).pipe(Effect.withSpan('pty-client.kill', { attributes: { 'span.label': input.name } }))
+  }
+  yield* wrapSync({
+    method: 'kill',
+    name: input.name,
+    thunk: () => process.kill(session.pid!, 'SIGTERM'),
+  })
+})
 
 /**
  * Build a `PtyClientSession` from a fresh `SessionConnection`.
@@ -444,17 +483,16 @@ const kill = (input: { readonly name: PtyName }) =>
  * The byte stream + exit Deferred are wired in `acquire`, before the
  * upstream `connect()` call resolves, so we never miss the initial frames.
  *
- * **Runtime caveat**: Event handlers (`conn.on(...)`) use `Effect.runFork`
- * with the global default runtime. If the consumer provides a custom
- * runtime (e.g. with different loggers, spans, or error handlers), these
- * fire-and-forget effects bypass it. Capturing the runtime properly would
- * require `Effect.runtime` plumbing through the event handlers — tracked
- * as a v2 improvement.
+ * Event handlers capture the current runtime so their fire-and-forget
+ * effects preserve the caller's fiber refs, spans, loggers, and runtime
+ * configuration instead of escaping to the global default runtime.
  */
-const attach = (spec: PtyAttachSpec): Effect.Effect<PtyClientSession, PtyError, Scope.Scope> =>
-  Effect.gen(function* () {
+const attach: (spec: PtyAttachSpec) => Effect.Effect<PtyClientSession, PtyError, Scope.Scope> =
+  Effect.fn('pty-client.attach')(function* (spec: PtyAttachSpec) {
+    yield* Effect.annotateCurrentSpan({ 'span.label': spec.name })
     const queue = yield* Queue.bounded<Uint8Array>(1024)
     const exitDeferred = yield* Deferred.make<{ readonly code: number }, PtyError>()
+    const runtime = yield* Effect.runtime<Scope.Scope>()
     const enc = new TextEncoder()
 
     const opts: SessionConnectionOptions = {
@@ -470,16 +508,18 @@ const attach = (spec: PtyAttachSpec): Effect.Effect<PtyClientSession, PtyError, 
       thunk: () => new SessionConnection(opts),
     })
 
+    const runAsync = <A, E>(effect: Effect.Effect<A, E, Scope.Scope>): void => {
+      void Runtime.runFork(runtime)(effect)
+    }
+
     conn.on('data', (chunk: string) => {
-      Effect.runFork(Queue.offer(queue, enc.encode(chunk)))
+      runAsync(Queue.offer(queue, enc.encode(chunk)))
     })
     conn.on('exit', (code: number) => {
-      Effect.runFork(
-        Deferred.succeed(exitDeferred, { code }).pipe(Effect.andThen(Queue.shutdown(queue))),
-      )
+      runAsync(Deferred.succeed(exitDeferred, { code }).pipe(Effect.andThen(Queue.shutdown(queue))))
     })
     conn.on('error', (err: Error) => {
-      Effect.runFork(
+      runAsync(
         Deferred.fail(
           exitDeferred,
           new PtyError({
@@ -492,7 +532,7 @@ const attach = (spec: PtyAttachSpec): Effect.Effect<PtyClientSession, PtyError, 
       )
     })
     conn.on('close', () => {
-      Effect.runFork(
+      runAsync(
         Deferred.fail(
           exitDeferred,
           new PtyError({ reason: 'Closed', method: 'attach.close', name: spec.name }),
@@ -517,22 +557,45 @@ const attach = (spec: PtyAttachSpec): Effect.Effect<PtyClientSession, PtyError, 
 
     const bytes: Stream.Stream<Uint8Array, PtyError> = Stream.fromQueue(queue)
 
-    const write: PtyClientSession['write'] = ({ data }) =>
-      wrapSync({ method: 'write', name: spec.name, thunk: () => conn.write(data) })
+    const write: PtyClientSession['write'] = Effect.fn('pty-client.write')(function* ({
+      data,
+    }: {
+      readonly data: string
+    }) {
+      yield* Effect.annotateCurrentSpan({ 'span.label': spec.name })
+      return yield* wrapSync({ method: 'write', name: spec.name, thunk: () => conn.write(data) })
+    })
 
-    const typeText: PtyClientSession['type'] = ({ text }) =>
-      wrapSync({ method: 'type', name: spec.name, thunk: () => conn.write(text) })
+    const typeText: PtyClientSession['type'] = Effect.fn('pty-client.type')(function* ({
+      text,
+    }: {
+      readonly text: string
+    }) {
+      yield* Effect.annotateCurrentSpan({ 'span.label': spec.name })
+      return yield* wrapSync({ method: 'type', name: spec.name, thunk: () => conn.write(text) })
+    })
 
-    const press: PtyClientSession['press'] = ({ key }) =>
-      wrapSync({ method: 'press', name: spec.name, thunk: () => conn.press(key) })
+    const press: PtyClientSession['press'] = Effect.fn('pty-client.press')(function* ({
+      key,
+    }: {
+      readonly key: string
+    }) {
+      yield* Effect.annotateCurrentSpan({ 'span.label': spec.name })
+      return yield* wrapSync({ method: 'press', name: spec.name, thunk: () => conn.press(key) })
+    })
 
-    const resize: PtyClientSession['resize'] = ({ rows, cols }) =>
-      wrapSync({
+    const resize: PtyClientSession['resize'] = Effect.fn('pty-client.resize')(function* ({
+      rows,
+      cols,
+    }: TerminalSize) {
+      yield* Effect.annotateCurrentSpan({ 'span.label': spec.name })
+      return yield* wrapSync({
         method: 'resize',
         reason: 'ResizeFailed',
         name: spec.name,
         thunk: () => conn.resize(rows, cols),
       })
+    })
 
     const screenshot: PtyClientSession['screenshot'] = Effect.gen(function* () {
       const ansi = yield* peek({ name: spec.name, plain: false })
@@ -541,57 +604,69 @@ const attach = (spec: PtyAttachSpec): Effect.Effect<PtyClientSession, PtyError, 
       return { lines, text, ansi } satisfies Screenshot
     }).pipe(Effect.withSpan('pty-client.screenshot', { attributes: { 'span.label': spec.name } }))
 
-    const waitForText: PtyClientSession['waitForText'] = ({ needle, schedule }) =>
-      pipe(
-        Stream.repeatEffectWithSchedule(screenshot, schedule ?? defaultPollSchedule),
-        Stream.filterMap((ss) =>
-          matches({ haystack: ss.text, needle }) === true ? Option.some(ss) : Option.none(),
-        ),
-        Stream.runHead,
-        Effect.flatMap(
-          Option.match({
-            onNone: () =>
-              Effect.fail(
-                new PtyError({
-                  reason: 'Timeout',
-                  method: `waitForText(${String(needle)})`,
-                  name: spec.name,
-                }),
-              ),
-            onSome: Effect.succeed,
-          }),
-        ),
-      ).pipe(
-        Effect.withSpan('pty-client.waitForText', {
-          attributes: { 'span.label': `${spec.name}: ${String(needle)}` },
-        }),
-      )
+    const waitForText: PtyClientSession['waitForText'] = Effect.fn('pty-client.waitForText')(
+      function* ({
+        needle,
+        schedule,
+      }: {
+        readonly needle: string | RegExp
+        readonly schedule?: Schedule.Schedule<unknown>
+      }) {
+        yield* Effect.annotateCurrentSpan({ 'span.label': `${spec.name}: ${String(needle)}` })
+        return yield* pipe(
+          Stream.repeatEffectWithSchedule(screenshot, schedule ?? defaultPollSchedule),
+          Stream.filterMap((ss) =>
+            matches({ haystack: ss.text, needle }) === true ? Option.some(ss) : Option.none(),
+          ),
+          Stream.runHead,
+          Effect.flatMap(
+            Option.match({
+              onNone: () =>
+                Effect.fail(
+                  new PtyError({
+                    reason: 'Timeout',
+                    method: `waitForText(${String(needle)})`,
+                    name: spec.name,
+                  }),
+                ),
+              onSome: Effect.succeed,
+            }),
+          ),
+        )
+      },
+    )
 
-    const waitForAbsent: PtyClientSession['waitForAbsent'] = ({ needle, schedule }) =>
-      pipe(
-        Stream.repeatEffectWithSchedule(screenshot, schedule ?? defaultPollSchedule),
-        Stream.filterMap((ss) =>
-          matches({ haystack: ss.text, needle }) === false ? Option.some(ss) : Option.none(),
-        ),
-        Stream.runHead,
-        Effect.flatMap(
-          Option.match({
-            onNone: () =>
-              Effect.fail(
-                new PtyError({
-                  reason: 'Timeout',
-                  method: `waitForAbsent(${String(needle)})`,
-                  name: spec.name,
-                }),
-              ),
-            onSome: Effect.succeed,
-          }),
-        ),
-      ).pipe(
-        Effect.withSpan('pty-client.waitForAbsent', {
-          attributes: { 'span.label': `${spec.name}: ${String(needle)}` },
-        }),
-      )
+    const waitForAbsent: PtyClientSession['waitForAbsent'] = Effect.fn('pty-client.waitForAbsent')(
+      function* ({
+        needle,
+        schedule,
+      }: {
+        readonly needle: string | RegExp
+        readonly schedule?: Schedule.Schedule<unknown>
+      }) {
+        yield* Effect.annotateCurrentSpan({ 'span.label': `${spec.name}: ${String(needle)}` })
+        return yield* pipe(
+          Stream.repeatEffectWithSchedule(screenshot, schedule ?? defaultPollSchedule),
+          Stream.filterMap((ss) =>
+            matches({ haystack: ss.text, needle }) === false ? Option.some(ss) : Option.none(),
+          ),
+          Stream.runHead,
+          Effect.flatMap(
+            Option.match({
+              onNone: () =>
+                Effect.fail(
+                  new PtyError({
+                    reason: 'Timeout',
+                    method: `waitForAbsent(${String(needle)})`,
+                    name: spec.name,
+                  }),
+                ),
+              onSome: Effect.succeed,
+            }),
+          ),
+        )
+      },
+    )
 
     return {
       name: spec.name,
@@ -606,7 +681,7 @@ const attach = (spec: PtyAttachSpec): Effect.Effect<PtyClientSession, PtyError, 
       waitForText,
       waitForAbsent,
     } satisfies PtyClientSession
-  }).pipe(Effect.withSpan('pty-client.attach', { attributes: { 'span.label': spec.name } }))
+  })
 
 /* ───────────────────────────── layer ────────────────────────────── */
 

--- a/packages/@overeng/pty-effect/src/client.ts
+++ b/packages/@overeng/pty-effect/src/client.ts
@@ -209,9 +209,9 @@ const resolveDaemonBin = () =>
   process.env.PTY_DAEMON_BIN ??
   path.join(path.dirname(require.resolve('@myobie/pty/client')), '..', 'bin', 'pty-daemon')
 
-const getDefaultRows = () => ((process.stdout as WriteStream | undefined)?.rows ?? 24)
+const getDefaultRows = () => (process.stdout as WriteStream | undefined)?.rows ?? 24
 
-const getDefaultCols = () => ((process.stdout as WriteStream | undefined)?.columns ?? 80)
+const getDefaultCols = () => (process.stdout as WriteStream | undefined)?.columns ?? 80
 
 const buildDaemonConfig = (spec: PtyDaemonSpec) => {
   const opts = {
@@ -310,7 +310,9 @@ const spawnDaemonEffect = (spec: PtyDaemonSpec) =>
           if (earlyExit === false) return
           const details = stderrOutput.trim()
           const msg = `Daemon process exited immediately (code ${earlyExitCode ?? 'unknown'}).`
-          throw new Error(details.length > 0 ? `${msg}\n${details}` : `${msg} Is the command valid?`)
+          throw new Error(
+            details.length > 0 ? `${msg}\n${details}` : `${msg} Is the command valid?`,
+          )
         },
       }).pipe(Effect.ensuring(Effect.sync(cleanupListeners))),
     )

--- a/packages/@overeng/pty-effect/src/client.ts
+++ b/packages/@overeng/pty-effect/src/client.ts
@@ -227,62 +227,37 @@ const buildDaemonConfig = (spec: PtyDaemonSpec) => {
   return opts
 }
 
+const socketNotReady = Symbol('socketNotReady')
+
+const isSocketNotReadyError = (cause: unknown) =>
+  Predicate.hasProperty(cause, 'code') === true &&
+  (cause as { readonly code?: unknown }).code === 'ENOENT'
+
 const waitForSocket = (opts: {
   readonly name: string
-  readonly signal: AbortSignal
   readonly timeoutMs: number
   readonly earlyCheck?: () => void
 }) =>
-  new Promise<void>((resolve, reject) => {
-    const start = Date.now()
-    let pollTimer: NodeJS.Timeout | undefined
-    let settleTimer: NodeJS.Timeout | undefined
-    let settled = false
+  Effect.try({
+    try: () => {
+      opts.earlyCheck?.()
+      fs.statSync(getSocketPath(opts.name))
+    },
+    catch: (cause) => (isSocketNotReadyError(cause) === true ? socketNotReady : cause),
+  }).pipe(
+    Effect.retry({
+      while: (cause) => cause === socketNotReady,
+      schedule: Schedule.spaced('50 millis'),
+    }),
+    Effect.timeoutFail({
+      duration: `${opts.timeoutMs} millis`,
+      onTimeout: () => new Error(`Timeout waiting for session "${opts.name}" to start`),
+    }),
+    Effect.andThen(Effect.sleep('100 millis')),
+  )
 
-    const finish = (effect: () => void) => {
-      if (settled === true) return
-      settled = true
-      if (pollTimer !== undefined) clearTimeout(pollTimer)
-      if (settleTimer !== undefined) clearTimeout(settleTimer)
-      opts.signal.removeEventListener('abort', onAbort)
-      effect()
-    }
-
-    const onAbort = () => finish(() => reject(opts.signal.reason))
-
-    const check = () => {
-      try {
-        opts.earlyCheck?.()
-      } catch (cause) {
-        finish(() => reject(cause))
-        return
-      }
-
-      if (Date.now() - start > opts.timeoutMs) {
-        finish(() => reject(new Error(`Timeout waiting for session "${opts.name}" to start`)))
-        return
-      }
-
-      try {
-        fs.statSync(getSocketPath(opts.name))
-        settleTimer = setTimeout(() => finish(resolve), 100)
-        return
-      } catch {
-        pollTimer = setTimeout(check, 50)
-      }
-    }
-
-    if (opts.signal.aborted === true) {
-      onAbort()
-      return
-    }
-
-    opts.signal.addEventListener('abort', onAbort, { once: true })
-    check()
-  })
-
-const spawnDaemonPromise = (spec: PtyDaemonSpec, signal: AbortSignal) =>
-  new Promise<void>((resolve, reject) => {
+const spawnDaemonEffect = (spec: PtyDaemonSpec) =>
+  Effect.async<void, unknown>((resume, signal) => {
     const child = spawnChild(resolveDaemonBin(), [], {
       detached: true,
       stdio: ['ignore', 'ignore', 'pipe'],
@@ -296,16 +271,6 @@ const spawnDaemonPromise = (spec: PtyDaemonSpec, signal: AbortSignal) =>
     let stderrOutput = ''
     let earlyExit = false
     let earlyExitCode: number | null = null
-    let settled = false
-
-    const finish = (effect: () => void) => {
-      if (settled === true) return
-      settled = true
-      signal.removeEventListener('abort', onAbort)
-      child.removeListener('exit', onExit)
-      child.stderr?.removeListener('data', onStderr)
-      effect()
-    }
 
     const onStderr = (data: Buffer) => {
       stderrOutput += data.toString()
@@ -316,18 +281,19 @@ const spawnDaemonPromise = (spec: PtyDaemonSpec, signal: AbortSignal) =>
       earlyExitCode = code
     }
 
+    const cleanupListeners = () => {
+      signal.removeEventListener('abort', onAbort)
+      child.removeListener('exit', onExit)
+      child.stderr?.removeListener('data', onStderr)
+    }
+
     const onAbort = () => {
+      cleanupListeners()
       try {
         child.kill('SIGTERM')
       } catch {
         // best effort: detached daemon might already be gone
       }
-    }
-
-    if (signal.aborted === true) {
-      onAbort()
-      finish(() => reject(signal.reason))
-      return
     }
 
     child.stderr?.on('data', onStderr)
@@ -336,48 +302,50 @@ const spawnDaemonPromise = (spec: PtyDaemonSpec, signal: AbortSignal) =>
     child.unref()
     signal.addEventListener('abort', onAbort, { once: true })
 
-    waitForSocket({
-      name: spec.name,
-      signal,
-      timeoutMs: 3_000,
-      earlyCheck: () => {
-        if (earlyExit === false) return
-        const details = stderrOutput.trim()
-        const msg = `Daemon process exited immediately (code ${earlyExitCode ?? 'unknown'}).`
-        throw new Error(details.length > 0 ? `${msg}\n${details}` : `${msg} Is the command valid?`)
-      },
-    }).then(
-      () => finish(resolve),
-      (cause) => finish(() => reject(cause)),
+    resume(
+      waitForSocket({
+        name: spec.name,
+        timeoutMs: 3_000,
+        earlyCheck: () => {
+          if (earlyExit === false) return
+          const details = stderrOutput.trim()
+          const msg = `Daemon process exited immediately (code ${earlyExitCode ?? 'unknown'}).`
+          throw new Error(details.length > 0 ? `${msg}\n${details}` : `${msg} Is the command valid?`)
+        },
+      }).pipe(Effect.ensuring(Effect.sync(cleanupListeners))),
     )
+
+    return Effect.sync(onAbort)
   })
 
-const connectSessionConnection = (opts: {
-  readonly conn: SessionConnection
-  readonly signal: AbortSignal
-}) =>
-  new Promise<string>((resolve, reject) => {
+const connectSessionConnection = (conn: SessionConnection) =>
+  Effect.async<string, unknown>((resume, signal) => {
     const onAbort = () => {
-      opts.conn.disconnect()
-      reject(opts.signal.reason)
+      conn.disconnect()
     }
 
-    if (opts.signal.aborted === true) {
+    if (signal.aborted === true) {
       onAbort()
+      resume(Effect.fail(signal.reason))
       return
     }
 
-    opts.signal.addEventListener('abort', onAbort, { once: true })
-    opts.conn.connect().then(
+    signal.addEventListener('abort', onAbort, { once: true })
+    conn.connect().then(
       (screen) => {
-        opts.signal.removeEventListener('abort', onAbort)
-        resolve(screen)
+        signal.removeEventListener('abort', onAbort)
+        resume(Effect.succeed(screen))
       },
       (cause) => {
-        opts.signal.removeEventListener('abort', onAbort)
-        reject(cause)
+        signal.removeEventListener('abort', onAbort)
+        resume(Effect.fail(cause))
       },
     )
+
+    return Effect.sync(() => {
+      signal.removeEventListener('abort', onAbort)
+      onAbort()
+    })
   })
 
 /** Regex matching helper — clones RegExp to avoid stateful `lastIndex`. */
@@ -412,12 +380,17 @@ const validateNameOrFail = (name: string) =>
 const spawnDaemon = (spec: PtyDaemonSpec): Effect.Effect<void, PtyError> =>
   Effect.gen(function* () {
     yield* validateNameOrFail(spec.name)
-    yield* wrapPromise({
-      method: 'spawnDaemon',
-      reason: 'SpawnFailed',
-      name: spec.name,
-      thunk: (signal) => spawnDaemonPromise(spec, signal),
-    })
+    yield* spawnDaemonEffect(spec).pipe(
+      Effect.mapError(
+        (cause) =>
+          new PtyError({
+            reason: 'SpawnFailed',
+            method: 'spawnDaemon',
+            name: spec.name,
+            cause,
+          }),
+      ),
+    )
   }).pipe(Effect.withSpan('pty-client.spawnDaemon', { attributes: { 'span.label': spec.name } }))
 
 const peek = (input: { readonly name: PtyName; readonly plain?: boolean }) =>
@@ -526,12 +499,17 @@ const attach = (spec: PtyAttachSpec): Effect.Effect<PtyClientSession, PtyError, 
     })
 
     const initialScreen = yield* Effect.acquireReleaseInterruptible(
-      wrapPromise({
-        method: 'attach.connect',
-        reason: 'ConnectFailed',
-        name: spec.name,
-        thunk: (signal) => connectSessionConnection({ conn, signal }),
-      }),
+      connectSessionConnection(conn).pipe(
+        Effect.mapError(
+          (cause) =>
+            new PtyError({
+              reason: 'ConnectFailed',
+              method: 'attach.connect',
+              name: spec.name,
+              cause,
+            }),
+        ),
+      ),
       () => Effect.sync(() => conn.disconnect()),
     )
 

--- a/packages/@overeng/pty-effect/src/client.unit.test.ts
+++ b/packages/@overeng/pty-effect/src/client.unit.test.ts
@@ -1,0 +1,114 @@
+import { EventEmitter } from 'node:events'
+
+import { Effect, Exit, Fiber } from 'effect'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('PtyClient interruption', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unmock('@myobie/pty/client')
+    vi.unmock('node:child_process')
+  })
+
+  it('kills a pending daemon spawn on interruption without mutating process.env', async () => {
+    const stderr = Object.assign(new EventEmitter(), { unref: vi.fn() })
+    const child = Object.assign(new EventEmitter(), {
+      stderr,
+      kill: vi.fn(),
+      unref: vi.fn(),
+      pid: 123,
+    })
+    const spawn = vi.fn(() => child)
+
+    vi.doMock('node:child_process', () => ({ spawn }))
+    vi.doMock('@myobie/pty/client', () => ({
+      SessionConnection: class extends EventEmitter {},
+      getSocketPath: vi.fn(() => '/definitely-missing-socket'),
+      listSessions: vi.fn(async () => []),
+      peekScreen: vi.fn(),
+      validateName: vi.fn(),
+    }))
+
+    const { PtyClient, layer } = await import('./client.ts')
+    const previous = process.env.PTY_EFFECT_TEST_VALUE
+
+    try {
+      delete process.env.PTY_EFFECT_TEST_VALUE
+
+      const exit = await Effect.runPromise(
+        Effect.gen(function* () {
+          const client = yield* PtyClient
+          return yield* client.spawnDaemon({
+            name: 'unit-spawn' as never,
+            command: 'sh',
+            args: ['-c', 'sleep 30'],
+            env: { PTY_EFFECT_TEST_VALUE: 'from-test' },
+          })
+        }).pipe(Effect.provide(layer), Effect.timeout('50 millis'), Effect.exit),
+      )
+
+      expect(Exit.isFailure(exit)).toBe(true)
+      expect(spawn).toHaveBeenCalledTimes(1)
+      const spawnCalls = spawn.mock.calls as unknown as Array<
+        readonly [string, ReadonlyArray<string>, { readonly env?: Record<string, string> }]
+      >
+      expect(spawnCalls[0]?.[2].env?.PTY_EFFECT_TEST_VALUE).toBe('from-test')
+      expect(child.kill).toHaveBeenCalledWith('SIGTERM')
+      expect(process.env.PTY_EFFECT_TEST_VALUE).toBeUndefined()
+    } finally {
+      if (previous === undefined) delete process.env.PTY_EFFECT_TEST_VALUE
+      else process.env.PTY_EFFECT_TEST_VALUE = previous
+    }
+  })
+
+  it('disconnects a pending attach when interrupted', async () => {
+    const disconnect = vi.fn()
+
+    class MockSessionConnection extends EventEmitter {
+      readonly connect = vi.fn(() => new Promise<string>(() => {}))
+      readonly disconnect = disconnect
+      readonly write = vi.fn()
+      readonly press = vi.fn()
+      readonly resize = vi.fn()
+
+      constructor(_: unknown) {
+        super()
+      }
+    }
+
+    vi.doMock('@myobie/pty/client', () => ({
+      SessionConnection: MockSessionConnection,
+      getSocketPath: vi.fn(),
+      listSessions: vi.fn(async () => []),
+      peekScreen: vi.fn(),
+      validateName: vi.fn(),
+    }))
+
+    const { PtyClient, layer } = await import('./client.ts')
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const fiber = yield* Effect.fork(
+          Effect.scoped(
+            Effect.gen(function* () {
+              const client = yield* PtyClient
+              return yield* client.attach({
+                name: 'unit-attach' as never,
+                size: { rows: 24, cols: 80 },
+              })
+            }).pipe(Effect.provide(layer)),
+          ),
+        )
+
+        yield* Effect.sleep('50 millis')
+        yield* Fiber.interrupt(fiber)
+      }),
+    )
+
+    expect(disconnect).toHaveBeenCalled()
+  })
+})

--- a/packages/@overeng/pty-effect/src/client.unit.test.ts
+++ b/packages/@overeng/pty-effect/src/client.unit.test.ts
@@ -65,6 +65,52 @@ describe('PtyClient interruption', () => {
     }
   })
 
+  it('fails fast when the daemon exits before creating its socket', async () => {
+    const stderr = Object.assign(new EventEmitter(), { unref: vi.fn() })
+    const child = Object.assign(new EventEmitter(), {
+      stderr,
+      kill: vi.fn(),
+      unref: vi.fn(),
+      pid: 123,
+    })
+    const spawn = vi.fn(() => {
+      queueMicrotask(() => {
+        stderr.emit('data', Buffer.from('daemon boot failed'))
+        child.emit('exit', 127)
+      })
+      return child
+    })
+
+    vi.doMock('node:child_process', () => ({ spawn }))
+    vi.doMock('@myobie/pty/client', () => ({
+      SessionConnection: class extends EventEmitter {},
+      getSocketPath: vi.fn(() => '/definitely-missing-socket'),
+      listSessions: vi.fn(async () => []),
+      peekScreen: vi.fn(),
+      validateName: vi.fn(),
+    }))
+
+    const { PtyClient, layer } = await import('./client.ts')
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const client = yield* PtyClient
+        return yield* client.spawnDaemon({
+          name: 'unit-early-exit' as never,
+          command: 'sh',
+          args: ['-c', 'exit 127'],
+        })
+      }).pipe(Effect.provide(layer), Effect.either),
+    )
+
+    expect(result._tag).toBe('Left')
+    if (result._tag === 'Left') {
+      expect(result.left.reason).toBe('SpawnFailed')
+      expect(result.left.message).toContain('Daemon process exited immediately')
+      expect(result.left.message).toContain('daemon boot failed')
+    }
+  })
+
   it('disconnects a pending attach when interrupted', async () => {
     const disconnect = vi.fn()
 


### PR DESCRIPTION
Closes #566

## Summary
- stop mutating parent `process.env` around daemon startup and pass env overrides to the daemon per call
- make pending `attach` acquisition interruptible with `Effect.acquireReleaseInterruptible` and `AbortSignal`-aware promise wrappers
- add live env-forwarding coverage plus interruption/shutdown tests for pending spawn and attach paths

## Root Cause
The public repro in #566 starves because env mutation was serialized through a global promise chain. This checkout no longer had that exact queue, but it still relied on parent `process.env` mutation around daemon startup, which is the same non-composable abstraction.

The fix moves env handling to the child-process boundary and uses Effect-native interruption for pending resource acquisition.

## Verification
- `pnpm exec vitest run --config vitest.config.ts`
- `pnpm exec tsc -p tsconfig.json --noEmit`
- `pnpm exec oxlint src`