### PR TITLE
Enforce canonical GitHub megarepo sources

### DIFF
--- a/nix/devenv-modules/tasks/shared/check.nix
+++ b/nix/devenv-modules/tasks/shared/check.nix
@@ -57,6 +57,7 @@ let
   megarepoTasks = lib.optionals hasMegarepoCheck [
     "mr:check"
     "mr:lock-sync-check"
+    "mr:source-policy-check"
   ];
 
   # Build description parts

--- a/nix/devenv-modules/tasks/shared/megarepo.nix
+++ b/nix/devenv-modules/tasks/shared/megarepo.nix
@@ -368,6 +368,27 @@ let
         fi
       '';
     };
+
+    "mr:source-policy-check" = {
+      guard = "mr";
+      description = "Verify megarepo GitHub source and lock-file policy";
+      status = trace.status "mr:source-policy-check" "binary" ''
+        if [ ! -f ./megarepo.lock ]; then
+          exit 0
+        fi
+
+        mr check --all
+      '';
+      exec = trace.exec "mr:source-policy-check" ''
+        set -euo pipefail
+
+        if [ ! -f ./megarepo.lock ]; then
+          exit 0
+        fi
+
+        mr check --all
+      '';
+    };
   };
 in
 {

--- a/packages/@overeng/megarepo/src/cli/commands/check.ts
+++ b/packages/@overeng/megarepo/src/cli/commands/check.ts
@@ -1,0 +1,77 @@
+import * as Cli from '@effect/cli'
+import { Console, Effect, Option } from 'effect'
+
+import { EffectPath } from '@overeng/effect-path'
+
+import { readMegarepoConfig } from '../../lib/config.ts'
+import { LOCK_FILE_NAME, readLockFile } from '../../lib/lock.ts'
+import { checkSourcePolicy, formatSourcePolicyViolation } from '../../lib/source-policy.ts'
+import { Cwd, findMegarepoRoot, jsonOption } from '../context.ts'
+
+const allOption = Cli.Options.boolean('all').pipe(
+  Cli.Options.withDescription('Check member source and lock files in repos/ as well as the root'),
+  Cli.Options.withDefault(false),
+)
+
+/** Check that the megarepo is structurally valid. */
+export const checkCommand = Cli.Command.make(
+  'check',
+  {
+    all: allOption,
+    json: jsonOption,
+  },
+  ({ all, json }) =>
+    Effect.gen(function* () {
+      const cwd = yield* Cwd
+      const rootOpt = yield* findMegarepoRoot(cwd)
+
+      if (Option.isNone(rootOpt) === true) {
+        return yield* Effect.fail(new Error('No megarepo config found'))
+      }
+
+      const root = rootOpt.value
+      const { config } = yield* readMegarepoConfig(root)
+      const lockPath = EffectPath.ops.join(root, EffectPath.unsafe.relativeFile(LOCK_FILE_NAME))
+      const lockFileOpt = yield* readLockFile(lockPath)
+
+      if (Option.isNone(lockFileOpt) === true) {
+        return yield* Effect.fail(
+          new Error('megarepo.lock is required for megarepo checks; run `mr lock` first'),
+        )
+      }
+
+      const sourcePolicy = yield* checkSourcePolicy({
+        megarepoRoot: root,
+        config,
+        lockFile: lockFileOpt.value,
+        includeMembers: all,
+      })
+
+      const result = {
+        checks: [
+          {
+            name: 'source-policy',
+            violations: sourcePolicy.violations,
+          },
+        ],
+        violations: sourcePolicy.violations,
+      }
+
+      if (json === true) {
+        yield* Console.log(JSON.stringify(result, null, 2))
+      } else if (result.violations.length === 0) {
+        yield* Console.log('Megarepo checks OK')
+      } else {
+        yield* Console.error('Megarepo check violations:')
+        for (const violation of result.violations) {
+          yield* Console.error(`- ${formatSourcePolicyViolation(violation)}`)
+        }
+      }
+
+      if (result.violations.length > 0) {
+        return yield* Effect.fail(
+          new Error(`Megarepo checks failed with ${result.violations.length} violation(s)`),
+        )
+      }
+    }),
+).pipe(Cli.Command.withDescription('Check that the megarepo is structurally valid'))

--- a/packages/@overeng/megarepo/src/cli/commands/mod.ts
+++ b/packages/@overeng/megarepo/src/cli/commands/mod.ts
@@ -6,6 +6,7 @@
 
 export { addCommand } from './add.ts'
 export { applyCommand } from './apply.ts'
+export { checkCommand } from './check.ts'
 export { depsCommand } from './deps.ts'
 export { syncMegarepo } from './engine.ts'
 export { envCommand } from './env.ts'

--- a/packages/@overeng/megarepo/src/cli/mod.ts
+++ b/packages/@overeng/megarepo/src/cli/mod.ts
@@ -14,6 +14,7 @@ import { MR_VERSION } from '../lib/version.ts'
 import {
   addCommand,
   applyCommand,
+  checkCommand,
   configCommand,
   depsCommand,
   envCommand,
@@ -54,6 +55,7 @@ export const mrCommand = Cli.Command.make('mr', { cwd: cwdOption }).pipe(
     envCommand,
     statusCommand,
     lsCommand,
+    checkCommand,
     fetchCommand,
     applyCommand,
     lockCommand,

--- a/packages/@overeng/megarepo/src/lib/source-policy.ts
+++ b/packages/@overeng/megarepo/src/lib/source-policy.ts
@@ -1,0 +1,451 @@
+import { FileSystem, type Error as PlatformError } from '@effect/platform'
+import { Effect, Option } from 'effect'
+
+import { EffectPath, type AbsoluteDirPath } from '@overeng/effect-path'
+
+import { getMemberPath, type MegarepoConfig, parseSourceString } from './config.ts'
+import type { LockFile, LockedMember } from './lock.ts'
+import { getRef, parseNixFlakeUrl, serializeNixFlakeUrl } from './nix-lock/flake-url.ts'
+import {
+  extractDevenvYamlInputs,
+  extractFlakeNixInputs,
+  matchUrlToMember,
+} from './nix-lock/input-discovery.ts'
+
+/** Files inspected by the GitHub source policy check. */
+export type SourcePolicyFile =
+  | 'megarepo config'
+  | 'flake.nix'
+  | 'devenv.yaml'
+  | 'flake.lock'
+  | 'devenv.lock'
+
+/** A canonical-source policy violation with enough context for CLI output. */
+export type SourcePolicyViolation =
+  | {
+      readonly _tag: 'NonCanonicalGitHubMemberSource'
+      readonly file: SourcePolicyFile
+      readonly path: string
+      readonly memberName: string
+      readonly actual: string
+      readonly expected: string
+    }
+  | {
+      readonly _tag: 'NonCanonicalNixInputSource'
+      readonly file: SourcePolicyFile
+      readonly path: string
+      readonly inputName: string
+      readonly upstreamMember: string
+      readonly actual: string
+      readonly expected: string
+    }
+  | {
+      readonly _tag: 'IncompleteGitHubLockMetadata'
+      readonly file: SourcePolicyFile
+      readonly path: string
+      readonly inputName: string
+      readonly upstreamMember: string
+      readonly missingFields: ReadonlyArray<string>
+    }
+
+/** Result of checking source and lock files for canonical GitHub input shape. */
+export interface SourcePolicyCheckResult {
+  readonly violations: ReadonlyArray<SourcePolicyViolation>
+}
+
+const isMainRef = (ref: string | undefined): boolean => ref === undefined || ref === 'main'
+
+const refSuffix = (ref: string | undefined): string => (isMainRef(ref) === true ? '' : `#${ref}`)
+
+const githubFlakeRefSuffix = (ref: string | undefined): string =>
+  isMainRef(ref) === true ? '' : `/${ref}`
+
+const normalizeRepoName = (repo: string): string => repo.replace(/\.git$/, '')
+
+const canonicalMemberSource = ({
+  owner,
+  repo,
+  ref,
+}: {
+  owner: string
+  repo: string
+  ref: string | undefined
+}) => `${owner}/${normalizeRepoName(repo)}${refSuffix(ref)}`
+
+const canonicalFlakeSource = ({
+  owner,
+  repo,
+  ref,
+  params = new Map<string, string>(),
+}: {
+  owner: string
+  repo: string
+  ref: string | undefined
+  params?: ReadonlyMap<string, string>
+}) => {
+  const canonicalParams = new Map(params)
+  canonicalParams.delete('ref')
+  canonicalParams.delete('rev')
+
+  return serializeNixFlakeUrl({
+    _tag: 'github',
+    owner,
+    repo: normalizeRepoName(repo),
+    ref: githubFlakeRefSuffix(ref) === '' ? undefined : ref,
+    params: canonicalParams,
+  })
+}
+
+const githubRepoFromUrl = (url: string): { owner: string; repo: string } | undefined => {
+  const patterns = [
+    /^https?:\/\/github\.com\/([^/]+)\/([^/#?]+?)(?:\.git)?(?:[/?#].*)?$/,
+    /^git@github\.com:([^/]+)\/([^/#?]+?)(?:\.git)?$/,
+    /^ssh:\/\/git@github\.com\/([^/]+)\/([^/#?]+?)(?:\.git)?(?:[/?#].*)?$/,
+  ]
+
+  for (const pattern of patterns) {
+    const match = url.match(pattern)
+    if (match?.[1] !== undefined && match[2] !== undefined) {
+      return { owner: match[1], repo: normalizeRepoName(match[2]) }
+    }
+  }
+
+  return undefined
+}
+
+const normalizedGithubRepo = (repo: {
+  owner: string
+  repo: string
+}): { owner: string; repo: string } => ({
+  owner: repo.owner.toLowerCase(),
+  repo: normalizeRepoName(repo.repo).toLowerCase(),
+})
+
+const memberByGithubRepo = (members: Record<string, LockedMember>) => {
+  const result = new Map<string, { memberName: string; owner: string; repo: string }>()
+
+  for (const [memberName, member] of Object.entries(members)) {
+    const repo = githubRepoFromUrl(member.url)
+    if (repo === undefined) continue
+    const normalized = normalizedGithubRepo(repo)
+    result.set(`${normalized.owner}/${normalized.repo}`, { memberName, ...repo })
+  }
+
+  return result
+}
+
+const checkConfigMemberSources = ({
+  config,
+  configPath,
+}: {
+  config: MegarepoConfig
+  configPath: string
+}): ReadonlyArray<SourcePolicyViolation> => {
+  const violations: SourcePolicyViolation[] = []
+
+  for (const [memberName, sourceString] of Object.entries(config.members)) {
+    const source = parseSourceString(sourceString)
+    if (source?.type !== 'url') continue
+
+    const repo = githubRepoFromUrl(source.url)
+    if (repo === undefined) continue
+
+    violations.push({
+      _tag: 'NonCanonicalGitHubMemberSource',
+      file: 'megarepo config',
+      path: configPath,
+      memberName,
+      actual: sourceString,
+      expected: canonicalMemberSource({ ...repo, ref: Option.getOrUndefined(source.ref) }),
+    })
+  }
+
+  return violations
+}
+
+const checkSourceInputs = ({
+  content,
+  file,
+  path,
+  members,
+}: {
+  content: string
+  file: 'flake.nix' | 'devenv.yaml'
+  path: string
+  members: Record<string, LockedMember>
+}): ReadonlyArray<SourcePolicyViolation> => {
+  const inputs =
+    file === 'flake.nix' ? extractFlakeNixInputs(content) : extractDevenvYamlInputs(content)
+  const violations: SourcePolicyViolation[] = []
+
+  for (const input of inputs) {
+    const upstreamMember = matchUrlToMember({ url: input.url, members })
+    if (upstreamMember === undefined) continue
+
+    const parsed = parseNixFlakeUrl(input.url)
+    if (parsed === undefined || parsed._tag === 'github') continue
+
+    violations.push({
+      _tag: 'NonCanonicalNixInputSource',
+      file,
+      path,
+      inputName: input.inputName,
+      upstreamMember,
+      actual: input.url,
+      expected: canonicalFlakeSource({
+        owner: parsed.owner,
+        repo: parsed.repo,
+        ref: getRef(parsed),
+        params: parsed.params,
+      }),
+    })
+  }
+
+  return violations
+}
+
+const lockSourceRepo = (
+  section: Record<string, unknown> | undefined,
+):
+  | {
+      owner: string
+      repo: string
+      ref: string | undefined
+      type: string | undefined
+      params: ReadonlyMap<string, string>
+    }
+  | undefined => {
+  if (section === undefined) return undefined
+
+  const type = typeof section['type'] === 'string' ? section['type'] : undefined
+  const params = lockSourceParams(section)
+
+  if (type === 'github') {
+    const owner = section['owner']
+    const repo = section['repo']
+    return typeof owner === 'string' && typeof repo === 'string'
+      ? {
+          owner,
+          repo,
+          ref: typeof section['ref'] === 'string' ? section['ref'] : undefined,
+          type,
+          params,
+        }
+      : undefined
+  }
+
+  if (type === 'git') {
+    const url = section['url']
+    if (typeof url !== 'string') return undefined
+    const repo = githubRepoFromUrl(url)
+    if (repo === undefined) return undefined
+    return {
+      ...repo,
+      ref: typeof section['ref'] === 'string' ? section['ref'] : undefined,
+      type,
+      params,
+    }
+  }
+
+  return undefined
+}
+
+const lockSourceParams = (section: Record<string, unknown>): ReadonlyMap<string, string> => {
+  const params = new Map<string, string>()
+  const url = section['url']
+
+  if (typeof url === 'string') {
+    try {
+      const parsed = new URL(url)
+      for (const [key, value] of parsed.searchParams.entries()) {
+        params.set(key, value)
+      }
+    } catch {
+      // Keep lock parsing permissive: malformed or non-standard URLs are handled elsewhere.
+    }
+  }
+
+  const dir = section['dir']
+  if (typeof dir === 'string') {
+    params.set('dir', dir)
+  }
+
+  return params
+}
+
+const checkLockFileInputs = ({
+  content,
+  file,
+  path,
+  members,
+}: {
+  content: string
+  file: 'flake.lock' | 'devenv.lock'
+  path: string
+  members: Record<string, LockedMember>
+}): ReadonlyArray<SourcePolicyViolation> => {
+  let parsed: { root?: string; nodes?: Record<string, Record<string, unknown>> }
+  try {
+    parsed = JSON.parse(content) as {
+      root?: string
+      nodes?: Record<string, Record<string, unknown>>
+    }
+  } catch {
+    return []
+  }
+
+  const nodes = parsed.nodes
+  if (nodes === undefined) return []
+
+  const root = nodes[parsed.root ?? 'root']
+  const rootInputs = root?.['inputs'] as Record<string, string> | undefined
+  if (rootInputs === undefined) return []
+
+  const membersByRepo = memberByGithubRepo(members)
+  const violations: SourcePolicyViolation[] = []
+
+  for (const [inputName, nodeName] of Object.entries(rootInputs)) {
+    const node = nodes[nodeName]
+    const locked = node?.['locked'] as Record<string, unknown> | undefined
+    if (locked === undefined) continue
+
+    const lockedRepo = lockSourceRepo(locked)
+    if (lockedRepo === undefined) continue
+
+    const normalized = normalizedGithubRepo(lockedRepo)
+    const upstream = membersByRepo.get(`${normalized.owner}/${normalized.repo}`)
+    if (upstream === undefined) continue
+
+    const original = node?.['original'] as Record<string, unknown> | undefined
+    const originalRepo = lockSourceRepo(original)
+
+    if (lockedRepo.type !== 'github' || originalRepo?.type === 'git') {
+      violations.push({
+        _tag: 'NonCanonicalNixInputSource',
+        file,
+        path,
+        inputName,
+        upstreamMember: upstream.memberName,
+        actual: JSON.stringify({ original, locked }),
+        expected: canonicalFlakeSource({
+          owner: upstream.owner,
+          repo: upstream.repo,
+          ref: originalRepo?.ref ?? lockedRepo.ref,
+          params: originalRepo?.params ?? lockedRepo.params,
+        }),
+      })
+      continue
+    }
+
+    const missingFields = ['rev', 'narHash', 'lastModified'].filter(
+      (field) => locked[field] === undefined,
+    )
+    if (missingFields.length > 0) {
+      violations.push({
+        _tag: 'IncompleteGitHubLockMetadata',
+        file,
+        path,
+        inputName,
+        upstreamMember: upstream.memberName,
+        missingFields,
+      })
+    }
+  }
+
+  return violations
+}
+
+const readIfExists = (path: string) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem
+    if ((yield* fs.exists(path)) === false) return undefined
+    return yield* fs.readFileString(path)
+  })
+
+const checkDirectoryFiles = ({
+  dir,
+  label,
+  members,
+}: {
+  dir: AbsoluteDirPath
+  label: string
+  members: Record<string, LockedMember>
+}) =>
+  Effect.gen(function* () {
+    const violations: SourcePolicyViolation[] = []
+
+    for (const file of ['flake.nix', 'devenv.yaml'] as const) {
+      const path = EffectPath.ops.join(dir, EffectPath.unsafe.relativeFile(file))
+      const content = yield* readIfExists(path)
+      if (content !== undefined) {
+        violations.push(...checkSourceInputs({ content, file, path: `${label}/${file}`, members }))
+      }
+    }
+
+    for (const file of ['flake.lock', 'devenv.lock'] as const) {
+      const path = EffectPath.ops.join(dir, EffectPath.unsafe.relativeFile(file))
+      const content = yield* readIfExists(path)
+      if (content !== undefined) {
+        violations.push(
+          ...checkLockFileInputs({ content, file, path: `${label}/${file}`, members }),
+        )
+      }
+    }
+
+    return violations
+  })
+
+/** Check a megarepo for canonical GitHub member sources and Nix input locks. */
+export const checkSourcePolicy = ({
+  megarepoRoot,
+  config,
+  lockFile,
+  includeMembers,
+}: {
+  megarepoRoot: AbsoluteDirPath
+  config: MegarepoConfig
+  lockFile: LockFile
+  includeMembers: boolean
+}): Effect.Effect<SourcePolicyCheckResult, PlatformError.PlatformError, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const violations: SourcePolicyViolation[] = [
+      ...checkConfigMemberSources({
+        config,
+        configPath: 'megarepo config',
+      }),
+    ]
+
+    violations.push(
+      ...(yield* checkDirectoryFiles({
+        dir: megarepoRoot,
+        label: '.',
+        members: lockFile.members,
+      })),
+    )
+
+    if (includeMembers === true) {
+      for (const memberName of Object.keys(config.members)) {
+        violations.push(
+          ...(yield* checkDirectoryFiles({
+            dir: getMemberPath({ megarepoRoot, name: memberName }),
+            label: `repos/${memberName}`,
+            members: lockFile.members,
+          })),
+        )
+      }
+    }
+
+    return { violations }
+  })
+
+/** Format a source-policy violation for human-readable CLI output. */
+export const formatSourcePolicyViolation = (violation: SourcePolicyViolation): string => {
+  switch (violation._tag) {
+    case 'NonCanonicalGitHubMemberSource':
+      return `${violation.path}: member ${violation.memberName} uses ${violation.actual}; expected ${violation.expected}`
+    case 'NonCanonicalNixInputSource':
+      return `${violation.path}: input ${violation.inputName} -> ${violation.upstreamMember} uses ${violation.actual}; expected ${violation.expected}`
+    case 'IncompleteGitHubLockMetadata':
+      return `${violation.path}: input ${violation.inputName} -> ${violation.upstreamMember} is missing GitHub lock metadata: ${violation.missingFields.join(', ')}`
+  }
+}

--- a/packages/@overeng/megarepo/src/lib/source-policy.unit.test.ts
+++ b/packages/@overeng/megarepo/src/lib/source-policy.unit.test.ts
@@ -1,0 +1,271 @@
+import { FileSystem } from '@effect/platform'
+import { NodeContext } from '@effect/platform-node'
+import { Effect, type Scope } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import { EffectPath, type AbsoluteDirPath } from '@overeng/effect-path'
+
+import type { MegarepoConfig } from './config.ts'
+import type { LockFile } from './lock.ts'
+import { checkSourcePolicy } from './source-policy.ts'
+
+const commit = '41e0ed18178ecef0afde18a932e24372d5d61b11'
+
+const makeConfig = (members: Record<string, string>): MegarepoConfig =>
+  ({ members }) as MegarepoConfig
+
+const makeLockFile = (): LockFile =>
+  ({
+    version: 1,
+    members: {
+      'private-member': {
+        url: 'https://github.com/overengineeringstudio/private-member',
+        ref: 'main',
+        commit,
+        pinned: false,
+        lockedAt: '2026-05-19T10:00:00Z',
+      },
+    },
+  }) as LockFile
+
+const runWithContext = <A, E>(effect: Effect.Effect<A, E, NodeContext.NodeContext | Scope.Scope>) =>
+  Effect.runPromise(effect.pipe(Effect.scoped, Effect.provide(NodeContext.layer)))
+
+const writeFile = ({
+  root,
+  path,
+  content,
+}: {
+  root: AbsoluteDirPath
+  path: string
+  content: string
+}) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem
+    const fullPath = EffectPath.ops.join(root, EffectPath.unsafe.relativeFile(path))
+    yield* fs.makeDirectory(EffectPath.ops.parent(fullPath), { recursive: true })
+    yield* fs.writeFileString(fullPath, content)
+  })
+
+const withWorkspace = <A, E>(
+  use: (root: AbsoluteDirPath) => Effect.Effect<A, E, NodeContext.NodeContext>,
+) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem
+    const root = EffectPath.unsafe.absoluteDir(`${yield* fs.makeTempDirectoryScoped()}/`)
+    return yield* use(root)
+  })
+
+describe('checkSourcePolicy', () => {
+  it('allows canonical GitHub source shape and complete GitHub lock metadata', () =>
+    runWithContext(
+      withWorkspace((root) =>
+        Effect.gen(function* () {
+          yield* writeFile({
+            root,
+            path: 'flake.nix',
+            content: `{
+  inputs.private-member.url = "github:overengineeringstudio/private-member";
+}`,
+          })
+          yield* writeFile({
+            root,
+            path: 'flake.lock',
+            content: JSON.stringify({
+              root: 'root',
+              nodes: {
+                root: { inputs: { 'private-member': 'private-member' } },
+                'private-member': {
+                  original: {
+                    owner: 'overengineeringstudio',
+                    repo: 'private-member',
+                    type: 'github',
+                  },
+                  locked: {
+                    lastModified: 1779125469,
+                    narHash: 'sha256-9GjX7BCxjoimhsxW7zLHuzK+rZS1m3DtiMoo3B0xpxc=',
+                    owner: 'overengineeringstudio',
+                    repo: 'private-member',
+                    rev: commit,
+                    type: 'github',
+                  },
+                },
+              },
+            }),
+          })
+
+          const result = yield* checkSourcePolicy({
+            megarepoRoot: root,
+            config: makeConfig({ 'private-member': 'overengineeringstudio/private-member' }),
+            lockFile: makeLockFile(),
+            includeMembers: false,
+          })
+
+          expect(result.violations).toEqual([])
+        }),
+      ),
+    ))
+
+  it('rejects GitHub SSH member sources and Nix git inputs for megarepo members', () =>
+    runWithContext(
+      withWorkspace((root) =>
+        Effect.gen(function* () {
+          yield* writeFile({
+            root,
+            path: 'flake.nix',
+            content: `{
+  inputs.private-member.url = "git+ssh://git@github.com/overengineeringstudio/private-member?ref=main";
+}`,
+          })
+          yield* writeFile({
+            root,
+            path: 'flake.lock',
+            content: JSON.stringify({
+              root: 'root',
+              nodes: {
+                root: { inputs: { 'private-member': 'private-member' } },
+                'private-member': {
+                  original: {
+                    ref: 'main',
+                    type: 'git',
+                    url: 'ssh://git@github.com/overengineeringstudio/private-member',
+                  },
+                  locked: {
+                    ref: 'main',
+                    rev: commit,
+                    type: 'git',
+                    url: 'ssh://git@github.com/overengineeringstudio/private-member',
+                  },
+                },
+              },
+            }),
+          })
+
+          const result = yield* checkSourcePolicy({
+            megarepoRoot: root,
+            config: makeConfig({
+              'private-member': 'git@github.com:overengineeringstudio/private-member.git',
+            }),
+            lockFile: makeLockFile(),
+            includeMembers: false,
+          })
+
+          expect(result.violations.map((violation) => violation._tag)).toEqual([
+            'NonCanonicalGitHubMemberSource',
+            'NonCanonicalNixInputSource',
+            'NonCanonicalNixInputSource',
+          ])
+        }),
+      ),
+    ))
+
+  it('preserves flake dir query params in canonical source suggestions', () =>
+    runWithContext(
+      withWorkspace((root) =>
+        Effect.gen(function* () {
+          yield* writeFile({
+            root,
+            path: 'flake.nix',
+            content: `{
+  inputs.private-member.url = "git+ssh://git@github.com/overengineeringstudio/private-member?ref=main&dir=nix/flake";
+}`,
+          })
+          yield* writeFile({
+            root,
+            path: 'flake.lock',
+            content: JSON.stringify({
+              root: 'root',
+              nodes: {
+                root: { inputs: { 'private-member': 'private-member' } },
+                'private-member': {
+                  original: {
+                    dir: 'nix/flake',
+                    ref: 'main',
+                    type: 'git',
+                    url: 'ssh://git@github.com/overengineeringstudio/private-member',
+                  },
+                  locked: {
+                    dir: 'nix/flake',
+                    ref: 'main',
+                    rev: commit,
+                    type: 'git',
+                    url: 'ssh://git@github.com/overengineeringstudio/private-member',
+                  },
+                },
+              },
+            }),
+          })
+
+          const result = yield* checkSourcePolicy({
+            megarepoRoot: root,
+            config: makeConfig({ 'private-member': 'overengineeringstudio/private-member' }),
+            lockFile: makeLockFile(),
+            includeMembers: false,
+          })
+
+          expect(
+            result.violations
+              .filter((violation) => violation._tag === 'NonCanonicalNixInputSource')
+              .map((violation) => violation.expected),
+          ).toEqual([
+            'github:overengineeringstudio/private-member?dir=nix/flake',
+            'github:overengineeringstudio/private-member?dir=nix/flake',
+          ])
+        }),
+      ),
+    ))
+
+  it('rejects GitHub lock nodes missing metadata required for stable Nix fetches', () =>
+    runWithContext(
+      withWorkspace((root) =>
+        Effect.gen(function* () {
+          yield* writeFile({
+            root,
+            path: 'flake.lock',
+            content: JSON.stringify({
+              root: 'root',
+              nodes: {
+                root: { inputs: { 'private-member': 'private-member' } },
+                'private-member': {
+                  original: {
+                    owner: 'overengineeringstudio',
+                    repo: 'private-member',
+                    type: 'github',
+                  },
+                  locked: {
+                    owner: 'overengineeringstudio',
+                    repo: 'private-member',
+                    rev: commit,
+                    type: 'github',
+                  },
+                },
+              },
+            }),
+          })
+
+          const result = yield* checkSourcePolicy({
+            megarepoRoot: root,
+            config: makeConfig({ 'private-member': 'overengineeringstudio/private-member' }),
+            lockFile: makeLockFile(),
+            includeMembers: false,
+          })
+
+          expect(result.violations).toMatchInlineSnapshot(`
+            [
+              {
+                "_tag": "IncompleteGitHubLockMetadata",
+                "file": "flake.lock",
+                "inputName": "private-member",
+                "missingFields": [
+                  "narHash",
+                  "lastModified",
+                ],
+                "path": "./flake.lock",
+                "upstreamMember": "private-member",
+              },
+            ]
+          `)
+        }),
+      ),
+    ))
+})


### PR DESCRIPTION
**Problem**
Megarepo lock sync normalizes GitHub inputs to the `github:` scheme, but repositories can still declare equivalent GitHub sources through SSH or git URLs. That lets source files and lock files drift into different auth/source shapes.

**Goal**
Add a reusable check that flags non-canonical GitHub member sources and incomplete GitHub lock metadata before lock sync drift reaches downstream repos.

**Decisions**
- Put the policy in `@overeng/megarepo` instead of a repo-local CI script, so all consumers can share the same rule.
- Expose it through generic `mr check [--all] [--json]`, not a policy-specific `mr config ...` command, so the CLI can grow structurally without adding one-off top-level concepts.
- Keep the check deterministic and local. It inspects megarepo config plus Nix source/lock files; it does not call GitHub or Nix during linting.
- Preserve non-ref flake URL query params such as `dir` in canonical suggestions, while dropping `ref`/`rev` from the query and representing refs in the canonical `github:owner/repo[/ref]` shape.
- Require complete GitHub lock metadata (`rev`, `narHash`, `lastModified`) for matched megarepo inputs so incomplete normalized locks are caught.

**Verification**
- `CI=1 ./node_modules/.bin/vitest run src/lib/source-policy.unit.test.ts` (4 tests, including `dir` query-param preservation)
- `devenv tasks run ts:check`
- `devenv tasks run lint:check:oxlint`
- `devenv tasks run lint:check:format`
- `devenv shell -- env DT_PASSTHROUGH=1 mr check --all --json` returned zero violations.
- `devenv shell -- env DT_PASSTHROUGH=1 mr config --help | rg "check-source-policy"` returned no matches.
- `devenv tasks run mr:source-policy-check --mode before --no-tui`
- `CI=1 devenv tasks run check:all` (passed after rerunning a transient `test:megarepo` timeout; `CI=1 devenv tasks run test:megarepo` passed independently)

**Complexity**
Adds one policy module and a generic CLI entrypoint. The CLI surface stays small because future structural checks can compose under `mr check` instead of introducing separate commands.

**Concerns**
This check enforces source shape only. Private GitHub auth still must be provided to Nix explicitly through `access-tokens` in `NIX_CONFIG`; `GH_TOKEN`/`GITHUB_TOKEN` alone are not sufficient for Nix `github:` fetches.

**Friction & bottlenecks**
Running multiple devenv commands concurrently briefly hit a local GC-root cleanup race. Sequential reruns succeeded.

**Follow-ups**
Downstream repos should adopt this helper version and switch private GitHub flake inputs to canonical `github:` sources with explicit Nix `access-tokens` in CI/root flows.

**References**
Refs the megarepo source/lock alignment work.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🪨 co1-butte |
| `agent_session_id` | d03e6b40-88b1-4fa3-aa63-b73c83cfdc47 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.130.0 |
| `agent_runtime` | Codex CLI 0.130.0 |
| `agent_model` | unknown |
| `worktree` | dotfiles/schickling/2026-05-19-github-source-policy |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@b228ad5 |
</details>
<!-- agent-footer:end -->