### PR TITLE
fix(genie): call GitHub ruleset task API correctly

### DIFF
--- a/nix/devenv-modules/tasks/shared/github-ruleset.nix
+++ b/nix/devenv-modules/tasks/shared/github-ruleset.nix
@@ -30,12 +30,18 @@ let
               reconcileGithubRuleset,
             } from '${githubRulesetModule}'
 
-            const report = await reconcileGithubRuleset(${builtins.toJSON mode}, {
-              repo: ${builtins.toJSON repo},
-              ruleset: ${builtins.toJSON ruleset},
-              file: ${builtins.toJSON file},
+            const report = await reconcileGithubRuleset({
+              mode: ${builtins.toJSON mode},
+              options: {
+                repo: ${builtins.toJSON repo},
+                ruleset: ${builtins.toJSON ruleset},
+                file: ${builtins.toJSON file},
+              },
             })
-            console.log(formatGithubRulesetReport(${builtins.toJSON mode}, report))
+            console.log(formatGithubRulesetReport({
+              mode: ${builtins.toJSON mode},
+              report,
+            }))
             ${exitOnDrift}
           ''}
         '';


### PR DESCRIPTION
## Problem
#713 merged the GitHub ruleset reconciler with an object-shaped runtime API, but the shared devenv task factory still called `reconcileGithubRuleset` and `formatGithubRulesetReport` with the older positional argument shape. Downstream `gh:check-settings` failed before it could read the generated ruleset file.

## Goal
Make the shared `gh:check-settings` and `gh:apply-settings` task factory invoke the merged Genie runtime API correctly.

## Decisions
Use the object-shaped call sites instead of adding compatibility overloads. This keeps the API surface narrow and matches the exported TypeScript contract from #713.

## Verification
- `nix build .#genie`
- Downstream dotfiles pinned to `3ce0937cfcfb61b2bfb21d3a87ce3b467d9d804c`:
  - `devenv tasks run gh:check-settings --mode before --no-tui --show-output --no-eval-cache`
  - `devenv tasks run gh:apply-settings --mode before --no-tui --show-output --no-eval-cache`
- Downstream result: `protect-main` matches generated settings; apply is a no-op.

## Complexity
No new complexity; this is a call-site correction.

## Concerns
Dotfiles is temporarily pinned to this PR commit until this merges. After merge, dotfiles should repin back to Effect Utils `main` at the merge commit.

## Friction & bottlenecks
Caught only after repinning dotfiles to the merged #713 commit because the task factory path is exercised downstream.

## Follow-ups
Merge this, then repin dotfiles from this temporary PR commit back to Effect Utils `main` after merge.

## References
Refs #713.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🟫 co2-dust |
| `agent_session_id` | aff1c2c5-1345-40c9-aed0-12e77e2e723a |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.135.0 |
| `agent_runtime` | Codex CLI 0.135.0 |
| `agent_model` | unknown |
| `worktree` | effect-utils-gh-ruleset-task-callfix/schickling/fix-github-ruleset-task-call |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@9f384ba |
</details>
<!-- agent-footer:end -->