### PR TITLE
feat(nix): auto-generate shell completions in CLI builders

### DIFF
--- a/nix/workspace-tools/lib/mk-bun-cli.nix
+++ b/nix/workspace-tools/lib/mk-bun-cli.nix
@@ -286,6 +286,14 @@ pkgs.stdenv.mkDerivation {
     mkdir -p "$out/bin"
     cp ".bun-build/${binaryName}" "$out/bin/${binaryName}"
 
+    # Generate shell completions (Effect CLI built-in support)
+    mkdir -p "$out/share/fish/vendor_completions.d"
+    mkdir -p "$out/share/bash-completion/completions"
+    mkdir -p "$out/share/zsh/site-functions"
+    $out/bin/${binaryName} --log-level none --completions fish > "$out/share/fish/vendor_completions.d/${binaryName}.fish" || true
+    $out/bin/${binaryName} --log-level none --completions bash > "$out/share/bash-completion/completions/${binaryName}" || true
+    $out/bin/${binaryName} --log-level none --completions zsh > "$out/share/zsh/site-functions/_${binaryName}" || true
+
     runHook postInstall
   '';
 }

--- a/nix/workspace-tools/lib/mk-pnpm-cli.nix
+++ b/nix/workspace-tools/lib/mk-pnpm-cli.nix
@@ -926,6 +926,14 @@ pkgs.stdenv.mkDerivation {
     installedBytes=$(du --apparent-size -sk "$out/bin/${binaryName}" 2>/dev/null | awk '{print $1 * 1024}')
     installedBytes=''${installedBytes:-0}
     echo "cli-build: phase=install cli=${binaryName} package=${packageDir} duration=$(install_timer_elapsed "$installStartedAt")s installed_size=$(install_format_bytes "$installedBytes")"
+
+    # Generate shell completions (Effect CLI built-in support)
+    mkdir -p "$out/share/fish/vendor_completions.d"
+    mkdir -p "$out/share/bash-completion/completions"
+    mkdir -p "$out/share/zsh/site-functions"
+    $out/bin/${binaryName} --log-level none --completions fish > "$out/share/fish/vendor_completions.d/${binaryName}.fish" || true
+    $out/bin/${binaryName} --log-level none --completions bash > "$out/share/bash-completion/completions/${binaryName}" || true
+    $out/bin/${binaryName} --log-level none --completions zsh > "$out/share/zsh/site-functions/_${binaryName}" || true
     runHook postInstall
   '';
 }

