### PR TITLE
fix(nix): make prepared workspace restore overwrite source files

### DIFF
--- a/nix/workspace-tools/lib/mk-pnpm-deps.nix
+++ b/nix/workspace-tools/lib/mk-pnpm-deps.nix
@@ -774,8 +774,13 @@ in
         restoreRoot=${lib.escapeShellArg target}/${lib.escapeShellArg label}
       fi
       if [ -d "$restoreRoot" ]; then
+        chmod -R u+w "$restoreRoot" 2>/dev/null || true
         ${pkgs.findutils}/bin/find "$restoreRoot" -name node_modules -prune \
           -exec ${pkgs.bash}/bin/bash -c 'for path do if [ -L "$path" ] || [ ! -d "$path" ]; then rm -f "$path"; else chmod -R u+w "$path" 2>/dev/null || true; rm -rf "$path"; fi; done' bash {} +
+        (
+          cd ${deps}
+          ${pkgs.findutils}/bin/find . -mindepth 1 -maxdepth 1 -exec ${pkgs.bash}/bin/bash -c 'root="$1"; shift; for path do rm -rf "$root/''${path#./}"; done' bash "$restoreRoot" {} +
+        )
       fi
 
       ${pkgs.gnutar}/bin/tar \


### PR DESCRIPTION
## Summary

Fix prepared pnpm workspace restore when the target already contains read-only source files from a store-backed workspace copy.

The restore helper already removes existing `node_modules` before extracting a prepared dependency tree. Composed downstream builds also need the install-root source directory itself to be writable, and top-level files owned by the prepared tree must be removed before tar extraction. Otherwise `tar` can fail with `Permission denied` / `File exists` while overlaying paths such as `repos/effect-utils/package.json`, `.root-patches`, and package-level `node_modules`.

## Rationale

This keeps the prepared-tree contract in effect-utils instead of pushing downstream repos toward local builder forks. The fix is limited to restore-time materialization; it does not change the FOD archive format or hash boundary.

## Validation

- `nixfmt nix/workspace-tools/lib/mk-pnpm-deps.nix`
- `git diff --check`
- Downstream reproducer: `schickling/dotfiles` discord-agent build failed after effect-utils #639 with tar overlay errors against `repos/effect-utils`; this patch targets that restore boundary.
