### PR TITLE
feat(genie): add packages option to netlifyStorybookCommentStep

### DIFF
--- a/genie/ci-workflow.ts
+++ b/genie/ci-workflow.ts
@@ -1001,10 +1001,43 @@ export const netlifyDeployStep = () => buildNetlifyDeployStep(runDevenvTasksBefo
 
 /**
  * Combined deploy comment step for Netlify storybook previews.
- * Discovers deployed storybooks by scanning for `storybook-static` build output
- * under `packages/@overeng/` and generates PR comments + job summaries with URLs.
  *
- * @param site - Netlify site name (e.g. 'overeng-utils')
+ * When `packages` is provided, constructs preview URLs directly from the known package list.
+ * This works regardless of whether the deploy task emits metadata markers, making it suitable
+ * for repos that pin an older effect-utils version for Nix while using the latest for genie.
+ *
+ * When omitted, uses the metadata-based approach that reads deploy output from the deploy step.
+ *
+ * The `packages` shape matches the Nix `taskModules.netlify` / `taskModules.storybook` config:
+ * `{ path: "flakes/oi", name: "flakes-oi" }` where `name` is the Netlify deploy alias.
  */
-export const netlifyStorybookCommentStep = (site: string) =>
-  buildNetlifyStorybookCommentStep(site, deployModeScript)
+export const netlifyStorybookCommentStep = (
+  site: string,
+  opts?: { packages?: ReadonlyArray<{ path: string; name: string }> },
+) => {
+  if (!opts?.packages) {
+    return buildNetlifyStorybookCommentStep(site, deployModeScript)
+  }
+
+  return deployCommentStep({
+    summaryTitle: 'Storybook Previews',
+    tableHeaders: ['Package', 'URL'],
+    noRowsMessage: 'No storybooks were deployed.',
+    modeScript: [
+      `site="${site}"`,
+      deployModeScript,
+      '# Set Netlify branch-deploy suffix based on mode',
+      'if [ "$label" = "prod" ]; then suffix=""; else suffix="-pr-${{ github.event.pull_request.number }}"; fi',
+    ].join('\n'),
+    rowsScript: [
+      'rows=""',
+      ...opts.packages.map((pkg) =>
+        [
+          `if [ -d "${pkg.path}/storybook-static" ]; then`,
+          `  rows="\${rows}| ${pkg.name} | https://${pkg.name}\${suffix}--\${site}.netlify.app |\\n"`,
+          'fi',
+        ].join('\n'),
+      ),
+    ].join('\n'),
+  })
+}


### PR DESCRIPTION
## Summary

- Add optional `packages` parameter to `netlifyStorybookCommentStep`
- When provided, constructs preview URLs from known `{ path, name }` pairs using `deployCommentStep`
- When omitted, uses existing metadata-based `buildNetlifyStorybookCommentStep` (backward compatible)

## Rationale

Repos like dotfiles store storybooks at `flakes/*/storybook-static` with aliases like `flakes-oi`, which doesn't match the `packages/@overeng/*` glob. The metadata-based approach (from the deploy step) requires the Nix `netlify.nix` module to emit `NETLIFY_DEPLOY_METADATA` markers, but dotfiles still pins an older effect-utils version for Nix that doesn't have this feature.

Accepting an explicit packages list bypasses both the glob and the metadata pipeline, working correctly regardless of the flake-pinned effect-utils version.

The `{ path, name }` shape matches `taskModules.netlify` / `taskModules.storybook` conventions.

## Test plan

- [ ] effect-utils CI passes (existing callers unchanged)
- [ ] dotfiles adopts with `packages` option, PR comment appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)