### PR TITLE
Repair stale pnpm GVS package projections

### DIFF
--- a/nix/devenv-modules/tasks/shared/check-node-modules-projection-health.cjs
+++ b/nix/devenv-modules/tasks/shared/check-node-modules-projection-health.cjs
@@ -16,6 +16,7 @@ const moduleDirs = (process.env.NODE_MODULES_DIRS || '')
   .filter((value) => fs.existsSync(value))
 
 const dependencyProjectionFailures = []
+const packageContentFailures = []
 
 const collectEntryPaths = (nodeModulesDir) => {
   const result = []
@@ -55,6 +56,60 @@ const resolveDependencyPackageRoot = ({ requireFromPkg, dependencyName }) => {
   return undefined
 }
 
+const collectExportTargets = (value) => {
+  if (typeof value === 'string') {
+    return [value]
+  }
+
+  if (Array.isArray(value)) {
+    return value.flatMap(collectExportTargets)
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.values(value).flatMap(collectExportTargets)
+  }
+
+  return []
+}
+
+const verifyPackageContent = ({ pkg, packageDir, entryPath }) => {
+  if (!packageDir.includes('/v11/links/')) return
+
+  const includedFiles = Array.isArray(pkg.files)
+    ? pkg.files.filter((file) => typeof file === 'string' && !file.startsWith('!'))
+    : []
+  if (includedFiles.length === 0) return
+
+  const targets = []
+
+  if (typeof pkg.main === 'string') {
+    targets.push(pkg.main)
+  }
+
+  if (pkg.exports !== undefined) {
+    targets.push(...collectExportTargets(pkg.exports))
+  }
+
+  for (const target of targets) {
+    if (!target.startsWith('./')) continue
+    if (target.includes('*')) continue
+
+    const relativeTarget = target.slice(2)
+    if (
+      !includedFiles.some(
+        (file) => file === relativeTarget || relativeTarget.startsWith(`${file}/`),
+      )
+    ) {
+      continue
+    }
+
+    const resolved = path.resolve(packageDir, target)
+    if (!fs.existsSync(resolved)) {
+      packageContentFailures.push(`${pkg.name ?? entryPath} -> ${target} (${packageDir})`)
+    }
+  }
+}
+
 for (const nodeModulesDir of moduleDirs) {
   for (const entryPath of collectEntryPaths(nodeModulesDir)) {
     let stat
@@ -77,6 +132,8 @@ for (const nodeModulesDir of moduleDirs) {
     if (!fs.existsSync(packageJsonPath)) continue
 
     const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
+    verifyPackageContent({ pkg, packageDir: realPath, entryPath })
+
     const dependencyNames = Object.keys(pkg.dependencies ?? {})
     if (dependencyNames.length === 0) continue
 
@@ -99,6 +156,13 @@ for (const nodeModulesDir of moduleDirs) {
 if (dependencyProjectionFailures.length > 0) {
   for (const failure of dependencyProjectionFailures) {
     console.error(`[pnpm] Missing dependency projection: ${failure}`)
+  }
+  process.exit(1)
+}
+
+if (packageContentFailures.length > 0) {
+  for (const failure of packageContentFailures) {
+    console.error(`[pnpm] Missing package content: ${failure}`)
   }
   process.exit(1)
 }

--- a/nix/devenv-modules/tasks/shared/check-node-modules-projection-health.cjs
+++ b/nix/devenv-modules/tasks/shared/check-node-modules-projection-health.cjs
@@ -64,6 +64,8 @@ const isDeclarationTarget = (value) =>
  * loaded. Declaration-only branches are intentionally ignored: several packages
  * publish type conditions that are absent from the GVS link projection while
  * their runtime `default` / `import` targets are present and load correctly.
+ * See https://github.com/pnpm/pnpm/issues/11385 for the stale runtime-export
+ * projection scenario this check guards.
  */
 const collectRuntimeExportTargets = (value, conditionName = undefined) => {
   if (typeof value === 'string') {

--- a/nix/devenv-modules/tasks/shared/check-node-modules-projection-health.cjs
+++ b/nix/devenv-modules/tasks/shared/check-node-modules-projection-health.cjs
@@ -56,17 +56,29 @@ const resolveDependencyPackageRoot = ({ requireFromPkg, dependencyName }) => {
   return undefined
 }
 
-const collectExportTargets = (value) => {
+const isDeclarationTarget = (value) =>
+  value.endsWith('.d.ts') || value.endsWith('.d.mts') || value.endsWith('.d.cts')
+
+/**
+ * Only runtime export targets prove whether the package projection can be
+ * loaded. Declaration-only branches are intentionally ignored: several packages
+ * publish type conditions that are absent from the GVS link projection while
+ * their runtime `default` / `import` targets are present and load correctly.
+ */
+const collectRuntimeExportTargets = (value, conditionName = undefined) => {
   if (typeof value === 'string') {
+    if (conditionName === 'types' || isDeclarationTarget(value)) return []
     return [value]
   }
 
   if (Array.isArray(value)) {
-    return value.flatMap(collectExportTargets)
+    return value.flatMap((entry) => collectRuntimeExportTargets(entry, conditionName))
   }
 
   if (value && typeof value === 'object') {
-    return Object.values(value).flatMap(collectExportTargets)
+    return Object.entries(value).flatMap(([nestedConditionName, nestedValue]) =>
+      collectRuntimeExportTargets(nestedValue, nestedConditionName),
+    )
   }
 
   return []
@@ -87,7 +99,7 @@ const verifyPackageContent = ({ pkg, packageDir, entryPath }) => {
   }
 
   if (pkg.exports !== undefined) {
-    targets.push(...collectExportTargets(pkg.exports))
+    targets.push(...collectRuntimeExportTargets(pkg.exports))
   }
 
   for (const target of targets) {

--- a/nix/devenv-modules/tasks/shared/check-node-modules-projection-health.cjs
+++ b/nix/devenv-modules/tasks/shared/check-node-modules-projection-health.cjs
@@ -66,6 +66,8 @@ const isDeclarationTarget = (value) =>
  * their runtime `default` / `import` targets are present and load correctly.
  * See https://github.com/pnpm/pnpm/issues/11385 for the stale runtime-export
  * projection scenario this check guards.
+ * TODO(pnpm#11385): remove this package-content check if pnpm starts repairing
+ * incomplete GVS link projections during forced installs.
  */
 const collectRuntimeExportTargets = (value, conditionName = undefined) => {
   if (typeof value === 'string') {

--- a/nix/devenv-modules/tasks/shared/pnpm.nix
+++ b/nix/devenv-modules/tasks/shared/pnpm.nix
@@ -343,6 +343,7 @@ let
           if [ ! -f "$_gvs_hash_file" ] || [ "$(cat "$_gvs_hash_file")" != "$_gvs_hash" ]; then
             echo "[pnpm] GVS config changed, forcing current workspace relink"
             purge_node_modules node_modules ${nodeModulesPaths}
+            rm -rf "$_gvs_links_dir"
             _purged_node_modules=true
             _force_install=true
           fi
@@ -351,12 +352,21 @@ let
         if [ "$_purged_node_modules" != true ] && ! check_node_modules_links_healthy ${pkgs.nodejs}/bin/node ${lib.escapeShellArg nodeModulesProjectionHealthScript} ${healthCheckNodeModulesPaths}; then
           echo "[pnpm] node_modules projection is stale, purging install state"
           purge_node_modules node_modules ${nodeModulesPaths}
+          if [ -n "''${_gvs_links_dir:-}" ]; then
+            rm -rf "$_gvs_links_dir"
+          fi
+          _force_install=true
         fi
 
         if [ "$_force_install" = true ]; then
           run_pnpm_install --force
         else
           run_pnpm_install
+        fi
+
+        if ! check_node_modules_links_healthy ${pkgs.nodejs}/bin/node ${lib.escapeShellArg nodeModulesProjectionHealthScript} ${healthCheckNodeModulesPaths}; then
+          echo "[pnpm] node_modules projection is still unhealthy after install" >&2
+          exit 1
         fi
 
         # Persist GVS hash after successful install

--- a/nix/devenv-modules/tasks/shared/pnpm.nix
+++ b/nix/devenv-modules/tasks/shared/pnpm.nix
@@ -343,6 +343,11 @@ let
           if [ ! -f "$_gvs_hash_file" ] || [ "$(cat "$_gvs_hash_file")" != "$_gvs_hash" ]; then
             echo "[pnpm] GVS config changed, forcing current workspace relink"
             purge_node_modules node_modules ${nodeModulesPaths}
+            # A workspace relink only rewrites node_modules. If the broken
+            # package projection is already cached under v11/links, pnpm can
+            # reuse that incomplete directory even for `pnpm install --force`.
+            # Dropping links/ keeps the content-addressed files/ store intact
+            # while forcing GVS to materialize fresh package link projections.
             rm -rf "$_gvs_links_dir"
             _purged_node_modules=true
             _force_install=true
@@ -353,6 +358,10 @@ let
           echo "[pnpm] node_modules projection is stale, purging install state"
           purge_node_modules node_modules ${nodeModulesPaths}
           if [ -n "''${_gvs_links_dir:-}" ]; then
+            # The health check can fail while package symlinks and package.json
+            # still exist, e.g. an exported runtime file is missing inside a GVS
+            # link projection. Deleting node_modules alone would just reconnect
+            # the workspace to the same incomplete v11/links package directory.
             rm -rf "$_gvs_links_dir"
           fi
           _force_install=true

--- a/nix/devenv-modules/tasks/shared/pnpm.nix
+++ b/nix/devenv-modules/tasks/shared/pnpm.nix
@@ -348,6 +348,7 @@ let
             # reuse that incomplete directory even for `pnpm install --force`.
             # Dropping links/ keeps the content-addressed files/ store intact
             # while forcing GVS to materialize fresh package link projections.
+            # See https://github.com/pnpm/pnpm/issues/11385.
             rm -rf "$_gvs_links_dir"
             _purged_node_modules=true
             _force_install=true
@@ -362,6 +363,7 @@ let
             # still exist, e.g. an exported runtime file is missing inside a GVS
             # link projection. Deleting node_modules alone would just reconnect
             # the workspace to the same incomplete v11/links package directory.
+            # See https://github.com/pnpm/pnpm/issues/11385.
             rm -rf "$_gvs_links_dir"
           fi
           _force_install=true

--- a/nix/devenv-modules/tasks/shared/pnpm.nix
+++ b/nix/devenv-modules/tasks/shared/pnpm.nix
@@ -349,6 +349,8 @@ let
             # Dropping links/ keeps the content-addressed files/ store intact
             # while forcing GVS to materialize fresh package link projections.
             # See https://github.com/pnpm/pnpm/issues/11385.
+            # TODO(pnpm#11385): remove this links/ purge once forced installs
+            # rebuild incomplete GVS link projections.
             rm -rf "$_gvs_links_dir"
             _purged_node_modules=true
             _force_install=true
@@ -364,6 +366,8 @@ let
             # link projection. Deleting node_modules alone would just reconnect
             # the workspace to the same incomplete v11/links package directory.
             # See https://github.com/pnpm/pnpm/issues/11385.
+            # TODO(pnpm#11385): remove this links/ purge once forced installs
+            # rebuild incomplete GVS link projections.
             rm -rf "$_gvs_links_dir"
           fi
           _force_install=true

--- a/nix/devenv-modules/tasks/shared/tests/pnpm.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/pnpm.test.sh
@@ -65,6 +65,31 @@ EOF
   fi
 }
 
+make_missing_export_fixture() {
+  local root="$1"
+  local package_root="$root/store/v11/links/pkg/1.0.0/hash/node_modules/pkg"
+
+  mkdir -p "$package_root"
+  mkdir -p "$root/node_modules"
+  cat > "$package_root/package.json" <<'EOF'
+{"name":"pkg","files":["src"],"exports":{"./vitest":{"default":"./src/vitest.js"}}}
+EOF
+  ln -s ../store/v11/links/pkg/1.0.0/hash/node_modules/pkg "$root/node_modules/pkg"
+}
+
+make_unshipped_conditional_export_fixture() {
+  local root="$1"
+  local package_root="$root/store/v11/links/pkg/1.0.0/hash/node_modules/pkg"
+
+  mkdir -p "$package_root/dist"
+  mkdir -p "$root/node_modules"
+  cat > "$package_root/package.json" <<'EOF'
+{"name":"pkg","files":["dist"],"exports":{".":{"custom-condition":"./src/index.ts","default":"./dist/index.js"}}}
+EOF
+  touch "$package_root/dist/index.js"
+  ln -s ../store/v11/links/pkg/1.0.0/hash/node_modules/pkg "$root/node_modules/pkg"
+}
+
 make_bin_fixture() {
   local root="$1"
 
@@ -248,6 +273,24 @@ check_node_modules_links_healthy node "$PROJECTION_SCRIPT" "$broken_dir/node_mod
 exit_code=$?
 set -e
 assert_exit_code 1 "$exit_code" "broken symlink is rejected"
+
+echo "Test 15: Projection health fails when a package export target is missing"
+missing_export_dir="$test_dir/missing-export"
+make_missing_export_fixture "$missing_export_dir"
+set +e
+check_node_modules_links_healthy node "$PROJECTION_SCRIPT" "$missing_export_dir/node_modules" >/dev/null 2>&1
+exit_code=$?
+set -e
+assert_exit_code 1 "$exit_code" "projection health detects missing package export target"
+
+echo "Test 16: Projection health ignores unshipped conditional export targets"
+unshipped_export_dir="$test_dir/unshipped-export"
+make_unshipped_conditional_export_fixture "$unshipped_export_dir"
+set +e
+check_node_modules_links_healthy node "$PROJECTION_SCRIPT" "$unshipped_export_dir/node_modules" >/dev/null 2>&1
+exit_code=$?
+set -e
+assert_exit_code 0 "$exit_code" "projection health ignores export targets outside package files"
 
 echo ""
 echo "All pnpm task helper tests passed"

--- a/nix/devenv-modules/tasks/shared/tests/pnpm.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/pnpm.test.sh
@@ -90,6 +90,19 @@ EOF
   ln -s ../store/v11/links/pkg/1.0.0/hash/node_modules/pkg "$root/node_modules/pkg"
 }
 
+make_missing_type_export_fixture() {
+  local root="$1"
+  local package_root="$root/store/v11/links/pkg/1.0.0/hash/node_modules/pkg"
+
+  mkdir -p "$package_root/dist"
+  mkdir -p "$root/node_modules"
+  cat > "$package_root/package.json" <<'EOF'
+{"name":"pkg","files":["dist"],"exports":{"./internal/module-runner":{"types":"./dist/module-runner.d.ts","default":"./dist/module-runner.js"}}}
+EOF
+  touch "$package_root/dist/module-runner.js"
+  ln -s ../store/v11/links/pkg/1.0.0/hash/node_modules/pkg "$root/node_modules/pkg"
+}
+
 make_bin_fixture() {
   local root="$1"
 
@@ -291,6 +304,15 @@ check_node_modules_links_healthy node "$PROJECTION_SCRIPT" "$unshipped_export_di
 exit_code=$?
 set -e
 assert_exit_code 0 "$exit_code" "projection health ignores export targets outside package files"
+
+echo "Test 17: Projection health ignores missing declaration-only export targets"
+missing_type_dir="$test_dir/missing-type-export"
+make_missing_type_export_fixture "$missing_type_dir"
+set +e
+check_node_modules_links_healthy node "$PROJECTION_SCRIPT" "$missing_type_dir/node_modules" >/dev/null 2>&1
+exit_code=$?
+set -e
+assert_exit_code 0 "$exit_code" "projection health ignores type-only export targets"
 
 echo ""
 echo "All pnpm task helper tests passed"


### PR DESCRIPTION
## Summary

- detect missing runtime package export targets in pnpm GVS link projections
- ignore declaration-only export targets so type metadata gaps do not block valid runtime projections
- purge stale GVS links and force relink when projection health fails
- cover missing-runtime-export and declaration-only false-positive cases in the pnpm helper regression test

## Rationale

The existing health check caught broken symlinks and missing transitive dependency projections, but not incomplete package contents under pnpm 11 GVS links. A package could keep a valid package.json while an exported runtime file was absent, causing downstream Vitest/build runs to fail later with less actionable module-load errors.

Concrete public repro from side experiments:

- Upstream issue: https://github.com/pnpm/pnpm/issues/11385
- Minimal repro repo: https://github.com/schickling-repros/2026-04-pnpm-gvs-force-repair


1. Install `@testing-library/svelte@5.3.1` in a PNPM 11 workspace with `enable-global-virtual-store=true`.
2. Delete only `src/vitest.js` from the resolved package projection under `store/v11/links/@testing-library/svelte/.../node_modules/@testing-library/svelte`.
3. The old health check passes because the workspace symlink and package.json still exist.
4. The new health check fails with `Missing package content: @testing-library/svelte -> ./src/vitest.js`.
5. `pnpm install --force` does not restore the missing file while the existing `v11/links` projection remains.
6. Deleting `store/v11/links` and reinstalling restores the missing runtime export target.

The repair path already detected GVS hash/config drift and forced a relink, but it only purged workspace `node_modules`. It now also removes the active `v11/links` directory before the forced install so pnpm cannot reuse incomplete package projections.

The content check intentionally validates runtime export targets only. During side experiments, `vitest@4.0.15` exposed declaration-only `types` targets that were absent from the GVS projection while the runtime targets were present and loadable. Treating those as package-content failures would make the health check too broad.

## Verification

- Public registry side experiment with `@testing-library/svelte@5.3.1`:
  - missing `src/vitest.js` is detected
  - `pnpm install --force` alone does not restore it
  - deleting `store/v11/links` plus reinstall restores it
- `PATH=/run/current-system/sw/bin:$PATH bash nix/devenv-modules/tasks/shared/tests/pnpm.test.sh`
- `PATH=/run/current-system/sw/bin:$PATH oxfmt --check nix/devenv-modules/tasks/shared/check-node-modules-projection-health.cjs`
- `PATH=/run/current-system/sw/bin:$PATH nixfmt --check nix/devenv-modules/tasks/shared/pnpm.nix`
- `git diff --check`
- `env -u OTEL_STATE_DIR -u OTEL_EXPORTER_OTLP_ENDPOINT -u OTEL_MODE CI=1 devenv tasks run --refresh-task-cache --no-eval-cache genie:check lint:nix:format lint:check:format lint:check:oxlint ts:build --mode before --no-tui`

Downstream LiveStore validation with the earlier candidate pinned:

- `env -u OTEL_STATE_DIR -u OTEL_EXPORTER_OTLP_ENDPOINT -u OTEL_MODE -u PNPM_HOME -u PNPM_STORE_DIR -u npm_config_store_dir CI=1 devenv tasks run --refresh-task-cache --no-eval-cache test:unit --mode before --no-tui`
- `env -u OTEL_STATE_DIR -u OTEL_EXPORTER_OTLP_ENDPOINT -u OTEL_MODE -u PNPM_HOME -u PNPM_STORE_DIR -u npm_config_store_dir CI=1 devenv tasks run --refresh-task-cache --no-eval-cache ts:build lint:check:format lint:check:oxlint test:unit --mode before --no-tui`

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🌱 co1-alder |
| `agent_session_id` | 6c624c62-4e38-435e-b267-475ef99d9340 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | codex-cli 0.124.0 |
| `agent_runtime` | Codex CLI codex-cli 0.124.0 |
| `agent_model` | unknown |
| `worktree` | effect-utils/schickling/2026-04-28-pnpm-gvs-content-health |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@19cf6f4 |
</details>
<!-- agent-footer:end -->