### PR TITLE
Trust devenv cache in shared CI resolver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,13 @@ jobs:
           fi
 
           resolve_devenv() {
-            nix build --no-link --print-out-paths "github:cachix/devenv/$DEVENV_REV#devenv"
+            nix build \
+              --accept-flake-config \
+              --option extra-substituters https://devenv.cachix.org \
+              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
+              --no-link \
+              --print-out-paths \
+              "github:cachix/devenv/$DEVENV_REV#devenv"
           }
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
@@ -543,7 +549,13 @@ jobs:
           fi
 
           resolve_devenv() {
-            nix build --no-link --print-out-paths "github:cachix/devenv/$DEVENV_REV#devenv"
+            nix build \
+              --accept-flake-config \
+              --option extra-substituters https://devenv.cachix.org \
+              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
+              --no-link \
+              --print-out-paths \
+              "github:cachix/devenv/$DEVENV_REV#devenv"
           }
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
@@ -881,7 +893,13 @@ jobs:
           fi
 
           resolve_devenv() {
-            nix build --no-link --print-out-paths "github:cachix/devenv/$DEVENV_REV#devenv"
+            nix build \
+              --accept-flake-config \
+              --option extra-substituters https://devenv.cachix.org \
+              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
+              --no-link \
+              --print-out-paths \
+              "github:cachix/devenv/$DEVENV_REV#devenv"
           }
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
@@ -1219,7 +1237,13 @@ jobs:
           fi
 
           resolve_devenv() {
-            nix build --no-link --print-out-paths "github:cachix/devenv/$DEVENV_REV#devenv"
+            nix build \
+              --accept-flake-config \
+              --option extra-substituters https://devenv.cachix.org \
+              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
+              --no-link \
+              --print-out-paths \
+              "github:cachix/devenv/$DEVENV_REV#devenv"
           }
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
@@ -1534,7 +1558,13 @@ jobs:
           fi
 
           resolve_devenv() {
-            nix build --no-link --print-out-paths "github:cachix/devenv/$DEVENV_REV#devenv"
+            nix build \
+              --accept-flake-config \
+              --option extra-substituters https://devenv.cachix.org \
+              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
+              --no-link \
+              --print-out-paths \
+              "github:cachix/devenv/$DEVENV_REV#devenv"
           }
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
@@ -1704,7 +1734,13 @@ jobs:
           fi
 
           resolve_devenv() {
-            nix build --no-link --print-out-paths "github:cachix/devenv/$DEVENV_REV#devenv"
+            nix build \
+              --accept-flake-config \
+              --option extra-substituters https://devenv.cachix.org \
+              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
+              --no-link \
+              --print-out-paths \
+              "github:cachix/devenv/$DEVENV_REV#devenv"
           }
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
@@ -1956,7 +1992,13 @@ jobs:
           fi
 
           resolve_devenv() {
-            nix build --no-link --print-out-paths "github:cachix/devenv/$DEVENV_REV#devenv"
+            nix build \
+              --accept-flake-config \
+              --option extra-substituters https://devenv.cachix.org \
+              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
+              --no-link \
+              --print-out-paths \
+              "github:cachix/devenv/$DEVENV_REV#devenv"
           }
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
@@ -2189,7 +2231,13 @@ jobs:
           fi
 
           resolve_devenv() {
-            nix build --no-link --print-out-paths "github:cachix/devenv/$DEVENV_REV#devenv"
+            nix build \
+              --accept-flake-config \
+              --option extra-substituters https://devenv.cachix.org \
+              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
+              --no-link \
+              --print-out-paths \
+              "github:cachix/devenv/$DEVENV_REV#devenv"
           }
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
@@ -2684,7 +2732,13 @@ jobs:
           fi
 
           resolve_devenv() {
-            nix build --no-link --print-out-paths "github:cachix/devenv/$DEVENV_REV#devenv"
+            nix build \
+              --accept-flake-config \
+              --option extra-substituters https://devenv.cachix.org \
+              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
+              --no-link \
+              --print-out-paths \
+              "github:cachix/devenv/$DEVENV_REV#devenv"
           }
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
@@ -3023,7 +3077,13 @@ jobs:
           fi
 
           resolve_devenv() {
-            nix build --no-link --print-out-paths "github:cachix/devenv/$DEVENV_REV#devenv"
+            nix build \
+              --accept-flake-config \
+              --option extra-substituters https://devenv.cachix.org \
+              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
+              --no-link \
+              --print-out-paths \
+              "github:cachix/devenv/$DEVENV_REV#devenv"
           }
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.

