### PR TITLE
refactor(devenv): parameterize repo in gh-labels module

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -278,7 +278,7 @@ in
     # OpenTelemetry observability stack (Collector + Tempo + Grafana)
     (import ./nix/devenv-modules/otel.nix { })
     # gh:apply-labels / gh:check-labels — reconcile .github/labels.json with live labels
-    ./nix/devenv-modules/gh-labels.nix
+    (import ./nix/devenv-modules/gh-labels.nix { repo = "overengineeringstudio/effect-utils"; })
     # Playwright browser drivers and environment setup
     inputs.playwright.devenvModules.default
     # Shared task modules

--- a/nix/devenv-modules/gh-labels.nix
+++ b/nix/devenv-modules/gh-labels.nix
@@ -7,13 +7,21 @@
 # The bash is wrapped in `pkgs.writeShellApplication` so shellcheck runs at
 # build time and `gh` / `jq` are pinned via `runtimeInputs` instead of relying
 # on the ambient devenv PATH at task-exec time.
+#
+# Usage in devenv.nix:
+#   imports = [
+#     (import ./nix/devenv-modules/gh-labels.nix { repo = "owner/name"; })
+#   ];
+{
+  # Target GitHub repository in `owner/name` form. Required so downstream
+  # consumers (e.g. schickling/dotfiles) can reuse this module without forking.
+  repo,
+}:
 {
   pkgs,
   ...
 }:
 let
-  repo = "overengineeringstudio/effect-utils";
-
   apply = pkgs.writeShellApplication {
     name = "gh-apply-labels";
     runtimeInputs = [


### PR DESCRIPTION
## Problem

`nix/devenv-modules/gh-labels.nix` (added in #736) hardcodes
`repo = "overengineeringstudio/effect-utils"` inside its `let` block. That
makes the module unreusable from any downstream consumer — every consumer
would have to fork the file just to change one string.

The immediate downstream is [`schickling/dotfiles#981`](https://github.com/schickling/dotfiles/pull/981),
which wants to wire `gh:apply-labels` / `gh:check-labels` against
`schickling/dotfiles` itself.

## Approach

Lift `repo` to a required module argument using the same curry pattern
already used by `otel.nix`:

```nix
# devenv.nix
imports = [
  (import ./nix/devenv-modules/gh-labels.nix {
    repo = "overengineeringstudio/effect-utils";
  })
];
```

The bash, `runtimeInputs`, task names, and behavior are unchanged. The
effect-utils `devenv.nix` continues to pass its own repo.

One commit, devenv-only change.

## Validation

- `devenv tasks list` still shows `gh:apply-labels`, `gh:apply-settings`, `gh:check-labels`.
- `devenv tasks run gh:check-labels` builds the `writeShellApplication` derivation (shellcheck passes) and produces the expected drift output against live GitHub.
- `.github/labels.json` is byte-identical (sha256 unchanged across `genie:run`).

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🔍 cl2-narrows |
| `agent_session_id` | 2a346954-b981-47d3-91ae-95889b40cd3b |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.145 |
| `agent_runtime` | Claude Code 2.1.145 |
| `agent_model` | claude-opus-4-7 |
| `worktree` | effect-utils/schickling-assistant/2026-06-03-gh-labels-parameterize-repo |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@38a54b0 |
</details>
<!-- agent-footer:end -->