### PR TITLE
Harden CI measurement baseline artifact downloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4231,6 +4231,26 @@ jobs:
           fi
           echo "Using GitHub CLI: $GH_BIN"
 
+          CURL_BIN="$(command -v curl || true)"
+          if [ -z "$CURL_BIN" ]; then
+            echo "::notice::curl is not on PATH; resolving curl through Nix"
+            if ! CURL_BIN="$(nix build --no-link --print-out-paths nixpkgs#curl 2>/dev/null)/bin/curl"; then
+              echo "::notice::unable to resolve curl through Nix; skipping previous artifact download"
+              exit 0
+            fi
+          fi
+          echo "Using curl: $CURL_BIN"
+
+          UNZIP_BIN="$(command -v unzip || true)"
+          if [ -z "$UNZIP_BIN" ]; then
+            echo "::notice::unzip is not on PATH; resolving unzip through Nix"
+            if ! UNZIP_BIN="$(nix build --no-link --print-out-paths nixpkgs#unzip 2>/dev/null)/bin/unzip"; then
+              echo "::notice::unable to resolve unzip through Nix; skipping previous artifact download"
+              exit 0
+            fi
+          fi
+          echo "Using unzip: $UNZIP_BIN"
+
           repo="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY not set}"
           workflow="${BASELINE_WORKFLOW_NAME:-CI}"
           branch="${BASELINE_BRANCH:-${GITHUB_BASE_REF:-${GITHUB_REF_NAME:-main}}}"
@@ -4318,6 +4338,35 @@ jobs:
             jq -e '.required | all(.satisfied == true)' "$BASELINE_OUTPUT_DIR/baseline-observation-counts.json" >/dev/null
           }
 
+          download_artifact_archive() {
+            local artifact_id="$1"
+            local output_dir="$2"
+            local archive_file="$output_dir/artifact.zip"
+            local artifact_url="https://api.github.com/repos/$repo/actions/artifacts/$artifact_id/zip"
+            local curl_args=(
+              --fail
+              --location
+              --silent
+              --show-error
+              --connect-timeout 15
+              --max-time "$download_timeout_seconds"
+              --retry 2
+              --retry-delay 2
+              --retry-max-time "$download_timeout_seconds"
+              --header "Accept: application/vnd.github+json"
+              --header "X-GitHub-Api-Version: 2022-11-28"
+              --output "$archive_file"
+            )
+
+            if [ -n "${GH_TOKEN:-}" ]; then
+              curl_args+=(--header "Authorization: Bearer ${GH_TOKEN}")
+            fi
+
+            "$CURL_BIN" "${curl_args[@]}" "$artifact_url"
+            "$UNZIP_BIN" -q -o "$archive_file" -d "$output_dir"
+            rm -f "$archive_file"
+          }
+
           run_id=""
           artifact_name=""
           artifact_id=""
@@ -4359,10 +4408,7 @@ jobs:
               current_artifact_id="$(printf '%s' "$artifact_json" | jq -r '.id')"
               current_output_dir="$BASELINE_OUTPUT_DIR/run-$candidate_run"
               mkdir -p "$current_output_dir"
-              if timeout "$download_timeout_seconds" "$GH_BIN" run download "$candidate_run" \
-                --repo "$repo" \
-                --name "$current_artifact_name" \
-                --dir "$current_output_dir"; then
+              if download_artifact_archive "$current_artifact_id" "$current_output_dir"; then
                 if [ -z "$run_id" ]; then
                   run_id="$candidate_run"
                   artifact_name="$current_artifact_name"
@@ -4378,11 +4424,7 @@ jobs:
               else
                 status="$?"
                 rm -rf "$current_output_dir"
-                if [ "$status" -eq 124 ]; then
-                  echo "::notice::timed out after ${download_timeout_seconds}s downloading baseline artifact $current_artifact_name from run $candidate_run; skipping candidate"
-                else
-                  echo "::notice::failed to download baseline artifact $current_artifact_name from run $candidate_run (exit $status)"
-                fi
+                echo "::notice::failed or timed out after ${download_timeout_seconds}s downloading baseline artifact $current_artifact_name from run $candidate_run (exit $status); skipping candidate"
               fi
             fi
           done
@@ -4450,6 +4492,26 @@ jobs:
           fi
           echo "Using GitHub CLI: $GH_BIN"
 
