### PR TITLE
fix(nix): upstream pnpm CLI builder hardening

### DIFF
--- a/nix/oxc-config-plugin.nix
+++ b/nix/oxc-config-plugin.nix
@@ -196,27 +196,27 @@ pkgs.stdenv.mkDerivation {
   dontFixup = true;
 
   buildPhase = ''
-        set -euo pipefail
-        runHook preBuild
+    set -euo pipefail
+    runHook preBuild
 
-        cp -r ${buildSrc} workspace
-        chmod -R +w workspace
-        ${pnpmDepsHelper.mkRestoreScript {
-          deps = pnpmDeps;
-          target = "workspace";
-        }}
-        cd workspace
+    cp -r ${buildSrc} workspace
+    chmod -R +w workspace
+    ${pnpmDepsHelper.mkRestoreScript {
+      deps = pnpmDeps;
+      target = "workspace";
+    }}
+    cd workspace
 
-        cd ${packageDir}
-        chmod +w .
+    cd ${packageDir}
+    chmod +w .
 
-        # Bundle into single JS file.
-        # --external jiti: eslint's config loader uses jiti for dynamic imports, but
-        # oxlint's JS plugin runtime never invokes the config loader, so jiti is safe
-        # to exclude. This avoids bundling issues with jiti's native module resolution.
-        bun build src/mod.ts --bundle --target=bun --external jiti --outfile=plugin.js
+    # Bundle into single JS file.
+    # --external jiti: eslint's config loader uses jiti for dynamic imports, but
+    # oxlint's JS plugin runtime never invokes the config loader, so jiti is safe
+    # to exclude. This avoids bundling issues with jiti's native module resolution.
+    bun build src/mod.ts --bundle --target=bun --external jiti --outfile=plugin.js
 
-        runHook postBuild
+    runHook postBuild
   '';
 
   checkPhase = ''

--- a/nix/workspace-tools/lib/mk-pnpm-cli.nix
+++ b/nix/workspace-tools/lib/mk-pnpm-cli.nix
@@ -42,9 +42,13 @@ let
         ? packageKey.indexOf("@", 1)
         : packageKey.indexOf("@");
       if (atIndex === -1) return undefined;
+      const version = packageKey.slice(atIndex + 1);
+      const suffixIndex = version.indexOf("(");
       return {
         name: packageKey.slice(0, atIndex),
-        version: packageKey.slice(atIndex + 1),
+        version,
+        baseVersion: suffixIndex === -1 ? version : version.slice(0, suffixIndex),
+        suffix: suffixIndex === -1 ? "" : version.slice(suffixIndex),
       };
     };
 
@@ -62,15 +66,30 @@ let
       return { startIndex, endIndex };
     };
 
