### PR TITLE
Remove direnv and adopt devenv SecretSpec workflow

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,0 @@
-use devenv

--- a/.envrc.local.example
+++ b/.envrc.local.example
@@ -1,5 +1,0 @@
-# Notion Integration Test Environment
-# Copy this file to .envrc.local and fill in your values
-
-# Notion API Token (get from https://www.notion.so/my-integrations)
-export NOTION_TOKEN="secret_xxx"

--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,6 @@ node_modules
 dist
 
 # Direnv
-.direnv
-.envrc.*
 repos/
 
 # Devenv
@@ -45,3 +43,5 @@ blob-report
 # Devenv generated / internal
 /devenv-swift-git-hooks
 .pnpm-home
+
+devenv.local.*

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -15,7 +15,7 @@
     "**/.astro/**",
     "**/.nitro/**",
     "**/.tanstack/**",
-    "**/.direnv/**",
+    "**/.devenv/**",
     "**/tmp/**",
     "**/playwright-report/**",
     "**/test-results/**",

--- a/context/wishlist.md
+++ b/context/wishlist.md
@@ -2,6 +2,6 @@
 
 ## Tooling
 
-- [ ] Otel support for nix builds
+- [x] Otel support for nix builds
 - [ ] local, fast, self-contained otel stack
-- [ ] direnv built into devenv https://github.com/cachix/devenv/issues/2061
+- [ ] devenv native auto-activation https://github.com/cachix/devenv/issues/2061

--- a/context/workarounds/devenv-issues.md
+++ b/context/workarounds/devenv-issues.md
@@ -233,7 +233,7 @@ Git hooks run in a subprocess that doesn't inherit the direnv environment.
 **Potential fixes:**
 
 - Use an absolute Nix store path for `dt` in the hook entry (like beads does)
-- Wrap the hook entry to source direnv: `direnv exec . dt check:quick`
+- Use `devenv shell -- dt check:quick` when a hook or agent runs outside an already-activated shell.
 - Use a wrapper script that resolves `dt` from the devenv profile
 
 **Current workaround:** Use `--no-verify` when committing from Claude Code

--- a/devenv.nix
+++ b/devenv.nix
@@ -39,6 +39,7 @@ let
     pnpm = import ./nix/devenv-modules/tasks/shared/pnpm.nix;
     megarepo = import ./nix/devenv-modules/tasks/shared/megarepo.nix;
     nix-cli = import ./nix/devenv-modules/tasks/shared/nix-cli.nix;
+    secretspec = import ./nix/devenv-modules/tasks/shared/secretspec.nix;
     context = ./nix/devenv-modules/tasks/shared/context.nix;
   };
   # Use bun source entrypoints for in-repo CLIs in devenv (flake builds stay strict).
@@ -360,6 +361,7 @@ in
     })
     # Nix CLI build and hash management
     (taskModules.nix-cli { cliPackages = nixCliPackages; })
+    (taskModules.secretspec { })
     # Local task: Validate allPackages matches filesystem packages (effect-utils specific)
     ./nix/devenv-modules/tasks/local/workspace-check.nix
     # Notion integration tests (requires NOTION_TOKEN)

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,3 +1,4 @@
+require_version: ">=2.1"
 inputs:
   devenv:
     url: github:cachix/devenv/v2.1

--- a/flake.nix
+++ b/flake.nix
@@ -175,6 +175,7 @@
           bun = import ./nix/devenv-modules/tasks/shared/bun.nix;
           pnpm = import ./nix/devenv-modules/tasks/shared/pnpm.nix;
           nix-cli = import ./nix/devenv-modules/tasks/shared/nix-cli.nix;
+          secretspec = import ./nix/devenv-modules/tasks/shared/secretspec.nix;
           # Prevent commits on default branch and optionally enforce worktree-only workflow
           worktree-guard = import ./nix/devenv-modules/tasks/shared/worktree-guard.nix;
           # Note: local/ directory contains effect-utils specific tasks (not exported)

--- a/genie/oxlint-base.ts
+++ b/genie/oxlint-base.ts
@@ -23,7 +23,7 @@ export const baseOxlintIgnorePatterns = [
   '**/.astro/**',
   '**/.nitro/**',
   '**/.tanstack/**',
-  '**/.direnv/**',
+  '**/.devenv/**',
   '**/tmp/**',
   '**/playwright-report/**',
   '**/test-results/**',

--- a/megarepo.lock
+++ b/megarepo.lock
@@ -4,9 +4,9 @@
     "effect": {
       "url": "https://github.com/effect-ts/effect",
       "ref": "main",
-      "commit": "39c934c1476be389f7469433910fdf30fc4dad82",
+      "commit": "3585f25110fca7af6aeec3f59c3fc05b20c8d316",
       "pinned": false,
-      "lockedAt": "2026-04-23T08:46:53.308Z"
+      "lockedAt": "2026-05-10T03:09:13.625Z"
     }
   }
 }

