### PR TITLE
Improve CI measurement regression signal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2359,6 +2359,7 @@ jobs:
           BASELINE_WORKFLOW_NAME: ${{ github.workflow }}
           BASELINE_BRANCH: ${{ github.base_ref || github.ref_name }}
           BASELINE_SEED_RUN_IDS: '25710204667'
+          BASELINE_MAX_RUNS: '5'
         run: |
           set -euo pipefail
 
@@ -2388,12 +2389,28 @@ jobs:
           candidate_runs="$candidate_runs
           $BASELINE_SEED_RUN_IDS"
 
+          max_runs="${BASELINE_MAX_RUNS:-5}"
+          if ! [[ "$max_runs" =~ ^[0-9]+$ ]] || [ "$max_runs" -lt 1 ]; then
+            max_runs=1
+          fi
+
           run_id=""
           artifact_name=""
           artifact_id=""
+          downloaded_runs_file="$BASELINE_OUTPUT_DIR/baseline-runs.jsonl"
+          seen_runs_file="$BASELINE_OUTPUT_DIR/baseline-seen-runs.txt"
+          : >"$downloaded_runs_file"
+          : >"$seen_runs_file"
           for candidate_run in $candidate_runs; do
             if [ -z "$candidate_run" ]; then
               continue
+            fi
+            if grep -qxF "$candidate_run" "$seen_runs_file"; then
+              continue
+            fi
+            printf '%s\n' "$candidate_run" >>"$seen_runs_file"
+            if [ "$(wc -l <"$downloaded_runs_file" | tr -d ' ')" -ge "$max_runs" ]; then
+              break
             fi
 
             artifact_json="$(
@@ -2407,10 +2424,29 @@ jobs:
             )"
 
             if [ -n "$artifact_json" ]; then
-              run_id="$candidate_run"
-              artifact_name="$(printf '%s' "$artifact_json" | jq -r '.name')"
-              artifact_id="$(printf '%s' "$artifact_json" | jq -r '.id')"
-              break
+              current_artifact_name="$(printf '%s' "$artifact_json" | jq -r '.name')"
+              current_artifact_id="$(printf '%s' "$artifact_json" | jq -r '.id')"
+              current_output_dir="$BASELINE_OUTPUT_DIR/run-$candidate_run"
+              mkdir -p "$current_output_dir"
+              if gh run download "$candidate_run" \
+                --repo "$repo" \
+                --name "$current_artifact_name" \
+                --dir "$current_output_dir"; then
+                if [ -z "$run_id" ]; then
+                  run_id="$candidate_run"
+                  artifact_name="$current_artifact_name"
+                  artifact_id="$current_artifact_id"
+                fi
+                jq -cn \
+                  --arg runId "$candidate_run" \
+                  --arg artifactName "$current_artifact_name" \
+                  --arg artifactId "$current_artifact_id" \
+                  --arg path "run-$candidate_run" \
+                  '{runId:$runId, artifactName:$artifactName, artifactId:$artifactId, path:$path}' \
+                  >>"$downloaded_runs_file"
+              else
+                echo "::notice::failed to download baseline artifact $current_artifact_name from run $candidate_run"
+              fi
             fi
           done
 
@@ -2419,15 +2455,8 @@ jobs:
             exit 0
           fi
 
-          if ! gh run download "$run_id" \
-            --repo "$repo" \
-            --name "$artifact_name" \
-            --dir "$BASELINE_OUTPUT_DIR"; then
-            echo "::notice::failed to download baseline artifact $artifact_name from run $run_id"
-            exit 0
-          fi
-
           jq -n \
+            --slurpfile runs "$downloaded_runs_file" \
             --argjson schemaVersion 1 \
             --arg repository "$repo" \
             --arg workflow "$workflow" \
@@ -2443,10 +2472,11 @@ jobs:
               branch: $branch,
               runId: $runId,
               artifactName: $artifactName,
-              artifactId: $artifactId
+              artifactId: $artifactId,
+              runs: $runs
             }' >"$BASELINE_OUTPUT_DIR/baseline-provenance.json"
 
-          echo "Downloaded baseline artifact $artifact_name from run $run_id into $BASELINE_OUTPUT_DIR"
+          echo "Downloaded $(wc -l <"$downloaded_runs_file" | tr -d ' ') baseline artifact(s), latest $artifact_name from run $run_id into $BASELINE_OUTPUT_DIR"
 
       - name: Benchmark devenv surfaces
         shell: bash
@@ -2463,8 +2493,15 @@ jobs:
             printf 'runner_name=%s\n' "${RUNNER_NAME:-unknown}"
             printf 'runner_os=%s\n' "${RUNNER_OS:-unknown}"
             printf 'runner_arch=%s\n' "${RUNNER_ARCH:-unknown}"
+            printf 'runner_class=%s\n' "${RUNNER_CLASS:-unknown}"
+            printf 'cpu_count=%s\n' "$(getconf _NPROCESSORS_ONLN 2>/dev/null || nproc 2>/dev/null || printf unknown)"
+            printf 'load_average=%s\n' "$(cat /proc/loadavg 2>/dev/null || uptime 2>/dev/null || printf unknown)"
+            printf 'memory=%s\n' "$(free -h 2>/dev/null | tr '\n' ';' || printf unknown)"
+            printf 'cpu_model=%s\n' "$(awk -F ': ' '/model name|Hardware|Processor/ { print $2; exit }' /proc/cpuinfo 2>/dev/null || printf unknown)"
             printf 'devenv_rev=%s\n' "${DEVENV_REV:-unknown}"
             printf 'otel_service_name=%s\n' "${OTEL_SERVICE_NAME:-unknown}"
+            nix store ping 2>/dev/null || true
+            nix config show substituters trusted-substituters builders max-jobs cores 2>/dev/null || true
             df -h / /nix 2>/dev/null || df -h /
             ps -eo pid,ppid,stat,etime,pcpu,pmem,comm,args 2>/dev/null \
               | grep -E 'devenv direnv-export|nix-daemon|nix build|nix flake|github-runner' \
@@ -2484,6 +2521,7 @@ jobs:
             local stdout="$7"
             local stderr="$8"
             local trace="$9"
+            local samples_file="$ARTIFACT_DIR/$id.samples.json"
 
             if [ "$first" -eq 0 ]; then
               printf ',' >>"$ARTIFACT_DIR/timings.json"
@@ -2491,6 +2529,7 @@ jobs:
             first=0
 
             jq -cn \
+              --slurpfile samples "$samples_file" \
               --arg id "$id" \
               --arg label "$label" \
               --arg group "$group" \
@@ -2500,7 +2539,28 @@ jobs:
               --arg stdout "$stdout" \
               --arg stderr "$stderr" \
               --arg trace "$trace" \
-              '{id:$id,name:$id,label:$label,group:(if $group == "" then null else $group end),description:(if $description == "" then null else $description end),status:$status,durationMs:$durationMs,stdout:$stdout,stderr:$stderr,trace:(if $trace == "" then null else $trace end)}' \
+              '($samples[0] // []) as $sampleList
+              | ($sampleList | map(select(.status == 0) | .durationMs)) as $successfulDurations
+              | {
+                  id:$id,
+                  name:$id,
+                  label:$label,
+                  group:(if $group == "" then null else $group end),
+                  description:(if $description == "" then null else $description end),
+                  status:$status,
+                  durationMs:$durationMs,
+                  stdout:$stdout,
+                  stderr:$stderr,
+                  trace:(if $trace == "" then null else $trace end),
+                  statistics: {
+                    sampleCount: ($sampleList | length),
+                    successfulSampleCount: ($successfulDurations | length),
+                    minDurationMs: ($successfulDurations | min),
+                    maxDurationMs: ($successfulDurations | max),
+                    medianDurationMs: $durationMs
+                  },
+                  samples:$sampleList
+                }' \
               >>"$ARTIFACT_DIR/timings.json"
           }
 
@@ -2510,34 +2570,84 @@ jobs:
             local group="$3"
             local description="$4"
             local trace_file="$5"
-            shift 5
+            local repetitions="$6"
+            shift 6
             case "$trace_file" in
               '$ARTIFACT_DIR'*) trace_file="${ARTIFACT_DIR}${trace_file#'$ARTIFACT_DIR'}" ;;
             esac
             local stdout="$ARTIFACT_DIR/$id.stdout"
             local stderr="$ARTIFACT_DIR/$id.stderr"
+            local samples_file="$ARTIFACT_DIR/$id.samples.json"
             local started ended status duration_ms
 
             mkdir -p "$(dirname "$trace_file")"
-            started="$(date +%s%3N)"
-            set +e
-            expanded=()
-            for arg in "$@"; do
-              case "$arg" in
-                '$DEVENV_BIN') expanded+=("${DEVENV_BIN:?DEVENV_BIN not set}") ;;
-                '$ARTIFACT_DIR'*) expanded+=("${ARTIFACT_DIR}${arg#'$ARTIFACT_DIR'}") ;;
-                'json:file:$trace_file') expanded+=("json:file:$trace_file") ;;
-                '$trace_file') expanded+=("file:$trace_file") ;;
-                *) expanded+=("$arg") ;;
-              esac
-            done
-            "${expanded[@]}" >"$stdout" 2>"$stderr"
-            status=$?
-            set -e
-            ended="$(date +%s%3N)"
-            duration_ms=$((ended - started))
+            if ! [[ "$repetitions" =~ ^[0-9]+$ ]] || [ "$repetitions" -lt 1 ]; then
+              repetitions=1
+            fi
 
