### PR TITLE
fix(megarepo): verify branch-pinned git locks

### DIFF
--- a/nix/devenv-modules/tasks/shared/megarepo.nix
+++ b/nix/devenv-modules/tasks/shared/megarepo.nix
@@ -30,11 +30,14 @@ let
   trace = import ../lib/trace.nix { inherit lib; };
   cliGuard = import ../lib/cli-guard.nix { inherit pkgs; };
   jq = "${pkgs.jq}/bin/jq";
-  bootstrapOnlyArgs = lib.concatMapStringsSep " " (member: "--only ${lib.escapeShellArg member}") bootstrapMembers;
+  bootstrapOnlyArgs = lib.concatMapStringsSep " " (
+    member: "--only ${lib.escapeShellArg member}"
+  ) bootstrapMembers;
 
   # Single-pass jq script that compares megarepo.lock member commits against
   # a Nix lock file (devenv.lock or flake.lock). Handles multiple inputs
-  # pointing to the same repo (e.g. effect-utils + playwright).
+  # pointing to the same repo (e.g. effect-utils + playwright), including
+  # branch-pinned git locks that encode GitHub remotes as `type = "git"`.
   # Takes two args: $1 = megarepo.lock path, $2 = lock file path
   lockSyncCheckScript = ''
     set -euo pipefail
@@ -45,9 +48,29 @@ let
     mismatches=$(${jq} -n \
       --slurpfile ml "$ml" \
       --slurpfile lf "$lf" '
+      def repo_key($node):
+        if $node.locked?.type == "github" then
+          "\($node.locked.owner)/\($node.locked.repo)"
+        elif $node.locked?.type == "git" then
+          ($node.locked.url // $node.original.url // "") as $url |
+          if $url == "" then
+            empty
+          else
+            $url
+            | sub("^git\\+ssh://git@github.com/"; "")
+            | sub("^ssh://git@github.com/"; "")
+            | sub("^git@github.com:"; "")
+            | sub("^https://github.com/"; "")
+            | sub("\\.git$"; "")
+          end
+        else
+          empty
+        end;
+
       [$lf[0].nodes | to_entries[] |
-        select(.value.locked?.type == "github") |
-        { key: "\(.value.locked.owner)/\(.value.locked.repo)", rev: .value.locked.rev, name: .key }
+        (repo_key(.value)) as $key |
+        select($key != null and $key != "") |
+        { key: $key, rev: .value.locked.rev, name: .key }
       ] as $lock_inputs |
       [$ml[0].members | to_entries[] |
         (.value.url | split("/") | .[-2:] | join("/")) as $mkey |


### PR DESCRIPTION
## Summary
- teach the megarepo lock sync check to compare branch-pinned GitHub inputs encoded as `locked.type = "git"`
- normalize common GitHub git URL forms to the same `owner/repo` key used by `megarepo.lock`
- remove the previously included pnpm version-probe change, which is already covered on `main`

## Rationale
Nix flakes can represent branch-pinned GitHub inputs as generic git locks instead of `type = "github"`. The existing megarepo lock sync check only inspected GitHub-typed nodes, so those branch-pinned inputs could drift from `megarepo.lock` without being reported. Normalizing GitHub git URLs preserves the existing single source of truth while covering both lock encodings.

## Verification
- `nixfmt --check nix/devenv-modules/tasks/shared/megarepo.nix`
- `nix-instantiate --parse nix/devenv-modules/tasks/shared/megarepo.nix`
- targeted jq reproduction for a mismatched `git+ssh://git@github.com/overengineeringstudio/effect-utils.git` lock
- `devenv tasks run lint:check --mode before`

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🎸 co1-bass |
| `agent_session_id` | afa610f7-71c7-410f-86d5-c08b2da67cb6 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | codex-cli 0.124.0 |
| `agent_runtime` | Codex CLI codex-cli 0.124.0 |
| `agent_model` | unknown |
| `worktree` | megarepo-all/schickling/2026-04-24-pnpm-fix/tmp/refocus-606/effect-utils |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@5c6e0c3 |
</details>
<!-- agent-footer:end -->