--- a/nix/devenv-modules/otel.nix
+++ b/nix/devenv-modules/otel.nix
@@ -441,9 +441,9 @@ let
     detect_otel_shell_entry_state() {
       # Detect cold vs warm start (setup-git-hash written by setup.nix)
       _cold_start="false"
-      if [ ! -f .direnv/task-cache/setup-git-hash ]; then
+      if [ ! -f .devenv/task-cache/setup-git-hash ]; then
         _cold_start="true"
-      elif [ "$(git rev-parse HEAD 2>/dev/null || echo no-git)" != "$(cat .direnv/task-cache/setup-git-hash 2>/dev/null || echo "")" ]; then
+      elif [ "$(git rev-parse HEAD 2>/dev/null || echo no-git)" != "$(cat .devenv/task-cache/setup-git-hash 2>/dev/null || echo "")" ]; then
         _cold_start="true"
       fi
 
@@ -453,7 +453,7 @@ let
       # Missing paths are tolerated here because input files can legitimately
       # disappear between eval and shell startup while the user is editing.
       _reload_trigger="unknown"
-      _otel_mtime_snapshot=".direnv/otel-watch-mtimes"
+      _otel_mtime_snapshot=".devenv/otel-watch-mtimes"
       if [ -f ".devenv/input-paths.txt" ]; then
         _otel_current=$(
           while IFS= read -r _otel_path; do
@@ -476,7 +476,7 @@ let
           )
           _reload_trigger="''${_otel_changed:-unknown}"
         fi
-        ${pkgs.coreutils}/bin/mkdir -p .direnv
+        ${pkgs.coreutils}/bin/mkdir -p .devenv
         echo "$_otel_current" > "$_otel_mtime_snapshot"
       fi
     }
@@ -862,7 +862,7 @@ in
       # ambient PATH, so the shell-entry task works before GNU tools are added.
       _test_shell_entry_state_without_path() {
         local workdir="$_tmp/shell-entry-state-no-path"
-        mkdir -p "$workdir/.devenv" "$workdir/.direnv"
+        mkdir -p "$workdir/.devenv"
         echo "$workdir/foo.nix" > "$workdir/.devenv/input-paths.txt"
         echo "x = 1;" > "$workdir/foo.nix"
 
@@ -872,7 +872,7 @@ in
           detect_otel_shell_entry_state
           [ "$_cold_start" = "true" ] || return 1
           [ "$_reload_trigger" = "initial" ] || return 1
-          [ -f ".direnv/otel-watch-mtimes" ] || return 1
+          [ -f ".devenv/otel-watch-mtimes" ] || return 1
         )
       }
       _check "shell-entry state detection without PATH" _test_shell_entry_state_without_path
@@ -881,7 +881,7 @@ in
       # between eval and shell startup instead of failing the shell-entry task.
       _test_shell_entry_state_missing_paths() {
         local workdir="$_tmp/shell-entry-state-missing-paths"
-        mkdir -p "$workdir/.devenv" "$workdir/.direnv"
+        mkdir -p "$workdir/.devenv"
         echo "$workdir/foo.nix" > "$workdir/.devenv/input-paths.txt"
         echo "$workdir/missing.nix" >> "$workdir/.devenv/input-paths.txt"
         echo "x = 1;" > "$workdir/foo.nix"
@@ -891,7 +891,7 @@ in
           export PATH="/nonexistent"
           detect_otel_shell_entry_state
           [ "$_reload_trigger" = "initial" ] || return 1
-          [ -f ".direnv/otel-watch-mtimes" ] || return 1
+          [ -f ".devenv/otel-watch-mtimes" ] || return 1
         )
       }
       _check "shell-entry state detection with missing paths" _test_shell_entry_state_missing_paths

--- a/nix/devenv-modules/tasks/lib/cache.nix
+++ b/nix/devenv-modules/tasks/lib/cache.nix
@@ -1,7 +1,7 @@
 # Task cache helpers
 #
 # Shared caching rules:
-# - Cache root: ${config.devenv.root}/.direnv/task-cache
+# - Cache root: ${config.devenv.root}/.devenv/task-cache
 # - Cache files are plain text fingerprints (git SHA, content hashes, etc).
 # - Updates must be atomic (temp file + rename) to avoid partial writes.
 # - Callers set `cache_value` before using `writeCacheFile`.
@@ -13,7 +13,7 @@
 # - Cache files stay local and disposable; correctness never depends on them.
 { config }:
 let
-  cacheRoot = "${config.devenv.root}/.direnv/task-cache";
+  cacheRoot = "${config.devenv.root}/.devenv/task-cache";
   mkCachePath = subPath: "${cacheRoot}/${subPath}";
   writeCacheFile = pathExpr: ''
     tmp_file="$(mktemp)"

--- a/nix/devenv-modules/tasks/shared/genie.nix
+++ b/nix/devenv-modules/tasks/shared/genie.nix
@@ -19,7 +19,7 @@ let
   genieTaskEnv = lib.optionalAttrs (megarepoStoreEnv != "") {
     MEGAREPO_STORE = megarepoStoreEnv;
   };
-  cacheRoot = ".direnv/task-cache/genie-run";
+  cacheRoot = ".devenv/task-cache/genie-run";
   stateFile = "${cacheRoot}/state.hash";
   generatedFilesFile = "${cacheRoot}/generated-files.txt";
   collectGenieGeneratedFiles = ''
@@ -29,7 +29,6 @@ let
       ${pkgs.ripgrep}/bin/rg -l \
         --glob '!tmp/**' \
         --glob '!.git/**' \
-        --glob '!.direnv/**' \
         --glob '!.devenv/**' \
         --glob '!node_modules/**' \
         '^// Source: .*\.genie\.ts|^# Source: .*\.genie\.ts' . || true
@@ -49,7 +48,6 @@ let
           -type f \
           -name '*.genie.ts' \
           -not -path './.git/*' \
-          -not -path './.direnv/*' \
           -not -path './.devenv/*' \
           -not -path './node_modules/*' \
           -print

