### PR TITLE
Sketch shared releaseWorkflow helper for Changesets-based releases

### DIFF
--- a/context/workflows/release-workflow.md
+++ b/context/workflows/release-workflow.md
@@ -1,0 +1,225 @@
+# Release Workflow Helper (`releaseWorkflow`)
+
+Status: **draft / skeleton in `genie/ci-workflow/release.ts`**.
+
+This document captures the intended shape of a shared
+`releaseWorkflow({...})` helper that codifies the Changesets-based
+supervised release flow LiveStore just shipped, so other megarepo
+members (`molty`, `openclaw`, …) can adopt the same structure via config
+instead of copying `release.yml.genie.ts` wholesale.
+
+The reference implementation it abstracts from is
+`livestorejs/livestore:.github/workflows/release.yml.genie.ts` plus the
+human-readable description at
+`livestorejs/livestore:contributor-docs/release-workflows.md`. See
+`Refs livestorejs/livestore#1269` for the immediate motivation (the
+stable-release auto-merge gate).
+
+## Goals
+
+- One `releaseWorkflow({...})` call per repo produces a complete
+  `.github/workflows/release.yml`.
+- Same job ids and `if` conditions across consumers so operators can
+  navigate any repo's release workflow without re-learning the layout.
+- Per-npm-tag policy is config, not branching code. In particular the
+  stable-vs-prerelease auto-merge distinction is one boolean per tag.
+- Repo-specific work (publish task names, devtools repack, prod docs
+  deploy, search sync, …) plugs in as `validateSteps` / `publishSteps`.
+  The helper does not try to model those directly.
+
+## Non-goals
+
+The first iteration intentionally does **not** cover:
+
+- Snapshot releases. Those have a separate workflow and lifecycle
+  (per-commit, `0.0.0-snapshot-<sha>`, no release plan) and do not
+  benefit from the supervised release-plan PR shape.
+- Devtools-style artifact repackaging. This is LiveStore-specific
+  glue; repos that need it pass extra steps into `validateSteps` /
+  `publishSteps`.
+- Docs / examples deploy and search-index sync. Same reasoning —
+  these are repo-specific post-publish hooks.
+- `release/version.json` / `release/devtools-artifact.json`
+  generation. LiveStore's release PR generator stages those files
+  before opening the PR. The skeleton names only the canonical
+  `release/release-plan.json` location and leaves the broader staged
+  file set to the repo (probably via a follow-up `stagedFiles` option).
+- A migration of LiveStore's own `release.yml.genie.ts` to consume the
+  helper. The intention is to land the skeleton, iterate on the
+  interface against a second adopter (molty or openclaw), and only
+  then migrate LiveStore so we get one round of real-world feedback
+  on the API before committing to it.
+
+## Input shape
+
+```ts
+import { releaseWorkflow } from '<effect-utils>/genie/ci-workflow.ts'
+
+export default releaseWorkflow({
+  workspaceName: 'livestore',
+  workspaceDisplayName: 'LiveStore',
+
+  releasePlanPath: 'release/release-plan.json',
+  releasePlanPaths: [
+    '.github/workflows/release.yml',
+    '.github/workflows/release.yml.genie.ts',
+    'genie/repo.ts',
+    'release/release-plan.json',
+    'release/version.json',
+    'release/devtools-artifact.json',
+    'scripts/src/commands/release.ts',
+    'scripts/src/commands/changesets.ts',
+  ],
+
+  // Per-npm-tag policy. `manualGate: true` keeps the release-plan PR
+  // human-merged. `manualGate: false` enables GitHub auto-merge for
+  // dev / prerelease PRs.
+  releaseChannels: {
+    latest: { manualGate: true },
+    dev: { manualGate: false },
+    next: { manualGate: false },
+  },
+  defaultNpmTag: 'latest',
+
+  // Per-job setup (devenv, nix cache, pnpm install, ...). The helper
+  // does not assume a particular CI prep contract; pass whatever the
+  // repo uses for the rest of its workflows. For LiveStore today this
+  // is `livestoreSetupSteps`.
+  setupSteps: livestoreSetupSteps,
+
+  // Dry-run + repack-dryrun substance for the release-plan PR.
+  validateSteps: [
+    devenvTaskStep('Dry-run stable package publish', 'release:stable:dryrun'),
+    devenvTaskStep(
+      'Repack DevTools artifact (dryrun)',
+      'release:devtools-artifact:repack-dryrun:no-install',
+    ),
+  ],
+
+  // Publish substance after the release-plan PR merges to main.
+  publishSteps: [
+    devenvTaskStep('Publish stable package release', 'release:stable:publish'),
+    devenvTaskStep(
+      'Publish DevTools artifact release',
+      'release:devtools-artifact:publish:no-install',
+    ),
+    // ...optional prod docs deploy, search sync, etc. — repo-specific.
+  ],
+
+  trustedPublishing: true, // OIDC, no NPM_TOKEN
+  sourcePolicyJob: livestoreDefaultRefPolicyJob,
+})
+```
+
+The full TypeScript type is at `genie/ci-workflow/release.ts`:
+
+```ts
+export type ReleaseChannel = {
+  readonly manualGate: boolean
+}
+
+export type ReleaseWorkflowOptions = {
+  readonly name?: string
+  readonly workspaceName: string
+  readonly workspaceDisplayName?: string
+  readonly releasePlanPath?: string
+  readonly releasePlanPaths: readonly string[]
+  readonly releaseChannels: Record<string, ReleaseChannel>
+  readonly defaultNpmTag?: string
+  readonly setupSteps: readonly WorkflowStep[]
+  readonly validateSteps: readonly WorkflowStep[]
+  readonly publishSteps: readonly WorkflowStep[]
+  readonly trustedPublishing?: boolean
+  readonly sourcePolicyJob?: WorkflowJob | false
+  readonly actionlint?: ActionlintConfig | false
+  readonly env?: Record<string, string>
+}
+```
+
+## Generated workflow shape
+
+`releaseWorkflow({...})` returns a `githubWorkflow({...})` value with:
+
+### Triggers
+
+- `workflow_dispatch` with two `choice` inputs:
+  - `npm_tag` — populated from `Object.keys(releaseChannels)`.
+  - `mode` — fixed to `['create-release-pr', 'validate-release-plan',
+'publish-release']`.
+- `pull_request` on `releasePlanPaths` (validates release tooling
+  changes even when they do not carry a real release plan).
+- `push` to `main` on `releasePlanPath` (the merge of the release-plan
+  PR is the publish trigger).
+
+### Permissions
+
+Workflow-level: `contents: read`, `id-token: write` (for npm OIDC).
+Per-job permissions tighten or widen as needed; `create-release-pr` is
+the only job that writes contents and pull-requests.
+
+### Jobs
+
+- `source-policy` — optional first-party ref policy job (LiveStore
+  uses `livestoreDefaultRefPolicyJob`). Omitted when
+  `sourcePolicyJob: false`.
+- `create-release-pr` — runs only on `workflow_dispatch` with
+  `mode == create-release-pr`. Runs `setupSteps`, generates the
+  release plan from Changesets, opens or refreshes the
+  `automation/release-<version>` branch + PR, dispatches the
+  `validate-release-plan` workflow against the branch, and (per
+  channel) either enables GitHub auto-merge (prerelease) or leaves
+  the PR for a human reviewer (stable). The stable manual-gate is the
+  behaviour introduced by livestorejs/livestore#1269.
+- `validate-release-plan` — runs on `pull_request` (against any of
+  `releasePlanPaths`) and on `workflow_dispatch` with
+  `mode == validate-release-plan`. Runs `setupSteps`, synthesizes a
+  release plan when the PR did not include one, then runs
+  `validateSteps`.
+- `publish-release` — runs on `push` to `main` touching
+  `releasePlanPath`, and on `workflow_dispatch` with
+  `mode == publish-release`. Runs `setupSteps`, reads the release
+  plan, (optionally) configures the npm token fallback, then runs
+  `publishSteps`.
+
+## What the skeleton does today
+
+`genie/ci-workflow/release.ts` returns a workflow with the correct
+triggers, permissions, env, and job ids / `if` conditions, but the job
+bodies are placeholders (each substantive step is replaced by an
+`echo TODO ... ; exit 1` so a partial migration cannot silently
+publish). The next iteration replaces those placeholders with the real
+step sequence from the LiveStore reference workflow, factored against
+the option surface above.
+
+## Open questions
+
+The following choices still want a human review before the helper goes
+beyond skeleton:
+
+1. **Granularity of `releaseChannels`.** Today every channel is just
+   `{ manualGate: boolean }`. The LiveStore reference workflow also
+   varies the deploy target (`prod` vs `dev`) per channel. Should the
+   channel record carry that, or should it stay opaque and live in
+   `publishSteps` per repo?
+2. **`setupSteps` vs structured prep.** `setupSteps` is currently a
+   flat `readonly WorkflowStep[]`, which means each repo can stay on
+   its existing setup helper. An alternative is to require
+   `standardSelfHostedPnpmCiPrepSteps(...)` and surface its options
+   instead, which would unify the four jobs but tie the helper to one
+   specific CI prep contract.
+3. **Release PR shell ownership.** The `create-release-pr` body is a
+   ~60-line bash script today (branch fork, `gh pr edit`/`create`,
+   workflow dispatch, auto-merge toggle). The skeleton keeps it as
+   one step in the helper. Alternatives: split into named composite
+   actions, or have the helper render the shell from typed inputs
+   (workspace name, branch prefix, etc.) so repos cannot accidentally
+   diverge on the PR body markup.
+
+## Worked example: LiveStore
+
+The shape above is the LiveStore release workflow re-expressed in the
+helper's vocabulary. The full migration is intentionally out of scope
+for the first PR — once the inputs above are signed off, the
+follow-up replaces the placeholder job bodies, then LiveStore swaps
+its hand-written `release.yml.genie.ts` for a `releaseWorkflow({...})`
+call and the diff should be a near-pure deletion.

