### PR TITLE
Expose structured CLI build identity

### DIFF
--- a/packages/@overeng/utils/src/node/cli-version.ts
+++ b/packages/@overeng/utils/src/node/cli-version.ts
@@ -51,39 +51,49 @@ export class CliVersion extends Context.Tag('CliVersion')<CliVersion, CliVersion
     })
 }
 
-/**
- * Local stamp: set via CLI_BUILD_STAMP env var when entering a dev shell.
- * Used for source-based CLI builds (running TypeScript directly).
- */
-export interface LocalStamp {
-  type: 'local'
-  rev: string
-  ts: number
-  dirty: boolean
+/** Build stamp for a CLI running directly from a local source tree. */
+export type LocalStamp = {
+  readonly type: 'local'
+  readonly rev: string
+  readonly ts: number
+  readonly dirty: boolean
 }
 
-/**
- * Nix stamp: embedded in the binary at Nix build time.
- * Contains version info and commit timestamp for reproducible builds.
- */
-export interface NixStamp {
-  type: 'nix'
-  version: string
-  rev: string
-  commitTs: number
-  dirty: boolean
-  buildTs?: number // only present for impure builds
+/** Build stamp embedded by Nix at build time. */
+export type NixStamp = {
+  readonly type: 'nix'
+  readonly version: string
+  readonly rev: string
+  readonly commitTs: number
+  /** Only present for intentionally impure builds. */
+  readonly buildTs?: number
+  readonly dirty: boolean
 }
 
 /** Discriminated union of build stamp types used to resolve CLI version strings. */
 export type CliStamp = LocalStamp | NixStamp
 
+/** Structured build identity shared by CLIs, UIs, diagnostics, and telemetry. */
+export type CliBuildIdentity = {
+  readonly baseVersion: string
+  readonly displayVersion: string
+  readonly machineVersion: string
+  readonly sourceKind: 'package' | 'local' | 'nix'
+  readonly rev?: string
+  readonly dirty: boolean
+  readonly commitTs?: number
+  readonly buildTs?: number
+}
+
+type VersionEnv = {
+  readonly [key: string]: string | undefined
+}
+
 /**
  * Format a Unix timestamp as a human-readable relative time.
  * Uses medium formatting: "5 min ago", "2 hours ago", "3 days ago", "Jan 15"
  */
-const formatRelativeTime = (ts: number): string => {
-  const now = Math.floor(Date.now() / 1000)
+const formatRelativeTime = ({ ts, now }: { ts: number; now: number }): string => {
   const diffSeconds = now - ts
 
   if (diffSeconds < 60) {
@@ -120,7 +130,7 @@ const formatRelativeTime = (ts: number): string => {
 /**
  * Parse a JSON string as a CliStamp (LocalStamp or NixStamp).
  */
-const parseStamp = (stamp: string): CliStamp | undefined => {
+export const parseCliBuildStamp = (stamp: string): CliStamp | undefined => {
   try {
     const parsed = JSON.parse(stamp)
     if (typeof parsed !== 'object' || parsed === null) {
@@ -133,7 +143,7 @@ const parseStamp = (stamp: string): CliStamp | undefined => {
         typeof parsed.ts === 'number' &&
         typeof parsed.dirty === 'boolean'
       ) {
-        return parsed as LocalStamp
+        return { type: 'local', rev: parsed.rev, ts: parsed.ts, dirty: parsed.dirty }
       }
     } else if (parsed.type === 'nix') {
       if (
@@ -142,7 +152,15 @@ const parseStamp = (stamp: string): CliStamp | undefined => {
         typeof parsed.commitTs === 'number' &&
         typeof parsed.dirty === 'boolean'
       ) {
-        return parsed as NixStamp
+        const buildTs = typeof parsed.buildTs === 'number' ? parsed.buildTs : undefined
+        return {
+          type: 'nix',
+          version: parsed.version,
+          rev: parsed.rev,
+          commitTs: parsed.commitTs,
+          ...(buildTs === undefined ? {} : { buildTs }),
+          dirty: parsed.dirty,
+        }
       }
     }
   } catch {
@@ -161,11 +179,13 @@ const parseStamp = (stamp: string): CliStamp | undefined => {
 const renderLocalVersion = ({
   baseVersion,
   stamp,
+  now,
 }: {
   baseVersion: string
   stamp: LocalStamp
+  now: number
 }): string => {
-  const timeAgo = formatRelativeTime(stamp.ts)
+  const timeAgo = formatRelativeTime({ ts: stamp.ts, now })
   const dirtyNote = stamp.dirty === true ? ', with uncommitted changes' : ''
   return `${baseVersion} — running from local source (${stamp.rev}, ${timeAgo}${dirtyNote})`
 }
@@ -179,25 +199,98 @@ const renderLocalVersion = ({
  * - impure, clean: "0.1.0+def456 — built 2 hours ago"
  * - impure, dirty: "0.1.0+def456-dirty — built 2 hours ago, with uncommitted changes"
  */
-const renderNixVersion = (stamp: NixStamp): string => {
-  // Only add -dirty suffix if the rev doesn't already include it
-  // (Nix flakes may provide dirtyShortRev which already has the suffix)
+const nixMachineVersion = (stamp: NixStamp): string => {
   const revAlreadyHasDirty = stamp.rev.endsWith('-dirty')
   const dirtySuffix = stamp.dirty === true && revAlreadyHasDirty === false ? '-dirty' : ''
-  const versionStr = `${stamp.version}+${stamp.rev}${dirtySuffix}`
+  return `${stamp.version}+${stamp.rev}${dirtySuffix}`
+}
 
+const localMachineVersion = ({
+  baseVersion,
+  stamp,
+}: {
+  baseVersion: string
+  stamp: LocalStamp
+}): string => `${baseVersion}+local.${stamp.rev}${stamp.dirty === true ? '.dirty' : ''}`
+
+const renderNixVersion = ({ stamp, now }: { stamp: NixStamp; now: number }): string => {
+  const versionStr = nixMachineVersion(stamp)
   const dirtyNote = stamp.dirty === true ? ', with uncommitted changes' : ''
 
   if (stamp.buildTs !== undefined) {
-    // Impure build: show build time
-    const timeAgo = formatRelativeTime(stamp.buildTs)
+    const timeAgo = formatRelativeTime({ ts: stamp.buildTs, now })
     return `${versionStr} — built ${timeAgo}${dirtyNote}`
   }
 
-  // Pure build: show commit time
-  const timeAgo = formatRelativeTime(stamp.commitTs)
+  const timeAgo = formatRelativeTime({ ts: stamp.commitTs, now })
   return `${versionStr} — committed ${timeAgo}${dirtyNote}`
 }
+
+/**
+ * Resolve the full CLI build identity from the embedded build stamp and optional runtime stamp.
+ */
+export const resolveCliBuildIdentity = (options: {
+  readonly baseVersion: string
+  readonly buildStamp: string
+  readonly env?: VersionEnv
+  readonly now?: number
+  readonly runtimeStampEnvVar?: string
+}): CliBuildIdentity => {
+  const {
+    baseVersion,
+    buildStamp,
+    env = process.env,
+    now = Math.floor(Date.now() / 1000),
+    runtimeStampEnvVar = 'CLI_BUILD_STAMP',
+  } = options
+  const buildTimeStamp = parseCliBuildStamp(buildStamp)
+
+  if (buildTimeStamp?.type === 'nix') {
+    return {
+      baseVersion,
+      displayVersion: renderNixVersion({ stamp: buildTimeStamp, now }),
+      machineVersion: nixMachineVersion(buildTimeStamp),
+      sourceKind: 'nix',
+      rev: buildTimeStamp.rev,
+      dirty: buildTimeStamp.dirty,
+      commitTs: buildTimeStamp.commitTs,
+      ...(buildTimeStamp.buildTs === undefined ? {} : { buildTs: buildTimeStamp.buildTs }),
+    }
+  }
+
+  const runtimeStampRaw = env[runtimeStampEnvVar]?.trim()
+  const runtimeStamp =
+    runtimeStampRaw === undefined || runtimeStampRaw.length === 0
+      ? undefined
+      : parseCliBuildStamp(runtimeStampRaw)
+
+  if (runtimeStamp?.type === 'local') {
+    return {
+      baseVersion,
+      displayVersion: renderLocalVersion({ baseVersion, stamp: runtimeStamp, now }),
+      machineVersion: localMachineVersion({ baseVersion, stamp: runtimeStamp }),
+      sourceKind: 'local',
+      rev: runtimeStamp.rev,
+      dirty: runtimeStamp.dirty,
+      buildTs: runtimeStamp.ts,
+    }
+  }
+
+  return {
+    baseVersion,
+    displayVersion: baseVersion,
+    machineVersion: baseVersion,
+    sourceKind: 'package',
+    dirty: false,
+  }
+}
+
+/**
+ * Resolve the machine-readable CLI version suitable for telemetry, logs, and protocol payloads.
+ */
+export const resolveCliMachineVersion = (
+  options: Parameters<typeof resolveCliBuildIdentity>[0],
+): string => resolveCliBuildIdentity(options).machineVersion
 
 /**
  * Resolve the CLI version from build stamp and optional runtime stamp.
@@ -210,25 +303,4 @@ export const resolveCliVersion = (options: {
   baseVersion: string
   buildStamp: string
   runtimeStampEnvVar?: string
-}): string => {
-  const { baseVersion, buildStamp, runtimeStampEnvVar = 'CLI_BUILD_STAMP' } = options
-
-  // Try to parse buildStamp as NixStamp (embedded at build time)
-  const nixStamp = parseStamp(buildStamp)
-  if (nixStamp?.type === 'nix') {
-    // Nix build: use embedded stamp, ignore runtime stamp
-    return renderNixVersion(nixStamp)
-  }
-
-  // Local/dev build: check for runtime stamp
-  const runtimeStampRaw = process.env[runtimeStampEnvVar]?.trim()
-  if (runtimeStampRaw !== undefined) {
-    const localStamp = parseStamp(runtimeStampRaw)
-    if (localStamp?.type === 'local') {
-      return renderLocalVersion({ baseVersion, stamp: localStamp })
-    }
-  }
-
-  // No valid stamp: just return base version
-  return baseVersion
-}
+}): string => resolveCliBuildIdentity(options).displayVersion

--- a/packages/@overeng/utils/src/node/cli-version.unit.test.ts
+++ b/packages/@overeng/utils/src/node/cli-version.unit.test.ts
@@ -1,0 +1,188 @@
+import { expect } from 'vitest'
+
+import { Vitest } from '@overeng/utils-dev/node-vitest'
+
+import {
+  parseCliBuildStamp,
+  resolveCliBuildIdentity,
+  resolveCliMachineVersion,
+  resolveCliVersion,
+} from './cli-version.ts'
+
+const placeholder = '__CLI_BUILD_STAMP__'
+const now = 1_740_000_000
+const fiveMinutesAgo = now - 5 * 60
+const threeDaysAgo = now - 3 * 86_400
+const dash = '\u2014'
+
+const localStamp = JSON.stringify({
+  type: 'local',
+  rev: 'abc123',
+  ts: fiveMinutesAgo,
+  dirty: true,
+})
+
+const nixStamp = JSON.stringify({
+  type: 'nix',
+  version: '0.1.0',
+  rev: 'def456',
+  commitTs: threeDaysAgo,
+  dirty: false,
+})
+
+Vitest.describe('parseCliBuildStamp', () => {
+  Vitest.it('parses local stamps without preserving extra fields', () => {
+    expect(
+      parseCliBuildStamp(
+        JSON.stringify({
+          type: 'local',
+          rev: 'abc123',
+          ts: fiveMinutesAgo,
+          dirty: false,
+          extra: 'ignored',
+        }),
+      ),
+    ).toEqual({
+      type: 'local',
+      rev: 'abc123',
+      ts: fiveMinutesAgo,
+      dirty: false,
+    })
+  })
+
+  Vitest.it('parses nix stamps with optional buildTs', () => {
+    expect(
+      parseCliBuildStamp(
+        JSON.stringify({
+          type: 'nix',
+          version: '0.1.0',
+          rev: 'def456',
+          commitTs: threeDaysAgo,
+          buildTs: fiveMinutesAgo,
+          dirty: false,
+        }),
+      ),
+    ).toEqual({
+      type: 'nix',
+      version: '0.1.0',
+      rev: 'def456',
+      commitTs: threeDaysAgo,
+      buildTs: fiveMinutesAgo,
+      dirty: false,
+    })
+  })
+
+  Vitest.it('ignores malformed stamps', () => {
+    expect(parseCliBuildStamp('not-json')).toBeUndefined()
+    expect(parseCliBuildStamp(JSON.stringify({ type: 'local', rev: 'abc123' }))).toBeUndefined()
+  })
+})
+
+Vitest.describe('resolveCliBuildIdentity', () => {
+  Vitest.it('falls back to package identity without build or runtime stamps', () => {
+    expect(
+      resolveCliBuildIdentity({ baseVersion: '0.1.0', buildStamp: placeholder, env: {}, now }),
+    ).toEqual({
+      baseVersion: '0.1.0',
+      displayVersion: '0.1.0',
+      machineVersion: '0.1.0',
+      sourceKind: 'package',
+      dirty: false,
+    })
+  })
+
+  Vitest.it('resolves local runtime identity from CLI_BUILD_STAMP', () => {
+    expect(
+      resolveCliBuildIdentity({
+        baseVersion: '0.1.0',
+        buildStamp: placeholder,
+        env: { CLI_BUILD_STAMP: localStamp },
+        now,
+      }),
+    ).toEqual({
+      baseVersion: '0.1.0',
+      displayVersion: `0.1.0 ${dash} running from local source (abc123, 5 min ago, with uncommitted changes)`,
+      machineVersion: '0.1.0+local.abc123.dirty',
+      sourceKind: 'local',
+      rev: 'abc123',
+      dirty: true,
+      buildTs: fiveMinutesAgo,
+    })
+  })
+
+  Vitest.it('resolves nix identity from embedded stamps and ignores runtime env', () => {
+    expect(
+      resolveCliBuildIdentity({
+        baseVersion: '0.1.0',
+        buildStamp: nixStamp,
+        env: { CLI_BUILD_STAMP: localStamp },
+        now,
+      }),
+    ).toEqual({
+      baseVersion: '0.1.0',
+      displayVersion: `0.1.0+def456 ${dash} committed 3 days ago`,
+      machineVersion: '0.1.0+def456',
+      sourceKind: 'nix',
+      rev: 'def456',
+      dirty: false,
+      commitTs: threeDaysAgo,
+    })
+  })
+
+  Vitest.it('does not duplicate the dirty suffix for dirty nix revs', () => {
+    const dirtyStamp = JSON.stringify({
+      type: 'nix',
+      version: '0.1.0',
+      rev: 'def456-dirty',
+      commitTs: threeDaysAgo,
+      dirty: true,
+    })
+
+    expect(
+      resolveCliBuildIdentity({ baseVersion: '0.1.0', buildStamp: dirtyStamp, env: {}, now }),
+    ).toMatchObject({
+      displayVersion: `0.1.0+def456-dirty ${dash} committed 3 days ago, with uncommitted changes`,
+      machineVersion: '0.1.0+def456-dirty',
+    })
+  })
+
+  Vitest.it('renders impure nix builds from buildTs while keeping machineVersion stable', () => {
+    const impureStamp = JSON.stringify({
+      type: 'nix',
+      version: '0.1.0',
+      rev: 'def456',
+      commitTs: threeDaysAgo,
+      buildTs: fiveMinutesAgo,
+      dirty: false,
+    })
+
+    expect(
+      resolveCliBuildIdentity({ baseVersion: '0.1.0', buildStamp: impureStamp, env: {}, now }),
+    ).toMatchObject({
+      displayVersion: `0.1.0+def456 ${dash} built 5 min ago`,
+      machineVersion: '0.1.0+def456',
+      buildTs: fiveMinutesAgo,
+    })
+  })
+
+  Vitest.it('keeps the existing display-only API source-compatible', () => {
+    expect(
+      resolveCliVersion({
+        baseVersion: '0.1.0',
+        buildStamp: placeholder,
+        runtimeStampEnvVar: 'CUSTOM_BUILD_STAMP',
+      }),
+    ).toBe('0.1.0')
+  })
+
+  Vitest.it('exposes a machine-version convenience wrapper', () => {
+    expect(
+      resolveCliMachineVersion({
+        baseVersion: '0.1.0',
+        buildStamp: nixStamp,
+        env: { CLI_BUILD_STAMP: localStamp },
+        now,
+      }),
+    ).toBe('0.1.0+def456')
+  })
+})


### PR DESCRIPTION
## Summary
- expose structured CLI build identity alongside the existing display-only `resolveCliVersion` helper
- export pure build-stamp parsing and machine-version resolution for telemetry/debug consumers
- add focused unit coverage for package, local, nix, dirty, and impure build stamp cases

## Rationale
Consumers such as Forge need the same canonical build identity for UI/debug/RPC surfaces, not only a human `--version` string. Keeping this in `@overeng/utils` removes downstream copy-pasted stamp parsing while preserving the current `resolveCliVersion` API.

## Validation
- `CI=1 pnpm --dir packages/@overeng/utils exec vitest run src/node/cli-version.unit.test.ts`
- `oxfmt --check packages/@overeng/utils/src/node/cli-version.ts packages/@overeng/utils/src/node/cli-version.unit.test.ts`
- `oxlint packages/@overeng/utils/src/node/cli-version.ts packages/@overeng/utils/src/node/cli-version.unit.test.ts`
- `CI=1 pnpm --dir packages/@overeng/utils exec tsc --build ../utils-dev/tsconfig.json tsconfig.json --pretty false`
- `CI=1 WORKSPACE_ROOT=$PWD pnpm --dir packages/@overeng/utils exec vitest run`

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🥉 co1-bronze |
| `agent_session_id` | 6d3a2909-a6e6-487b-b4f3-894c92caa629 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | codex-cli 0.124.0 |
| `agent_runtime` | Codex CLI codex-cli 0.124.0 |
| `agent_model` | unknown |
| `worktree` | effect-utils/schickling%2F2026-04-28-build-identity |
| `machine` | mbp2025 |
| `tooling_profile` | dotfiles@1093d8c |
</details>
<!-- agent-footer:end -->