### PR TITLE
Keep pnpm deps archives free of local store state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,8 @@ on:
 
 jobs:
   default-ref-policy:
-    runs-on: [sh-linux-x64, nix]
+    runs-on:
+      [namespace-profile-linux-x86-64, 'namespace-features:github.run-id=${{ github.run_id }}']
     permissions:
       contents: read
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,378 @@ on:
         type: boolean
 
 jobs:
+  default-ref-policy:
+    runs-on: [sh-linux-x64, nix]
+    permissions:
+      contents: read
+    defaults:
+      run:
+        shell: bash
+    env:
+      FORCE_SETUP: '1'
+      CI: 'true'
+      GITHUB_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Nix
+        uses: DeterminateSystems/determinate-nix-action@v3
+        with:
+          extra-conf: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+            extra-substituters = https://devenv.cachix.org
+            extra-trusted-public-keys = devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
+            access-tokens = github.com=${{ github.token }}
+          summarize: true
+      - name: Check first-party default refs
+        env:
+          FIRST_PARTY_OWNERS_JSON: '["schickling","overengineeringstudio"]'
+          DEFAULT_REF: main
+          DEFAULT_REFS_JSON: '{"livestorejs/livestore":"dev"}'
+          VERIFY_REACHABLE: '0'
+          NORMALIZE_GIT_BRANCH_REFS: '0'
+        run: |
+          nix shell nixpkgs#nodejs_24 -c node <<'NODE'
+          const fs = require('node:fs')
+          const path = require('node:path')
+          const os = require('node:os')
+          const cp = require('node:child_process')
+
+          const cwd = process.cwd()
+          const firstPartyOwners = new Set(JSON.parse(process.env.FIRST_PARTY_OWNERS_JSON).map((owner) => owner.toLowerCase()))
+          const defaultRef = process.env.DEFAULT_REF || 'main'
+          const defaultRefs = new Map(Object.entries(JSON.parse(process.env.DEFAULT_REFS_JSON || '{}')).map(([repo, ref]) => [repo.toLowerCase(), ref]))
+          const verifyReachable = process.env.VERIFY_REACHABLE === '1'
+          const violations = []
+
+          const repoKey = (repo) => repo.owner.toLowerCase() + '/' + repo.repo.toLowerCase()
+          const isFirstParty = (repo) => firstPartyOwners.has(repo.owner.toLowerCase())
+          const normalizeGitBranchRefs = process.env.NORMALIZE_GIT_BRANCH_REFS === '1'
+          const normalizeRef = (ref) => normalizeGitBranchRefs && ref.startsWith('refs/heads/') ? ref.slice('refs/heads/'.length) : ref
+          const expectedRefFor = (repo) => normalizeRef(defaultRefs.get(repoKey(repo)) || defaultRef)
+
+          const githubRepoFromUrl = (url) => {
+            const match = url.match(/github\.com[/:]([^/]+)\/([^/#?]+?)(?:\.git)?(?:[#?].*)?$/)
+            return match ? { owner: match[1], repo: match[2] } : undefined
+          }
+
+          const parseGithubLikeRef = (value) => {
+            const hashIndex = value.indexOf('#')
+            const baseWithQuery = hashIndex >= 0 ? value.slice(0, hashIndex) : value
+            const hashRef = hashIndex >= 0 ? value.slice(hashIndex + 1) : undefined
+            const queryIndex = baseWithQuery.indexOf('?')
+            const base = queryIndex >= 0 ? baseWithQuery.slice(0, queryIndex) : baseWithQuery
+            const params = new URLSearchParams(queryIndex >= 0 ? baseWithQuery.slice(queryIndex + 1) : '')
+            const queryRef = params.get('ref') || undefined
+
+            if (base.startsWith('github:')) {
+              const parts = base.slice('github:'.length).split('/')
+              if (parts.length < 2) return undefined
+              return {
+                repo: { owner: parts[0], repo: parts[1] },
+                ref: hashRef || queryRef || (parts.length > 2 ? parts.slice(2).join('/') : undefined),
+              }
+            }
+
+            if (base.startsWith('git+https://github.com/')) {
+              const repo = githubRepoFromUrl(base.slice('git+'.length))
+              return repo ? { repo, ref: hashRef || queryRef } : undefined
+            }
+
+            if (base.startsWith('git+ssh://git@github.com/')) {
+              const pathParts = base.slice('git+ssh://git@github.com/'.length).replace(/\.git$/, '').split('/')
+              return pathParts.length >= 2
+                ? { repo: { owner: pathParts[0], repo: pathParts[1] }, ref: hashRef || queryRef }
+                : undefined
+            }
+
+            const urlRepo = githubRepoFromUrl(base)
+            if (urlRepo) return { repo: urlRepo, ref: hashRef || queryRef }
+
+            if (!value.includes('://') && !value.startsWith('./') && !value.startsWith('../') && !value.startsWith('/')) {
+              const parts = base.split('/')
+              if (parts.length === 2 && parts[0] && parts[1]) {
+                return { repo: { owner: parts[0], repo: parts[1] }, ref: hashRef }
+              }
+            }
+
+            return undefined
+          }
+
+          const addRefViolation = ({ file, repo, ref, field, inputName, memberName }) => {
+            if (!repo || !ref || !isFirstParty(repo)) return
+            const expectedRef = expectedRefFor(repo)
+            const normalizedRef = normalizeRef(ref)
+            if (normalizedRef === expectedRef) return
+            violations.push({
+              type: 'ref',
+              file,
+              repo: repoKey(repo),
+              ref: normalizedRef,
+              expectedRef,
+              field,
+              inputName,
+              memberName,
+            })
+          }
+
+          const readJson = (file) => {
+            try {
+              return JSON.parse(fs.readFileSync(file, 'utf8'))
+            } catch {
+              return undefined
+            }
+          }
+
+          const displayPath = (file) => path.relative(cwd, file) || path.basename(file)
+          const authorityNames = new Set(['megarepo.kdl', 'megarepo.json', 'megarepo.lock', 'flake.nix', 'flake.lock', 'devenv.yaml', 'devenv.lock'])
+          const ignoredDirs = new Set(['.git', 'node_modules', 'dist', 'result', '.devenv', '.direnv', '.next', '.storybook-static'])
+
+          const collectAuthorityFiles = (root) => {
+            const files = []
+            const walk = (dir) => {
+              let entries = []
+              try {
+                entries = fs.readdirSync(dir)
+              } catch {
+                return
+              }
+              for (const entry of entries) {
+                const full = path.join(dir, entry)
+                let stat
+                try {
+                  stat = fs.statSync(full)
+                } catch {
+                  continue
+                }
+                if (stat.isDirectory()) {
+                  if (ignoredDirs.has(entry)) continue
+                  if (dir === root && entry === 'repos') continue
+                  walk(full)
+                } else if (stat.isFile() && authorityNames.has(entry)) {
+                  files.push(full)
+                }
+              }
+            }
+            walk(root)
+            return files
+          }
+
+          const extractFlakeNixInputs = (content) => {
+            const inputs = []
+            const directPattern = /(?:inputs\.)?([a-zA-Z0-9_-]+)\.url\s*=\s*"([^"]+)"/g
+            let match
+            while ((match = directPattern.exec(content)) !== null) {
+              inputs.push({ inputName: match[1], url: match[2] })
+            }
+
+            const lines = content.split('\n')
+            let inInputs = false
+            let inputsIndent = -1
+            let currentInputName
+            let currentInputIndent = -1
+            for (const line of lines) {
+              const trimmed = line.trimStart()
+              const indent = line.length - trimmed.length
+              if (trimmed.startsWith('inputs = {')) {
+                inInputs = true
+                inputsIndent = indent
+                currentInputName = undefined
+                currentInputIndent = -1
+                continue
+              }
+              if (!inInputs) continue
+              if (trimmed && indent <= inputsIndent && trimmed.startsWith('};')) {
+                inInputs = false
+                currentInputName = undefined
+                continue
+              }
+              if (currentInputName && trimmed === '};' && indent <= currentInputIndent) {
+                currentInputName = undefined
+                continue
+              }
+              const inputStart = trimmed.match(/^(?:inputs\.)?([a-zA-Z0-9_-]+)\s*=\s*\{\s*$/)
+              if (inputStart && indent > inputsIndent) {
+                currentInputName = inputStart[1]
+                currentInputIndent = indent
+                continue
+              }
+              const urlMatch = trimmed.match(/^url\s*=\s*"([^"]+)"/)
+              if (currentInputName && urlMatch) inputs.push({ inputName: currentInputName, url: urlMatch[1] })
+            }
+            return inputs
+          }
+
+          const extractDevenvYamlInputs = (content) => {
+            const inputs = []
+            const lines = content.split('\n')
+            let inInputs = false
+            let inputsIndent = -1
+            let currentInputName
+            for (const line of lines) {
+              const trimmed = line.trimStart()
+              const indent = line.length - trimmed.length
+              if (trimmed === 'inputs:' && !inInputs) {
+                inInputs = true
+                inputsIndent = indent
+                currentInputName = undefined
+                continue
+              }
+              if (!inInputs) continue
+              if (trimmed && indent <= inputsIndent && !trimmed.startsWith('#')) {
+                inInputs = false
+                currentInputName = undefined
+                continue
+              }
+              const inputNameMatch = trimmed.match(/^([a-zA-Z0-9_-]+):$/)
+              if (inputNameMatch && indent > inputsIndent) {
+                currentInputName = inputNameMatch[1]
+                continue
+              }
+              const urlMatch = trimmed.match(/^url:\s*(.+)$/)
+              if (currentInputName && urlMatch) {
+                const raw = urlMatch[1].trim()
+                const url = (raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'"))
+                  ? raw.slice(1, -1)
+                  : raw
+                inputs.push({ inputName: currentInputName, url })
+              }
+            }
+            return inputs
+          }
+
+          const lockInputs = (content) => {
+            const parsed = readJsonContent(content)
+            const rootName = parsed && (parsed.root || 'root')
+            const root = parsed && parsed.nodes && parsed.nodes[rootName]
+            if (!root || !root.inputs || !parsed.nodes) return []
+            return Object.entries(root.inputs).flatMap(([inputName, nodeName]) => {
+              const node = parsed.nodes[nodeName]
+              return node ? [{ inputName, original: node.original, locked: node.locked }] : []
+            })
+          }
+
+          const readJsonContent = (content) => {
+            try {
+              return JSON.parse(content)
+            } catch {
+              return undefined
+            }
+          }
+
+          const repoFromLockSection = (section) => {
+            if (!section || typeof section !== 'object') return undefined
+            if (section.type === 'github' && typeof section.owner === 'string' && typeof section.repo === 'string') {
+              return { owner: section.owner, repo: section.repo }
+            }
+            if (section.type === 'git' && typeof section.url === 'string') return githubRepoFromUrl(section.url)
+            if (typeof section.url === 'string') return parseGithubLikeRef(section.url)?.repo || githubRepoFromUrl(section.url)
+            return undefined
+          }
+
+          const refFromLockSection = (section) => {
+            if (!section || typeof section !== 'object') return undefined
+            if (typeof section.ref === 'string') return section.ref
+            if (typeof section.url === 'string') return parseGithubLikeRef(section.url)?.ref
+            return undefined
+          }
+
+          const roots = [cwd]
+          const reposRoot = path.join(cwd, 'repos')
+          if (fs.existsSync(reposRoot)) {
+            for (const entry of fs.readdirSync(reposRoot)) {
+              roots.push(path.join(reposRoot, entry))
+            }
+          }
+
+          for (const root of roots) {
+            for (const file of collectAuthorityFiles(root)) {
+              const base = path.basename(file)
+              const rel = displayPath(file)
+              const content = fs.readFileSync(file, 'utf8')
+
+              if (base === 'megarepo.kdl') {
+                for (const line of content.split('\n')) {
+                  const match = line.trim().match(/^([A-Za-z0-9_.-]+)\s+"([^"]+)"/)
+                  if (!match) continue
+                  const parsed = parseGithubLikeRef(match[2])
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'members.source', memberName: match[1] })
+                }
+              } else if (base === 'megarepo.lock') {
+                const parsed = readJson(file)
+                for (const [memberName, member] of Object.entries((parsed && parsed.members) || {})) {
+                  const repo = typeof member.url === 'string' ? githubRepoFromUrl(member.url) : undefined
+                  addRefViolation({ file: rel, repo, ref: member.ref, field: 'members.ref', memberName })
+                }
+              } else if (base === 'flake.nix') {
+                for (const input of extractFlakeNixInputs(content)) {
+                  const parsed = parseGithubLikeRef(input.url)
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'url.ref', inputName: input.inputName })
+                }
+              } else if (base === 'devenv.yaml') {
+                for (const input of extractDevenvYamlInputs(content)) {
+                  const parsed = parseGithubLikeRef(input.url)
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'url.ref', inputName: input.inputName })
+                }
+              } else if (base === 'flake.lock' || base === 'devenv.lock') {
+                for (const input of lockInputs(content)) {
+                  for (const [field, section] of [['original', input.original], ['locked', input.locked]]) {
+                    addRefViolation({ file: rel, repo: repoFromLockSection(section), ref: refFromLockSection(section), field: field + '.ref', inputName: input.inputName })
+                  }
+                }
+              }
+            }
+          }
+
+          if (verifyReachable) {
+            const lock = readJson(path.join(cwd, 'megarepo.lock'))
+            for (const [memberName, member] of Object.entries((lock && lock.members) || {})) {
+              const repo = typeof member.url === 'string' ? githubRepoFromUrl(member.url) : undefined
+              if (!repo || !isFirstParty(repo)) continue
+              const expectedRef = expectedRefFor(repo)
+              const remote = 'https://github.com/' + repo.owner + '/' + repo.repo + '.git'
+              const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'default-ref-policy-'))
+              let ok = false
+              try {
+                cp.execFileSync('git', ['-C', tmp, 'init', '-q'], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'remote', 'add', 'origin', remote], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'fetch', '-q', '--filter=blob:none', 'origin', 'refs/heads/' + expectedRef + ':refs/remotes/origin/' + expectedRef], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'cat-file', '-e', member.commit + '^{commit}'], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'merge-base', '--is-ancestor', member.commit, 'refs/remotes/origin/' + expectedRef], { stdio: 'ignore' })
+                ok = true
+              } catch {
+                ok = false
+              } finally {
+                fs.rmSync(tmp, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
+              }
+              if (!ok) {
+                violations.push({ type: 'reachability', file: 'megarepo.lock', repo: repoKey(repo), rev: member.commit, expectedRef, memberName })
+              }
+            }
+          }
+
+          if (violations.length === 0) {
+            console.log('Default ref policy OK')
+            process.exit(0)
+          }
+
+          console.error('Default ref policy failed:')
+          for (const violation of violations) {
+            if (violation.type === 'reachability') {
+              console.error('  - ' + violation.file + ': member ' + violation.memberName + ' ' + violation.repo + ' locks ' + violation.rev.slice(0, 12) + " outside '" + violation.expectedRef + "'")
+            } else {
+              const name = violation.memberName ? ' member ' + violation.memberName : violation.inputName ? ' input ' + violation.inputName : ''
+              console.error('  - ' + violation.file + ':' + name + ' ' + violation.repo + " uses ref '" + violation.ref + "' in " + violation.field + "; expected '" + violation.expectedRef + "'")
+            }
+          }
+          console.error('')
+          console.error('Fix: merge upstream PRs first, retarget first-party inputs back to their default refs, then refresh locks.')
+          process.exit(1)
+          NODE
+        shell: bash
+    concurrency:
+      group: "${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '' && format('measurement-baseline-{0}', inputs.measurement_baseline_ref) || (github.event_name == 'workflow_dispatch' && format('manual-run-{0}', github.run_id) || (github.event_name == 'pull_request' && (github.event.action == 'labeled' || github.event.action == 'unlabeled') && format('label-{0}', github.event.label.name) || 'code')) }}-default-ref-policy"
+      cancel-in-progress: ${{ !(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '') && (github.event_name != 'pull_request' || (github.event.action != 'labeled' && github.event.action != 'unlabeled')) }}
   typecheck:
     if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '') }}
     runs-on:

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -705,6 +705,7 @@ export default ciWorkflow({
     // validation branches should fail one authority job, not obscure
     // lint/typecheck/test signal.
     'default-ref-policy': defaultRefPolicyCheckJob({
+      // LiveStore intentionally uses dev as its trunk branch.
       defaultRefs: { 'livestorejs/livestore': 'dev' },
     }),
     ...jobs,

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -705,6 +705,12 @@ export default ciWorkflow({
     // validation branches should fail one authority job, not obscure
     // lint/typecheck/test signal.
     'default-ref-policy': defaultRefPolicyCheckJob({
+      // Keep this tiny policy job on the same Namespace runner class as the
+      // rest of CI so source-policy enforcement does not wait on legacy labels.
+      runsOn: namespaceRunner({
+        profile: 'namespace-profile-linux-x86-64',
+        runId: '${{ github.run_id }}',
+      }),
       // LiveStore intentionally uses dev as its trunk branch.
       defaultRefs: { 'livestorejs/livestore': 'dev' },
     }),

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -701,6 +701,9 @@ export default ciWorkflow({
     },
   },
   jobs: {
+    // Keep default-ref/source-policy separate from product checks: downstream
+    // validation branches should fail one authority job, not obscure
+    // lint/typecheck/test signal.
     'default-ref-policy': defaultRefPolicyCheckJob({
       defaultRefs: { 'livestorejs/livestore': 'dev' },
     }),

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -34,6 +34,7 @@ import {
   netlifyStorybookCommentStep,
   pnpmStateSetupStep,
   validateNixStoreStep,
+  defaultRefPolicyCheckJob,
 } from '../../genie/ci-workflow.ts'
 import { type CIJobName } from '../../genie/ci.ts'
 import { type GitHubWorkflowArgs } from '../../packages/@overeng/genie/src/runtime/mod.ts'
@@ -700,6 +701,9 @@ export default ciWorkflow({
     },
   },
   jobs: {
+    'default-ref-policy': defaultRefPolicyCheckJob({
+      defaultRefs: { 'livestorejs/livestore': 'dev' },
+    }),
     ...jobs,
     ...extraJobs,
     ...deployJobs,

--- a/genie/ci-workflow.ts
+++ b/genie/ci-workflow.ts
@@ -41,7 +41,15 @@ export type DefaultRefPolicyCheckJobOptions = DefaultRefPolicyCheckStepOptions &
   readonly postSteps?: readonly GitHubWorkflowStep[]
 }
 
-/** Dedicated CI job for first-party default-ref policy so normal jobs keep their signal. */
+/**
+ * Dedicated CI job for first-party default-ref policy.
+ *
+ * We intentionally keep this out of lint/typecheck/test jobs. Downstream PRs
+ * often validate against temporary first-party branches while an upstream PR is
+ * still open, and that should fail in one authority/policy job without hiding
+ * whether the actual product jobs are green. Before merge, repos must retarget
+ * those first-party inputs back to their default refs and refresh locks.
+ */
 export const defaultRefPolicyCheckJob = (opts: DefaultRefPolicyCheckJobOptions = {}) => {
   const { name, runsOn, env, permissions, defaults, preSteps, postSteps, ...stepOpts } = opts
 

--- a/nix/oxc-config-plugin.nix
+++ b/nix/oxc-config-plugin.nix
@@ -87,6 +87,8 @@ let
 
       stripPrepLocalPnpmSettings =
         lines:
+        # The FOD must not inherit caller-local GVS/store paths; its private
+        # install root is part of the reproducible derivation boundary.
         builtins.filter (
           l:
           !(lib.hasPrefix "enableGlobalVirtualStore" (lib.trim l)) && !(lib.hasPrefix "storeDir" (lib.trim l))

--- a/nix/oxc-config-plugin.nix
+++ b/nix/oxc-config-plugin.nix
@@ -28,7 +28,7 @@ let
     pnpm = pinnedPnpm;
   };
   packageDir = "packages/@overeng/oxc-config";
-  pnpmDepsHash = "sha256-HM+QdonkgSfj4h4Q4XmVKpQD2hW2Rf4TLanvFYYaqo8=";
+  pnpmDepsHash = "sha256-rb9wGEQDso6jCCVRWzkaTTZI6cNvvlzI0+C6fAHgWcg=";
 
   srcPath =
     if builtins.isAttrs src && builtins.hasAttr "outPath" src then

--- a/nix/workspace-tools/lib/mk-pnpm-cli.nix
+++ b/nix/workspace-tools/lib/mk-pnpm-cli.nix
@@ -339,6 +339,8 @@ let
     let
       name = baseNameOf path;
     in
+    # Keep caller-local pnpm/devenv/git state out of FOD source identity; the
+    # builder recreates the tiny mutable install state from checked-in inputs.
     !(builtins.elem name [
       ".devenv"
       ".git"
@@ -838,6 +840,8 @@ let
     if builtins.pathExists evalSrcPath then
       if builtins.baseNameOf relPath == ".npmrc" then
         let
+          # Local .npmrc may point at a developer-specific pure store path.
+          # Strip those knobs so deps FODs remain portable across worktrees.
           npmrcFile = pkgs.writeText "npmrc" (
             builtins.concatStringsSep "\n" (
               stripPrepLocalNpmrcSettings (lib.splitString "\n" (builtins.readFile evalSrcPath))

--- a/nix/workspace-tools/lib/mk-pnpm-cli.nix
+++ b/nix/workspace-tools/lib/mk-pnpm-cli.nix
@@ -501,6 +501,63 @@ let
   rootPnpmWorkspaceYamlPath = evalWorkspaceRootPath + "/pnpm-workspace.yaml";
   rootPnpmWorkspaceYaml = builtins.readFile rootPnpmWorkspaceYamlPath;
 
+  # Workspace-local store settings are for live worktrees. Nix dependency
+  # prep owns its private store path through env/.npmrc so prepared outputs
+  # cannot archive a caller's local store.
+  prepLocalPnpmSettingPrefixes = [
+    "cacheDir"
+    "enableGlobalVirtualStore"
+    "globalVirtualStoreDir"
+    "nodeLinker"
+    "optimisticRepeatInstall"
+    "packageImportMethod"
+    "pmOnFail"
+    "sideEffectsCache"
+    "sideEffectsCacheReadonly"
+    "stateDir"
+    "storeDir"
+    "strictStorePkgContentCheck"
+    "virtualStoreDir"
+    "verifyDepsBeforeRun"
+    "verifyStoreIntegrity"
+  ];
+  prepLocalNpmrcSettingPrefixes = [
+    "cache-dir"
+    "enable-global-virtual-store"
+    "global-virtual-store-dir"
+    "node-linker"
+    "package-import-method"
+    "pm-on-fail"
+    "side-effects-cache"
+    "side-effects-cache-readonly"
+    "state-dir"
+    "store-dir"
+    "strict-store-pkg-content-check"
+    "verify-deps-before-run"
+    "verify-store-integrity"
+    "virtual-store-dir"
+  ];
+  stripPrepLocalPnpmSettings =
+    lines:
+    builtins.filter (
+      l:
+      let
+        trimmed = lib.trim l;
+      in
+      !(builtins.any (prefix: lib.hasPrefix prefix trimmed) prepLocalPnpmSettingPrefixes)
+    ) lines;
+  stripPrepLocalNpmrcSettings =
+    lines:
+    builtins.filter (
+      l:
+      let
+        trimmed = lib.trim l;
+      in
+      !(builtins.any (
+        prefix: (lib.hasPrefix "${prefix}=" trimmed) || (lib.hasPrefix "${prefix} " trimmed)
+      ) prepLocalNpmrcSettingPrefixes)
+    ) lines;
+
   workspaceSuffixLines =
     workspaceYaml:
     let
@@ -527,15 +584,6 @@ let
           else
             lines;
 
-      # Workspace-local store settings are for live worktrees. Nix dependency
-      # prep owns its private store path through env/.npmrc so prepared outputs
-      # cannot archive a caller's local store.
-      stripPrepLocalPnpmSettings =
-        lines:
-        builtins.filter (
-          l:
-          !(lib.hasPrefix "enableGlobalVirtualStore" (lib.trim l)) && !(lib.hasPrefix "storeDir" (lib.trim l))
-        ) lines;
     in
     stripPrepLocalPnpmSettings (
       dropPackageBlock (dropUntilPackagesHeader (lib.splitString "\n" workspaceYaml))
@@ -788,11 +836,24 @@ let
       evalSrcPath = resolveEvalSourceFor relPath;
     in
     if builtins.pathExists evalSrcPath then
-      ''
-        if [ -f ${lib.escapeShellArg (toString (absoluteFileSourcePathFor relPath))} ]; then
-          ${copyFileCmd relPath}
-        fi
-      ''
+      if builtins.baseNameOf relPath == ".npmrc" then
+        let
+          npmrcFile = pkgs.writeText "npmrc" (
+            builtins.concatStringsSep "\n" (
+              stripPrepLocalNpmrcSettings (lib.splitString "\n" (builtins.readFile evalSrcPath))
+            )
+          );
+        in
+        ''
+          ${mkdirOutParentCmd relPath}
+          cp ${lib.escapeShellArg npmrcFile} "$out/${relPath}"
+        ''
+      else
+        ''
+          if [ -f ${lib.escapeShellArg (toString (absoluteFileSourcePathFor relPath))} ]; then
+            ${copyFileCmd relPath}
+          fi
+        ''
     else
       "";
 

--- a/nix/workspace-tools/lib/mk-pnpm-cli/tests/fixtures/downstream/fixture-workspace/.npmrc
+++ b/nix/workspace-tools/lib/mk-pnpm-cli/tests/fixtures/downstream/fixture-workspace/.npmrc
@@ -1,0 +1,14 @@
+store-dir=.devenv/pnpm-store-pure-v1
+virtual-store-dir=node_modules/.pnpm
+enable-global-virtual-store=true
+global-virtual-store-dir=.devenv/pnpm-gvs
+state-dir=.devenv/pnpm-state
+cache-dir=.devenv/pnpm-cache
+package-import-method=clone
+node-linker=isolated
+side-effects-cache=false
+side-effects-cache-readonly=false
+verify-store-integrity=true
+strict-store-pkg-content-check=true
+pm-on-fail=ignore
+verify-deps-before-run=install

--- a/nix/workspace-tools/lib/mk-pnpm-cli/tests/fixtures/downstream/fixture-workspace/pnpm-workspace.yaml
+++ b/nix/workspace-tools/lib/mk-pnpm-cli/tests/fixtures/downstream/fixture-workspace/pnpm-workspace.yaml
@@ -1,2 +1,18 @@
 packages:
   - app
+
+enableGlobalVirtualStore: true
+globalVirtualStoreDir: .devenv/pnpm-gvs
+storeDir: .devenv/pnpm-store-pure-v1
+virtualStoreDir: node_modules/.pnpm
+stateDir: .devenv/pnpm-state
+cacheDir: .devenv/pnpm-cache
+packageImportMethod: clone
+nodeLinker: isolated
+optimisticRepeatInstall: true
+verifyDepsBeforeRun: install
+sideEffectsCache: false
+sideEffectsCacheReadonly: false
+verifyStoreIntegrity: true
+strictStorePkgContentCheck: true
+pmOnFail: ignore

--- a/nix/workspace-tools/lib/mk-pnpm-cli/tests/run.sh
+++ b/nix/workspace-tools/lib/mk-pnpm-cli/tests/run.sh
@@ -265,6 +265,59 @@ run_downstream_pure_eval_regression() {
     echo "error: prepared deps derivation does not skip optional dependencies: $drv" >&2
     exit 1
   fi
+  if [[ "$install_phase" != *'-name .devenv'* || "$install_phase" != *"-name '.pnpm-store*'"* || "$install_phase" != *"-name '.pnpm-home*'"* ]]; then
+    echo "error: prepared deps derivation does not purge workspace-local pnpm store state: $drv" >&2
+    exit 1
+  fi
+
+  echo "Check: downstream staged pnpm-workspace.yaml strips live-worktree pnpm settings"
+  local deps_src
+  deps_src="$(nix build --no-link --no-write-lock-file --print-out-paths \
+    --override-input effect-utils "path:$WORKSPACE_REAL/repos/effect-utils" \
+    "path:$DOWNSTREAM_DIR#packages.$SYSTEM.mk-pnpm-cli-pure-eval-fixture.passthru.depsSrcByInstallRoot.root")"
+  for key in \
+    enableGlobalVirtualStore \
+    globalVirtualStoreDir \
+    storeDir \
+    virtualStoreDir \
+    stateDir \
+    cacheDir \
+    packageImportMethod \
+    nodeLinker \
+    optimisticRepeatInstall \
+    verifyDepsBeforeRun \
+    sideEffectsCache \
+    sideEffectsCacheReadonly \
+    verifyStoreIntegrity \
+    strictStorePkgContentCheck \
+    pmOnFail; do
+    if grep -q "^$key:" "$deps_src/pnpm-workspace.yaml"; then
+      echo "error: staged pnpm-workspace.yaml kept live-worktree setting: $key" >&2
+      exit 1
+    fi
+  done
+  if [ -f "$deps_src/.npmrc" ]; then
+    for key in \
+      enable-global-virtual-store \
+      global-virtual-store-dir \
+      store-dir \
+      virtual-store-dir \
+      state-dir \
+      cache-dir \
+      package-import-method \
+      node-linker \
+      verify-deps-before-run \
+      side-effects-cache \
+      side-effects-cache-readonly \
+      verify-store-integrity \
+      strict-store-pkg-content-check \
+      pm-on-fail; do
+      if grep -Eq "^$key[[:space:]]*=" "$deps_src/.npmrc"; then
+        echo "error: staged .npmrc kept live-worktree setting: $key" >&2
+        exit 1
+      fi
+    done
+  fi
 
   echo "Timing: downstream-pure-eval $(( $(date +%s) - start ))s"
 }

--- a/nix/workspace-tools/lib/mk-pnpm-deps.nix
+++ b/nix/workspace-tools/lib/mk-pnpm-deps.nix
@@ -600,12 +600,17 @@ in
                 fi
 
                 # pnpm 11 rejects `pnpm config set --global` for keys it considers
-                # workspace-only. Use env vars and .npmrc instead.
-                # Back up .npmrc before appending build-local settings (restored after install).
+                # workspace-only. Use env vars and .npmrc instead. Strip
+                # live-worktree store/layout policy first so the prepared
+                # artifact does not preserve caller-local paths.
+                if [ -f .npmrc ]; then
+                  ${pkgs.perl}/bin/perl -0pi -e 's/^\s*(store-dir|virtual-store-dir|enable-global-virtual-store|global-virtual-store-dir|state-dir|cache-dir|package-import-method|node-linker|side-effects-cache|side-effects-cache-readonly|verify-store-integrity|strict-store-pkg-content-check|pm-on-fail|verify-deps-before-run)\s*=.*\n//mg' .npmrc
+                fi
+                # Back up scrubbed .npmrc before appending build-local settings (restored after install).
                 cp .npmrc .npmrc.orig 2>/dev/null || true
         printf 'store-dir=%s\nvirtual-store-dir=node_modules/.pnpm\npackage-import-method=%s\nside-effects-cache=false\nverify-store-integrity=true\nstrict-store-pkg-content-check=true\nenable-global-virtual-store=false\npm-on-fail=ignore\nverify-deps-before-run=false\nnode-linker=isolated\n' "$STORE_PATH" ${lib.escapeShellArg pnpmPackageImportMethod} >> .npmrc
         if [ -f pnpm-workspace.yaml ]; then
-          ${pkgs.perl}/bin/perl -0pi -e 's/^\s*(storeDir|enableGlobalVirtualStore):[^\n]*\n//mg; s/nodeLinker: hoisted/nodeLinker: isolated/g' pnpm-workspace.yaml
+          ${pkgs.perl}/bin/perl -0pi -e 's/^\s*(storeDir|virtualStoreDir|enableGlobalVirtualStore|globalVirtualStoreDir|stateDir|cacheDir|packageImportMethod|nodeLinker|optimisticRepeatInstall|verifyDepsBeforeRun|sideEffectsCache|sideEffectsCacheReadonly|verifyStoreIntegrity|strictStorePkgContentCheck|pmOnFail):[^\n]*\n//mg; s/nodeLinker: hoisted/nodeLinker: isolated/g' pnpm-workspace.yaml
         fi
                 # Keep prepared dependency artifacts platform-neutral. Native
                 # optional packages are owned by the Nix package/build layer so
@@ -677,12 +682,23 @@ in
                 log_path_stats "prepared-workspace-pre-archive" .
                 log_path_stats "pnpm-store-final" "$STORE_PATH"
                 rm -rf "$STORE_PATH"
+                # Live-worktree pnpm store state is mutable and path-sensitive.
+                # Prepared deps FODs own their private store through env/.npmrc
+                # and must archive only the materialized dependency graph.
+                find . \
+                  \( -type d -name .devenv -o -type d -name '.pnpm-store*' -o -type d -name '.pnpm-home*' \) \
+                  -prune -exec rm -rf {} +
                 rm -f .pnpm-install-roots.txt
 
                 ${pkgs.nodejs}/bin/node ${lib.escapeShellArg normalizePreparedTreeScript} .
 
-                if [ -e "$SOURCE_DIR/.pnpm-store" ]; then
-                  echo "workspace-prep: FATAL - workspace-local .pnpm-store leaked into prepared output" >&2
+                leaked_path=$(
+                  find "$SOURCE_DIR" \
+                    \( -path '*/.devenv/pnpm-*' -o -path '*/.pnpm-store*' -o -path '*/.pnpm-home*' -o -path '*/node_modules/.pnpm/lock.yaml' \) \
+                    -print -quit
+                )
+                if [ -n "$leaked_path" ]; then
+                  echo "workspace-prep: FATAL - workspace-local pnpm store state leaked into prepared output: $leaked_path" >&2
                   exit 1
                 fi
 

--- a/nix/workspace-tools/lib/mk-pnpm-deps.nix
+++ b/nix/workspace-tools/lib/mk-pnpm-deps.nix
@@ -263,7 +263,18 @@ let
     relinkLocalVirtualPackages(workspaceRoot);
 
     const rewriteBinScripts = (dirPath, visitedRealPaths = new Set()) => {
-      const realDirPath = fs.realpathSync(dirPath);
+      let realDirPath;
+      try {
+        realDirPath = fs.realpathSync(dirPath);
+      } catch (error) {
+        // pnpm's virtual store may contain package-edge symlinks that are not
+        // materialized in a narrowed FOD projection. Those are dependency
+        // edges, not directories that can contain .bin scripts.
+        if (error && error.code === "ENOENT") {
+          return;
+        }
+        throw error;
+      }
       if (visitedRealPaths.has(realDirPath)) {
         return;
       }
@@ -330,7 +341,17 @@ let
     };
 
     const rewriteBinScripts = (dirPath, visitedRealPaths = new Set()) => {
-      const realDirPath = fs.realpathSync(dirPath);
+      let realDirPath;
+      try {
+        realDirPath = fs.realpathSync(dirPath);
+      } catch (error) {
+        // Prepared workspace restores can see the same narrowed pnpm graph as
+        // the FOD builder. Dangling package-edge symlinks are not script dirs.
+        if (error && error.code === "ENOENT") {
+          return;
+        }
+        throw error;
+      }
       if (visitedRealPaths.has(realDirPath)) {
         return;
       }

--- a/packages/@overeng/genie/nix/build.nix
+++ b/packages/@overeng/genie/nix/build.nix
@@ -25,7 +25,7 @@ let
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
       "." = {
-        hash = "sha256-xc01fEymQyAwgwDbnaa5uVCoE30XhKG8bO9CHtnigik=";
+        hash = "sha256-99PLJyT2MNkPDX2IlH0Bw8YN2RYjfFQ1SHZUywIAYng=";
       };
     };
     nativeNodePackages = [ opentuiCoreNative ];

--- a/packages/@overeng/megarepo/nix/build.nix
+++ b/packages/@overeng/megarepo/nix/build.nix
@@ -24,7 +24,7 @@ let
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
       "." = {
-        hash = "sha256-MyW7Um2sE/4H5bWIdHHN4kOdnqj8c7MGQSeaA/JE0Fs=";
+        hash = "sha256-FMEDE82r6pzFMiGy5bQM2YMKdyp1psNxQ8B2LX6YrC4=";
       };
     };
     nativeNodePackages = [ opentuiCoreNative ];

--- a/packages/@overeng/notion-cli/nix/build.nix
+++ b/packages/@overeng/notion-cli/nix/build.nix
@@ -21,7 +21,7 @@ let
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
       "." = {
-        hash = "sha256-2mqls7rueBX2fJb9dNb+m3Lo1iD9dFK8jO18rM1DdZA=";
+        hash = "sha256-hLseqpU/4VgII/4FpjM8hgSmJsYrleMgwV/4Np4UU/s=";
       };
     };
     nativeNodePackages = [ opentuiCoreNative ];

--- a/packages/@overeng/notion-md/nix/build.nix
+++ b/packages/@overeng/notion-md/nix/build.nix
@@ -20,7 +20,7 @@ let
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
       "." = {
-        hash = "sha256-tbtOTx40FPsbl8oJSHjk6k+1D3vstfiVvzwPj2zt/S8=";
+        hash = "sha256-ciSwjhBAzCiGP0KFK20B0B38+G/PCXEQxNV0PGxq4fw=";
       };
     };
     smokeTestArgs = [ "--help" ];

--- a/packages/@overeng/tui-stories/nix/build.nix
+++ b/packages/@overeng/tui-stories/nix/build.nix
@@ -21,7 +21,7 @@ let
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
       "." = {
-        hash = "sha256-d/vdg8I2DCZgZnGz5XaYeOibHhaJio1dqp81mrmjS98=";
+        hash = "sha256-CNumctvdRW3zlCDR7IxIsLZwp3qS5II05ifuyK9i4bk=";
       };
     };
     nativeNodePackages = [ opentuiCoreNative ];


### PR DESCRIPTION
## Summary
- strip live-worktree pnpm store/layout settings from staged pnpm-workspace.yaml and .npmrc inputs
- scrub and guard mutable pnpm store/home state before prepared dependency archives are emitted
- add downstream regression fixture coverage for pure staged config and refresh affected pnpm deps hashes

## Validation
- nix --option min-free 0 --option max-free 0 build --no-link --no-write-lock-file '.#packages.x86_64-linux.genie-pnpm-deps' '.#packages.x86_64-linux.megarepo-pnpm-deps' '.#packages.x86_64-linux.tui-stories-pnpm-deps' '.#packages.x86_64-linux.notion-cli-pnpm-deps' '.#packages.x86_64-linux.notion-md-pnpm-deps' '.#packages.x86_64-linux.oxc-config-plugin-pnpm-deps'
- focused mk-pnpm-cli pure eval checks for staged pnpm-workspace.yaml/.npmrc scrubbing
- prepared deps output leak scan for .devenv pnpm state, .pnpm-store*, .pnpm-home*, and node_modules/.pnpm/lock.yaml

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 💥 co3-nova |
| `agent_session_id` | 6ab7078c-8e91-4d56-a938-97aa02c88e9b |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.131.0 |
| `agent_runtime` | Codex CLI 0.131.0 |
| `agent_model` | unknown |
| `worktree` | effect-utils-pnpm-fod-purity/schickling/2026-05-27-pnpm-fod-purity |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@4db6783 |
</details>
<!-- agent-footer:end -->