### PR TITLE
Fix pnpm nested installs to share store-dir

### DIFF
--- a/nix/devenv-modules/tasks/shared/pnpm-task-helpers.sh
+++ b/nix/devenv-modules/tasks/shared/pnpm-task-helpers.sh
@@ -40,9 +40,14 @@ emit_dir_state() {
 }
 
 resolve_gvs_links_dir() {
-  # Prefer the explicit pnpm home because CI now intentionally decouples the
-  # mutable store location from the workspace-relative GVS projection root.
-  if [ -n "${PNPM_HOME:-}" ]; then
+  # pnpm 11 stores the GVS links under the effective store-dir. Prefer the
+  # explicit store setting when tasks share storage across isolated PNPM_HOME
+  # directories.
+  if [ -n "${npm_config_store_dir:-}" ]; then
+    printf '%s\n' "${npm_config_store_dir}/v11/links"
+  elif [ -n "${PNPM_STORE_DIR:-}" ]; then
+    printf '%s\n' "${PNPM_STORE_DIR}/v11/links"
+  elif [ -n "${PNPM_HOME:-}" ]; then
     printf '%s\n' "${PNPM_HOME}/store/v11/links"
   elif [ -n "${XDG_DATA_HOME:-}" ] && [ -d "${XDG_DATA_HOME}/pnpm/store/v11" ]; then
     printf '%s\n' "${XDG_DATA_HOME}/pnpm/store/v11/links"

--- a/nix/devenv-modules/tasks/shared/pnpm.nix
+++ b/nix/devenv-modules/tasks/shared/pnpm.nix
@@ -192,13 +192,14 @@ let
 
   runPnpmInstallFn = ''
     run_pnpm_install() {
+      local extra_install_args=("$@")
       local install_args
       if [ -n "''${CI:-}" ] && ${if frozenInCi then "true" else "false"}; then
-        install_args=(install --config.confirmModulesPurge=false --config.store-dir="$npm_config_store_dir" --frozen-lockfile ${installFlagsString})
+        install_args=(install --config.confirmModulesPurge=false --config.store-dir="$npm_config_store_dir" "''${extra_install_args[@]}" --frozen-lockfile ${installFlagsString})
       elif [ -n "''${CI:-}" ]; then
-        install_args=(install --config.confirmModulesPurge=false --config.store-dir="$npm_config_store_dir" --no-frozen-lockfile ${installFlagsString})
+        install_args=(install --config.confirmModulesPurge=false --config.store-dir="$npm_config_store_dir" "''${extra_install_args[@]}" --no-frozen-lockfile ${installFlagsString})
       else
-        install_args=(install --config.confirmModulesPurge=false --config.store-dir="$npm_config_store_dir" ${installFlagsString})
+        install_args=(install --config.confirmModulesPurge=false --config.store-dir="$npm_config_store_dir" "''${extra_install_args[@]}" ${installFlagsString})
       fi
 
       if [ -z "''${CI:-}" ]; then
@@ -334,15 +335,16 @@ let
         _gvs_hash_file=""
         _gvs_links_dir="$(resolve_gvs_links_dir)"
         _purged_node_modules=false
+        _force_install=false
 
         if [ -n "''${_gvs_links_dir:-}" ]; then
           _gvs_hash_file="$(dirname "$_gvs_links_dir")/.effect-utils-gvs-links.hash"
           mkdir -p "$(dirname "$_gvs_links_dir")"
           if [ ! -f "$_gvs_hash_file" ] || [ "$(cat "$_gvs_hash_file")" != "$_gvs_hash" ]; then
-            echo "[pnpm] GVS config changed, clearing stale links"
-            rm -rf "$_gvs_links_dir"
+            echo "[pnpm] GVS config changed, forcing current workspace relink"
             purge_node_modules node_modules ${nodeModulesPaths}
             _purged_node_modules=true
+            _force_install=true
           fi
         fi
 
@@ -351,7 +353,11 @@ let
           purge_node_modules node_modules ${nodeModulesPaths}
         fi
 
-        run_pnpm_install
+        if [ "$_force_install" = true ]; then
+          run_pnpm_install --force
+        else
+          run_pnpm_install
+        fi
 
         # Persist GVS hash after successful install
         if [ -n "''${_gvs_hash_file:-}" ]; then
@@ -416,13 +422,9 @@ let
 
         purge_node_modules node_modules ${nodeModulesPaths}
 
-        # `pnpm:clean` is expected to force a genuinely fresh install. Keeping
-        # the live GVS projection around defeats that expectation because pnpm
-        # may reuse stale `links/` entries even after node_modules is gone.
-        gvs_links_dir="$(resolve_gvs_links_dir)"
-        if [ -n "''${gvs_links_dir:-}" ]; then
-          rm -rf "$gvs_links_dir" "$(dirname "$gvs_links_dir")/.effect-utils-gvs-links.hash"
-        fi
+        # The GVS `links/` directory lives under the shared store-dir. Deleting
+        # it from one workspace would break node_modules projections in other
+        # workspaces that point at the same shared store.
       '';
     };
 

--- a/nix/devenv-modules/tasks/shared/pnpm.nix
+++ b/nix/devenv-modules/tasks/shared/pnpm.nix
@@ -53,6 +53,7 @@ let
       "${config.devenv.root}/.direnv/pnpm-home"
     else
       "${config.devenv.root}/.direnv/pnpm-home/${workspaceCacheName}";
+  defaultPnpmStoreDir = "${config.devenv.root}/.direnv/pnpm-store";
   installTaskName =
     if taskSuffix == null then "${taskNamePrefix}:install" else "${taskNamePrefix}:install:${taskSuffix}";
   updateTaskName =
@@ -136,6 +137,16 @@ let
         */${workspaceCacheName}) ;;
         *) export PNPM_HOME="$PNPM_HOME/${workspaceCacheName}" ;;
       esac