-            json_append_timing "$id" "$label" "$group" "$description" "$status" "$duration_ms" "$stdout" "$stderr" "$trace_file"
+            printf '[' >"$samples_file"
+            local sample_first=1
+            local sample_index sample_stdout sample_stderr sample_trace expanded
+            for sample_index in $(seq 1 "$repetitions"); do
+              sample_stdout="$ARTIFACT_DIR/$id.$sample_index.stdout"
+              sample_stderr="$ARTIFACT_DIR/$id.$sample_index.stderr"
+              sample_trace=""
+              if [ -n "$trace_file" ]; then
+                sample_trace="$trace_file"
+                if [ "$repetitions" -gt 1 ]; then
+                  sample_trace="${trace_file%.*}.$sample_index.${trace_file##*.}"
+                fi
+              fi
+
+              started="$(date +%s%3N)"
+              set +e
+              expanded=()
+              for arg in "$@"; do
+                case "$arg" in
+                  '$DEVENV_BIN') expanded+=("${DEVENV_BIN:?DEVENV_BIN not set}") ;;
+                  '$ARTIFACT_DIR'*) expanded+=("${ARTIFACT_DIR}${arg#'$ARTIFACT_DIR'}") ;;
+                  'json:file:$trace_file') expanded+=("json:file:$sample_trace") ;;
+                  '$trace_file') expanded+=("file:$sample_trace") ;;
+                  *) expanded+=("$arg") ;;
+                esac
+              done
+              "${expanded[@]}" >"$sample_stdout" 2>"$sample_stderr"
+              status=$?
+              set -e
+              ended="$(date +%s%3N)"
+              duration_ms=$((ended - started))
+
+              if [ "$sample_first" -eq 0 ]; then
+                printf ',' >>"$samples_file"
+              fi
+              sample_first=0
+              jq -cn \
+                --argjson index "$sample_index" \
+                --argjson status "$status" \
+                --argjson durationMs "$duration_ms" \
+                --arg stdout "$sample_stdout" \
+                --arg stderr "$sample_stderr" \
+                --arg trace "$sample_trace" \
+                '{index:$index,status:$status,durationMs:$durationMs,stdout:$stdout,stderr:$stderr,trace:(if $trace == "" then null else $trace end)}' \
+                >>"$samples_file"
+
+              stdout="$sample_stdout"
+              stderr="$sample_stderr"
+              trace_file="$sample_trace"
+
+              if [ "$status" -ne 0 ]; then
+                break
+              fi
+            done
+            printf ']\n' >>"$samples_file"
+
+            status="$(jq -r 'map(.status) | max // 0' "$samples_file")"
+            duration_ms="$(jq -r 'map(select(.status == 0) | .durationMs) as $values | if ($values | length) == 0 then (map(.durationMs) | max // 0) else ($values | sort | .[(length - 1) / 2 | floor]) end' "$samples_file")"
+
+            cp "$stdout" "$ARTIFACT_DIR/$id.stdout" 2>/dev/null || true
+            cp "$stderr" "$ARTIFACT_DIR/$id.stderr" 2>/dev/null || true
+
+            json_append_timing "$id" "$label" "$group" "$description" "$status" "$duration_ms" "$ARTIFACT_DIR/$id.stdout" "$ARTIFACT_DIR/$id.stderr" "$trace_file"
 
             if [ "$status" -ne 0 ]; then
               echo "::error::$id failed after ${duration_ms}ms; stderr tail follows"
@@ -2546,14 +2656,14 @@ jobs:
             fi
           }
 
-          measure 'shell_eval_traced' 'Shell eval with OTEL trace' 'devenv shell' 'Evaluates the dev shell with native devenv JSON tracing enabled.' '$ARTIFACT_DIR/traces/shell_eval_traced.json' '$DEVENV_BIN' '--trace-to' 'json:file:$trace_file' 'shell' '--no-reload' '--' 'true'
-          measure 'shell_eval_warm' 'Warm shell eval' 'devenv shell' 'Evaluates a warm dev shell without reloading direnv state.' '' '$DEVENV_BIN' 'shell' '--no-reload' '--' 'true'
-          measure 'tasks_list' 'devenv tasks list' 'devenv cli' 'Lists devenv tasks to measure task graph loading overhead.' '' '$DEVENV_BIN' 'tasks' 'list'
-          measure 'processes_help' 'devenv processes --help' 'devenv cli' 'Loads the devenv processes command help path.' '' '$DEVENV_BIN' 'processes' '--help'
-          measure 'task_pnpm_install' 'pnpm install task' 'workspace setup' 'Runs the cached pnpm install devenv task.' '' '$DEVENV_BIN' 'tasks' 'run' 'pnpm:install' '--mode' 'before' '--no-tui' '--show-output'
-          measure 'task_genie_run' 'Genie run task' 'genie' 'Runs the normal devenv genie:run task including its declared dependencies.' '' '$DEVENV_BIN' 'tasks' 'run' 'genie:run' '--mode' 'before' '--no-tui' '--show-output'
-          measure 'task_check_quick' 'Quick check task' 'quality gates' 'Runs the fast local quality gate through devenv.' '' '$DEVENV_BIN' 'tasks' 'run' 'check:quick' '--mode' 'before' '--no-tui' '--show-output'
-          measure 'genie_check_direct' 'Genie check direct' 'genie' 'Runs Genie directly in check mode to isolate generator runtime from devenv task dependency overhead.' '' '$DEVENV_BIN' 'shell' '--no-reload' '--' 'bun' 'packages/@overeng/genie/bin/genie.tsx' '--output' 'ci-plain' '--check'
+          measure 'shell_eval_traced' 'Shell eval with OTEL trace' 'devenv shell' 'Evaluates the dev shell with native devenv JSON tracing enabled.' '$ARTIFACT_DIR/traces/shell_eval_traced.json' '1' '$DEVENV_BIN' '--trace-to' 'json:file:$trace_file' 'shell' '--no-reload' '--' 'true'
+          measure 'shell_eval_warm' 'Warm shell eval' 'devenv shell' 'Evaluates a warm dev shell without reloading direnv state.' '' '3' '$DEVENV_BIN' 'shell' '--no-reload' '--' 'true'
+          measure 'tasks_list' 'devenv tasks list' 'devenv cli' 'Lists devenv tasks to measure task graph loading overhead.' '' '5' '$DEVENV_BIN' 'tasks' 'list'
+          measure 'processes_help' 'devenv processes --help' 'devenv cli' 'Loads the devenv processes command help path.' '' '5' '$DEVENV_BIN' 'processes' '--help'
+          measure 'task_pnpm_install' 'pnpm install task' 'workspace setup' 'Runs the cached pnpm install devenv task.' '' '1' '$DEVENV_BIN' 'tasks' 'run' 'pnpm:install' '--mode' 'before' '--no-tui' '--show-output'
+          measure 'task_genie_run' 'Genie run task' 'genie' 'Runs the normal devenv genie:run task including its declared dependencies.' '' '1' '$DEVENV_BIN' 'tasks' 'run' 'genie:run' '--mode' 'before' '--no-tui' '--show-output'
+          measure 'task_check_quick' 'Quick check task' 'quality gates' 'Runs the fast local quality gate through devenv.' '' '1' '$DEVENV_BIN' 'tasks' 'run' 'check:quick' '--mode' 'before' '--no-tui' '--show-output'
+          measure 'genie_check_direct' 'Genie check direct' 'genie' 'Runs Genie directly in check mode to isolate generator runtime from devenv task dependency overhead.' '' '3' '$DEVENV_BIN' 'shell' '--no-reload' '--' 'bun' 'packages/@overeng/genie/bin/genie.tsx' '--output' 'ci-plain' '--check'
 
           printf ']\n' >>"$ARTIFACT_DIR/timings.json"
 
@@ -2636,10 +2746,18 @@ jobs:
                     name: ("devenv." + .id + ".duration"),
                     unit: "seconds",
                     value: (.durationMs / 1000),
