### PR TITLE
fix(genie): prefer locked megarepo commits for #mr imports

### DIFF
--- a/packages/@overeng/genie/src/core/import-map/import-map.unit.test.ts
+++ b/packages/@overeng/genie/src/core/import-map/import-map.unit.test.ts
@@ -453,6 +453,81 @@ export default packageJson({
         )
       }, Effect.provide(TestLayer)),
     )
+
+    Vitest.it.effect(
+      'prefers locked megarepo commit worktrees over mutable ref worktrees',
+      Effect.fnUntraced(function* () {
+        const lockedCommit = '0123456789abcdef0123456789abcdef01234567'
+
+        process.env[MEGAREPO_STORE_ENV] = path.join(tempDir, '.megarepo')
+        yield* writeFile(path.join(tempDir, '.git'), '')
+        yield* writeFile(
+          path.join(tempDir, 'megarepo.lock'),
+          toJson({
+            members: {
+              'effect-utils': {
+                url: 'https://github.com/overengineeringstudio/effect-utils',
+                ref: 'main',
+                commit: lockedCommit,
+              },
+            },
+          }),
+        )
+        yield* writeFile(
+          path.join(
+            tempDir,
+            '.megarepo',
+            'github.com',
+            'overengineeringstudio',
+            'effect-utils',
+            'refs',
+            'heads',
+            'main',
+            'genie',
+            'external.ts',
+          ),
+          '',
+        )
+        yield* writeFile(
+          path.join(
+            tempDir,
+            '.megarepo',
+            'github.com',
+            'overengineeringstudio',
+            'effect-utils',
+            'refs',
+            'commits',
+            lockedCommit,
+            'genie',
+            'external.ts',
+          ),
+          '',
+        )
+
+        const importerPath = path.join(tempDir, 'src', 'genie-file.ts')
+        yield* writeFile(importerPath, '')
+
+        const resolved = yield* resolveImportMapSpecifierForImporter({
+          specifier: '#mr/effect-utils/genie/external.ts',
+          importerPath,
+        })
+
+        expect(Option.getOrNull(resolved)).toBe(
+          path.join(
+            tempDir,
+            '.megarepo',
+            'github.com',
+            'overengineeringstudio',
+            'effect-utils',
+            'refs',
+            'commits',
+            lockedCommit,
+            'genie',
+            'external.ts',
+          ),
+        )
+      }, Effect.provide(TestLayer)),
+    )
   })
 
   Vitest.describe('resolveImportMapSpecifierForImporterSync', () => {
@@ -544,6 +619,81 @@ export default packageJson({
         })
 
         expect(resolved).toBe(path.join(tempDir, 'override-effect-utils', 'genie', 'external.ts'))
+      }, Effect.provide(TestLayer)),
+    )
+
+    Vitest.it.effect(
+      'prefers locked megarepo commit worktrees over mutable ref worktrees',
+      Effect.fnUntraced(function* () {
+        const lockedCommit = '0123456789abcdef0123456789abcdef01234567'
+
+        process.env[MEGAREPO_STORE_ENV] = path.join(tempDir, '.megarepo')
+        yield* writeFile(path.join(tempDir, '.git'), '')
+        yield* writeFile(
+          path.join(tempDir, 'megarepo.lock'),
+          toJson({
+            members: {
+              'effect-utils': {
+                url: 'https://github.com/overengineeringstudio/effect-utils',
+                ref: 'main',
+                commit: lockedCommit,
+              },
+            },
+          }),
+        )
+        yield* writeFile(
+          path.join(
+            tempDir,
+            '.megarepo',
+            'github.com',
+            'overengineeringstudio',
+            'effect-utils',
+            'refs',
+            'heads',
+            'main',
+            'genie',
+            'external.ts',
+          ),
+          '',
+        )
+        yield* writeFile(
+          path.join(
+            tempDir,
+            '.megarepo',
+            'github.com',
+            'overengineeringstudio',
+            'effect-utils',
+            'refs',
+            'commits',
+            lockedCommit,
+            'genie',
+            'external.ts',
+          ),
+          '',
+        )
+
+        const importerPath = path.join(tempDir, 'src', 'genie-file.ts')
+        yield* writeFile(importerPath, '')
+
+        const resolved = resolveImportMapSpecifierForImporterSync({
+          specifier: '#mr/effect-utils/genie/external.ts',
+          importerPath,
+        })
+
+        expect(resolved).toBe(
+          path.join(
+            tempDir,
+            '.megarepo',
+            'github.com',
+            'overengineeringstudio',
+            'effect-utils',
+            'refs',
+            'commits',
+            lockedCommit,
+            'genie',
+            'external.ts',
+          ),
+        )
       }, Effect.provide(TestLayer)),
     )
   })