-    const parsePatchedDependencies = (lockfile) => {
+    const parseWorkspacePatchedDependencyPaths = (workspaceYaml) => {
+      const lines = workspaceYaml.split("\n");
+      const section = findTopLevelSection(lines, "patchedDependencies");
+      if (section === undefined) return new Map();
+
+      return new Map(
+        lines
+          .slice(section.startIndex + 1, section.endIndex)
+          .map((line) => line.match(/^  (.+?):\s*(.+)$/))
+          .filter((match) => match !== null)
+          .map((match) => [stripYamlQuotes(match[1]), match[2].trim()])
+      );
+    };
+
+    const parsePatchedDependencies = (lockfile, workspaceYaml) => {
       const lines = lockfile.split("\n");
       const section = findTopLevelSection(lines, "patchedDependencies");
       if (section === undefined) return [];
 
+      const workspacePaths = parseWorkspacePatchedDependencyPaths(workspaceYaml);
       const entries = [];
       let index = section.startIndex + 1;
       while (index < section.endIndex) {
-        const match = lines[index].match(/^  (.+?):\s*$/);
+        const match = lines[index].match(/^  (.+?):\s*(.*)$/);
         if (match === null) {
           index += 1;
           continue;
@@ -78,8 +97,8 @@ let
 
         const key = stripYamlQuotes(match[1]);
         const parsed = parsePackageNameVersion(key);
-        let hash;
-        let patchPath;
+        let hash = match[2].trim() === "" ? undefined : match[2].trim();
+        let patchPath = workspacePaths.get(key);
         index += 1;
         while (index < section.endIndex && lines[index].startsWith("    ")) {
           const hashMatch = lines[index].match(/^    hash:\s*(.+)$/);
@@ -110,14 +129,50 @@ let
       );
     };
 
+    const parseLockfileSelectors = (lockfile) => {
+      const lines = lockfile.split("\n");
+      const selectors = [];
+
+      for (const sectionName of ["packages", "snapshots"]) {
+        const section = findTopLevelSection(lines, sectionName);
+        if (section === undefined) continue;
+        for (let index = section.startIndex + 1; index < section.endIndex; index += 1) {
+          const match = lines[index].match(/^  (.+?):/);
+          if (match !== null) selectors.push(stripYamlQuotes(match[1]));
+        }
+      }
+
+      const importers = findTopLevelSection(lines, "importers");
+      if (importers !== undefined) {
+        let currentDependencyName;
+        for (let index = importers.startIndex + 1; index < importers.endIndex; index += 1) {
+          const dependencyMatch = lines[index].match(/^      (.+):$/);
+          if (dependencyMatch !== null) {
+            currentDependencyName = stripYamlQuotes(dependencyMatch[1]);
+            continue;
+          }
+
+          const versionMatch = lines[index].match(/^        version: ([^\s]+).*$/);
+          if (versionMatch !== null && currentDependencyName !== undefined) {
+            selectors.push(currentDependencyName + "@" + versionMatch[1]);
+          }
+        }
+      }
+
+      return selectors;
+    };
+
+    const selectorMatchesEntry = (selector, entry) => {
+      const parsed = parsePackageNameVersion(selector);
+      return parsed !== undefined && parsed.name === entry.name && parsed.baseVersion === entry.version;
+    };
+
     const insertPatchedDependencyLockEntries = (lockfile, entries) => {
       if (entries.length === 0) return lockfile;
       const lines = lockfile.split("\n");
       const section = findTopLevelSection(lines, "patchedDependencies");
       const rendered = entries.flatMap((entry) => [
-        "  '" + entry.key + "':",
-        "    hash: " + entry.hash,
-        "    path: .root-patches/" + entry.path,
+        "  '" + entry.key + "': " + entry.hash,
       ]);
 
       if (section !== undefined) {
@@ -161,9 +216,9 @@ let
           const key = stripYamlQuotes(snapshotMatch[1]);
           const parsed = parsePackageNameVersion(key);
           if (parsed === undefined) continue;
-          const entry = byNameVersion.get(parsed.name + "@" + parsed.version);
+          const entry = byNameVersion.get(parsed.name + "@" + parsed.baseVersion);
           if (entry === undefined || key.includes("patch_hash=")) continue;
-          lines[index] = "  '" + entry.key + "(patch_hash=" + entry.hash + ")':" + snapshotMatch[2];
+          lines[index] = "  '" + parsed.name + "@" + parsed.baseVersion + "(patch_hash=" + entry.hash + ")" + parsed.suffix + "':" + snapshotMatch[2];
         }
       }
 
@@ -194,16 +249,18 @@ let
     };
 
     const rootLockfile = fs.readFileSync(path.join(authorityDir, "pnpm-lock.yaml"), "utf8");
+    const rootWorkspaceYaml = fs.readFileSync(path.join(authorityDir, "pnpm-workspace.yaml"), "utf8");
     const targetRoot = installDir;
     const targetLockfilePath = path.join(targetRoot, "pnpm-lock.yaml");
     const targetWorkspaceYamlPath = path.join(targetRoot, "pnpm-workspace.yaml");
     const targetLockfile = fs.readFileSync(targetLockfilePath, "utf8");
     const targetWorkspaceYaml = fs.readFileSync(targetWorkspaceYamlPath, "utf8");
     const existingKeys = parseExistingPatchedDependencyKeys(targetLockfile);
-    const inheritedEntries = parsePatchedDependencies(rootLockfile).filter(
+    const targetSelectors = parseLockfileSelectors(targetLockfile);
+    const inheritedEntries = parsePatchedDependencies(rootLockfile, rootWorkspaceYaml).filter(
       (entry) =>
         !existingKeys.has(entry.key) &&
-        targetLockfile.includes(entry.key) &&
+        targetSelectors.some((selector) => selectorMatchesEntry(selector, entry)) &&
         fs.existsSync(path.join(targetRoot, ".root-patches", entry.path))
     );
 
@@ -1085,7 +1142,7 @@ pkgs.stdenv.mkDerivation {
   dontFixup = true;
   passthru = {
     depsSrc = rootDepsSrc;
-    inherit depsSrcByInstallRoot depsBuildsByInstallRoot;
+    inherit depsSrcByInstallRoot depsBuildsByInstallRoot inheritRootPatchedDependenciesScript;
     installRoots = map (root: {
       inherit (root) attrName installDir lockfilePath;
       memberDirs = installRootMemberDirs root;

--- a/nix/workspace-tools/lib/mk-pnpm-cli.nix
+++ b/nix/workspace-tools/lib/mk-pnpm-cli.nix
@@ -24,6 +24,211 @@
 let
   lib = pkgs.lib;
   pnpmDepsHelper = import ./mk-pnpm-deps.nix { inherit pkgs pnpm; };
+  inheritRootPatchedDependenciesScript = pkgs.writeText "inherit-root-patched-dependencies.cjs" ''
+    const fs = require("node:fs");
+    const path = require("node:path");
+
+    const [authorityDir, installDir] = process.argv.slice(2);
+    if (!authorityDir || !installDir) {
+      console.error("usage: inherit-root-patched-dependencies.cjs <authority-dir> <install-dir>");
+      process.exit(1);
+    }
+
+    const stripYamlQuotes = (key) =>
+      key.startsWith("'") && key.endsWith("'") ? key.slice(1, -1) : key;
+
+    const parsePackageNameVersion = (packageKey) => {
+      const atIndex = packageKey.startsWith("@")
+        ? packageKey.indexOf("@", 1)
+        : packageKey.indexOf("@");
+      if (atIndex === -1) return undefined;
+      return {
+        name: packageKey.slice(0, atIndex),
+        version: packageKey.slice(atIndex + 1),
+      };
+    };
+
+    const findTopLevelSection = (lines, sectionName) => {
+      const startIndex = lines.findIndex((line) => line === sectionName + ":");
+      if (startIndex === -1) return undefined;
+      let endIndex = lines.length;
+      for (let index = startIndex + 1; index < lines.length; index += 1) {
+        const line = lines[index];
+        if (line.trim() !== "" && /^\S/.test(line)) {
+          endIndex = index;
+          break;
+        }
+      }
+      return { startIndex, endIndex };
+    };
+
+    const parsePatchedDependencies = (lockfile) => {
+      const lines = lockfile.split("\n");
+      const section = findTopLevelSection(lines, "patchedDependencies");
+      if (section === undefined) return [];
+
+      const entries = [];
+      let index = section.startIndex + 1;
+      while (index < section.endIndex) {
+        const match = lines[index].match(/^  (.+?):\s*$/);
+        if (match === null) {
+          index += 1;
+          continue;
+        }
+
+        const key = stripYamlQuotes(match[1]);
+        const parsed = parsePackageNameVersion(key);
+        let hash;
+        let patchPath;
+        index += 1;
+        while (index < section.endIndex && lines[index].startsWith("    ")) {
+          const hashMatch = lines[index].match(/^    hash:\s*(.+)$/);
+          const pathMatch = lines[index].match(/^    path:\s*(.+)$/);
+          if (hashMatch !== null) hash = hashMatch[1].trim();
+          if (pathMatch !== null) patchPath = pathMatch[1].trim();
+          index += 1;
+        }
+
+        if (parsed !== undefined && hash !== undefined && patchPath !== undefined) {
+          entries.push({ key, ...parsed, hash, path: patchPath });
+        }
+      }
+
+      return entries;
+    };
+
+    const parseExistingPatchedDependencyKeys = (lockfile) => {
+      const lines = lockfile.split("\n");
+      const section = findTopLevelSection(lines, "patchedDependencies");
+      if (section === undefined) return new Set();
+      return new Set(
+        lines
+          .slice(section.startIndex + 1, section.endIndex)
+          .map((line) => line.match(/^  (.+?):/))
+          .filter((match) => match !== null)
+          .map((match) => stripYamlQuotes(match[1]))
+      );
+    };
+
+    const insertPatchedDependencyLockEntries = (lockfile, entries) => {
+      if (entries.length === 0) return lockfile;
+      const lines = lockfile.split("\n");
+      const section = findTopLevelSection(lines, "patchedDependencies");
+      const rendered = entries.flatMap((entry) => [
+        "  '" + entry.key + "':",
+        "    hash: " + entry.hash,
+        "    path: .root-patches/" + entry.path,
+      ]);
+
+      if (section !== undefined) {
+        lines.splice(section.endIndex, 0, ...rendered);
+        return lines.join("\n");
+      }
+
+      const importersIndex = lines.findIndex((line) => line === "importers:");
+      const insertionIndex = importersIndex === -1 ? lines.length : importersIndex;
+      lines.splice(insertionIndex, 0, "patchedDependencies:", ...rendered, "");
+      return lines.join("\n");
+    };
+
+    const rewriteLockfilePatchVersions = (lockfile, entries) => {
+      if (entries.length === 0) return lockfile;
+      const byNameVersion = new Map(entries.map((entry) => [entry.name + "@" + entry.version, entry]));
+      const lines = lockfile.split("\n");
+      const importers = findTopLevelSection(lines, "importers");
+      if (importers !== undefined) {
+        let currentDependencyName;
+        for (let index = importers.startIndex + 1; index < importers.endIndex; index += 1) {
+          const dependencyMatch = lines[index].match(/^      (.+):$/);
+          if (dependencyMatch !== null) {
+            currentDependencyName = stripYamlQuotes(dependencyMatch[1]);
+            continue;
+          }
+
+          const versionMatch = lines[index].match(/^        version: ([^\s(]+)(.*)$/);
+          if (versionMatch === null || currentDependencyName === undefined) continue;
+          const entry = byNameVersion.get(currentDependencyName + "@" + versionMatch[1]);
+          if (entry === undefined || versionMatch[2].includes("patch_hash=")) continue;
+          lines[index] = "        version: " + versionMatch[1] + "(patch_hash=" + entry.hash + ")" + versionMatch[2];
+        }
+      }
+
+      const snapshots = findTopLevelSection(lines, "snapshots");
+      if (snapshots !== undefined) {
+        for (let index = snapshots.startIndex + 1; index < snapshots.endIndex; index += 1) {
+          const snapshotMatch = lines[index].match(/^  (.+?):(.*)$/);
+          if (snapshotMatch === null) continue;
+          const key = stripYamlQuotes(snapshotMatch[1]);
+          const parsed = parsePackageNameVersion(key);
+          if (parsed === undefined) continue;
+          const entry = byNameVersion.get(parsed.name + "@" + parsed.version);
+          if (entry === undefined || key.includes("patch_hash=")) continue;
+          lines[index] = "  '" + entry.key + "(patch_hash=" + entry.hash + ")':" + snapshotMatch[2];
+        }
+      }
+
+      return lines.join("\n");
+    };
+
+    const insertWorkspacePatchEntries = (workspaceYaml, entries) => {
+      if (entries.length === 0) return workspaceYaml;
+      const lines = workspaceYaml.split("\n");
+      const section = findTopLevelSection(lines, "patchedDependencies");
+      const rendered = entries.map((entry) => "  '" + entry.key + "': .root-patches/" + entry.path);
+
+      if (section !== undefined) {
+        lines.splice(section.endIndex, 0, ...rendered);
+        return lines.join("\n");
+      }
+
+      const insertionIndex = (() => {
+        const preferred = ["allowUnusedPatches:", "packageExtensions:", "peerDependencyRules:", "allowBuilds:", "supportedArchitectures:"];
+        for (const header of preferred) {
+          const index = lines.findIndex((line) => line === header);
+          if (index !== -1) return index;
+        }
+        return lines.length;
+      })();
+      lines.splice(insertionIndex, 0, "patchedDependencies:", ...rendered, "");
+      return lines.join("\n");
+    };
+
+    const rootLockfile = fs.readFileSync(path.join(authorityDir, "pnpm-lock.yaml"), "utf8");
+    const targetRoot = installDir;
+    const targetLockfilePath = path.join(targetRoot, "pnpm-lock.yaml");
+    const targetWorkspaceYamlPath = path.join(targetRoot, "pnpm-workspace.yaml");
+    const targetLockfile = fs.readFileSync(targetLockfilePath, "utf8");
+    const targetWorkspaceYaml = fs.readFileSync(targetWorkspaceYamlPath, "utf8");
+    const existingKeys = parseExistingPatchedDependencyKeys(targetLockfile);
+    const inheritedEntries = parsePatchedDependencies(rootLockfile).filter(
+      (entry) =>
+        !existingKeys.has(entry.key) &&
+        targetLockfile.includes(entry.key) &&
+        fs.existsSync(path.join(targetRoot, ".root-patches", entry.path))
+    );
+
+    if (inheritedEntries.length === 0) {
+      fs.rmSync(path.join(targetRoot, ".root-patches"), { recursive: true, force: true });
+      process.exit(0);
+    }
+
+    const nextTargetLockfile = rewriteLockfilePatchVersions(
+      insertPatchedDependencyLockEntries(targetLockfile, inheritedEntries),
+      inheritedEntries
+    );
+    const nextTargetWorkspaceYaml = insertWorkspacePatchEntries(targetWorkspaceYaml, inheritedEntries);
+
+    fs.writeFileSync(targetLockfilePath, nextTargetLockfile);
+    fs.writeFileSync(targetWorkspaceYamlPath, nextTargetWorkspaceYaml);
+    console.error(
+      "workspace-prep: phase=inherit-root-patched-dependencies install_root=" +
+        installDir +
+        " count=" +
+        inheritedEntries.length +
+        " packages=" +
+        inheritedEntries.map((entry) => entry.key).join(",")
+    );
+  '';
 
   coerceSourceRoot =
     sourceRoot:
@@ -36,6 +241,18 @@ let
 
   workspaceRootPath = coerceSourceRoot workspaceRoot;
 
+  sourcePathFilter =
+    path: type:
+    let
+      name = baseNameOf path;
+    in
+    !(builtins.elem name [
+      ".direnv"
+      ".git"
+      "node_modules"
+    ])
+    && !(name == "result" && type == "symlink");
+
   normalizeSourceRoot =
     prefix: sourceRoot:
     let
@@ -43,6 +260,7 @@ let
       normalizedName = lib.strings.sanitizeDerivationName (lib.replaceStrings [ "/" ] [ "-" ] prefix);
       sanitizedPath = builtins.path {
         path = rawPath;
+        filter = sourcePathFilter;
         name = normalizedName;
       };
     in
@@ -96,6 +314,7 @@ let
       snapshotName = lib.strings.sanitizeDerivationName (lib.replaceStrings [ "/" ] [ "-" ] namePrefix);
       sanitizedPath = builtins.path {
         path = path;
+        filter = sourcePathFilter;
         name = snapshotName;
       };
     in
@@ -381,10 +600,7 @@ let
     let
       parent = builtins.dirOf relPath;
     in
-    if parent == "." then
-      ''mkdir -p "$out"''
-    else
-      ''mkdir -p "$out/${parent}"'';
+    if parent == "." then ''mkdir -p "$out"'' else ''mkdir -p "$out/${parent}"'';
 
   copyFileCmd =
     relPath:
@@ -583,6 +799,16 @@ let
           mkdir -p "$out"
         ''
         + stageExternalInstallRootManifestOnlyCmd root
+        + copyResolvedPatchFilesCmd {
+          sourcePrefix = "";
+          workspaceYamlContent = rootPnpmWorkspaceYaml;
+          targetPrefix = "${root.installDir}/.root-patches";
+        }
+        + ''
+          mkdir -p "$out/.root-patch-authority"
+          cp ${lib.escapeShellArg (toString (absoluteFileSourcePathFor "pnpm-lock.yaml"))} "$out/.root-patch-authority/pnpm-lock.yaml"
+          cp ${lib.escapeShellArg (toString (absoluteFileSourcePathFor "pnpm-workspace.yaml"))} "$out/.root-patch-authority/pnpm-workspace.yaml"
+        ''
       );
       lockfilePath = installRootScopedPath root.installDir "pnpm-lock.yaml";
       depsBuild = pnpmDepsHelper.mkDeps {
@@ -596,6 +822,8 @@ let
         frozenLockfile = true;
         preInstall = ''
           chmod -R +w .
+          ${pkgs.nodejs}/bin/node ${inheritRootPatchedDependenciesScript} .root-patch-authority ${lib.escapeShellArg root.installDir}
+          rm -rf .root-patch-authority
         '';
         pnpmDepsHash = depsBuildHashForInstallRoot root.installDir;
       };
@@ -800,7 +1028,10 @@ let
       '';
 
   nativeNodePackageEntries = builtins.concatStringsSep "\n" (
-    map (nativePackage: "${lib.escapeShellArg nativePackage.name}\t${lib.escapeShellArg nativePackage.package}") nativeNodePackages
+    map (
+      nativePackage:
+      "${lib.escapeShellArg nativePackage.name}\t${lib.escapeShellArg nativePackage.package}"
+    ) nativeNodePackages
   );
 
   linkNativeNodePackagesScript =
@@ -809,7 +1040,9 @@ let
     else
       let
         externalRootNodeModulesDirs = builtins.concatStringsSep "\n" (
-          map (root: ''native_node_modules_dirs+=("$NIX_BUILD_TOP/workspace/${root.installDir}/node_modules")'') externalInstallRoots
+          map (
+            root: ''native_node_modules_dirs+=("$NIX_BUILD_TOP/workspace/${root.installDir}/node_modules")''
+          ) externalInstallRoots
         );
       in
       ''
@@ -824,14 +1057,13 @@ let
           for node_modules_dir in "''${native_node_modules_dirs[@]}"; do
             [ -d "$node_modules_dir" ] || continue
             target="$node_modules_dir/$native_package_name"
+            chmod u+w "$node_modules_dir" "$(dirname "$target")" 2>/dev/null || true
             mkdir -p "$(dirname "$target")"
             rm -rf "$target"
             ln -s "$native_package_path" "$target"
           done
           log_cli_phase "link-native-node-package" "package=$native_package_name"
-        done <<'NATIVE_NODE_PACKAGES'
-        ${nativeNodePackageEntries}
-        NATIVE_NODE_PACKAGES
+        done < <(printf '%s\n' ${lib.escapeShellArg nativeNodePackageEntries})
 
         log_cli_phase "link-native-node-packages" "duration=$(timer_elapsed "$nativePackageLinkStartedAt")s packages=$native_package_count node_modules_dirs=''${#native_node_modules_dirs[@]}"
       '';
@@ -908,7 +1140,7 @@ pkgs.stdenv.mkDerivation {
     chmod -R +w workspace
     log_cli_phase "workspace-copy" "duration=$(timer_elapsed "$workspaceCopyStartedAt")s"
 
-    ${builtins.concatStringsSep "\nchmod -R +w workspace\n" (
+    ${builtins.concatStringsSep "\n" (
       map (
         root:
         pnpmDepsHelper.mkRestoreScript {
@@ -918,7 +1150,8 @@ pkgs.stdenv.mkDerivation {
         }
       ) depsInstallRoots
     )}
-    chmod -R +w workspace
+    chmod u+w workspace workspace/.npmrc 2>/dev/null || true
+    chmod -R u+w workspace/${packageDir} 2>/dev/null || true
 
     ${dedupPnpmScript}
 
@@ -967,7 +1200,7 @@ pkgs.stdenv.mkDerivation {
     if [ -n "${smokeTestArgsStr}" ]; then
       echo "Running smoke test..."
       smokeStartedAt=$(timer_now)
-      ./output/${binaryName} ${smokeTestArgsStr}
+      NODE_PATH="$NIX_BUILD_TOP/workspace/node_modules" ./output/${binaryName} ${smokeTestArgsStr}
       log_cli_phase "smoke-test" "duration=$(timer_elapsed "$smokeStartedAt")s args=${lib.escapeShellArg (builtins.concatStringsSep " " smokeTestArgs)}"
     fi
 

--- a/nix/workspace-tools/lib/mk-pnpm-cli/tests/run.sh
+++ b/nix/workspace-tools/lib/mk-pnpm-cli/tests/run.sh
@@ -270,6 +270,80 @@ run_downstream_pure_eval_regression() {
   echo "Timing: downstream-pure-eval $(( $(date +%s) - start ))s"
 }
 
+run_inherit_root_patched_dependencies_regression() {
+  local start
+  start="$(date +%s)"
+
+  echo "Check: inherit-root-patched-dependencies scalar lockfile and selector handling"
+  local script
+  script="$(
+    cd "$ROOT" &&
+      nix build --no-link --no-write-lock-file --print-out-paths ".#packages.$SYSTEM.genie.passthru.inheritRootPatchedDependenciesScript"
+  )"
+
+  local fixture
+  fixture="$(mktemp -d "${TMPDIR:-/tmp}/mk-pnpm-cli-patches.XXXXXX")"
+  mkdir -p "$fixture/authority/patches" "$fixture/target/.root-patches/patches"
+  cat >"$fixture/authority/pnpm-workspace.yaml" <<'YAML'
+packages: []
+
+patchedDependencies:
+  foo@1.2.3: patches/foo.patch
+  foo@1.2.30: patches/foo-1.2.30.patch
+  peer-pkg@2.0.0: patches/peer.patch
+YAML
+  cat >"$fixture/authority/pnpm-lock.yaml" <<'YAML'
+lockfileVersion: '9.0'
+
+patchedDependencies:
+  foo@1.2.3: hash-foo
+  foo@1.2.30: hash-foo-30
+  peer-pkg@2.0.0: hash-peer
+
+importers:
+  .: {}
+YAML
+  cat >"$fixture/target/pnpm-workspace.yaml" <<'YAML'
+packages: []
+YAML
+  cat >"$fixture/target/pnpm-lock.yaml" <<'YAML'
+lockfileVersion: '9.0'
+
+importers:
+  .:
+    dependencies:
+      foo:
+        specifier: 1.2.30
+        version: 1.2.30
+      peer-pkg:
+        specifier: 2.0.0
+        version: 2.0.0(peer@1.0.0)
+
+snapshots:
+  foo@1.2.30: {}
+  peer-pkg@2.0.0(peer@1.0.0): {}
+YAML
+  touch \
+    "$fixture/target/.root-patches/patches/foo.patch" \
+    "$fixture/target/.root-patches/patches/foo-1.2.30.patch" \
+    "$fixture/target/.root-patches/patches/peer.patch"
+
+  node "$script" "$fixture/authority" "$fixture/target"
+
+  if grep -q "'foo@1.2.3'" "$fixture/target/pnpm-lock.yaml"; then
+    echo "error: inherited prefix-matched patch foo@1.2.3 for target foo@1.2.30" >&2
+    exit 1
+  fi
+  grep -q "'foo@1.2.30': hash-foo-30" "$fixture/target/pnpm-lock.yaml"
+  grep -q "'peer-pkg@2.0.0': hash-peer" "$fixture/target/pnpm-lock.yaml"
+  grep -q "version: 2.0.0(patch_hash=hash-peer)(peer@1.0.0)" "$fixture/target/pnpm-lock.yaml"
+  grep -q "'peer-pkg@2.0.0(patch_hash=hash-peer)(peer@1.0.0)':" "$fixture/target/pnpm-lock.yaml"
+  grep -q "'peer-pkg@2.0.0': .root-patches/patches/peer.patch" "$fixture/target/pnpm-workspace.yaml"
+  rm -rf "$fixture"
+
+  echo "Timing: inherit-root-patched-dependencies $(( $(date +%s) - start ))s"
+}
+
 if [ "$SKIP_GENIE" -eq 0 ]; then
   build_and_smoke "genie" "genie"
 fi
@@ -279,6 +353,7 @@ if [ "$SKIP_MEGAREPO" -eq 0 ]; then
 fi
 
 if [ "$SKIP_DOWNSTREAM" -eq 0 ]; then
+  run_inherit_root_patched_dependencies_regression
   prepare_downstream_workspace
   run_downstream_pure_eval_regression
   run_downstream_regression "genie" "genie"

--- a/nix/workspace-tools/lib/mk-pnpm-deps.nix
+++ b/nix/workspace-tools/lib/mk-pnpm-deps.nix
@@ -448,7 +448,7 @@ in
       # strategy changes, even if the recursive output hash stays the same.
       # Self-hosted darwin runners can otherwise keep colliding with stale temp
       # output paths for earlier artifact layouts while evaluating the same FOD.
-      pname = "${name}-pnpm-deps-${srcFingerprint}-v12";
+      pname = "${name}-pnpm-deps-${srcFingerprint}-v15";
       version = "0.0.0";
 
       inherit src sourceRoot;
@@ -601,7 +601,10 @@ in
                 # workspace-only. Use env vars and .npmrc instead.
                 # Back up .npmrc before appending build-local settings (restored after install).
                 cp .npmrc .npmrc.orig 2>/dev/null || true
-        printf 'store-dir=%s\nvirtual-store-dir=node_modules/.pnpm\npackage-import-method=%s\nside-effects-cache=false\nenable-global-virtual-store=false\nmanage-package-manager-versions=false\n' "$STORE_PATH" ${lib.escapeShellArg pnpmPackageImportMethod} >> .npmrc
+        printf 'store-dir=%s\nvirtual-store-dir=node_modules/.pnpm\npackage-import-method=%s\nside-effects-cache=false\nenable-global-virtual-store=false\nmanage-package-manager-versions=false\nnode-linker=isolated\n' "$STORE_PATH" ${lib.escapeShellArg pnpmPackageImportMethod} >> .npmrc
+        if [ -f pnpm-workspace.yaml ]; then
+          ${pkgs.perl}/bin/perl -0pi -e 's/nodeLinker: hoisted/nodeLinker: isolated/g' pnpm-workspace.yaml
+        fi
                 # Keep prepared dependency artifacts platform-neutral. Native
                 # optional packages are owned by the Nix package/build layer so
                 # pnpm dependency preparation stays pure, smaller, and stable
@@ -678,29 +681,33 @@ in
 
                 archiveStartedAt=$(timer_now)
                 log_path_stats "prepared-workspace-output" "$SOURCE_DIR"
-                # Materialize the prepared workspace directly as the fixed-output
-                # directory. This keeps the hash boundary aligned with the actual
-                # restored tree and avoids serializer-specific failures for large
-                # prepared workspaces.
-                #
                 # Self-hosted darwin runners have shown `cp -a` spuriously failing
                 # with `create_symlink: File exists` while materializing pnpm's
                 # symlink-heavy trees into `$out.tmp`, even after clearing the
-                # destination. Stream the tree through tar instead so the output
-                # model stays recursive without relying on `cp`'s platform-specific
-                # directory copy semantics.
+                # destination. Stream the tree through tar for copying, but keep
+                # the fixed-output boundary as a recursive directory tree so
+                # serializer details do not turn platform-neutral installs into
+                # per-platform hashes.
                 rm -rf "$out"
                 mkdir -p "$out"
-                (
-                  cd "$SOURCE_DIR"
-                  tar -cf - .
-                ) | (
-                  cd "$out"
-                  tar -xf -
-                )
+                ${pkgs.gnutar}/bin/tar \
+                  --create \
+                  --sort=name \
+                  --mtime='@1' \
+                  --owner=0 \
+                  --group=0 \
+                  --numeric-owner \
+                  --file - \
+                  --directory "$SOURCE_DIR" \
+                  . \
+                  | ${pkgs.gnutar}/bin/tar \
+                    --extract \
+                    --file - \
+                    --directory "$out" \
+                    --delay-directory-restore
                 archiveDuration=$(timer_elapsed "$archiveStartedAt")
-                log_prep_phase "archive" "duration=''${archiveDuration}s mode=tar-stream-copy"
-                log_prep_event "archive" "$archiveDuration" "mode=tar-stream-copy"
+                log_prep_phase "archive" "duration=''${archiveDuration}s mode=tar-stream-tree"
+                log_prep_event "archive" "$archiveDuration" "mode=tar-stream-tree"
                 prepDuration=$(timer_elapsed "$prepStartedAt")
                 log_prep_phase "complete" "duration=''${prepDuration}s output_hash=${pnpmDepsHash}"
                 log_prep_event "complete" "$prepDuration" "output_hash=${pnpmDepsHash}"
@@ -729,48 +736,66 @@ in
       label ? "prepared-workspace",
     }:
     ''
-            restore_timer_now() {
-              perl -MTime::HiRes=time -e 'printf "%.3f", time'
-            }
+      restore_timer_now() {
+        perl -MTime::HiRes=time -e 'printf "%.3f", time'
+      }
 
-            restore_timer_elapsed() {
-              perl -e 'printf "%.3f", $ARGV[1] - $ARGV[0]' "$1" "$(restore_timer_now)"
-            }
+      restore_timer_elapsed() {
+        perl -e 'printf "%.3f", $ARGV[1] - $ARGV[0]' "$1" "$(restore_timer_now)"
+      }
 
-            restore_format_bytes() {
-              numfmt --to=iec-i --suffix=B --format='%.1f' "$1" 2>/dev/null || echo "$1"'B'
-            }
+      restore_format_bytes() {
+        numfmt --to=iec-i --suffix=B --format='%.1f' "$1" 2>/dev/null || echo "$1"'B'
+      }
 
-            restore_path_bytes() {
-              if [ -d "$1" ]; then
-                du --apparent-size -sk "$1" 2>/dev/null | awk '{print $1 * 1024}'
-              else
-                stat -c%s "$1" 2>/dev/null || stat -f%z "$1"
-              fi
-            }
+      restore_path_bytes() {
+        if [ -d "$1" ]; then
+          du --apparent-size -sk "$1" 2>/dev/null | awk '{print $1 * 1024}'
+        else
+          stat -c%s "$1" 2>/dev/null || stat -f%z "$1"
+        fi
+      }
 
-            restore_file_count() {
-              if [ -d "$1" ]; then
-                ${pkgs.nodejs}/bin/node ${lib.escapeShellArg fileCountScript} "$1"
-              else
-                echo 1
-              fi
-            }
+      restore_file_count() {
+        if [ -d "$1" ]; then
+          ${pkgs.nodejs}/bin/node ${lib.escapeShellArg fileCountScript} "$1"
+        else
+          echo 1
+        fi
+      }
 
-            restoreStartedAt=$(restore_timer_now)
-            mkdir -p ${lib.escapeShellArg target}
-            # Restore with overlay semantics because the caller's target already
-            # contains the real source tree.
-            cp -a ${deps}/. ${lib.escapeShellArg target}/
+      restoreStartedAt=$(restore_timer_now)
+      mkdir -p ${lib.escapeShellArg target}
+      # Restore with overlay semantics because the caller's target already
+      # contains the real source tree.
+      if [ ${lib.escapeShellArg label} = "." ]; then
+        restoreRoot=${lib.escapeShellArg target}
+      else
+        restoreRoot=${lib.escapeShellArg target}/${lib.escapeShellArg label}
+      fi
+      if [ -d "$restoreRoot" ]; then
+        ${pkgs.findutils}/bin/find "$restoreRoot" -name node_modules -prune \
+          -exec ${pkgs.bash}/bin/bash -c 'for path do if [ -L "$path" ] || [ ! -d "$path" ]; then rm -f "$path"; else chmod -R u+w "$path" 2>/dev/null || true; rm -rf "$path"; fi; done' bash {} +
+      fi
 
-            export PREPARED_WORKSPACE_PLACEHOLDER='${preparedWorkspacePlaceholder}'
-            export PREPARED_WORKSPACE_TARGET="$(cd ${lib.escapeShellArg target} && pwd -P)"
+      ${pkgs.gnutar}/bin/tar \
+        --create \
+        --file - \
+        --directory ${deps} \
+        . \
+        | ${pkgs.gnutar}/bin/tar \
+        --extract \
+        --file - \
+        --directory ${lib.escapeShellArg target} \
+        --delay-directory-restore
 
-            ${pkgs.nodejs}/bin/node ${lib.escapeShellArg chmodBinScriptsWritableScript} "$PREPARED_WORKSPACE_TARGET"
-            ${pkgs.nodejs}/bin/node ${lib.escapeShellArg restorePreparedWorkspaceScript}
+      export PREPARED_WORKSPACE_PLACEHOLDER='${preparedWorkspacePlaceholder}'
+      export PREPARED_WORKSPACE_TARGET="$(cd ${lib.escapeShellArg target} && pwd -P)"
 
-            restored_bytes=$(restore_path_bytes "$PREPARED_WORKSPACE_TARGET")
-            restored_files=$(restore_file_count "$PREPARED_WORKSPACE_TARGET")
-            echo "workspace-restore: phase=restore label=${label} target=$PREPARED_WORKSPACE_TARGET duration=$(restore_timer_elapsed "$restoreStartedAt")s size=$(restore_format_bytes "$restored_bytes") files=$restored_files"
+      ${pkgs.nodejs}/bin/node ${lib.escapeShellArg chmodBinScriptsWritableScript} "$PREPARED_WORKSPACE_TARGET"
+      ${pkgs.nodejs}/bin/node ${lib.escapeShellArg restorePreparedWorkspaceScript}
+
+      restored_payload_bytes=$(restore_path_bytes ${deps})
+      echo "workspace-restore: phase=restore label=${label} target=$PREPARED_WORKSPACE_TARGET duration=$(restore_timer_elapsed "$restoreStartedAt")s payload_size=$(restore_format_bytes "$restored_payload_bytes") mode=tar-stream-tree"
     '';
 }

--- a/packages/@overeng/genie/nix/build.nix
+++ b/packages/@overeng/genie/nix/build.nix
@@ -37,7 +37,12 @@ pkgs.runCommand "genie"
     nativeBuildInputs = [ pkgs.makeWrapper ];
     meta.mainProgram = "genie";
     passthru = {
-      inherit (unwrapped.passthru) depsBuildEntries depsBuildsByInstallRoot installRoots;
+      inherit (unwrapped.passthru)
+        depsBuildEntries
+        depsBuildsByInstallRoot
+        inheritRootPatchedDependenciesScript
+        installRoots
+        ;
     };
   }
   ''


### PR DESCRIPTION
## Summary

Upstreams the pnpm CLI builder hardening currently needed by downstream dotfiles builds so downstream repos do not need to carry a patched copy of `mk-pnpm-cli.nix` / `mk-pnpm-deps.nix`.

## Rationale

The downstream dotfiles Home Manager build exposed three shared-builder issues:

- prepared workspace restores were expensive and fragile as recursive `node_modules` trees;
- external install roots did not inherit root-level patched dependency authority, which made composed workspaces diverge from the root lockfile contract;
- native Node packages should remain owned by Nix while prepared pnpm artifacts stay platform-neutral.

This keeps that logic in effect-utils, where the builder contract lives, instead of duplicating a patched builder in downstream repos.

The important correction during review was to preserve the old platform-neutral FOD hash boundary. A previous version wrote `workspace.tar` as the fixed-output artifact, which made tar serialization bytes part of the hash and caused Linux/Darwin hash drift. This PR now uses tar only as the copy/restore transport and keeps `$out` as a recursive directory tree.

## Changes

- Restore prepared pnpm dependency artifacts through deterministic `gnutar` streams while keeping the fixed-output result directory-shaped.
- Force isolated node linker during dependency preparation.
- Carry root patched dependency metadata into external install roots when the nested lockfile needs the root patch authority.
- Keep native Node package linking in the CLI build phase and make smoke tests resolve Nix-provided native packages via `NODE_PATH`.
- Refresh the representative `megarepo` prepared-deps hash for the v15 artifact layout, still as one platform-neutral hash.

## Benchmarks

Measured locally on `aarch64-darwin` against clean PR base `7efdbee4` and this PR `a1b01835`. Sizes use `nix path-info -S` for closure size and `nix path-info -s` for NAR/self size. FOD output sizes are unchanged; the PR changes restore/copy mechanics and hash stability, not the final closure footprint.

### Output and Closure Sizes

| Output | Base closure | PR closure | Base NAR/self | PR NAR/self | Delta |
| --- | ---: | ---: | ---: | ---: | ---: |
| `oxc-config-plugin-pnpm-deps` | 80.1 MiB | 80.1 MiB | 80.1 MiB | 80.1 MiB | 0.0 MiB |
| `genie-pnpm-deps` | 282.3 MiB | 282.3 MiB | 282.3 MiB | 282.3 MiB | 0.0 MiB |
| `megarepo-pnpm-deps` | 264.1 MiB | 264.1 MiB | 264.1 MiB | 264.1 MiB | 0.0 MiB |
| `oxlint-npm` | 118.3 MiB | 118.3 MiB | 13.9 MiB | 13.9 MiB | 0.0 MiB |
| `genie` wrapper | 1,789.1 MiB | 1,789.1 MiB | 0.003 MiB | 0.003 MiB | 0.0 MiB |

### Prepared Dependency Build Phases

| FOD | Base mode | PR mode | Base install | PR install | Base archive/restore prep | PR archive/restore prep | Base total | PR total |
| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `oxc-config-plugin-pnpm-deps` | `tar-stream-copy` | `tar-stream-tree` | 21.259s | 5.838s | 3.572s | 4.265s | 33.034s | 13.502s |
| `genie-pnpm-deps` | `tar-stream-copy` | `tar-stream-tree` | 31.678s | 12.072s | 23.319s | 11.981s | 65.178s | 34.497s |
| `megarepo-pnpm-deps` | recursive tree output | `tar-stream-tree` | 31.950s | 6.294s | not logged by old builder | 5.657s | not logged by old builder | 14.271s |

The install-phase differences are affected by local cache state, so the table should be read as representative instrumentation rather than a controlled microbenchmark. The stable signal is that v15 keeps the same output sizes while making the restore path explicit and preserving the recursive FOD hash boundary.

### Local Realization Check

| Benchmark set | Base `7efdbee4` | PR `a1b01835` | Notes |
| --- | ---: | ---: | --- |
| Five-output benchmark set | 141s | 17s | Base had to realize eight derivations; PR reused more existing store paths and built three derivations, so this is a sanity check rather than a normalized cold-build comparison. |

### Cross-Platform FOD Hash Stability

| FOD | Base behavior | PR behavior | Evidence |
| --- | --- | --- | --- |
| `oxc-config-plugin-pnpm-deps` | one platform-neutral hash | same single hash retained | local build passes with original hash; CI `nix-fod-check` passes on Linux and macOS |
| `genie-pnpm-deps` | one platform-neutral hash | same single hash retained | local build passes with original hash; CI `nix-fod-check` passes on Linux and macOS |
| `megarepo-pnpm-deps` | one platform-neutral hash | refreshed to one new platform-neutral hash | Linux and macOS both converged on `sha256-3CS4PQWD2EcV0TUWWnhH4iM73XaymhYbz8/PlMZQgk4=`; CI `nix-fod-check` passes on both |

## Validation

- `nixfmt nix/workspace-tools/lib/mk-pnpm-cli.nix nix/workspace-tools/lib/mk-pnpm-deps.nix packages/@overeng/megarepo/nix/build.nix nix/oxc-config-plugin.nix`
- `nix build .#oxc-config-plugin-pnpm-deps .#genie-pnpm-deps --out-link /tmp/effect-utils-neutral-fod-proof`
- `nix build .#megarepo-pnpm-deps --out-link /tmp/effect-utils-megarepo-fod-proof`
- `nix build .#oxlint-npm .#packages.aarch64-darwin.genie --out-link /tmp/effect-utils-consumer-proof-final`
- CI PR #639: passing. Linux/macOS `nix-fod-check`, Linux/macOS `nix-check`, lint, typecheck, tests, pnpm checks, integration, and deploy-storybooks all pass.