+    fi
+  '';
+  ensureLocalPnpmStoreDirFn = ''
+    if [ -n "''${npm_config_store_dir:-}" ]; then
+      export PNPM_STORE_DIR="''${PNPM_STORE_DIR:-$npm_config_store_dir}"
+    elif [ -n "''${PNPM_STORE_DIR:-}" ]; then
+      export npm_config_store_dir="$PNPM_STORE_DIR"
+    else
+      export PNPM_STORE_DIR=${lib.escapeShellArg defaultPnpmStoreDir}
+      export npm_config_store_dir="$PNPM_STORE_DIR"
     fi
   '';
 
@@ -266,6 +277,7 @@ let
         cd ${lib.escapeShellArg workspaceRootAbs}
         ${loadPnpmTaskHelpersFn}
         ${ensureLocalPnpmHomeFn}
+        ${ensureLocalPnpmStoreDirFn}
         mkdir -p "${cacheRoot}"
         # This cache tracks the effective install state, not just workspace
         # manifests. The fingerprint also includes the active GVS projection
@@ -286,6 +298,15 @@ let
         if ! ${flock} -w 600 201; then
           echo "[pnpm] PNPM_HOME lock timeout after 600s: $pnpm_home_lockfile" >&2
           echo "[pnpm] Another pnpm install sharing this PNPM_HOME may be stuck" >&2
+          exit 1
+        fi
+
+        pnpm_store_lockfile="''${npm_config_store_dir:-${cacheRoot}}/.effect-utils-pnpm-store.lock"
+        mkdir -p "$(dirname "$pnpm_store_lockfile")"
+        exec 202>"$pnpm_store_lockfile"
+        if ! ${flock} -w 600 202; then
+          echo "[pnpm] store-dir lock timeout after 600s: $pnpm_store_lockfile" >&2
+          echo "[pnpm] Another pnpm install sharing this store-dir may be stuck" >&2
           exit 1
         fi
 
@@ -345,6 +366,7 @@ let
         cd ${lib.escapeShellArg workspaceRootAbs}
         ${loadPnpmTaskHelpersFn}
         ${ensureLocalPnpmHomeFn}
+        ${ensureLocalPnpmStoreDirFn}
         hash_file="${cacheRoot}/install-state.hash"
 
         if [ ! -d node_modules ] || [ ! -f pnpm-lock.yaml ] || [ ! -f "$hash_file" ]; then
