### PR TITLE
fix(genie): provide cachix CLI from /nix/store instead of mutating runner profile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,12 @@ jobs:
             extra-trusted-public-keys = devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
             access-tokens = github.com=${{ github.token }}
           summarize: true
+      - name: Provide cachix CLI from nixpkgs
+        shell: bash
+        run: |
+          set -euo pipefail
+          out=$(nix build --no-link --print-out-paths nixpkgs#cachix)
+          echo "$out/bin" >> "$GITHUB_PATH"
       - name: Enable Cachix cache
         uses: cachix/cachix-action@v17
         with:
@@ -494,6 +500,12 @@ jobs:
             extra-trusted-public-keys = devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
             access-tokens = github.com=${{ github.token }}
           summarize: true
+      - name: Provide cachix CLI from nixpkgs
+        shell: bash
+        run: |
+          set -euo pipefail
+          out=$(nix build --no-link --print-out-paths nixpkgs#cachix)
+          echo "$out/bin" >> "$GITHUB_PATH"
       - name: Enable Cachix cache
         uses: cachix/cachix-action@v17
         with:
@@ -826,6 +838,12 @@ jobs:
             extra-trusted-public-keys = devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
             access-tokens = github.com=${{ github.token }}
           summarize: true
+      - name: Provide cachix CLI from nixpkgs
+        shell: bash
+        run: |
+          set -euo pipefail
+          out=$(nix build --no-link --print-out-paths nixpkgs#cachix)
+          echo "$out/bin" >> "$GITHUB_PATH"
       - name: Enable Cachix cache
         uses: cachix/cachix-action@v17
         with:
@@ -1158,6 +1176,12 @@ jobs:
             extra-trusted-public-keys = devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
             access-tokens = github.com=${{ github.token }}
           summarize: true
+      - name: Provide cachix CLI from nixpkgs
+        shell: bash
+        run: |
+          set -euo pipefail
+          out=$(nix build --no-link --print-out-paths nixpkgs#cachix)
+          echo "$out/bin" >> "$GITHUB_PATH"
       - name: Enable Cachix cache
         uses: cachix/cachix-action@v17
         with:
@@ -1490,6 +1514,12 @@ jobs:
             extra-trusted-public-keys = devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
             access-tokens = github.com=${{ github.token }}
           summarize: true
+      - name: Provide cachix CLI from nixpkgs
+        shell: bash
+        run: |
+          set -euo pipefail
+          out=$(nix build --no-link --print-out-paths nixpkgs#cachix)
+          echo "$out/bin" >> "$GITHUB_PATH"
       - name: Enable Cachix cache
         uses: cachix/cachix-action@v17
         with:
@@ -1631,6 +1661,12 @@ jobs:
             extra-trusted-public-keys = devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
             access-tokens = github.com=${{ github.token }}
           summarize: true
+      - name: Provide cachix CLI from nixpkgs
+        shell: bash
+        run: |
+          set -euo pipefail
+          out=$(nix build --no-link --print-out-paths nixpkgs#cachix)
+          echo "$out/bin" >> "$GITHUB_PATH"
       - name: Enable Cachix cache
         uses: cachix/cachix-action@v17
         with:
@@ -1877,6 +1913,12 @@ jobs:
             extra-trusted-public-keys = devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
             access-tokens = github.com=${{ github.token }}
           summarize: true
+      - name: Provide cachix CLI from nixpkgs
+        shell: bash
+        run: |
+          set -euo pipefail
+          out=$(nix build --no-link --print-out-paths nixpkgs#cachix)
+          echo "$out/bin" >> "$GITHUB_PATH"
       - name: Enable Cachix cache
         uses: cachix/cachix-action@v17
         with:
@@ -2104,6 +2146,12 @@ jobs:
             extra-trusted-public-keys = devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
             access-tokens = github.com=${{ github.token }}
           summarize: true
+      - name: Provide cachix CLI from nixpkgs
+        shell: bash
+        run: |
+          set -euo pipefail
+          out=$(nix build --no-link --print-out-paths nixpkgs#cachix)
+          echo "$out/bin" >> "$GITHUB_PATH"
       - name: Enable Cachix cache
         uses: cachix/cachix-action@v17
         with:
@@ -2593,6 +2641,12 @@ jobs:
             extra-trusted-public-keys = devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
             access-tokens = github.com=${{ github.token }}
           summarize: true
+      - name: Provide cachix CLI from nixpkgs
+        shell: bash
+        run: |
+          set -euo pipefail
+          out=$(nix build --no-link --print-out-paths nixpkgs#cachix)
+          echo "$out/bin" >> "$GITHUB_PATH"
       - name: Enable Cachix cache
         uses: cachix/cachix-action@v17
         with:
@@ -2926,6 +2980,12 @@ jobs:
             extra-trusted-public-keys = devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
             access-tokens = github.com=${{ github.token }}
           summarize: true
+      - name: Provide cachix CLI from nixpkgs
+        shell: bash
+        run: |
+          set -euo pipefail
+          out=$(nix build --no-link --print-out-paths nixpkgs#cachix)
+          echo "$out/bin" >> "$GITHUB_PATH"
       - name: Enable Cachix cache
         uses: cachix/cachix-action@v17
         with:

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -2,6 +2,7 @@ import {
   RUNNER_PROFILES,
   type RunnerProfile,
   bashShellDefaults,
+  cachixCliBuildStep,
   cachixStep,
   checkoutStep,
   notifyAlignmentJob,
@@ -29,6 +30,7 @@ import { type GitHubWorkflowArgs } from '../../packages/@overeng/genie/src/runti
 const baseSteps = [
   checkoutStep(),
   installNixStep(),
+  cachixCliBuildStep,
   cachixStep({ name: 'overeng-effect-utils', authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}' }),
   preparePinnedDevenvStep,
   pnpmStateSetupStep,
@@ -84,10 +86,10 @@ const verifyOtelShellEntryStep = {
     'command -v script >/dev/null 2>&1',
     'tmp_log="$(mktemp)"',
     `printf 'printf "OTEL_MODE=%%s\\n" "$OTEL_MODE"\nprintf "OTEL_GRAFANA_LINK_URL=%%s\\n" "$OTEL_GRAFANA_LINK_URL"\nexit\n' | script -qefc '"${'${DEVENV_BIN:?DEVENV_BIN not set}'}" shell --no-reload' "$tmp_log"`,
-    "grep -q '\\[otel\\] Using .* OTEL stack' \"$tmp_log\"",
-    "grep -q '\\[otel\\] Start with: devenv up' \"$tmp_log\"",
-    "grep -q '^OTEL_MODE=' \"$tmp_log\"",
-    "grep -q '^OTEL_GRAFANA_LINK_URL=http' \"$tmp_log\"",
+    'grep -q \'\\[otel\\] Using .* OTEL stack\' "$tmp_log"',
+    'grep -q \'\\[otel\\] Start with: devenv up\' "$tmp_log"',
+    'grep -q \'^OTEL_MODE=\' "$tmp_log"',
+    'grep -q \'^OTEL_GRAFANA_LINK_URL=http\' "$tmp_log"',
     'rm -f "$tmp_log"',
   ].join('\n'),
 } as const
@@ -180,6 +182,7 @@ const multiPlatformJob = (step: { name: string; run: string }) => ({
 const strictNixJobBaseSteps = [
   checkoutStep(),
   installNixStep(),
+  cachixCliBuildStep,
   cachixStep({ name: 'overeng-effect-utils', authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}' }),
   validateNixStoreStep,
 ] as const
@@ -208,10 +211,13 @@ const multiPlatformStrictNixJob = (step: ReturnType<typeof validateColdPnpmDepsS
 
 // Jobs keyed by CIJobName for type safety with required status checks
 const jobs: Record<CIJobName, ReturnType<typeof job> | ReturnType<typeof multiPlatformJob>> = {
-  typecheck: job({
-    name: 'Type check',
-    run: runDevenvTasksBefore('ts:check:strict'),
-  }, [verifyOtelShellEntryStep]),
+  typecheck: job(
+    {
+      name: 'Type check',
+      run: runDevenvTasksBefore('ts:check:strict'),
+    },
+    [verifyOtelShellEntryStep],
+  ),
   lint: job({
     name: 'Format + lint',
     run: runDevenvTasksBefore('lint:check'),

--- a/genie/ci-workflow.ts
+++ b/genie/ci-workflow.ts
@@ -1193,7 +1193,25 @@ export const installNixStep = (opts?: {
   },
 })
 
-/** Enable a Cachix binary cache */
+/**
+ * Provide the cachix CLI to subsequent steps from a /nix/store output.
+ *
+ * Must run before `cachixStep` in the same job. cachix-action's
+ * `which.sync('cachix', { nothrow: true })` short-circuit then skips its
+ * built-in installer, so the binary stays a /nix/store path and the runner's
+ * nix profile is never mutated.
+ */
+export const cachixCliBuildStep = {
+  name: 'Provide cachix CLI from nixpkgs',
+  shell: 'bash',
+  run: [
+    'set -euo pipefail',
+    'out=$(nix build --no-link --print-out-paths nixpkgs#cachix)',
+    'echo "$out/bin" >> "$GITHUB_PATH"',
+  ].join('\n'),
+} as const
+
+/** Enable a Cachix binary cache. Requires `cachixCliBuildStep` earlier in the job. */
 export const cachixStep = (opts: { name: string; authToken?: string }) => ({
   name: 'Enable Cachix cache',
   uses: 'cachix/cachix-action@v17' as const,

--- a/genie/external.ts
+++ b/genie/external.ts
@@ -633,6 +633,7 @@ export const testFilesOxlintOverride = {
 export {
   bashShellDefaults,
   checkoutStep,
+  cachixCliBuildStep,
   cachixStep,
   cachixBinaryCache,
   devenvBinaryCache,

--- a/megarepo.lock
+++ b/megarepo.lock
@@ -4,9 +4,9 @@
     "effect": {
       "url": "https://github.com/effect-ts/effect",
       "ref": "main",
-      "commit": "3585f25110fca7af6aeec3f59c3fc05b20c8d316",
+      "commit": "1a63ec87cd295972b05b51c9b4ad2db9567dc994",
       "pinned": false,
-      "lockedAt": "2026-05-10T03:09:13.625Z"
+      "lockedAt": "2026-05-12T02:00:43.137Z"
     }
   }
 }

--- a/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
@@ -254,6 +254,18 @@ describe('ci workflow shared auth helpers', () => {
     expect(ciWorkflowSource).toContain("uses: 'cachix/cachix-action@v17' as const")
   })
 
+  it('provides cachix CLI from /nix/store on PATH instead of mutating the runner nix profile', () => {
+    expect(ciWorkflowSource).toContain('export const cachixCliBuildStep')
+    expect(ciWorkflowSource).toContain('nix build --no-link --print-out-paths nixpkgs#cachix')
+    expect(ciWorkflowSource).toContain('echo "$out/bin" >> "$GITHUB_PATH"')
+  })
+
+  it('keeps cachixStep free of installCommand so cachix-action short-circuits via PATH', () => {
+    const cachixStepSource = extractSourceBlock(ciWorkflowSource, 'export const cachixStep', '})\n')
+    expect(cachixStepSource).not.toContain('installCommand')
+    expect(cachixStepSource).not.toContain('nix profile install')
+  })
+
   it('uses the Nix-provided Netlify CLI for parallel deploy safety', () => {
     expect(netlifyTaskModuleSource).toContain('netlify = "${pkgs.netlify-cli}/bin/netlify";')
     expect(netlifyTaskModuleSource).not.toContain('bunx netlify-cli@24.11.3')


### PR DESCRIPTION
## Why

cachix-action's built-in installer mutates the runner's nix profile via legacy \`nix-env -iA\` shorthand. Two problems:

1. **Breaks on Determinate Nix 3.17+** (legacy \`nix-env -iA\` removed → \`error: unrecognised flag '-i'\`).
2. **Mutates a global nix profile** — not hermetic, conflicts with our broader "no global package installs in CI" stance.

## What

Add a sibling \`cachixCliBuildStep\` that builds cachix from nixpkgs and prepends its \`/nix/store/.../bin\` to \`\$GITHUB_PATH\`. \`cachixStep\` then no longer needs an installer at all: cachix-action's built-in \`which.sync('cachix', { nothrow: true })\` check finds the binary on PATH and skips its install path entirely.

The pattern mirrors the existing \`installMegarepoStep\` helper (lines 1099+ in \`genie/ci-workflow.ts\`), which already does \`nix build --print-out-paths\` + \`>> \$GITHUB_PATH\` for the megarepo CLI. So no new idiom — just applying the established hermetic-install pattern to cachix.

Consumers compose it in their base steps:

\`\`\`ts
const baseSteps = [
  checkoutStep(),
  installNixStep(),
  cachixCliBuildStep,       // ← new, runs before cachixStep
  cachixStep({ name: '...' }),
  ...,
]
\`\`\`

Effect-utils' own self-CI base steps are updated accordingly.

## Validation

- Unit tests assert (a) \`cachixCliBuildStep\` exists and uses \`nix build --no-link --print-out-paths nixpkgs#cachix\` + \`\$GITHUB_PATH\`, and (b) \`cachixStep\` contains neither \`installCommand\` nor \`nix profile install\`.
- effect-utils self-CI exercises the new path end-to-end on Determinate-Nix-3.17+ runners.

## Stack

Three coordinated downstream PRs adopt this — see the megarepo alignment stack referenced in the linked PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🦤 cl2-ibis |
| `agent_session_id` | d035a3bb-7d45-4893-9fa4-ec787212edb4 |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.121 |
| `agent_runtime` | Claude Code 2.1.121 |
| `agent_model` | claude-opus-4-7 |
| `worktree` | schickling-stiftung/schickling/2026-05-10-swift-turing-33 |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@21f0837 |
</details>
<!-- agent-footer:end -->