### PR TITLE
fix(nix): freeze mk-pnpm-cli prepared deps installs

### DIFF
--- a/nix/workspace-tools/lib/mk-pnpm-cli.nix
+++ b/nix/workspace-tools/lib/mk-pnpm-cli.nix
@@ -559,9 +559,10 @@ let
         src = depsSrc;
         sourceRoot = ".";
         lockfilePaths = [ lockfilePath ];
-        # Staged install roots are synthetic workspace subsets; pnpm 11 correctly
-        # rejects validating them against the source workspace's full lockfile.
-        frozenLockfile = false;
+        # Fixed-output dependency preparation must not let pnpm repair or
+        # resolve the staged lockfile inside the sandbox. If a synthetic
+        # install root is stale, fail here and fix the staged lockfile source.
+        frozenLockfile = true;
         preInstall = ''
           chmod -R +w .
         '';
@@ -589,9 +590,10 @@ let
       src = rootDepsSrc;
       sourceRoot = ".";
       lockfilePaths = [ "pnpm-lock.yaml" ];
-      # The aggregate staged root includes external workspace members so link:
-      # deps resolve as workspace packages, which requires a derived subset lock.
-      frozenLockfile = false;
+      # Fixed-output dependency preparation must be a pure materialization of
+      # the staged manifests and lockfile. Unfrozen installs can rewrite the
+      # effective dependency graph and produce hash ping-pong across builders.
+      frozenLockfile = true;
       preInstall = ''
         chmod -R +w .
       '';

--- a/nix/workspace-tools/lib/mk-pnpm-cli/tests/fixtures/downstream/flake.nix
+++ b/nix/workspace-tools/lib/mk-pnpm-cli/tests/fixtures/downstream/flake.nix
@@ -81,6 +81,7 @@
         packages = {
           genie = effectUtilsPackages.genie;
           megarepo = effectUtilsPackages.megarepo;
+          "mk-pnpm-cli-pure-eval-fixture" = pureEvalFixture;
           oxlint-npm = effectUtilsPackages.oxlint-npm;
           default = effectUtilsPackages.megarepo;
         };

--- a/nix/workspace-tools/lib/mk-pnpm-cli/tests/run.sh
+++ b/nix/workspace-tools/lib/mk-pnpm-cli/tests/run.sh
@@ -245,6 +245,24 @@ run_downstream_pure_eval_regression() {
     --override-input effect-utils "path:$WORKSPACE_REAL/repos/effect-utils" \
     "path:$DOWNSTREAM_DIR#checks.$SYSTEM.pure-eval-derived-workspace-root"
 
+  echo "Check: downstream prepared deps use frozen lockfile mode"
+  local drv
+  drv="$(
+    nix eval --raw --no-write-lock-file \
+      --override-input effect-utils "path:$WORKSPACE_REAL/repos/effect-utils" \
+      "path:$DOWNSTREAM_DIR#packages.$SYSTEM.mk-pnpm-cli-pure-eval-fixture.passthru.depsBuildsByInstallRoot.root.drvPath"
+  )"
+  local install_phase
+  install_phase="$(nix derivation show "$drv" | jq -r '.derivations | to_entries[0].value.env.installPhase')"
+  if [[ "$install_phase" != *'install --frozen-lockfile --ignore-scripts'* ]]; then
+    echo "error: prepared deps derivation does not use --frozen-lockfile: $drv" >&2
+    exit 1
+  fi
+  if [[ "$install_phase" == *'install --no-frozen-lockfile --ignore-scripts'* ]]; then
+    echo "error: prepared deps derivation still uses --no-frozen-lockfile: $drv" >&2
+    exit 1
+  fi
+
   echo "Timing: downstream-pure-eval $(( $(date +%s) - start ))s"
 }
 

--- a/packages/@overeng/genie/nix/build.nix
+++ b/packages/@overeng/genie/nix/build.nix
@@ -24,7 +24,7 @@ let
     # Managed by `dt nix:hash:genie` — do not edit manually.
     depsBuilds = {
       "." = {
-        hash = "sha256-D7R3eVcqh8EKUVS+M8mZFHfEuX6yDsP0LsId+1k8pmE=";
+        hash = "sha256-botZT9BfaxJabjmacIg0A5aqoMM0/XbEIPe4X/an0Ts=";
       };
     };
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/megarepo/nix/build.nix
+++ b/packages/@overeng/megarepo/nix/build.nix
@@ -23,7 +23,7 @@ let
     # Managed by `dt nix:hash:megarepo` — do not edit manually.
     depsBuilds = {
       "." = {
-        hash = "sha256-fpW5r7UTWeZyJZdFZHGTe//9zHdQYps+kNVLV9/HDGY=";
+        hash = "sha256-XTeIZNM0c/YkFZjGeKpOPIGOKxBrpOVoLODv41J2/A8=";
       };
     };
     smokeTestArgs = [ "--help" ];

--- a/packages/@overeng/notion-cli/nix/build.nix
+++ b/packages/@overeng/notion-cli/nix/build.nix
@@ -20,7 +20,7 @@ let
     # Managed by `dt nix:hash:notion-cli` — do not edit manually.
     depsBuilds = {
       "." = {
-        hash = "sha256-aurQRcKgEEknOUdGi/x3zIVjJU3ZRWFIXRUMG4vJWZs=";
+        hash = "sha256-+aj/VtFscz3eG6CfH9l3hsHzPEULih7xEpq10f9+fP0=";
       };
     };
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/tui-stories/nix/build.nix
+++ b/packages/@overeng/tui-stories/nix/build.nix
@@ -20,7 +20,7 @@ let
     # Managed by `dt nix:hash:tui-stories` — do not edit manually.
     depsBuilds = {
       "." = {
-        hash = "sha256-oocSxJSju9ReXX8FNDiRC9F1lB8agjXodCdlICVR5bs=";
+        hash = "sha256-ZUQJf1PMrG4SXxJrusLPPGHg2w64uN5nrBxAaZHZ8Xg=";
       };
     };
     inherit gitRev commitTs dirty;


### PR DESCRIPTION
## What
Freeze mk-pnpm-cli prepared dependency installs so fixed-output derivations materialize the staged lockfile instead of allowing pnpm to repair or re-resolve dependencies inside the sandbox.

## Why
Downstream dotfiles factory builds were seeing pnpm-deps hash ping-pong across rebuild surfaces. The generated derivation still used `--no-frozen-lockfile`, so changing the committed hash could flip the next rebuild to the other output.

## Validation
- `bash nix/workspace-tools/lib/mk-pnpm-cli/tests/run.sh --skip-genie --skip-megarepo --skip-oxlint --skip-devenv-shell --skip-downstream-megarepo`
- `nix build --no-link .#packages.x86_64-linux.{genie,megarepo,notion-cli,tui-stories}.passthru.depsBuildsByInstallRoot.root`
- `nix build --no-link --rebuild` for the same four prepared deps attrs

Downstream validation target: schickling/dotfiles#621 / dotfiles#790.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🌨️ co2-sleet |
| `agent_session_id` | fd19ebc1-07ab-4cd3-970a-e95b3d99db76 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | codex-cli 0.124.0 |
| `agent_runtime` | Codex CLI codex-cli 0.124.0 |
| `agent_model` | unknown |
| `worktree` | effect-utils/schickling/2026-04-27-pnpm-fod-frozen |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@0093610-dirty |
</details>
<!-- agent-footer:end -->