### PR TITLE
feat(genie): add megarepo member import resolution

### DIFF
--- a/genie/ci-workflow.ts
+++ b/genie/ci-workflow.ts
@@ -1057,6 +1057,8 @@ ${args.join(' ')}`,
  */
 export const applyMegarepoLockStep = (opts?: { skip?: string[] }) => {
   const skipArgs = opts?.skip?.flatMap((s) => ['--skip', s]).join(' ') ?? ''
+  const skipCsv = opts?.skip?.join(',') ?? ''
+  const quotedSkipCsv = shellSingleQuote(skipCsv)
   return {
     name: 'Sync megarepo dependencies',
     env: { MEGAREPO_STORE: jobLocalMegarepoStore },
@@ -1067,6 +1069,9 @@ if [ -z "$EU_REV" ] || [ "$EU_REV" = "null" ]; then
 fi
 mkdir -p "$MEGAREPO_STORE"
 echo "Using job-local megarepo store: $MEGAREPO_STORE"
+if [ -n "${'${GITHUB_ENV:-}'}" ]; then
+  printf 'MEGAREPO_SKIP_MEMBERS=%s\n' ${quotedSkipCsv} >> "$GITHUB_ENV"
+fi
 nix run "github:overengineeringstudio/effect-utils/$EU_REV#megarepo" -- apply --all${skipArgs !== '' ? ` ${skipArgs}` : ''}`,
     shell: 'bash',
   }

