### PR TITLE
feat(genie): support expressions in workflow boolean/number fields

### DIFF
--- a/.github/workflows/auto-review.yml
+++ b/.github/workflows/auto-review.yml
@@ -17,5 +17,5 @@ jobs:
     steps:
       - name: Request review from schickling
         env:
-          GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: 'nix shell nixpkgs#gh --command gh pr edit ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --add-reviewer schickling'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     env:
       FORCE_SETUP: '1'
       CI: 'true'
-      GITHUB_TOKEN: '${{ github.token }}'
+      GITHUB_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v6
       - name: Install Nix
@@ -47,7 +47,7 @@ jobs:
         uses: cachix/cachix-action@v17
         with:
           name: overeng-effect-utils
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -172,7 +172,7 @@ jobs:
           fi
           rm -f "$entriesJson"
       - name: Force diagnostics failure (debug)
-        if: "${{ github.event_name == 'workflow_dispatch' && (inputs.debug_force_nix_diagnostics_failure == true || inputs.debug_force_nix_diagnostics_failure == 'true') }}"
+        if: ${{ github.event_name == 'workflow_dispatch' && (inputs.debug_force_nix_diagnostics_failure == true || inputs.debug_force_nix_diagnostics_failure == 'true') }}
         shell: bash
         run: |
           diag_dir="${NIX_STORE_DIAGNOSTICS_DIR:-${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-missing}"
@@ -295,7 +295,7 @@ jobs:
           rm -f "$__nix_gc_retry_helper"
           run_nix_gc_race_retry 'devenv tasks run ts:check:strict --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run ts:check:strict --mode before'
       - name: Save pnpm state
