### PR TITLE
fix(devenv): preserve symlinks in source CLI wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **devenv/pnpm-install**: Invalidate pnpm 11 GVS links on any `pnpm-lock.yaml` content change, not just `packageExtensions:` / `allowBuilds:` tweaks. Previously, stale GVS symlinks survived lockfile bumps on runners with persistent volumes (e.g. Namespace bundled cache), leading to non-deterministic "Cannot find package/module" errors for transitive deps after catalog updates
 - **@overeng/pty-effect/client**: Fix flaky timeout in `followEvents` (#577) — `asyncScoped`'s setup ran lazily inside the forked consumer fiber, missing events fired before the fiber started. Replaced with `Stream.asyncPush` (setup still lazy, but `emit.single` is now correctly synchronous for `fs.watch` callbacks). Test updated to watch `session_exit` instead of `session_start`, since `EventFollower.watchFile` starts reading at the current end-of-file when a new session is discovered, making `session_start` unreachable via live following.
 
 ### Changed

--- a/nix/devenv-modules/lib/mk-source-cli.nix
+++ b/nix/devenv-modules/lib/mk-source-cli.nix
@@ -23,6 +23,8 @@
 { name, entry }:
 pkgs.writeShellScriptBin name ''
   root="''${WORKSPACE_ROOT:-$PWD}"
+  # Source CLIs in megarepo workspaces depend on linked packages resolving
+  # through the workspace symlink graph, not through realpath locations.
   exec ${pkgs.bun}/bin/bun \
     --preserve-symlinks \
     --preserve-symlinks-main \

--- a/nix/devenv-modules/lib/mk-source-cli.nix
+++ b/nix/devenv-modules/lib/mk-source-cli.nix
@@ -23,5 +23,8 @@
 { name, entry }:
 pkgs.writeShellScriptBin name ''
   root="''${WORKSPACE_ROOT:-$PWD}"
-  exec ${pkgs.bun}/bin/bun "$root/${entry}" "$@"
+  exec ${pkgs.bun}/bin/bun \
+    --preserve-symlinks \
+    --preserve-symlinks-main \
+    "$root/${entry}" "$@"
 ''

--- a/nix/devenv-modules/tasks/shared/pnpm.nix
+++ b/nix/devenv-modules/tasks/shared/pnpm.nix
@@ -172,16 +172,19 @@ let
         ${runPnpmInstallFn}
 
         # pnpm 11 GVS: hash-based link invalidation. pnpm reuses existing GVS
-        # entries without re-resolving packageExtensions, so stale entries break
-        # TypeScript resolution. Only clear links/ when config changes.
-        # Content-addressable store (files/) is unaffected.
-        # See: pnpm/pnpm#9739
+        # entries without re-resolving, so stale entries break module resolution
+        # across lockfile bumps (observed on Namespace runners where a bundled
+        # cache carries a previous workspace state across runs). Invalidate
+        # links/ whenever the lockfile content changes, not just on
+        # packageExtensions/allowBuilds tweaks. Content-addressable store
+        # (files/) is unaffected. See: pnpm/pnpm#9739
         _gvs_hash=$({
           # pnpm 11 keeps the process alive when stdin stays open, which is
           # what GitHub Actions does for long-lived shell steps.
           pnpm --version < /dev/null
           sed -n '/^packageExtensions:/,/^[a-zA-Z]/p' pnpm-workspace.yaml 2>/dev/null || true
           sed -n '/^allowBuilds:/,/^[a-zA-Z]/p' pnpm-workspace.yaml 2>/dev/null || true
+          cat pnpm-lock.yaml
         } | compute_hash)
 
         _gvs_hash_file=""


### PR DESCRIPTION
## Summary
- pass `--preserve-symlinks` and `--preserve-symlinks-main` through `mkSourceCli` Bun wrappers
- keeps source CLIs aligned with symlinked megarepo workspace layouts, where linked packages should resolve through the workspace graph instead of realpaths
- **fix pnpm 11 GVS staleness**: fold `pnpm-lock.yaml` content into `_gvs_hash` so any lockfile change invalidates GVS `links/`, not just `packageExtensions` / `allowBuilds` tweaks

## Verification
- built a `mkSourceCli` wrapper from latest `origin/main` with `nix build --impure --no-link --print-out-paths --expr ...`
- inspected the generated `bin/test-source-cli` wrapper and confirmed both Bun symlink flags are present

## Rationale for the pnpm fix
The first CI on this PR failed `lint` / `typecheck` with `Cannot find package 'fast-check'` inside `effect/.../FastCheck.js`. A rerun failed again with a *different* missing module (`@effect/platform-node-shared`), on a different Namespace runner — same code, same lockfile. Root cause: after #616 bumped the Effect catalog, pnpm 11's GVS `links/` was reused from pre-bump state on Namespace runners whose 50 GB bundled cache persists workspace state across runs. The existing GVS hash only tripped on `packageExtensions` / `allowBuilds` changes, not on lockfile content, so stale symlinks survived the bump. Including the lockfile content in the hash forces a links/ rebuild on any resolution change.

## Downstream
- dotfiles can consume this by bumping `effect-utils`, then remove any local fallback/import workaround for `mkSourceCli`