@@ -374,6 +396,7 @@ let
         cd ${lib.escapeShellArg workspaceRootAbs}
         ${loadPnpmTaskHelpersFn}
         ${ensureLocalPnpmHomeFn}
+        ${ensureLocalPnpmStoreDirFn}
         export npm_config_manage_package_manager_versions=false
         pnpm install --fix-lockfile --config.confirmModulesPurge=false
         echo "Repo-root lockfile updated. Run 'dt nix:hash' to update Nix hashes."
@@ -389,6 +412,7 @@ let
         cd ${lib.escapeShellArg workspaceRootAbs}
         ${loadPnpmTaskHelpersFn}
         ${ensureLocalPnpmHomeFn}
+        ${ensureLocalPnpmStoreDirFn}
 
         purge_node_modules node_modules ${nodeModulesPaths}
 
@@ -418,6 +442,8 @@ in
 
   enterShell = lib.mkIf (globalCache && workspaceRoot == ".") ''
     export PNPM_HOME="''${PNPM_HOME:-${config.devenv.root}/.direnv/pnpm-home}"
+    export PNPM_STORE_DIR="''${PNPM_STORE_DIR:-${defaultPnpmStoreDir}}"
+    export npm_config_store_dir="''${npm_config_store_dir:-$PNPM_STORE_DIR}"
     export npm_config_cache="$HOME/.cache/pnpm"
     export npm_config_manage_package_manager_versions=false
   '';

--- a/nix/devenv-modules/tasks/shared/pnpm.nix
+++ b/nix/devenv-modules/tasks/shared/pnpm.nix
@@ -194,11 +194,11 @@ let
     run_pnpm_install() {
       local install_args
       if [ -n "''${CI:-}" ] && ${if frozenInCi then "true" else "false"}; then
-        install_args=(install --config.confirmModulesPurge=false --frozen-lockfile ${installFlagsString})
+        install_args=(install --config.confirmModulesPurge=false --config.store-dir="$npm_config_store_dir" --frozen-lockfile ${installFlagsString})
       elif [ -n "''${CI:-}" ]; then
-        install_args=(install --config.confirmModulesPurge=false --no-frozen-lockfile ${installFlagsString})
+        install_args=(install --config.confirmModulesPurge=false --config.store-dir="$npm_config_store_dir" --no-frozen-lockfile ${installFlagsString})
       else
-        install_args=(install --config.confirmModulesPurge=false ${installFlagsString})
+        install_args=(install --config.confirmModulesPurge=false --config.store-dir="$npm_config_store_dir" ${installFlagsString})
       fi
 
       if [ -z "''${CI:-}" ]; then
@@ -398,7 +398,7 @@ let
         ${ensureLocalPnpmHomeFn}
         ${ensureLocalPnpmStoreDirFn}
         export npm_config_manage_package_manager_versions=false
-        pnpm install --fix-lockfile --config.confirmModulesPurge=false
+        pnpm install --fix-lockfile --config.confirmModulesPurge=false --config.store-dir="$npm_config_store_dir"
         echo "Repo-root lockfile updated. Run 'dt nix:hash' to update Nix hashes."
       '';
     };

--- a/nix/devenv-modules/tasks/shared/tests/pnpm-task-smoke.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/pnpm-task-smoke.test.sh
@@ -364,7 +364,7 @@ echo "Test 11: install flags and pre-install hooks are applied"
   : > "$tmpdir/pnpm.log"
   bash "$tmpdir/pnpm-install-flags.exec.sh"
   test -f .preinstall-marker
-  grep -qxF "install --config.confirmModulesPurge=false --ignore-scripts --config.public-hoist-pattern=*" "$tmpdir/pnpm.log"
+  grep -qxF "install --config.confirmModulesPurge=false --config.store-dir=$workspace/.direnv/pnpm-store --ignore-scripts --config.public-hoist-pattern=*" "$tmpdir/pnpm.log"
 )
 
 echo "Test 12: CI install failures preserve and classify the pnpm log"

--- a/nix/devenv-modules/tasks/shared/tests/pnpm-task-smoke.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/pnpm-task-smoke.test.sh
@@ -151,6 +151,8 @@ if [ "${1:-}" = "--version" ]; then
 fi
 if [ "${1:-}" = "install" ]; then
   printf 'PNPM_HOME=%s\n' "${PNPM_HOME:-}" >> "${TEST_PNPM_LOG:?}"
