### PR TITLE
feat(notion-md): first-class agent frontmatter parent tag

### DIFF
--- a/packages/@overeng/notion-effect-client/src/nmd.ts
+++ b/packages/@overeng/notion-effect-client/src/nmd.ts
@@ -128,6 +128,9 @@ export const NmdParentRef = Schema.Union(
     id: NotionUUID,
   }),
   Schema.TaggedStruct('workspace', {}),
+  Schema.TaggedStruct('agent', {
+    id: NotionUUID,
+  }),
   Schema.TaggedStruct('unknown', {
     raw: Schema.Unknown,
   }),

--- a/packages/@overeng/notion-effect-client/src/nmd.unit.test.ts
+++ b/packages/@overeng/notion-effect-client/src/nmd.unit.test.ts
@@ -1,9 +1,11 @@
+import { Schema } from 'effect'
 import { describe, expect, it } from 'vitest'
 
 import {
   classifyNmdFrontmatterPayload,
   decodeNmdFrontmatterV1Sync,
   makeNmdObjectRef,
+  NmdParentRef,
   nmdObjectRelativePath,
   nmdSha256Hex,
   nmdSyncStateRelativePath,
@@ -170,5 +172,14 @@ describe('NMD local metadata paths', () => {
       media_type: 'application/json',
       byte_length: 6,
     })
+  })
+})
+
+describe('NmdParentRef', () => {
+  const decode = Schema.decodeUnknownSync(NmdParentRef)
+  const id = '00000000-0000-4000-8000-000000000001'
+
+  it('round-trips an agent parent (Custom Agent instruction pages)', () => {
+    expect(decode({ _tag: 'agent', id })).toEqual({ _tag: 'agent', id })
   })
 })

--- a/packages/@overeng/notion-md/src/sync.ts
+++ b/packages/@overeng/notion-md/src/sync.ts
@@ -148,6 +148,8 @@ const toParentRef = (page: RemotePageSnapshot): NmdParentRef => {
       return { _tag: 'block', id: page.parent.block_id }
     case 'workspace':
       return { _tag: 'workspace' }
+    case 'agent_id':
+      return { _tag: 'agent', id: page.parent.agent_id }
     default:
       return { _tag: 'unknown', raw: page.parent }
   }


### PR DESCRIPTION
## Problem

Follow-up to #741. With `agent_id` page parents now modeled, `notion-md` serialized Custom Agent instruction pages to the generic `{ _tag: 'unknown', raw: { type: 'agent_id', … } }` frontmatter shape — functional, but lossy and noisy for an agent-centric workflow.

## Goal

Custom Agent instruction pages get a dedicated, typed `agent` parent ref in `.nmd` frontmatter.

## Decisions

- Add `agent` (id only) to `NmdParentRef` and map `agent_id` → `{ _tag: 'agent' }` in `toParentRef`. The previous `default → unknown` branch stays for genuinely unmodeled parent types.

## Verification

- `dt check:all` green (ts strict + lint + tests) on this change layered on #741's model — validated with only the three files here changed.
- New unit test round-trips the `agent` parent ref through `NmdParentRef`.

## Complexity

No new complexity — one union member, one switch case, one test.

## Concerns

None. `.nmd` files written before this change with an `unknown` agent parent re-serialize to `agent` on next sync; both decode fine.

## Follow-ups

None.

## References

Follows #741.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🦤 cl2-ibis |
| `agent_session_id` | 49ccf2ed-0881-48a7-b504-fa512767a52a |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.160 |
| `agent_runtime` | Claude Code 2.1.160 |
| `agent_model` | claude-opus-4-8 |
| `worktree` | effect-utils/schickling/2026-06-04-notion-agent-frontmatter |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->