### PR TITLE
fix(megarepo): exclude skipped members from lock sync

### DIFF
--- a/packages/@overeng/megarepo/src/cli/commands/engine.ts
+++ b/packages/@overeng/megarepo/src/cli/commands/engine.ts
@@ -428,7 +428,10 @@ export const syncMegarepo = <R = never>({
           (lockSyncExplicitSetting !== false && (devenvLockExists || flakeLockExists))
 
         if (lockSyncEnabled === true) {
-          const excludeMembers = new Set(config.lockSync?.exclude ?? [])
+          const excludeMembers = new Set([
+            ...(config.lockSync?.exclude ?? []),
+            ...skippedMemberNames,
+          ])
           nixLockResult = yield* syncNixLocks({
             megarepoRoot,
             config,
@@ -453,7 +456,12 @@ export const syncMegarepo = <R = never>({
       yield* generateAll({
         megarepoRoot: megarepoRoot,
         outermostRoot,
-        config,
+        config: {
+          ...config,
+          members: Object.fromEntries(
+            Object.entries(config.members).filter(([name]) => !skippedMemberNames.has(name)),
+          ),
+        },
       })
     }
 

--- a/packages/@overeng/megarepo/src/cli/sync.integration.test.ts
+++ b/packages/@overeng/megarepo/src/cli/sync.integration.test.ts
@@ -1475,6 +1475,42 @@ describe('nested megarepo.lock sync scope', () => {
   )
 
   it.effect(
+    'should not use skipped members as nested lock-sync authorities',
+    Effect.fnUntraced(
+      function* () {
+        const { parentPath, childPath, storePath, staleNestedCommit } =
+          yield* createNestedWorkspaceFixture()
+
+        const nestedLockPath = EffectPath.ops.join(
+          childPath,
+          EffectPath.unsafe.relativeFile(LOCK_FILE_NAME),
+        )
+        const beforeNestedLockOpt = yield* readLockFile(nestedLockPath)
+        expect(Option.isSome(beforeNestedLockOpt)).toBe(true)
+        const beforeNestedLock = Option.getOrThrow(beforeNestedLockOpt)
+        expect(beforeNestedLock.members['shared']?.commit).toBe(staleNestedCommit)
+
+        const result = yield* runFetchApplyCommand({
+          cwd: parentPath,
+          args: ['--output', 'json', '--all', '--skip', 'shared'],
+          env: {
+            MEGAREPO_STORE: storePath.slice(0, -1),
+          },
+        })
+        expect(result.exitCode).toBe(0)
+
+        const afterNestedLockOpt = yield* readLockFile(nestedLockPath)
+        expect(Option.isSome(afterNestedLockOpt)).toBe(true)
+        const afterNestedLock = Option.getOrThrow(afterNestedLockOpt)
+        expect(afterNestedLock.members['shared']?.commit).toBe(staleNestedCommit)
+      },
+      Effect.provide(NodeContext.layer),
+      Effect.scoped,
+    ),
+    { timeout: 15_000 },
+  )
+
+  it.effect(
     'should not sync member megarepo.lock in --all mode when member is not a megarepo',
     Effect.fnUntraced(
       function* () {

--- a/packages/@overeng/megarepo/src/lib/nix-lock/mod.ts
+++ b/packages/@overeng/megarepo/src/lib/nix-lock/mod.ts
@@ -1134,8 +1134,11 @@ export const syncNixLocks = Effect.fn('megarepo/nix-lock/sync')((options: NixLoc
     const excludeMembers = options.excludeMembers ?? new Set()
     const scope = options.scope ?? 'direct'
 
-    // Build a map of megarepo member URLs to their locked data
-    const megarepoMembers = options.lockFile.members
+    // Excluded members are outside the active graph for this invocation:
+    // they are neither lock-sync targets nor source authorities.
+    const megarepoMembers = Object.fromEntries(
+      Object.entries(options.lockFile.members).filter(([name]) => !excludeMembers.has(name)),
+    )
 
     const memberNames = Object.keys(options.config.members).filter(
       (name) => !excludeMembers.has(name),
@@ -1167,11 +1170,15 @@ export const syncNixLocks = Effect.fn('megarepo/nix-lock/sync')((options: NixLoc
 
     // Preflight: validate shared input source before any writes
     const sharedInputSource = options.config.lockSync?.sharedInputSource
+    const activeSharedInputSource =
+      sharedInputSource !== undefined && excludeMembers.has(sharedInputSource) === false
+        ? sharedInputSource
+        : undefined
     const validatedSharedInputSource =
-      sharedInputSource !== undefined
+      activeSharedInputSource !== undefined
         ? yield* validateSharedInputSource({
             megarepoRoot: options.megarepoRoot,
-            sourceMemberName: sharedInputSource,
+            sourceMemberName: activeSharedInputSource,
           })
         : undefined
 


### PR DESCRIPTION
**Problem**

`mr apply --skip ...` kept parts of skipped members in the lock-sync and generated-workspace proof graph. That meant a skipped member could still be used as a nested lock-sync target, shared lock authority source, or generator input even though the active apply scope excluded it.

**Goal**

A skipped megarepo member is outside the active proof graph for the invocation: it is not materialized as a target, not used as a nested lock-sync root, not used as a shared input authority, and not fed into generated workspace inputs.

**Decisions**

- Thread CLI skipped member names into lock-sync exclusions instead of treating skips as only a worktree status filter.
- Filter generated workspace inputs to the active member set so generators do not observe skipped members.
- Ignore `sharedInputSource` when that source is excluded, because an excluded member cannot remain an authority for the active graph.

**Verification**

- `devenv tasks run test:megarepo`
- `devenv tasks run ts:check`

Both commands passed locally on this branch.

**Complexity**

No new abstraction. This tightens existing skip propagation across the existing megarepo engine and lock-sync boundaries.

**Concerns**

This changes `--skip` from a partial worktree convenience into a stricter active-graph boundary for lock-sync. That is the intended long-term contract, but callers that relied on excluded members as hidden authorities will need to make those dependencies explicit.

**Friction & bottlenecks**

The main friction was that skip semantics were split across status filtering, lock-sync planning, and generator input construction, so the invariant was easy to violate without an integration test. No measured resource bottleneck.

**Follow-ups**

After this lands, downstream repos should move branch pins back to the default effect-utils branch.

**References**

Refs downstream Hypermerge/Evergreen active-proof graph work.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🧥 co2-mink |
| `agent_session_id` | f56ab229-395a-466d-81a3-7c7453c23ac5 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.136.0 |
| `agent_runtime` | Codex CLI 0.136.0 |
| `agent_model` | unknown |
| `worktree` | dotfiles/schickling/2026-05-30-hypermerge-post-cutover |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->