### PR TITLE
fix(utils): import shouldNeverHappen directly to avoid eager effect-distributed-lock load

### DIFF
--- a/packages/@overeng/utils/src/node/playwright/config/mod.ts
+++ b/packages/@overeng/utils/src/node/playwright/config/mod.ts
@@ -15,7 +15,7 @@ import { createServer } from 'node:net'
 import type { PlaywrightTestConfig } from '@playwright/test'
 export type { PlaywrightTestConfig }
 
-import { shouldNeverHappen } from '../../../isomorphic/mod.ts'
+import { shouldNeverHappen } from '../../../isomorphic/core.ts'
 /** Web server configuration for Vite. */
 export interface WebServerConfig {
   /** Command to start the dev server (use `{{port}}` placeholder) */


### PR DESCRIPTION
## Summary

The playwright config module only uses `shouldNeverHappen` from `isomorphic/`, but imported it through the `isomorphic/mod.ts` barrel. That barrel re-exports symbols from `effect-distributed-lock`, so ESM resolution eagerly loads that package at module load time even though the playwright config has nothing to do with distributed locks.

This breaks downstream consumers of the playwright config helper when their pnpm setup does not have `effect-distributed-lock` reachable from the linked `@overeng/utils` realpath (first real consumer hit it).

## Change

One-line import swap from `'../../../isomorphic/mod.ts'` to `'../../../isomorphic/core.ts'`. `shouldNeverHappen` is defined directly in `core.ts`; the barrel just re-exported it. Importing from the source file avoids the transitive `effect-distributed-lock` load without changing behavior.

## Rationale

Targeted minimal fix at the import site. Whether the `isomorphic/mod.ts` barrel should pull in `effect-distributed-lock` at all is a separate question; this PR just unblocks the immediate consumer.

## Test plan

- [x] Confirmed `shouldNeverHappen` is defined directly in `isomorphic/core.ts`.
- [x] Local typecheck shows no new errors introduced by the change. Pre-existing errors are due to missing node_modules in the worktree and are unrelated.
- [ ] Downstream verification on a dependent repo.

<details>
<summary>Posted on behalf of @schickling</summary>

- `agent_name`: 🦤 cl2-ibis
- `agent_session_id`: 6af23769-6d88-483a-a92d-7d38eb16657b
- `agent_tool`: Claude Code
- `agent_tool_version`: 2.1.114 (Claude Code)
- `agent_runtime`: Claude Code 2.1.114 (Claude Code)
- `agent_model`: unknown
- `worktree`: effect-utils/schickling-assistant/2026-04-26-pw-config-no-distributed-lock
- `machine`: dev3
</details>
