### PR TITLE
fix(nix): make pnpm dedup remove restored entries

### DIFF
--- a/nix/workspace-tools/lib/mk-pnpm-cli.nix
+++ b/nix/workspace-tools/lib/mk-pnpm-cli.nix
@@ -1062,10 +1062,12 @@ let
           ''
             ext_pnpm="workspace/${root.installDir}/node_modules/.pnpm"
             if [ -d "$ext_pnpm" ]; then
+              chmod u+w "$ext_pnpm" 2>/dev/null || true
               for entry in "$ext_pnpm"/*/; do
                 [ -d "$entry" ] || continue
                 entry_name="$(basename "$entry")"
                 if [ -d "$agg_pnpm/$entry_name" ] && [ ! -L "''${entry%/}" ]; then
+                  chmod -R u+w "''${entry%/}" 2>/dev/null || true
                   rm -rf "''${entry%/}"
                   ln -s "${relPrefix}/$entry_name" "''${entry%/}"
                   dedup_count=$((dedup_count + 1))


### PR DESCRIPTION
## Summary

Follow-up to #640: make the post-restore `.pnpm` dedup step chmod restored package directories before replacing duplicate external-root entries with symlinks to the aggregate root.

## Rationale

Prepared workspace restore intentionally preserves store-like read-only file modes. Dedup is the step that mutates restored `.pnpm` entries, so it must own the writable transition locally instead of depending on tar extraction modes or downstream builders.

## Validation

- `nixfmt nix/workspace-tools/lib/mk-pnpm-cli.nix`
- `git diff --check`
- Downstream dotfiles `discord-agent` build with #640 restored both install roots, then failed in dedup with `rm: cannot remove ... Permission denied`; this patch targets that exact mutation boundary.
