### PR TITLE
Add Genie repo context helper

### DIFF
--- a/genie/external.ts
+++ b/genie/external.ts
@@ -10,6 +10,7 @@
 import {
   defineCatalog,
   definePatchedDependencies,
+  defineRepoContext,
   githubRuleset,
   githubWorkflow,
   megarepoJson,
@@ -29,6 +30,7 @@ import {
   type PatchesRegistry,
   type PnpmSettings,
   type PnpmWorkspaceData,
+  type RepoContext,
   type ScriptValue,
   type TSConfigArgs,
   type TSConfigCompilerOptions,
@@ -50,6 +52,7 @@ import type { PnpmPackageClosureConfig } from '../packages/@overeng/genie/src/ru
 export {
   defineCatalog,
   definePatchedDependencies,
+  defineRepoContext,
   githubRuleset,
   githubWorkflow,
   megarepoJson,
@@ -72,6 +75,7 @@ export type {
   PnpmPackageClosureConfig,
   PnpmSettings,
   PnpmWorkspaceData,
+  RepoContext,
   ScriptValue,
   TSConfigArgs,
   TSConfigCompilerOptions,

--- a/packages/@overeng/genie/src/runtime/mod.ts
+++ b/packages/@overeng/genie/src/runtime/mod.ts
@@ -7,6 +7,7 @@ export * from './json-artifact/mod.ts'
 export * from './megarepo-config/mod.ts'
 export * from './oxfmt-config/mod.ts'
 export * from './oxlint-config/mod.ts'
+export * from './repo-context/mod.ts'
 export {
   CatalogConflictError,
   OverrideConflictError,

--- a/packages/@overeng/genie/src/runtime/repo-context/mod.ts
+++ b/packages/@overeng/genie/src/runtime/repo-context/mod.ts
@@ -1,0 +1,79 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, isAbsolute, join, parse, sep } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+/** Repo-local file access anchored at the repository that owns a generator module. */
+export interface RepoContext {
+  readonly name: string
+  readonly rootPath: string
+  readonly resolve: (...segments: ReadonlyArray<string>) => string
+  readonly readText: (...segments: ReadonlyArray<string>) => string
+  readonly readJson: <A = unknown>(...segments: ReadonlyArray<string>) => A
+}
+
+/** Inputs for deriving a repository context from a module's `import.meta.url`. */
+export interface DefineRepoContextOptions {
+  readonly name: string
+  readonly importMetaUrl: string
+}
+
+const findRepoRoot = (startPath: string): string | undefined => {
+  let current = dirname(startPath)
+  const root = parse(current).root
+
+  while (true) {
+    if (existsSync(join(current, '.git')) === true) return current
+    if (current === root) return undefined
+    current = dirname(current)
+  }
+}
+
+const recoverOriginalModulePath = (mirroredPath: string): string | undefined => {
+  const parts = mirroredPath.split(sep).filter(Boolean)
+
+  for (let index = 1; index < parts.length; index++) {
+    const candidate = `${sep}${parts.slice(index).join(sep)}`
+    if (
+      isAbsolute(candidate) === true &&
+      existsSync(candidate) === true &&
+      findRepoRoot(candidate) !== undefined
+    ) {
+      return candidate
+    }
+  }
+
+  return undefined
+}
+
+/** Find the closest repository root above the module identified by `importMetaUrl`. */
+export const repoRootFromModuleUrl = (importMetaUrl: string): string => {
+  const modulePath = fileURLToPath(importMetaUrl)
+  const directRoot = findRepoRoot(modulePath)
+  if (directRoot !== undefined) return directRoot
+
+  const originalModulePath = recoverOriginalModulePath(modulePath)
+  if (originalModulePath !== undefined) {
+    const recoveredRoot = findRepoRoot(originalModulePath)
+    if (recoveredRoot !== undefined) return recoveredRoot
+  }
+
+  throw new Error(`Could not find repository root for module ${importMetaUrl}`)
+}
+
+/** Create a repo context for generator code that may run from aggregate megarepos. */
+export const defineRepoContext = ({
+  name,
+  importMetaUrl,
+}: DefineRepoContextOptions): RepoContext => {
+  const rootPath = repoRootFromModuleUrl(importMetaUrl)
+  const resolve = (...segments: ReadonlyArray<string>) => join(rootPath, ...segments)
+
+  return {
+    name,
+    rootPath,
+    resolve,
+    readText: (...segments) => readFileSync(resolve(...segments), 'utf8'),
+    readJson: <A = unknown>(...segments: ReadonlyArray<string>) =>
+      JSON.parse(readFileSync(resolve(...segments), 'utf8')) as A,
+  }
+}

--- a/packages/@overeng/genie/src/runtime/repo-context/repo-context.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/repo-context/repo-context.unit.test.ts
@@ -1,0 +1,60 @@
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+import { defineRepoContext, repoRootFromModuleUrl } from './mod.ts'
+
+const createRepoFixture = () => {
+  const root = mkdtempSync(join(tmpdir(), 'genie-repo-context-'))
+  mkdirSync(join(root, '.git'))
+  mkdirSync(join(root, 'genie'), { recursive: true })
+  mkdirSync(join(root, 'release'), { recursive: true })
+  writeFileSync(join(root, 'genie', 'repo.ts'), '')
+  writeFileSync(join(root, 'release', 'version.json'), JSON.stringify({ version: '1.2.3' }))
+  return { root, moduleUrl: pathToFileURL(join(root, 'genie', 'repo.ts')).href }
+}
+
+describe('repo context', () => {
+  it('finds the repository root from a generator module URL', () => {
+    const fixture = createRepoFixture()
+
+    expect(repoRootFromModuleUrl(fixture.moduleUrl)).toBe(fixture.root)
+  })
+
+  it('reads repo-local files independent of process cwd', () => {
+    const fixture = createRepoFixture()
+    const previousCwd = process.cwd()
+    process.chdir(tmpdir())
+    try {
+      const repo = defineRepoContext({
+        name: 'example',
+        importMetaUrl: fixture.moduleUrl,
+      })
+
+      expect(repo.name).toBe('example')
+      expect(repo.rootPath).toBe(fixture.root)
+      expect(repo.readJson<{ readonly version: string }>('release/version.json')).toEqual({
+        version: '1.2.3',
+      })
+    } finally {
+      process.chdir(previousCwd)
+    }
+  })
+
+  it('recovers the repo root from Genie temp import mirror paths', () => {
+    const fixture = createRepoFixture()
+    const mirroredModulePath = join(
+      mkdtempSync(join(tmpdir(), 'genie-import-')),
+      fixture.root.slice(1),
+      'genie',
+      'repo.ts',
+    )
+    mkdirSync(join(mirroredModulePath, '..'), { recursive: true })
+    writeFileSync(mirroredModulePath, '')
+
+    expect(repoRootFromModuleUrl(pathToFileURL(mirroredModulePath).href)).toBe(fixture.root)
+  })
+})


### PR DESCRIPTION
## Summary

- add `defineRepoContext` / `repoRootFromModuleUrl` for repo-local file access from Genie modules
- recover original repo paths for `/tmp/genie-import-*` mirrored module URLs
- export the helper through the Genie runtime surface

## Verification

- `CI=1 devenv tasks run test:genie lint:check:oxlint --mode before --no-tui --refresh-task-cache`

## Stack

- Upstream for the LiveStore PR that uses the helper from `genie/repo.ts`
- Downstream dotfiles PR will temporarily pin this branch until it lands on `main`

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🚢 co1-strait |
| `agent_session_id` | 49bf45e3-2392-4c41-83a2-8043f4dcc1d1 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.125.0 |
| `agent_runtime` | Codex CLI 0.125.0 |
| `agent_model` | unknown |
| `worktree` | effect-utils/schickling-assistant/2026-05-08-genie-repo-context |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->