+          CURL_BIN="$(command -v curl || true)"
+          if [ -z "$CURL_BIN" ]; then
+            echo "::notice::curl is not on PATH; resolving curl through Nix"
+            if ! CURL_BIN="$(nix build --no-link --print-out-paths nixpkgs#curl 2>/dev/null)/bin/curl"; then
+              echo "::notice::unable to resolve curl through Nix; skipping previous artifact download"
+              exit 0
+            fi
+          fi
+          echo "Using curl: $CURL_BIN"
+
+          UNZIP_BIN="$(command -v unzip || true)"
+          if [ -z "$UNZIP_BIN" ]; then
+            echo "::notice::unzip is not on PATH; resolving unzip through Nix"
+            if ! UNZIP_BIN="$(nix build --no-link --print-out-paths nixpkgs#unzip 2>/dev/null)/bin/unzip"; then
+              echo "::notice::unable to resolve unzip through Nix; skipping previous artifact download"
+              exit 0
+            fi
+          fi
+          echo "Using unzip: $UNZIP_BIN"
+
           repo="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY not set}"
           workflow="${BASELINE_WORKFLOW_NAME:-CI}"
           branch="${BASELINE_BRANCH:-${GITHUB_BASE_REF:-${GITHUB_REF_NAME:-main}}}"
@@ -4537,6 +4599,35 @@ jobs:
             jq -e '.required | all(.satisfied == true)' "$BASELINE_OUTPUT_DIR/baseline-observation-counts.json" >/dev/null
           }
 
+          download_artifact_archive() {
+            local artifact_id="$1"
+            local output_dir="$2"
+            local archive_file="$output_dir/artifact.zip"
+            local artifact_url="https://api.github.com/repos/$repo/actions/artifacts/$artifact_id/zip"
+            local curl_args=(
+              --fail
+              --location
+              --silent
+              --show-error
+              --connect-timeout 15
+              --max-time "$download_timeout_seconds"
+              --retry 2
+              --retry-delay 2
+              --retry-max-time "$download_timeout_seconds"
+              --header "Accept: application/vnd.github+json"
+              --header "X-GitHub-Api-Version: 2022-11-28"
+              --output "$archive_file"
+            )
+
+            if [ -n "${GH_TOKEN:-}" ]; then
+              curl_args+=(--header "Authorization: Bearer ${GH_TOKEN}")
+            fi
+
+            "$CURL_BIN" "${curl_args[@]}" "$artifact_url"
+            "$UNZIP_BIN" -q -o "$archive_file" -d "$output_dir"
+            rm -f "$archive_file"
+          }
+
           run_id=""
           artifact_name=""
           artifact_id=""
@@ -4578,10 +4669,7 @@ jobs:
               current_artifact_id="$(printf '%s' "$artifact_json" | jq -r '.id')"
               current_output_dir="$BASELINE_OUTPUT_DIR/run-$candidate_run"
               mkdir -p "$current_output_dir"
-              if timeout "$download_timeout_seconds" "$GH_BIN" run download "$candidate_run" \
-                --repo "$repo" \
-                --name "$current_artifact_name" \
-                --dir "$current_output_dir"; then
+              if download_artifact_archive "$current_artifact_id" "$current_output_dir"; then
                 if [ -z "$run_id" ]; then
                   run_id="$candidate_run"
                   artifact_name="$current_artifact_name"
@@ -4597,11 +4685,7 @@ jobs:
               else
                 status="$?"
                 rm -rf "$current_output_dir"
-                if [ "$status" -eq 124 ]; then
-                  echo "::notice::timed out after ${download_timeout_seconds}s downloading baseline artifact $current_artifact_name from run $candidate_run; skipping candidate"
-                else
-                  echo "::notice::failed to download baseline artifact $current_artifact_name from run $candidate_run (exit $status)"
-                fi
+                echo "::notice::failed or timed out after ${download_timeout_seconds}s downloading baseline artifact $current_artifact_name from run $candidate_run (exit $status); skipping candidate"
               fi
             fi
           done
@@ -4669,6 +4753,26 @@ jobs:
           fi
           echo "Using GitHub CLI: $GH_BIN"
 
+          CURL_BIN="$(command -v curl || true)"
+          if [ -z "$CURL_BIN" ]; then
+            echo "::notice::curl is not on PATH; resolving curl through Nix"
+            if ! CURL_BIN="$(nix build --no-link --print-out-paths nixpkgs#curl 2>/dev/null)/bin/curl"; then
+              echo "::notice::unable to resolve curl through Nix; skipping previous artifact download"
+              exit 0
+            fi
+          fi
+          echo "Using curl: $CURL_BIN"
+
+          UNZIP_BIN="$(command -v unzip || true)"
+          if [ -z "$UNZIP_BIN" ]; then
+            echo "::notice::unzip is not on PATH; resolving unzip through Nix"
+            if ! UNZIP_BIN="$(nix build --no-link --print-out-paths nixpkgs#unzip 2>/dev/null)/bin/unzip"; then
+              echo "::notice::unable to resolve unzip through Nix; skipping previous artifact download"
+              exit 0
+            fi
+          fi
+          echo "Using unzip: $UNZIP_BIN"
+
           repo="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY not set}"
           workflow="${BASELINE_WORKFLOW_NAME:-CI}"
           branch="${BASELINE_BRANCH:-${GITHUB_BASE_REF:-${GITHUB_REF_NAME:-main}}}"
