### PR TITLE
Relax pnpm health for conditional exports

### DIFF
--- a/nix/devenv-modules/tasks/shared/check-node-modules-projection-health.cjs
+++ b/nix/devenv-modules/tasks/shared/check-node-modules-projection-health.cjs
@@ -122,6 +122,16 @@ const targetExistsWithNodeResolution = (packageDir, target) => {
   return false
 }
 
+const packageTargetIsShipped = ({ includedFiles, target }) => {
+  if (!target.startsWith('./')) return false
+  if (target.includes('*')) return false
+
+  const relativeTarget = target.slice(2)
+  return includedFiles.some(
+    (file) => file === relativeTarget || relativeTarget.startsWith(`${file}/`),
+  )
+}
+
 const verifyPackageContent = ({ pkg, packageDir, entryPath, failures }) => {
   if (!packageDir.includes('/v11/links/')) return
 
@@ -130,31 +140,26 @@ const verifyPackageContent = ({ pkg, packageDir, entryPath, failures }) => {
     : []
   if (includedFiles.length === 0) return
 
-  const targets = []
-
   if (typeof pkg.main === 'string') {
-    targets.push(pkg.main)
+    if (
+      packageTargetIsShipped({ includedFiles, target: pkg.main }) &&
+      !targetExistsWithNodeResolution(packageDir, pkg.main)
+    ) {
+      failures.push(`${pkg.name ?? entryPath} -> ${pkg.main} (${packageDir})`)
+    }
   }
 
   if (pkg.exports !== undefined) {
-    targets.push(...collectRootRuntimeExportTargets(pkg.exports))
-  }
-
-  for (const target of targets) {
-    if (!target.startsWith('./')) continue
-    if (target.includes('*')) continue
-
-    const relativeTarget = target.slice(2)
+    const shippedExportTargets = collectRootRuntimeExportTargets(pkg.exports).filter((target) =>
+      packageTargetIsShipped({ includedFiles, target }),
+    )
     if (
-      !includedFiles.some(
-        (file) => file === relativeTarget || relativeTarget.startsWith(`${file}/`),
-      )
+      shippedExportTargets.length > 0 &&
+      !shippedExportTargets.some((target) => targetExistsWithNodeResolution(packageDir, target))
     ) {
-      continue
-    }
-
-    if (!targetExistsWithNodeResolution(packageDir, target)) {
-      failures.push(`${pkg.name ?? entryPath} -> ${target} (${packageDir})`)
+      failures.push(
+        `${pkg.name ?? entryPath} -> ${shippedExportTargets.join(' | ')} (${packageDir})`,
+      )
     }
   }
 }

--- a/nix/devenv-modules/tasks/shared/tests/pnpm.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/pnpm.test.sh
@@ -90,6 +90,20 @@ EOF
   ln -s ../store/v11/links/pkg/1.0.0/hash/node_modules/pkg "$root/node_modules/pkg"
 }
 