+  printf 'PNPM_STORE_DIR=%s\n' "${PNPM_STORE_DIR:-}" >> "${TEST_PNPM_LOG:?}"
+  printf 'npm_config_store_dir=%s\n' "${npm_config_store_dir:-}" >> "${TEST_PNPM_LOG:?}"
   if [ "${TEST_PNPM_FAIL_NETWORK:-0}" = "1" ]; then
     echo "ERR_PNPM_META_FETCH_FAIL GET https://registry.npmjs.org/demo: request to https://registry.npmjs.org/demo failed, reason: Socket timeout" >&2
     exit 42
@@ -251,7 +253,9 @@ echo "Test 2: exec runs fake pnpm and populates cache"
   test -d "$workspace/node_modules"
   grep -qxF "flock -w 600 200" "$tmpdir/flock.log"
   grep -qxF "flock -w 600 201" "$tmpdir/flock.log"
+  grep -qxF "flock -w 600 202" "$tmpdir/flock.log"
   grep -qF ".effect-utils-pnpm-install.lock" "$tmpdir/pnpm-install.exec.sh"
+  grep -qF ".effect-utils-pnpm-store.lock" "$tmpdir/pnpm-install.exec.sh"
 )
 
 echo "Test 3: status hits after install with same GVS path"
@@ -274,6 +278,8 @@ echo "Test 4: exec defaults PNPM_HOME to a workspace-local projection"
   : > "$tmpdir/pnpm.log"
   bash "$tmpdir/pnpm-install.exec.sh"
   grep -qxF "PNPM_HOME=$workspace/.direnv/pnpm-home" "$tmpdir/pnpm.log"
+  grep -qxF "PNPM_STORE_DIR=$workspace/.direnv/pnpm-store" "$tmpdir/pnpm.log"
+  grep -qxF "npm_config_store_dir=$workspace/.direnv/pnpm-store" "$tmpdir/pnpm.log"
 )
 
 echo "Test 5: status hits after install with the default GVS path"
@@ -288,7 +294,7 @@ echo "Test 5: status hits after install with the default GVS path"
   assert_exit_code 0 "$exit_code" "status should hit after default-PNPM_HOME install"
 )
 
-echo "Test 6: status misses after effective GVS path changes"
+echo "Test 6: status still hits when PNPM_HOME changes but store-dir stays shared"
 (
   cd "$workspace"
   export HOME="$tmpdir/home"
@@ -297,30 +303,49 @@ echo "Test 6: status misses after effective GVS path changes"
   bash "$tmpdir/pnpm-install.status.sh"
   exit_code=$?
   set -e
-  assert_exit_code 1 "$exit_code" "status should miss when GVS path changes"
+  assert_exit_code 0 "$exit_code" "status should hit when only PNPM_HOME changes"
 )
 
-echo "Test 7: exec invoked pnpm install"
+echo "Test 7: status misses after effective store-dir changes"
+(
+  cd "$workspace"
+  export HOME="$tmpdir/home"
+  export PNPM_STORE_DIR="$workspace/.other-pnpm-store"
+  unset npm_config_store_dir
+  set +e
+  bash "$tmpdir/pnpm-install.status.sh"
+  exit_code=$?
+  set -e
+  assert_exit_code 1 "$exit_code" "status should miss when store-dir changes"
+)
+
+echo "Test 8: exec invoked pnpm install"
 grep -q "^install " "$tmpdir/pnpm.log"
 
