### PR TITLE
fix: validate megarepo setup against current members

### DIFF
--- a/nix/devenv-modules/tasks/shared/megarepo.nix
+++ b/nix/devenv-modules/tasks/shared/megarepo.nix
@@ -136,9 +136,26 @@ let
     }
   '';
 
+  checkWorkspaceMembersScript = ''
+    set -o pipefail
+    [ -d ./repos ] || exit 1
+
+    ${loadCheckSkipMembersScript}
+
+    members=$(mr ls --output json | ${jq} -r '${mrLsMemberNamesJq}') || exit 1
+    for member in $members; do
+      if should_skip_member "$member"; then
+        continue
+      fi
+      if [ ! -L "./repos/$member" ] && [ ! -d "./repos/$member" ]; then
+        exit 1
+      fi
+    done
+  '';
+
   mrLsMemberNamesJq = ''
     select(._tag == "Success")
-    | (.value.members // .value.value.members // [])
+    | (.members // .value.members // .value.value.members // [])
     | .[].name
   '';
 
@@ -150,20 +167,11 @@ let
     fi
 
     if [ "''${DEVENV_SETUP_OUTER_CACHE_HIT:-0}" = "1" ]; then
-      [ -d ./repos ] || exit 1
-      [ -f ${lib.escapeShellArg membersFile} ] || exit 1
-      while IFS= read -r member; do
-        [ -n "$member" ] || continue
-        if [ ! -L "./repos/$member" ] && [ ! -d "./repos/$member" ]; then
-          exit 1
-        fi
-      done < ${lib.escapeShellArg membersFile}
+      ${checkWorkspaceMembersScript}
       exit 0
     fi
 
-    if [ ! -d ./repos ]; then
-      exit 1
-    fi
+    ${checkWorkspaceMembersScript}
 
     status_json=$(mr status --output json 2>/dev/null) || exit 1
     echo "$status_json" | ${jq} -e '(.workspaceSyncNeeded // false) == false' >/dev/null 2>&1
@@ -259,29 +267,11 @@ let
       after = [ "mr:apply" ];
       # Check that repos dir exists and all members have symlinks
       status = trace.status "mr:check" "path" ''
-        set -o pipefail
         if [ ! -f ./megarepo.kdl ] && [ ! -f ./megarepo.json ]; then
           exit 0
         fi
 
-        # Check that repos directory exists
-        if [ ! -d ./repos ]; then
-          exit 1
-        fi
-
-        ${loadCheckSkipMembersScript}
-
-        # Verify all configured members have symlinks in repos/
-        members=$(mr ls --output json | ${jq} -r '${mrLsMemberNamesJq}') || exit 1
-        for member in $members; do
-          if should_skip_member "$member"; then
-            continue
-          fi
-          if [ ! -L "./repos/$member" ] && [ ! -d "./repos/$member" ]; then
-            exit 1
-          fi
-        done
-
+        ${checkWorkspaceMembersScript}
         exit 0
       '';
       exec = trace.exec "mr:check" ''

--- a/nix/devenv-modules/tasks/shared/tests/megarepo-status.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/megarepo-status.test.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Tests for megarepo task output checks.
+#
+# Warm shell setup may skip expensive task execution, but task status still has
+# to validate the current workspace outputs against the current megarepo config.
+set -euo pipefail
+
+assert_exit_code() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+
+  if [ "$expected" != "$actual" ]; then
+    echo "FAIL: $label"
+    echo "  expected exit code: $expected"
+    echo "  actual exit code:   $actual"
+    exit 1
+  fi
+  echo "  ok: $label"
+}
+
+check_workspace_members() {
+  set -o pipefail
+  [ -d ./repos ] || exit 1
+
+  _mr_skip_csv="${MEGAREPO_SKIP_MEMBERS:-}"
+
+  should_skip_member() {
+    local member="$1"
+    if [ -z "$_mr_skip_csv" ]; then
+      return 1
+    fi
+
+    case ",$_mr_skip_csv," in
+      *,"$member",*) return 0 ;;
+      *) return 1 ;;
+    esac
+  }
+
+  members=$(mr ls --output json | jq -r '
+    select(._tag == "Success")
+    | (.members // .value.members // .value.value.members // [])
+    | .[].name
+  ') || exit 1
+
+  for member in $members; do
+    if should_skip_member "$member"; then
+      continue
+    fi
+    if [ ! -L "./repos/$member" ] && [ ! -d "./repos/$member" ]; then
+      exit 1
+    fi
+  done
+}
+
+run_check() {
+  (
+    cd "$workspace"
+    check_workspace_members
+  )
+}
+
+echo "Running megarepo status tests..."
+echo ""
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+workspace="$tmpdir/workspace"
+mkdir -p "$workspace/repos/one" "$workspace/.devenv/task-cache/mr-apply" "$tmpdir/bin"
+touch "$workspace/megarepo.kdl"
+
+cat > "$tmpdir/bin/mr" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$1" != "ls" ] || [ "$2" != "--output" ] || [ "$3" != "json" ]; then
+  echo "unexpected mr invocation: $*" >&2
+  exit 2
+fi
+
+cat <<'JSON'
+{
+  "_tag": "Success",
+  "members": [
+    { "name": "one" },
+    { "name": "two" }
+  ]
+}
+JSON
+EOF
+chmod +x "$tmpdir/bin/mr"
+export PATH="$tmpdir/bin:$PATH"
+
+echo "Test 1: missing configured member fails even with stale cached manifest"
+printf 'one\n' > "$workspace/.devenv/task-cache/mr-apply/members.txt"
+set +e
+run_check
+exit_code=$?
+set -e
+assert_exit_code 1 "$exit_code" "current mr ls output is authoritative"
+
+echo ""
+echo "Test 2: materialized configured members pass"
+mkdir -p "$workspace/repos/two"
+set +e
+run_check
+exit_code=$?
+set -e
+assert_exit_code 0 "$exit_code" "all current members materialized"
+
+echo ""
+echo "Test 3: explicit skip allows intentionally omitted member"
+rm -rf "$workspace/repos/two"
+set +e
+MEGAREPO_SKIP_MEMBERS=two run_check
+exit_code=$?
+set -e
+assert_exit_code 0 "$exit_code" "skipped member is ignored"
+
+echo ""
+echo "All megarepo status tests passed"

--- a/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
@@ -219,8 +219,10 @@ describe('ci workflow pnpm cache defaults', () => {
     expect(megarepoTaskModuleSource).not.toContain('MR_SKIP_ARGS+=(--skip "$member")')
   })
 
-  it('accepts both historical and nested mr ls success payloads', () => {
-    expect(megarepoTaskModuleSource).toContain('(.value.members // .value.value.members // [])')
+  it('accepts current, historical, and nested mr ls success payloads', () => {
+    expect(megarepoTaskModuleSource).toContain(
+      '(.members // .value.members // .value.value.members // [])',
+    )
     expect(megarepoTaskModuleSource).not.toContain('.value.members[].name')
   })
 


### PR DESCRIPTION
## Summary
- validate warm megarepo task status against the current `mr ls` member set instead of a cached manifest
- support current top-level `.members`, historical `.value.members`, and nested `.value.value.members` success payloads
- share the member materialization proof between `mr:apply`/`mr:fetch-apply` status and `mr:check`
- add a regression test for stale cached member manifests and `MEGAREPO_SKIP_MEMBERS`

## Verification
- `bash nix/devenv-modules/tasks/shared/tests/megarepo-status.test.sh`
- `bash nix/devenv-modules/tasks/shared/tests/setup-cache.test.sh`
- `nix-instantiate --parse nix/devenv-modules/tasks/shared/megarepo.nix >/dev/null`
- extracted generated `mr:apply` status and verified warm-missing=1, warm-complete=0, cold-complete=0
- `nixfmt --check nix/devenv-modules/tasks/shared/megarepo.nix`
- `devenv tasks run test:genie --mode before --refresh-task-cache --show-output`
- `git diff --check`

## Context
This closes the setup-gate hole seen from dotfiles #881/#882: a warm outer setup cache could accept a partial `repos/` tree when member discovery was vacuous or based on stale output. The status check now treats live `mr ls` output as the current authority and validates actual workspace outputs every time.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | ☁️ co2-billow |
| `agent_session_id` | 49ab84ac-5027-4924-8a6f-eeb76eb7b0fe |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.129.0 |
| `agent_runtime` | Codex CLI 0.129.0 |
| `agent_model` | unknown |
| `worktree` | dotfiles/schickling/2026-05-17-darwin-runner-scaler-activation |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@bff5c42 |
</details>
<!-- agent-footer:end -->