--- a/genie/ci-workflow.ts
+++ b/genie/ci-workflow.ts
@@ -223,3 +223,8 @@ export {
   vercelDeployStep,
   vercelGitAuthorStep,
 } from './ci-workflow/deploy.ts'
+export {
+  releaseWorkflow,
+  type ReleaseChannel,
+  type ReleaseWorkflowOptions,
+} from './ci-workflow/release.ts'

--- a/genie/ci-workflow/release.ts
+++ b/genie/ci-workflow/release.ts
@@ -1,0 +1,315 @@
+/**
+ * Reusable Changesets-based supervised release workflow generator.
+ *
+ * Skeleton in-progress: this module captures the shape and contract that
+ * `effect-utils` will codify for the LiveStore release flow so downstream
+ * megarepo members (molty, openclaw, …) can adopt the same workflow
+ * structure by configuration instead of copy-paste.
+ *
+ * See `context/workflows/release-workflow.md` for the design document.
+ *
+ * Status: STUB. The function returns a `githubWorkflow({...})` value with the
+ * correct triggers, permissions, and job ids/conditions, but the job bodies
+ * are intentionally placeholders. The next iteration wires the real
+ * `create-release-pr` / `validate-release-plan` / `publish-release` step
+ * sequences once the input shape and option naming have been reviewed.
+ */
+
+import {
+  githubWorkflow,
+  type ActionlintConfig,
+  type GitHubWorkflowArgs,
+} from '../../packages/@overeng/genie/src/runtime/mod.ts'
+import { bashShellDefaults, linuxX64Runner } from './shared.ts'
+
+type WorkflowJob = GitHubWorkflowArgs['jobs'][string]
+type WorkflowStep = WorkflowJob['steps'][number]
+
+const placeholderRun = (label: string) =>
+  `echo "TODO: ${label} — wired in follow-up; see context/workflows/release-workflow.md"\nexit 1`
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * Per-npm-tag policy.
+ *
+ * `manualGate: true` keeps the release-plan PR human-merged (stable releases).
+ * `manualGate: false` enables GitHub auto-merge for the generated PR
+ * (prerelease / dev releases).
+ *
+ * Tag-specific deploy targets and validation overrides are intentionally
+ * left out of the skeleton; the spec doc tracks them as open questions.
+ */
+export type ReleaseChannel = {
+  readonly manualGate: boolean
+}
+
+/**
+ * Inputs to `releaseWorkflow`.
+ *
+ * The shape intentionally mirrors the existing LiveStore release.yml so the
+ * first migration is a faithful encode-then-decode. Options that look
+ * LiveStore-specific (e.g. devtools artifact repack, prod docs deploy) are
+ * pushed out to `validateSteps` / `publishSteps` so the helper does not need
+ * to model them directly.
+ */
+export type ReleaseWorkflowOptions = {
+  /**
+   * Workflow `name:` field. Defaults to `'Release'`.
+   */
+  readonly name?: string
+
+  /**
+   * Workspace identifier used in branch names and commit messages.
+   * For LiveStore this is `'livestore'`; the generated branch is
+   * `automation/release-<version>` and the commit subject is
+   * `Prepare <Workspace> <version> release`.
+   *
+   * Open question: should this carry a separate `releaseBranchPrefix` /
+   * `commitSubject` override, or always derive from `workspaceName`?
+   */
+  readonly workspaceName: string
+
+  /**
+   * Workspace display name used in PR titles and bodies. Defaults to
+   * `workspaceName` with the first letter uppercased.
+   */
+  readonly workspaceDisplayName?: string
+
+  /**
+   * Path to the canonical release-plan JSON file relative to the repo root.
+   * Defaults to `'release/release-plan.json'`.
+   */
+  readonly releasePlanPath?: string
+
+  /**
+   * Files whose change should trigger the `validate-release-plan` job via
+   * `pull_request`. This is intentionally broader than `releasePlanPath`
+   * alone because release tooling changes also need to exercise the
+   * dry-run before they land.
+   */
+  readonly releasePlanPaths: readonly string[]
+
+  /**
+   * Per-npm-tag release policy. Keys are the npm dist-tags surfaced in the
+   * workflow_dispatch `npm_tag` input (`latest`, `dev`, `next`, …).
+   *
+   * The keys here drive the `choice` options of the `npm_tag` input.
+   */
+  readonly releaseChannels: Record<string, ReleaseChannel>
+
+  /**
+   * Default `npm_tag` for the workflow_dispatch input.
+   * Must be a key in `releaseChannels`. Defaults to `'latest'`.
+   */
+  readonly defaultNpmTag?: string
+
+  /**
+   * Steps run at the start of each job after `actions/checkout@v4`.
+   *
+   * Typically this is the repo's `standardSelfHostedPnpmCiPrepSteps(...)`
+   * (or `livestoreSetupSteps`) — devenv setup, nix cache restore, pnpm
+   * install, etc. The helper keeps this opaque on purpose; the release
+   * workflow only needs *some* working devenv to run `dt` tasks.
+   */
+  readonly setupSteps: readonly WorkflowStep[]
+
+  /**
+   * Steps that perform the `validate-release-plan` payload. These run after
+   * `setupSteps` inside the `validate-release-plan` job and must:
+   *
+   * - dry-run the actual npm publish (no token writes), and
+   * - exercise any additional release-time repackaging the repo performs
+   *   (LiveStore: DevTools artifact repack-dryrun).
+   *
+   * The helper appends a "select release plan for validation" step before
+   * this, and a "read release plan" step after, so this list can focus on
+   * the dry-run substance.
+   */
+  readonly validateSteps: readonly WorkflowStep[]
+
+  /**
+   * Steps that perform the `publish-release` payload. These run after
+   * `setupSteps` inside the `publish-release` job and must:
+   *
+   * - publish the npm package set, and
+   * - perform any post-publish hooks (docs deploy, search sync, GitHub
+   *   release upload, …).
+   *
+   * The helper appends the "read release plan" + npm-token fallback steps
+   * before this; consumers do not need to repeat them.
+   */
+  readonly publishSteps: readonly WorkflowStep[]
+
+  /**
+   * If `true`, the publish job skips the explicit `NPM_TOKEN` fallback and
+   * relies on npm OIDC trusted publishing. LiveStore currently keeps the
+   * fallback as a safety net; new repos should default to `true`.
+   *
+   * Open question: should this be `true` by default for new repos and
+   * `false` by default for repos that opt-in via `legacyNpmToken: true`?
+   */
+  readonly trustedPublishing?: boolean
+
+  /**
+   * Optional first-party policy job to run alongside the release jobs
+   * (`livestoreDefaultRefPolicyJob`-equivalent). Pass `false` to omit.
+   */
+  readonly sourcePolicyJob?: WorkflowJob | false
+
+  /**
+   * Optional `actionlint` config. Defaults to the workflow's parent default
+   * (see `ciWorkflow` / `defaultActionlintConfig`). Most repos can omit it.
+   */
+  readonly actionlint?: ActionlintConfig | false
+
+  /**
+   * Additional workflow-level env. Merged with the standard release env.
+   */
+  readonly env?: Record<string, string>
+}
+
+// =============================================================================
+// Implementation (skeleton)
+// =============================================================================
+
+/**
+ * Build a Changesets-based supervised release workflow.
+ *
+ * The shape is fixed across consumers:
+ *
+ * - Jobs: `source-policy` (optional), `create-release-pr`,
+ *   `validate-release-plan`, `publish-release`.
+ * - Triggers: `workflow_dispatch` (mode input), `pull_request` on
+ *   `releasePlanPaths`, `push` to `main` on `releasePlanPath`.
+ * - Job `if` conditions wire each job to the right subset of triggers.
+ *
+ * The job bodies are intentionally minimal in this skeleton; see the design
+ * doc for the planned content and the LiveStore reference implementation at
+ * `livestorejs/livestore:.github/workflows/release.yml.genie.ts` for the
+ * shape this generator will eventually produce.
+ */
+export const releaseWorkflow = (opts: ReleaseWorkflowOptions) => {
+  const npmTagOptions = Object.keys(opts.releaseChannels)
+  if (npmTagOptions.length === 0) {
+    throw new Error('releaseWorkflow: at least one releaseChannels entry is required')
+  }
+
+  const defaultNpmTag =
+    opts.defaultNpmTag ?? (npmTagOptions.includes('latest') === true ? 'latest' : npmTagOptions[0]!)
+  if (npmTagOptions.includes(defaultNpmTag) === false) {
+    throw new Error(
+      `releaseWorkflow: defaultNpmTag '${defaultNpmTag}' is not present in releaseChannels keys: ${npmTagOptions.join(', ')}`,
+    )
+  }
+
+  const releasePlanPath = opts.releasePlanPath ?? 'release/release-plan.json'
+
+  // PLACEHOLDER job bodies. The next iteration replaces these `run` blocks
+  // with the real step sequence from the LiveStore reference workflow:
+  //  - create-release-pr: changeset:version + open/refresh PR + dispatch
+  //    validate workflow + (auto-merge based on channel.manualGate).
+  //  - validate-release-plan: synthetic-plan selection + dryrun publish +
+  //    repo-supplied validateSteps.
+  //  - publish-release: read release plan + (optional) npm token fallback +
+  //    repo-supplied publishSteps.
+
+  const createReleasePrJob: WorkflowJob = {
+    if: "github.event_name == 'workflow_dispatch' && inputs.mode == 'create-release-pr'",
+    'runs-on': 'ubuntu-latest',
+    permissions: {
+      actions: 'write',
+      contents: 'write',
+      'id-token': 'write',
+      'pull-requests': 'write',
+    },
+    defaults: bashShellDefaults,
+    steps: [
+      { name: 'Checkout', uses: 'actions/checkout@v4', with: { ref: 'main' } },
+      ...opts.setupSteps,
+      { name: 'Create release plan PR (placeholder)', run: placeholderRun('create-release-pr') },
+    ],
+  }
+
+  const validateReleasePlanJob: WorkflowJob = {
+    if: "github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.mode == 'validate-release-plan')",
+    'runs-on': linuxX64Runner as unknown as string[],
+    defaults: bashShellDefaults,
+    steps: [
+      ...opts.setupSteps,
+      { name: 'Select release plan for validation (placeholder)', run: placeholderRun('select release plan') },
+      ...opts.validateSteps,
+    ],
+  }
+
+  const publishReleaseJob: WorkflowJob = {
+    if: "github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.mode == 'publish-release')",
+    'runs-on': linuxX64Runner as unknown as string[],
+    permissions: {
+      contents: 'write',
+      'id-token': 'write',
+    },
+    env: {
+      GH_TOKEN: '${{ github.token }}',
+      ...(opts.trustedPublishing === false ? { NODE_AUTH_TOKEN: '${{ secrets.NPM_TOKEN }}' } : {}),
+    },
+    defaults: bashShellDefaults,
+    steps: [
+      ...opts.setupSteps,
+      { name: 'Read release plan (placeholder)', run: placeholderRun('read release plan') },
+      ...opts.publishSteps,
+    ],
+  }
+
+  const jobs: Record<string, WorkflowJob> = {}
+  if (opts.sourcePolicyJob !== undefined && opts.sourcePolicyJob !== false) {
+    jobs['source-policy'] = opts.sourcePolicyJob
+  }
+  jobs['create-release-pr'] = createReleasePrJob
+  jobs['validate-release-plan'] = validateReleasePlanJob
+  jobs['publish-release'] = publishReleaseJob
+
+  return githubWorkflow({
+    name: opts.name ?? 'Release',
+    ...(opts.actionlint === false ? {} : opts.actionlint !== undefined ? { actionlint: opts.actionlint } : {}),
+    on: {
+      workflow_dispatch: {
+        inputs: {
+          npm_tag: {
+            description: 'npm dist-tag for the release',
+            required: true,
+            default: defaultNpmTag,
+            type: 'choice',
+            options: npmTagOptions,
+          },
+          mode: {
+            description: 'Release workflow mode',
+            required: true,
+            default: 'create-release-pr',
+            type: 'choice',
+            options: ['create-release-pr', 'validate-release-plan', 'publish-release'],
+          },
+        },
+      },
+      pull_request: {
+        paths: [...opts.releasePlanPaths],
+      },
+      push: {
+        branches: ['main'],
+        paths: [releasePlanPath],
+      },
+    },
+    permissions: {
+      contents: 'read',
+      'id-token': 'write',
+    },
+    env: {
+      CI: 'true',
+      FORCE_SETUP: '1',
+      ...opts.env,
+    },
+    jobs,
+  })
+}


