### PR TITLE
ci: retry default-ref policy temp cleanup

### DIFF
--- a/genie/ci-workflow/megarepo.ts
+++ b/genie/ci-workflow/megarepo.ts
@@ -412,7 +412,7 @@ if (verifyReachable) {
     } catch {
       ok = false
     } finally {
-      fs.rmSync(tmp, { recursive: true, force: true })
+      fs.rmSync(tmp, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
     }
     if (!ok) {
       violations.push({ type: 'reachability', file: 'megarepo.lock', repo: repoKey(repo), rev: member.commit, expectedRef, memberName })

--- a/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
@@ -247,6 +247,12 @@ describe('ci workflow pnpm cache defaults', () => {
     expect(defaultRefPolicyCheckStepSource).toContain('NORMALIZE_GIT_BRANCH_REFS')
     expect(defaultRefPolicyCheckStepSource).toContain("ref.startsWith('refs/heads/')")
   })
+
+  it('retries temporary git repository cleanup after reachability checks', () => {
+    expect(defaultRefPolicyCheckStepSource).toContain(
+      'fs.rmSync(tmp, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })',
+    )
+  })
 })
 
 describe('ci workflow merge queue helpers', () => {


### PR DESCRIPTION
## Summary
- make the shared default-ref policy helper retry recursive cleanup of its temporary git repo
- covers GitHub-hosted runner / Node ENOTEMPTY cleanup races after reachability fetches
- add a focused regression assertion for the generated helper source

## Verification
- devenv tasks run test:genie --mode before --no-tui --show-output
- devenv tasks run genie:check --mode before --no-tui --show-output
- git diff --check

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🌊 co3-gorge |
| `agent_session_id` | 5c075603-28d0-4b6d-ae70-857f26d20929 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.131.0 |
| `agent_runtime` | Codex CLI 0.131.0 |
| `agent_model` | unknown |
| `worktree` | effect-utils-default-ref-guard/schickling/default-ref-policy-cleanup-retry |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@4db6783 |
</details>
<!-- agent-footer:end -->