### PR TITLE
fix(ci): avoid false gc-race retries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,22 +193,22 @@ jobs:
           run_nix_gc_race_retry() {
             local task="$1"
             local command="$2"
-            local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
-            local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
+            local max="\${NIX_GC_RACE_MAX_RETRIES:-10}"
+            local heartbeat="\${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
             local attempt=1
             local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
 
             start="$(date +%s)"
 
             write_summary() {
-              [ -n "${GITHUB_STEP_SUMMARY:-}" ] || return 0
+              [ -n "\${GITHUB_STEP_SUMMARY:-}" ] || return 0
               {
                 echo "### CI Task"
                 echo "- Task: $task"
                 echo "- Status: $1"
                 echo "- Duration: $elapsed s"
                 echo "- Attempts: $attempt/$max"
-                [ -z "${2:-}" ] || echo "- Note: $2"
+                [ -z "\${2:-}" ] || echo "- Note: $2"
               } >> "$GITHUB_STEP_SUMMARY"
             }
 
@@ -252,7 +252,7 @@ jobs:
                 return 0
               fi
 
-              flattened=$(tr '\r\n' '  ' < "$log" | sed -E $'s/\x1B\\[[0-9;]*m//g')
+              flattened=$(tr '\r\n' '  ' < "$log" | sed -E $'s/\x1B\[[0-9;]*m//g')
               path=$(printf '%s' "$flattened" |
                 grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" |
                 head -1 |
@@ -524,22 +524,22 @@ jobs:
           run_nix_gc_race_retry() {
             local task="$1"
             local command="$2"
-            local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
-            local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
+            local max="\${NIX_GC_RACE_MAX_RETRIES:-10}"
+            local heartbeat="\${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
             local attempt=1
             local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
 
             start="$(date +%s)"
 
             write_summary() {
-              [ -n "${GITHUB_STEP_SUMMARY:-}" ] || return 0
+              [ -n "\${GITHUB_STEP_SUMMARY:-}" ] || return 0
               {
                 echo "### CI Task"
                 echo "- Task: $task"
                 echo "- Status: $1"
                 echo "- Duration: $elapsed s"
                 echo "- Attempts: $attempt/$max"
-                [ -z "${2:-}" ] || echo "- Note: $2"
+                [ -z "\${2:-}" ] || echo "- Note: $2"
               } >> "$GITHUB_STEP_SUMMARY"
             }
 
@@ -583,7 +583,7 @@ jobs:
                 return 0
               fi
 
-              flattened=$(tr '\r\n' '  ' < "$log" | sed -E $'s/\x1B\\[[0-9;]*m//g')
+              flattened=$(tr '\r\n' '  ' < "$log" | sed -E $'s/\x1B\[[0-9;]*m//g')
               path=$(printf '%s' "$flattened" |
                 grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" |
                 head -1 |
@@ -858,22 +858,22 @@ jobs:
           run_nix_gc_race_retry() {
             local task="$1"
             local command="$2"
-            local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
-            local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
+            local max="\${NIX_GC_RACE_MAX_RETRIES:-10}"
+            local heartbeat="\${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
             local attempt=1
             local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
 
             start="$(date +%s)"
 
             write_summary() {
-              [ -n "${GITHUB_STEP_SUMMARY:-}" ] || return 0
+              [ -n "\${GITHUB_STEP_SUMMARY:-}" ] || return 0
               {
                 echo "### CI Task"
                 echo "- Task: $task"
                 echo "- Status: $1"
                 echo "- Duration: $elapsed s"
                 echo "- Attempts: $attempt/$max"
-                [ -z "${2:-}" ] || echo "- Note: $2"
+                [ -z "\${2:-}" ] || echo "- Note: $2"
               } >> "$GITHUB_STEP_SUMMARY"
             }
 
@@ -917,7 +917,7 @@ jobs:
                 return 0
               fi
 
-              flattened=$(tr '\r\n' '  ' < "$log" | sed -E $'s/\x1B\\[[0-9;]*m//g')
+              flattened=$(tr '\r\n' '  ' < "$log" | sed -E $'s/\x1B\[[0-9;]*m//g')
               path=$(printf '%s' "$flattened" |
                 grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" |
                 head -1 |
@@ -1192,22 +1192,22 @@ jobs:
           run_nix_gc_race_retry() {
             local task="$1"
             local command="$2"
-            local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
-            local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
+            local max="\${NIX_GC_RACE_MAX_RETRIES:-10}"
+            local heartbeat="\${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
             local attempt=1
             local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
 
             start="$(date +%s)"
 
             write_summary() {
-              [ -n "${GITHUB_STEP_SUMMARY:-}" ] || return 0
+              [ -n "\${GITHUB_STEP_SUMMARY:-}" ] || return 0
               {
                 echo "### CI Task"
                 echo "- Task: $task"
                 echo "- Status: $1"
                 echo "- Duration: $elapsed s"
                 echo "- Attempts: $attempt/$max"
-                [ -z "${2:-}" ] || echo "- Note: $2"
+                [ -z "\${2:-}" ] || echo "- Note: $2"
               } >> "$GITHUB_STEP_SUMMARY"
             }
 
@@ -1251,7 +1251,7 @@ jobs:
                 return 0
               fi
 
-              flattened=$(tr '\r\n' '  ' < "$log" | sed -E $'s/\x1B\\[[0-9;]*m//g')
+              flattened=$(tr '\r\n' '  ' < "$log" | sed -E $'s/\x1B\[[0-9;]*m//g')
               path=$(printf '%s' "$flattened" |
                 grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" |
                 head -1 |
@@ -2143,22 +2143,22 @@ jobs:
           run_nix_gc_race_retry() {
             local task="$1"
             local command="$2"
-            local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
-            local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
+            local max="\${NIX_GC_RACE_MAX_RETRIES:-10}"
+            local heartbeat="\${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
             local attempt=1
             local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
 
             start="$(date +%s)"
 
             write_summary() {
-              [ -n "${GITHUB_STEP_SUMMARY:-}" ] || return 0
+              [ -n "\${GITHUB_STEP_SUMMARY:-}" ] || return 0
               {
                 echo "### CI Task"
                 echo "- Task: $task"
                 echo "- Status: $1"
                 echo "- Duration: $elapsed s"
                 echo "- Attempts: $attempt/$max"
-                [ -z "${2:-}" ] || echo "- Note: $2"
+                [ -z "\${2:-}" ] || echo "- Note: $2"
               } >> "$GITHUB_STEP_SUMMARY"
             }
 
@@ -2202,7 +2202,7 @@ jobs:
                 return 0
               fi
 
-              flattened=$(tr '\r\n' '  ' < "$log" | sed -E $'s/\x1B\\[[0-9;]*m//g')
+              flattened=$(tr '\r\n' '  ' < "$log" | sed -E $'s/\x1B\[[0-9;]*m//g')
               path=$(printf '%s' "$flattened" |
                 grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" |
                 head -1 |
@@ -2487,22 +2487,22 @@ jobs:
           run_nix_gc_race_retry() {
             local task="$1"
             local command="$2"
-            local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
-            local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
+            local max="\${NIX_GC_RACE_MAX_RETRIES:-10}"
+            local heartbeat="\${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
             local attempt=1
             local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
 
             start="$(date +%s)"
 
             write_summary() {
-              [ -n "${GITHUB_STEP_SUMMARY:-}" ] || return 0
+              [ -n "\${GITHUB_STEP_SUMMARY:-}" ] || return 0
               {
                 echo "### CI Task"
                 echo "- Task: $task"
                 echo "- Status: $1"
                 echo "- Duration: $elapsed s"
                 echo "- Attempts: $attempt/$max"
-                [ -z "${2:-}" ] || echo "- Note: $2"
+                [ -z "\${2:-}" ] || echo "- Note: $2"
               } >> "$GITHUB_STEP_SUMMARY"
             }
 
@@ -2546,7 +2546,7 @@ jobs:
                 return 0
               fi
 
-              flattened=$(tr '\r\n' '  ' < "$log" | sed -E $'s/\x1B\\[[0-9;]*m//g')
+              flattened=$(tr '\r\n' '  ' < "$log" | sed -E $'s/\x1B\[[0-9;]*m//g')
               path=$(printf '%s' "$flattened" |
                 grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" |
                 head -1 |
@@ -2596,22 +2596,22 @@ jobs:
           run_nix_gc_race_retry() {
             local task="$1"
             local command="$2"
-            local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
-            local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
+            local max="\${NIX_GC_RACE_MAX_RETRIES:-10}"
+            local heartbeat="\${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
             local attempt=1
             local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
 
             start="$(date +%s)"
 
             write_summary() {
-              [ -n "${GITHUB_STEP_SUMMARY:-}" ] || return 0
+              [ -n "\${GITHUB_STEP_SUMMARY:-}" ] || return 0
               {
                 echo "### CI Task"
                 echo "- Task: $task"
                 echo "- Status: $1"
                 echo "- Duration: $elapsed s"
                 echo "- Attempts: $attempt/$max"
-                [ -z "${2:-}" ] || echo "- Note: $2"
+                [ -z "\${2:-}" ] || echo "- Note: $2"
               } >> "$GITHUB_STEP_SUMMARY"
             }
 
@@ -2655,7 +2655,7 @@ jobs:
                 return 0
               fi
 
-              flattened=$(tr '\r\n' '  ' < "$log" | sed -E $'s/\x1B\\[[0-9;]*m//g')
+              flattened=$(tr '\r\n' '  ' < "$log" | sed -E $'s/\x1B\[[0-9;]*m//g')
               path=$(printf '%s' "$flattened" |
                 grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" |
                 head -1 |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,22 +193,22 @@ jobs:
           run_nix_gc_race_retry() {
             local task="$1"
             local command="$2"
-            local max="\${NIX_GC_RACE_MAX_RETRIES:-10}"
-            local heartbeat="\${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
+            local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
+            local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
             local attempt=1
             local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
 
             start="$(date +%s)"
 
             write_summary() {
-              [ -n "\${GITHUB_STEP_SUMMARY:-}" ] || return 0
+              [ -n "${GITHUB_STEP_SUMMARY:-}" ] || return 0
               {
                 echo "### CI Task"
                 echo "- Task: $task"
                 echo "- Status: $1"
                 echo "- Duration: $elapsed s"
                 echo "- Attempts: $attempt/$max"
-                [ -z "\${2:-}" ] || echo "- Note: $2"
+                [ -z "${2:-}" ] || echo "- Note: $2"
               } >> "$GITHUB_STEP_SUMMARY"
             }
 
@@ -524,22 +524,22 @@ jobs:
           run_nix_gc_race_retry() {
             local task="$1"
             local command="$2"
-            local max="\${NIX_GC_RACE_MAX_RETRIES:-10}"
-            local heartbeat="\${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
+            local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
+            local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
             local attempt=1
             local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
 
             start="$(date +%s)"
 
             write_summary() {
-              [ -n "\${GITHUB_STEP_SUMMARY:-}" ] || return 0
+              [ -n "${GITHUB_STEP_SUMMARY:-}" ] || return 0
               {
                 echo "### CI Task"
                 echo "- Task: $task"
                 echo "- Status: $1"
                 echo "- Duration: $elapsed s"
                 echo "- Attempts: $attempt/$max"
-                [ -z "\${2:-}" ] || echo "- Note: $2"
+                [ -z "${2:-}" ] || echo "- Note: $2"
               } >> "$GITHUB_STEP_SUMMARY"
             }
 
@@ -858,22 +858,22 @@ jobs:
           run_nix_gc_race_retry() {
             local task="$1"
             local command="$2"
-            local max="\${NIX_GC_RACE_MAX_RETRIES:-10}"
-            local heartbeat="\${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
+            local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
+            local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
             local attempt=1
             local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
 
             start="$(date +%s)"
 
             write_summary() {
-              [ -n "\${GITHUB_STEP_SUMMARY:-}" ] || return 0
+              [ -n "${GITHUB_STEP_SUMMARY:-}" ] || return 0
               {
                 echo "### CI Task"
                 echo "- Task: $task"
                 echo "- Status: $1"
                 echo "- Duration: $elapsed s"
                 echo "- Attempts: $attempt/$max"
-                [ -z "\${2:-}" ] || echo "- Note: $2"
+                [ -z "${2:-}" ] || echo "- Note: $2"
               } >> "$GITHUB_STEP_SUMMARY"
             }
 
@@ -1192,22 +1192,22 @@ jobs:
           run_nix_gc_race_retry() {
             local task="$1"
             local command="$2"
-            local max="\${NIX_GC_RACE_MAX_RETRIES:-10}"
-            local heartbeat="\${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
+            local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
+            local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
             local attempt=1
             local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
 
             start="$(date +%s)"
 
             write_summary() {
-              [ -n "\${GITHUB_STEP_SUMMARY:-}" ] || return 0
+              [ -n "${GITHUB_STEP_SUMMARY:-}" ] || return 0
               {
                 echo "### CI Task"
                 echo "- Task: $task"
                 echo "- Status: $1"
                 echo "- Duration: $elapsed s"
                 echo "- Attempts: $attempt/$max"
-                [ -z "\${2:-}" ] || echo "- Note: $2"
+                [ -z "${2:-}" ] || echo "- Note: $2"
               } >> "$GITHUB_STEP_SUMMARY"
             }
 
@@ -2143,22 +2143,22 @@ jobs:
           run_nix_gc_race_retry() {
             local task="$1"
             local command="$2"
-            local max="\${NIX_GC_RACE_MAX_RETRIES:-10}"
-            local heartbeat="\${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
+            local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
+            local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
             local attempt=1
             local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
 
             start="$(date +%s)"
 
             write_summary() {
-              [ -n "\${GITHUB_STEP_SUMMARY:-}" ] || return 0
+              [ -n "${GITHUB_STEP_SUMMARY:-}" ] || return 0
               {
                 echo "### CI Task"
                 echo "- Task: $task"
                 echo "- Status: $1"
                 echo "- Duration: $elapsed s"
                 echo "- Attempts: $attempt/$max"
-                [ -z "\${2:-}" ] || echo "- Note: $2"
+                [ -z "${2:-}" ] || echo "- Note: $2"
               } >> "$GITHUB_STEP_SUMMARY"
             }
 
@@ -2487,22 +2487,22 @@ jobs:
           run_nix_gc_race_retry() {
             local task="$1"
             local command="$2"
-            local max="\${NIX_GC_RACE_MAX_RETRIES:-10}"
-            local heartbeat="\${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
+            local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
+            local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
             local attempt=1
             local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
 
             start="$(date +%s)"
 
             write_summary() {
-              [ -n "\${GITHUB_STEP_SUMMARY:-}" ] || return 0
+              [ -n "${GITHUB_STEP_SUMMARY:-}" ] || return 0
               {
                 echo "### CI Task"
                 echo "- Task: $task"
                 echo "- Status: $1"
                 echo "- Duration: $elapsed s"
                 echo "- Attempts: $attempt/$max"
-                [ -z "\${2:-}" ] || echo "- Note: $2"
+                [ -z "${2:-}" ] || echo "- Note: $2"
               } >> "$GITHUB_STEP_SUMMARY"
             }
 
@@ -2596,22 +2596,22 @@ jobs:
           run_nix_gc_race_retry() {
             local task="$1"
             local command="$2"
-            local max="\${NIX_GC_RACE_MAX_RETRIES:-10}"
-            local heartbeat="\${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
+            local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
+            local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
             local attempt=1
             local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
 
             start="$(date +%s)"
 
             write_summary() {
-              [ -n "\${GITHUB_STEP_SUMMARY:-}" ] || return 0
+              [ -n "${GITHUB_STEP_SUMMARY:-}" ] || return 0
               {
                 echo "### CI Task"
                 echo "- Task: $task"
                 echo "- Status: $1"
                 echo "- Duration: $elapsed s"
                 echo "- Attempts: $attempt/$max"
-                [ -z "\${2:-}" ] || echo "- Note: $2"
+                [ -z "${2:-}" ] || echo "- Note: $2"
               } >> "$GITHUB_STEP_SUMMARY"
             }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,8 +261,8 @@ jobs:
               saw_invalid_path=false
               saw_cachix_signature=false
               [ -n "$path" ] && saw_invalid_path=true
-              printf '%s' "$flattened" | grep -q 'Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
-              printf '%s' "$flattened" | grep -q 'while evaluating the option' && printf '%s' "$flattened" | grep -q 'cachix\.package' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
               rm -f "$log"
 
               if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then
@@ -592,8 +592,8 @@ jobs:
               saw_invalid_path=false
               saw_cachix_signature=false
               [ -n "$path" ] && saw_invalid_path=true
-              printf '%s' "$flattened" | grep -q 'Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
-              printf '%s' "$flattened" | grep -q 'while evaluating the option' && printf '%s' "$flattened" | grep -q 'cachix\.package' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
               rm -f "$log"
 
               if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then
@@ -926,8 +926,8 @@ jobs:
               saw_invalid_path=false
               saw_cachix_signature=false
               [ -n "$path" ] && saw_invalid_path=true
-              printf '%s' "$flattened" | grep -q 'Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
-              printf '%s' "$flattened" | grep -q 'while evaluating the option' && printf '%s' "$flattened" | grep -q 'cachix\.package' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
               rm -f "$log"
 
               if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then
@@ -1260,8 +1260,8 @@ jobs:
               saw_invalid_path=false
               saw_cachix_signature=false
               [ -n "$path" ] && saw_invalid_path=true
-              printf '%s' "$flattened" | grep -q 'Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
-              printf '%s' "$flattened" | grep -q 'while evaluating the option' && printf '%s' "$flattened" | grep -q 'cachix\.package' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
               rm -f "$log"
 
               if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then
@@ -2211,8 +2211,8 @@ jobs:
               saw_invalid_path=false
               saw_cachix_signature=false
               [ -n "$path" ] && saw_invalid_path=true
-              printf '%s' "$flattened" | grep -q 'Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
-              printf '%s' "$flattened" | grep -q 'while evaluating the option' && printf '%s' "$flattened" | grep -q 'cachix\.package' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
               rm -f "$log"
 
               if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then
@@ -2555,8 +2555,8 @@ jobs:
               saw_invalid_path=false
               saw_cachix_signature=false
               [ -n "$path" ] && saw_invalid_path=true
-              printf '%s' "$flattened" | grep -q 'Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
-              printf '%s' "$flattened" | grep -q 'while evaluating the option' && printf '%s' "$flattened" | grep -q 'cachix\.package' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
               rm -f "$log"
 
               if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then
@@ -2664,8 +2664,8 @@ jobs:
               saw_invalid_path=false
               saw_cachix_signature=false
               [ -n "$path" ] && saw_invalid_path=true
-              printf '%s' "$flattened" | grep -q 'Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
-              printf '%s' "$flattened" | grep -q 'while evaluating the option' && printf '%s' "$flattened" | grep -q 'cachix\.package' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
               rm -f "$log"
 
               if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then

--- a/genie/ci-scripts/nix-gc-race-retry.sh
+++ b/genie/ci-scripts/nix-gc-race-retry.sh
@@ -71,8 +71,8 @@ run_nix_gc_race_retry() {
     saw_invalid_path=false
     saw_cachix_signature=false
     [ -n "$path" ] && saw_invalid_path=true
-    printf '%s' "$flattened" | grep -q 'Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
-    printf '%s' "$flattened" | grep -q 'while evaluating the option' && printf '%s' "$flattened" | grep -q 'cachix\.package' && saw_cachix_signature=true || true
+    printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
+    printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
     rm -f "$log"
 
     if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then

--- a/genie/ci-scripts/nix-gc-race-retry.test.sh
+++ b/genie/ci-scripts/nix-gc-race-retry.test.sh
@@ -70,8 +70,8 @@ if [ -f "\$attempt_file" ]; then
 fi
 if [ "\$attempt" -eq 1 ]; then
   echo 2 > "\$attempt_file"
-  echo "Failed to convert config.cachix to JSON" >&2
-  echo "while evaluating the option cachix.package" >&2
+  echo "error: Failed to convert config.cachix to JSON" >&2
+  echo "error: while evaluating the option cachix.package" >&2
   exit 1
 fi
 echo "cachix recovered"
@@ -80,7 +80,23 @@ chmod +x "$cachix_fixture"
 CI_PROGRESS_HEARTBEAT_SECONDS=1 NIX_GC_RACE_MAX_RETRIES=2 run_nix_gc_race_retry "cachix-fixture" "$cachix_fixture" >/dev/null
 assert_eq "2" "$(cat "$test_dir/cachix-attempt")" "cachix wrapper retry count"
 
-echo "Test 3: preserves the original exit code when no GC-race signature is present"
+echo "Test 3: does not retry when literal signature strings appear outside Nix error context"
+false_positive_fixture="$test_dir/false-positive-fixture.sh"
+cat > "$false_positive_fixture" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "AssertionError: expected source to contain Failed to convert config.cachix to JSON" >&2
+echo "source snippet: while evaluating the option cachix.package" >&2
+exit 9
+EOF
+chmod +x "$false_positive_fixture"
+set +e
+CI_PROGRESS_HEARTBEAT_SECONDS=1 NIX_GC_RACE_MAX_RETRIES=2 run_nix_gc_race_retry "false-positive-fixture" "$false_positive_fixture" >/dev/null 2>&1
+exit_code=$?
+set -e
+assert_exit_code 9 "$exit_code" "non-error-context strings do not trigger retries"
+
+echo "Test 4: preserves the original exit code when no GC-race signature is present"
 non_retry_fixture="$test_dir/non-retry-fixture.sh"
 cat > "$non_retry_fixture" <<'EOF'
 #!/usr/bin/env bash

--- a/genie/ci-workflow.ts
+++ b/genie/ci-workflow.ts
@@ -283,8 +283,8 @@ run_nix_gc_race_retry() {
     saw_invalid_path=false
     saw_cachix_signature=false
     [ -n "$path" ] && saw_invalid_path=true
-    printf '%s' "$flattened" | grep -q 'Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
-    printf '%s' "$flattened" | grep -q 'while evaluating the option' && printf '%s' "$flattened" | grep -q 'cachix\.package' && saw_cachix_signature=true || true
+    printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
+    printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
     rm -f "$log"
 
     if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then

--- a/genie/ci-workflow.ts
+++ b/genie/ci-workflow.ts
@@ -189,6 +189,8 @@ const withAppendedNixConfig = ({
   return `if [ -n "${'${NIX_CONFIG:-}'}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '%s\\n%s' "$NIX_CONFIG" ${quotedExtraConf}); else NIX_CONFIG_WITH_APPEND=${quotedExtraConf}; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" ${command}`
 }
 
+const dollar = '$'
+
 /**
  * Fall back to the standard CI pnpm paths when a workflow has not exported
  * them via `pnpmStateSetupStep` yet. This keeps `runDevenvTasksBefore` safe for
@@ -213,22 +215,22 @@ const nixGcRaceRetryScript = String.raw`#!/usr/bin/env bash
 run_nix_gc_race_retry() {
   local task="$1"
   local command="$2"
-  local max="\${NIX_GC_RACE_MAX_RETRIES:-10}"
-  local heartbeat="\${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
+  local max="${dollar}{NIX_GC_RACE_MAX_RETRIES:-10}"
+  local heartbeat="${dollar}{CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
   local attempt=1
   local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
 
   start="$(date +%s)"
 
   write_summary() {
-    [ -n "\${GITHUB_STEP_SUMMARY:-}" ] || return 0
+    [ -n "${dollar}{GITHUB_STEP_SUMMARY:-}" ] || return 0
     {
       echo "### CI Task"
       echo "- Task: $task"
       echo "- Status: $1"
       echo "- Duration: $elapsed s"
       echo "- Attempts: $attempt/$max"
-      [ -z "\${2:-}" ] || echo "- Note: $2"
+      [ -z "${dollar}{2:-}" ] || echo "- Note: $2"
     } >> "$GITHUB_STEP_SUMMARY"
   }
 

--- a/genie/ci-workflow.ts
+++ b/genie/ci-workflow.ts
@@ -210,7 +210,14 @@ const runDevenvTasksBeforeWithOptions = (opts: NixConfigOptions, ...args: [strin
 const readCiHelperScript = (relativePath: string) =>
   readFileSync(new URL(relativePath, import.meta.url), 'utf8').trim()
 
-const nixGcRaceRetryScript = readCiHelperScript('./ci-scripts/nix-gc-race-retry.sh')
+let nixGcRaceRetryScriptCache: string | undefined
+
+const getNixGcRaceRetryScript = () => {
+  if (nixGcRaceRetryScriptCache === undefined) {
+    nixGcRaceRetryScriptCache = readCiHelperScript('./ci-scripts/nix-gc-race-retry.sh')
+  }
+  return nixGcRaceRetryScriptCache
+}
 
 /**
  * Retry wrapper for the Nix store validity race where `derivationStrict` fails
@@ -232,7 +239,7 @@ const withGcRaceRetry = ({ command, label }: { command: string; label: string })
   return [
     '__nix_gc_retry_helper=$(mktemp)',
     'cat > "$__nix_gc_retry_helper" <<\'EOF\'',
-    nixGcRaceRetryScript,
+    getNixGcRaceRetryScript(),
     'EOF',
     '. "$__nix_gc_retry_helper"',
     'rm -f "$__nix_gc_retry_helper"',

--- a/genie/ci-workflow.ts
+++ b/genie/ci-workflow.ts
@@ -710,26 +710,27 @@ const pnpmInstallFailureSummaryScript = [
  * Run the repo-root pnpm install while teeing the full log to the diagnostics
  * directory and summarizing failures in the job output.
  */
-export const pnpmInstallWithDiagnosticsStep = {
-  name: 'Install pnpm dependencies',
-  shell: 'bash',
-  run: [
-    'set -euo pipefail',
-    'mkdir -p "$CI_DIAGNOSTICS_DIR"',
-    'log_file="$CI_DIAGNOSTICS_DIR/pnpm-install.log"',
-    'set +e',
-    '(',
-    runDevenvTasksBefore('pnpm:install'),
-    ') 2>&1 | tee "$log_file"',
-    'rc=${PIPESTATUS[0]}',
-    'set -e',
-    'if [ "$rc" -ne 0 ]; then',
-    pnpmInstallFailureSummaryScript,
-    '  classify_pnpm_failure "$log_file"',
-    'fi',
-    'exit "$rc"',
-  ].join('\n'),
-} as const
+export const pnpmInstallWithDiagnosticsStep = () =>
+  ({
+    name: 'Install pnpm dependencies',
+    shell: 'bash',
+    run: [
+      'set -euo pipefail',
+      'mkdir -p "$CI_DIAGNOSTICS_DIR"',
+      'log_file="$CI_DIAGNOSTICS_DIR/pnpm-install.log"',
+      'set +e',
+      '(',
+      runDevenvTasksBefore('pnpm:install'),
+      ') 2>&1 | tee "$log_file"',
+      'rc=${PIPESTATUS[0]}',
+      'set -e',
+      'if [ "$rc" -ne 0 ]; then',
+      pnpmInstallFailureSummaryScript,
+      '  classify_pnpm_failure "$log_file"',
+      'fi',
+      'exit "$rc"',
+    ].join('\n'),
+  }) as const
 
 const nixCachePrimaryKey = (keyPrefix: string, hashFilesExpression: string) =>
   `${keyPrefix}-${'${{ runner.os }}'}-${'${{ runner.arch }}'}-${hashFilesExpression}`
@@ -875,7 +876,7 @@ export const standardSelfHostedPnpmCiPrepSteps = (opts?: {
     ciDiagnosticsSetupStep,
     ...(opts?.includeDiagnostics === false ? [] : [captureRunnerPressureStep]),
     restorePnpmStateStep(opts?.restorePnpmState),
-    pnpmInstallWithDiagnosticsStep,
+    pnpmInstallWithDiagnosticsStep(),
   ] as const
 
 /**

--- a/genie/ci-workflow.ts
+++ b/genie/ci-workflow.ts
@@ -23,8 +23,6 @@
  * ```
  */
 
-import { readFileSync } from 'node:fs'
-
 import {
   githubWorkflow,
   type ActionlintConfig,
@@ -207,17 +205,111 @@ const runDevenvTasksBeforeWithOptions = (opts: NixConfigOptions, ...args: [strin
     opts,
   })
 
-const readCiHelperScript = (relativePath: string) =>
-  readFileSync(new URL(relativePath, import.meta.url), 'utf8').trim()
+// Keep helper script bodies inline so downstream Genie imports stay bootstrap-safe.
+// The temporary import sandbox copies TypeScript modules, not arbitrary adjacent
+// shell scripts, so runtime file reads during workflow generation are unsafe.
+const nixGcRaceRetryScript = String.raw`#!/usr/bin/env bash
 
-let nixGcRaceRetryScriptCache: string | undefined
+run_nix_gc_race_retry() {
+  local task="$1"
+  local command="$2"
+  local max="\${NIX_GC_RACE_MAX_RETRIES:-10}"
+  local heartbeat="\${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
+  local attempt=1
+  local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
 
-const getNixGcRaceRetryScript = () => {
-  if (nixGcRaceRetryScriptCache === undefined) {
-    nixGcRaceRetryScriptCache = readCiHelperScript('./ci-scripts/nix-gc-race-retry.sh')
+  start="$(date +%s)"
+
+  write_summary() {
+    [ -n "\${GITHUB_STEP_SUMMARY:-}" ] || return 0
+    {
+      echo "### CI Task"
+      echo "- Task: $task"
+      echo "- Status: $1"
+      echo "- Duration: $elapsed s"
+      echo "- Attempts: $attempt/$max"
+      [ -z "\${2:-}" ] || echo "- Note: $2"
+    } >> "$GITHUB_STEP_SUMMARY"
   }
-  return nixGcRaceRetryScriptCache
-}
+
+  while [ "$attempt" -le "$max" ]; do
+    echo "::notice::[ci] starting $task (attempt $attempt/$max)"
+    (
+      while sleep "$heartbeat"; do
+        now=$(date +%s)
+        elapsed=$((now - start))
+        echo "::notice::[ci] $task still running after $elapsed s (attempt $attempt/$max)"
+      done
+    ) &
+    hb_pid=$!
+
+    log=$(mktemp)
+    had_errexit=false
+    case $- in
+      *e*) had_errexit=true ;;
+    esac
+    set +e
+    eval "$command" > >(tee -a "$log") 2> >(tee -a "$log" >&2)
+    rc=$?
+    if [ "$had_errexit" = true ]; then
+      set -e
+    fi
+
+    kill "$hb_pid" 2>/dev/null || true
+    wait "$hb_pid" 2>/dev/null || true
+
+    now=$(date +%s)
+    elapsed=$((now - start))
+
+    if [ "$rc" -eq 0 ]; then
+      echo "::notice::[ci] completed $task in $elapsed s"
+      if [ "$attempt" -gt 1 ]; then
+        write_summary success "Recovered from Nix GC race after retry"
+      else
+        write_summary success
+      fi
+      rm -f "$log"
+      return 0
+    fi
+
+    flattened=$(tr '\r\n' '  ' < "$log" | sed -E $'s/\x1B\[[0-9;]*m//g')
+    path=$(printf '%s' "$flattened" |
+      grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" |
+      head -1 |
+      grep -o "/nix/store/[^']*" |
+      tr -d '[:space:]' || true)
+    saw_invalid_path=false
+    saw_cachix_signature=false
+    [ -n "$path" ] && saw_invalid_path=true
+    printf '%s' "$flattened" | grep -q 'Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
+    printf '%s' "$flattened" | grep -q 'while evaluating the option' && printf '%s' "$flattened" | grep -q 'cachix\.package' && saw_cachix_signature=true || true
+    rm -f "$log"
+
+    if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then
+      echo "::warning::[ci] $task failed after $elapsed s without a detected Nix store validity race"
+      write_summary failure "No Nix GC race signature detected"
+      return "$rc"
+    fi
+
+    if [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
+      echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
+    elif [ "$saw_cachix_signature" = true ]; then
+      echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
+    else
+      echo "::warning::Nix store validity race detected for $task (attempt $attempt/$max): $path"
+    fi
+
+    [ -z "$path" ] || nix-store --realise "$path" 2>/dev/null || true
+    rm -rf ~/.cache/nix/eval-cache-*
+    attempt=$((attempt + 1))
+  done
+
+  now=$(date +%s)
+  elapsed=$((now - start))
+  echo "::error::Nix GC race retry exhausted for $task ($max attempts)"
+  write_summary failure "Nix GC race retry exhausted"
+  return 1
+}`
 
 /**
  * Retry wrapper for the Nix store validity race where `derivationStrict` fails
@@ -239,7 +331,7 @@ const withGcRaceRetry = ({ command, label }: { command: string; label: string })
   return [
     '__nix_gc_retry_helper=$(mktemp)',
     'cat > "$__nix_gc_retry_helper" <<\'EOF\'',
-    getNixGcRaceRetryScript(),
+    nixGcRaceRetryScript,
     'EOF',
     '. "$__nix_gc_retry_helper"',
     'rm -f "$__nix_gc_retry_helper"',

--- a/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
@@ -74,8 +74,9 @@ const applyMegarepoLockStepSource = extractSourceBlock(
 )
 
 describe('ci workflow retry helpers', () => {
-  it('sources the retry helper from a checked-in shell script', () => {
-    expect(ciWorkflowSource).toContain('./ci-scripts/nix-gc-race-retry.sh')
+  it('inlines the retry helper for bootstrap-safe downstream imports', () => {
+    expect(ciWorkflowSource).toContain('const nixGcRaceRetryScript = String.raw')
+    expect(ciWorkflowSource).toContain('Keep helper script bodies inline')
     expect(ciWorkflowSource).toContain('__nix_gc_retry_helper=$(mktemp)')
     expect(ciWorkflowSource).toContain('run_nix_gc_race_retry')
     expect(nixGcRaceRetryScriptSource).toContain("tr '\\r\\n' '  ' < \"$log\"")


### PR DESCRIPTION
## Summary

This PR fixes the follow-up regressions around the CI retry helper after we moved it inline for bootstrap-safe downstream Genie imports.

## Root cause

We previously stopped sourcing `genie/ci-scripts/nix-gc-race-retry.sh` at import time because downstream Genie generation runs in a temporary import sandbox and does not carry along arbitrary adjacent shell scripts. That old pattern caused downstream generation failures like:

- `GenieImportError`
- `ENOENT ... repos/effect-utils/genie/ci-scripts/nix-gc-race-retry.sh`

After switching to the inline helper body, two issues remained:

1. A stale Genie unit test still asserted the old checked-in shell-script import pattern.
2. The CI retry heuristic was too loose and treated any output containing strings like `config.cachix` / `cachix.package` as a Nix GC race, even when those strings only appeared inside an ordinary failing test diff.

That caused PR CI to retry normal test failures until it exhausted retries, which hid the real failure and kept the `test` lanes red.

## What changed

- Kept the retry helper inline in `genie/ci-workflow.ts` so downstream imports stay bootstrap-safe.
- Updated the stale Genie unit test to assert the inline-helper design instead of the removed file-import path.
- Tightened the retry classifier so the Cachix-wrapper fallback only triggers on actual Nix `error:` context, not on arbitrary test output containing similar strings.
- Added a regression shell test that proves literal `config.cachix` / `cachix.package` strings outside Nix error context do not trigger retries.
- Regenerated `.github/workflows/ci.yml` from the updated Genie source.

## Validation

- `bash genie/ci-scripts/nix-gc-race-retry.test.sh`
- `./node_modules/.bin/vitest run src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts` (from `packages/@overeng/genie`)
- `pnpm exec bun packages/@overeng/genie/bin/genie.tsx --cwd .`
- `pnpm exec bun packages/@overeng/genie/bin/genie.tsx --cwd . --check`

## Notes

The downstream `ENOENT ... nix-gc-race-retry.sh` failures seen in consumer repos are stale-pin fallout from older `effect-utils` revisions, not a regression introduced by this PR head. Once this lands, downstream repos need to repin to the updated `effect-utils` revision.