--- a/genie/ci-workflow.ts
+++ b/genie/ci-workflow.ts
@@ -1059,6 +1059,12 @@ export const applyMegarepoLockStep = (opts?: { skip?: string[] }) => {
   const skipArgs = opts?.skip?.flatMap((s) => ['--skip', s]).join(' ') ?? ''
   const skipCsv = opts?.skip?.join(',') ?? ''
   const quotedSkipCsv = shellSingleQuote(skipCsv)
+  const exportSkipMembersScript =
+    skipCsv === ''
+      ? ''
+      : `if [ -n "${'${GITHUB_ENV:-}'}" ]; then
+  printf 'MEGAREPO_SKIP_MEMBERS=%s\n' ${quotedSkipCsv} >> "$GITHUB_ENV"
+fi`
   return {
     name: 'Sync megarepo dependencies',
     env: { MEGAREPO_STORE: jobLocalMegarepoStore },
@@ -1069,9 +1075,7 @@ if [ -z "$EU_REV" ] || [ "$EU_REV" = "null" ]; then
 fi
 mkdir -p "$MEGAREPO_STORE"
 echo "Using job-local megarepo store: $MEGAREPO_STORE"
-if [ -n "${'${GITHUB_ENV:-}'}" ]; then
-  printf 'MEGAREPO_SKIP_MEMBERS=%s\n' ${quotedSkipCsv} >> "$GITHUB_ENV"
-fi
+${exportSkipMembersScript}
 nix run "github:overengineeringstudio/effect-utils/$EU_REV#megarepo" -- apply --all${skipArgs !== '' ? ` ${skipArgs}` : ''}`,
     shell: 'bash',
   }

--- a/genie/ci-workflow.ts
+++ b/genie/ci-workflow.ts
@@ -1043,6 +1043,9 @@ export const syncMegarepoWorkspaceStep = (opts?: { skip?: string[] }) => {
     env: { MEGAREPO_STORE: jobLocalMegarepoStore },
     run: `mkdir -p "$MEGAREPO_STORE"
 echo "Using job-local megarepo store: $MEGAREPO_STORE"
+if [ -n "${'${GITHUB_ENV:-}'}" ]; then
+  printf 'MEGAREPO_STORE=%s\n' "$MEGAREPO_STORE" >> "$GITHUB_ENV"
+fi
 ${args.join(' ')}`,
     shell: 'bash',
   }
@@ -1075,6 +1078,9 @@ if [ -z "$EU_REV" ] || [ "$EU_REV" = "null" ]; then
 fi
 mkdir -p "$MEGAREPO_STORE"
 echo "Using job-local megarepo store: $MEGAREPO_STORE"
+if [ -n "${'${GITHUB_ENV:-}'}" ]; then
+  printf 'MEGAREPO_STORE=%s\n' "$MEGAREPO_STORE" >> "$GITHUB_ENV"
+fi
 ${exportSkipMembersScript}
 nix run "github:overengineeringstudio/effect-utils/$EU_REV#megarepo" -- apply --all${skipArgs !== '' ? ` ${skipArgs}` : ''}`,
     shell: 'bash',

--- a/nix/devenv-modules/tasks/shared/genie.nix
+++ b/nix/devenv-modules/tasks/shared/genie.nix
@@ -15,16 +15,22 @@
 let
   trace = import ../lib/trace.nix { inherit lib; };
   cliGuard = import ../lib/cli-guard.nix { inherit pkgs; };
+  megarepoStoreEnv = builtins.getEnv "MEGAREPO_STORE";
+  genieTaskEnv = lib.optionalAttrs (megarepoStoreEnv != "") {
+    MEGAREPO_STORE = megarepoStoreEnv;
+  };
 
   tasks = {
     "genie:prepare" = {
       description = "Run shared prerequisites before invoking genie";
       exec = "true";
+      env = genieTaskEnv;
     };
     "genie:run" = {
       guard = "genie";
       description = "Generate config files from .genie.ts sources";
       after = [ "genie:prepare" ];
+      env = genieTaskEnv;
       exec = trace.exec "genie:run" "genie";
       status = trace.status "genie:run" "binary" ''
         set -euo pipefail
@@ -37,12 +43,14 @@ let
       guard = "genie";
       description = "Watch and regenerate config files";
       after = [ "genie:prepare" ];
+      env = genieTaskEnv;
       exec = "genie --watch";
     };
     "genie:check" = {
       guard = "genie";
       description = "Check if generated files are up to date (CI)";
       after = [ "genie:prepare" ];
+      env = genieTaskEnv;
       exec = trace.exec "genie:check" "genie --check";
     };
   };

--- a/nix/devenv-modules/tasks/shared/genie.nix
+++ b/nix/devenv-modules/tasks/shared/genie.nix
@@ -3,7 +3,7 @@
 # Usage in devenv.nix:
 #   imports = [ inputs.effect-utils.devenvModules.tasks.genie ];
 #
-# Provides: genie:run, genie:watch, genie:check
+# Provides: genie:prepare, genie:run, genie:watch, genie:check
 #
 # NOTE: No pnpm:install:genie dependency here — this shared module is used by
 # repos where genie may be a Nix package (no pnpm install needed). Repos that
@@ -17,9 +17,14 @@ let
   cliGuard = import ../lib/cli-guard.nix { inherit pkgs; };
 
   tasks = {
+    "genie:prepare" = {
+      description = "Run shared prerequisites before invoking genie";
+      exec = "true";
+    };
     "genie:run" = {
       guard = "genie";
       description = "Generate config files from .genie.ts sources";
+      after = [ "genie:prepare" ];
       exec = trace.exec "genie:run" "genie";
       status = trace.status "genie:run" "binary" ''
         set -euo pipefail
@@ -31,11 +36,13 @@ let
     "genie:watch" = {
       guard = "genie";
       description = "Watch and regenerate config files";
+      after = [ "genie:prepare" ];
       exec = "genie --watch";
     };
     "genie:check" = {
       guard = "genie";
       description = "Check if generated files are up to date (CI)";
+      after = [ "genie:prepare" ];
       exec = trace.exec "genie:check" "genie --check";
     };
   };

--- a/nix/devenv-modules/tasks/shared/lint-genie.nix
+++ b/nix/devenv-modules/tasks/shared/lint-genie.nix
@@ -15,6 +15,7 @@ in
   tasks = cliGuard.stripGuards {
     "lint:check:genie" = {
       description = "Check generated files are up to date";
+      after = [ "genie:prepare" ];
       exec = trace.exec "lint:check:genie" "genie --check";
     };
     "lint:check:lockfile" = {

--- a/nix/devenv-modules/tasks/shared/lint-genie.nix
+++ b/nix/devenv-modules/tasks/shared/lint-genie.nix
@@ -10,12 +10,17 @@
 let
   trace = import ../lib/trace.nix { inherit lib; };
   cliGuard = import ../lib/cli-guard.nix { inherit pkgs; };
+  megarepoStoreEnv = builtins.getEnv "MEGAREPO_STORE";
+  genieTaskEnv = lib.optionalAttrs (megarepoStoreEnv != "") {
+    MEGAREPO_STORE = megarepoStoreEnv;
+  };
 in
 {
   tasks = cliGuard.stripGuards {
     "lint:check:genie" = {
       description = "Check generated files are up to date";
       after = [ "genie:prepare" ];
+      env = genieTaskEnv;
       exec = trace.exec "lint:check:genie" "genie --check";
     };
     "lint:check:lockfile" = {

--- a/nix/devenv-modules/tasks/shared/lint-oxc.nix
+++ b/nix/devenv-modules/tasks/shared/lint-oxc.nix
@@ -116,6 +116,7 @@ let
   otherTasks = {
     "lint:check:genie" = {
       description = "Check generated files are up to date";
+      after = [ "genie:prepare" ];
       exec = trace.exec "lint:check:genie" "genie --check";
       execIfModified = geniePatterns;
     };

--- a/nix/devenv-modules/tasks/shared/lint-oxc.nix
+++ b/nix/devenv-modules/tasks/shared/lint-oxc.nix
@@ -56,6 +56,10 @@
 let
   trace = import ../lib/trace.nix { inherit lib; };
   cliGuard = import ../lib/cli-guard.nix { inherit pkgs; };
+  megarepoStoreEnv = builtins.getEnv "MEGAREPO_STORE";
+  genieTaskEnv = lib.optionalAttrs (megarepoStoreEnv != "") {
+    MEGAREPO_STORE = megarepoStoreEnv;
+  };
   git = "${pkgs.git}/bin/git";
   scanDirsSetup = builtins.concatStringsSep "\n" (
     map (dir: "scan_dir_args+=(${builtins.toJSON dir})") genieCoverageDirs
@@ -117,6 +121,7 @@ let
     "lint:check:genie" = {
       description = "Check generated files are up to date";
       after = [ "genie:prepare" ];
+      env = genieTaskEnv;
       exec = trace.exec "lint:check:genie" "genie --check";
       execIfModified = geniePatterns;
     };

--- a/nix/devenv-modules/tasks/shared/megarepo.nix
+++ b/nix/devenv-modules/tasks/shared/megarepo.nix
@@ -3,6 +3,7 @@
 # Uses the `mr` CLI for megarepo operations.
 #
 # Tasks:
+# - mr:bootstrap - Materialize the minimal lock-based members needed for local tooling
 # - mr:fetch-apply - Fetch latest refs and apply to workspace (mr fetch --apply)
 # - mr:lock - Record the current workspace into megarepo.lock (mr lock)
 # - mr:apply - Apply megarepo.lock exactly (mr apply)
@@ -13,18 +14,28 @@
 # - syncAll: Whether to use `--all` (recursive nested sync). Default: true.
 #   Set to false in CI where root members are already synced and nested sync
 #   may fail due to credential scoping or version mismatches.
+# - bootstrapMembers: Minimal members that must exist before tooling like genie
+#   can evaluate. Uses lock-based `mr apply --only ...` and never fetches remote
+#   refs. Default: [ ] (task becomes a no-op)
+# - checkSkipMembers: Members that `mr:check` should ignore when a repo
+#   intentionally does a partial lock apply (for example CI skipping a sensitive
+#   or heavyweight member). Default: [ ]
 # NOTE: No pnpm:install:megarepo dependency here — this shared module is used by
 # repos where megarepo may be a Nix package (no pnpm install needed). Repos that
 # use source-mode megarepo via pnpm should add the dependency in their devenv.nix:
 #   tasks."mr:fetch-apply".after = [ "pnpm:install:megarepo" ];
 {
   syncAll ? true,
+  bootstrapMembers ? [ ],
+  checkSkipMembers ? [ ],
 }:
 { lib, pkgs, ... }:
 let
   trace = import ../lib/trace.nix { inherit lib; };
   cliGuard = import ../lib/cli-guard.nix { inherit pkgs; };
   jq = "${pkgs.jq}/bin/jq";
+  bootstrapOnlyArgs = lib.concatMapStringsSep " " (member: "--only ${lib.escapeShellArg member}") bootstrapMembers;
+  staticCheckSkipCsv = lib.concatStringsSep "," checkSkipMembers;
 
   # Single-pass jq script that compares megarepo.lock member commits against
   # a Nix lock file (devenv.lock or flake.lock). Handles multiple inputs
@@ -62,7 +73,67 @@ let
     return 0
   '';
 
+  loadCheckSkipMembersScript = ''
+    _mr_skip_csv=${lib.escapeShellArg staticCheckSkipCsv}
+    if [ -n "''${MEGAREPO_SKIP_MEMBERS:-}" ]; then
+      if [ -n "$_mr_skip_csv" ]; then
+        _mr_skip_csv="$_mr_skip_csv,''${MEGAREPO_SKIP_MEMBERS}"
+      else
+        _mr_skip_csv="''${MEGAREPO_SKIP_MEMBERS}"
+      fi
+    fi
+
+    should_skip_member() {
+      local member="$1"
+      if [ -z "$_mr_skip_csv" ]; then
+        return 1
+      fi
+
+      case ",$_mr_skip_csv," in
+        *,"$member",*) return 0 ;;
+        *) return 1 ;;
+      esac
+    }
+  '';
+
   tasks = {
+    "mr:bootstrap" = {
+      guard = "mr";
+      description = "Materialize bootstrap members from megarepo.lock";
+      exec = trace.exec "mr:bootstrap" ''
+        if [ ! -f ./megarepo.kdl ] && [ ! -f ./megarepo.json ]; then
+          exit 0
+        fi
+
+        if [ "${toString (builtins.length bootstrapMembers)}" -eq 0 ]; then
+          exit 0
+        fi
+
+        mr apply ${bootstrapOnlyArgs}
+      '';
+      status = trace.status "mr:bootstrap" "path" ''
+        if [ ! -f ./megarepo.kdl ] && [ ! -f ./megarepo.json ]; then
+          exit 0
+        fi
+
+        if [ "${toString (builtins.length bootstrapMembers)}" -eq 0 ]; then
+          exit 0
+        fi
+
+        if [ ! -d ./repos ]; then
+          exit 1
+        fi
+
+        ${lib.concatMapStringsSep "\n" (member: ''
+          if [ ! -L "./repos/${member}" ] && [ ! -d "./repos/${member}" ]; then
+            exit 1
+          fi
+        '') bootstrapMembers}
+
+        exit 0
+      '';
+    };
+
     "mr:fetch-apply" = {
       guard = "mr";
       description = "Fetch latest refs and apply to workspace";
@@ -118,7 +189,7 @@ let
     "mr:check" = {
       guard = "mr";
       description = "Verify megarepo setup is complete";
-      after = [ "mr:fetch-apply" ];
+      after = [ "mr:apply" ];
       # Check that repos dir exists and all members have symlinks
       status = trace.status "mr:check" "path" ''
         set -o pipefail
@@ -131,9 +202,14 @@ let
           exit 1
         fi
 
+        ${loadCheckSkipMembersScript}
+
         # Verify all configured members have symlinks in repos/
         members=$(mr ls --output json | ${jq} -r 'select(._tag == "Success") | .value.members[].name') || exit 1
         for member in $members; do
+          if should_skip_member "$member"; then
+            continue
+          fi
           if [ ! -L "./repos/$member" ] && [ ! -d "./repos/$member" ]; then
             exit 1
           fi
@@ -149,14 +225,19 @@ let
 
         if [ ! -d ./repos ]; then
           echo "[devenv] Missing repos/ directory." >&2
-          echo "[devenv] Fix: devenv tasks run mr:fetch-apply" >&2
+          echo "[devenv] Fix: devenv tasks run mr:apply" >&2
           exit 1
         fi
+
+        ${loadCheckSkipMembersScript}
 
         # Check for missing member symlinks
         missing=""
         members=$(mr ls --output json | ${jq} -r 'select(._tag == "Success") | .value.members[].name') || exit 1
         for member in $members; do
+          if should_skip_member "$member"; then
+            continue
+          fi
           if [ ! -L "./repos/$member" ] && [ ! -d "./repos/$member" ]; then
             missing="$missing $member"
           fi
@@ -164,7 +245,7 @@ let
 
         if [ -n "$missing" ]; then
           echo "[devenv] Missing member symlinks:$missing" >&2
-          echo "[devenv] Fix: devenv tasks run mr:fetch-apply" >&2
+          echo "[devenv] Fix: devenv tasks run mr:apply" >&2
           exit 1
         fi
       '';
@@ -172,7 +253,6 @@ let
 
     "mr:lock-sync-check" = {
       description = "Verify Nix lock files match megarepo.lock revisions";
-      after = [ "mr:fetch-apply" ];
       status = trace.status "mr:lock-sync-check" "binary" ''
         if [ ! -f ./megarepo.lock ]; then
           exit 0
@@ -226,7 +306,7 @@ let
         if [ "$failed" -eq 1 ]; then
           echo ""
           echo "Lock files out of sync with megarepo.lock."
-          echo "Fix: dt mr:fetch-apply"
+          echo "Fix: dt mr:apply"
           exit 1
         fi
       '';
@@ -242,4 +322,13 @@ in
   ++ cliGuard.fromTasks tasks;
 
   tasks = cliGuard.stripGuards tasks;
+}
+// lib.optionalAttrs (bootstrapMembers != [ ]) {
+  # Repos that source-import genie helpers from bootstrap members should not
+  # attempt to run genie before those members exist in repos/.
+  tasks."genie:run".after = lib.mkAfter [ "mr:bootstrap" ];
+  tasks."genie:watch".after = lib.mkAfter [ "mr:bootstrap" ];
+  tasks."genie:check".after = lib.mkAfter [ "mr:bootstrap" ];
+  tasks."lint:check:genie".after = lib.mkAfter [ "mr:bootstrap" ];
+  tasks."lint:check:genie:coverage".after = lib.mkAfter [ "mr:bootstrap" ];
 }

--- a/nix/devenv-modules/tasks/shared/megarepo.nix
+++ b/nix/devenv-modules/tasks/shared/megarepo.nix
@@ -309,10 +309,11 @@ in
   ]
   ++ cliGuard.fromTasks tasks;
 
-  tasks = cliGuard.stripGuards tasks;
-}
-// lib.optionalAttrs (bootstrapMembers != [ ]) {
-  # Repos that source-import genie helpers from bootstrap members should ensure
-  # those members exist before any genie-backed task runs.
-  tasks."genie:prepare".after = lib.mkAfter [ "mr:bootstrap" ];
+  tasks =
+    cliGuard.stripGuards tasks
+    // lib.optionalAttrs (bootstrapMembers != [ ]) {
+      # Repos that source-import genie helpers from bootstrap members should ensure
+      # those members exist before any genie-backed task runs.
+      "genie:prepare".after = lib.mkAfter [ "mr:bootstrap" ];
+    };
 }

--- a/nix/devenv-modules/tasks/shared/megarepo.nix
+++ b/nix/devenv-modules/tasks/shared/megarepo.nix
@@ -312,11 +312,7 @@ in
   tasks = cliGuard.stripGuards tasks;
 }
 // lib.optionalAttrs (bootstrapMembers != [ ]) {
-  # Repos that source-import genie helpers from bootstrap members should not
-  # attempt to run genie before those members exist in repos/.
-  tasks."genie:run".after = lib.mkAfter [ "mr:bootstrap" ];
-  tasks."genie:watch".after = lib.mkAfter [ "mr:bootstrap" ];
-  tasks."genie:check".after = lib.mkAfter [ "mr:bootstrap" ];
-  tasks."lint:check:genie".after = lib.mkAfter [ "mr:bootstrap" ];
-  tasks."lint:check:genie:coverage".after = lib.mkAfter [ "mr:bootstrap" ];
+  # Repos that source-import genie helpers from bootstrap members should ensure
+  # those members exist before any genie-backed task runs.
+  tasks."genie:prepare".after = lib.mkAfter [ "mr:bootstrap" ];
 }

--- a/nix/devenv-modules/tasks/shared/megarepo.nix
+++ b/nix/devenv-modules/tasks/shared/megarepo.nix
@@ -17,9 +17,6 @@
 # - bootstrapMembers: Minimal members that must exist before tooling like genie
 #   can evaluate. Uses lock-based `mr apply --only ...` and never fetches remote
 #   refs. Default: [ ] (task becomes a no-op)
-# - checkSkipMembers: Members that `mr:check` should ignore when a repo
-#   intentionally does a partial lock apply (for example CI skipping a sensitive
-#   or heavyweight member). Default: [ ]
 # NOTE: No pnpm:install:megarepo dependency here — this shared module is used by
 # repos where megarepo may be a Nix package (no pnpm install needed). Repos that
 # use source-mode megarepo via pnpm should add the dependency in their devenv.nix:
@@ -27,7 +24,6 @@
 {
   syncAll ? true,
   bootstrapMembers ? [ ],
-  checkSkipMembers ? [ ],
 }:
 { lib, pkgs, ... }:
 let
@@ -35,7 +31,6 @@ let
   cliGuard = import ../lib/cli-guard.nix { inherit pkgs; };
   jq = "${pkgs.jq}/bin/jq";
   bootstrapOnlyArgs = lib.concatMapStringsSep " " (member: "--only ${lib.escapeShellArg member}") bootstrapMembers;
-  staticCheckSkipCsv = lib.concatStringsSep "," checkSkipMembers;
 
   # Single-pass jq script that compares megarepo.lock member commits against
   # a Nix lock file (devenv.lock or flake.lock). Handles multiple inputs
@@ -74,14 +69,7 @@ let
   '';
 
   loadCheckSkipMembersScript = ''
-    _mr_skip_csv=${lib.escapeShellArg staticCheckSkipCsv}
-    if [ -n "''${MEGAREPO_SKIP_MEMBERS:-}" ]; then
-      if [ -n "$_mr_skip_csv" ]; then
-        _mr_skip_csv="$_mr_skip_csv,''${MEGAREPO_SKIP_MEMBERS}"
-      else
-        _mr_skip_csv="''${MEGAREPO_SKIP_MEMBERS}"
-      fi
-    fi
+    _mr_skip_csv="''${MEGAREPO_SKIP_MEMBERS:-}"
 
     should_skip_member() {
       local member="$1"

--- a/packages/@overeng/genie/README.md
+++ b/packages/@overeng/genie/README.md
@@ -2,6 +2,8 @@
 
 TypeScript-based code generator for config files. Define your `package.json`, `tsconfig.json`, `oxlint.jsonc`, `oxfmt.jsonc`, and GitHub workflow files as TypeScript and generate them with consistent formatting.
 
+Architecture and subsystem behavior are specified in [docs/spec.md](./docs/spec.md).
+
 ## Installation (Nix)
 
 Genie is distributed as a native binary via Nix. **This is the only supported installation method** to avoid chicken-egg problems: since genie generates `package.json` files, it must be available before `pnpm install`.

--- a/packages/@overeng/genie/README.md
+++ b/packages/@overeng/genie/README.md
@@ -2,7 +2,11 @@
 
 TypeScript-based code generator for config files. Define your `package.json`, `tsconfig.json`, `oxlint.jsonc`, `oxfmt.jsonc`, and GitHub workflow files as TypeScript and generate them with consistent formatting.
 
-Architecture and subsystem behavior are specified in [docs/spec.md](./docs/spec.md).
+Architecture and subsystem behavior are documented in the VRS set:
+
+- [docs/vision.md](./docs/vision.md)
+- [docs/requirements.md](./docs/requirements.md)
+- [docs/spec.md](./docs/spec.md)
 
 ## Installation (Nix)
 

--- a/packages/@overeng/genie/docs/requirements.md
+++ b/packages/@overeng/genie/docs/requirements.md
@@ -1,0 +1,108 @@
+# Genie Requirements
+
+## Context
+
+Genie is the shared repository-configuration generator used across the
+`effect-utils` ecosystem and downstream megarepos. It must serve both
+standalone repositories and composed megarepo workspaces, while remaining
+usable in fresh-checkout and CI bootstrap paths where JavaScript dependencies
+may not yet be installed.
+
+## Assumptions
+
+- **A01 Vision anchor:** These requirements serve the
+  [vision](./vision.md).
+- **A02 Package context:** The package-level README and build/runtime READMEs
+  describe the current package surface and module boundaries; these
+  requirements constrain that subsystem rather than redefining unrelated Nix or
+  repository policy.
+- **A03 Typed source model:** Repository configuration is authored in
+  colocated `.genie.ts` source files and rendered into adjacent generated
+  artifacts.
+
+## Acceptable Tradeoffs
+
+- **T01 Generated artifacts remain checked in:** Repositories may continue to
+  commit generated outputs when downstream tooling expects real files, as long
+  as those outputs remain mechanically derived from `.genie.ts` sources.
+- **T02 Watch mode may be less complete than full batch mode:** Interactive
+  watch flows may prioritize fast incremental regeneration as long as strict
+  batch generation and check mode remain authoritative.
+- **T03 Runtime constraints over convenience:** Runtime helpers may reject
+  normal npm dependency patterns if that restriction is required to keep Genie
+  bootstrap-safe and composable.
+
+## Requirements
+
+### Must preserve a single source of truth
+
+- **R01 Colocated source:** Every generated artifact must have one canonical
+  colocated `.genie.ts` source from which its target path is derived
+  mechanically.
+- **R02 Drift detection:** Genie must provide a strict check mode that fails
+  when a generated artifact does not match the content implied by its
+  `.genie.ts` source.
+- **R03 Deterministic output:** For the same repository state, CLI options, and
+  referenced generator inputs, Genie must produce byte-stable output.
+- **R04 Direct-edit discouragement:** The default generation path must preserve
+  a clear signal that generated artifacts are derived outputs rather than
+  primary editable files.
+
+### Must be bootstrap-safe
+
+- **R05 Pre-install availability:** Repositories must be able to invoke Genie
+  before `pnpm install` or equivalent JavaScript dependency materialization.
+- **R06 Runtime independence:** Code imported directly by `.genie.ts` files
+  must remain usable without depending on an already-installed npm dependency
+  graph.
+- **R07 Fresh-checkout safety:** A fresh checkout must be able to run Genie
+  successfully once its declared non-JS prerequisites are available, without
+  requiring a pre-existing generated state.
+
+### Must support repository and megarepo composition
+
+- **R08 Shared helper reuse:** `.genie.ts` files must be able to reuse shared
+  runtime factories and helper modules across package and repository
+  boundaries.
+- **R09 Lock-pinned member resolution:** When a `.genie.ts` source imports from
+  a megarepo member, resolution must respect the locked member identity instead
+  of drifting to unrelated branch heads or ambient global state.
+- **R10 Local iteration compatibility:** Cross-repo reuse must still allow
+  local source iteration against the active composed worktree rather than
+  forcing copy-paste or publish-and-upgrade loops.
+
+### Must validate and fail clearly
+
+- **R11 Duplicate-target rejection:** Genie must reject configurations where
+  multiple sources claim the same generated target.
+- **R12 Repository validation:** Genie must run repository-level validation so
+  cross-file invariants are checked before reporting a successful run.
+- **R13 Root-cause reporting:** Import cycles, TDZ failures, catalog conflicts,
+  and comparable configuration errors must surface actionable diagnostics
+  instead of opaque incidental stack traces.
+- **R14 File-level reporting:** Batch runs must report per-file outcomes and an
+  aggregate summary suitable for both local use and CI.
+
+### Must support the main operating modes
+
+- **R15 Generate mode:** Genie must write generated targets to disk for normal
+  repository authoring workflows.
+- **R16 Check mode:** Genie must verify up-to-date state without mutating
+  targets.
+- **R17 Dry-run mode:** Genie must support previewing prospective changes
+  without writing files.
+- **R18 Watch mode:** Genie must support an interactive mode that reacts to
+  `.genie.ts` source changes and regenerates the affected output set.
+
+### Must preserve output quality
+
+- **R19 Supported formatting:** Generated outputs must respect the repository's
+  supported formatting conventions so repeated generation does not create
+  formatting churn.
+- **R20 Stable metadata channel:** Composition metadata required by other
+  generators must flow through an explicit structured channel rather than being
+  reconstructed from rendered artifact text.
+- **R21 Multi-artifact coverage:** The system must remain capable of generating
+  the major repository artifact classes it already serves, including package
+  manifests, TypeScript configuration, formatter/linter config, and GitHub
+  workflow artifacts.

--- a/packages/@overeng/genie/docs/requirements.md
+++ b/packages/@overeng/genie/docs/requirements.md
@@ -25,12 +25,14 @@ may not yet be installed.
 - **T01 Generated artifacts remain checked in:** Repositories may continue to
   commit generated outputs when downstream tooling expects real files, as long
   as those outputs remain mechanically derived from `.genie.ts` sources.
-- **T02 Watch mode may be less complete than full batch mode:** Interactive
-  watch flows may prioritize fast incremental regeneration as long as strict
-  batch generation and check mode remain authoritative.
-- **T03 Runtime constraints over convenience:** Runtime helpers may reject
-  normal npm dependency patterns if that restriction is required to keep Genie
-  bootstrap-safe and composable.
+- **T02 Runtime constraints over convenience:** Code imported directly by
+  `.genie.ts` sources may reject otherwise-convenient npm dependency patterns
+  when those patterns would require an already-installed `node_modules`,
+  generated workspace state, or other post-bootstrap JavaScript environment.
+  Helpers that need that richer environment may need to live in the CLI/build
+  layer rather than the runtime layer. This tradeoff is acceptable because
+  bootstrap safety and cross-repo composability are more important than making
+  every helper usable from the runtime surface.
 
 ## Requirements
 

--- a/packages/@overeng/genie/docs/requirements.md
+++ b/packages/@overeng/genie/docs/requirements.md
@@ -31,8 +31,8 @@ may not yet be installed.
   generated workspace state, or other post-bootstrap JavaScript environment.
   Helpers that need that richer environment may need to live in the CLI/build
   layer rather than the runtime layer. This tradeoff is acceptable because
-  bootstrap safety and cross-repo composability are more important than making
-  every helper usable from the runtime surface.
+  bootstrap safety and cross-repo composability matter more than making every
+  helper usable from the runtime surface.
 
 ## Requirements
 

--- a/packages/@overeng/genie/docs/spec.md
+++ b/packages/@overeng/genie/docs/spec.md
@@ -1,6 +1,6 @@
 # Genie Specification
 
-This document specifies the `@overeng/genie` subsystem in `effect-utils`. It builds on the package-level context in [../README.md](../README.md) and the build/runtime module boundaries in [../src/build/README.md](../src/build/README.md) and [../src/runtime/README.md](../src/runtime/README.md).
+This document specifies the `@overeng/genie` subsystem in `effect-utils`. It builds on [requirements.md](./requirements.md).
 
 ## Status
 
@@ -21,6 +21,12 @@ This spec does not define:
 - the detailed API contract of each individual runtime factory such as `package-json` or `tsconfig-json`
 - the packaging and hash-refresh mechanics of the Nix CLI wrappers outside the `genie` package itself
 - repository-local task wiring beyond the prerequisite boundary that ensures bootstrap members exist before Genie-backed tasks run
+
+The package-level context and current module-boundary docs remain:
+
+- [../README.md](../README.md)
+- [../src/build/README.md](../src/build/README.md)
+- [../src/runtime/README.md](../src/runtime/README.md)
 
 ## Public Surface
 

--- a/packages/@overeng/genie/docs/spec.md
+++ b/packages/@overeng/genie/docs/spec.md
@@ -32,19 +32,19 @@ The package-level context and current module-boundary docs remain:
 
 Genie exposes two coupled surfaces:
 
-| Surface | Role |
-| --- | --- |
-| `genie` CLI | discovers `.genie.ts` files, loads them, validates them, renders outputs, and reports status |
-| runtime libraries under `src/runtime/` | provide pure or mostly-pure factories and helpers imported by `.genie.ts` source files |
+| Surface                                | Role                                                                                         |
+| -------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `genie` CLI                            | discovers `.genie.ts` files, loads them, validates them, renders outputs, and reports status |
+| runtime libraries under `src/runtime/` | provide pure or mostly-pure factories and helpers imported by `.genie.ts` source files       |
 
 The CLI supports four operating modes:
 
-| Mode | Trigger | Behavior |
-| --- | --- | --- |
-| generate | default | writes generated targets to disk |
-| check | `--check` | verifies generated targets are already up to date |
-| dry-run | `--dry-run` | computes target content and diffs without writing |
-| watch | `--watch` | watches `.genie.ts` files and regenerates changed targets |
+| Mode     | Trigger     | Behavior                                                  |
+| -------- | ----------- | --------------------------------------------------------- |
+| generate | default     | writes generated targets to disk                          |
+| check    | `--check`   | verifies generated targets are already up to date         |
+| dry-run  | `--dry-run` | computes target content and diffs without writing         |
+| watch    | `--watch`   | watches `.genie.ts` files and regenerates changed targets |
 
 Generated targets are read-only by default. `--writeable` opts out of that protection.
 
@@ -54,10 +54,10 @@ Every generator source is a `*.genie.ts` file colocated with its generated targe
 
 Examples:
 
-| Source | Target |
-| --- | --- |
-| `package.json.genie.ts` | `package.json` |
-| `tsconfig.json.genie.ts` | `tsconfig.json` |
+| Source                              | Target                     |
+| ----------------------------------- | -------------------------- |
+| `package.json.genie.ts`             | `package.json`             |
+| `tsconfig.json.genie.ts`            | `tsconfig.json`            |
 | `.github/workflows/ci.yml.genie.ts` | `.github/workflows/ci.yml` |
 
 Genie treats the `.genie.ts` source as the source of truth. Direct edits to generated files are non-authoritative and are expected to be overwritten by the next generation run.
@@ -74,10 +74,10 @@ Factories must propagate composition metadata through `meta` instead of reverse-
 
 Genie is split into two execution domains:
 
-| Domain | Directory | Constraint |
-| --- | --- | --- |
-| build-time CLI | `src/build/` | bundled into the native CLI binary; normal build-time dependencies are allowed |
-| runtime generator library | `src/runtime/` | dynamically imported by `.genie.ts` modules; npm dependencies are disallowed |
+| Domain                    | Directory      | Constraint                                                                     |
+| ------------------------- | -------------- | ------------------------------------------------------------------------------ |
+| build-time CLI            | `src/build/`   | bundled into the native CLI binary; normal build-time dependencies are allowed |
+| runtime generator library | `src/runtime/` | dynamically imported by `.genie.ts` modules; npm dependencies are disallowed   |
 
 The runtime layer must stay lightweight and loadable in arbitrary repository contexts because `.genie.ts` files import it directly during evaluation. The build layer may own TUI concerns, CLI option parsing, process orchestration, and other binary-local concerns.
 

--- a/packages/@overeng/genie/docs/spec.md
+++ b/packages/@overeng/genie/docs/spec.md
@@ -1,0 +1,187 @@
+# Genie Specification
+
+This document specifies the `@overeng/genie` subsystem in `effect-utils`. It builds on the package-level context in [../README.md](../README.md) and the build/runtime module boundaries in [../src/build/README.md](../src/build/README.md) and [../src/runtime/README.md](../src/runtime/README.md).
+
+## Status
+
+Active
+
+## Scope
+
+This spec defines:
+
+- the public operating modes of the `genie` CLI
+- the source and target file conventions for `.genie.ts` generators
+- the boundary between build-time CLI code and runtime generator code
+- import resolution, including megarepo-aware `#mr/...` imports
+- the end-to-end generation and check pipeline
+
+This spec does not define:
+
+- the detailed API contract of each individual runtime factory such as `package-json` or `tsconfig-json`
+- the packaging and hash-refresh mechanics of the Nix CLI wrappers outside the `genie` package itself
+- repository-local task wiring beyond the prerequisite boundary that ensures bootstrap members exist before Genie-backed tasks run
+
+## Public Surface
+
+Genie exposes two coupled surfaces:
+
+| Surface | Role |
+| --- | --- |
+| `genie` CLI | discovers `.genie.ts` files, loads them, validates them, renders outputs, and reports status |
+| runtime libraries under `src/runtime/` | provide pure or mostly-pure factories and helpers imported by `.genie.ts` source files |
+
+The CLI supports four operating modes:
+
+| Mode | Trigger | Behavior |
+| --- | --- | --- |
+| generate | default | writes generated targets to disk |
+| check | `--check` | verifies generated targets are already up to date |
+| dry-run | `--dry-run` | computes target content and diffs without writing |
+| watch | `--watch` | watches `.genie.ts` files and regenerates changed targets |
+
+Generated targets are read-only by default. `--writeable` opts out of that protection.
+
+## Source and Target Model
+
+Every generator source is a `*.genie.ts` file colocated with its generated target. The target path is derived mechanically by removing the `.genie.ts` suffix.
+
+Examples:
+
+| Source | Target |
+| --- | --- |
+| `package.json.genie.ts` | `package.json` |
+| `tsconfig.json.genie.ts` | `tsconfig.json` |
+| `.github/workflows/ci.yml.genie.ts` | `.github/workflows/ci.yml` |
+
+Genie treats the `.genie.ts` source as the source of truth. Direct edits to generated files are non-authoritative and are expected to be overwritten by the next generation run.
+
+The generator default export must resolve to a `GenieOutput<TData, TMeta>` shape:
+
+- `data` is the canonical emitted value
+- `meta` carries non-emitted composition data
+- `stringify(ctx)` renders the final file content
+
+Factories must propagate composition metadata through `meta` instead of reverse-engineering data back out of generated files.
+
+## Build and Runtime Boundary
+
+Genie is split into two execution domains:
+
+| Domain | Directory | Constraint |
+| --- | --- | --- |
+| build-time CLI | `src/build/` | bundled into the native CLI binary; normal build-time dependencies are allowed |
+| runtime generator library | `src/runtime/` | dynamically imported by `.genie.ts` modules; npm dependencies are disallowed |
+
+The runtime layer must stay lightweight and loadable in arbitrary repository contexts because `.genie.ts` files import it directly during evaluation. The build layer may own TUI concerns, CLI option parsing, process orchestration, and other binary-local concerns.
+
+## Import Resolution
+
+Genie must resolve three classes of imports used by `.genie.ts` sources:
+
+- normal Node/TypeScript relative and package imports
+- repository-local helper imports
+- megarepo member imports using the `#mr/<member>/...` prefix
+
+Megarepo member resolution follows this precedence order:
+
+1. `GENIE_MEMBER_OVERRIDE_MAP`
+2. a local member root derived from the importing repository
+3. `GENIE_MEMBER_SOURCE_MAP`
+
+Local member root resolution follows this order:
+
+1. discover the enclosing repository root by walking upward from the importer path
+2. if `megarepo.lock` exists and contains the member, derive the expected global store worktree path from the locked URL and ref
+3. if that derived path exists, use it
+4. otherwise fall back to `repos/<member>` if present
+
+This means Genie can resolve `#mr/...` imports against the lock-pinned global megarepo store without requiring the local `repos/` symlink tree, as long as the referenced member worktree already exists in the store.
+
+Genie does not materialize missing megarepo members itself. Repository task wiring is responsible for ensuring required bootstrap members exist before Genie-backed tasks run.
+
+## Discovery and Validation
+
+The core pipeline begins by recursively discovering `*.genie.ts` files beneath the working directory.
+
+Discovery must enforce these invariants before generation begins:
+
+- each source maps to exactly one target
+- no two sources may claim the same target path
+
+After discovery, Genie runs repository-wide validation before reporting success. Validation warnings are emitted to the event stream and surfaced in the UI, but hard validation failures abort the run.
+
+## Generation Pipeline
+
+The non-watch pipeline is:
+
+1. normalize the working directory to its real path
+2. resolve the active `oxfmt` config path from the explicit CLI option or the standard convention paths
+3. discover `.genie.ts` files and reject duplicate targets
+4. emit a complete discovered-file list to the event bus
+5. load and generate all discovered files concurrently
+6. collect per-file successes and failures
+7. if temporal dead zone failures were seen, re-check files sequentially to isolate root causes
+8. emit final summary counts and fail the run if any file failed
+
+Concurrent generation is the default behavior for throughput. Sequential revalidation exists only as an error-analysis path for ambiguous module-initialization failures.
+
+Check mode reuses the same file loading model but verifies the rendered output against the existing target instead of writing.
+
+## Watch Mode
+
+Watch mode is CLI-specific and intentionally simpler than the full batch pipeline:
+
+1. watch the resolved working directory
+2. filter for changes to `*.genie.ts` files
+3. re-discover sources so newly added files enter the working set
+4. regenerate the changed file
+5. mark unchanged files explicitly in the UI summary
+
+Watch mode is only valid for writable generation, not for `--check` or `--dry-run`.
+
+## Output Semantics
+
+Genie-generated files must preserve these semantics:
+
+- target content is rendered from the canonical `GenieOutput`
+- supported file types are formatted consistently, including `oxfmt` integration where applicable
+- generated files may carry source headers when the output format supports them
+- read-only mode is the default safety mechanism for generated targets
+
+The CLI reports per-file status using the normalized statuses:
+
+- `created`
+- `updated`
+- `unchanged`
+- `skipped`
+- `error`
+
+Batch completion also reports an aggregate summary across those statuses.
+
+## Error Model
+
+Generation failures are file-oriented but reported at both file and run level.
+
+The run-level failure contract is:
+
+- the event stream reports file start, completion, validation warnings, and terminal completion or error states
+- any run with one or more file failures exits with `GenieGenerationFailedError`
+- catalog conflicts and TDZ-style import failures are promoted into clearer root-cause reporting instead of surfacing only the first incidental stack trace
+
+This keeps CI-facing `genie --check` behavior strict while still making interactive failures diagnosable.
+
+## Integration Boundary with Devenv and Megarepo
+
+Genie assumes that any source-imported bootstrap members are already available before execution begins.
+
+The shared task boundary is:
+
+- repositories that need bootstrap members wire `mr:bootstrap` into `genie:prepare`
+- all Genie-backed tasks depend on `genie:prepare`
+
+This keeps the bootstrap requirement centralized at one task boundary rather than duplicating the same megarepo prerequisite across every Genie task name.
+
+## Design Questions
+
+- **DQ1 Self-hydrating `#mr` imports:** Genie currently resolves existing lock-pinned member worktrees but does not materialize missing ones. A future design may move bootstrap from external task wiring into the import resolver or a dedicated preflight phase if that can be done without hiding expensive or surprising side effects.

--- a/packages/@overeng/genie/docs/vision.md
+++ b/packages/@overeng/genie/docs/vision.md
@@ -1,0 +1,82 @@
+# Vision: Genie
+
+## The Problem
+
+### Problem 1: Repository configuration drifts when source and artifact are both editable
+
+Files such as `package.json`, `tsconfig.json`, formatter configs, and GitHub
+workflows are high-churn configuration artifacts. When teams edit both the
+source intent and the rendered artifact directly, repositories accumulate
+formatting noise, inconsistent conventions, and silent divergence between the
+declared model and the file that tooling actually consumes.
+
+### Problem 2: Cross-file configuration logic is duplicated instead of composed
+
+Repository configuration has real structure: package manifests need shared
+catalog data, workspace graphs need to agree with package metadata, CI
+workflows need to share conventions, and generated paths must line up across
+packages and repositories. Hand-authored files force the same logic to be
+re-expressed repeatedly in incompatible formats instead of being composed once
+as code.
+
+### Problem 3: JS-native generators are fragile in the bootstrap path
+
+If the generator itself depends on `pnpm install`, it cannot reliably generate
+the very files that define the install. Fresh checkouts, CI bootstrapping, and
+megarepo composition all expose this chicken-and-egg failure mode. The system
+needs a generator that is available before the JavaScript dependency graph has
+been materialized.
+
+### Problem 4: Generated config is only useful if drift and failures are obvious
+
+A code generator that silently rewrites files, hides root causes, or produces
+non-deterministic output makes CI and local iteration less trustworthy. Teams
+need generated configuration to be strict enough for CI, diagnosable enough for
+interactive work, and deterministic enough that diffs carry signal.
+
+### Problem 5: Cross-repo composition should not force copy-paste configuration
+
+In the megarepo stack, downstream repos need to reuse shared generators and
+shared config logic from upstream members such as `effect-utils`. That reuse
+must work against the lock-pinned local development topology rather than
+forcing every consumer to vendor or duplicate the same generator code.
+
+## The Vision
+
+- **One authoritative source per generated artifact.** Repository config is
+  defined in colocated `.genie.ts` sources, while generated artifacts are
+  treated as derived outputs.
+- **Configuration is composed as code, not duplicated as text.** Shared package
+  metadata, workspace rules, CI helpers, and formatting conventions are reused
+  mechanically through typed runtime factories.
+- **Genie is bootstrap-safe.** The generator is available as a native CLI
+  before `pnpm install`, so fresh checkouts, CI, and megarepo workflows can
+  rely on it without circular setup steps.
+- **Generated output is deterministic and strict.** The same inputs produce the
+  same outputs, drift is caught in `--check`, and failures surface clear
+  root-cause information.
+- **Cross-repo reuse is first-class.** Downstream repos can import shared
+  generator logic from lock-pinned megarepo members and iterate locally without
+  copy-pasting that logic into each consuming repo.
+
+## What This Is Not
+
+- Not a general-purpose build system or task runner. Genie defines and renders
+  generated artifacts; it does not own the full repository workflow.
+- Not a replacement for package managers, TypeScript, formatters, or GitHub
+  Actions. It generates inputs for those tools rather than reimplementing them.
+- Not a free-form templating engine. Its value is principled, typed composition
+  of repository configuration, not arbitrary text expansion.
+
+## Success Criteria
+
+1. A fresh checkout can run Genie before `pnpm install` and before any
+   generator-produced artifact has been materialized.
+2. `genie --check` fails on any generated drift and passes when artifacts match
+   their `.genie.ts` sources.
+3. Downstream repos can reuse shared generator logic from lock-pinned
+   megarepo members without vendoring that logic locally.
+4. Re-running Genie without source changes produces no artifact changes.
+5. Common repository artifacts such as manifests, TypeScript configs, linter
+   configs, and CI workflows are generated through one coherent model rather
+   than a mix of hand-maintained conventions.

--- a/packages/@overeng/genie/docs/vision.md
+++ b/packages/@overeng/genie/docs/vision.md
@@ -2,81 +2,88 @@
 
 ## The Problem
 
-### Problem 1: Repository configuration drifts when source and artifact are both editable
+### Problem 1: Repository configuration formats are too weak for the job
 
-Files such as `package.json`, `tsconfig.json`, formatter configs, and GitHub
-workflows are high-churn configuration artifacts. When teams edit both the
-source intent and the rendered artifact directly, repositories accumulate
-formatting noise, inconsistent conventions, and silent divergence between the
-declared model and the file that tooling actually consumes.
+Modern repositories depend on a large amount of configuration: package
+manifests, TypeScript config, linter and formatter config, CI workflows, and
+more. Those formats are usually static data formats with only limited reuse
+mechanisms. Compared to real programming languages, they are missing basic
+tools such as single-source-of-truth definitions, principled abstraction,
+shared helpers, and comments in the places where teams actually need to explain
+why something exists.
 
-### Problem 2: Cross-file configuration logic is duplicated instead of composed
+### Problem 2: Partial extension systems add complexity instead of solving composition
 
-Repository configuration has real structure: package manifests need shared
-catalog data, workspace graphs need to agree with package metadata, CI
-workflows need to share conventions, and generated paths must line up across
-packages and repositories. Hand-authored files force the same logic to be
-re-expressed repeatedly in incompatible formats instead of being composed once
-as code.
+Some configuration ecosystems add narrow escape hatches such as `extends`,
+includes, merges, or inheritance. These features help locally but do not give
+one coherent model for composing configuration across files, packages, and
+repositories. The result is still fragmented logic, hidden coupling, and
+another layer of format-specific complexity that teams have to learn and debug.
 
-### Problem 3: JS-native generators are fragile in the bootstrap path
+### Problem 3: Repository configuration needs the power of code without giving up the real artifacts
 
-If the generator itself depends on `pnpm install`, it cannot reliably generate
-the very files that define the install. Fresh checkouts, CI bootstrapping, and
-megarepo composition all expose this chicken-and-egg failure mode. The system
-needs a generator that is available before the JavaScript dependency graph has
-been materialized.
+Teams need to express repository intent once, in a clean and reusable form,
+while still producing the actual files that existing tools consume. Without
+that split, configuration either stays trapped in weak static formats or moves
+into ad hoc templating systems that are hard to validate, hard to share, and
+hard to trust.
 
-### Problem 4: Generated config is only useful if drift and failures are obvious
+### Problem 4: Invalid or drifting configuration is usually detected too late
 
-A code generator that silently rewrites files, hides root causes, or produces
-non-deterministic output makes CI and local iteration less trustworthy. Teams
-need generated configuration to be strict enough for CI, diagnosable enough for
-interactive work, and deterministic enough that diffs carry signal.
+Many configuration mistakes are only discovered when the downstream tool reads
+the file at runtime or in CI. That pushes feedback too far away from the source
+of truth. Repository configuration needs earlier validation, clearer errors, and
+generated artifacts whose diffs carry signal rather than noise.
 
-### Problem 5: Cross-repo composition should not force copy-paste configuration
+### Problem 5: Shared configuration logic should scale across repositories
 
-In the megarepo stack, downstream repos need to reuse shared generators and
-shared config logic from upstream members such as `effect-utils`. That reuse
-must work against the lock-pinned local development topology rather than
-forcing every consumer to vendor or duplicate the same generator code.
+Real repository stacks reuse the same conventions across many packages and
+often across many repositories. Copy-pasting config logic between repos creates
+drift immediately. Shared configuration logic must be reusable across repo
+boundaries without forcing each consumer to reimplement the same rules in its
+own local configuration files.
 
 ## The Vision
 
-- **One authoritative source per generated artifact.** Repository config is
-  defined in colocated `.genie.ts` sources, while generated artifacts are
-  treated as derived outputs.
-- **Configuration is composed as code, not duplicated as text.** Shared package
-  metadata, workspace rules, CI helpers, and formatting conventions are reused
-  mechanically through typed runtime factories.
-- **Genie is bootstrap-safe.** The generator is available as a native CLI
-  before `pnpm install`, so fresh checkouts, CI, and megarepo workflows can
-  rely on it without circular setup steps.
-- **Generated output is deterministic and strict.** The same inputs produce the
-  same outputs, drift is caught in `--check`, and failures surface clear
-  root-cause information.
-- **Cross-repo reuse is first-class.** Downstream repos can import shared
-  generator logic from lock-pinned megarepo members and iterate locally without
-  copy-pasting that logic into each consuming repo.
+- **Configuration is first-class code.** Repository intent is authored in a
+  real programming language instead of being fragmented across weak static
+  config formats.
+- **One clean source of truth drives many concrete artifacts.** Teams define
+  shared facts, rules, and conventions once, then generate the concrete config
+  files that tools expect.
+- **Repository configuration is reusable and explainable.** Shared logic,
+  constants, comments, and helper functions can be composed cleanly within a
+  repo and across repos.
+- **Each config domain has a typed, constrained authoring model.** Instead of
+  writing arbitrary text templates, teams use domain-specific generators that
+  guide what is valid and catch problems during generation.
+- **Generated artifacts remain simple, boring, and tool-compatible.** The value
+  lives in the source model and validation, while the emitted files stay as the
+  standard artifacts consumed by package managers, compilers, linters, and CI
+  systems.
 
 ## What This Is Not
 
 - Not a general-purpose build system or task runner. Genie defines and renders
   generated artifacts; it does not own the full repository workflow.
-- Not a replacement for package managers, TypeScript, formatters, or GitHub
-  Actions. It generates inputs for those tools rather than reimplementing them.
-- Not a free-form templating engine. Its value is principled, typed composition
-  of repository configuration, not arbitrary text expansion.
+- Not a replacement for package managers, compilers, formatters, or CI systems.
+  It generates inputs for those tools rather than reimplementing them.
+- Not a free-form templating engine. Its value is principled configuration as
+  code with typed domain-specific generators, not arbitrary text expansion.
+- Not an argument that every repository artifact should become programmable.
+  Genie exists for configuration that benefits from reuse, composition, and
+  validation, not for generating files with no meaningful structure.
 
 ## Success Criteria
 
-1. A fresh checkout can run Genie before `pnpm install` and before any
-   generator-produced artifact has been materialized.
-2. `genie --check` fails on any generated drift and passes when artifacts match
-   their `.genie.ts` sources.
-3. Downstream repos can reuse shared generator logic from lock-pinned
-   megarepo members without vendoring that logic locally.
-4. Re-running Genie without source changes produces no artifact changes.
-5. Common repository artifacts such as manifests, TypeScript configs, linter
-   configs, and CI workflows are generated through one coherent model rather
-   than a mix of hand-maintained conventions.
+1. Common repository artifacts such as manifests, TypeScript configs, linter
+   configs, and CI workflows can be defined from one coherent source model
+   rather than a mix of hand-maintained conventions.
+2. Shared configuration facts and rules can be defined once and reused across
+   multiple generated artifacts without duplication.
+3. Configuration authors can express intent with normal code-level tools such
+   as reuse, abstraction, comments, and typed composition.
+4. Domain-specific generators catch invalid or inconsistent configuration before
+   downstream tools consume the emitted files.
+5. Repositories and downstream consumers can share configuration logic across
+   repo boundaries without vendoring or copy-pasting that logic locally.

--- a/packages/@overeng/genie/docs/vision.md
+++ b/packages/@overeng/genie/docs/vision.md
@@ -2,17 +2,17 @@
 
 ## The Problem
 
-### Problem 1: Repository configuration formats are too weak for the job
+### Problem 1: Repository configuration formats are too weak
 
 Modern repositories depend on a large amount of configuration: package
 manifests, TypeScript config, linter and formatter config, CI workflows, and
 more. Those formats are usually static data formats with only limited reuse
 mechanisms. Compared to real programming languages, they are missing basic
 tools such as single-source-of-truth definitions, principled abstraction,
-shared helpers, and comments in the places where teams actually need to explain
-why something exists.
+shared helpers, and comments in the places where teams actually need to
+explain why something exists.
 
-### Problem 2: Partial extension systems add complexity instead of solving composition
+### Problem 2: Partial extension systems do not solve composition
 
 Some configuration ecosystems add narrow escape hatches such as `extends`,
 includes, merges, or inheritance. These features help locally but do not give
@@ -20,7 +20,7 @@ one coherent model for composing configuration across files, packages, and
 repositories. The result is still fragmented logic, hidden coupling, and
 another layer of format-specific complexity that teams have to learn and debug.
 
-### Problem 3: Repository configuration needs the power of code without giving up the real artifacts
+### Problem 3: Configuration needs code without losing real artifacts
 
 Teams need to express repository intent once, in a clean and reusable form,
 while still producing the actual files that existing tools consume. Without
@@ -31,9 +31,9 @@ hard to trust.
 ### Problem 4: Invalid or drifting configuration is usually detected too late
 
 Many configuration mistakes are only discovered when the downstream tool reads
-the file at runtime or in CI. That pushes feedback too far away from the source
-of truth. Repository configuration needs earlier validation, clearer errors, and
-generated artifacts whose diffs carry signal rather than noise.
+the file at runtime or in CI. That pushes feedback too far away from the
+source of truth. Repository configuration needs earlier validation, clearer
+errors, and generated artifacts whose diffs carry signal rather than noise.
 
 ### Problem 5: Shared configuration logic should scale across repositories
 
@@ -57,10 +57,10 @@ own local configuration files.
 - **Each config domain has a typed, constrained authoring model.** Instead of
   writing arbitrary text templates, teams use domain-specific generators that
   guide what is valid and catch problems during generation.
-- **Generated artifacts remain simple, boring, and tool-compatible.** The value
-  lives in the source model and validation, while the emitted files stay as the
-  standard artifacts consumed by package managers, compilers, linters, and CI
-  systems.
+- **Generated artifacts remain simple, boring, and tool-compatible.** The
+  value lives in the source model and validation, while the emitted files stay
+  as the standard artifacts consumed by package managers, compilers, linters,
+  and CI systems.
 
 ## What This Is Not
 

--- a/packages/@overeng/genie/src/core/discovery.ts
+++ b/packages/@overeng/genie/src/core/discovery.ts
@@ -10,7 +10,7 @@ import type { StatResult } from './types.ts'
 let importMapResolverRegistered = false
 
 /** Detect if we're running as a compiled Bun binary (bunfs paths indicate compiled binary) */
-const isCompiledBinary = (): boolean => {
+export const isCompiledBinary = (): boolean => {
   try {
     return process.argv[1]?.includes('/$bunfs/') ?? false
   } catch {

--- a/packages/@overeng/genie/src/core/generation.ts
+++ b/packages/@overeng/genie/src/core/generation.ts
@@ -1,5 +1,8 @@
 import { createHash } from 'node:crypto'
+import fs from 'node:fs/promises'
+import os from 'node:os'
 import path from 'node:path'
+import { pathToFileURL } from 'node:url'
 
 import type { Path } from '@effect/platform'
 import {
@@ -15,13 +18,14 @@ import { FileSystemBacking } from '@overeng/utils/node'
 
 import type { GenieOutput } from '../runtime/mod.ts'
 import { CatalogConflictError } from '../runtime/package-json/catalog.ts'
-import { ensureImportMapResolver } from './discovery.ts'
+import { ensureImportMapResolver, isCompiledBinary } from './discovery.ts'
 import {
   GenieCheckError,
   GenieFileError,
   GenieImportError,
   InvalidOxfmtConfigError,
 } from './errors.ts'
+import { resolveImportMapsInSource } from './import-map/mod.ts'
 import type { GenerateSuccess, GenieContext } from './types.ts'
 
 /** Loaded genie module plus base context reused across check and validation phases. */
@@ -30,6 +34,163 @@ export type LoadedGenieFile = {
   output: GenieOutput<unknown>
   ctx: GenieContext
 }
+
+const IMPORT_SPECIFIER_REGEX = /(?:import|export)\s+(?:[\s\S]*?\s+from\s+)?(['"])([^'"]+)\1/g
+
+const isRelativeImportSpecifier = (specifier: string): boolean =>
+  specifier.startsWith('./') === true || specifier.startsWith('../') === true
+
+const resolveRelativeImportPath = async ({
+  importerPath,
+  specifier,
+}: {
+  importerPath: string
+  specifier: string
+}): Promise<string | undefined> => {
+  const resolvedBase = path.resolve(path.dirname(importerPath), specifier)
+  const candidates = [
+    resolvedBase,
+    `${resolvedBase}.ts`,
+    `${resolvedBase}.tsx`,
+    `${resolvedBase}.mts`,
+    `${resolvedBase}.cts`,
+    `${resolvedBase}.js`,
+    `${resolvedBase}.mjs`,
+    path.join(resolvedBase, 'index.ts'),
+    path.join(resolvedBase, 'index.tsx'),
+    path.join(resolvedBase, 'mod.ts'),
+    path.join(resolvedBase, 'mod.tsx'),
+  ]
+
+  for (const candidate of candidates) {
+    try {
+      const stat = await fs.stat(candidate)
+      if (stat.isFile() === true) {
+        return candidate
+      }
+    } catch {
+      // Try the next candidate.
+    }
+  }
+
+  return undefined
+}
+
+const collectRelativeImportPaths = async ({
+  sourceCode,
+  sourcePath,
+}: {
+  sourceCode: string
+  sourcePath: string
+}): Promise<string[]> => {
+  const relativeImportPaths = new Set<string>()
+  const importSpecifierRegex = new RegExp(IMPORT_SPECIFIER_REGEX)
+  let match: RegExpExecArray | null = importSpecifierRegex.exec(sourceCode)
+  while (match !== null) {
+    const specifier = match[2]
+    if (specifier !== undefined && isRelativeImportSpecifier(specifier) === true) {
+      const resolved = await resolveRelativeImportPath({ importerPath: sourcePath, specifier })
+      if (resolved !== undefined) {
+        relativeImportPaths.add(resolved)
+      }
+    }
+    match = importSpecifierRegex.exec(sourceCode)
+  }
+
+  return Array.from(relativeImportPaths)
+}
+
+const stageCompiledBinaryImportGraph = ({
+  entryPath,
+}: {
+  entryPath: string
+}): Effect.Effect<string, GenieImportError, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const tempRoot = yield* Effect.tryPromise({
+      try: () => fs.mkdtemp(path.join(os.tmpdir(), 'genie-import-')),
+      catch: (error) =>
+        new GenieImportError({
+          genieFilePath: entryPath,
+          message: `Failed to create compiled-binary staging directory for ${entryPath}: ${safeErrorString(error)}`,
+          cause: error,
+        }),
+    })
+
+    const stagedPaths = new Map<string, string>()
+    const relativeEntryPath = entryPath.replace(/^(?:[A-Za-z]:)?[\\/]+/, '')
+
+    const stageModule = (
+      sourcePath: string,
+    ): Effect.Effect<string, GenieImportError, FileSystem.FileSystem> =>
+      Effect.gen(function* () {
+        const existingStagePath = stagedPaths.get(sourcePath)
+        if (existingStagePath !== undefined) {
+          return existingStagePath
+        }
+
+        const relativeSourcePath =
+          sourcePath === entryPath
+            ? relativeEntryPath
+            : path.relative(path.parse(sourcePath).root, sourcePath)
+        const stagePath = path.join(tempRoot, relativeSourcePath)
+        stagedPaths.set(sourcePath, stagePath)
+
+        const sourceCode = yield* Effect.tryPromise({
+          try: () => fs.readFile(sourcePath, 'utf8'),
+          catch: (error) =>
+            new GenieImportError({
+              genieFilePath: entryPath,
+              message: `Failed to read ${sourcePath} while staging compiled-binary imports: ${safeErrorString(error)}`,
+              cause: error,
+            }),
+        })
+
+        const transformedSource = yield* resolveImportMapsInSource({
+          sourceCode,
+          sourcePath,
+        }).pipe(
+          Effect.mapError(
+            (error) =>
+              new GenieImportError({
+                genieFilePath: entryPath,
+                message: `Failed to resolve imports in ${sourcePath} for compiled-binary staging: ${safeErrorString(error)}`,
+                cause: error,
+              }),
+          ),
+        )
+
+        const relativeImportPaths = yield* Effect.tryPromise({
+          try: () => collectRelativeImportPaths({ sourceCode, sourcePath }),
+          catch: (error) =>
+            new GenieImportError({
+              genieFilePath: entryPath,
+              message: `Failed to analyze imports in ${sourcePath} for compiled-binary staging: ${safeErrorString(error)}`,
+              cause: error,
+            }),
+        })
+
+        yield* Effect.tryPromise({
+          try: async () => {
+            await fs.mkdir(path.dirname(stagePath), { recursive: true })
+            await fs.writeFile(stagePath, transformedSource)
+          },
+          catch: (error) =>
+            new GenieImportError({
+              genieFilePath: entryPath,
+              message: `Failed to write staged module ${stagePath}: ${safeErrorString(error)}`,
+              cause: error,
+            }),
+        })
+
+        for (const relativeImportPath of relativeImportPaths) {
+          yield* stageModule(relativeImportPath)
+        }
+
+        return stagePath
+      })
+
+    return yield* stageModule(entryPath)
+  })
 
 /**
  * Safely convert error to string.
@@ -356,7 +517,13 @@ export const loadGenieFile = Effect.fn('loadGenieFile')(function* ({
 }) {
   yield* ensureImportMapResolver
 
-  const importPath = `${genieFilePath}?import=${Date.now()}`
+  const importPathBase =
+    isCompiledBinary() === true
+      ? yield* stageCompiledBinaryImportGraph({ entryPath: genieFilePath }).pipe(
+          Effect.map((stagePath) => pathToFileURL(stagePath).href),
+        )
+      : genieFilePath
+  const importPath = `${importPathBase}?import=${Date.now()}`
 
   const module = yield* Effect.tryPromise({
     // oxlint-disable-next-line eslint-plugin-import/no-dynamic-require -- dynamic import path required for genie

--- a/packages/@overeng/genie/src/core/generation.ts
+++ b/packages/@overeng/genie/src/core/generation.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto'
-import fs from 'node:fs/promises'
+import nodeFs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import { pathToFileURL } from 'node:url'
@@ -62,18 +62,18 @@ const resolveRelativeImportPath = async ({
     path.join(resolvedBase, 'mod.tsx'),
   ]
 
-  for (const candidate of candidates) {
-    try {
-      const stat = await fs.stat(candidate)
-      if (stat.isFile() === true) {
-        return candidate
+  const resolvedCandidates = await Promise.all(
+    candidates.map(async (candidate) => {
+      try {
+        const stat = await nodeFs.stat(candidate)
+        return stat.isFile() === true ? candidate : undefined
+      } catch {
+        return undefined
       }
-    } catch {
-      // Try the next candidate.
-    }
-  }
+    }),
+  )
 
-  return undefined
+  return resolvedCandidates.find((candidate) => candidate !== undefined)
 }
 
 const collectRelativeImportPaths = async ({
@@ -83,21 +83,24 @@ const collectRelativeImportPaths = async ({
   sourceCode: string
   sourcePath: string
 }): Promise<string[]> => {
-  const relativeImportPaths = new Set<string>()
   const importSpecifierRegex = new RegExp(IMPORT_SPECIFIER_REGEX)
+  const relativeSpecifiers: string[] = []
   let match: RegExpExecArray | null = importSpecifierRegex.exec(sourceCode)
   while (match !== null) {
     const specifier = match[2]
     if (specifier !== undefined && isRelativeImportSpecifier(specifier) === true) {
-      const resolved = await resolveRelativeImportPath({ importerPath: sourcePath, specifier })
-      if (resolved !== undefined) {
-        relativeImportPaths.add(resolved)
-      }
+      relativeSpecifiers.push(specifier)
     }
     match = importSpecifierRegex.exec(sourceCode)
   }
 
-  return Array.from(relativeImportPaths)
+  const resolvedPaths = await Promise.all(
+    relativeSpecifiers.map((specifier) =>
+      resolveRelativeImportPath({ importerPath: sourcePath, specifier }),
+    ),
+  )
+
+  return Array.from(new Set(resolvedPaths.filter((resolved): resolved is string => resolved !== undefined)))
 }
 
 const stageCompiledBinaryImportGraph = ({
@@ -107,7 +110,7 @@ const stageCompiledBinaryImportGraph = ({
 }): Effect.Effect<string, GenieImportError, FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const tempRoot = yield* Effect.tryPromise({
-      try: () => fs.mkdtemp(path.join(os.tmpdir(), 'genie-import-')),
+      try: () => nodeFs.mkdtemp(path.join(os.tmpdir(), 'genie-import-')),
       catch: (error) =>
         new GenieImportError({
           genieFilePath: entryPath,
@@ -136,7 +139,7 @@ const stageCompiledBinaryImportGraph = ({
         stagedPaths.set(sourcePath, stagePath)
 
         const sourceCode = yield* Effect.tryPromise({
-          try: () => fs.readFile(sourcePath, 'utf8'),
+          try: () => nodeFs.readFile(sourcePath, 'utf8'),
           catch: (error) =>
             new GenieImportError({
               genieFilePath: entryPath,
@@ -171,8 +174,8 @@ const stageCompiledBinaryImportGraph = ({
 
         yield* Effect.tryPromise({
           try: async () => {
-            await fs.mkdir(path.dirname(stagePath), { recursive: true })
-            await fs.writeFile(stagePath, transformedSource)
+            await nodeFs.mkdir(path.dirname(stagePath), { recursive: true })
+            await nodeFs.writeFile(stagePath, transformedSource)
           },
           catch: (error) =>
             new GenieImportError({

--- a/packages/@overeng/genie/src/core/generation.ts
+++ b/packages/@overeng/genie/src/core/generation.ts
@@ -100,7 +100,9 @@ const collectRelativeImportPaths = async ({
     ),
   )
 
-  return Array.from(new Set(resolvedPaths.filter((resolved): resolved is string => resolved !== undefined)))
+  return Array.from(
+    new Set(resolvedPaths.filter((resolved): resolved is string => resolved !== undefined)),
+  )
 }
 
 const stageCompiledBinaryImportGraph = ({

--- a/packages/@overeng/genie/src/core/import-map/import-map.unit.test.ts
+++ b/packages/@overeng/genie/src/core/import-map/import-map.unit.test.ts
@@ -623,6 +623,35 @@ import { baz } from './local.ts'`
     )
 
     Vitest.it.effect(
+      'transforms multiline imports with # specifiers',
+      Effect.fnUntraced(function* () {
+        const packageJsonPath = path.join(tempDir, 'package.json')
+        yield* writeFile(
+          packageJsonPath,
+          toJson({
+            imports: { '#lib/*': './src/lib/*' },
+          }),
+        )
+        const filePath = path.join(tempDir, 'src', 'file.ts')
+        yield* writeFile(filePath, '')
+
+        const sourceCode = `import {
+  foo,
+  bar,
+} from '#lib/mod.ts'`
+        const result = yield* resolveImportMapsInSource({
+          sourceCode,
+          sourcePath: filePath,
+        })
+
+        expect(result).toBe(`import {
+  foo,
+  bar,
+} from '${tempDir}/src/lib/mod.ts'`)
+      }, Effect.provide(TestLayer)),
+    )
+
+    Vitest.it.effect(
       'transforms #mr member imports without a package.json import map',
       Effect.fnUntraced(function* () {
         process.env[GENIE_MEMBER_SOURCE_MAP_ENV] = JSON.stringify({

--- a/packages/@overeng/genie/src/core/import-map/import-map.unit.test.ts
+++ b/packages/@overeng/genie/src/core/import-map/import-map.unit.test.ts
@@ -427,10 +427,7 @@ export default packageJson({
           ),
           '',
         )
-        yield* writeFile(
-          path.join(tempDir, 'fallback-effect-utils', 'genie', 'external.ts'),
-          '',
-        )
+        yield* writeFile(path.join(tempDir, 'fallback-effect-utils', 'genie', 'external.ts'), '')
 
         const importerPath = path.join(tempDir, 'src', 'genie-file.ts')
         yield* writeFile(importerPath, '')
@@ -489,10 +486,7 @@ export default packageJson({
         process.env[GENIE_MEMBER_SOURCE_MAP_ENV] = JSON.stringify({
           'effect-utils': path.join(tempDir, 'fallback-effect-utils'),
         })
-        yield* writeFile(
-          path.join(tempDir, 'fallback-effect-utils', 'genie', 'external.ts'),
-          '',
-        )
+        yield* writeFile(path.join(tempDir, 'fallback-effect-utils', 'genie', 'external.ts'), '')
         const importerPath = path.join(tempDir, 'src', 'genie-file.ts')
         yield* writeFile(importerPath, '')
 
@@ -540,10 +534,7 @@ export default packageJson({
           ),
           '',
         )
-        yield* writeFile(
-          path.join(tempDir, 'override-effect-utils', 'genie', 'external.ts'),
-          '',
-        )
+        yield* writeFile(path.join(tempDir, 'override-effect-utils', 'genie', 'external.ts'), '')
         const importerPath = path.join(tempDir, 'src', 'genie-file.ts')
         yield* writeFile(importerPath, '')
 
@@ -639,10 +630,7 @@ import { baz } from './local.ts'`
         })
         const filePath = path.join(tempDir, 'src', 'file.ts')
         yield* writeFile(filePath, '')
-        yield* writeFile(
-          path.join(tempDir, 'fallback-effect-utils', 'genie', 'external.ts'),
-          '',
-        )
+        yield* writeFile(path.join(tempDir, 'fallback-effect-utils', 'genie', 'external.ts'), '')
 
         const sourceCode = `import { packageJson } from '#mr/effect-utils/genie/external.ts'`
         const result = yield* resolveImportMapsInSource({

--- a/packages/@overeng/genie/src/core/import-map/import-map.unit.test.ts
+++ b/packages/@overeng/genie/src/core/import-map/import-map.unit.test.ts
@@ -21,6 +21,9 @@ import {
 } from './mod.ts'
 
 const TestLayer = NodeFileSystem.layer
+const GENIE_MEMBER_OVERRIDE_MAP_ENV = 'GENIE_MEMBER_OVERRIDE_MAP'
+const GENIE_MEMBER_SOURCE_MAP_ENV = 'GENIE_MEMBER_SOURCE_MAP'
+const MEGAREPO_STORE_ENV = 'MEGAREPO_STORE'
 
 /** Type-safe JSON stringify using Schema */
 const toJson = Schema.encodeSync(Schema.parseJson(Schema.Unknown))
@@ -62,6 +65,9 @@ Vitest.describe('import-map', () => {
   })
 
   afterEach(async () => {
+    delete process.env[GENIE_MEMBER_OVERRIDE_MAP_ENV]
+    delete process.env[GENIE_MEMBER_SOURCE_MAP_ENV]
+    delete process.env[MEGAREPO_STORE_ENV]
     await Effect.runPromise(removeTempDir(tempDir).pipe(Effect.provide(TestLayer)))
   })
 
@@ -385,6 +391,71 @@ export default packageJson({
         expect(Option.getOrNull(resolved)).toBe(path.join(tempDir, 'genie', 'mod.ts'))
       }, Effect.provide(TestLayer)),
     )
+
+    Vitest.it.effect(
+      'prefers local editable megarepo member over fallback source map',
+      Effect.fnUntraced(function* () {
+        process.env[MEGAREPO_STORE_ENV] = path.join(tempDir, '.megarepo')
+        process.env[GENIE_MEMBER_SOURCE_MAP_ENV] = JSON.stringify({
+          'effect-utils': path.join(tempDir, 'fallback-effect-utils'),
+        })
+
+        yield* writeFile(path.join(tempDir, '.git'), '')
+        yield* writeFile(
+          path.join(tempDir, 'megarepo.lock'),
+          toJson({
+            members: {
+              'effect-utils': {
+                url: 'https://github.com/overengineeringstudio/effect-utils',
+                ref: 'dev',
+              },
+            },
+          }),
+        )
+        yield* writeFile(
+          path.join(
+            tempDir,
+            '.megarepo',
+            'github.com',
+            'overengineeringstudio',
+            'effect-utils',
+            'refs',
+            'heads',
+            'dev',
+            'genie',
+            'external.ts',
+          ),
+          '',
+        )
+        yield* writeFile(
+          path.join(tempDir, 'fallback-effect-utils', 'genie', 'external.ts'),
+          '',
+        )
+
+        const importerPath = path.join(tempDir, 'src', 'genie-file.ts')
+        yield* writeFile(importerPath, '')
+
+        const resolved = yield* resolveImportMapSpecifierForImporter({
+          specifier: '#mr/effect-utils/genie/external.ts',
+          importerPath,
+        })
+
+        expect(Option.getOrNull(resolved)).toBe(
+          path.join(
+            tempDir,
+            '.megarepo',
+            'github.com',
+            'overengineeringstudio',
+            'effect-utils',
+            'refs',
+            'heads',
+            'dev',
+            'genie',
+            'external.ts',
+          ),
+        )
+      }, Effect.provide(TestLayer)),
+    )
   })
 
   Vitest.describe('resolveImportMapSpecifierForImporterSync', () => {
@@ -409,6 +480,79 @@ export default packageJson({
         })
 
         expect(resolved).toBe(path.join(tempDir, 'genie', 'mod.ts'))
+      }, Effect.provide(TestLayer)),
+    )
+
+    Vitest.it.effect(
+      'uses fallback source map when local megarepo member is absent',
+      Effect.fnUntraced(function* () {
+        process.env[GENIE_MEMBER_SOURCE_MAP_ENV] = JSON.stringify({
+          'effect-utils': path.join(tempDir, 'fallback-effect-utils'),
+        })
+        yield* writeFile(
+          path.join(tempDir, 'fallback-effect-utils', 'genie', 'external.ts'),
+          '',
+        )
+        const importerPath = path.join(tempDir, 'src', 'genie-file.ts')
+        yield* writeFile(importerPath, '')
+
+        const resolved = resolveImportMapSpecifierForImporterSync({
+          specifier: '#mr/effect-utils/genie/external.ts',
+          importerPath,
+        })
+
+        expect(resolved).toBe(path.join(tempDir, 'fallback-effect-utils', 'genie', 'external.ts'))
+      }, Effect.provide(TestLayer)),
+    )
+
+    Vitest.it.effect(
+      'prefers explicit override over local editable megarepo member',
+      Effect.fnUntraced(function* () {
+        process.env[MEGAREPO_STORE_ENV] = path.join(tempDir, '.megarepo')
+        process.env[GENIE_MEMBER_OVERRIDE_MAP_ENV] = JSON.stringify({
+          'effect-utils': path.join(tempDir, 'override-effect-utils'),
+        })
+
+        yield* writeFile(path.join(tempDir, '.git'), '')
+        yield* writeFile(
+          path.join(tempDir, 'megarepo.lock'),
+          toJson({
+            members: {
+              'effect-utils': {
+                url: 'https://github.com/overengineeringstudio/effect-utils',
+                ref: 'dev',
+              },
+            },
+          }),
+        )
+        yield* writeFile(
+          path.join(
+            tempDir,
+            '.megarepo',
+            'github.com',
+            'overengineeringstudio',
+            'effect-utils',
+            'refs',
+            'heads',
+            'dev',
+            'genie',
+            'external.ts',
+          ),
+          '',
+        )
+        yield* writeFile(
+          path.join(tempDir, 'override-effect-utils', 'genie', 'external.ts'),
+          '',
+        )
+        const importerPath = path.join(tempDir, 'src', 'genie-file.ts')
+        yield* writeFile(importerPath, '')
+
+        const resolved = resolveImportMapSpecifierForImporterSync({
+          specifier: '#mr/effect-utils/genie/external.ts',
+          importerPath,
+        })
+
+        expect(resolved).toBe(path.join(tempDir, 'override-effect-utils', 'genie', 'external.ts'))
       }, Effect.provide(TestLayer)),
     )
   })
@@ -484,6 +628,31 @@ import { baz } from './local.ts'`
         expect(result).toContain(`from '${tempDir}/src/lib/foo.ts'`)
         expect(result).toContain(`from '${tempDir}/src/lib/bar.ts'`)
         expect(result).toContain(`from './local.ts'`)
+      }, Effect.provide(TestLayer)),
+    )
+
+    Vitest.it.effect(
+      'transforms #mr member imports without a package.json import map',
+      Effect.fnUntraced(function* () {
+        process.env[GENIE_MEMBER_SOURCE_MAP_ENV] = JSON.stringify({
+          'effect-utils': path.join(tempDir, 'fallback-effect-utils'),
+        })
+        const filePath = path.join(tempDir, 'src', 'file.ts')
+        yield* writeFile(filePath, '')
+        yield* writeFile(
+          path.join(tempDir, 'fallback-effect-utils', 'genie', 'external.ts'),
+          '',
+        )
+
+        const sourceCode = `import { packageJson } from '#mr/effect-utils/genie/external.ts'`
+        const result = yield* resolveImportMapsInSource({
+          sourceCode,
+          sourcePath: filePath,
+        })
+
+        expect(result).toBe(
+          `import { packageJson } from '${path.join(tempDir, 'fallback-effect-utils', 'genie', 'external.ts')}'`,
+        )
       }, Effect.provide(TestLayer)),
     )
 

--- a/packages/@overeng/genie/src/core/import-map/mod.ts
+++ b/packages/@overeng/genie/src/core/import-map/mod.ts
@@ -254,6 +254,221 @@ export const extractImportMapSync = (packageJsonPath: string): ImportMap => {
   return {}
 }
 
+const MEGAREPO_MEMBER_PREFIX = '#mr/'
+const GENIE_MEMBER_OVERRIDE_MAP_ENV = 'GENIE_MEMBER_OVERRIDE_MAP'
+const GENIE_MEMBER_SOURCE_MAP_ENV = 'GENIE_MEMBER_SOURCE_MAP'
+
+type MemberSourceMap = Record<string, string>
+
+type MegarepoLockMember = {
+  readonly url: string
+  readonly ref: string
+}
+
+type MegarepoLock = {
+  readonly members?: Record<string, MegarepoLockMember>
+}
+
+const parseMemberSourceMap = (value: string | undefined): MemberSourceMap => {
+  if (value === undefined || value === '') return {}
+
+  try {
+    const parsed = JSON.parse(value) as unknown
+    if (parsed === null || typeof parsed !== 'object') return {}
+
+    return Object.fromEntries(
+      Object.entries(parsed).filter(
+        ([key, sourcePath]) =>
+          key.length > 0 && typeof sourcePath === 'string' && sourcePath.length > 0,
+      ),
+    )
+  } catch {
+    return {}
+  }
+}
+
+const parseMegarepoLockContent = (content: string): MegarepoLock => {
+  try {
+    return JSON.parse(content) as MegarepoLock
+  } catch {
+    return {}
+  }
+}
+
+const classifyMegarepoRef = (ref: string): 'commit' | 'tag' | 'branch' => {
+  if (/^[a-f0-9]{40}$/.test(ref) === true) return 'commit'
+  if (/^v?\d+(?:\.\d+)*(?:[-+].+)?$/.test(ref) === true) return 'tag'
+  return 'branch'
+}
+
+const refTypeToPathSegment = (refType: 'commit' | 'tag' | 'branch'): string => {
+  switch (refType) {
+    case 'commit':
+      return 'commits'
+    case 'tag':
+      return 'tags'
+    case 'branch':
+      return 'heads'
+  }
+}
+
+const parseMemberSpecifier = (
+  specifier: string,
+): { memberName: string; subPath: string } | undefined => {
+  if (specifier.startsWith(MEGAREPO_MEMBER_PREFIX) === false) {
+    return undefined
+  }
+
+  const remainder = specifier.slice(MEGAREPO_MEMBER_PREFIX.length)
+  if (remainder.length === 0) return undefined
+
+  const [memberName, ...rest] = remainder.split('/')
+  if (memberName === undefined || memberName.length === 0) {
+    return undefined
+  }
+
+  return {
+    memberName,
+    subPath: rest.join('/'),
+  }
+}
+
+const joinMemberSubPath = ({
+  memberRoot,
+  subPath,
+}: {
+  memberRoot: string
+  subPath: string
+}): string => (subPath.length === 0 ? memberRoot : path.join(memberRoot, subPath))
+
+const getMegarepoStoreBasePath = (): string =>
+  process.env.MEGAREPO_STORE ?? path.join(process.env.HOME ?? '~', '.megarepo')
+
+const deriveStoreWorktreePathFromLockMember = ({
+  member,
+}: {
+  member: MegarepoLockMember
+}): string | undefined => {
+  const url = member.url.replace(/^https?:\/\//, '')
+  const [host, owner, repo] = url.split('/')
+  if (
+    host === undefined ||
+    host.length === 0 ||
+    owner === undefined ||
+    owner.length === 0 ||
+    repo === undefined ||
+    repo.length === 0
+  ) {
+    return undefined
+  }
+
+  const refType = classifyMegarepoRef(member.ref)
+  return path.join(
+    getMegarepoStoreBasePath(),
+    host,
+    owner,
+    repo,
+    'refs',
+    refTypeToPathSegment(refType),
+    member.ref,
+  )
+}
+
+const findRepoRootSync = (fromPath: string): string | undefined => {
+  let current = path.dirname(fromPath)
+  let previous = ''
+
+  while (current !== previous) {
+    if (
+      fs.existsSync(path.join(current, 'megarepo.lock')) === true ||
+      fs.existsSync(path.join(current, 'megarepo.kdl')) === true ||
+      fs.existsSync(path.join(current, 'megarepo.json')) === true ||
+      fs.existsSync(path.join(current, '.git')) === true
+    ) {
+      return current
+    }
+
+    previous = current
+    current = path.dirname(current)
+  }
+
+  return undefined
+}
+
+const resolveLocalMegarepoMemberRootSync = ({
+  memberName,
+  importerPath,
+}: {
+  memberName: string
+  importerPath: string
+}): string | undefined => {
+  const repoRoot = findRepoRootSync(importerPath)
+  if (repoRoot === undefined) return undefined
+
+  const lockPath = path.join(repoRoot, 'megarepo.lock')
+  if (fs.existsSync(lockPath) === true) {
+    try {
+      const lockContent = fs.readFileSync(lockPath, 'utf8')
+      const lock = parseMegarepoLockContent(lockContent)
+      const lockMember = lock.members?.[memberName]
+      if (lockMember !== undefined) {
+        const derivedPath = deriveStoreWorktreePathFromLockMember({ member: lockMember })
+        if (derivedPath !== undefined && fs.existsSync(derivedPath) === true) {
+          return derivedPath
+        }
+      }
+    } catch {
+      // Ignore lock parse/read errors and continue to local symlink fallback.
+    }
+  }
+
+  const memberPath = path.join(repoRoot, 'repos', memberName)
+  if (fs.existsSync(memberPath) === true) {
+    try {
+      return fs.realpathSync(memberPath)
+    } catch {
+      return memberPath
+    }
+  }
+
+  return undefined
+}
+
+const resolveMegarepoMemberSpecifierSync = ({
+  specifier,
+  importerPath,
+}: {
+  specifier: string
+  importerPath: string
+}): string | undefined => {
+  const parsed = parseMemberSpecifier(specifier)
+  if (parsed === undefined) {
+    return undefined
+  }
+
+  const overrideMap = parseMemberSourceMap(process.env[GENIE_MEMBER_OVERRIDE_MAP_ENV])
+  const overrideRoot = overrideMap[parsed.memberName]
+  if (overrideRoot !== undefined) {
+    return joinMemberSubPath({ memberRoot: overrideRoot, subPath: parsed.subPath })
+  }
+
+  const localRoot = resolveLocalMegarepoMemberRootSync({
+    memberName: parsed.memberName,
+    importerPath,
+  })
+  if (localRoot !== undefined) {
+    return joinMemberSubPath({ memberRoot: localRoot, subPath: parsed.subPath })
+  }
+
+  const sourceMap = parseMemberSourceMap(process.env[GENIE_MEMBER_SOURCE_MAP_ENV])
+  const sourceRoot = sourceMap[parsed.memberName]
+  if (sourceRoot !== undefined) {
+    return joinMemberSubPath({ memberRoot: sourceRoot, subPath: parsed.subPath })
+  }
+
+  return undefined
+}
+
 /**
  * Check if a specifier is an import map specifier (starts with #).
  */
@@ -312,6 +527,14 @@ export const resolveImportMapSpecifierForImporter = Effect.fn(
     return Option.none()
   }
 
+  const resolvedMegarepoMember = resolveMegarepoMemberSpecifierSync({
+    specifier,
+    importerPath,
+  })
+  if (resolvedMegarepoMember !== undefined) {
+    return Option.some(resolvedMegarepoMember)
+  }
+
   const packageJsonPathOption = yield* findPackageJsonWithImports(importerPath)
   if (Option.isNone(packageJsonPathOption) === true) {
     return Option.none()
@@ -348,6 +571,14 @@ export const resolveImportMapSpecifierForImporterSync = ({
 }): string | undefined => {
   if (isImportMapSpecifier(specifier) === false) {
     return undefined
+  }
+
+  const resolvedMegarepoMember = resolveMegarepoMemberSpecifierSync({
+    specifier,
+    importerPath,
+  })
+  if (resolvedMegarepoMember !== undefined) {
+    return resolvedMegarepoMember
   }
 
   const packageJsonPath = findPackageJsonWithImportsSync(importerPath)
@@ -393,17 +624,9 @@ export const resolveImportMapsInSource = Effect.fn('resolveImportMapsInSource')(
   resolveRelativeImports?: boolean
 }) {
   const packageJsonPathOption = yield* findPackageJsonWithImports(sourcePath)
-  if (Option.isNone(packageJsonPathOption) === true) {
-    return sourceCode
-  }
-  const packageJsonPath = packageJsonPathOption.value
-
-  const importMap = yield* extractImportMap(packageJsonPath)
-  if (Object.keys(importMap).length === 0) {
-    return sourceCode
-  }
-
-  const packageJsonDir = path.dirname(packageJsonPath)
+  const packageJsonPath = Option.getOrUndefined(packageJsonPathOption)
+  const importMap = packageJsonPath === undefined ? {} : yield* extractImportMap(packageJsonPath)
+  const packageJsonDir = packageJsonPath === undefined ? undefined : path.dirname(packageJsonPath)
   const sourceDir = path.dirname(sourcePath)
   const normalizeSpecifier = (filePath: string) =>
     resolveRelativeImports === true ? pathToFileURL(filePath).href : filePath
@@ -420,11 +643,18 @@ export const resolveImportMapsInSource = Effect.fn('resolveImportMapsInSource')(
       return match
     }
 
-    const resolved = resolveImportMapSpecifier({
-      specifier,
-      importMap,
-      packageJsonDir,
-    })
+    const resolved =
+      resolveMegarepoMemberSpecifierSync({
+        specifier,
+        importerPath: sourcePath,
+      }) ??
+      (packageJsonDir === undefined || Object.keys(importMap).length === 0
+        ? null
+        : resolveImportMapSpecifier({
+            specifier,
+            importMap,
+            packageJsonDir,
+          }))
 
     if (resolved === null) {
       return match

--- a/packages/@overeng/genie/src/core/import-map/mod.ts
+++ b/packages/@overeng/genie/src/core/import-map/mod.ts
@@ -604,7 +604,7 @@ export const resolveImportMapSpecifierForImporterSync = ({
  * Regex to match import/export statements with string specifiers.
  * Captures: full match, quote char, specifier
  */
-const IMPORT_REGEX = /(?:import|export)\s+(?:.*?\s+from\s+)?(['"])([^'"]+)\1/g
+const IMPORT_REGEX = /(?:import|export)\s+(?:[\s\S]*?\s+from\s+)?(['"])([^'"]+)\1/g
 
 /**
  * Transform source code by resolving all `#...` import specifiers.

--- a/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
@@ -161,8 +161,9 @@ describe('ci workflow pnpm cache defaults', () => {
     )
   })
 
-  it('exports skipped megarepo members for downstream lock-based checks', () => {
+  it('only exports skipped megarepo members when the CI lane actually skips members', () => {
     expect(applyMegarepoLockStepSource).toContain('MEGAREPO_SKIP_MEMBERS')
+    expect(applyMegarepoLockStepSource).toContain("skipCsv === ''")
     expect(applyMegarepoLockStepSource).toContain(`printf 'MEGAREPO_SKIP_MEMBERS=%s\\n'`)
   })
 })

--- a/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
@@ -160,6 +160,11 @@ describe('ci workflow pnpm cache defaults', () => {
       'nix run "github:overengineeringstudio/effect-utils?ref=$EU_REF&rev=$EU_REV#megarepo"',
     )
   })
+
+  it('exports skipped megarepo members for downstream lock-based checks', () => {
+    expect(applyMegarepoLockStepSource).toContain('MEGAREPO_SKIP_MEMBERS')
+    expect(applyMegarepoLockStepSource).toContain(`printf 'MEGAREPO_SKIP_MEMBERS=%s\\n'`)
+  })
 })
 
 describe('ci workflow shared auth helpers', () => {


### PR DESCRIPTION
## Summary
- add `#mr/<member>/...` import resolution to Genie using lock-derived megarepo members
- add shared megarepo bootstrap/check-skip task support for downstream repos and CI
- cover the new import and CI-step behavior with focused unit tests

## Validation
- `pnpm exec vitest run src/core/import-map/import-map.unit.test.ts src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts`