### PR TITLE
ci: add job-local private Cachix read auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,9 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **genie/ci-workflow**: Add a shared step decorator for job-local private Cachix read auth
+  - Creates a per-step netrc file and appends `netrc-file` to `NIX_CONFIG` instead of relying on runner-global Determinate state
+  - Lets downstream repos decorate `devenv` and deploy run steps without exposing the Cachix token to unrelated actions
 - **devenv/tasks/shared/vercel.nix**: Preserve dotfiles when packaging static prebuilt output for Vercel deploys
   - Copies `staticDir/.` into `.vercel/output/static/` instead of globbing `staticDir/*`, so hidden assets and config files are not silently dropped
 - **@overeng/notion-effect-client**: Raise user integration-test timeouts to tolerate current Notion API latency in CI

--- a/genie/ci-workflow.ts
+++ b/genie/ci-workflow.ts
@@ -127,16 +127,23 @@ export const devenvBinaryCache = {
 } as const satisfies NixBinaryCache
 
 /** Build a binary-cache descriptor for a Cachix cache. */
-export const cachixBinaryCache = (opts: {
-  name: string
-  publicKey: string
-}): NixBinaryCache => ({
+export const cachixBinaryCache = (opts: { name: string; publicKey: string }): NixBinaryCache => ({
   uri: `https://${opts.name}.cachix.org`,
   publicKey: opts.publicKey,
 })
 
-const dedupeBinaryCaches = (caches: readonly NixBinaryCache[]) =>
-  [...new Map(caches.map((cache) => [cache.uri, cache])).values()]
+const dedupeBinaryCaches = (caches: readonly NixBinaryCache[]) => [
+  ...new Map(caches.map((cache) => [cache.uri, cache])).values(),
+]
+
+const cachixHostsFromBinaryCaches = (caches: readonly NixBinaryCache[]) => [
+  ...new Set(
+    caches.flatMap((cache) => {
+      const host = new URL(cache.uri).host
+      return host.endsWith('.cachix.org') ? [host] : []
+    }),
+  ),
+]
 
 /** Render `extra-conf` lines for one or more binary caches. */
 export const nixBinaryCachesExtraConf = (caches: readonly NixBinaryCache[]) => {
@@ -377,6 +384,74 @@ export const withGitHubAccessTokenEnv = <
     ...githubAccessTokenEnv(tokenExpression),
   },
 })
