### PR TITLE
Fix pnpm projection health false positives

### DIFF
--- a/nix/devenv-modules/tasks/shared/check-node-modules-projection-health.cjs
+++ b/nix/devenv-modules/tasks/shared/check-node-modules-projection-health.cjs
@@ -1,6 +1,6 @@
 const fs = require('fs')
 const path = require('path')
-const { createRequire } = require('module')
+const { builtinModules, createRequire } = require('module')
 const crypto = require('crypto')
 
 const mode = process.env.NODE_MODULES_HELPER_MODE || 'health'
@@ -48,6 +48,13 @@ const collectHealthEntryPaths = (nodeModulesDir) => {
 }
 
 const resolveDependencyPackageRoot = ({ requireFromPkg, dependencyName }) => {
+  if (
+    builtinModules.includes(dependencyName) ||
+    builtinModules.includes(dependencyName.replace(/^node:/, ''))
+  ) {
+    return 'builtin'
+  }
+
   const packagePath = dependencyName.split('/')
   const searchPaths = requireFromPkg.resolve.paths(dependencyName) ?? []
 
@@ -83,6 +90,38 @@ const collectRuntimeExportTargets = (value, conditionName = undefined) => {
   return []
 }
 
+const collectRootRuntimeExportTargets = (exportsValue) => {
+  if (typeof exportsValue === 'string' || Array.isArray(exportsValue)) {
+    return collectRuntimeExportTargets(exportsValue)
+  }
+
+  if (!exportsValue || typeof exportsValue !== 'object') return []
+
+  if (Object.hasOwn(exportsValue, '.')) {
+    return collectRuntimeExportTargets(exportsValue['.'])
+  }
+
+  const keys = Object.keys(exportsValue)
+  if (keys.some((key) => key.startsWith('.'))) return []
+
+  return collectRuntimeExportTargets(exportsValue)
+}
+
+const targetExistsWithNodeResolution = (packageDir, target) => {
+  const resolved = path.resolve(packageDir, target)
+  if (fs.existsSync(resolved)) return true
+
+  for (const suffix of ['.js', '.json', '.node', '.mjs', '.cjs']) {
+    if (fs.existsSync(`${resolved}${suffix}`)) return true
+  }
+
+  for (const indexFile of ['index.js', 'index.json', 'index.node', 'index.mjs', 'index.cjs']) {
+    if (fs.existsSync(path.join(resolved, indexFile))) return true
+  }
+
+  return false
+}
+
 const verifyPackageContent = ({ pkg, packageDir, entryPath, failures }) => {
   if (!packageDir.includes('/v11/links/')) return
 
@@ -98,7 +137,7 @@ const verifyPackageContent = ({ pkg, packageDir, entryPath, failures }) => {
   }
 
   if (pkg.exports !== undefined) {
-    targets.push(...collectRuntimeExportTargets(pkg.exports))
+    targets.push(...collectRootRuntimeExportTargets(pkg.exports))
   }
 
   for (const target of targets) {
@@ -114,8 +153,7 @@ const verifyPackageContent = ({ pkg, packageDir, entryPath, failures }) => {
       continue
     }
 
-    const resolved = path.resolve(packageDir, target)
-    if (!fs.existsSync(resolved)) {
+    if (!targetExistsWithNodeResolution(packageDir, target)) {
       failures.push(`${pkg.name ?? entryPath} -> ${target} (${packageDir})`)
     }
   }

--- a/nix/devenv-modules/tasks/shared/pnpm.nix
+++ b/nix/devenv-modules/tasks/shared/pnpm.nix
@@ -116,9 +116,12 @@ let
   injectedSourcePaths = lib.unique (lib.concatMap getInjectedDeps packages);
 
   manifestPaths = lib.concatMapStringsSep " " (path: ''"${path}/package.json"'') packages;
-  nodeModulesPaths = lib.concatMapStringsSep " " (path: ''"${path}/node_modules"'') packages;
+  packageNodeModulesPaths = map (
+    path: if path == "." then "node_modules" else "${path}/node_modules"
+  ) packages;
+  nodeModulesPaths = lib.concatMapStringsSep " " lib.escapeShellArg packageNodeModulesPaths;
   healthCheckNodeModulesPaths = lib.concatStringsSep " " (
-    [ ''"node_modules"'' ] ++ (map (path: ''"${path}/node_modules"'') packages)
+    map lib.escapeShellArg (lib.unique ([ "node_modules" ] ++ packageNodeModulesPaths))
   );
   lockFilePaths = ''"pnpm-lock.yaml"'';
 

--- a/nix/devenv-modules/tasks/shared/tests/pnpm.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/pnpm.test.sh
@@ -72,7 +72,7 @@ make_missing_export_fixture() {
   mkdir -p "$package_root"
   mkdir -p "$root/node_modules"
   cat > "$package_root/package.json" <<'EOF'
-{"name":"pkg","files":["src"],"exports":{"./vitest":{"default":"./src/vitest.js"}}}
+{"name":"pkg","files":["src"],"exports":{".":{"default":"./src/index.js"}}}
 EOF
   ln -s ../store/v11/links/pkg/1.0.0/hash/node_modules/pkg "$root/node_modules/pkg"
 }
@@ -100,6 +100,43 @@ make_missing_type_export_fixture() {
 {"name":"pkg","files":["dist"],"exports":{"./internal/module-runner":{"types":"./dist/module-runner.d.ts","default":"./dist/module-runner.js"}}}
 EOF
   touch "$package_root/dist/module-runner.js"
+  ln -s ../store/v11/links/pkg/1.0.0/hash/node_modules/pkg "$root/node_modules/pkg"
+}
+
+make_builtin_dependency_fixture() {
+  local root="$1"
+
+  mkdir -p "$root/node_modules/.pnpm/pkg@1.0.0/node_modules/pkg"
+  mkdir -p "$root/node_modules"
+  cat > "$root/node_modules/.pnpm/pkg@1.0.0/node_modules/pkg/package.json" <<'EOF'
+{"name":"pkg","dependencies":{"buffer":"^5.0.0","node:test":"^1.0.0"}}
+EOF
+  ln -s .pnpm/pkg@1.0.0/node_modules/pkg "$root/node_modules/pkg"
+}
+
+make_extensionless_main_fixture() {
+  local root="$1"
+  local package_root="$root/store/v11/links/pkg/1.0.0/hash/node_modules/pkg"
+
+  mkdir -p "$package_root/lib"
+  mkdir -p "$root/node_modules"
+  cat > "$package_root/package.json" <<'EOF'
+{"name":"pkg","files":["lib"],"main":"./lib/index","exports":{".":{"default":"./lib/index"}}}
+EOF
+  touch "$package_root/lib/index.js"
+  ln -s ../store/v11/links/pkg/1.0.0/hash/node_modules/pkg "$root/node_modules/pkg"
+}
+
+make_missing_subpath_export_fixture() {
+  local root="$1"
+  local package_root="$root/store/v11/links/pkg/1.0.0/hash/node_modules/pkg"
+
+  mkdir -p "$package_root/dist"
+  mkdir -p "$root/node_modules"
+  cat > "$package_root/package.json" <<'EOF'
+{"name":"pkg","files":["dist"],"main":"./dist/index.js","exports":{".":{"default":"./dist/index.js"},"./optional":{"default":"./dist/optional.js"}}}
+EOF
+  touch "$package_root/dist/index.js"
   ln -s ../store/v11/links/pkg/1.0.0/hash/node_modules/pkg "$root/node_modules/pkg"
 }
 
@@ -313,6 +350,33 @@ check_node_modules_links_healthy node "$PROJECTION_SCRIPT" "$missing_type_dir/no
 exit_code=$?
 set -e
 assert_exit_code 0 "$exit_code" "projection health ignores type-only export targets"
+
+echo "Test 18: Projection health ignores dependency names that Node resolves as built-ins"
+builtin_dependency_dir="$test_dir/builtin-dependency"
+make_builtin_dependency_fixture "$builtin_dependency_dir"
+set +e
+check_node_modules_links_healthy node "$PROJECTION_SCRIPT" "$builtin_dependency_dir/node_modules" >/dev/null 2>&1
+exit_code=$?
+set -e
+assert_exit_code 0 "$exit_code" "projection health ignores built-in dependency names"
+
+echo "Test 19: Projection health accepts extensionless main and root export targets"
+extensionless_main_dir="$test_dir/extensionless-main"
+make_extensionless_main_fixture "$extensionless_main_dir"
+set +e
+check_node_modules_links_healthy node "$PROJECTION_SCRIPT" "$extensionless_main_dir/node_modules" >/dev/null 2>&1
+exit_code=$?
+set -e
+assert_exit_code 0 "$exit_code" "projection health accepts extensionless runtime targets"
+
+echo "Test 20: Projection health ignores missing optional subpath export targets"
+missing_subpath_export_dir="$test_dir/missing-subpath-export"
+make_missing_subpath_export_fixture "$missing_subpath_export_dir"
+set +e
+check_node_modules_links_healthy node "$PROJECTION_SCRIPT" "$missing_subpath_export_dir/node_modules" >/dev/null 2>&1
+exit_code=$?
+set -e
+assert_exit_code 0 "$exit_code" "projection health ignores optional subpath exports"
 
 echo ""
 echo "All pnpm task helper tests passed"


### PR DESCRIPTION
**Problem**

The shared pnpm projection health check can reject healthy installs in large pnpm 11 GVS workspaces. It treats Node built-in dependency names as missing package projections, requires raw file-path existence for extensionless runtime entries, and checks every subpath export as if it were proof of projection health.

**Goal**

Keep the health check focused on install/projection breakage so downstream repos can fail fast on stale node_modules without failing on valid Node resolution or unrelated package metadata quirks.

**Decisions**

- Skip dependency names that Node resolves as built-ins.
- Resolve package runtime targets with Node-like extension and index fallback.
- Check root package runtime entrypoints, not every optional subpath export.
- Deduplicate generated node_modules paths before passing them to the helper.

**Verification**

- `bash nix/devenv-modules/tasks/shared/tests/pnpm.test.sh`
- `devenv tasks run pnpm:install --mode before --no-tui`
- `devenv tasks run lint:check:format --mode before --no-tui`
- `git diff --check`
- Verified the patched helper exits cleanly against the downstream overeng workspace projection that currently fails with the old helper.

**Complexity**

No new abstraction. The checker now models the runtime resolution behavior it is validating.

**Concerns**

Subpath export metadata bugs are no longer treated as install-health failures. That is intentional: the install-health check should detect stale or broken projections, not lint every published package export.

**Friction & bottlenecks**

The downstream failure was only visible after a large workspace install and relink cycle. The focused shell fixtures now cover the false-positive cases directly.

**Follow-ups**

Repin downstream overeng once this lands and re-run its pnpm install gate.

**References**

Refs https://github.com/overengineeringstudio/overeng/pull/188

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🏝️ co2-cove |
| `agent_session_id` | 0da77e12-f53f-475f-b53a-e0bccf9eaa25 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.125.0 |
| `agent_runtime` | Codex CLI 0.125.0 |
| `agent_model` | unknown |
| `worktree` | effect-utils/schickling/2026-05-19-pnpm-health-check-realism |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@21f0837 |
</details>
<!-- agent-footer:end -->