--- a/nix/devenv-modules/tasks/shared/megarepo.nix
+++ b/nix/devenv-modules/tasks/shared/megarepo.nix
@@ -33,7 +33,7 @@ let
   bootstrapOnlyArgs = lib.concatMapStringsSep " " (
     member: "--only ${lib.escapeShellArg member}"
   ) bootstrapMembers;
-  cacheRoot = ".direnv/task-cache/mr-apply";
+  cacheRoot = ".devenv/task-cache/mr-apply";
   membersFile = "${cacheRoot}/members.txt";
   recordWorkspaceMembers = ''
     set -o pipefail

--- a/nix/devenv-modules/tasks/shared/netlify.nix
+++ b/nix/devenv-modules/tasks/shared/netlify.nix
@@ -60,7 +60,7 @@ let
         ${deployTask.mkRequiredEnvCheck {
           envName = "NETLIFY_AUTH_TOKEN";
           errorMessage = "Error: NETLIFY_AUTH_TOKEN is not set.";
-          hint = "Set it via: export NETLIFY_AUTH_TOKEN=$(op read 'op://...')";
+          hint = "Run through: secrets-run --reason 'deploy Netlify preview' -- dt netlify:deploy:<target>";
         }}
 
         deploy_dir="${pkg.path}/storybook-static"