-echo "Test 8: nested workspace exec uses its own cwd, cache, and PNPM_HOME"
+echo "Test 9: nested workspace exec uses its own cwd, cache, PNPM_HOME, and shared store-dir"
 (
   cd "$workspace"
   export HOME="$tmpdir/home"
   unset PNPM_HOME
+  unset PNPM_STORE_DIR
+  unset npm_config_store_dir
   : > "$tmpdir/pnpm.log"
   bash "$tmpdir/pnpm-install-nested.exec.sh"
   test -f "$workspace/.direnv/task-cache/pnpm-install/nested/install-state.hash"
   test -d "$workspace/nested/node_modules"
   grep -qxF "PWD=$workspace/nested" "$tmpdir/pnpm.log"
   grep -qxF "PNPM_HOME=$workspace/.direnv/pnpm-home/nested" "$tmpdir/pnpm.log"
+  grep -qxF "PNPM_STORE_DIR=$workspace/.direnv/pnpm-store" "$tmpdir/pnpm.log"
+  grep -qxF "npm_config_store_dir=$workspace/.direnv/pnpm-store" "$tmpdir/pnpm.log"
 )
 
-echo "Test 9: nested workspace status hits after nested install"
+echo "Test 10: nested workspace status hits after nested install"
 (
   cd "$workspace"
   export HOME="$tmpdir/home"
   unset PNPM_HOME
+  unset PNPM_STORE_DIR
+  unset npm_config_store_dir
   set +e
   bash "$tmpdir/pnpm-install-nested.status.sh"
   exit_code=$?
@@ -328,11 +353,13 @@ echo "Test 9: nested workspace status hits after nested install"
   assert_exit_code 0 "$exit_code" "nested status should hit after nested install"
 )
 
-echo "Test 10: install flags and pre-install hooks are applied"
+echo "Test 11: install flags and pre-install hooks are applied"
 (
   cd "$workspace"
   export HOME="$tmpdir/home"
   unset PNPM_HOME
+  unset PNPM_STORE_DIR
+  unset npm_config_store_dir
   rm -f .preinstall-marker
   : > "$tmpdir/pnpm.log"
   bash "$tmpdir/pnpm-install-flags.exec.sh"
@@ -340,7 +367,7 @@ echo "Test 10: install flags and pre-install hooks are applied"
   grep -qxF "install --config.confirmModulesPurge=false --ignore-scripts --config.public-hoist-pattern=*" "$tmpdir/pnpm.log"
 )
 
-echo "Test 11: CI install failures preserve and classify the pnpm log"
+echo "Test 12: CI install failures preserve and classify the pnpm log"
 (
   cd "$workspace"
   export HOME="$tmpdir/home"
@@ -348,6 +375,8 @@ echo "Test 11: CI install failures preserve and classify the pnpm log"
   export CI_DIAGNOSTICS_DIR="$tmpdir/diagnostics"
   export TEST_PNPM_FAIL_NETWORK=1
   unset PNPM_HOME
+  unset PNPM_STORE_DIR
+  unset npm_config_store_dir
   rm -f "$workspace/.direnv/task-cache/pnpm-install/install-state.hash"
   set +e
   output="$(bash "$tmpdir/pnpm-install.exec.sh" 2>&1)"
@@ -362,14 +391,14 @@ echo "Test 11: CI install failures preserve and classify the pnpm log"
   grep -qF "Socket timeout" <<< "$output"
 )
 
-echo "Test 12: generated test task runs vitest without pnpm exec"
+echo "Test 13: generated test task runs vitest without pnpm exec"
 (
   cd "$workspace/packages/demo"
   output="$(bash "$tmpdir/test-demo.exec.sh")"
   [ "$output" = "vitest-shim:run" ]
 )
 
