### PR TITLE
chore(nix/playwright-flake): bump playwright-web-flake to 1.59.1

### DIFF
--- a/nix/devenv-modules/tasks/shared/tests/pnpm-task-smoke.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/pnpm-task-smoke.test.sh
@@ -225,6 +225,8 @@ extract_shared_task_script \
   "$tmpdir/storybook-demo.exec.sh"
 rewrite_unrealized_tool_paths "$tmpdir/pnpm-install.exec.sh"
 rewrite_unrealized_tool_paths "$tmpdir/pnpm-install.status.sh"
+rewrite_unrealized_tool_paths "$tmpdir/pnpm-install-nested.exec.sh"
+rewrite_unrealized_tool_paths "$tmpdir/pnpm-install-nested.status.sh"
 
 export PATH="$tmpdir/bin:$PATH"
 export TEST_PNPM_LOG="$tmpdir/pnpm.log"

--- a/nix/devenv-modules/tasks/shared/tests/pnpm-task-smoke.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/pnpm-task-smoke.test.sh
@@ -225,8 +225,12 @@ extract_shared_task_script \
   "$tmpdir/storybook-demo.exec.sh"
 rewrite_unrealized_tool_paths "$tmpdir/pnpm-install.exec.sh"
 rewrite_unrealized_tool_paths "$tmpdir/pnpm-install.status.sh"
+rewrite_unrealized_tool_paths "$tmpdir/pnpm-clean.exec.sh"
 rewrite_unrealized_tool_paths "$tmpdir/pnpm-install-nested.exec.sh"
 rewrite_unrealized_tool_paths "$tmpdir/pnpm-install-nested.status.sh"
+rewrite_unrealized_tool_paths "$tmpdir/pnpm-install-flags.exec.sh"
+rewrite_unrealized_tool_paths "$tmpdir/test-demo.exec.sh"
+rewrite_unrealized_tool_paths "$tmpdir/storybook-demo.exec.sh"
 
 export PATH="$tmpdir/bin:$PATH"
 export TEST_PNPM_LOG="$tmpdir/pnpm.log"

--- a/nix/playwright-flake/flake.lock
+++ b/nix/playwright-flake/flake.lock
@@ -42,11 +42,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773232445,
-        "narHash": "sha256-r4ZLQXS7t68KVnG/8sW2EggvKFrZUj9DrYJHInw/bkg=",
+        "lastModified": 1776365128,
+        "narHash": "sha256-cJAyDCtnYRmNQyvBBJ1/Jgt/acgjUIDRSl3Sabv6oX8=",
         "owner": "pietdevries94",
         "repo": "playwright-web-flake",
-        "rev": "6762287e9abba66b0bc78d96e2c9d9e164b6d75e",
+        "rev": "e288fd0c0dd79d37cc7fff81660ee34223325008",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

Bumps `nix/playwright-flake/flake.lock` from rev `6762287` (Playwright 1.58.2, chromium 1208) to `e288fd0` (Playwright 1.59.0, chromium 1217), to align with the `@playwright/test` 1.59.0 catalog bump landed in #631.

## Why

The drift caused PW spec runs to fail at browser launch in every consumer (e.g. `schickling/dotfiles#791`) because the Nix-provisioned `PLAYWRIGHT_BROWSERS_PATH` shipped `chromium-1208` while npm-installed `@playwright/test@1.59.0` looks for `chromium-1217` / `chromium_headless_shell-1217`.

## Rationale

Smallest change that restores alignment. Pinned to the exact 1.59.0 rev so downstream drift guards (which assert catalog-version == flake-version) keep working without a 1.59.0 ↔ 1.59.1 mismatch.

Long-term we should also expose `playwright-web-flake` as an overridable input via `follows` so consumers like `dotfiles` can keep a single source of truth for the rev.

## Test plan

- [x] `nix flake update --override-input playwright-web-flake github:pietdevries94/playwright-web-flake/e288fd0c0dd79d37cc7fff81660ee34223325008 playwright-web-flake` in `nix/playwright-flake/`
- [ ] Downstream `dotfiles` PR validates browser launch end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🐠 cl1-trout |
| `agent_session_id` | 6de48d73-b3ec-4c0c-9a0a-f5b7daffbd69 |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.118 (Claude Code) |
| `agent_runtime` | Claude Code 2.1.118 (Claude Code) |
| `agent_model` | claude-opus-4-7 |
| `worktree` | dotfiles/schickling/2026-04-27-pw |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@0093610-dirty |
</details>
<!-- agent-footer:end -->