+
+const withPrivateCachixReadAuthCommand = ({
+  command,
+  cacheHosts,
+}: {
+  command: string
+  cacheHosts: readonly string[]
+}) => {
+  if (cacheHosts.length === 0) {
+    return command
+  }
+
+  return [
+    'if [ -z "${CACHIX_AUTH_TOKEN:-}" ]; then',
+    '  echo "::error::CACHIX_AUTH_TOKEN is not set"',
+    '  exit 1',
+    'fi',
+    'cachix_netrc="$(mktemp "${RUNNER_TEMP:-/tmp}/cachix-netrc.XXXXXX")"',
+    'trap \'rm -f "$cachix_netrc"\' EXIT',
+    'chmod 600 "$cachix_netrc"',
+    `for host in ${cacheHosts.map(shellSingleQuote).join(' ')}; do`,
+    `  printf 'machine %s\\npassword %s\\n' "$host" "$CACHIX_AUTH_TOKEN" >> "$cachix_netrc"`,
+    'done',
+    'if [ -n "${NIX_CONFIG:-}" ]; then',
+    '  NIX_CONFIG_WITH_APPEND=$(printf \'%s\\n%s\' "$NIX_CONFIG" "netrc-file = $cachix_netrc")',
+    'else',
+    '  NIX_CONFIG_WITH_APPEND="netrc-file = $cachix_netrc"',
+    'fi',
+    'NIX_CONFIG="$NIX_CONFIG_WITH_APPEND"',
+    command,
+  ].join('\n')
+}
+
+/**
+ * Attach job-local Cachix read auth to a shell step.
+ *
+ * This keeps private cache pull auth local to the step instead of relying on
+ * host-global netrc state owned by the runner image.
+ */
+export const withPrivateCachixReadAuth = <
+  TStep extends {
+    run: string
+    env?: Record<string, string>
+  },
+>(
+  step: TStep,
+  opts: {
+    authTokenExpression: string
+    binaryCaches: readonly NixBinaryCache[]
+  },
+): TStep => {
+  const cacheHosts = cachixHostsFromBinaryCaches(opts.binaryCaches)
+  if (cacheHosts.length === 0) {
+    return step
+  }
+
+  return {
+    ...step,
+    env: {
+      ...step.env,
+      CACHIX_AUTH_TOKEN: opts.authTokenExpression,
+    },
+    run: withPrivateCachixReadAuthCommand({
+      command: step.run,
+      cacheHosts,
+    }),
+  }
+}
 
 /**
  * Append a GitHub access token line to NIX_CONFIG for later shell steps.
@@ -977,6 +1052,10 @@ export const vercelDeployJobs = (opts: {
   includeComment?: boolean
   commentTitle?: string
   noRowsMessage?: string
+  deployStepDecorator?: (
+    step: Record<string, unknown>,
+    project: VercelProject,
+  ) => Record<string, unknown>
 }): Record<string, Record<string, unknown>> => {
   return buildVercelDeployJobs({
     ...opts,

--- a/genie/ci-workflow.ts
+++ b/genie/ci-workflow.ts
@@ -412,7 +412,7 @@ const withPrivateCachixReadAuthCommand = ({
     'else',
     '  NIX_CONFIG_WITH_APPEND="netrc-file = $cachix_netrc"',
     'fi',
-    'NIX_CONFIG="$NIX_CONFIG_WITH_APPEND"',
+    'export NIX_CONFIG="$NIX_CONFIG_WITH_APPEND"',
     command,
   ].join('\n')
 }

--- a/genie/deploy-preview/vercel.ts
+++ b/genie/deploy-preview/vercel.ts
@@ -410,6 +410,7 @@ export const vercelDeployJobs = (opts: {
   deployCommentPermissions: Record<string, string>
   bashShellDefaults: { run: { shell: string } }
   commentRunner: readonly string[]
+  deployStepDecorator?: (step: StepRecord, project: VercelProject) => StepRecord
 }) => {
   const deployCondition =
     opts.deployCondition ??
@@ -442,7 +443,10 @@ export const vercelDeployJobs = (opts: {
         steps: [
           ...opts.baseSteps,
           ...(project.stepsBeforeDeploy ?? []),
-          vercelDeployStep(project, opts.runDevenvTasksBefore),
+          opts.deployStepDecorator?.(
+            vercelDeployStep(project, opts.runDevenvTasksBefore),
+            project,
+          ) ?? vercelDeployStep(project, opts.runDevenvTasksBefore),
           ...(opts.extraSteps ?? []),
         ],
       },

--- a/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
@@ -10,6 +10,10 @@ const generatedWorkflowSource = readFileSync(
   new URL(['../../../../../../.github/workflows', 'ci.yml.genie.ts'].join('/'), import.meta.url),
   'utf8',
 )
+const vercelDeploySource = readFileSync(
+  new URL(['../../../../../../genie/deploy-preview', 'vercel.ts'].join('/'), import.meta.url),
+  'utf8',
+)
 const nixGcRaceRetryScriptSource = readFileSync(
   new URL(
     ['../../../../../../genie/ci-scripts', 'nix-gc-race-retry.sh'].join('/'),
@@ -134,6 +138,15 @@ describe('ci workflow shared auth helpers', () => {
     expect(ciWorkflowSource).toContain('export const withGitHubAccessTokenEnv')
   })
 
+  it('can wrap shell steps with job-local private Cachix read auth', () => {
+    expect(ciWorkflowSource).toContain('export const withPrivateCachixReadAuth')
+    expect(ciWorkflowSource).toContain('CACHIX_AUTH_TOKEN: opts.authTokenExpression')
+    expect(ciWorkflowSource).toContain(
+      'cachix_netrc="$(mktemp "${RUNNER_TEMP:-/tmp}/cachix-netrc.XXXXXX")"',
+    )
+    expect(ciWorkflowSource).toContain('netrc-file = $cachix_netrc')
+  })
+
   it('only appends GitHub access tokens to NIX_CONFIG through GITHUB_ENV', () => {
     expect(ciWorkflowSource).toContain('export const appendGitHubAccessTokenToNixConfigStep')
     expect(ciWorkflowSource).toContain('access-tokens = github.com=%s')
@@ -145,5 +158,12 @@ describe('ci workflow shared auth helpers', () => {
   it('pins the shared CI actions to the Node-24-safe majors', () => {
     expect(ciWorkflowSource).toContain("uses: 'actions/checkout@v6' as const")
     expect(ciWorkflowSource).toContain("uses: 'cachix/cachix-action@v17' as const")
+  })
+
+  it('lets Vercel deploy jobs decorate the deploy run step', () => {
+    expect(ciWorkflowSource).toContain('deployStepDecorator?: (')
+    expect(ciWorkflowSource).toContain('project: VercelProject')
+    expect(vercelDeploySource).toContain('opts.deployStepDecorator?.(')
+    expect(vercelDeploySource).toContain('vercelDeployStep(project, opts.runDevenvTasksBefore)')
   })
 })

--- a/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
@@ -145,6 +145,7 @@ describe('ci workflow shared auth helpers', () => {
       'cachix_netrc="$(mktemp "${RUNNER_TEMP:-/tmp}/cachix-netrc.XXXXXX")"',
     )
     expect(ciWorkflowSource).toContain('netrc-file = $cachix_netrc')
+    expect(ciWorkflowSource).toContain('export NIX_CONFIG="$NIX_CONFIG_WITH_APPEND"')
   })
 
   it('only appends GitHub access tokens to NIX_CONFIG through GITHUB_ENV', () => {


### PR DESCRIPTION
## Summary

- add a shared `withPrivateCachixReadAuth(...)` CI helper for private Cachix read access
- mint a step-local netrc and append `netrc-file` to `NIX_CONFIG` instead of relying on host-global runner state
- allow Vercel deploy jobs to decorate deploy steps with the same helper
- cover the helper with focused workflow helper tests

## Root Cause

Self-hosted CI jobs were configuring a private Cachix cache as a Nix substituter while skipping `cachix use`. That left private-cache reads dependent on host-global Determinate netrc state. On the runner, that netrc is root-owned, so Nix reads from the job user could fail with `401` even though `cachix push` succeeded.

## Rationale

Private Cachix pull auth should be explicit and job-local. The shared helper keeps that contract in one place and makes downstream repos opt into the same mechanism without duplicating shell glue.

## Validation

- `oxfmt --check genie/ci-workflow.ts genie/deploy-preview/vercel.ts packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts CHANGELOG.md`
- `oxlint genie/ci-workflow.ts genie/deploy-preview/vercel.ts packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts`
- focused helper test passed from the existing effect-utils checkout: `packages/@overeng/genie/node_modules/.bin/vitest packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts --run`

_Automation note: the clean publish worktree reused the already-installed workspace from a sibling checkout for validation because it did not have its own installed dependencies._

_Acting on behalf of the user._