### PR TITLE
Debug CI measurement source-shape scenario

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, schickling/2026-05-14-ci-measurement-gates]
   workflow_dispatch:
     inputs:
       measurement_baseline_ref:

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -554,7 +554,9 @@ export default ciWorkflow({
   name: 'CI',
   on: {
     push: { branches: ['main'] },
-    pull_request: { branches: ['main'] },
+    pull_request: {
+      branches: ['main', 'schickling/2026-05-14-ci-measurement-gates'],
+    },
     workflow_dispatch: {
       inputs: {
         ...ciMeasurementBaselineWorkflowDispatchInputs,

--- a/genie/ci-workflow/debug-source-shape-measurement.ts
+++ b/genie/ci-workflow/debug-source-shape-measurement.ts
@@ -1,0 +1,8 @@
+export const debugSourceShapeMeasurement = {
+  purpose: 'exercise-source-shape-ci-measurement',
+  notes: [
+    'This file is intentionally included by the Genie CI workflow source-shape scope.',
+    'It lets the source-shape measurement comment show a deterministic source growth scenario.',
+    'The branch should be closed after validating the debug comment.',
+  ],
+}


### PR DESCRIPTION
**Problem**

We need a production PR that deterministically changes source shape so the measurement comment can be reviewed outside wall-clock timing noise.

**Goal**

Exercise deterministic source-shape measurement reporting with a small added TypeScript file.

**Decisions**

The branch adds one small source file under the CI workflow scope so the source-shape comment should show a deterministic increase.

**Verification**

Local whitespace check passed before push. The production CI source-shape comment is the review artifact.

**Complexity**

No lasting production complexity; this is a temporary debug branch scoped to CI measurement validation.

**Concerns**

This PR should be closed after validating the measurement comment.

**Friction & bottlenecks**

None beyond the measurement-system validation this PR exists to exercise.

**Follow-ups**

Use the generated comment to tune deterministic measurement presentation in PR #658.

**References**

Refs #658

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🔔 co2-bell |
| `agent_session_id` | d4fe2a2f-be5f-468e-be47-cf35c97811b7 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.129.0 |
| `agent_runtime` | Codex CLI 0.129.0 |
| `agent_model` | unknown |
| `worktree` | eu-debug-source-shape/schickling/2026-05-19-ci-measurement-debug-source-shape |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@bff5c42 |
</details>
<!-- agent-footer:end -->