--- a/nix/devenv-modules/tasks/shared/pnpm-task-helpers.sh
+++ b/nix/devenv-modules/tasks/shared/pnpm-task-helpers.sh
@@ -22,7 +22,6 @@ emit_dir_state() {
   find "$dir" \
     \( \
       -name .git -o \
-      -name .direnv -o \
       -name .devenv -o \
       -name .turbo -o \
       -name .cache -o \

--- a/nix/devenv-modules/tasks/shared/pnpm.nix
+++ b/nix/devenv-modules/tasks/shared/pnpm.nix
@@ -47,10 +47,10 @@ let
     if workspaceRoot == "." then config.devenv.root else "${config.devenv.root}/${workspaceRoot}";
   defaultPnpmHome =
     if workspaceRoot == "." then
-      "${config.devenv.root}/.direnv/pnpm-home"
+      "${config.devenv.root}/.devenv/pnpm-home"
     else
-      "${config.devenv.root}/.direnv/pnpm-home/${workspaceCacheName}";
-  defaultPnpmStoreDir = "${config.devenv.root}/.direnv/pnpm-store";
+      "${config.devenv.root}/.devenv/pnpm-home/${workspaceCacheName}";
+  defaultPnpmStoreDir = "${config.devenv.root}/.devenv/pnpm-store";
   installTaskName =
     if taskSuffix == null then
       "${taskNamePrefix}:install"
@@ -504,7 +504,7 @@ in
   packages = cliGuard.fromTasks allTasks;
 
   enterShell = lib.mkIf (globalCache && workspaceRoot == ".") ''
-    export PNPM_HOME="''${PNPM_HOME:-${config.devenv.root}/.direnv/pnpm-home}"
+    export PNPM_HOME="''${PNPM_HOME:-${config.devenv.root}/.devenv/pnpm-home}"
     export PNPM_STORE_DIR="''${PNPM_STORE_DIR:-${defaultPnpmStoreDir}}"
     export npm_config_store_dir="''${npm_config_store_dir:-$PNPM_STORE_DIR}"
     export npm_config_cache="$HOME/.cache/pnpm"

--- a/nix/devenv-modules/tasks/shared/secretspec.nix
+++ b/nix/devenv-modules/tasks/shared/secretspec.nix
@@ -1,0 +1,159 @@
+# SecretSpec tasks and op-proxy-backed runtime injection.
+#
+# Repos commit a `secretspec.toml` with standard SecretSpec declarations.
+# Optional `[x-op-proxy.refs]` entries map env names to `op://...` references for
+# local development without using raw `op` or plaintext dotenv files.
+{
+  file ? "secretspec.toml",
+}:
+{ lib, pkgs, ... }:
+let
+  secretspec = "${pkgs.secretspec}/bin/secretspec";
+  escapedFile = lib.escapeShellArg file;
+  secretsRun = pkgs.writeShellApplication {
+    name = "secrets-run";
+    runtimeInputs = [
+      pkgs.gawk
+      pkgs.secretspec
+    ];
+    text = ''
+      set -euo pipefail
+
+      secrets_file=""
+      profile_args=()
+      reason="run command with repo secrets"
+      cache="1d"
+
+      usage() {
+        cat >&2 <<'EOF'
+      Usage: secrets-run [--file secretspec.toml] [--profile name] [--reason text] [--cache ttl] -- command [args...]
+
+      Loads missing variables declared in [x-op-proxy.refs] via op-proxy, then
+      runs the command through `secretspec run --provider env`.
+      EOF
+      }
+
+      while [ "$#" -gt 0 ]; do
+        case "$1" in
+          -f|--file)
+            secrets_file="''${2:-}"
+            shift 2
+            ;;
+          -P|--profile)
+            profile_args+=(--profile "''${2:-}")
+            shift 2
+            ;;
+          --reason)
+            reason="''${2:-}"
+            shift 2
+            ;;
+          --cache)
+            cache="''${2:-}"
+            shift 2
+            ;;
+          --)
+            shift
+            break
+            ;;
+          -h|--help)
+            usage
+            exit 0
+            ;;
+          -*)
+            echo "Unknown option: $1" >&2
+            usage
+            exit 2
+            ;;
+          *)
+            break
+            ;;
+        esac
+      done
+
+      if [ "$#" -eq 0 ]; then
+        usage
+        exit 2
+      fi
+
+      if [ -z "$secrets_file" ]; then
+        dir="$PWD"
+        while true; do
+          if [ -f "$dir/secretspec.toml" ]; then
+            secrets_file="$dir/secretspec.toml"
+            break
+          fi
+          if [ "$dir" = "/" ]; then
+            echo "No secretspec.toml found; pass --file explicitly." >&2
+            exit 1
+          fi
+          dir="$(dirname "$dir")"
+        done
+      fi
+
+      refs="$(gawk '
+        /^\[x-op-proxy\.refs\][[:space:]]*$/ { in_refs = 1; next }
+        /^\[/ { in_refs = 0 }
+        in_refs && /^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*[[:space:]]*=/ {
+          key = $0
+          sub(/^[[:space:]]*/, "", key)
+          sub(/[[:space:]]*=.*/, "", key)
+          value = $0
+          sub(/^[^=]*=[[:space:]]*"/, "", value)
+          sub(/"[[:space:]]*(#.*)?$/, "", value)
+          if (value ~ /^op:\/\//) {
+            printf "%s\t%s\n", key, value
+          }
+        }
+      ' "$secrets_file")"
+
+      if [ -n "$refs" ]; then
+        while IFS="$(printf '\t')" read -r name ref; do
+          [ -n "$name" ] || continue
+          if [ -n "''${!name:-}" ]; then
+            continue
+          fi
+          if ! command -v op-proxy >/dev/null 2>&1; then
+            echo "op-proxy is required to resolve missing [x-op-proxy.refs] entry: $name" >&2
+            exit 1
+          fi
+          value="$(op-proxy read "$ref" --reason "$reason" --cache "$cache")"
+          export "$name=$value"
+        done <<< "$refs"
+      fi
+
+      exec secretspec -f "$secrets_file" run --provider env "''${profile_args[@]}" -- "$@"
+    '';
+  };
+in
+{
+  packages = [
+    pkgs.secretspec
+    secretsRun
+  ];
+
+  tasks = {
+    "secrets:check" = {
+      description = "Check required secrets against the current process environment";
+      exec = ''
+        set -euo pipefail
+        if [ ! -f ${escapedFile} ]; then
+          echo "No ${file}; nothing to check."
+          exit 0
+        fi
+        ${secretspec} -f ${escapedFile} check --provider env --no-prompt
+      '';
+    };
+
+    "secrets:prefetch" = {
+      description = "Resolve op-proxy-backed secrets into the op-proxy cache";
+      exec = ''
+        set -euo pipefail
+        if [ ! -f ${escapedFile} ]; then
+          echo "No ${file}; nothing to prefetch."
+          exit 0
+        fi
+        secrets-run --file ${escapedFile} --reason "prefetch repo secrets" -- true
+      '';
+    };
+  };
+}

--- a/nix/devenv-modules/tasks/shared/tests/pnpm-task-smoke.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/pnpm-task-smoke.test.sh
@@ -109,7 +109,7 @@ tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
 
 workspace="$tmpdir/workspace"
-mkdir -p "$workspace/.direnv/task-cache" "$workspace/.pnpm-home-a/store/v11" "$workspace/.pnpm-home-b/store/v11" "$tmpdir/bin" "$workspace/packages/demo/node_modules/.bin" "$workspace/nested/pkg"
+mkdir -p "$workspace/.devenv/task-cache" "$workspace/.pnpm-home-a/store/v11" "$workspace/.pnpm-home-b/store/v11" "$tmpdir/bin" "$workspace/packages/demo/node_modules/.bin" "$workspace/nested/pkg"
 
 cat > "$workspace/package.json" <<'EOF'
 {"name":"smoke-workspace","private":true}
@@ -275,14 +275,14 @@ echo "Test 2: exec runs fake pnpm and populates cache"
   export PNPM_HOME="$workspace/.pnpm-home-a"
   : > "$tmpdir/flock.log"
   bash "$tmpdir/pnpm-install.exec.sh"
-  test -f "$workspace/.direnv/task-cache/pnpm-install/install-state.hash"
-  test -f "$workspace/.direnv/task-cache/pnpm-install/projection-state.hash"
+  test -f "$workspace/.devenv/task-cache/pnpm-install/install-state.hash"
+  test -f "$workspace/.devenv/task-cache/pnpm-install/projection-state.hash"
   test -d "$workspace/node_modules"
   test -f "$workspace/node_modules/.modules.yaml"
   grep -qxF "flock -w 600 200" "$tmpdir/flock.log"
   grep -qxF "flock -w 600 201" "$tmpdir/flock.log"
   grep -qxF "flock -w 600 202" "$tmpdir/flock.log"
-  grep -qxF "install --config.confirmModulesPurge=false --config.store-dir=$workspace/.direnv/pnpm-store --force" "$tmpdir/pnpm.log"
+  grep -qxF "install --config.confirmModulesPurge=false --config.store-dir=$workspace/.devenv/pnpm-store --force" "$tmpdir/pnpm.log"
   grep -qF ".effect-utils-pnpm-install.lock" "$tmpdir/pnpm-install.exec.sh"
   grep -qF ".effect-utils-pnpm-store.lock" "$tmpdir/pnpm-install.exec.sh"
 )
@@ -347,9 +347,9 @@ echo "Test 7: exec defaults PNPM_HOME to a workspace-local projection"
   unset PNPM_HOME
   : > "$tmpdir/pnpm.log"
   bash "$tmpdir/pnpm-install.exec.sh"
-  grep -qxF "PNPM_HOME=$workspace/.direnv/pnpm-home" "$tmpdir/pnpm.log"
-  grep -qxF "PNPM_STORE_DIR=$workspace/.direnv/pnpm-store" "$tmpdir/pnpm.log"
-  grep -qxF "npm_config_store_dir=$workspace/.direnv/pnpm-store" "$tmpdir/pnpm.log"
+  grep -qxF "PNPM_HOME=$workspace/.devenv/pnpm-home" "$tmpdir/pnpm.log"
+  grep -qxF "PNPM_STORE_DIR=$workspace/.devenv/pnpm-store" "$tmpdir/pnpm.log"
+  grep -qxF "npm_config_store_dir=$workspace/.devenv/pnpm-store" "$tmpdir/pnpm.log"
 )
 
 echo "Test 8: status hits after install with the default GVS path"
