### PR TITLE
fix(notion-effect-schema): model agent_id page parent

### DIFF
--- a/packages/@overeng/notion-effect-schema/src/objects.ts
+++ b/packages/@overeng/notion-effect-schema/src/objects.ts
@@ -51,6 +51,15 @@ export const PageParent = Schema.Union(
     type: Schema.Literal('workspace'),
     workspace: Schema.Literal(true),
   }),
+  /*
+   * Custom Agent instruction pages are parented by the agent itself. Modeled
+   * explicitly (rather than via an opaque `type: string` fallback) so the union
+   * stays discriminable for downstream `switch (parent.type)` consumers.
+   */
+  Schema.Struct({
+    type: Schema.Literal('agent_id'),
+    agent_id: NotionUUID,
+  }),
 ).annotations({
   identifier: 'Notion.PageParent',
   [docsPath]: 'page#page-parent',

--- a/packages/@overeng/notion-effect-schema/src/objects.unit.test.ts
+++ b/packages/@overeng/notion-effect-schema/src/objects.unit.test.ts
@@ -1,0 +1,28 @@
+import { Schema } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import { PageParent } from './objects.ts'
+
+const decode = Schema.decodeUnknownSync(PageParent)
+const uuid = '01234567-89ab-cdef-0123-456789abcdef'
+
+describe('Notion.PageParent', () => {
+  it('decodes the modeled parent types', () => {
+    expect(decode({ type: 'page_id', page_id: uuid })).toEqual({ type: 'page_id', page_id: uuid })
+    expect(decode({ type: 'workspace', workspace: true })).toEqual({
+      type: 'workspace',
+      workspace: true,
+    })
+  })
+
+  it('decodes agent_id parents (Custom Agent instruction pages)', () => {
+    expect(decode({ type: 'agent_id', agent_id: uuid })).toEqual({
+      type: 'agent_id',
+      agent_id: uuid,
+    })
+  })
+
+  it('rejects an unmodeled parent type rather than silently degrading', () => {
+    expect(() => decode({ type: 'something_new', something_new: uuid })).toThrow()
+  })
+})

--- a/packages/@overeng/notion-md/src/model.ts
+++ b/packages/@overeng/notion-md/src/model.ts
@@ -17,6 +17,7 @@ export type RemoteParent =
   | { readonly type: 'database_id'; readonly database_id: string }
   | { readonly type: 'block_id'; readonly block_id: string }
   | { readonly type: 'workspace'; readonly workspace: true }
+  | { readonly type: 'agent_id'; readonly agent_id: string }
   | { readonly type: 'unknown'; readonly raw: unknown }
 
 /** Stable page metadata needed to rebuild `.nmd` frontmatter after a pull. */


### PR DESCRIPTION
## Problem

Notion Custom Agent **instruction pages** are parented by the agent itself — their `parent` is `{ "type": "agent_id", "agent_id": "…" }`. `Notion.PageParent` modeled only `database_id | data_source_id | page_id | block_id | workspace`, so decoding `Notion.Page` for any agent-parented page failed:

```
Notion.PageParent
└─ ["type"]
   └─ Expected "database_id" | "data_source_id" | "page_id" | "block_id" | "workspace", actual "agent_id"
```

Downstream, `notion-md` could neither pull nor sync such a page (`pull_page` failed at parse), even though the parent is just metadata for an already-resolved page.

## Goal

`Notion.Page` decodes agent-parented pages, and `notion-md` can pull/sync a Custom Agent instruction page like any other.

## Decisions

- **Model `agent_id` as an explicit literal variant**, not an opaque `type: string` catch-all. A `{ type: Schema.String }` fallback was tried first but collapses the discriminated union: `switch (parent.type)` consumers lose narrowing, and it broke `notion-md/live.ts` (`PageParent` no longer assignable to `RemoteParent`) and `notion-datasource-sync` (an index-signature `unknown` where a `string` was expected). Explicit literals keep the union discriminable. This also means a genuinely *new* Notion parent type will still fail loudly rather than silently degrade — preferred over an opaque passthrough.
- **`RemoteParent` mirrors the new variant**; `toParentRef`'s existing `default` branch already normalizes unmatched parents to the `{ _tag: 'unknown' }` frontmatter shape, so agent-parented pages round-trip without a new frontmatter tag (no `.nmd` schema-version bump).

## Verification

- `dt check:all` green (ts:check strict + lint + tests across the workspace) with only the three files in this PR changed.
- New unit test `objects.unit.test.ts`: decodes the modeled parents + `agent_id`, and asserts an unmodeled parent type is rejected. Passes (3/3).
- End-to-end: built `notion-md` from this branch and ran `notion-md status` against a real `agent_id`-parented page — previously a hard `pull_page` parse failure, now resolves and reports a clean idempotent round-trip (`localChanged: false`, `remoteBodyChanged: false`).

## Complexity

No new complexity — two union members and a mirrored type, plus a unit test.

## Concerns

A future, still-unmodeled Notion parent type will fail to parse `Notion.Page` (same failure class this fixes). That is intentional under the explicit-literal decision; the alternative (opaque fallback) was rejected. If Notion's parent-type set churns, a follow-up could add a tested transform that maps unrecognized parents to the existing `unknown` shape at decode time without weakening the discriminated union.

## Friction & bottlenecks

- `dt ts:check` / `dt lint:check` surface only a pass/fail summary; the underlying compiler/formatter diagnostics are swallowed by the task wrapper. Had to invoke `tsgo --build` directly to see the actual errors. Minor papercut.
- `dt lint:fix` reformats the whole workspace, pulling in pre-existing format drift in unrelated files; reverted those to keep the diff scoped.

## Follow-ups

- Optional: a first-class `agent` frontmatter parent tag in `notion-md` (currently agent-parented pages serialize as `{ _tag: 'unknown', raw: … }`). Functional today; a dedicated tag would be tidier for an agent-centric workflow.

## References

Surfaced while syncing Custom Agent instruction pages via `@overeng/notion-md`.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🦤 cl2-ibis |
| `agent_session_id` | 49ccf2ed-0881-48a7-b504-fa512767a52a |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.160 |
| `agent_runtime` | Claude Code 2.1.160 |
| `agent_model` | claude-opus-4-8 |
| `worktree` | effect-utils/schickling/2026-06-04-notion-pageparent-agent-id |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->