### PR TITLE
chore: bump nixpkgs for Grafana 13.0.2

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780125817,
-        "narHash": "sha256-A44psESF9sRBg5kkkYwPPKcDakheLDnpwWMguKpA2xw=",
+        "lastModified": 1780747962,
+        "narHash": "sha256-IX7G1dlKrOqPOImfbo7ADDfV5yU1+j+MRChI3TL4tAA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cc8609d47cd9ddda67f70bd4729b0c1dfb2e7f21",
+        "rev": "cbb5cf358f50aa6acc9efd6113b7bcfbc352cd73",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bumps the canonical effect-utils nixpkgs pin from cc8609d to cbb5cf3 so downstream flakes that follow effect-utils/nixpkgs pick up Grafana 13.0.2 without adding a separate nixpkgs input.\n\nVerification:\n- nix flake check --no-build\n- nix eval github:NixOS/nixpkgs/cbb5cf358f50aa6acc9efd6113b7bcfbc352cd73#grafana.version => 13.0.2\n\nContext: avoids adding a dotfiles-local grafana-nixpkgs input while addressing https://github.com/grafana/grafana/issues/125963 mitigations downstream.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | ✨ co3-quartz |
| `agent_session_id` | f012d2dd-f83a-4f52-8310-3ee879634905 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.137.0 |
| `agent_runtime` | Codex CLI 0.137.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/09dry0vkdckh6x5bfd005nvvif6jah2x-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/nhbhipdhwmcqh669bpr15g39hr17cqbb-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling/2026-06-08-grafana-nixpkgs-13-0-2 |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@b9dac04 |
</details>
<!-- agent-footer:end -->