### PR TITLE
feat(pty-effect): honor PTY_SERVER_MODULE_PATH env override

### DIFF
--- a/packages/@overeng/pty-effect/src/client.ts
+++ b/packages/@overeng/pty-effect/src/client.ts
@@ -326,7 +326,23 @@ const withEnvOverrides = <A, E, R>({
   }).pipe(Effect.flatMap((saved) => effect.pipe(Effect.ensuring(restore(saved)))))
 }
 
-const resolvePtyServerModulePath = () => require.resolve('@myobie/pty/server')
+/**
+ * Locate `@myobie/pty/server` for the spawned daemon child.
+ *
+ * Honors `PTY_SERVER_MODULE_PATH` first so consumers can pin the path
+ * explicitly. This is required when the consumer is a single-file
+ * `bun build --compile` binary: `require.resolve('@myobie/pty/server')`
+ * inside the bundle returns a `bunfs:` path that the spawned `node`
+ * child can't read, so the spawn fails with
+ * `Cannot find module '@myobie/pty/server' from '/$bunfs/root/<bin>'`.
+ * The wrapper script around the bundle sets the env var to a real
+ * on-disk path materialized in `node_modules/@myobie/pty/dist/server.js`.
+ *
+ * TODO(upstream): push this env-var override into a future
+ * `@overeng/pty-effect` release so consumers don't need to patch.
+ */
+const resolvePtyServerModulePath = () =>
+  process.env['PTY_SERVER_MODULE_PATH'] ?? require.resolve('@myobie/pty/server')
 
 const spawnDaemonViaNode = (spec: PtyDaemonSpec) =>
   wrapPromise({


### PR DESCRIPTION
## Summary

\`spawnDaemonViaNode\` in \`@overeng/pty-effect\` resolves \`@myobie/pty/server\` via \`require.resolve()\` to find the script the daemon child runs. Inside a \`bun build --compile\` single-file binary, that returns a \`bunfs:\` path the spawned \`node\` child can't read, and the spawn fails with:

\`\`\`
Cannot find module '@myobie/pty/server' from '/\$bunfs/root/<bin>'
\`\`\`

Add a \`PTY_SERVER_MODULE_PATH\` env override that \`resolvePtyServerModulePath\` honors first, before falling back to \`require.resolve\`. Consumers that ship a bun-bundled binary (forge does) can wrap it with a small shell that exports the env to a real on-disk copy of \`node_modules/@myobie/pty/dist/server.js\`. No public API changes; existing consumers behave identically when the env isn't set.

## Verification

Verified end-to-end on dev3: forge built as a bun single-file binary, wrapped to set the env, was previously failing every \`workspace.create\` RPC at \`spawnDaemonViaNode\` and now spawns the daemon successfully.

## Stack

Downstream consumer (forge wrapper): https://github.com/schickling/dotfiles/pull/836

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🌸 cl2-glade |
| `agent_session_id` | 246b956a-0258-4209-8265-143eb77329b1 |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.121 |
| `agent_runtime` | Claude Code 2.1.121 |
| `agent_model` | claude-opus-4-7 |
| `worktree` | effect-utils/main |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->