--- a/nix/workspace-tools/lib/mk-pnpm-cli/tests/run.sh
+++ b/nix/workspace-tools/lib/mk-pnpm-cli/tests/run.sh
@@ -141,6 +141,8 @@ build_and_smoke() {
 
   echo "Smoke: $bin_name --help"
   "$out/bin/$bin_name" --help >/dev/null
+
+  check_completions "$out" "$bin_name"
 }
 
 prepare_downstream_workspace() {
@@ -164,8 +166,29 @@ prepare_downstream_workspace() {
   copy_repo "$ROOT" "$WORKSPACE_REAL/repos/effect-utils"
 }
 
+check_completions() {
+  local out="$1"
+  local bin_name="$2"
+
+  echo "Check: $bin_name shell completions"
+  local fish_file="$out/share/fish/vendor_completions.d/${bin_name}.fish"
+  local bash_file="$out/share/bash-completion/completions/${bin_name}"
+  local zsh_file="$out/share/zsh/site-functions/_${bin_name}"
+  for f in "$fish_file" "$bash_file" "$zsh_file"; do
+    if [ ! -f "$f" ] && [ ! -L "$f" ]; then
+      echo "error: missing completion file: $f" >&2
+      exit 1
+    fi
+    if [ ! -s "$f" ]; then
+      echo "error: empty completion file: $f" >&2
+      exit 1
+    fi
+  done
+}
+
 run_downstream_regression() {
   local attr="$1"
+  local bin_name="${2:-}"
   local start
   start="$(date +%s)"
 
@@ -175,9 +198,14 @@ run_downstream_regression() {
     "path:$DOWNSTREAM_DIR#packages.$SYSTEM.$attr"
 
   echo "Build: downstream $attr (composed repos/effect-utils path)"
-  nix build --no-link --no-write-lock-file \
+  local out
+  out="$(nix build --no-link --no-write-lock-file --print-out-paths \
     --override-input effect-utils "path:$WORKSPACE_REAL/repos/effect-utils" \
-    "path:$DOWNSTREAM_DIR#packages.$SYSTEM.$attr"
+    "path:$DOWNSTREAM_DIR#packages.$SYSTEM.$attr")"
+
+  if [ -n "$bin_name" ]; then
+    check_completions "$out" "$bin_name"
+  fi
 
   if [ "$SKIP_DEVENV_SHELL" -eq 0 ]; then
     echo "Devenv: downstream shell with composed repos/effect-utils path"
@@ -231,9 +259,9 @@ fi
 if [ "$SKIP_DOWNSTREAM" -eq 0 ]; then
   prepare_downstream_workspace
   run_downstream_pure_eval_regression
-  run_downstream_regression "genie"
+  run_downstream_regression "genie" "genie"
   if [ "$SKIP_DOWNSTREAM_MEGAREPO" -eq 0 ]; then
-    run_downstream_regression "megarepo"
+    run_downstream_regression "megarepo" "mr"
   fi
   if [ "$SKIP_OXLINT" -eq 0 ]; then
     run_downstream_regression "oxlint-npm"

--- a/packages/@overeng/genie/nix/build.nix
+++ b/packages/@overeng/genie/nix/build.nix
@@ -43,4 +43,12 @@ pkgs.runCommand "genie"
     makeWrapper ${unwrapped}/bin/genie $out/bin/genie \
       --suffix PATH : ${pkgs.oxfmt}/bin \
       --set GENIE_ACTIONLINT_BIN ${pkgs.actionlint}/bin/actionlint
+
+    # Propagate shell completions from the unwrapped derivation
+    for dir in share/fish/vendor_completions.d share/bash-completion/completions share/zsh/site-functions; do
+      if [ -d "${unwrapped}/$dir" ]; then
+        mkdir -p "$out/$dir"
+        ln -s "${unwrapped}/$dir"/* "$out/$dir/"
+      fi
+    done
   ''


### PR DESCRIPTION
## Summary

- **mkPnpmCli** and **mkBunCli** now generate fish/bash/zsh completions automatically during `installPhase` using Effect CLI's built-in `--completions` flag
- Genie's wrapper derivation propagates completions from the unwrapped derivation via symlinks
- `|| true` ensures non-Effect CLIs built with these builders don't fail

## Rationale

Every Effect CLI in dotfiles was manually wiring up completions via `.overrideAttrs` postInstall hooks (janitor-cli, service-hub, op-proxy, oi). This was boilerplate that each new CLI had to remember to add. By baking it into the builders, all CLIs get completions for free.

This also enables completions for CLIs that were missing them entirely (gh-ci-utils, otel-cli, mcporter, etc.).

## Downstream cleanup

Once this lands and dotfiles updates its effect-utils pin, the following `.overrideAttrs` completion hooks can be removed:
- `flakes/janitor-cli/flake.nix` (fish/bash/zsh completions)
- `flakes/service-hub/nix/build.nix` (fish completions)
- `flakes/op-proxy/nix/build.nix` (fish completions)
- `flakes/oi/nix/build.nix` (fish/bash/zsh completions)
- `lib/builders.nix` mr CLI (fish/bash/zsh completions)

## Test plan

- [x] Built genie-unwrapped — verified fish/bash/zsh completion files generated in `$out/share/`
- [x] Built genie wrapper — verified completions propagated via symlinks
- [x] Confirmed completion content is valid (fish `complete` commands, bash/zsh functions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)