### PR DESCRIPTION
## Problem

Other megarepo members (`molty`, `openclaw`, …) want the same supervised
release-plan PR flow LiveStore just shipped, but the LiveStore
`release.yml.genie.ts` is ~340 lines of hand-written workflow glue that
will drift the moment a second repo copies it. We want one helper in
`effect-utils` that codifies the shape so adopters configure it instead
of copy-pasting.

Refs livestorejs/livestore#1269 — the immediate motivation is the
stable-release auto-merge gate, which only makes sense if the
auto-merge policy is one boolean per npm tag instead of a hand-rolled
`if` chain per repo.

## Approach

This PR is a **vision + skeleton**, not a drop-in replacement. It
lands:

- **Design doc** at `context/workflows/release-workflow.md` — goals,
  non-goals, proposed input shape, generated workflow shape, and open
  questions for review.
- **Skeleton implementation** at `genie/ci-workflow/release.ts` —
  `releaseWorkflow({...})` returns a `githubWorkflow(...)` value with
  the correct triggers, permissions, env, and job ids / `if`
  conditions. The substantive job bodies are placeholders that
  `echo TODO ... ; exit 1` so a partial migration cannot silently
  publish.
- **Public export** wired through `genie/ci-workflow.ts`.

A worked example for LiveStore is in the design doc. The actual
migration of LiveStore's `release.yml.genie.ts` to consume the helper
is intentionally out of scope here — once the input shape is signed
off, a follow-up replaces the placeholders with the real step
sequence and only then swaps LiveStore over.

