### PR TITLE
fix(nix): restore lockfile synthesis for composed workspace closures

### DIFF
--- a/nix/workspace-tools/lib/mk-pnpm-deps.nix
+++ b/nix/workspace-tools/lib/mk-pnpm-deps.nix
@@ -288,9 +288,12 @@ in
                   installStartedAt=$(timer_now)
                   (
                     cd "$install_root"
-                    # Keep the legacy wrapper invocation literal in-source so downstream
-                    # contract checks can verify the install mode by string match:
-                    # pnpm install --frozen-lockfile --ignore-scripts
+                    # Filtered staged workspaces can differ from the repo's
+                    # committed workspace graph. Refresh the lockfile inside the
+                    # staged tree first so pnpm validates against the exact
+                    # install root we are about to materialize, then enforce
+                    # that synthesized lockfile with a frozen install.
+                    node "$PNPM_MJS" install --lockfile-only --ignore-scripts
                     node "$PNPM_MJS" install --frozen-lockfile --ignore-scripts
                   )
                   log_prep_phase "install" "install_root=$install_root duration=$(timer_elapsed "$installStartedAt")s"


### PR DESCRIPTION
## Summary

- Restores the `pnpm install --lockfile-only --ignore-scripts` pre-step before `--frozen-lockfile` in the pnpm deps FOD builder
- This was originally added in 043132f40 but removed in 0bbcf3fec

## Rationale

The staged workspace lists external packages (e.g. `repos/effect-utils/packages/@overeng/tui-core`) as workspace members in the root `pnpm-workspace.yaml` (needed since 043132f40 to avoid zero-byte placeholders). But the downstream lockfile doesn't have importer entries for these packages. The `--lockfile-only` step synthesizes the missing entries before `--frozen-lockfile` enforces them.

Without this, all downstream consumers (dotfiles CLIs) fail with `ERR_PNPM_OUTDATED_LOCKFILE` when bumping the effect-utils pin.

## Test plan

- [x] Built dotfiles gh-ci-utils with `--override-input` — progresses past lockfile error to normal hash mismatch (expected, needs hash refresh)

🤖 Generated with [Claude Code](https://claude.com/claude-code)