### PR TITLE
Fix recursive megarepo commit worktree lock reacquire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **@overeng/megarepo**: Avoid recursive `mr fetch --apply --all` hangs when nested apply falls back from a detached branch worktree to an already-created commit worktree.
 - **@overeng/react-inspector**: Render the schema display name exactly once in collapsed schema-aware object previews (#684). `SchemaAwareObjectPreview` is now the single owner of the schema title (rendered in the object-description slot, italicized when sourced from a `title`/`identifier` annotation); the collapsed branch in `SchemaAwareNodeRenderer` no longer prefixes a duplicate copy. Fixes `0: Source Origin Summary Source Origin Summary {…}` → `0: Source Origin Summary {…}`.
 - **devenv/tasks/shared/nix-cli**: Make `dt nix:hash:*` update nested `depsBuilds.".".hash` entries used by `mkPnpmCli`
   - Lets CLI package hash refreshes converge again after repo-root `pnpm-lock.yaml` changes instead of looping until max iterations

--- a/packages/@overeng/megarepo/src/cli/sync.integration.test.ts
+++ b/packages/@overeng/megarepo/src/cli/sync.integration.test.ts
@@ -1564,7 +1564,7 @@ describe('nested megarepo.lock sync scope', () => {
 
         const result = yield* runFetchApplyCommand({
           cwd: parentPath,
-          args: ['--output', 'json', '--all'],
+          args: ['--output', 'json', '--all', '--worktree-mode', 'tracking'],
           env: {
             MEGAREPO_STORE: storePath.slice(0, -1),
           },

--- a/packages/@overeng/megarepo/src/lib/sync/member.ts
+++ b/packages/@overeng/megarepo/src/lib/sync/member.ts
@@ -806,6 +806,13 @@ export const syncMember = <R = never>({
           ref: targetCommit!,
           refType: 'commit',
         })
+        const commitWorktreeExists = yield* store.hasWorktree({
+          source,
+          ref: targetCommit!,
+          refType: 'commit',
+        })
+        if (commitWorktreeExists === true) return
+
         yield* storeLock.withWorktreeLock(commitWorktreePath)(
           Effect.gen(function* () {
             const exists = yield* store.hasWorktree({


### PR DESCRIPTION
**Problem**
Recursive `mr fetch --apply --all` can hang when a nested apply enters tracking mode from a detached branch worktree and falls back to a commit worktree that the parent apply already created. The fallback path always acquired the commit-worktree lock before checking whether the commit worktree already existed, so a nested apply could wait indefinitely on the same lock path.

**Goal**
Keep recursive apply idempotent and non-blocking when the desired commit worktree already exists.

**Decisions**
This keeps `StoreLock` non-reentrant. Reentrant locks would be a broad semantic change and could mask real overlapping critical sections. Instead, the commit fallback now mirrors the main worktree creation path: check whether the commit worktree exists before acquiring the lock, then retain the existing in-lock double-check for races.

The regression test now forces `--worktree-mode tracking` for the alias case so CI does not bypass the fallback path through automatic commit mode.

**Verification**
Passed:

```text
DT_PASSTHROUGH=1 pnpm exec vitest run src/cli/sync.integration.test.ts -t "multiple parent aliases" --reporter verbose
Test Files  1 passed (1)
Tests  1 passed | 43 skipped (44)
```

```text
CI=true DT_PASSTHROUGH=1 pnpm exec vitest run src/cli/sync.integration.test.ts -t "multiple parent aliases" --reporter verbose
Test Files  1 passed (1)
Tests  1 passed | 43 skipped (44)
```

```text
devenv tasks run check:quick --mode before --no-tui
✓ Running check:quick
```

```text
devenv tasks run test:megarepo --mode before --no-tui
✓ Running test:megarepo
```

`devenv tasks run check:all --mode before --no-tui` was also run. It failed in existing `test:notion-cli` dump unit tests with `NotionApiError: Invalid request URL`; unrelated megarepo checks and `test:megarepo` passed. Follow-up filed as #694.

**Complexity**
No new abstraction. This is a local guard that avoids taking an unnecessary lock when the target worktree already exists.

**Concerns**
The fallback still relies on the existing in-lock double-check for true concurrent creation. This PR only avoids redundant lock acquisition after the worktree is already present.

**Friction & bottlenecks**
`check:all` currently fails outside this change because several Notion CLI dump unit tests attempt invalid Notion request URLs.

**Follow-ups**
- #694 tracks the unrelated Notion CLI dump unit test failures discovered during validation.

**References**
Closes #689
Closes: #690

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🐴 co2-saddle |
| `agent_session_id` | 8a3b02c3-d4d0-451d-ac29-175a9fb62386 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.130.0 |
| `agent_runtime` | Codex CLI 0.130.0 |
| `agent_model` | unknown |
| `worktree` | effect-utils/schickling/schickling-2026-05-26-mr-worktree-lock-reacquire |
| `machine` | mbp2025 |
| `tooling_profile` | dotfiles@4e6515b |
</details>
<!-- agent-footer:end -->