--- a/packages/@overeng/genie/src/core/import-map/mod.ts
+++ b/packages/@overeng/genie/src/core/import-map/mod.ts
@@ -263,6 +263,7 @@ type MemberSourceMap = Record<string, string>
 type MegarepoLockMember = {
   readonly url: string
   readonly ref: string
+  readonly commit?: string
 }
 
 type MegarepoLock = {
@@ -344,13 +345,15 @@ const joinMemberSubPath = ({
 const getMegarepoStoreBasePath = (): string =>
   process.env.MEGAREPO_STORE ?? path.join(process.env.HOME ?? '~', '.megarepo')
 
-const deriveStoreWorktreePathFromLockMember = ({
-  member,
+const deriveStoreWorktreePath = ({
+  selector,
+  url,
 }: {
-  member: MegarepoLockMember
+  selector: string
+  url: string
 }): string | undefined => {
-  const url = member.url.replace(/^https?:\/\//, '')
-  const [host, owner, repo] = url.split('/')
+  const normalizedUrl = url.replace(/^https?:\/\//, '')
+  const [host, owner, repo] = normalizedUrl.split('/')
   if (
     host === undefined ||
     host.length === 0 ||
@@ -362,7 +365,7 @@ const deriveStoreWorktreePathFromLockMember = ({
     return undefined
   }
 
-  const refType = classifyMegarepoRef(member.ref)
+  const refType = classifyMegarepoRef(selector)
   return path.join(
     getMegarepoStoreBasePath(),
     host,
@@ -370,8 +373,38 @@ const deriveStoreWorktreePathFromLockMember = ({
     repo,
     'refs',
     refTypeToPathSegment(refType),
-    member.ref,
+    selector,
   )
+}
+
+const deriveStoreWorktreePathFromLockMember = ({
+  member,
+}: {
+  member: MegarepoLockMember
+}): string | undefined => {
+  const selectors = [
+    ...(member.commit !== undefined && member.commit.length > 0 ? [member.commit] : []),
+    member.ref,
+  ]
+
+  for (const selector of selectors) {
+    const derivedPath = deriveStoreWorktreePath({
+      selector,
+      url: member.url,
+    })
+    if (derivedPath !== undefined && fs.existsSync(derivedPath) === true) {
+      return derivedPath
+    }
+  }
+
+  return selectors
+    .map((selector) =>
+      deriveStoreWorktreePath({
+        selector,
+        url: member.url,
+      }),
+    )
+    .find((derivedPath): derivedPath is string => derivedPath !== undefined)
 }
 
 const findRepoRootSync = (fromPath: string): string | undefined => {


### PR DESCRIPTION
## What

- teach Genie megarepo import resolution to prefer `megarepo.lock.members[*].commit` over the mutable `ref` when both are available
- keep the existing `ref` fallback for cases where a commit worktree is not present
- add async and sync regression tests for `#mr/...` resolution so both resolver paths prefer commit worktrees

## Why

Genie currently resolves `#mr/...` imports from the lock member `ref` and ignores the locked `commit`. That makes generation depend on whichever branch worktree happens to exist on the machine instead of the exact megarepo lock state.

In practice this showed up downstream: local generation was stable, but CI regenerated a workflow differently and `lint:check:genie` failed because the runner resolved imports from a mutable branch worktree instead of the locked commit.

## Rationale

The lock file is the source of truth for megarepo composition. If we prefer `ref` over `commit`, generated outputs can drift across machines even when everyone is using the same lock file. Preferring `commit` restores deterministic generation without adding a new protocol or a downstream workaround.

Keeping the `ref` fallback is still useful for environments that do not yet have a commit worktree materialized, so this stays compatible with existing store layouts while making the locked path authoritative when available.

## Validation

- `CI=1 pnpm exec vitest run src/core/import-map/import-map.unit.test.ts` from `packages/@overeng/genie`
- verified downstream by repinning the affected repo to this branch, regenerating, and getting CI green there