-echo "Test 13: generated storybook task runs storybook without pnpm exec"
+echo "Test 14: generated storybook task runs storybook without pnpm exec"
 (
   cd "$workspace/packages/demo"
   output="$(bash "$tmpdir/storybook-demo.exec.sh")"

--- a/nix/devenv-modules/tasks/shared/tests/pnpm-task-smoke.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/pnpm-task-smoke.test.sh
@@ -230,6 +230,8 @@ export PATH="$tmpdir/bin:$PATH"
 export TEST_PNPM_LOG="$tmpdir/pnpm.log"
 export TEST_FLOCK_LOG="$tmpdir/flock.log"
 unset CI
+unset PNPM_STORE_DIR
+unset npm_config_store_dir
 
 echo "Test 1: status misses before install"
 (

--- a/nix/devenv-modules/tasks/shared/tests/pnpm-task-smoke.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/pnpm-task-smoke.test.sh
@@ -207,6 +207,7 @@ chmod +x "$workspace/packages/demo/node_modules/.bin/storybook"
 
 extract_task_script "$workspace" "exec" "$tmpdir/pnpm-install.exec.sh"
 extract_task_script "$workspace" "status" "$tmpdir/pnpm-install.status.sh"
+extract_task_script "$workspace" "exec" "$tmpdir/pnpm-clean.exec.sh" 'packages = [ "packages/demo" ];' "pnpm:clean"
 extract_task_script "$workspace" "exec" "$tmpdir/pnpm-install-nested.exec.sh" 'packages = [ "pkg" ]; workspaceRoot = "nested"; taskSuffix = "nested";' "pnpm:install:nested"
 extract_task_script "$workspace" "status" "$tmpdir/pnpm-install-nested.status.sh" 'packages = [ "pkg" ]; workspaceRoot = "nested"; taskSuffix = "nested";' "pnpm:install:nested"
 extract_task_script "$workspace" "exec" "$tmpdir/pnpm-install-flags.exec.sh" 'packages = [ "." ]; installFlags = [ "--ignore-scripts" "--config.public-hoist-pattern=*" ]; preInstall = "touch .preinstall-marker";'
@@ -254,6 +255,7 @@ echo "Test 2: exec runs fake pnpm and populates cache"
   grep -qxF "flock -w 600 200" "$tmpdir/flock.log"
   grep -qxF "flock -w 600 201" "$tmpdir/flock.log"
   grep -qxF "flock -w 600 202" "$tmpdir/flock.log"
+  grep -qxF "install --config.confirmModulesPurge=false --config.store-dir=$workspace/.direnv/pnpm-store --force" "$tmpdir/pnpm.log"
   grep -qF ".effect-utils-pnpm-install.lock" "$tmpdir/pnpm-install.exec.sh"
   grep -qF ".effect-utils-pnpm-store.lock" "$tmpdir/pnpm-install.exec.sh"
 )
@@ -403,6 +405,17 @@ echo "Test 14: generated storybook task runs storybook without pnpm exec"
   cd "$workspace/packages/demo"
   output="$(bash "$tmpdir/storybook-demo.exec.sh")"
   [ "$output" = "storybook-shim:build" ]
+)
+
+echo "Test 15: clean leaves shared GVS links intact"
+(
+  cd "$workspace"
+  mkdir -p "$workspace/.direnv/pnpm-store/v11/links/shared-pkg"
+  mkdir -p "$workspace/node_modules" "$workspace/packages/demo/node_modules"
+  bash "$tmpdir/pnpm-clean.exec.sh"
+  test -d "$workspace/.direnv/pnpm-store/v11/links/shared-pkg"
+  test ! -e "$workspace/node_modules"
+  test ! -e "$workspace/packages/demo/node_modules"
 )
 
 echo ""

--- a/nix/devenv-modules/tasks/shared/tests/pnpm.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/pnpm.test.sh
@@ -104,21 +104,51 @@ echo ""
 test_dir="$(mktemp -d)"
 trap 'rm -rf "$test_dir"' EXIT
 