@@ -4756,6 +4860,35 @@ jobs:
             jq -e '.required | all(.satisfied == true)' "$BASELINE_OUTPUT_DIR/baseline-observation-counts.json" >/dev/null
           }
 
+          download_artifact_archive() {
+            local artifact_id="$1"
+            local output_dir="$2"
+            local archive_file="$output_dir/artifact.zip"
+            local artifact_url="https://api.github.com/repos/$repo/actions/artifacts/$artifact_id/zip"
+            local curl_args=(
+              --fail
+              --location
+              --silent
+              --show-error
+              --connect-timeout 15
+              --max-time "$download_timeout_seconds"
+              --retry 2
+              --retry-delay 2
+              --retry-max-time "$download_timeout_seconds"
+              --header "Accept: application/vnd.github+json"
+              --header "X-GitHub-Api-Version: 2022-11-28"
+              --output "$archive_file"
+            )
+
+            if [ -n "${GH_TOKEN:-}" ]; then
+              curl_args+=(--header "Authorization: Bearer ${GH_TOKEN}")
+            fi
+
+            "$CURL_BIN" "${curl_args[@]}" "$artifact_url"
+            "$UNZIP_BIN" -q -o "$archive_file" -d "$output_dir"
+            rm -f "$archive_file"
+          }
+
           run_id=""
           artifact_name=""
           artifact_id=""
@@ -4797,10 +4930,7 @@ jobs:
               current_artifact_id="$(printf '%s' "$artifact_json" | jq -r '.id')"
               current_output_dir="$BASELINE_OUTPUT_DIR/run-$candidate_run"
               mkdir -p "$current_output_dir"
-              if timeout "$download_timeout_seconds" "$GH_BIN" run download "$candidate_run" \
-                --repo "$repo" \
-                --name "$current_artifact_name" \
-                --dir "$current_output_dir"; then
+              if download_artifact_archive "$current_artifact_id" "$current_output_dir"; then
                 if [ -z "$run_id" ]; then
                   run_id="$candidate_run"
                   artifact_name="$current_artifact_name"
@@ -4816,11 +4946,7 @@ jobs:
               else
                 status="$?"
                 rm -rf "$current_output_dir"
-                if [ "$status" -eq 124 ]; then
-                  echo "::notice::timed out after ${download_timeout_seconds}s downloading baseline artifact $current_artifact_name from run $candidate_run; skipping candidate"
-                else
-                  echo "::notice::failed to download baseline artifact $current_artifact_name from run $candidate_run (exit $status)"
-                fi
+                echo "::notice::failed or timed out after ${download_timeout_seconds}s downloading baseline artifact $current_artifact_name from run $candidate_run (exit $status); skipping candidate"
               fi
             fi
           done

--- a/genie/ci-workflow/measurements.ts
+++ b/genie/ci-workflow/measurements.ts
@@ -1233,6 +1233,26 @@ else
 fi
 echo "Using GitHub CLI: $GH_BIN"
 
+CURL_BIN="$(command -v curl || true)"
+if [ -z "$CURL_BIN" ]; then
+  echo "::notice::curl is not on PATH; resolving curl through Nix"
+  if ! CURL_BIN="$(nix build --no-link --print-out-paths nixpkgs#curl 2>/dev/null)/bin/curl"; then
+    echo "::notice::unable to resolve curl through Nix; skipping previous artifact download"
+    exit 0
+  fi
+fi
+echo "Using curl: $CURL_BIN"
+
+UNZIP_BIN="$(command -v unzip || true)"
+if [ -z "$UNZIP_BIN" ]; then
+  echo "::notice::unzip is not on PATH; resolving unzip through Nix"
+  if ! UNZIP_BIN="$(nix build --no-link --print-out-paths nixpkgs#unzip 2>/dev/null)/bin/unzip"; then
+    echo "::notice::unable to resolve unzip through Nix; skipping previous artifact download"
+    exit 0
+  fi
+fi
+echo "Using unzip: $UNZIP_BIN"
+
 repo="${dollar}{GITHUB_REPOSITORY:?GITHUB_REPOSITORY not set}"
 workflow="${dollar}{BASELINE_WORKFLOW_NAME:-CI}"
 branch="${dollar}{BASELINE_BRANCH:-${dollar}{GITHUB_BASE_REF:-${dollar}{GITHUB_REF_NAME:-main}}}"
@@ -1320,6 +1340,35 @@ baseline_requirements_satisfied() {
   jq -e '.required | all(.satisfied == true)' "$BASELINE_OUTPUT_DIR/baseline-observation-counts.json" >/dev/null
 }
 
