### PR TITLE
Model reusable workflow_call jobs as a Job variant in genie github-workflow

### DIFF
--- a/packages/@overeng/genie/src/runtime/github-workflow/github-workflow.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/github-workflow/github-workflow.unit.test.ts
@@ -392,3 +392,68 @@ describe.runIf(hasActionlint)('actionlint integration', () => {
     expect(yaml).not.toContain('selfHostedRunnerLabels')
   })
 })
+
+describe('reusable workflow call jobs', () => {
+  it('accepts a job that delegates via `uses:` without `runs-on`/`steps`', () => {
+    const workflow = githubWorkflow({
+      actionlint: false,
+      name: 'caller',
+      on: { workflow_dispatch: null },
+      jobs: {
+        validate: {
+          uses: './.github/workflows/reusable.yml',
+          with: { 'target-scope': 'stable' },
+        },
+        downstream: {
+          'runs-on': 'ubuntu-latest',
+          needs: 'validate',
+          steps: [{ run: 'echo "${{ needs.validate.outputs.release-version }}"' }],
+        },
+      },
+    })
+
+    const issues = workflow.validate?.(mockGenieContext) ?? []
+    expect(issues.filter((i) => i.rule.startsWith('github-workflow-runs-on'))).toEqual([])
+
+    const yaml = workflow.stringify(mockGenieContext)
+    expect(yaml).toContain('uses: ./.github/workflows/reusable.yml')
+    expect(yaml).toContain('target-scope: stable')
+  })
+
+  it('accepts a reusable workflow definition with workflow_call inputs/outputs', () => {
+    const workflow = githubWorkflow({
+      actionlint: false,
+      name: 'reusable',
+      on: {
+        workflow_call: {
+          inputs: {
+            'target-scope': { type: 'string', required: true },
+          },
+          outputs: {
+            'release-version': {
+              value: '${{ jobs.derive.outputs.release-version }}',
+            },
+          },
+        },
+      },
+      jobs: {
+        derive: {
+          'runs-on': 'ubuntu-latest',
+          outputs: {
+            'release-version': '${{ steps.read.outputs.version }}',
+          },
+          steps: [
+            {
+              id: 'read',
+              run: 'echo "version=1.2.3" >> "$GITHUB_OUTPUT"',
+            },
+          ],
+        },
+      },
+    })
+
+    const yaml = workflow.stringify(mockGenieContext)
+    expect(yaml).toContain('workflow_call:')
+    expect(yaml).toContain('release-version:')
+  })
+})

--- a/packages/@overeng/genie/src/runtime/github-workflow/mod.ts
+++ b/packages/@overeng/genie/src/runtime/github-workflow/mod.ts
@@ -222,7 +222,7 @@ type Concurrency = {
   'cancel-in-progress'?: boolean | Expression
 }
 
-type Job = {
+type JobWithSteps = {
   name?: string
   'runs-on': string | string[]
   needs?: string | string[]
@@ -240,6 +240,31 @@ type Job = {
   container?: string | Container
   services?: Record<string, Service>
 }
+
+/**
+ * Reusable workflow call job — a job that delegates to another workflow via
+ * `uses:`. No `runs-on`/`steps`; instead it consumes the called workflow's
+ * `on.workflow_call.inputs` (via `with:`) and exposes its declared outputs
+ * to dependent jobs via `needs.<job-id>.outputs.<output-name>`.
+ *
+ * GitHub workflow_call reference:
+ * https://docs.github.com/en/actions/sharing-automations/reusing-workflows
+ */
+type JobWithUses = {
+  name?: string
+  uses: string
+  needs?: string | string[]
+  if?: string
+  permissions?: Permissions
+  with?: Record<string, string | number | boolean>
+  secrets?: 'inherit' | Record<string, string>
+  strategy?: Strategy
+  concurrency?: string | Concurrency
+}
+
+type Job = JobWithSteps | JobWithUses
+
+const isJobWithUses = (job: Job): job is JobWithUses => 'uses' in job
 
 /** Arguments for generating a GitHub Actions workflow file */
 export type GitHubWorkflowArgs = {
@@ -342,6 +367,7 @@ const validateDeterminateNixExtraConf = ({
   const issues: GenieValidationIssue[] = []
 
   for (const [jobName, job] of Object.entries(args.jobs)) {
+    if (isJobWithUses(job) === true) continue
     for (const [stepIndex, step] of job.steps.entries()) {
       if ('uses' in step === false) continue
       if (step.uses.startsWith('DeterminateSystems/determinate-nix-action') === false) continue
@@ -434,6 +460,9 @@ const validateWorkflow = ({
   const issues: GenieValidationIssue[] = []
 
   for (const [jobName, job] of Object.entries(args.jobs)) {
+    // Reusable workflow call jobs (`uses:`) don't have their own `runs-on`;
+    // the runner is determined by the called workflow.
+    if (isJobWithUses(job) === true) continue
     issues.push(...validateRunsOn({ jobName, runsOn: job['runs-on'], location }))
   }
 


### PR DESCRIPTION
## Problem

The genie \`githubWorkflow\` runtime's \`Job\` type required every job to have \`runs-on\` and \`steps\`, with no variant for reusable workflow call jobs (\`uses: ./.github/workflows/<name>.yml\`). That blocks downstream callers (notably LiveStore) from factoring shared validation/publish substance out of multiple workflow files using the typed workflow_call schema that's already half-modeled here (\`on.workflow_call.inputs\`/\`outputs\` are supported, but a caller can't actually call them).

The motivating case is livestorejs/livestore#1278: \`LIVESTORE_RELEASE_DEPLOY_TARGET\` was set via \`\$GITHUB_ENV\` in one job and silently dropped in the next, because env doesn't carry across jobs. Typed workflow_call outputs makes that bug class unrepresentable — but only if the caller can express the \`uses:\` job.

## Approach

- Split \`Job\` into a discriminated union:
  - \`JobWithSteps\` — the existing shape (\`runs-on\` + \`steps\`).
  - \`JobWithUses\` — \`uses:\` reusable workflow call, with optional \`with\`/\`secrets\`/\`needs\`/\`if\`/\`permissions\`/\`strategy\`/\`concurrency\`. No \`runs-on\`/\`steps\` (the called workflow owns the runner and steps).
- Add an \`isJobWithUses\` type guard.
- Skip \`validateRunsOn\` and the DeterminateSystems extra-conf scan for \`JobWithUses\` jobs since neither applies.

## Validation

- \`devenv tasks run test:genie\` — new tests for both sides of the contract (caller delegating via \`uses:\`, callee declaring \`workflow_call\` inputs/outputs) pass alongside the existing suite.
- \`devenv tasks run ts:check\` — clean.
- \`devenv tasks run lint:check:oxlint\` — clean.
- \`devenv tasks run check:all\` — green.

## Follow-ups

- LiveStore will land a stacked PR that pins this commit, introduces \`validate-publish-substance.yml\`, and migrates the \`release.yml\` / \`ci.yml\` validation paths off \`\$GITHUB_ENV\` to typed workflow_call outputs.