-echo "Test 1: PNPM_HOME takes precedence for GVS links path"
-mkdir -p "$test_dir/pnpm-home/store/v11" "$test_dir/xdg/pnpm/store/v11" "$test_dir/home/.local/share/pnpm/store/v11"
+echo "Test 1: explicit store-dir takes precedence for GVS links path"
+mkdir -p "$test_dir/pnpm-store/v11" "$test_dir/pnpm-home/store/v11" "$test_dir/xdg/pnpm/store/v11" "$test_dir/home/.local/share/pnpm/store/v11"
 (
   export HOME="$test_dir/home"
+  export npm_config_store_dir="$test_dir/pnpm-store"
+  export PNPM_STORE_DIR="$test_dir/ignored-pnpm-store"
+  export PNPM_HOME="$test_dir/pnpm-home"
+  export XDG_DATA_HOME="$test_dir/xdg"
+  assert_eq \
+    "$test_dir/pnpm-store/v11/links" \
+    "$(resolve_gvs_links_dir)" \
+    "resolve_gvs_links_dir prefers npm_config_store_dir"
+)
+
+echo "Test 2: PNPM_STORE_DIR is used when npm_config_store_dir is unset"
+(
+  export HOME="$test_dir/home"
+  unset npm_config_store_dir
+  export PNPM_STORE_DIR="$test_dir/pnpm-store"
+  export PNPM_HOME="$test_dir/pnpm-home"
+  export XDG_DATA_HOME="$test_dir/xdg"
+  assert_eq \
+    "$test_dir/pnpm-store/v11/links" \
+    "$(resolve_gvs_links_dir)" \
+    "resolve_gvs_links_dir uses PNPM_STORE_DIR"
+)
+
+echo "Test 3: PNPM_HOME is used when store-dir is unset"
+(
+  export HOME="$test_dir/home"
+  unset npm_config_store_dir
+  unset PNPM_STORE_DIR
   export PNPM_HOME="$test_dir/pnpm-home"
   export XDG_DATA_HOME="$test_dir/xdg"
   assert_eq \
     "$test_dir/pnpm-home/store/v11/links" \
     "$(resolve_gvs_links_dir)" \
-    "resolve_gvs_links_dir prefers PNPM_HOME"
+    "resolve_gvs_links_dir falls back to PNPM_HOME"
 )
 
-echo "Test 2: XDG_DATA_HOME is used when PNPM_HOME is unset"
+echo "Test 4: XDG_DATA_HOME is used when PNPM_HOME is unset"
 (
   export HOME="$test_dir/home"
+  unset npm_config_store_dir
+  unset PNPM_STORE_DIR
   unset PNPM_HOME
   export XDG_DATA_HOME="$test_dir/xdg"
   assert_eq \
@@ -127,7 +157,7 @@ echo "Test 2: XDG_DATA_HOME is used when PNPM_HOME is unset"
     "resolve_gvs_links_dir uses XDG_DATA_HOME"
 )
 
-echo "Test 3: ensure_local_pnpm_home_default sets a workspace-local default"
+echo "Test 5: ensure_local_pnpm_home_default sets a workspace-local default"
 (
   unset PNPM_HOME
   ensure_local_pnpm_home_default "$test_dir/workspace"
@@ -137,7 +167,7 @@ echo "Test 3: ensure_local_pnpm_home_default sets a workspace-local default"
     "ensure_local_pnpm_home_default sets PNPM_HOME"
 )
 
-echo "Test 4: ensure_local_pnpm_home_default preserves an explicit PNPM_HOME"
+echo "Test 6: ensure_local_pnpm_home_default preserves an explicit PNPM_HOME"
 (
   export PNPM_HOME="$test_dir/custom-home"
   ensure_local_pnpm_home_default "$test_dir/workspace"
@@ -147,7 +177,7 @@ echo "Test 4: ensure_local_pnpm_home_default preserves an explicit PNPM_HOME"
     "ensure_local_pnpm_home_default keeps explicit PNPM_HOME"
 )
 
-echo "Test 5: Cache fingerprint changes when GVS path changes"
+echo "Test 7: Cache fingerprint changes when GVS path changes"
 fingerprint_a="$(cache_fingerprint "workspace-hash" "/tmp/a/store/v11/links")"
 fingerprint_b="$(cache_fingerprint "workspace-hash" "/tmp/b/store/v11/links")"
 if [ "$fingerprint_a" = "$fingerprint_b" ]; then
@@ -155,7 +185,7 @@ if [ "$fingerprint_a" = "$fingerprint_b" ]; then
   exit 1
 fi
 
-echo "Test 6: resolve_package_bin prefers package-local .bin shims"
+echo "Test 8: resolve_package_bin prefers package-local .bin shims"
 bin_fixture="$test_dir/bin-fixture"
 make_bin_fixture "$bin_fixture"
 resolved_bin="$(resolve_package_bin fake-tool fake-tool "$bin_fixture")"
@@ -165,14 +195,14 @@ assert_eq \
   "$resolved_bin" \
   "resolve_package_bin prefers the generated .bin shim"
 
-echo "Test 7: run_package_bin executes the .bin shim when present"
+echo "Test 9: run_package_bin executes the .bin shim when present"
 output="$(cd "$bin_fixture" && run_package_bin fake-tool fake-tool alpha beta)"
 assert_eq \
   "fake-tool-shim:alpha beta" \
   "$output" \
   "run_package_bin executes the resolved shim"
 