-        if: "${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}"
+        if: ${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4
         with:
           path: |
@@ -343,7 +343,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: 'nix-store-diagnostics-${{ github.job }}-${{ runner.os }}-run-${{ github.run_id }}-attempt-${{ github.run_attempt }}'
-          path: '${{ env.NIX_STORE_DIAGNOSTICS_DIR }}'
+          path: ${{ env.NIX_STORE_DIAGNOSTICS_DIR }}
           if-no-files-found: ignore
           retention-days: 14
       - name: Failure note
@@ -361,7 +361,7 @@ jobs:
     env:
       FORCE_SETUP: '1'
       CI: 'true'
-      GITHUB_TOKEN: '${{ github.token }}'
+      GITHUB_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v6
       - name: Install Nix
@@ -378,7 +378,7 @@ jobs:
         uses: cachix/cachix-action@v17
         with:
           name: overeng-effect-utils
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -503,7 +503,7 @@ jobs:
           fi
           rm -f "$entriesJson"
       - name: Force diagnostics failure (debug)
-        if: "${{ github.event_name == 'workflow_dispatch' && (inputs.debug_force_nix_diagnostics_failure == true || inputs.debug_force_nix_diagnostics_failure == 'true') }}"
+        if: ${{ github.event_name == 'workflow_dispatch' && (inputs.debug_force_nix_diagnostics_failure == true || inputs.debug_force_nix_diagnostics_failure == 'true') }}
         shell: bash
         run: |
           diag_dir="${NIX_STORE_DIAGNOSTICS_DIR:-${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-missing}"
@@ -626,7 +626,7 @@ jobs:
           rm -f "$__nix_gc_retry_helper"
           run_nix_gc_race_retry 'devenv tasks run lint:check --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run lint:check --mode before'
       - name: Save pnpm state
-        if: "${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}"
+        if: ${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4
         with:
           path: |
@@ -674,7 +674,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: 'nix-store-diagnostics-${{ github.job }}-${{ runner.os }}-run-${{ github.run_id }}-attempt-${{ github.run_attempt }}'
-          path: '${{ env.NIX_STORE_DIAGNOSTICS_DIR }}'
+          path: ${{ env.NIX_STORE_DIAGNOSTICS_DIR }}
           if-no-files-found: ignore
           retention-days: 14
       - name: Failure note
@@ -695,7 +695,7 @@ jobs:
     env:
       FORCE_SETUP: '1'
       CI: 'true'
-      GITHUB_TOKEN: '${{ github.token }}'
+      GITHUB_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v6
       - name: Install Nix
@@ -712,7 +712,7 @@ jobs:
         uses: cachix/cachix-action@v17
         with:
           name: overeng-effect-utils
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -837,7 +837,7 @@ jobs:
           fi
           rm -f "$entriesJson"
       - name: Force diagnostics failure (debug)
-        if: "${{ github.event_name == 'workflow_dispatch' && (inputs.debug_force_nix_diagnostics_failure == true || inputs.debug_force_nix_diagnostics_failure == 'true') }}"
+        if: ${{ github.event_name == 'workflow_dispatch' && (inputs.debug_force_nix_diagnostics_failure == true || inputs.debug_force_nix_diagnostics_failure == 'true') }}
         shell: bash
         run: |
           diag_dir="${NIX_STORE_DIAGNOSTICS_DIR:-${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-missing}"
@@ -960,7 +960,7 @@ jobs:
           rm -f "$__nix_gc_retry_helper"
           run_nix_gc_race_retry 'devenv tasks run test:run --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run test:run --mode before'
       - name: Save pnpm state
-        if: "${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}"
+        if: ${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4
         with:
           path: |
@@ -1008,7 +1008,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: 'nix-store-diagnostics-${{ github.job }}-${{ runner.os }}-run-${{ github.run_id }}-attempt-${{ github.run_attempt }}'
-          path: '${{ env.NIX_STORE_DIAGNOSTICS_DIR }}'
+          path: ${{ env.NIX_STORE_DIAGNOSTICS_DIR }}
           if-no-files-found: ignore
           retention-days: 14
       - name: Failure note
@@ -1029,7 +1029,7 @@ jobs:
     env:
       FORCE_SETUP: '1'
       CI: 'true'
-      GITHUB_TOKEN: '${{ github.token }}'
+      GITHUB_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v6
       - name: Install Nix
@@ -1046,7 +1046,7 @@ jobs:
         uses: cachix/cachix-action@v17
         with:
           name: overeng-effect-utils
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -1171,7 +1171,7 @@ jobs:
           fi
           rm -f "$entriesJson"
       - name: Force diagnostics failure (debug)
-        if: "${{ github.event_name == 'workflow_dispatch' && (inputs.debug_force_nix_diagnostics_failure == true || inputs.debug_force_nix_diagnostics_failure == 'true') }}"
+        if: ${{ github.event_name == 'workflow_dispatch' && (inputs.debug_force_nix_diagnostics_failure == true || inputs.debug_force_nix_diagnostics_failure == 'true') }}
         shell: bash
         run: |
           diag_dir="${NIX_STORE_DIAGNOSTICS_DIR:-${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-missing}"
@@ -1294,7 +1294,7 @@ jobs:
           rm -f "$__nix_gc_retry_helper"
           run_nix_gc_race_retry 'devenv tasks run nix:check --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run nix:check --mode before'
       - name: Save pnpm state
-        if: "${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}"
+        if: ${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4
         with:
           path: |
@@ -1342,7 +1342,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: 'nix-store-diagnostics-${{ github.job }}-${{ runner.os }}-run-${{ github.run_id }}-attempt-${{ github.run_attempt }}'
-          path: '${{ env.NIX_STORE_DIAGNOSTICS_DIR }}'
+          path: ${{ env.NIX_STORE_DIAGNOSTICS_DIR }}
           if-no-files-found: ignore
           retention-days: 14
       - name: Failure note
@@ -1363,7 +1363,7 @@ jobs:
     env:
       FORCE_SETUP: '1'
       CI: 'true'
-      GITHUB_TOKEN: '${{ github.token }}'
+      GITHUB_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v6
       - name: Install Nix
@@ -1380,7 +1380,7 @@ jobs:
         uses: cachix/cachix-action@v17
         with:
           name: overeng-effect-utils
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Resolve devenv
         run: |
           if [ -z "${DEVENV_REV:-}" ]; then
@@ -1488,7 +1488,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: 'nix-store-diagnostics-${{ github.job }}-${{ runner.os }}-run-${{ github.run_id }}-attempt-${{ github.run_attempt }}'
-          path: '${{ env.NIX_STORE_DIAGNOSTICS_DIR }}'
+          path: ${{ env.NIX_STORE_DIAGNOSTICS_DIR }}
           if-no-files-found: ignore
           retention-days: 14
       - name: Failure note
@@ -1506,7 +1506,7 @@ jobs:
     env:
       FORCE_SETUP: '1'
       CI: 'true'
-      GITHUB_TOKEN: '${{ github.token }}'
+      GITHUB_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v6
       - name: Install Nix
@@ -1523,7 +1523,7 @@ jobs:
         uses: cachix/cachix-action@v17
         with:
           name: overeng-effect-utils
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -1648,7 +1648,7 @@ jobs:
           fi
           rm -f "$entriesJson"
       - name: Force diagnostics failure (debug)
-        if: "${{ github.event_name == 'workflow_dispatch' && (inputs.debug_force_nix_diagnostics_failure == true || inputs.debug_force_nix_diagnostics_failure == 'true') }}"
+        if: ${{ github.event_name == 'workflow_dispatch' && (inputs.debug_force_nix_diagnostics_failure == true || inputs.debug_force_nix_diagnostics_failure == 'true') }}
         shell: bash
         run: |
           diag_dir="${NIX_STORE_DIAGNOSTICS_DIR:-${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-missing}"
@@ -1688,7 +1688,7 @@ jobs:
             fi
           done
       - name: Save pnpm state
-        if: "${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}"
+        if: ${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4
         with:
           path: |
@@ -1736,7 +1736,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: 'nix-store-diagnostics-${{ github.job }}-${{ runner.os }}-run-${{ github.run_id }}-attempt-${{ github.run_attempt }}'
-          path: '${{ env.NIX_STORE_DIAGNOSTICS_DIR }}'
+          path: ${{ env.NIX_STORE_DIAGNOSTICS_DIR }}
           if-no-files-found: ignore
           retention-days: 14
       - name: Failure note
@@ -1754,7 +1754,7 @@ jobs:
     env:
       FORCE_SETUP: '1'
       CI: 'true'
-      GITHUB_TOKEN: '${{ github.token }}'
+      GITHUB_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v6
       - name: Install Nix
@@ -1771,7 +1771,7 @@ jobs:
         uses: cachix/cachix-action@v17
         with:
           name: overeng-effect-utils
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -1896,7 +1896,7 @@ jobs:
           fi
           rm -f "$entriesJson"
       - name: Force diagnostics failure (debug)
-        if: "${{ github.event_name == 'workflow_dispatch' && (inputs.debug_force_nix_diagnostics_failure == true || inputs.debug_force_nix_diagnostics_failure == 'true') }}"
+        if: ${{ github.event_name == 'workflow_dispatch' && (inputs.debug_force_nix_diagnostics_failure == true || inputs.debug_force_nix_diagnostics_failure == 'true') }}
         shell: bash
         run: |
           diag_dir="${NIX_STORE_DIAGNOSTICS_DIR:-${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-missing}"
@@ -1913,7 +1913,7 @@ jobs:
           bash genie/ci-scripts/nix-gc-race-retry.test.sh
           bash nix/workspace-tools/lib/mk-pnpm-cli/tests/run.sh --skip-genie --skip-megarepo --skip-devenv-shell --skip-downstream-megarepo
       - name: Save pnpm state
-        if: "${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}"
+        if: ${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4
         with:
           path: |
@@ -1961,7 +1961,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: 'nix-store-diagnostics-${{ github.job }}-${{ runner.os }}-run-${{ github.run_id }}-attempt-${{ github.run_attempt }}'
-          path: '${{ env.NIX_STORE_DIAGNOSTICS_DIR }}'
+          path: ${{ env.NIX_STORE_DIAGNOSTICS_DIR }}
           if-no-files-found: ignore
           retention-days: 14
       - name: Failure note
@@ -1979,8 +1979,8 @@ jobs:
     env:
       FORCE_SETUP: '1'
       CI: 'true'
-      GITHUB_TOKEN: '${{ github.token }}'
-      NOTION_TOKEN: '${{ secrets.NOTION_TOKEN }}'
+      GITHUB_TOKEN: ${{ github.token }}
+      NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
     steps:
       - uses: actions/checkout@v6
       - name: Install Nix
@@ -1997,7 +1997,7 @@ jobs:
         uses: cachix/cachix-action@v17
         with:
           name: overeng-effect-utils
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -2122,7 +2122,7 @@ jobs:
           fi
           rm -f "$entriesJson"
       - name: Force diagnostics failure (debug)
-        if: "${{ github.event_name == 'workflow_dispatch' && (inputs.debug_force_nix_diagnostics_failure == true || inputs.debug_force_nix_diagnostics_failure == 'true') }}"
+        if: ${{ github.event_name == 'workflow_dispatch' && (inputs.debug_force_nix_diagnostics_failure == true || inputs.debug_force_nix_diagnostics_failure == 'true') }}
         shell: bash
         run: |
           diag_dir="${NIX_STORE_DIAGNOSTICS_DIR:-${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-missing}"
@@ -2245,7 +2245,7 @@ jobs:
           rm -f "$__nix_gc_retry_helper"
           run_nix_gc_race_retry 'devenv tasks run test:notion-integration --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run test:notion-integration --mode before'
       - name: Save pnpm state
-        if: "${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}"
+        if: ${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4
         with:
           path: |
@@ -2293,7 +2293,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: 'nix-store-diagnostics-${{ github.job }}-${{ runner.os }}-run-${{ github.run_id }}-attempt-${{ github.run_attempt }}'
-          path: '${{ env.NIX_STORE_DIAGNOSTICS_DIR }}'
+          path: ${{ env.NIX_STORE_DIAGNOSTICS_DIR }}
           if-no-files-found: ignore
           retention-days: 14
       - name: Failure note
@@ -2314,8 +2314,8 @@ jobs:
     env:
       FORCE_SETUP: '1'
       CI: 'true'
-      GITHUB_TOKEN: '${{ github.token }}'
-      NETLIFY_AUTH_TOKEN: '${{ secrets.NETLIFY_AUTH_TOKEN }}'
+      GITHUB_TOKEN: ${{ github.token }}
+      NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
     steps:
       - uses: actions/checkout@v6
       - name: Install Nix
@@ -2332,7 +2332,7 @@ jobs:
         uses: cachix/cachix-action@v17
         with:
           name: overeng-effect-utils
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -2457,7 +2457,7 @@ jobs:
           fi
           rm -f "$entriesJson"
       - name: Force diagnostics failure (debug)
-        if: "${{ github.event_name == 'workflow_dispatch' && (inputs.debug_force_nix_diagnostics_failure == true || inputs.debug_force_nix_diagnostics_failure == 'true') }}"
+        if: ${{ github.event_name == 'workflow_dispatch' && (inputs.debug_force_nix_diagnostics_failure == true || inputs.debug_force_nix_diagnostics_failure == 'true') }}
         shell: bash
         run: |
           diag_dir="${NIX_STORE_DIAGNOSTICS_DIR:-${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-missing}"
@@ -2728,11 +2728,11 @@ jobs:
           packages_json="$(nix run nixpkgs#bun -- /tmp/extract-netlify-preview-packages.mjs "$tmp_log")"
           printf 'packages_json<<__NETLIFY_PACKAGES__\n%s\n__NETLIFY_PACKAGES__\n' "$packages_json" >> "$GITHUB_OUTPUT"
       - name: Post storybook preview comment
-        if: '${{ !cancelled() }}'
+        if: ${{ !cancelled() }}
         env:
-          GH_TOKEN: '${{ github.token }}'
-          GH_REPO: '${{ github.repository }}'
-          STORYBOOK_PREVIEW_PACKAGES_JSON: '${{ steps.deploy.outputs.packages_json }}'
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          STORYBOOK_PREVIEW_PACKAGES_JSON: ${{ steps.deploy.outputs.packages_json }}
         run: |
           site="overeng-utils"
           if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ]; then
@@ -3052,7 +3052,7 @@ jobs:
             nix run nixpkgs#gh -- api "repos/$GH_REPO/issues/${{ github.event.pull_request.number }}/comments" --method POST --field body="$(cat /tmp/storybook-preview-comment.md)" >/dev/null
           fi
       - name: Save pnpm state
-        if: "${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}"
+        if: ${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4
         with:
           path: |
@@ -3100,7 +3100,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: 'nix-store-diagnostics-${{ github.job }}-${{ runner.os }}-run-${{ github.run_id }}-attempt-${{ github.run_attempt }}'
-          path: '${{ env.NIX_STORE_DIAGNOSTICS_DIR }}'
+          path: ${{ env.NIX_STORE_DIAGNOSTICS_DIR }}
           if-no-files-found: ignore
           retention-days: 14
       - name: Failure note
@@ -3123,6 +3123,6 @@ jobs:
     steps:
       - name: Dispatch alignment to coordinator
         env:
-          GH_TOKEN: '${{ secrets.MEGAREPO_ALIGNMENT_TOKEN }}'
+          GH_TOKEN: ${{ secrets.MEGAREPO_ALIGNMENT_TOKEN }}
         run: "export NIX_CONFIG=\"${NIX_CONFIG:+$NIX_CONFIG$'\\n'}access-tokens = github.com=${GH_TOKEN}\" && printf '{\"event_type\":\"upstream-changed\",\"client_payload\":{\"source_repo\":\"%s\",\"source_sha\":\"%s\"}}' \"${{ github.repository }}\" \"${{ github.sha }}\" | nix run nixpkgs#gh -- api repos/schickling/megarepo-all/dispatches --input -"
         shell: bash

--- a/package.json.genie.ts
+++ b/package.json.genie.ts
@@ -17,12 +17,12 @@ import notionCliPkg from './packages/@overeng/notion-cli/package.json.genie.ts'
 import notionEffectClientPkg from './packages/@overeng/notion-effect-client/package.json.genie.ts'
 import notionEffectSchemaPkg from './packages/@overeng/notion-effect-schema/package.json.genie.ts'
 import oxcConfigPkg from './packages/@overeng/oxc-config/package.json.genie.ts'
+import ptyEffectPkg from './packages/@overeng/pty-effect/package.json.genie.ts'
 import reactInspectorPkg from './packages/@overeng/react-inspector/package.json.genie.ts'
 import tuiCorePkg from './packages/@overeng/tui-core/package.json.genie.ts'
 import tuiReactPkg from './packages/@overeng/tui-react/package.json.genie.ts'
 import tuiStoriesPkg from './packages/@overeng/tui-stories/package.json.genie.ts'
 import utilsDevPkg from './packages/@overeng/utils-dev/package.json.genie.ts'
-import ptyEffectPkg from './packages/@overeng/pty-effect/package.json.genie.ts'
 import utilsPkg from './packages/@overeng/utils/package.json.genie.ts'
 
 /** All package.json genie definitions that belong to the root pnpm workspace */

--- a/packages/@overeng/genie/src/runtime/github-workflow/github-workflow.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/github-workflow/github-workflow.unit.test.ts
@@ -213,6 +213,55 @@ describe('GitHub expression validation', () => {
     expect(issues.filter((i) => i.rule === 'github-workflow-expression-nesting')).toEqual([])
   })
 
+  it('emits pure expressions unquoted in block context', () => {
+    const workflow = githubWorkflow({
+      name: 'CI',
+      on: { push: { branches: ['main'] } },
+      concurrency: {
+        group: '${{ github.workflow }}-${{ github.ref }}',
+        'cancel-in-progress': "${{ github.event_name != 'pull_request' }}",
+      },
+      jobs: {
+        build: {
+          'runs-on': 'ubuntu-latest',
+          if: "${{ github.event_name != 'schedule' }}",
+          'continue-on-error': '${{ matrix.experimental }}',
+          steps: [{ run: 'echo ok' }],
+          strategy: {
+            'fail-fast': '${{ !contains(github.ref, "main") }}',
+            'max-parallel': '${{ github.event_name == "push" && 2 || 4 }}',
+          },
+        },
+      },
+    })
+
+    const yaml = workflow.stringify(mockGenieContext)
+
+    expect(yaml).toContain("cancel-in-progress: ${{ github.event_name != 'pull_request' }}")
+    expect(yaml).toContain("if: ${{ github.event_name != 'schedule' }}")
+    expect(yaml).toContain('continue-on-error: ${{ matrix.experimental }}')
+    expect(yaml).toContain('fail-fast: ${{ !contains(github.ref, "main") }}')
+    expect(yaml).toContain('max-parallel: ${{ github.event_name == "push" && 2 || 4 }}')
+    // Embedded expressions (multiple ${{ in one string) stay quoted
+    expect(yaml).toContain("group: '${{ github.workflow }}-${{ github.ref }}'")
+  })
+
+  it('keeps expressions quoted in inline arrays', () => {
+    const workflow = githubWorkflow({
+      name: 'CI',
+      on: { push: { branches: ['main'] } },
+      jobs: {
+        build: {
+          'runs-on': ['${{ matrix.runner }}', 'nix'],
+          steps: [{ run: 'echo ok' }],
+        },
+      },
+    })
+
+    const yaml = workflow.stringify(mockGenieContext)
+    expect(yaml).toContain("runs-on: ['${{ matrix.runner }}', nix]")
+  })
+
   it('stringifies valid cache keys with multiple top-level expressions unchanged', () => {
     const workflow = githubWorkflow({
       name: 'CI',

--- a/packages/@overeng/genie/src/runtime/github-workflow/mod.ts
+++ b/packages/@overeng/genie/src/runtime/github-workflow/mod.ts
@@ -160,8 +160,8 @@ type Matrix = {
 
 type Strategy = {
   matrix?: Matrix | Expression
-  'fail-fast'?: boolean
-  'max-parallel'?: number
+  'fail-fast'?: boolean | Expression
+  'max-parallel'?: number | Expression
 }
 
 type Container = {
@@ -193,8 +193,8 @@ type StepBase = {
   name?: string
   if?: string
   env?: Record<string, string>
-  'continue-on-error'?: boolean
-  'timeout-minutes'?: number
+  'continue-on-error'?: boolean | Expression
+  'timeout-minutes'?: number | Expression
   'working-directory'?: string
 }
 
@@ -219,7 +219,7 @@ type Defaults = {
 
 type Concurrency = {
   group: string
-  'cancel-in-progress'?: boolean
+  'cancel-in-progress'?: boolean | Expression
 }
 
 type Job = {
@@ -234,9 +234,9 @@ type Job = {
   env?: Record<string, string>
   defaults?: Defaults
   steps: Step[]
-  'timeout-minutes'?: number
+  'timeout-minutes'?: number | Expression
   strategy?: Strategy
-  'continue-on-error'?: boolean
+  'continue-on-error'?: boolean | Expression
   container?: string | Container
   services?: Record<string, Service>
 }

--- a/packages/@overeng/genie/src/runtime/utils/yaml.ts
+++ b/packages/@overeng/genie/src/runtime/utils/yaml.ts
@@ -12,6 +12,21 @@ const INDENT = '  '
 /** Symbol for comment values that should render as YAML comments */
 export const COMMENT_KEY = '$comment'
 
+/**
+ * A string whose entire content is a single `${{ … }}` GitHub Actions expression.
+ * In block-style YAML (mapping values, sequence items) these can be emitted
+ * unquoted — GitHub evaluates the expression either way, and unquoted is the
+ * idiomatic style in workflow files.
+ *
+ * Flow sequences (inline `[a, b]` arrays) still need quoting because `{{` is
+ * ambiguous with YAML flow-mapping syntax — that path uses `quoteString`
+ * directly and is unaffected by this helper.
+ */
+const isPureExpression = (str: string): boolean => {
+  const trimmed = str.trim()
+  return trimmed.startsWith('${{') && trimmed.endsWith('}}') && trimmed.indexOf('${{', 3) === -1
+}
+
 const needsQuoting = (str: string): boolean => {
   if (str === '') return true
   if (str === 'true' || str === 'false' || str === 'null') return true
@@ -61,6 +76,7 @@ const stringifyValue = ({ value, indent }: { value: unknown; indent: number }): 
   }
 
   if (typeof value === 'string') {
+    if (isPureExpression(value)) return value
     return quoteString({ str: value, indent })
   }
 

--- a/packages/@overeng/genie/src/runtime/utils/yaml.ts
+++ b/packages/@overeng/genie/src/runtime/utils/yaml.ts
@@ -76,7 +76,7 @@ const stringifyValue = ({ value, indent }: { value: unknown; indent: number }): 
   }
 
   if (typeof value === 'string') {
-    if (isPureExpression(value)) return value
+    if (isPureExpression(value) === true) return value
     return quoteString({ str: value, indent })
   }
 


### PR DESCRIPTION
## Summary

- Pure `${{ ... }}` expressions are now emitted unquoted in block-style YAML output, matching idiomatic GitHub Actions style
- Widened 7 fields across 4 types (`Concurrency`, `Strategy`, `StepBase`, `Job`) to accept `Expression` alongside `boolean`/`number`
- Flow sequence (inline array) contexts continue to quote expressions to avoid YAML `{{` flow-mapping ambiguity

## Rationale

The genie workflow generator previously forced all `${{ }}` strings to be quoted in YAML output. This was overly conservative — quoting is only needed in flow sequences where `{{` is ambiguous with flow-mapping syntax. In block-style YAML (mapping values, sequence items), unquoted expressions are valid and idiomatic.

Additionally, fields like `cancel-in-progress` were typed as strict `boolean`, preventing the use of conditional expressions like `${{ github.event_name != 'pull_request' }}`. This forced downstream workarounds (e.g. hardcoding `false`) instead of using GitHub's native expression evaluation.

## Test plan

- [x] All 217 existing genie tests pass
- [x] Added 2 new tests: pure expressions unquoted in block context, expressions quoted in inline arrays
- [x] Verified generated workflow files update correctly (pure expressions unquoted)
- [x] Verified embedded expressions (multiple `${{` in one string) remain quoted
- [x] Verified YAML parse validity of unquoted expressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)