### PR TITLE
Fix closure measurement artifact path expansion

### DIFF
--- a/genie/ci-workflow/measurements.ts
+++ b/genie/ci-workflow/measurements.ts
@@ -792,7 +792,10 @@ export const ciMeasurementsArtifactStep = (opts: CiMeasurementsArtifactStepOptio
 
 export const nixClosureMeasurementStep = (opts: NixClosureMeasurementStepOptions) => {
   const artifactDir = opts.artifactDir ?? 'tmp/ci-measurements'
-  const artifactFile = opts.artifactFile ?? '$ARTIFACT_DIR/measurements.json'
+  const artifactFileAssignment =
+    opts.artifactFile === undefined
+      ? '"$ARTIFACT_DIR/measurements.json"'
+      : shellSingleQuote(opts.artifactFile)
   const targetName = opts.targetName ?? opts.installable
   const targetId = opts.targetId ?? targetName
   const targetLabel = opts.targetLabel ?? targetName
@@ -818,7 +821,7 @@ target_id=${shellSingleQuote(targetId)}
 target_name=${shellSingleQuote(targetName)}
 target_label=${shellSingleQuote(targetLabel)}
 target_group=${shellSingleQuote(targetGroup)}
-artifact_file=${shellSingleQuote(artifactFile)}
+artifact_file=${artifactFileAssignment}
 ${targetSystemAssignment}
 
 out_path="$(nix build --no-link --print-out-paths "$installable")"

--- a/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
@@ -429,6 +429,8 @@ describe('ci workflow devenv perf helpers', () => {
     expect(ciWorkflowSource).toContain('nix.closure.nar_size')
     expect(ciWorkflowSource).toContain('nix.closure.path_count')
     expect(ciWorkflowSource).toContain('nix.closure.bucket.nar_size')
+    expect(ciWorkflowSource).toContain('artifact_file=${artifactFileAssignment}')
+    expect(ciWorkflowSource).not.toContain('artifact_file=${shellSingleQuote(artifactFile)}')
     expect(ciWorkflowSource).toContain(
       'target: { kind: "nix-closure", id: $targetId, name: $targetName, label: $targetLabel, group: $targetGroup, system: $targetSystem }',
     )


### PR DESCRIPTION
**Problem**

`nixClosureMeasurementStep` defaulted `artifactFile` to `$ARTIFACT_DIR/measurements.json`, then rendered that default through `shellSingleQuote`. Generated CI therefore assigned `artifact_file='$ARTIFACT_DIR/measurements.json'`, so Bash treated `$ARTIFACT_DIR` as a literal directory name and failed before writing closure measurements.

**Goal**

Generated closure measurement jobs write `measurements.json` under the configured artifact directory by default.

**Decisions**

The default artifact path is now rendered as a shell assignment that expands `ARTIFACT_DIR`. Explicit caller-provided artifact paths still use the existing single-quote path for literal values.

**Verification**

```bash
CI=1 devenv tasks run test:genie --mode before --refresh-task-cache --no-tui --show-output
```

Passed: 14 test files, 254 tests.

```bash
git diff --check
```

Passed.

**Complexity**

No new abstraction; this is a narrow quoting fix plus a regression assertion.

**Concerns**

This branch is intended to unblock downstream generated CI consumers that use the default closure measurement artifact path.

**Friction & bottlenecks**

None beyond the downstream CI failure that exposed the quoting bug.

**Follow-ups**

Repin downstream CI reuse PRs to this commit once reviewed or merged.

**References**

Refs schickling/dotfiles#876

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🚿 co1-spray |
| `agent_session_id` | cc57739b-02d9-402f-9c98-76484d3167c5 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.129.0 |
| `agent_runtime` | Codex CLI 0.129.0 |
| `agent_model` | unknown |
| `worktree` | effect-utils-fix-closure-artifact/schickling/2026-05-13-fix-nix-closure-artifact-file |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->