## Why a skeleton instead of the full implementation

The full release flow is intricate (synthetic plan selection,
release-plan PR markup, npm OIDC, repack hooks, manual-vs-auto-merge,
…) and the abstraction is high-leverage. Landing the shape first lets
the input surface get reviewed without 300+ lines of inline shell
debate on top, and avoids committing to an API before a second
adopter has tried to consume it.

## Open questions for review

Captured in the design doc, but worth surfacing:

1. **Channel granularity.** Today `releaseChannels[tag]` is just
   `{ manualGate: boolean }`. Should it also carry the deploy target
   (`prod` vs `dev`), or should that stay in `publishSteps` per repo?
2. **`setupSteps` vs structured prep.** Flat `WorkflowStep[]` lets
   each repo keep its existing setup helper; alternative is requiring
   `standardSelfHostedPnpmCiPrepSteps(...)` and surfacing its options.
3. **Release PR shell ownership.** The `create-release-pr` body is
   ~60 lines of bash today. Keep it as one step in the helper, split
   into composite actions, or have the helper render the shell from
   typed inputs?

## Validation

- `dt ts:check` passes.
- `oxlint genie/ci-workflow/release.ts genie/ci-workflow.ts` is clean
  on our new file. The one remaining warning is pre-existing in
  `genie/ci-workflow.ts` (`DefaultRefPolicyCheckJobOptions` jsdoc),
  not introduced here.
- `dt check:quick` has pre-existing failures on `main` (nix format +
  unrelated oxlint warnings); this PR does not regress them.
- No runtime behaviour for downstream repos changes (the helper is
  not yet consumed anywhere), so external integration testing is not
  expected.

## Follow-ups

- Replace placeholder job bodies with the real step sequence from
  LiveStore's reference workflow, factored against this option
  surface (separate PR).
- Migrate LiveStore's `release.yml.genie.ts` to consume the helper
  (separate PR, after a second adopter has exercised the API).

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 💨 cl2-mist |
| `agent_session_id` | c1934b02-14a7-4f20-a3e4-9e7b987c77ab |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.145 |
| `agent_runtime` | Claude Code 2.1.145 |
| `agent_model` | claude-opus-4-7 |
| `worktree` | effect-utils/schickling-assistant/2026-06-01-release-workflow-generator |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->