+                    statistics: {
+                      sampleCount: (.statistics.sampleCount // 1),
+                      successfulSampleCount: (.statistics.successfulSampleCount // (if .status == 0 then 1 else 0 end)),
+                      min: ((.statistics.minDurationMs // .durationMs) / 1000),
+                      max: ((.statistics.maxDurationMs // .durationMs) / 1000),
+                      median: ((.statistics.medianDurationMs // .durationMs) / 1000)
+                    },
                     dimensions: {
                       probe: .id,
                       probeLabel: .label,
                       status: .status,
+                      sampleCount: (.statistics.sampleCount // 1),
                       devenvRev: $devenvRev,
                       otelServiceName: $otelServiceName
                     }
@@ -2816,7 +2934,7 @@ jobs:
 
           current_index="$(mktemp)"
           baseline_index="$(mktemp)"
-          find "$current_dir" -name measurements.json -type f -print | sort >"$current_index" || true
+          find "$current_dir" -path "$baseline_dir" -prune -o -name measurements.json -type f -print | sort >"$current_index" || true
           find "$baseline_dir" -name measurements.json -type f -print | sort >"$baseline_index" || true
 
           if [ ! -s "$current_index" ]; then
@@ -2844,7 +2962,7 @@ jobs:
               def identity_dimensions:
                 (.dimensions // {})
                 | to_entries
-                | map(select(.key as $key | ["devenvRev", "otelServiceName", "status", "probeLabel"] | index($key) | not))
+                | map(select(.key as $key | ["devenvRev", "otelServiceName", "status", "probeLabel", "sampleCount"] | index($key) | not))
                 | sort_by(.key)
                 | map("\(.key)=\(.value|tostring)")
                 | join(",");
@@ -2859,20 +2977,41 @@ jobs:
                   identity_dimensions
                 ] | join("|");
 
+              def median:
+                sort as $sorted
+                | ($sorted | length) as $count
+                | if $count == 0 then null
+                  elif ($count % 2) == 1 then $sorted[($count / 2 | floor)]
+                  else (($sorted[($count / 2 - 1)] + $sorted[($count / 2)]) / 2)
+                  end;
+
               def observations_by_key($docs):
                 reduce $docs[]? as $doc
                   ({};
                     reduce (($doc.observations // [])[]? | select(.value | type == "number")) as $obs
                       (.;
-                        . + {
-                          ($obs | observation_key($doc)): {
+                        ($obs | observation_key($doc)) as $key
+                        | .[$key] = ((.[$key] // []) + [{
                             target: $doc.target,
                             observation: $obs,
                             generatedAt: $doc.generatedAt
-                          }
-                        }
+                          }])
                       )
                   );
+
+              def observation_stats($items):
+                ($items | map(.observation.value)) as $values
+                | ($items | map(.observation.statistics.sampleCount // 1) | add // ($items | length)) as $sampleCount
+                | {
+                    target: ($items[0].target // {}),
+                    observation: ($items[-1].observation // {}),
+                    value: ($values | median),
+                    min: ($values | min),
+                    max: ($values | max),
+                    sourceCount: ($items | length),
+                    sampleCount: $sampleCount,
+                    generatedAt: ($items[-1].generatedAt // null)
+                  };
 
               def budget($metric; $unit):
                 if $metric == "nix.closure.nar_size" then
@@ -2887,8 +3026,17 @@ jobs:
                   {warnRatio:1.25, failRatio:1.50, warnAbs:1, failAbs:3}
                 end;
 
-              def classify($metric; $unit; $current; $baseline):
+              def noise_floor($metric; $unit):
+                if $metric == "nix.closure.nar_size" or $metric == "nix.closure.bucket.nar_size" then 10485760
+                elif $metric == "nix.closure.path_count" then 10
+                elif $unit == "seconds" then 0.1
+                else 0
+                end;
+              def abs_value: if . < 0 then -. else . end;
+
+              def classify($metric; $unit; $current; $baseline; $currentSamples; $baselineSources):
                 budget($metric; $unit) as $b
+                | noise_floor($metric; $unit) as $noise
                 | ($current - $baseline) as $delta
                 | (if $baseline > 0 then ($current / $baseline) else null end) as $ratio
                 | (
@@ -2898,10 +3046,25 @@ jobs:
                     else "pass"
                     end
                   ) as $status
-                | {status:$status,current:$current,baseline:$baseline,delta:$delta,ratio:$ratio,budget:$b};
+                | (
+                    if $baseline <= 0 then "unknown"
+                    elif ($delta | abs_value) <= $noise then "noise_floor"
+                    elif ($baselineSources < 3 and $currentSamples < 3 and $status == "pass") then "low_sample_count"
+                    elif $status == "pass" then "within_budget"
+                    else "threshold_exceeded"
+                    end
+                  ) as $confidence
+                | (
+                    if $baseline <= 0 then "unknown"
+                    elif ($delta | abs_value) <= $noise then "unchanged"
+                    elif $delta < 0 then "improved"
+                    else "regressed"
+                    end
+                  ) as $direction
+                | {status:$status,current:$current,baseline:$baseline,delta:$delta,ratio:$ratio,budget:$b,confidence:$confidence,direction:$direction};
 
-              (observations_by_key($current[0])) as $currentObs
-              | (observations_by_key($baseline[0])) as $baselineObs
+              (observations_by_key($current[0]) | with_entries(.value = observation_stats(.value))) as $currentObs
+              | (observations_by_key($baseline[0]) | with_entries(.value = observation_stats(.value))) as $baselineObs
               | (
                   $currentObs
                   | to_entries
@@ -2917,17 +3080,27 @@ jobs:
                                 status: "missing_baseline",
                                 target: $currentValue.target,
                                 observation: $currentValue.observation,
-                                current: $currentValue.observation.value
+                                current: $currentValue.value,
+                                currentSamples: $currentValue.sampleCount,
+                                baselineSources: 0,
+                                confidence: "missing_baseline",
+                                direction: "unknown"
                               }
                             else
                               classify(
                                 $currentValue.observation.name;
                                 $currentValue.observation.unit;
-                                $currentValue.observation.value;
-                                $baselineValue.observation.value
+                                $currentValue.value;
+                                $baselineValue.value;
+                                $currentValue.sampleCount;
+                                $baselineValue.sourceCount
                               ) + {
                                 target: $currentValue.target,
-                                observation: $currentValue.observation
+                                observation: $currentValue.observation,
+                                currentSamples: $currentValue.sampleCount,
+                                baselineSources: $baselineValue.sourceCount,
+                                baselineMin: $baselineValue.min,
+                                baselineMax: $baselineValue.max
                               }
                             end
                           )
@@ -3142,6 +3315,16 @@ jobs:
             return formatNumber(Math.round((value - 1) * 1000) / 10) + '%'
           }
 
+          const formatResult = (row) => {
+            if (row.status === 'fail') return 'red regression'
+            if (row.status === 'warn') return 'yellow regression'
+            if (row.status === 'missing_baseline') return 'gray no baseline'
+            if (row.confidence === 'noise_floor') return 'gray noise floor'
+            if (row.confidence === 'low_sample_count') return 'gray low confidence'
+            if (row.direction === 'improved') return 'green improved'
+            return 'gray unchanged'
+          }
+
           const escapeCell = (value) => String(value ?? '-').replaceAll('|', '\\|').replaceAll('\n', '<br>')
           const escapeXml = (value) => String(value)
             .replaceAll('&', '&amp;')
@@ -3217,16 +3400,20 @@ jobs:
           const comparisonTable = (rows) => {
             if (rows.length === 0) return 'No measurement regressions detected.'
             return [
-              '| Probe | Baseline | Current | Change | Result |',
-              '| --- | ---: | ---: | ---: | --- |',
+              '| Probe | Baseline | Current | Change | Result | Confidence |',
+              '| --- | ---: | ---: | ---: | --- | --- |',
               ...rows.map((row) => {
                 const unit = row.observation?.unit
+                const baselineRange = typeof row.baselineMin === 'number' && typeof row.baselineMax === 'number' && row.baselineMin !== row.baselineMax
+                  ? '<br><sub>range ' + formatValue(row.baselineMin, unit) + ' - ' + formatValue(row.baselineMax, unit) + '</sub>'
+                  : ''
                 return '| ' + [
                   humanProbe(row),
-                  formatValue(row.baseline, unit),
+                  formatValue(row.baseline, unit) + baselineRange,
                   formatValue(row.current, unit),
                   formatDelta(row.delta, unit) + ' / ' + formatRatio(row.ratio),
-                  row.status,
+                  formatResult(row),
+                  (row.confidence || 'unknown') + '<br><sub>baseline n=' + (row.baselineSources ?? 0) + ', current samples=' + (row.currentSamples ?? 1) + '</sub>',
                 ].map(escapeCell).join(' | ') + ' |'
               }),
             ].join('\n')
@@ -3373,7 +3560,8 @@ jobs:
           const runLink = runUrl ? '[workflow run](' + runUrl + ')' : 'workflow run unavailable'
           const baselineProvenance = comparison.baselineProvenance
           const baselineLabel = baselineProvenance?.runId
-            ? '[main run ' + baselineProvenance.runId + '](' + serverUrl + '/' + repo + '/actions/runs/' + baselineProvenance.runId + ')'
+            ? '[main run ' + baselineProvenance.runId + '](' + serverUrl + '/' + repo + '/actions/runs/' + baselineProvenance.runId + ')' +
+              (Array.isArray(baselineProvenance.runs) && baselineProvenance.runs.length > 1 ? ' + ' + (baselineProvenance.runs.length - 1) + ' older baseline runs' : '')
             : 'not available'
           const chartSvg = hasComparableBaseline ? renderPerfChangeSvg(visibleRows.length > 0 ? visibleRows : allRows) : ''
           if (chartPath && chartSvg) writeFileSync(chartPath, chartSvg)
@@ -3389,7 +3577,7 @@ jobs:
             '- Baseline: ' + baselineLabel,
             '',
             hasComparableBaseline
-              ? 'Chart: performance change versus baseline. Green is faster, red is slower.'
+              ? 'Chart: performance change versus baseline median. Green is faster, red is slower.'
               : 'No compatible baseline was available, so this run shows current measurements only.',
             '',
             chartMarkdown,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3034,11 +3034,17 @@ jobs:
                 end;
               def abs_value: if . < 0 then -. else . end;
 
-              def classify($metric; $unit; $current; $baseline; $currentSamples; $baselineSources):
+              def classify($metric; $unit; $current; $baseline; $baselineMin; $baselineMax; $currentSamples; $baselineSources):
                 budget($metric; $unit) as $b
                 | noise_floor($metric; $unit) as $noise
                 | ($current - $baseline) as $delta
                 | (if $baseline > 0 then ($current / $baseline) else null end) as $ratio
+                | (
+                    $baselineMin != null
+                    and $baselineMax != null
+                    and $current >= $baselineMin
+                    and $current <= $baselineMax
+                  ) as $withinBaselineRange
                 | (
                     if $baseline <= 0 then "unknown"
                     elif ($delta > $b.failAbs and $current > ($baseline * $b.failRatio)) then "fail"
@@ -3049,7 +3055,8 @@ jobs:
                 | (
                     if $baseline <= 0 then "unknown"
                     elif ($delta | abs_value) <= $noise then "noise_floor"
-                    elif ($baselineSources < 3 and $currentSamples < 3 and $status == "pass") then "low_sample_count"
+                    elif ($withinBaselineRange and $status == "pass") then "within_baseline_range"
+                    elif (($baselineSources < 3 or $currentSamples < 3) and $status == "pass") then "low_sample_count"
                     elif $status == "pass" then "within_budget"
                     else "threshold_exceeded"
                     end
@@ -3057,6 +3064,7 @@ jobs:
                 | (
                     if $baseline <= 0 then "unknown"
                     elif ($delta | abs_value) <= $noise then "unchanged"
+                    elif ($withinBaselineRange and $status == "pass") then "unchanged"
                     elif $delta < 0 then "improved"
                     else "regressed"
                     end
@@ -3092,6 +3100,8 @@ jobs:
                                 $currentValue.observation.unit;
                                 $currentValue.value;
                                 $baselineValue.value;
+                                $baselineValue.min;
+                                $baselineValue.max;
                                 $currentValue.sampleCount;
                                 $baselineValue.sourceCount
                               ) + {
@@ -3320,6 +3330,7 @@ jobs:
             if (row.status === 'warn') return 'yellow regression'
             if (row.status === 'missing_baseline') return 'gray no baseline'
             if (row.confidence === 'noise_floor') return 'gray noise floor'
+            if (row.confidence === 'within_baseline_range') return 'gray within range'
             if (row.confidence === 'low_sample_count') return 'gray low confidence'
             if (row.direction === 'improved') return 'green improved'
             return 'gray unchanged'
@@ -3577,7 +3588,7 @@ jobs:
             '- Baseline: ' + baselineLabel,
             '',
             hasComparableBaseline
-              ? 'Chart: performance change versus baseline median. Green is faster, red is slower.'
+              ? 'Chart: performance change versus baseline median. Green is faster, red is slower, gray is within noise or baseline range.'
               : 'No compatible baseline was available, so this run shows current measurements only.',
             '',
             chartMarkdown,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3051,20 +3051,26 @@ jobs:
                     elif ($delta > $b.warnAbs and $current > ($baseline * $b.warnRatio)) then "warn"
                     else "pass"
                     end
-                  ) as $status
+                  ) as $thresholdStatus
                 | (
                     if $baseline <= 0 then "unknown"
                     elif ($delta | abs_value) <= $noise then "noise_floor"
-                    elif ($withinBaselineRange and $status == "pass") then "within_baseline_range"
+                    elif ($withinBaselineRange and $thresholdStatus == "pass") then "within_baseline_range"
                     elif ($baselineSources < 3 or $currentSamples < 3) then "low_sample_count"
-                    elif $status == "pass" then "within_budget"
+                    elif $thresholdStatus == "pass" then "within_budget"
                     else "threshold_exceeded"
                     end
                   ) as $confidence
                 | (
+                    if $confidence == "threshold_exceeded" then $thresholdStatus
+                    elif $thresholdStatus == "unknown" then "unknown"
+                    else "pass"
+                    end
+                  ) as $status
+                | (
                     if $baseline <= 0 then "unknown"
                     elif ($delta | abs_value) <= $noise then "unchanged"
-                    elif ($withinBaselineRange and $status == "pass") then "unchanged"
+                    elif ($withinBaselineRange and $thresholdStatus == "pass") then "unchanged"
                     elif $delta < 0 then "improved"
                     else "regressed"
                     end

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3056,7 +3056,7 @@ jobs:
                     if $baseline <= 0 then "unknown"
                     elif ($delta | abs_value) <= $noise then "noise_floor"
                     elif ($withinBaselineRange and $status == "pass") then "within_baseline_range"
-                    elif (($baselineSources < 3 or $currentSamples < 3) and $status == "pass") then "low_sample_count"
+                    elif ($baselineSources < 3 or $currentSamples < 3) then "low_sample_count"
                     elif $status == "pass" then "within_budget"
                     else "threshold_exceeded"
                     end
@@ -3326,12 +3326,12 @@ jobs:
           }
 
           const formatResult = (row) => {
+            if (row.confidence === 'low_sample_count') return 'gray needs repeat'
             if (row.status === 'fail') return 'red regression'
             if (row.status === 'warn') return 'yellow regression'
             if (row.status === 'missing_baseline') return 'gray no baseline'
             if (row.confidence === 'noise_floor') return 'gray noise floor'
             if (row.confidence === 'within_baseline_range') return 'gray within range'
-            if (row.confidence === 'low_sample_count') return 'gray low confidence'
             if (row.direction === 'improved') return 'green improved'
             return 'gray unchanged'
           }

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -300,6 +300,7 @@ const extraJobs: Record<string, any> = {
           group: 'genie',
           description:
             'Runs Genie directly in check mode to isolate generator runtime from devenv task dependency overhead.',
+          repetitions: 3,
           command: [
             '$DEVENV_BIN',
             'shell',

--- a/genie/ci-workflow/measurements.ts
+++ b/genie/ci-workflow/measurements.ts
@@ -1089,20 +1089,26 @@ jq -n \
           elif ($delta > $b.warnAbs and $current > ($baseline * $b.warnRatio)) then "warn"
           else "pass"
           end
-        ) as $status
+        ) as $thresholdStatus
       | (
           if $baseline <= 0 then "unknown"
           elif ($delta | abs_value) <= $noise then "noise_floor"
-          elif ($withinBaselineRange and $status == "pass") then "within_baseline_range"
+          elif ($withinBaselineRange and $thresholdStatus == "pass") then "within_baseline_range"
           elif ($baselineSources < 3 or $currentSamples < 3) then "low_sample_count"
-          elif $status == "pass" then "within_budget"
+          elif $thresholdStatus == "pass" then "within_budget"
           else "threshold_exceeded"
           end
         ) as $confidence
       | (
+          if $confidence == "threshold_exceeded" then $thresholdStatus
+          elif $thresholdStatus == "unknown" then "unknown"
+          else "pass"
+          end
+        ) as $status
+      | (
           if $baseline <= 0 then "unknown"
           elif ($delta | abs_value) <= $noise then "unchanged"
-          elif ($withinBaselineRange and $status == "pass") then "unchanged"
+          elif ($withinBaselineRange and $thresholdStatus == "pass") then "unchanged"
           elif $delta < 0 then "improved"
           else "regressed"
           end

--- a/genie/ci-workflow/measurements.ts
+++ b/genie/ci-workflow/measurements.ts
@@ -1094,7 +1094,7 @@ jq -n \
           if $baseline <= 0 then "unknown"
           elif ($delta | abs_value) <= $noise then "noise_floor"
           elif ($withinBaselineRange and $status == "pass") then "within_baseline_range"
-          elif (($baselineSources < 3 or $currentSamples < 3) and $status == "pass") then "low_sample_count"
+          elif ($baselineSources < 3 or $currentSamples < 3) then "low_sample_count"
           elif $status == "pass" then "within_budget"
           else "threshold_exceeded"
           end
@@ -1364,12 +1364,12 @@ const formatRatio = (value) => {
 }
 
 const formatResult = (row) => {
+  if (row.confidence === 'low_sample_count') return 'gray needs repeat'
   if (row.status === 'fail') return 'red regression'
   if (row.status === 'warn') return 'yellow regression'
   if (row.status === 'missing_baseline') return 'gray no baseline'
   if (row.confidence === 'noise_floor') return 'gray noise floor'
   if (row.confidence === 'within_baseline_range') return 'gray within range'
-  if (row.confidence === 'low_sample_count') return 'gray low confidence'
   if (row.direction === 'improved') return 'green improved'
   return 'gray unchanged'
 }

--- a/genie/ci-workflow/measurements.ts
+++ b/genie/ci-workflow/measurements.ts
@@ -1072,11 +1072,17 @@ jq -n \
       end;
     def abs_value: if . < 0 then -. else . end;
 
-    def classify($metric; $unit; $current; $baseline; $currentSamples; $baselineSources):
+    def classify($metric; $unit; $current; $baseline; $baselineMin; $baselineMax; $currentSamples; $baselineSources):
       budget($metric; $unit) as $b
       | noise_floor($metric; $unit) as $noise
       | ($current - $baseline) as $delta
       | (if $baseline > 0 then ($current / $baseline) else null end) as $ratio
+      | (
+          $baselineMin != null
+          and $baselineMax != null
+          and $current >= $baselineMin
+          and $current <= $baselineMax
+        ) as $withinBaselineRange
       | (
           if $baseline <= 0 then "unknown"
           elif ($delta > $b.failAbs and $current > ($baseline * $b.failRatio)) then "fail"
@@ -1087,7 +1093,8 @@ jq -n \
       | (
           if $baseline <= 0 then "unknown"
           elif ($delta | abs_value) <= $noise then "noise_floor"
-          elif ($baselineSources < 3 and $currentSamples < 3 and $status == "pass") then "low_sample_count"
+          elif ($withinBaselineRange and $status == "pass") then "within_baseline_range"
+          elif (($baselineSources < 3 or $currentSamples < 3) and $status == "pass") then "low_sample_count"
           elif $status == "pass" then "within_budget"
           else "threshold_exceeded"
           end
@@ -1095,6 +1102,7 @@ jq -n \
       | (
           if $baseline <= 0 then "unknown"
           elif ($delta | abs_value) <= $noise then "unchanged"
+          elif ($withinBaselineRange and $status == "pass") then "unchanged"
           elif $delta < 0 then "improved"
           else "regressed"
           end
@@ -1130,6 +1138,8 @@ jq -n \
                       $currentValue.observation.unit;
                       $currentValue.value;
                       $baselineValue.value;
+                      $baselineValue.min;
+                      $baselineValue.max;
                       $currentValue.sampleCount;
                       $baselineValue.sourceCount
                     ) + {
@@ -1358,6 +1368,7 @@ const formatResult = (row) => {
   if (row.status === 'warn') return 'yellow regression'
   if (row.status === 'missing_baseline') return 'gray no baseline'
   if (row.confidence === 'noise_floor') return 'gray noise floor'
+  if (row.confidence === 'within_baseline_range') return 'gray within range'
   if (row.confidence === 'low_sample_count') return 'gray low confidence'
   if (row.direction === 'improved') return 'green improved'
   return 'gray unchanged'
@@ -1615,7 +1626,7 @@ const summaryLines = [
   '- Baseline: ' + baselineLabel,
   '',
   hasComparableBaseline
-    ? 'Chart: performance change versus baseline median. Green is faster, red is slower.'
+    ? 'Chart: performance change versus baseline median. Green is faster, red is slower, gray is within noise or baseline range.'
     : 'No compatible baseline was available, so this run shows current measurements only.',
   '',
   chartMarkdown,

--- a/genie/ci-workflow/measurements.ts
+++ b/genie/ci-workflow/measurements.ts
@@ -23,6 +23,7 @@ export type CiMeasurementDescriptor = {
 export type DevenvPerfProbe = CiMeasurementDescriptor & {
   readonly command: readonly [string, ...string[]]
   readonly traceOutput?: string
+  readonly repetitions?: number
 }
 
 export type CiMeasurementObservation = {
@@ -66,6 +67,7 @@ export type GitHubPreviousArtifactStepOptions = {
   readonly workflowName?: string
   readonly branch?: string
   readonly seedRunIds?: readonly string[]
+  readonly maxRuns?: number
   readonly tokenExpression?: string
 }
 
@@ -106,6 +108,7 @@ export type DevenvPerfTaskProbe =
       readonly label?: string
       readonly group?: string
       readonly description?: string
+      readonly repetitions?: number
     }
 
 export type DevenvPerfJobOptions = {
@@ -114,6 +117,7 @@ export type DevenvPerfJobOptions = {
   readonly artifactName?: string
   readonly baselineArtifactName?: string
   readonly baselineSeedRunIds?: readonly string[]
+  readonly baselineMaxRuns?: number
   readonly setupSteps?: readonly DevenvPerfSetupStep[]
   readonly env?: Record<string, string>
   readonly taskProbes?: readonly DevenvPerfTaskProbe[]
@@ -127,7 +131,8 @@ export type DevenvPerfJobOptions = {
 const devenvPerfProbeLine = (probe: DevenvPerfProbe) => {
   const args = probe.command.map(shellSingleQuote).join(' ')
   const trace = probe.traceOutput ?? ''
-  return `measure ${shellSingleQuote(probe.id)} ${shellSingleQuote(probe.label)} ${shellSingleQuote(probe.group ?? '')} ${shellSingleQuote(probe.description ?? '')} ${shellSingleQuote(trace)} ${args}`
+  const repetitions = Math.max(1, Math.floor(probe.repetitions ?? 1))
+  return `measure ${shellSingleQuote(probe.id)} ${shellSingleQuote(probe.label)} ${shellSingleQuote(probe.group ?? '')} ${shellSingleQuote(probe.description ?? '')} ${shellSingleQuote(trace)} ${shellSingleQuote(String(repetitions))} ${args}`
 }
 
 const defaultDevenvPerfTaskProbe = (probe: DevenvPerfTaskProbe): DevenvPerfProbe => {
@@ -136,11 +141,13 @@ const defaultDevenvPerfTaskProbe = (probe: DevenvPerfTaskProbe): DevenvPerfProbe
   const label = typeof probe === 'string' ? undefined : probe.label
   const group = typeof probe === 'string' ? undefined : probe.group
   const description = typeof probe === 'string' ? undefined : probe.description
+  const repetitions = typeof probe === 'string' ? undefined : probe.repetitions
   return {
     id: id ?? `task_${task.replaceAll(':', '_')}`,
     label: label ?? task,
     group: group ?? 'devenv tasks',
     description: description ?? `Runs the devenv task '${task}' in before mode without the TUI.`,
+    repetitions,
     command: ['$DEVENV_BIN', 'tasks', 'run', task, '--mode', 'before', '--no-tui', '--show-output'],
   }
 }
@@ -170,6 +177,7 @@ const renderDevenvPerfScript = (
       label: 'Warm shell eval',
       group: 'devenv shell',
       description: 'Evaluates a warm dev shell without reloading direnv state.',
+      repetitions: 3,
       command: ['$DEVENV_BIN', 'shell', '--no-reload', '--', 'true'],
     },
     {
@@ -177,6 +185,7 @@ const renderDevenvPerfScript = (
       label: 'devenv tasks list',
       group: 'devenv cli',
       description: 'Lists devenv tasks to measure task graph loading overhead.',
+      repetitions: 5,
       command: ['$DEVENV_BIN', 'tasks', 'list'],
     },
     {
@@ -184,6 +193,7 @@ const renderDevenvPerfScript = (
       label: 'devenv processes --help',
       group: 'devenv cli',
       description: 'Loads the devenv processes command help path.',
+      repetitions: 5,
       command: ['$DEVENV_BIN', 'processes', '--help'],
     },
     ...opts.taskProbes.map(defaultDevenvPerfTaskProbe),
@@ -202,8 +212,15 @@ mkdir -p "$ARTIFACT_DIR/traces"
   printf 'runner_name=%s\n' "${dollar}{RUNNER_NAME:-unknown}"
   printf 'runner_os=%s\n' "${dollar}{RUNNER_OS:-unknown}"
   printf 'runner_arch=%s\n' "${dollar}{RUNNER_ARCH:-unknown}"
+  printf 'runner_class=%s\n' "${dollar}{RUNNER_CLASS:-unknown}"
+  printf 'cpu_count=%s\n' "$(getconf _NPROCESSORS_ONLN 2>/dev/null || nproc 2>/dev/null || printf unknown)"
+  printf 'load_average=%s\n' "$(cat /proc/loadavg 2>/dev/null || uptime 2>/dev/null || printf unknown)"
+  printf 'memory=%s\n' "$(free -h 2>/dev/null | tr '\n' ';' || printf unknown)"
+  printf 'cpu_model=%s\n' "$(awk -F ': ' '/model name|Hardware|Processor/ { print $2; exit }' /proc/cpuinfo 2>/dev/null || printf unknown)"
   printf 'devenv_rev=%s\n' "${dollar}{DEVENV_REV:-unknown}"
   printf 'otel_service_name=%s\n' "${dollar}{OTEL_SERVICE_NAME:-unknown}"
+  nix store ping 2>/dev/null || true
+  nix config show substituters trusted-substituters builders max-jobs cores 2>/dev/null || true
   df -h / /nix 2>/dev/null || df -h /
   ps -eo pid,ppid,stat,etime,pcpu,pmem,comm,args 2>/dev/null \
     | grep -E 'devenv direnv-export|nix-daemon|nix build|nix flake|github-runner' \
@@ -223,6 +240,7 @@ json_append_timing() {
   local stdout="$7"
   local stderr="$8"
   local trace="$9"
+  local samples_file="$ARTIFACT_DIR/$id.samples.json"
 
   if [ "$first" -eq 0 ]; then
     printf ',' >>"$ARTIFACT_DIR/timings.json"
@@ -230,6 +248,7 @@ json_append_timing() {
   first=0
 
   jq -cn \
+    --slurpfile samples "$samples_file" \
     --arg id "$id" \
     --arg label "$label" \
     --arg group "$group" \
@@ -239,7 +258,28 @@ json_append_timing() {
     --arg stdout "$stdout" \
     --arg stderr "$stderr" \
     --arg trace "$trace" \
-    '{id:$id,name:$id,label:$label,group:(if $group == "" then null else $group end),description:(if $description == "" then null else $description end),status:$status,durationMs:$durationMs,stdout:$stdout,stderr:$stderr,trace:(if $trace == "" then null else $trace end)}' \
+    '($samples[0] // []) as $sampleList
+    | ($sampleList | map(select(.status == 0) | .durationMs)) as $successfulDurations
+    | {
+        id:$id,
+        name:$id,
+        label:$label,
+        group:(if $group == "" then null else $group end),
+        description:(if $description == "" then null else $description end),
+        status:$status,
+        durationMs:$durationMs,
+        stdout:$stdout,
+        stderr:$stderr,
+        trace:(if $trace == "" then null else $trace end),
+        statistics: {
+          sampleCount: ($sampleList | length),
+          successfulSampleCount: ($successfulDurations | length),
+          minDurationMs: ($successfulDurations | min),
+          maxDurationMs: ($successfulDurations | max),
+          medianDurationMs: $durationMs
+        },
+        samples:$sampleList
+      }' \
     >>"$ARTIFACT_DIR/timings.json"
 }
 
@@ -249,34 +289,84 @@ measure() {
   local group="$3"
   local description="$4"
   local trace_file="$5"
-  shift 5
+  local repetitions="$6"
+  shift 6
   case "$trace_file" in
     '$ARTIFACT_DIR'*) trace_file="${dollar}{ARTIFACT_DIR}${dollar}{trace_file#'$ARTIFACT_DIR'}" ;;
   esac
   local stdout="$ARTIFACT_DIR/$id.stdout"
   local stderr="$ARTIFACT_DIR/$id.stderr"
+  local samples_file="$ARTIFACT_DIR/$id.samples.json"
   local started ended status duration_ms
 
   mkdir -p "$(dirname "$trace_file")"
-  started="$(date +%s%3N)"
-  set +e
-  expanded=()
-  for arg in "$@"; do
-    case "$arg" in
-      '$DEVENV_BIN') expanded+=("${dollar}{DEVENV_BIN:?DEVENV_BIN not set}") ;;
-      '$ARTIFACT_DIR'*) expanded+=("${dollar}{ARTIFACT_DIR}${dollar}{arg#'$ARTIFACT_DIR'}") ;;
-      'json:file:$trace_file') expanded+=("json:file:$trace_file") ;;
-      '$trace_file') expanded+=("file:$trace_file") ;;
-      *) expanded+=("$arg") ;;
-    esac
-  done
-  "${dollar}{expanded[@]}" >"$stdout" 2>"$stderr"
-  status=$?
-  set -e
-  ended="$(date +%s%3N)"
-  duration_ms=$((ended - started))
+  if ! [[ "$repetitions" =~ ^[0-9]+$ ]] || [ "$repetitions" -lt 1 ]; then
+    repetitions=1
+  fi
 
-  json_append_timing "$id" "$label" "$group" "$description" "$status" "$duration_ms" "$stdout" "$stderr" "$trace_file"
+  printf '[' >"$samples_file"
+  local sample_first=1
+  local sample_index sample_stdout sample_stderr sample_trace expanded
+  for sample_index in $(seq 1 "$repetitions"); do
+    sample_stdout="$ARTIFACT_DIR/$id.$sample_index.stdout"
+    sample_stderr="$ARTIFACT_DIR/$id.$sample_index.stderr"
+    sample_trace=""
+    if [ -n "$trace_file" ]; then
+      sample_trace="$trace_file"
+      if [ "$repetitions" -gt 1 ]; then
+        sample_trace="${dollar}{trace_file%.*}.$sample_index.${dollar}{trace_file##*.}"
+      fi
+    fi
+
+    started="$(date +%s%3N)"
+    set +e
+    expanded=()
+    for arg in "$@"; do
+      case "$arg" in
+        '$DEVENV_BIN') expanded+=("${dollar}{DEVENV_BIN:?DEVENV_BIN not set}") ;;
+        '$ARTIFACT_DIR'*) expanded+=("${dollar}{ARTIFACT_DIR}${dollar}{arg#'$ARTIFACT_DIR'}") ;;
+        'json:file:$trace_file') expanded+=("json:file:$sample_trace") ;;
+        '$trace_file') expanded+=("file:$sample_trace") ;;
+        *) expanded+=("$arg") ;;
+      esac
+    done
+    "${dollar}{expanded[@]}" >"$sample_stdout" 2>"$sample_stderr"
+    status=$?
+    set -e
+    ended="$(date +%s%3N)"
+    duration_ms=$((ended - started))
+
+    if [ "$sample_first" -eq 0 ]; then
+      printf ',' >>"$samples_file"
+    fi
+    sample_first=0
+    jq -cn \
+      --argjson index "$sample_index" \
+      --argjson status "$status" \
+      --argjson durationMs "$duration_ms" \
+      --arg stdout "$sample_stdout" \
+      --arg stderr "$sample_stderr" \
+      --arg trace "$sample_trace" \
+      '{index:$index,status:$status,durationMs:$durationMs,stdout:$stdout,stderr:$stderr,trace:(if $trace == "" then null else $trace end)}' \
+      >>"$samples_file"
+
+    stdout="$sample_stdout"
+    stderr="$sample_stderr"
+    trace_file="$sample_trace"
+
+    if [ "$status" -ne 0 ]; then
+      break
+    fi
+  done
+  printf ']\n' >>"$samples_file"
+
+  status="$(jq -r 'map(.status) | max // 0' "$samples_file")"
+  duration_ms="$(jq -r 'map(select(.status == 0) | .durationMs) as $values | if ($values | length) == 0 then (map(.durationMs) | max // 0) else ($values | sort | .[(length - 1) / 2 | floor]) end' "$samples_file")"
+
+  cp "$stdout" "$ARTIFACT_DIR/$id.stdout" 2>/dev/null || true
+  cp "$stderr" "$ARTIFACT_DIR/$id.stderr" 2>/dev/null || true
+
+  json_append_timing "$id" "$label" "$group" "$description" "$status" "$duration_ms" "$ARTIFACT_DIR/$id.stdout" "$ARTIFACT_DIR/$id.stderr" "$trace_file"
 
   if [ "$status" -ne 0 ]; then
     echo "::error::$id failed after ${dollar}{duration_ms}ms; stderr tail follows"
@@ -368,10 +458,18 @@ jq -n \
           name: ("devenv." + .id + ".duration"),
           unit: "seconds",
           value: (.durationMs / 1000),
+          statistics: {
+            sampleCount: (.statistics.sampleCount // 1),
+            successfulSampleCount: (.statistics.successfulSampleCount // (if .status == 0 then 1 else 0 end)),
+            min: ((.statistics.minDurationMs // .durationMs) / 1000),
+            max: ((.statistics.maxDurationMs // .durationMs) / 1000),
+            median: ((.statistics.medianDurationMs // .durationMs) / 1000)
+          },
           dimensions: {
             probe: .id,
             probeLabel: .label,
             status: .status,
+            sampleCount: (.statistics.sampleCount // 1),
             devenvRev: $devenvRev,
             otelServiceName: $otelServiceName
           }
@@ -541,6 +639,7 @@ export const downloadPreviousGitHubArtifactStep = (opts: GitHubPreviousArtifactS
       BASELINE_WORKFLOW_NAME: opts.workflowName ?? '${{ github.workflow }}',
       BASELINE_BRANCH: opts.branch ?? '${{ github.base_ref || github.ref_name }}',
       BASELINE_SEED_RUN_IDS: opts.seedRunIds?.join(' ') ?? '',
+      BASELINE_MAX_RUNS: String(opts.maxRuns ?? 5),
     },
     run: String.raw`set -euo pipefail
 
@@ -570,12 +669,28 @@ candidate_runs="$(
 candidate_runs="$candidate_runs
 $BASELINE_SEED_RUN_IDS"
 
+max_runs="${dollar}{BASELINE_MAX_RUNS:-5}"
+if ! [[ "$max_runs" =~ ^[0-9]+$ ]] || [ "$max_runs" -lt 1 ]; then
+  max_runs=1
+fi
+
 run_id=""
 artifact_name=""
 artifact_id=""
+downloaded_runs_file="$BASELINE_OUTPUT_DIR/baseline-runs.jsonl"
+seen_runs_file="$BASELINE_OUTPUT_DIR/baseline-seen-runs.txt"
+: >"$downloaded_runs_file"
+: >"$seen_runs_file"
 for candidate_run in $candidate_runs; do
   if [ -z "$candidate_run" ]; then
     continue
+  fi
+  if grep -qxF "$candidate_run" "$seen_runs_file"; then
+    continue
+  fi
+  printf '%s\n' "$candidate_run" >>"$seen_runs_file"
+  if [ "$(wc -l <"$downloaded_runs_file" | tr -d ' ')" -ge "$max_runs" ]; then
+    break
   fi
 
   artifact_json="$(
@@ -589,10 +704,29 @@ for candidate_run in $candidate_runs; do
   )"
 
   if [ -n "$artifact_json" ]; then
-    run_id="$candidate_run"
-    artifact_name="$(printf '%s' "$artifact_json" | jq -r '.name')"
-    artifact_id="$(printf '%s' "$artifact_json" | jq -r '.id')"
-    break
+    current_artifact_name="$(printf '%s' "$artifact_json" | jq -r '.name')"
+    current_artifact_id="$(printf '%s' "$artifact_json" | jq -r '.id')"
+    current_output_dir="$BASELINE_OUTPUT_DIR/run-$candidate_run"
+    mkdir -p "$current_output_dir"
+    if gh run download "$candidate_run" \
+      --repo "$repo" \
+      --name "$current_artifact_name" \
+      --dir "$current_output_dir"; then
+      if [ -z "$run_id" ]; then
+        run_id="$candidate_run"
+        artifact_name="$current_artifact_name"
+        artifact_id="$current_artifact_id"
+      fi
+      jq -cn \
+        --arg runId "$candidate_run" \
+        --arg artifactName "$current_artifact_name" \
+        --arg artifactId "$current_artifact_id" \
+        --arg path "run-$candidate_run" \
+        '{runId:$runId, artifactName:$artifactName, artifactId:$artifactId, path:$path}' \
+        >>"$downloaded_runs_file"
+    else
+      echo "::notice::failed to download baseline artifact $current_artifact_name from run $candidate_run"
+    fi
   fi
 done
 
@@ -601,15 +735,8 @@ if [ -z "$run_id" ] || [ -z "$artifact_name" ]; then
   exit 0
 fi
 
-if ! gh run download "$run_id" \
-  --repo "$repo" \
-  --name "$artifact_name" \
-  --dir "$BASELINE_OUTPUT_DIR"; then
-  echo "::notice::failed to download baseline artifact $artifact_name from run $run_id"
-  exit 0
-fi
-
 jq -n \
+  --slurpfile runs "$downloaded_runs_file" \
   --argjson schemaVersion 1 \
   --arg repository "$repo" \
   --arg workflow "$workflow" \
@@ -625,10 +752,11 @@ jq -n \
     branch: $branch,
     runId: $runId,
     artifactName: $artifactName,
-    artifactId: $artifactId
+    artifactId: $artifactId,
+    runs: $runs
   }' >"$BASELINE_OUTPUT_DIR/baseline-provenance.json"
 
-echo "Downloaded baseline artifact $artifact_name from run $run_id into $BASELINE_OUTPUT_DIR"
+echo "Downloaded $(wc -l <"$downloaded_runs_file" | tr -d ' ') baseline artifact(s), latest $artifact_name from run $run_id into $BASELINE_OUTPUT_DIR"
 `,
   }) as const
 
@@ -844,7 +972,7 @@ fi
 
 current_index="$(mktemp)"
 baseline_index="$(mktemp)"
-find "$current_dir" -name measurements.json -type f -print | sort >"$current_index" || true
+find "$current_dir" -path "$baseline_dir" -prune -o -name measurements.json -type f -print | sort >"$current_index" || true
 find "$baseline_dir" -name measurements.json -type f -print | sort >"$baseline_index" || true
 
 if [ ! -s "$current_index" ]; then
@@ -872,7 +1000,7 @@ jq -n \
     def identity_dimensions:
       (.dimensions // {})
       | to_entries
-      | map(select(.key as $key | ["devenvRev", "otelServiceName", "status", "probeLabel"] | index($key) | not))
+      | map(select(.key as $key | ["devenvRev", "otelServiceName", "status", "probeLabel", "sampleCount"] | index($key) | not))
       | sort_by(.key)
       | map("\(.key)=\(.value|tostring)")
       | join(",");
@@ -887,20 +1015,41 @@ jq -n \
         identity_dimensions
       ] | join("|");
 
+    def median:
+      sort as $sorted
+      | ($sorted | length) as $count
+      | if $count == 0 then null
+        elif ($count % 2) == 1 then $sorted[($count / 2 | floor)]
+        else (($sorted[($count / 2 - 1)] + $sorted[($count / 2)]) / 2)
+        end;
+
     def observations_by_key($docs):
       reduce $docs[]? as $doc
         ({};
           reduce (($doc.observations // [])[]? | select(.value | type == "number")) as $obs
             (.;
-              . + {
-                ($obs | observation_key($doc)): {
+              ($obs | observation_key($doc)) as $key
+              | .[$key] = ((.[$key] // []) + [{
                   target: $doc.target,
                   observation: $obs,
                   generatedAt: $doc.generatedAt
-                }
-              }
+                }])
             )
         );
+
+    def observation_stats($items):
+      ($items | map(.observation.value)) as $values
+      | ($items | map(.observation.statistics.sampleCount // 1) | add // ($items | length)) as $sampleCount
+      | {
+          target: ($items[0].target // {}),
+          observation: ($items[-1].observation // {}),
+          value: ($values | median),
+          min: ($values | min),
+          max: ($values | max),
+          sourceCount: ($items | length),
+          sampleCount: $sampleCount,
+          generatedAt: ($items[-1].generatedAt // null)
+        };
 
     def budget($metric; $unit):
       if $metric == "nix.closure.nar_size" then
@@ -915,8 +1064,17 @@ jq -n \
         {warnRatio:1.25, failRatio:1.50, warnAbs:1, failAbs:3}
       end;
 
-    def classify($metric; $unit; $current; $baseline):
+    def noise_floor($metric; $unit):
+      if $metric == "nix.closure.nar_size" or $metric == "nix.closure.bucket.nar_size" then 10485760
+      elif $metric == "nix.closure.path_count" then 10
+      elif $unit == "seconds" then 0.1
+      else 0
+      end;
+    def abs_value: if . < 0 then -. else . end;
+
+    def classify($metric; $unit; $current; $baseline; $currentSamples; $baselineSources):
       budget($metric; $unit) as $b
+      | noise_floor($metric; $unit) as $noise
       | ($current - $baseline) as $delta
       | (if $baseline > 0 then ($current / $baseline) else null end) as $ratio
       | (
@@ -926,10 +1084,25 @@ jq -n \
           else "pass"
           end
         ) as $status
-      | {status:$status,current:$current,baseline:$baseline,delta:$delta,ratio:$ratio,budget:$b};
+      | (
+          if $baseline <= 0 then "unknown"
+          elif ($delta | abs_value) <= $noise then "noise_floor"
+          elif ($baselineSources < 3 and $currentSamples < 3 and $status == "pass") then "low_sample_count"
+          elif $status == "pass" then "within_budget"
+          else "threshold_exceeded"
+          end
+        ) as $confidence
+      | (
+          if $baseline <= 0 then "unknown"
+          elif ($delta | abs_value) <= $noise then "unchanged"
+          elif $delta < 0 then "improved"
+          else "regressed"
+          end
+        ) as $direction
+      | {status:$status,current:$current,baseline:$baseline,delta:$delta,ratio:$ratio,budget:$b,confidence:$confidence,direction:$direction};
 
-    (observations_by_key($current[0])) as $currentObs
-    | (observations_by_key($baseline[0])) as $baselineObs
+    (observations_by_key($current[0]) | with_entries(.value = observation_stats(.value))) as $currentObs
+    | (observations_by_key($baseline[0]) | with_entries(.value = observation_stats(.value))) as $baselineObs
     | (
         $currentObs
         | to_entries
@@ -945,17 +1118,27 @@ jq -n \
                       status: "missing_baseline",
                       target: $currentValue.target,
                       observation: $currentValue.observation,
-                      current: $currentValue.observation.value
+                      current: $currentValue.value,
+                      currentSamples: $currentValue.sampleCount,
+                      baselineSources: 0,
+                      confidence: "missing_baseline",
+                      direction: "unknown"
                     }
                   else
                     classify(
                       $currentValue.observation.name;
                       $currentValue.observation.unit;
-                      $currentValue.observation.value;
-                      $baselineValue.observation.value
+                      $currentValue.value;
+                      $baselineValue.value;
+                      $currentValue.sampleCount;
+                      $baselineValue.sourceCount
                     ) + {
                       target: $currentValue.target,
-                      observation: $currentValue.observation
+                      observation: $currentValue.observation,
+                      currentSamples: $currentValue.sampleCount,
+                      baselineSources: $baselineValue.sourceCount,
+                      baselineMin: $baselineValue.min,
+                      baselineMax: $baselineValue.max
                     }
                   end
                 )
@@ -1170,6 +1353,16 @@ const formatRatio = (value) => {
   return formatNumber(Math.round((value - 1) * 1000) / 10) + '%'
 }
 
+const formatResult = (row) => {
+  if (row.status === 'fail') return 'red regression'
+  if (row.status === 'warn') return 'yellow regression'
+  if (row.status === 'missing_baseline') return 'gray no baseline'
+  if (row.confidence === 'noise_floor') return 'gray noise floor'
+  if (row.confidence === 'low_sample_count') return 'gray low confidence'
+  if (row.direction === 'improved') return 'green improved'
+  return 'gray unchanged'
+}
+
 const escapeCell = (value) => String(value ?? '-').replaceAll('|', '\\|').replaceAll('\n', '<br>')
 const escapeXml = (value) => String(value)
   .replaceAll('&', '&amp;')
@@ -1245,16 +1438,20 @@ const visibleRows = (hasComparableBaseline
 const comparisonTable = (rows) => {
   if (rows.length === 0) return 'No measurement regressions detected.'
   return [
-    '| Probe | Baseline | Current | Change | Result |',
-    '| --- | ---: | ---: | ---: | --- |',
+    '| Probe | Baseline | Current | Change | Result | Confidence |',
+    '| --- | ---: | ---: | ---: | --- | --- |',
     ...rows.map((row) => {
       const unit = row.observation?.unit
+      const baselineRange = typeof row.baselineMin === 'number' && typeof row.baselineMax === 'number' && row.baselineMin !== row.baselineMax
+        ? '<br><sub>range ' + formatValue(row.baselineMin, unit) + ' - ' + formatValue(row.baselineMax, unit) + '</sub>'
+        : ''
       return '| ' + [
         humanProbe(row),
-        formatValue(row.baseline, unit),
+        formatValue(row.baseline, unit) + baselineRange,
         formatValue(row.current, unit),
         formatDelta(row.delta, unit) + ' / ' + formatRatio(row.ratio),
-        row.status,
+        formatResult(row),
+        (row.confidence || 'unknown') + '<br><sub>baseline n=' + (row.baselineSources ?? 0) + ', current samples=' + (row.currentSamples ?? 1) + '</sub>',
       ].map(escapeCell).join(' | ') + ' |'
     }),
   ].join('\n')
@@ -1401,7 +1598,8 @@ const historyRows = state.runs.slice(1).map((run) => {
 const runLink = runUrl ? '[workflow run](' + runUrl + ')' : 'workflow run unavailable'
 const baselineProvenance = comparison.baselineProvenance
 const baselineLabel = baselineProvenance?.runId
-  ? '[main run ' + baselineProvenance.runId + '](' + serverUrl + '/' + repo + '/actions/runs/' + baselineProvenance.runId + ')'
+  ? '[main run ' + baselineProvenance.runId + '](' + serverUrl + '/' + repo + '/actions/runs/' + baselineProvenance.runId + ')' +
+    (Array.isArray(baselineProvenance.runs) && baselineProvenance.runs.length > 1 ? ' + ' + (baselineProvenance.runs.length - 1) + ' older baseline runs' : '')
   : 'not available'
 const chartSvg = hasComparableBaseline ? renderPerfChangeSvg(visibleRows.length > 0 ? visibleRows : allRows) : ''
 if (chartPath && chartSvg) writeFileSync(chartPath, chartSvg)
@@ -1417,7 +1615,7 @@ const summaryLines = [
   '- Baseline: ' + baselineLabel,
   '',
   hasComparableBaseline
-    ? 'Chart: performance change versus baseline. Green is faster, red is slower.'
+    ? 'Chart: performance change versus baseline median. Green is faster, red is slower.'
     : 'No compatible baseline was available, so this run shows current measurements only.',
   '',
   chartMarkdown,
@@ -1523,6 +1721,7 @@ export const devenvPerfJob = (opts?: DevenvPerfJobOptions) => {
               artifactName: baselineArtifactName,
               outputDir: `${artifactDir}/baseline`,
               seedRunIds: opts?.baselineSeedRunIds,
+              maxRuns: opts?.baselineMaxRuns,
             }),
           ]),
       devenvPerfBenchmarkStep({

--- a/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
@@ -414,6 +414,8 @@ describe('ci workflow devenv perf helpers', () => {
     expect(generatedCiWorkflowYamlSource).toContain('sampleCount: (.statistics.sampleCount // 1)')
     expect(generatedCiWorkflowYamlSource).toContain('baselineSources')
     expect(generatedCiWorkflowYamlSource).toContain('low_sample_count')
+    expect(generatedCiWorkflowYamlSource).toContain('within_baseline_range')
+    expect(generatedCiWorkflowYamlSource).toContain('$baselineSources < 3 or $currentSamples < 3')
     expect(generatedCiWorkflowYamlSource).toContain('RUNNER_CLASS:')
     expect(generatedCiWorkflowYamlSource).toContain('namespace-profile-linux-x86-64')
     expect(ciWorkflowSource).toContain('nix.closure.nar_size')
@@ -445,7 +447,7 @@ describe('ci workflow devenv perf helpers', () => {
     )
     expect(ciWorkflowSource).toContain('chart_file="$comment_tmp_dir/perf-change-vs-baseline.svg"')
     expect(ciWorkflowSource).toContain(
-      'Chart: performance change versus baseline median. Green is faster, red is slower.',
+      'Chart: performance change versus baseline median. Green is faster, red is slower, gray is within noise or baseline range.',
     )
     expect(ciWorkflowSource).toContain('renderPerfChangeSvg')
     expect(ciWorkflowSource).toContain('Perf change vs baseline (%)')

--- a/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
@@ -415,7 +415,12 @@ describe('ci workflow devenv perf helpers', () => {
     expect(generatedCiWorkflowYamlSource).toContain('baselineSources')
     expect(generatedCiWorkflowYamlSource).toContain('low_sample_count')
     expect(generatedCiWorkflowYamlSource).toContain('within_baseline_range')
-    expect(generatedCiWorkflowYamlSource).toContain('$baselineSources < 3 or $currentSamples < 3')
+    expect(generatedCiWorkflowYamlSource).toContain(
+      'elif ($baselineSources < 3 or $currentSamples < 3) then "low_sample_count"',
+    )
+    expect(ciWorkflowSource).toContain(
+      "if (row.confidence === 'low_sample_count') return 'gray needs repeat'",
+    )
     expect(generatedCiWorkflowYamlSource).toContain('RUNNER_CLASS:')
     expect(generatedCiWorkflowYamlSource).toContain('namespace-profile-linux-x86-64')
     expect(ciWorkflowSource).toContain('nix.closure.nar_size')

--- a/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
@@ -418,6 +418,9 @@ describe('ci workflow devenv perf helpers', () => {
     expect(generatedCiWorkflowYamlSource).toContain(
       'elif ($baselineSources < 3 or $currentSamples < 3) then "low_sample_count"',
     )
+    expect(generatedCiWorkflowYamlSource).toContain(
+      'if $confidence == "threshold_exceeded" then $thresholdStatus',
+    )
     expect(ciWorkflowSource).toContain(
       "if (row.confidence === 'low_sample_count') return 'gray needs repeat'",
     )

--- a/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
@@ -388,13 +388,16 @@ describe('ci workflow devenv perf helpers', () => {
     expect(generatedCiWorkflowYamlSource).toContain('devenv-perf:')
     expect(generatedCiWorkflowYamlSource).toContain('OTEL_SERVICE_NAME: devenv-perf-ci')
     expect(generatedCiWorkflowYamlSource).toContain(
-      "measure 'shell_eval_traced' 'Shell eval with OTEL trace'",
+      "measure 'shell_eval_traced' 'Shell eval with OTEL trace' 'devenv shell' 'Evaluates the dev shell with native devenv JSON tracing enabled.' '$ARTIFACT_DIR/traces/shell_eval_traced.json' '1'",
     )
     expect(generatedCiWorkflowYamlSource).toContain('--trace-to')
     expect(generatedCiWorkflowYamlSource).toContain('json:file:$trace_file')
     expect(generatedCiWorkflowYamlSource).toContain('$ARTIFACT_DIR/traces/shell_eval_traced.json')
     expect(generatedCiWorkflowYamlSource).toContain("measure 'shell_eval_warm' 'Warm shell eval'")
     expect(generatedCiWorkflowYamlSource).toContain("measure 'tasks_list' 'devenv tasks list'")
+    expect(generatedCiWorkflowYamlSource).toContain(
+      "'Loads the devenv processes command help path.' '' '5'",
+    )
   })
 
   it('writes a stable summary artifact for regression tracking', () => {
@@ -408,6 +411,9 @@ describe('ci workflow devenv perf helpers', () => {
       'target: { kind: "devenv", id: "dev-shell", name: "dev-shell", label: "Dev shell", group: "devenv", system: $targetSystem }',
     )
     expect(generatedCiWorkflowYamlSource).toContain('probeLabel: .label')
+    expect(generatedCiWorkflowYamlSource).toContain('sampleCount: (.statistics.sampleCount // 1)')
+    expect(generatedCiWorkflowYamlSource).toContain('baselineSources')
+    expect(generatedCiWorkflowYamlSource).toContain('low_sample_count')
     expect(generatedCiWorkflowYamlSource).toContain('RUNNER_CLASS:')
     expect(generatedCiWorkflowYamlSource).toContain('namespace-profile-linux-x86-64')
     expect(ciWorkflowSource).toContain('nix.closure.nar_size')
@@ -435,11 +441,11 @@ describe('ci workflow devenv perf helpers', () => {
     expect(ciWorkflowSource).toContain('baselineSeedRunIds?: readonly string[]')
     expect(ciWorkflowSource).toContain('baselineProvenance: ($baselineProvenance[0] // null)')
     expect(ciWorkflowSource).toContain(
-      '["devenvRev", "otelServiceName", "status", "probeLabel"] | index($key) | not',
+      '["devenvRev", "otelServiceName", "status", "probeLabel", "sampleCount"] | index($key) | not',
     )
     expect(ciWorkflowSource).toContain('chart_file="$comment_tmp_dir/perf-change-vs-baseline.svg"')
     expect(ciWorkflowSource).toContain(
-      'Chart: performance change versus baseline. Green is faster, red is slower.',
+      'Chart: performance change versus baseline median. Green is faster, red is slower.',
     )
     expect(ciWorkflowSource).toContain('renderPerfChangeSvg')
     expect(ciWorkflowSource).toContain('Perf change vs baseline (%)')


### PR DESCRIPTION
**Problem**

The devenv performance comment added in #651 compared a PR run against one baseline artifact. For noisy CI surfaces that made small percent deltas look more meaningful than they were, and it could not distinguish a real regression from a runner/eval/cache outlier.

**Goal**

Make CI measurement comments useful as review signals: repeated samples where cheap, multiple recent main baselines, clear confidence metadata, and enough host context to explain outliers.

**Decisions**

- `devenvPerfProbe` supports `repetitions`; cheap CLI probes run 5 samples, warm shell runs 3, expensive probes stay single-sample unless a repo opts in.
- Baseline download keeps up to 5 recent main artifacts and comparison uses the baseline median instead of one overwritten value.
- Comparison output records `direction`, `confidence`, `baselineSources`, sample counts, and baseline min/max so comments can say `noise_floor`, `within_baseline_range`, or `low_sample_count`.
- Threshold status is separated from review status: sparse/noisy/in-range rows do not make the aggregate comment warn/fail; only `confidence=threshold_exceeded` contributes warn/fail.
- Host context includes runner class, CPU count/model, load, memory, Nix daemon/config, and disk state.

**Verification**

- `CI=1 pnpm --filter @overeng/genie exec vitest run src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts` passed: 35 tests.
- `bun packages/@overeng/genie/bin/genie.tsx --output ci-plain --check` passed: 60 files up to date.
- `git diff --check` and `oxfmt --check genie/ci-workflow/measurements.ts packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts` passed.
- Local investigation of #651 artifacts showed high run-to-run variance: shell eval traced ranged 68.3s-105.7s across 8 runs; `tasks_list` ranged 44ms-154ms in CI.
- Bounded local repetition on dev3 reproduced the problem directly: one `devenv tasks list` sample took 342.3s, then the next four samples were 54-58ms.
- Current CI run for the final SHA: https://github.com/overengineeringstudio/effect-utils/actions/runs/25801156316
- Production managed comment: https://github.com/overengineeringstudio/effect-utils/pull/656#issuecomment-4439845211

**Complexity**

This adds schema surface, but keeps the existing workflow shape and artifact contract. The added complexity buys a better long-term measurement model: distributions and confidence instead of single-point deltas.

**Concerns**

- `devenv tasks run check:quick` was started locally but stayed in shell evaluation for 7m25s on dev3 and was stopped to avoid consuming shared resources. This matches the observed measurement bottleneck rather than a code failure.
- Direct `tsc --noEmit` for `@overeng/genie` is not a valid standalone proof in this worktree without building referenced packages first; it failed with existing TS6305 project-reference output errors.
- The new `genie_check_direct` row is expected to show missing baseline until this PR has landed on main and produced baseline artifacts.

**References**

Refs #651.
Refs schickling/dotfiles#876.
Refs schickling/megarepo-all#86.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🌄 co1-vale |
| `agent_session_id` | ee2f8a7b-5623-4ad7-a682-0dbe5737d042 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.125.0 |
| `agent_runtime` | Codex CLI 0.125.0 |
| `agent_model` | unknown |
| `worktree` | effect-utils/schickling/2026-05-13-ci-measurement-statistics |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->