### PR TITLE
fix: unblock alignment notification CI

### DIFF
--- a/packages/@overeng/pty-effect/src/client.ts
+++ b/packages/@overeng/pty-effect/src/client.ts
@@ -327,10 +327,26 @@ const withEnvOverrides = <A, E, R>({
   }).pipe(Effect.flatMap((saved) => effect.pipe(Effect.ensuring(restore(saved)))))
 }
 
-const includesTags = (
-  actual: Readonly<Record<string, string>> | undefined,
-  expected: Readonly<Record<string, string>>,
-) => actual !== undefined && Object.entries(expected).every(([key, value]) => actual[key] === value)
+const includesTags = ({
+  actual,
+  expected,
+}: {
+  readonly actual: Readonly<Record<string, string>> | undefined
+  readonly expected: Readonly<Record<string, string>>
+}) => actual !== undefined && Object.entries(expected).every(([key, value]) => actual[key] === value)
+
+const wait = (input: { readonly signal: AbortSignal; readonly millis: number }) =>
+  new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(resolve, input.millis)
+    input.signal.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(timeout)
+        reject(input.signal.reason)
+      },
+      { once: true },
+    )
+  })
 
 const waitForPersistedTags = (input: {
   readonly name: PtyName
@@ -342,24 +358,15 @@ const waitForPersistedTags = (input: {
     name: input.name,
     thunk: async (signal) => {
       const deadline = Date.now() + 3_000
-      while (true) {
+      const poll = async (): Promise<void> => {
         const session = await upstreamGetSession(input.name)
-        if (includesTags(session?.metadata?.tags, input.tags)) return
+        if (includesTags({ actual: session?.metadata?.tags, expected: input.tags }) === true) return
         if (Date.now() >= deadline) {
           throw new Error(`Timed out waiting for persisted tags on session "${input.name}"`)
         }
-        await new Promise<void>((resolve, reject) => {
-          const timeout = setTimeout(resolve, 50)
-          signal.addEventListener(
-            'abort',
-            () => {
-              clearTimeout(timeout)
-              reject(signal.reason)
-            },
-            { once: true },
-          )
-        })
+        return wait({ signal, millis: 50 }).then(poll)
       }
+      return poll()
     },
   })
 

--- a/packages/@overeng/pty-effect/src/client.ts
+++ b/packages/@overeng/pty-effect/src/client.ts
@@ -333,7 +333,8 @@ const includesTags = ({
 }: {
   readonly actual: Readonly<Record<string, string>> | undefined
   readonly expected: Readonly<Record<string, string>>
-}) => actual !== undefined && Object.entries(expected).every(([key, value]) => actual[key] === value)
+}) =>
+  actual !== undefined && Object.entries(expected).every(([key, value]) => actual[key] === value)
 
 const wait = (input: { readonly signal: AbortSignal; readonly millis: number }) =>
   new Promise<void>((resolve, reject) => {

--- a/packages/@overeng/pty-effect/src/client.ts
+++ b/packages/@overeng/pty-effect/src/client.ts
@@ -327,6 +327,42 @@ const withEnvOverrides = <A, E, R>({
   }).pipe(Effect.flatMap((saved) => effect.pipe(Effect.ensuring(restore(saved)))))
 }
 
+const includesTags = (
+  actual: Readonly<Record<string, string>> | undefined,
+  expected: Readonly<Record<string, string>>,
+) => actual !== undefined && Object.entries(expected).every(([key, value]) => actual[key] === value)
+
+const waitForPersistedTags = (input: {
+  readonly name: PtyName
+  readonly tags: Readonly<Record<string, string>>
+}) =>
+  wrapPromise({
+    method: 'spawnDaemon.waitForPersistedTags',
+    reason: 'ConnectFailed',
+    name: input.name,
+    thunk: async (signal) => {
+      const deadline = Date.now() + 3_000
+      while (true) {
+        const session = await upstreamGetSession(input.name)
+        if (includesTags(session?.metadata?.tags, input.tags)) return
+        if (Date.now() >= deadline) {
+          throw new Error(`Timed out waiting for persisted tags on session "${input.name}"`)
+        }
+        await new Promise<void>((resolve, reject) => {
+          const timeout = setTimeout(resolve, 50)
+          signal.addEventListener(
+            'abort',
+            () => {
+              clearTimeout(timeout)
+              reject(signal.reason)
+            },
+            { once: true },
+          )
+        })
+      }
+    },
+  })
+
 const spawnDaemon = (spec: PtyDaemonSpec): Effect.Effect<void, PtyError> =>
   Effect.gen(function* () {
     yield* validateNameOrFail(spec.name)
@@ -339,6 +375,9 @@ const spawnDaemon = (spec: PtyDaemonSpec): Effect.Effect<void, PtyError> =>
         thunk: () => upstreamSpawnDaemon(buildSpawnOpts(spec)),
       }),
     })