+download_artifact_archive() {
+  local artifact_id="$1"
+  local output_dir="$2"
+  local archive_file="$output_dir/artifact.zip"
+  local artifact_url="https://api.github.com/repos/$repo/actions/artifacts/$artifact_id/zip"
+  local curl_args=(
+    --fail
+    --location
+    --silent
+    --show-error
+    --connect-timeout 15
+    --max-time "$download_timeout_seconds"
+    --retry 2
+    --retry-delay 2
+    --retry-max-time "$download_timeout_seconds"
+    --header "Accept: application/vnd.github+json"
+    --header "X-GitHub-Api-Version: 2022-11-28"
+    --output "$archive_file"
+  )
+
+  if [ -n "${dollar}{GH_TOKEN:-}" ]; then
+    curl_args+=(--header "Authorization: Bearer ${dollar}{GH_TOKEN}")
+  fi
+
+  "$CURL_BIN" "${dollar}{curl_args[@]}" "$artifact_url"
+  "$UNZIP_BIN" -q -o "$archive_file" -d "$output_dir"
+  rm -f "$archive_file"
+}
+
 run_id=""
 artifact_name=""
 artifact_id=""
@@ -1361,10 +1410,7 @@ for candidate_run in $candidate_runs; do
     current_artifact_id="$(printf '%s' "$artifact_json" | jq -r '.id')"
     current_output_dir="$BASELINE_OUTPUT_DIR/run-$candidate_run"
     mkdir -p "$current_output_dir"
-    if timeout "$download_timeout_seconds" "$GH_BIN" run download "$candidate_run" \
-      --repo "$repo" \
-      --name "$current_artifact_name" \
-      --dir "$current_output_dir"; then
+    if download_artifact_archive "$current_artifact_id" "$current_output_dir"; then
       if [ -z "$run_id" ]; then
         run_id="$candidate_run"
         artifact_name="$current_artifact_name"
@@ -1380,11 +1426,7 @@ for candidate_run in $candidate_runs; do
     else
       status="$?"
       rm -rf "$current_output_dir"
-      if [ "$status" -eq 124 ]; then
-        echo "::notice::timed out after ${dollar}{download_timeout_seconds}s downloading baseline artifact $current_artifact_name from run $candidate_run; skipping candidate"
-      else
-        echo "::notice::failed to download baseline artifact $current_artifact_name from run $candidate_run (exit $status)"
-      fi
+      echo "::notice::failed or timed out after ${dollar}{download_timeout_seconds}s downloading baseline artifact $current_artifact_name from run $candidate_run (exit $status); skipping candidate"
     fi
   fi
 done


### PR DESCRIPTION
**Problem**

The CI measurement report helper used `gh run download` for historical baseline artifacts. In the dotfiles production PR this made the report spend several minutes in a single baseline download step, so the intended timeout did not give a tight bound.

**Goal**

Make baseline artifact downloads bounded and reusable across repos, so CI measurement comments can be trusted to finish promptly even when a historical artifact endpoint is slow.

**Decisions**

The helper now keeps GitHub CLI for run/artifact discovery, but downloads the selected artifact archive directly through the GitHub artifact API with `curl --connect-timeout` and `--max-time`, then extracts it with `unzip`. This avoids the opaque `gh run download` transfer path while preserving the existing seed-run, candidate-history, and required-observation logic.

**Verification**

- `devenv tasks run genie:run --mode before --no-tui --show-output`
- `devenv tasks run ts:check lint:check:genie --mode before --no-tui --show-output`
- Standalone smoke against a real dotfiles `source-shape` artifact: downloaded `actions/artifacts/<id>/zip` with curl, unzipped it, and verified `current/dotfiles/measurements.json` with 8 observations.

**Complexity**

Adds no new abstraction. It swaps the download implementation to standard `curl`/`unzip` tooling with explicit network timeouts.

**Concerns**

The helper now depends on `curl` and `unzip`; if absent, it resolves them via Nix and skips baseline download only if resolution fails.

**Friction & Bottlenecks**

The production dotfiles report showed `gh run download` taking about seven minutes for one baseline artifact candidate despite the intended 120-second bound. This PR addresses that bottleneck in the shared helper.

**Follow-ups**

Repin dotfiles to this PR and re-run the production measurement report to verify the bounded path end to end.

**References**

Follow-up to https://github.com/overengineeringstudio/effect-utils/pull/658.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🔔 co2-bell |
| `agent_session_id` | d4fe2a2f-be5f-468e-be47-cf35c97811b7 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.129.0 |
| `agent_runtime` | Codex CLI 0.129.0 |
| `agent_model` | unknown |
| `worktree` | effect-utils/schickling/2026-05-20-ci-artifact-download-timeout |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@bff5c42 |
</details>
<!-- agent-footer:end -->