+make_missing_conditional_export_alternative_fixture() {
+  local root="$1"
+  local package_root="$root/store/v11/links/pkg/1.0.0/hash/node_modules/pkg"
+
+  mkdir -p "$package_root/build"
+  mkdir -p "$root/node_modules"
+  cat > "$package_root/package.json" <<'EOF'
+{"name":"pkg","files":["build"],"main":"./build/pkg.esm.js","exports":{".":{"import":"./build/pkg.esm.js","require":"./build/index.js","browser":"./build/pkg.min.js"}}}
+EOF
+  touch "$package_root/build/pkg.esm.js"
+  touch "$package_root/build/pkg.min.js"
+  ln -s ../store/v11/links/pkg/1.0.0/hash/node_modules/pkg "$root/node_modules/pkg"
+}
+
 make_missing_type_export_fixture() {
   local root="$1"
   local package_root="$root/store/v11/links/pkg/1.0.0/hash/node_modules/pkg"
@@ -351,7 +365,16 @@ exit_code=$?
 set -e
 assert_exit_code 0 "$exit_code" "projection health ignores type-only export targets"
 
-echo "Test 18: Projection health ignores dependency names that Node resolves as built-ins"
+echo "Test 18: Projection health accepts a package when one root conditional export target exists"
+missing_condition_alternative_dir="$test_dir/missing-condition-alternative"
+make_missing_conditional_export_alternative_fixture "$missing_condition_alternative_dir"
+set +e
+check_node_modules_links_healthy node "$PROJECTION_SCRIPT" "$missing_condition_alternative_dir/node_modules" >/dev/null 2>&1
+exit_code=$?
+set -e
+assert_exit_code 0 "$exit_code" "projection health accepts alternate runtime export targets"
+
+echo "Test 19: Projection health ignores dependency names that Node resolves as built-ins"
 builtin_dependency_dir="$test_dir/builtin-dependency"
 make_builtin_dependency_fixture "$builtin_dependency_dir"
 set +e
@@ -360,7 +383,7 @@ exit_code=$?
 set -e
 assert_exit_code 0 "$exit_code" "projection health ignores built-in dependency names"
 
-echo "Test 19: Projection health accepts extensionless main and root export targets"
+echo "Test 20: Projection health accepts extensionless main and root export targets"
 extensionless_main_dir="$test_dir/extensionless-main"
 make_extensionless_main_fixture "$extensionless_main_dir"
 set +e
@@ -369,7 +392,7 @@ exit_code=$?
 set -e
 assert_exit_code 0 "$exit_code" "projection health accepts extensionless runtime targets"
 
-echo "Test 20: Projection health ignores missing optional subpath export targets"
+echo "Test 21: Projection health ignores missing optional subpath export targets"
 missing_subpath_export_dir="$test_dir/missing-subpath-export"
 make_missing_subpath_export_fixture "$missing_subpath_export_dir"
 set +e


### PR DESCRIPTION
**Problem**

The pnpm projection health check added for GVS corruption detection is still too strict for real packages that publish a valid root runtime entry plus a stale or unused conditional export target. In overeng CI, `@upsetjs/venn.js` exposes working `main`/`import`/browser files but also lists a missing `require` target, so the helper treats a valid install as a corrupted projection.

**Goal**

Keep detecting genuinely broken pnpm link projections while avoiding false positives for conditional export alternatives when at least one shipped root runtime target exists.

**Decisions**

`main` stays strict when it points at shipped package content. Root `exports` are treated as alternative runtime entries for projection health: if none of the shipped root runtime targets exists, the projection is unhealthy; if one exists, the package is materially present and the helper does not try to validate every package authoring condition.

**Verification**

- `bash nix/devenv-modules/tasks/shared/tests/pnpm.test.sh`
- `node -c nix/devenv-modules/tasks/shared/check-node-modules-projection-health.cjs`
- `git diff --check`
- `devenv tasks run lint:check:format --mode before --no-tui`
- `devenv tasks run pnpm:install --mode before --no-tui`

**Complexity**

No new abstraction; this narrows the existing health predicate to projection health instead of full package metadata validation.

**Concerns**

A package with only a broken `require` condition and a valid ESM/browser condition will now pass this health check. That is intentional because this helper is meant to decide whether pnpm materialized package content, not whether every conditional export path is semantically valid for every resolver.

**Friction & bottlenecks**

Found by running the downstream overeng PR against a fresh CI pnpm store. The failure reproduced locally with `pnpm:install:livestore` before this helper change.

**Follow-ups**

None.

**References**

Refs overengineeringstudio/overeng#188.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🏝️ co2-cove |
| `agent_session_id` | 0da77e12-f53f-475f-b53a-e0bccf9eaa25 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.125.0 |
| `agent_runtime` | Codex CLI 0.125.0 |
| `agent_model` | unknown |
| `worktree` | effect-utils/schickling/2026-05-19-pnpm-health-export-conditions |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@21f0837 |
</details>
<!-- agent-footer:end -->