### PR TITLE
fix(nix): disable pnpm managed-version downloads in deps builder

### DIFF
--- a/nix/workspace-tools/lib/mk-pnpm-deps.nix
+++ b/nix/workspace-tools/lib/mk-pnpm-deps.nix
@@ -623,6 +623,7 @@ in
                 export CI=true
                 export NPM_CONFIG_PRODUCTION=false
                 export npm_config_production=false
+                export npm_config_manage_package_manager_versions=false
                 export NODE_ENV=development
                 # Keep pnpm's Node runtime warnings from overwhelming Darwin
                 # builders. pnpm's own install/progress output still reaches logs.
@@ -699,7 +700,7 @@ in
                   ''}
                   pnpm_install_log=$(mktemp "$NIX_BUILD_TOP/pnpm-install.XXXXXX.log")
                   set +e
-                  ${pnpmNodejs}/bin/node "$PNPM_MJS" install ${pnpmLockfileModeArg} ${pnpmOptionalModeArg} --ignore-scripts ${pnpmFilterArgs} 2>&1 | tee "$pnpm_install_log"
+                  ${pnpmNodejs}/bin/node "$PNPM_MJS" install ${pnpmLockfileModeArg} ${pnpmOptionalModeArg} --ignore-scripts --config.manage-package-manager-versions=false ${pnpmFilterArgs} 2>&1 | tee "$pnpm_install_log"
                   pnpm_install_status=''${PIPESTATUS[0]}
                   set -e
                   if [ "$pnpm_install_status" -ne 0 ]; then


### PR DESCRIPTION
## Motivation

`schickling/dotfiles#1015` exposed a stale contract in the shared pnpm prepared-deps builder. Dotfiles CI has a `pnpm-builder-contract` check that requires prepared-deps generation to disable pnpm managed-version resolution, but the actual shared builder still invoked pnpm without that guard. Repinning dotfiles alone cannot fix this cleanly: every downstream repo consumes the same `mk-pnpm-deps.nix`, so the invariant belongs in effect-utils as the source of truth.

The failure mode is concrete: pnpm can try to resolve or download the package-manager version declared by project metadata during fixed-output dependency preparation. That is exactly the kind of network/toolchain drift the prepared-deps builder is supposed to eliminate. The builder already controls the pnpm entrypoint via Nix (`PNPM_MJS`); it should also force pnpm to use that pinned runtime instead of consulting package-manager management.

## Summary

- pass `--config.manage-package-manager-versions=false` to the shared prepared-deps pnpm install invocation
- set `npm_config_manage_package_manager_versions=false` in the builder environment so child pnpm/npm config lookup sees the same policy
- keep the contract centralized in effect-utils rather than adding repo-local downstream workarounds

## Downstream Flow

After this lands, dotfiles can repin `effect-utils/main` and its existing `pnpm-builder-contract` check should validate the shared builder directly. That keeps the rollout aligned with the megarepo principle: upstream shared build policy first, downstream locks second, aggregate repin last.

## Verification

- local pnpm builder contract grep
- `devenv tasks run lint:nix:format --mode before`
- `devenv tasks run lint:nix:deadcode --mode before`

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | ♨️ co3-ember |
| `agent_session_id` | 0f123047-2265-45bd-a42d-f92608c370fc |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.137.0 |
| `agent_runtime` | Codex CLI 0.137.0 |
| `agent_model` | unknown |
| `worktree` | effect-utils/schickling-assistant/2026-06-07-pnpm-builder-managed-version |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->