-echo "Test 8: resolve_package_bin falls back to the package bin file"
+echo "Test 10: resolve_package_bin falls back to the package bin file"
 fallback_fixture="$test_dir/fallback-bin-fixture"
 make_bin_fixture_without_shim "$fallback_fixture"
 resolved_fallback_bin="$(resolve_package_bin fallback-tool fallback-tool "$fallback_fixture")"
@@ -182,7 +212,7 @@ assert_eq \
   "$resolved_fallback_bin" \
   "resolve_package_bin falls back to the package bin file"
 
-echo "Test 9: Projection health passes when symlinked package can resolve deps"
+echo "Test 11: Projection health passes when symlinked package can resolve deps"
 healthy_dir="$test_dir/healthy"
 make_projection_fixture "$healthy_dir" 1
 set +e
@@ -191,7 +221,7 @@ exit_code=$?
 set -e
 assert_exit_code 0 "$exit_code" "projection health passes"
 
-echo "Test 10: Projection health ignores packages that do not export ./package.json"
+echo "Test 12: Projection health ignores packages that do not export ./package.json"
 exports_dir="$test_dir/exports"
 make_projection_fixture "$exports_dir" 1 1
 set +e
@@ -200,7 +230,7 @@ exit_code=$?
 set -e
 assert_exit_code 0 "$exit_code" "projection health should not depend on package.json exports"
 
-echo "Test 11: Projection health fails when symlinked package loses a transitive dep"
+echo "Test 13: Projection health fails when symlinked package loses a transitive dep"
 stale_dir="$test_dir/stale"
 make_projection_fixture "$stale_dir" 0
 set +e
@@ -209,7 +239,7 @@ exit_code=$?
 set -e
 assert_exit_code 1 "$exit_code" "projection health detects missing dep"
 
-echo "Test 12: Broken node_modules symlink is rejected before projection checks"
+echo "Test 14: Broken node_modules symlink is rejected before projection checks"
 broken_dir="$test_dir/broken"
 mkdir -p "$broken_dir/node_modules"
 ln -s ../missing "$broken_dir/node_modules/broken"


### PR DESCRIPTION
## Summary

- keep nested pnpm workspaces on separate `PNPM_HOME` state directories
- default all generated pnpm tasks to a shared repo-local `.direnv/pnpm-store`
- resolve pnpm 11 GVS links from the effective store-dir before falling back to `PNPM_HOME`
- serialize installs sharing the same store-dir and cover the contract in pnpm task smoke tests

## Rationale

PR #626 intentionally isolated nested workspace state with per-workspace `PNPM_HOME`, but pnpm 11 also defaults `store-dir` under `PNPM_HOME`. That fragmented the global virtual store, so identical package versions in linked nested workspaces resolved through different physical GVS roots and TypeScript treated them as separate module instances.

A shared `store-dir` preserves the isolation #626 needed for per-workspace state while restoring a single GVS identity for packages shared across parent and nested workspaces.

## Validation

- `CI=1 bash nix/devenv-modules/tasks/shared/tests/pnpm.test.sh`
- `CI=1 bash nix/devenv-modules/tasks/shared/tests/pnpm-task-smoke.test.sh`
- `nix-instantiate --parse nix/devenv-modules/tasks/shared/pnpm.nix`
- `bash -n nix/devenv-modules/tasks/shared/tests/pnpm.test.sh nix/devenv-modules/tasks/shared/tests/pnpm-task-smoke.test.sh`
- `git diff --check`

Refs overengineeringstudio/overeng#182
Refs schickling/megarepo-all#57

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🎸 co1-bass |
| `agent_session_id` | afa610f7-71c7-410f-86d5-c08b2da67cb6 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | codex-cli 0.124.0 |
| `agent_runtime` | Codex CLI codex-cli 0.124.0 |
| `agent_model` | unknown |
| `worktree` | effect-utils/schickling/2026-04-24-pnpm-fix |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@5c6e0c3 |
</details>
<!-- agent-footer:end -->