### PR TITLE
fix(nix): restore deterministic lockfile pruning for composed workspaces

### DIFF
--- a/nix/workspace-tools/lib/mk-pnpm-deps.nix
+++ b/nix/workspace-tools/lib/mk-pnpm-deps.nix
@@ -36,6 +36,56 @@ let
   lib = pkgs.lib;
   pnpmPlatform = import ./pnpm-platform.nix;
   preparedWorkspacePlaceholder = "/__pnpm_prepared_workspace__";
+  pruneLockfileScript = pkgs.writeText "prune-lockfile.cjs" ''
+    const fs = require("fs");
+    const path = require("path");
+
+    const lockfilePath = "pnpm-lock.yaml";
+    const content = fs.readFileSync(lockfilePath, "utf8");
+    const lines = content.split("\n");
+    const output = [];
+    let inImporters = false;
+    let skipEntry = false;
+    let importerIndent = -1;
+
+    for (const line of lines) {
+      const trimmed = line.trimStart();
+      const indent = line.length - trimmed.length;
+
+      if (!inImporters) {
+        if (trimmed === "importers:") {
+          inImporters = true;
+          importerIndent = indent;
+        }
+        output.push(line);
+        continue;
+      }
+
+      if (trimmed.length === 0) {
+        if (!skipEntry) output.push(line);
+        continue;
+      }
+
+      if (indent <= importerIndent) {
+        inImporters = false;
+        skipEntry = false;
+        output.push(line);
+        continue;
+      }
+
+      if (indent === importerIndent + 2 && trimmed.endsWith(":")) {
+        const key = trimmed.slice(0, -1).replace(/^['"]|['"]$/g, "");
+        const dir = key === "." ? "." : key;
+        skipEntry = !fs.existsSync(path.join(dir, "package.json"));
+      }
+
+      if (!skipEntry) {
+        output.push(line);
+      }
+    }
+
+    fs.writeFileSync(lockfilePath, output.join("\n"));
+  '';
   nixClosureBytesScript = pkgs.writeText "nix-closure-bytes.cjs" ''
     const fs = require("fs");
     const raw = fs.readFileSync(0, "utf8");
@@ -288,9 +338,13 @@ in
                   installStartedAt=$(timer_now)
                   (
                     cd "$install_root"
-                    # Keep the legacy wrapper invocation literal in-source so downstream
-                    # contract checks can verify the install mode by string match:
-                    # pnpm install --frozen-lockfile --ignore-scripts
+
+                    # Prune lockfile importers that don't exist in the staged workspace.
+                    # The downstream lockfile may contain importers for packages outside
+                    # this workspace closure. Removing them keeps --frozen-lockfile happy
+                    # without needing --lockfile-only (which contacts the registry).
+                    node ${pruneLockfileScript}
+
                     node "$PNPM_MJS" install --frozen-lockfile --ignore-scripts
                   )
                   log_prep_phase "install" "install_root=$install_root duration=$(timer_elapsed "$installStartedAt")s"


### PR DESCRIPTION
## Summary

Restores the lockfile pruning approach from 294e2d05a that was lost during subsequent refactors. Before `--frozen-lockfile`, prunes importers whose `package.json` doesn't exist in the staged workspace.

## Rationale

Since 043132f40, the staged workspace lists all workspace closure members in `pnpm-workspace.yaml`. The downstream lockfile may have extra importers for packages outside this specific closure. Without pruning, `--frozen-lockfile` fails.

The previous fix (#570, `--lockfile-only`) was non-deterministic because it contacts the registry. This pruning approach is:
- **Pure** — no registry access, no network
- **Deterministic** — same lockfile + same workspace = same result
- **Satisfies R05** — FOD purity requirement

## Downstream requirement

The downstream lockfile must include importers for all composed workspace members. Since pnpm skips importers for symlinked packages (megarepo), the lockfile must be generated with dereferenced paths during hash refresh.

## Test plan

- [ ] Build dotfiles CLIs with `--override-input` pointing here
- [ ] Verify FOD hashes are stable across rebuilds

🤖 Generated with [Claude Code](https://claude.com/claude-code)