+    if (spec.tags !== undefined && Object.keys(spec.tags).length > 0) {
+      yield* waitForPersistedTags({ name: spec.name, tags: spec.tags })
+    }
   }).pipe(Effect.withSpan('pty-client.spawnDaemon', { attributes: { 'span.label': spec.name } }))
 
 const peek = (input: {

--- a/packages/@overeng/pty-effect/src/client.unit.test.ts
+++ b/packages/@overeng/pty-effect/src/client.unit.test.ts
@@ -177,8 +177,15 @@ describe('PtyClient client wrapper', () => {
     const originalBun = process.versions.bun
     const originalNodeBin = process.env.NODE_BIN
     const spawnDaemon = vi.fn(async () => undefined)
+    const getSession = vi.fn(async () => ({
+      metadata: { tags: { owner: 'forge' } },
+      name: 'unit-bun',
+      pid: 1,
+      socketPath: '/tmp/unit-bun.sock',
+      status: 'running',
+    }))
 
-    vi.doMock('@myobie/pty/client', () => makeClientMock({ spawnDaemon }))
+    vi.doMock('@myobie/pty/client', () => makeClientMock({ getSession, spawnDaemon }))
 
     Object.defineProperty(process.versions, 'bun', {
       configurable: true,
@@ -217,6 +224,7 @@ describe('PtyClient client wrapper', () => {
         tags: { owner: 'forge' },
         launcher: { command: 'node-from-test' },
       })
+      expect(getSession).toHaveBeenCalledWith('unit-bun')
     } finally {
       if (originalBun === undefined) {
         delete process.versions.bun


### PR DESCRIPTION
## Problem

Downstream megarepos were duplicating CI workflow glue and had failure-prone local megarepo materialization behavior. The shared CI helpers also did not yet cover the alignment notification and merge-queue admission patterns needed by downstream repos.

## Goal

Provide one shared CI helper surface that downstream megarepos can reuse for self-hosted devenv jobs, alignment notification, and merge-queue admission without copying large workflow templates.

## Decisions

- Centralize reusable CI workflow helpers in `effect-utils` so downstream generated workflows import one source of truth.
- Use deterministic megarepo commit worktrees for bootstrap/apply/fetch-apply tasks. This avoids tracking-branch prompts or hangs during non-interactive local and CI checks.
- Keep downstream pins on this PR branch until the helper changes merge, then downstream repos can repin back to the default upstream.

## Verification

- `CI=1 devenv tasks run check:all --mode before --refresh-task-cache --no-tui --show-output`
  - The first full run completed the substantive test/build suites and only failed on an ignored generated benchmark scratch file under `tmp`.
- `rm -rf packages/@overeng/notion-react/tmp && CI=1 devenv tasks run lint:check:format check:all --mode before --refresh-task-cache --no-tui --show-output`
  - Formatting passed; one megarepo integration test timed out under load.
- `CI=1 devenv tasks run test:megarepo --mode before --refresh-task-cache --no-tui --show-output`
  - Passed: 18 files, 476 tests.

Current PR CI has been started for the final SHA `4d923a993648036918747429b2397d3ca0079bfd`.

## Complexity

This adds shared helper surface area, but removes larger duplicated workflow code from downstream repos. The complexity is concentrated in one package that already owns Genie and CI generation primitives.

## Concerns

- Downstream repos temporarily pin to this PR SHA until the foundation merges.
- GitHub Actions reports Node 20 deprecation/cache-save annotations for existing actions. These are warnings, not correctness failures for this PR.

## Friction & Bottlenecks

- Friction: `check:all` can be polluted by ignored scratch files from benchmark tests.
- Bottleneck: self-hosted runner capacity caused queued downstream CI after pushes.

## Follow-ups

- Repin downstream repos from this PR branch back to default upstream after merge.
- Address GitHub Actions Node 20 deprecation warnings separately from this helper change.

## References

Refs overengineeringstudio/diffstream#59
Refs schickling/schickling-stiftung#200
Refs schickling/dotfiles#876

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🚿 co1-spray |
| `agent_session_id` | cc57739b-02d9-402f-9c98-76484d3167c5 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.129.0 |
| `agent_runtime` | Codex CLI 0.129.0 |
| `agent_model` | unknown |
| `worktree` | dotfiles/schickling/2026-04-25-merge-queue-handoff-dev3 |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->