@@ -418,12 +418,12 @@ echo "Test 13: nested workspace exec uses its own cwd, cache, PNPM_HOME, and sha
   unset npm_config_store_dir
   : > "$tmpdir/pnpm.log"
   bash "$tmpdir/pnpm-install-nested.exec.sh"
-  test -f "$workspace/.direnv/task-cache/pnpm-install/nested/install-state.hash"
+  test -f "$workspace/.devenv/task-cache/pnpm-install/nested/install-state.hash"
   test -d "$workspace/nested/node_modules"
   grep -qxF "PWD=$workspace/nested" "$tmpdir/pnpm.log"
-  grep -qxF "PNPM_HOME=$workspace/.direnv/pnpm-home/nested" "$tmpdir/pnpm.log"
-  grep -qxF "PNPM_STORE_DIR=$workspace/.direnv/pnpm-store" "$tmpdir/pnpm.log"
-  grep -qxF "npm_config_store_dir=$workspace/.direnv/pnpm-store" "$tmpdir/pnpm.log"
+  grep -qxF "PNPM_HOME=$workspace/.devenv/pnpm-home/nested" "$tmpdir/pnpm.log"
+  grep -qxF "PNPM_STORE_DIR=$workspace/.devenv/pnpm-store" "$tmpdir/pnpm.log"
+  grep -qxF "npm_config_store_dir=$workspace/.devenv/pnpm-store" "$tmpdir/pnpm.log"
 )
 
 echo "Test 14: nested workspace status hits after nested install"
@@ -451,7 +451,7 @@ echo "Test 15: install flags and pre-install hooks are applied"
   : > "$tmpdir/pnpm.log"
   bash "$tmpdir/pnpm-install-flags.exec.sh"
   test -f .preinstall-marker
-  grep -qxF "install --config.confirmModulesPurge=false --config.store-dir=$workspace/.direnv/pnpm-store --ignore-scripts --config.public-hoist-pattern=*" "$tmpdir/pnpm.log"
+  grep -qxF "install --config.confirmModulesPurge=false --config.store-dir=$workspace/.devenv/pnpm-store --ignore-scripts --config.public-hoist-pattern=*" "$tmpdir/pnpm.log"
 )
 
 echo "Test 16: CI install failures preserve and classify the pnpm log"
@@ -464,7 +464,7 @@ echo "Test 16: CI install failures preserve and classify the pnpm log"
   unset PNPM_HOME
   unset PNPM_STORE_DIR
   unset npm_config_store_dir
-  rm -f "$workspace/.direnv/task-cache/pnpm-install/install-state.hash"
+  rm -f "$workspace/.devenv/task-cache/pnpm-install/install-state.hash"
   set +e
   output="$(bash "$tmpdir/pnpm-install.exec.sh" 2>&1)"
   exit_code=$?
@@ -495,10 +495,10 @@ echo "Test 18: generated storybook task runs storybook without pnpm exec"
 echo "Test 19: clean leaves shared GVS links intact"
 (
   cd "$workspace"
-  mkdir -p "$workspace/.direnv/pnpm-store/v11/links/shared-pkg"
+  mkdir -p "$workspace/.devenv/pnpm-store/v11/links/shared-pkg"
   mkdir -p "$workspace/node_modules" "$workspace/packages/demo/node_modules"
   bash "$tmpdir/pnpm-clean.exec.sh"
-  test -d "$workspace/.direnv/pnpm-store/v11/links/shared-pkg"
+  test -d "$workspace/.devenv/pnpm-store/v11/links/shared-pkg"
   test ! -e "$workspace/node_modules"
   test ! -e "$workspace/packages/demo/node_modules"
 )

--- a/nix/devenv-modules/tasks/shared/tests/setup-cache.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/setup-cache.test.sh
@@ -61,7 +61,7 @@ echo ""
 test_dir=$(mktemp -d)
 trap 'rm -rf "$test_dir"' EXIT
 
-cache_root="$test_dir/.direnv/task-cache"
+cache_root="$test_dir/.devenv/task-cache"
 fingerprint_file="$cache_root/setup-fingerprint"
 
 mkdir -p "$cache_root"