--- a/devenv.nix
+++ b/devenv.nix
@@ -238,6 +238,7 @@ let
       port = 6014;
     }
   ];
+  packagesWithNetlifyPreview = lib.filter (pkg: pkg.name != "tui-stories") packagesWithStorybook;
 in
 {
   imports = [
@@ -276,7 +277,7 @@ in
     (taskModules.netlify {
       siteName = "overeng-utils";
       siteId = "462d2440-fb38-4e69-8023-9c425d1e2132";
-      packages = packagesWithStorybook;
+      packages = packagesWithNetlifyPreview;
     })
     (taskModules.lint-oxc {
       lintPaths = [

--- a/genie/ci-workflow.ts
+++ b/genie/ci-workflow.ts
@@ -161,7 +161,13 @@ if [ -z "$DEVENV_REV" ] || [ "$DEVENV_REV" = "null" ]; then
 fi`
 
 const resolveDevenvFnScript = `resolve_devenv() {
-  nix build --no-link --print-out-paths "github:cachix/devenv/$DEVENV_REV#devenv"
+  nix build \\
+    --accept-flake-config \\
+    --option extra-substituters ${devenvBinaryCache.uri} \\
+    --option extra-trusted-public-keys ${devenvBinaryCache.publicKey} \\
+    --no-link \\
+    --print-out-paths \\
+    "github:cachix/devenv/$DEVENV_REV#devenv"
 }`
 
 const shellSingleQuote = (value: string) => `'${value.replaceAll("'", `'"'"'`)}'`
@@ -909,7 +915,7 @@ export const devenvPerfJob = (opts?: DevenvPerfJobOptions) => {
       OTEL_SERVICE_NAME: 'devenv-perf-ci',
       DEVENV_PERF_REGRESSION_MODE: opts?.regressionMode ?? 'warn',
       RUNNER_CLASS: (opts?.runsOn ?? linuxX64Runner).join(','),
-      ...(opts?.env ?? {}),
+      ...opts?.env,
     },
     steps: [
       ...(opts?.setupSteps ?? [


### PR DESCRIPTION
**Problem**

Self-hosted CI jobs that resolve pinned devenv can ignore flake cache config when Determinate Nix is already installed. In Overeng PR #189 this left the pinned devenv resolver dependent on runner-level Nix config and made CI more fragile under store pressure.

**Goal**

Make the shared Genie CI resolver use the same explicit trust/cache contract as workflows expect from the install step, so generated CI does not depend on runner-global Nix config mutation.

**Decisions**

- Put `--accept-flake-config` and the devenv Cachix substituter/key directly on the shared `resolve_devenv` command.
- Reuse the existing `devenvBinaryCache` constant so the cache URI/key stay single-sourced.
- Regenerate the effect-utils CI workflow from the shared helper.
- Keep `tui-stories` in Storybook builds but exclude it from Netlify previews; CI proved that target has no linked Netlify project.
- Fixed a same-file oxlint issue in `devenvPerfJob` because the branch touches this file and the lint gate enforces the current rule set.

**Verification**

- `git diff --check`
- `devenv tasks run lint:check --mode before`
- `devenv tasks run test:run --mode before`
- Effect-utils CI run 25712299462 passed on head `7dedc72c0fc0d88338a2cb74403a71baa9fd0ee9`: https://github.com/overengineeringstudio/effect-utils/actions/runs/25712299462

**Complexity**

No new abstraction. This tightens an existing shared helper and separates Storybook build coverage from Netlify deploy coverage where a deploy target does not exist.

**Concerns**

This only addresses the resolver command and a stale preview target. It does not solve runner disk pressure or global Nix GC contention directly.

**Friction & bottlenecks**

Overeng PR #189 exposed runner pressure: jobs were delayed by disk/capacity pressure and pinned devenv resolution was brittle when runner-level cache trust was not applied.

**Follow-ups**

Once this lands, downstream generated workflows can pick up the helper change instead of carrying local resolver hardening.

**References**

Refs overengineeringstudio/overeng#189.