--- a/nix/devenv-modules/tasks/shared/vercel.nix
+++ b/nix/devenv-modules/tasks/shared/vercel.nix
@@ -64,7 +64,7 @@ let
       ${deployTask.mkRequiredEnvCheck {
         envName = "VERCEL_TOKEN";
         errorMessage = "Error: VERCEL_TOKEN is not set.";
-        hint = "Set it via: export VERCEL_TOKEN=$(op read 'op://...')";
+        hint = "Run through: secrets-run --reason 'deploy Vercel preview' -- dt vercel:deploy:<target>";
       }}
       ${deployTask.mkRequiredEnvCheck {
         envName = orgIdEnv;

--- a/nix/oxc-config-plugin.nix
+++ b/nix/oxc-config-plugin.nix
@@ -106,7 +106,6 @@ let
 
   sourceExclusions = [
     ".git"
-    ".direnv"
     ".devenv"
     ".cache"
     ".turbo"

--- a/nix/oxlint-npm.nix
+++ b/nix/oxlint-npm.nix
@@ -22,7 +22,7 @@
 #
 # 2. Update `version` below to the new version number
 #
-# 3. Calculate new hashes (run in /tmp to avoid direnv issues):
+# 3. Calculate new hashes (run in /tmp to avoid devenv cache issues):
 #    cd /tmp
 #    VERSION=1.39.0  # <-- set to new version
 #
@@ -40,7 +40,7 @@
 # 4. Update hashes in this file (mainPackage.hash and platformPackages.*.hash)
 #
 # 5. Reload devenv and verify:
-#    direnv reload
+#    rm -rf .devenv
 #    oxlint --version
 #    mono lint  # should show "WARNING: JS plugins are experimental..."
 #

--- a/nix/workspace-tools/lib/mk-bun-cli/source.nix
+++ b/nix/workspace-tools/lib/mk-bun-cli/source.nix
@@ -29,8 +29,8 @@ let
   # Keep the staged workspace lean (skip caches, outputs, and node_modules).
   defaultExcludedSourceNames = [
     ".git"
-    ".direnv"
     ".devenv"
+    ".direnv"
     ".cache"
     ".turbo"
     ".next"

--- a/nix/workspace-tools/lib/mk-bun-cli/tests/run.sh
+++ b/nix/workspace-tools/lib/mk-bun-cli/tests/run.sh
@@ -117,8 +117,8 @@ copy_repo() {
   local dest="$2"
   local excludes=(
     ".git"
-    ".direnv"
     ".devenv"
+    ".direnv"
     ".cache"
     ".turbo"
     ".next"

--- a/nix/workspace-tools/lib/mk-pnpm-cli.nix
+++ b/nix/workspace-tools/lib/mk-pnpm-cli.nix
@@ -304,7 +304,7 @@ let
       name = baseNameOf path;
     in
     !(builtins.elem name [
-      ".direnv"
+      ".devenv"
       ".git"
       "node_modules"
     ])

--- a/nix/workspace-tools/lib/mk-pnpm-cli/tests/fixtures/downstream/.gitignore
+++ b/nix/workspace-tools/lib/mk-pnpm-cli/tests/fixtures/downstream/.gitignore
@@ -1,2 +1,2 @@
 result
-.direnv
+.devenv

--- a/nix/workspace-tools/lib/mk-pnpm-cli/tests/run.sh
+++ b/nix/workspace-tools/lib/mk-pnpm-cli/tests/run.sh
@@ -107,7 +107,6 @@ copy_repo() {
   local dest="$2"
   local excludes=(
     ".git"
-    ".direnv"
     ".devenv"
     ".cache"
     ".turbo"

--- a/packages/@overeng/genie/src/core/discovery.ts
+++ b/packages/@overeng/genie/src/core/discovery.ts
@@ -92,7 +92,7 @@ export const ensureImportMapResolver = Effect.sync(() => {
 const shouldSkipDirectory = (name: string): boolean => {
   if (name === 'node_modules' || name === 'dist' || name === 'tmp') return true
   if (name === '.pnpm' || name === '.pnpm-store' || name === '.pnpm-home') return true
-  if (name === '.git' || name === '.devenv' || name === '.direnv') return true
+  if (name === '.git' || name === '.devenv') return true
   // Megarepo member root (symlinked peer repos).
   if (name === 'repos') return true
   // Nix build output symlink (points to /nix/store/...)

--- a/packages/@overeng/genie/src/core/workspace.ts
+++ b/packages/@overeng/genie/src/core/workspace.ts
@@ -10,7 +10,6 @@ const DEFAULT_SKIP_DIRS = new Set([
   '.pnpm',
   '.pnpm-store',
   '.git',
-  '.direnv',
   '.devenv',
   'dist',
   'tmp',

--- a/packages/@overeng/genie/src/runtime/megarepo-config/mod.ts
+++ b/packages/@overeng/genie/src/runtime/megarepo-config/mod.ts
@@ -54,7 +54,7 @@ export type VscodeGeneratorConfig = {
    * Environment variable name to read the workspace color from at generation time.
    * This allows per-worktree colors without changing megarepo.json.
    *
-   * Example: Set `colorEnvVar: "MEGAREPO_COLOR"` in config, then in .envrc.local:
+   * Example: Set `colorEnvVar: "MEGAREPO_COLOR"` in config, then in devenv.local.nix:
    *   export MEGAREPO_COLOR="#372d8e"
    *
    * Takes precedence over the `color` field if both are set.

--- a/packages/@overeng/megarepo/docs/integrations/nix.md
+++ b/packages/@overeng/megarepo/docs/integrations/nix.md
@@ -69,9 +69,9 @@ Using GitHub URLs ensures:
 2. Portable across local dev and CI
 3. Explicit versioning via git refs
 
-## Local Development Override Pattern
+## Local Development
 
-You can use GitHub URLs in `devenv.yaml` for CI compatibility while overriding inputs locally via `.envrc` for development:
+Use GitHub URLs in `devenv.yaml` for standalone and CI compatibility. For local cross-repo iteration, compose the repos with megarepo and let lock sync move the consumer lock files to the sibling member commits.
 
 ### 1. devenv.yaml (committed, CI-compatible)
 
@@ -81,36 +81,33 @@ inputs:
     url: github:overengineeringstudio/effect-utils?dir=nix/playwright-flake
 ```
 
-### 2. .envrc (local only, gitignored)
+### 2. Megarepo lock sync
 
 ```bash
-# Override flake inputs for local development
-export DEVENV_NIX_FLAGS="--override-input playwright path:$(pwd)/repos/effect-utils/nix/playwright-flake"
+mr apply --all
+# edit repos/effect-utils
+mr lock --all
 ```
 
 This pattern gives you:
 
 - **CI**: Uses GitHub URL (works without symlinks)
-- **Local dev**: Uses resolved local path (live updates)
+- **Local dev**: Uses the composed sibling commit recorded in `megarepo.lock`
 
 ### Notes
 
-- The `$(pwd)` resolves to an absolute path, bypassing the symlink issue
-- Add `.envrc` to `.gitignore` to keep overrides local
-- You can override multiple inputs by chaining flags:
-  ```bash
-  export DEVENV_NIX_FLAGS="--override-input foo path:... --override-input bar path:..."
-  ```
+- Do not use per-shell `--override-input` for normal megarepo iteration.
+- `devenv shell` should evaluate from checked-in lock files, so shell entry does not secretly change dependency identity.
 
 ## Trade-offs
 
-| Approach                     | Pros                                  | Cons                              |
-| ---------------------------- | ------------------------------------- | --------------------------------- |
-| GitHub URL                   | Works everywhere, explicit versioning | Can't test local changes directly |
-| GitHub URL + .envrc override | Best of both worlds                   | Requires local .envrc setup       |
-| Local path                   | Live updates during dev               | Fails through megarepo symlinks   |
+| Approach               | Pros                                  | Cons                              |
+| ---------------------- | ------------------------------------- | --------------------------------- |
+| GitHub URL             | Works everywhere, explicit versioning | Can't test local changes directly |
+| GitHub URL + lock sync | Local iteration with CI parity        | Requires composing the megarepo   |
+| Local path             | Live updates during dev               | Fails through megarepo symlinks   |
 
-For flakes you're actively developing, use the `.envrc` override pattern or keep them in the same repo.
+For flakes you're actively developing, use megarepo lock sync or keep them in the same repo.
 
 ## Nix Lock Sync
 

--- a/packages/@overeng/megarepo/docs/spec.md
+++ b/packages/@overeng/megarepo/docs/spec.md
@@ -823,7 +823,6 @@ my-megarepo/                    # Git repo (the megarepo itself)
 ├── megarepo.kdl
 ├── megarepo.lock               # Committed for CI reproducibility
 ├── devenv.nix                  # Devenv configuration
-├── .envrc                      # Simple: use devenv
 └── repos/
     ├── effect -> ~/.megarepo/github.com/effect-ts/effect/refs/heads/main/
     ├── local-lib/              # Local path: actual directory, not symlink
@@ -999,16 +998,13 @@ After a lock-writing or lock-applying command, the flake.lock will be updated to
 
 ## Shell Integration
 
-### With direnv (recommended)
+### With devenv hook
 
-Use devenv for shell integration:
+Use devenv 2.1+ native auto-activation for shell integration:
 
 ```bash
-# .envrc
-source_env_if_exists .envrc.local
-if has devenv && test -f devenv.nix; then
-    use devenv
-fi
+devenv hook fish | source
+devenv allow
 ```
 
 ### Manual

--- a/packages/@overeng/megarepo/src/cli/components/LogLine.stories.tsx
+++ b/packages/@overeng/megarepo/src/cli/components/LogLine.stories.tsx
@@ -68,7 +68,7 @@ export const InfoLogs: Story = {
         <Box flexDirection="column">
           <LogLine type="info" message="Syncing livestore from github.com/livestore/livestore" />
           <LogLine type="info" message="Generated flake.nix" />
-          <LogLine type="info" message="Generated .envrc" />
+          <LogLine type="info" message="Generated workspace" />
         </Box>
       )}
       initialState={null}

--- a/packages/@overeng/megarepo/src/cli/renderers/SyncOutput/stories/fetch/Results.stories.tsx
+++ b/packages/@overeng/megarepo/src/cli/renderers/SyncOutput/stories/fetch/Results.stories.tsx
@@ -78,7 +78,7 @@ const MixedResultsRender = (args: StoryArgs) => {
       results: exampleSyncResults,
       members: exampleSyncResults.map((r) => r.name),
       nestedMegarepos: [MEMBERS.devTools],
-      generatedFiles: ['flake.nix', '.envrc'],
+      generatedFiles: ['flake.nix'],
     }),
     [args.dryRun, args.all, args.verbose, args.force],
   )

--- a/packages/@overeng/megarepo/src/lib/config.ts
+++ b/packages/@overeng/megarepo/src/lib/config.ts
@@ -78,7 +78,7 @@ export class VscodeGeneratorConfig extends Schema.Class<VscodeGeneratorConfig>(
    * Environment variable name to read the workspace color from at generation time.
    * This allows per-worktree colors without changing megarepo.json.
    *
-   * Example: Set `colorEnvVar: "MEGAREPO_COLOR"` in config, then in .envrc.local:
+   * Example: Set `colorEnvVar: "MEGAREPO_COLOR"` in config, then in the shell:
    *   export MEGAREPO_COLOR="#372d8e"
    *
    * Takes precedence over the `color` field if both are set.

--- a/packages/@overeng/notion-react/docs/testing.md
+++ b/packages/@overeng/notion-react/docs/testing.md
@@ -70,7 +70,7 @@ Required environment variables:
 
 Missing either env var silently skips the whole E2E suite via
 `describe.skipIf(SKIP_E2E)`. Both are typically sourced from
-`packages/@overeng/notion-react/.envrc.local` via `direnv`.
+`secretspec.toml` / `secrets-run` from the repo shell.
 
 #### E2E sub-suites
 
@@ -108,12 +108,7 @@ Missing either env var silently skips the whole E2E suite via
 
 ## Pointing at a different Notion workspace
 
-Create or update `packages/@overeng/notion-react/.envrc.local`:
-
-```sh
-export NOTION_TOKEN="secret_..."
-export NOTION_TEST_PARENT_PAGE_ID="..."
-```
+Export `NOTION_TOKEN` and `NOTION_TEST_PARENT_PAGE_ID` in the local shell, or add op-proxy references for them under `[x-op-proxy.refs]` in `secretspec.toml`.
 
 Notes:
 
@@ -122,7 +117,7 @@ Notes:
   parent page via "Add connections" in Notion.
 - The parent page must be reachable by the integration; scratch pages
   inherit its permissions.
-- `direnv allow` after editing `.envrc.local`.
+- Run live tests through `secrets-run --reason "run notion-react live tests" -- <command>`.
 
 ## What the E2E harness proves (and does not)
 

--- a/packages/@overeng/notion-react/package.json.genie.ts
+++ b/packages/@overeng/notion-react/package.json.genie.ts
@@ -85,8 +85,7 @@ export default packageJson(
       'storybook:build': 'storybook build',
       // Integration + e2e tests hit the live Notion API. Both require
       // `NOTION_TOKEN` and `NOTION_TEST_PARENT_PAGE_ID` (tests skip silently
-      // when either is missing). Source the package-local `.envrc.local`
-      // via direnv or run `op-proxy` inline. See helpers.ts for details.
+      // when either is missing). Load the package-local `devenv.local.nix` through devenv or run `op-proxy` inline. See helpers.ts for details.
       'test:integration': 'vitest run --config vitest.integration.config.ts',
       'test:integration:e2e': 'vitest run --config vitest.integration.config.ts e2e',
     },

--- a/packages/@overeng/notion-react/src/test/integration/e2e/helpers.ts
+++ b/packages/@overeng/notion-react/src/test/integration/e2e/helpers.ts
@@ -28,7 +28,7 @@ export const TEST_PARENT_PAGE_ID = process.env.NOTION_TEST_PARENT_PAGE_ID ?? ''
 export const assertEnv = (env: NodeJS.ProcessEnv = process.env): void => {
   if (!env.NOTION_TOKEN) {
     throw new Error(
-      'NOTION_TOKEN is not set. See packages/@overeng/notion-react/.envrc.local for the expected value.',
+      'NOTION_TOKEN is not set. See packages/@overeng/notion-react/devenv.local.nix for the expected value.',
     )
   }
   if (!env.NOTION_TEST_PARENT_PAGE_ID) {

--- a/secretspec.toml
+++ b/secretspec.toml
@@ -1,0 +1,8 @@
+[project]
+name = "effect-utils"
+revision = "1.0"
+
+[profiles.default]
+NOTION_TOKEN = { description = "Notion integration token for live Notion integration tests", required = false }
+NOTION_TEST_PARENT_PAGE_ID = { description = "Parent Notion page used by notion-react live E2E tests", required = false }
+


### PR DESCRIPTION
**Problem**

The repo still carried direnv entrypoints and `.envrc.local` conventions even though devenv now owns shell activation directly. That split the local environment contract across two tools and made local overrides/secrets ambiguous.

**Goal**

Use devenv as the shell activation authority, remove direnv wiring, and replace ad hoc local secret loading with a declared SecretSpec/op-proxy workflow.

**Decisions**

- Use `devenv.local.*` only for non-secret local configuration.
- Use `secretspec.toml` plus `secrets-run` for runtime secrets instead of cloning `.envrc.local` semantics.
- Keep megarepo PR-stack iteration explicit through branch pins and lockfiles, not shell-local `--override-input` state.

**Verification**

- Root stack: `devenv shell -- dt check:quick` passed.
- Root stack: `nix build .#alignment-cli --no-link` passed, including smoke test.
- `effect-utils`: `devenv shell -- dt check:quick` passed.
- Root `mr lock` passed and all stack member refs are synced.
- `git diff --check` passed across root and touched member repos before final push.
- Search for active direnv patterns (`.envrc.local`, `direnv hook/exec/allow`, `nix-direnv`) returned clean.

**Complexity**

Adds a small shared SecretSpec task module and wrapper so secret contracts are explicit and reusable instead of shell-local.

**Concerns**

Some downstream validation repos still have unrelated pre-existing check failures around nested megarepo lock-sync and pnpm GVS projection health. The root stack and upstream `effect-utils` validation are green locally.

**Friction & Bottlenecks**

Initial devenv shell setup had a slow first build/cache refresh; subsequent shell entry and root checks completed normally.

**Follow-ups**

After the upstream stack lands, retarget temporary `effect-utils` branch pins back to `main` in downstream repos before merging them.

**References**

Refs cachix/devenv#2488.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🏝️ co2-cove |
| `agent_session_id` | 0da77e12-f53f-475f-b53a-e0bccf9eaa25 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.125.0 |
| `agent_runtime` | Codex CLI 0.125.0 |
| `agent_model` | unknown |
| `worktree` | megarepo-all/schickling/2026-05-10-remove-direnv |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@21f0837 |
</details>
<!-- agent-footer:end -->