### PR TITLE
fix(notion-effect-client): guard body observation edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **@overeng/notion-effect-client**: Make live `NotionBody.observe` fail closed across concurrent remote edits by bracketing Markdown and block-tree reads with page metadata retrieval, retrying unstable observation windows up to three total attempts, and returning `NotionBodyObservationChangedError` when all attempts see `last_edited_time` change (#761).
 - **@overeng/notion-md + @overeng/notion-datasource-sync**: Fail closed when a remote Notion Markdown body observation is lossy, including endpoint truncation, empty endpoint bodies with non-empty rendered evidence, unknown blocks, unsupported body inventory, or rendered suffix content omitted after dividers and toggleable headings, so partial bodies are not adopted as clean `.nmd` bases or settled through datasource-sync body guards (#759).
 - **@overeng/notion-md**: Adopt block-tree-rendered Markdown, not endpoint Markdown reparsed through CommonMark, as the live pull clean-base body so divider/heading-dense pages do not turn paragraph blocks into `##` headings (#763).
 - **@overeng/notion-md**: Guard unified tree sync planning and destructive operations by reporting dry-run moves, blocking missing-file trash unless forced, checking tree `replace_content` races, and documenting the explicit tree/flat-batch CLI contract.

--- a/packages/@overeng/notion-effect-client/docs/requirements.md
+++ b/packages/@overeng/notion-effect-client/docs/requirements.md
@@ -43,3 +43,11 @@ and wire schemas from
   or sidecar contracts.
 - **R08 No root CLI ownership:** The client must not own user-facing root CLI
   command composition.
+
+### Must Provide Conservative Body Evidence
+
+- **R09 Conservative body observation:** Live body observation must not present
+  evidence from a known-unstable Notion read window as a stable body
+  observation. When the client can detect that the remote page changed while
+  assembling body evidence, it must retry or fail closed rather than returning
+  mixed-snapshot evidence.

--- a/packages/@overeng/notion-effect-client/docs/spec.md
+++ b/packages/@overeng/notion-effect-client/docs/spec.md
@@ -49,12 +49,17 @@ client package.
 
 ## Live Body Observation
 
-Requirement trace: R02-R08.
+Requirement trace: R02-R09.
 
 `@overeng/notion-effect-client` owns the live Notion observation needed to turn
 core's pure body-fidelity classifier into evidence from the real workspace.
 
 ```
+GET /pages/{page_id}
+        |
+        v
+BeforePageMetadata
+
 GET /pages/{page_id}/markdown
         |
         v
@@ -64,6 +69,11 @@ retrieve block tree -> render with client Markdown renderer
         |
         v
 BlockInventory
+
+GET /pages/{page_id}
+        |
+        v
+AfterPageMetadata
 
 MarkdownBodySnapshot + BlockInventory
         |
@@ -88,9 +98,13 @@ Notion's markdown endpoint against the block tree, but callers must not reparse
 endpoint Markdown as the canonical pull body when block-level fidelity matters.
 
 Because Markdown and block-tree reads are separate Notion API observations,
-callers that require race-free adoption should treat lossy evidence as
-authoritative and may add page timestamp rechecks around observation when their
-workflow needs stronger concurrency proof.
+the client brackets them with page metadata reads and compares
+`last_edited_time`. If the metadata changes across the observation window, the
+client retries the full window up to a small fixed bound, then fails closed with
+`NotionBodyObservationChangedError`. This makes live body observation
+conservative without changing the pure classifier: `last_edited_time` is a
+stability signal, not a transactional snapshot token, and callers still own
+adoption/write policy.
 
 ## Resource Modules
 

--- a/packages/@overeng/notion-effect-client/src/body-observation.ts
+++ b/packages/@overeng/notion-effect-client/src/body-observation.ts
@@ -1,4 +1,5 @@
-import { Effect } from 'effect'
+import type { HttpClient } from '@effect/platform'
+import { Effect, Schema } from 'effect'
 
 import {
   classifyBodyCompleteness,
@@ -9,6 +10,8 @@ import {
 import type { PageMarkdown } from '@overeng/notion-effect-schema'
 
 import { NotionBlocks, type BlockTree } from './blocks.ts'
+import type { NotionConfig } from './config.ts'
+import type { NotionApiError } from './error.ts'
 import { NotionMarkdown } from './markdown.ts'
 import { NotionPages } from './pages.ts'
 
@@ -22,6 +25,20 @@ export interface NotionBodyObservation {
   readonly inventory: BlockInventory
   readonly completeness: BodyCompleteness
 }
+
+/** Raised when a live body observation cannot find a stable page metadata window. */
+export class NotionBodyObservationChangedError extends Schema.TaggedError<NotionBodyObservationChangedError>()(
+  'NotionBodyObservationChangedError',
+  {
+    pageId: Schema.String,
+    attempts: Schema.Int,
+    beforeLastEditedTime: Schema.String,
+    afterLastEditedTime: Schema.String,
+    message: Schema.String,
+  },
+) {}
+
+const NOTION_BODY_OBSERVATION_ATTEMPTS = 3
 
 const inventoryEntries = (tree: BlockTree): readonly BlockInventoryEntry[] => {
   const entries: BlockInventoryEntry[] = []
@@ -66,10 +83,39 @@ export const observeFromSnapshots = Effect.fn('NotionBody.observeFromSnapshots')
 export const observe = Effect.fn('NotionBody.observe')(function* (opts: {
   readonly pageId: string
 }) {
-  const markdown = yield* NotionPages.getMarkdown({ pageId: opts.pageId })
-  const tree = yield* NotionBlocks.retrieveAsTree({ blockId: opts.pageId })
-  return yield* observeFromSnapshots({ pageId: opts.pageId, markdown, tree })
+  return yield* observeStable({ pageId: opts.pageId, attempt: 0 })
 })
+
+const observeStable = (opts: {
+  readonly pageId: string
+  readonly attempt: number
+}): Effect.Effect<
+  NotionBodyObservation,
+  NotionApiError | NotionBodyObservationChangedError,
+  NotionConfig | HttpClient.HttpClient
+> =>
+  Effect.gen(function* () {
+    const before = yield* NotionPages.retrieve({ pageId: opts.pageId })
+    const markdown = yield* NotionPages.getMarkdown({ pageId: opts.pageId })
+    const tree = yield* NotionBlocks.retrieveAsTree({ blockId: opts.pageId })
+    const after = yield* NotionPages.retrieve({ pageId: opts.pageId })
+
+    if (before.last_edited_time === after.last_edited_time) {
+      return yield* observeFromSnapshots({ pageId: opts.pageId, markdown, tree })
+    }
+
+    if (opts.attempt + 1 < NOTION_BODY_OBSERVATION_ATTEMPTS) {
+      return yield* observeStable({ pageId: opts.pageId, attempt: opts.attempt + 1 })
+    }
+
+    return yield* new NotionBodyObservationChangedError({
+      pageId: opts.pageId,
+      attempts: NOTION_BODY_OBSERVATION_ATTEMPTS,
+      beforeLastEditedTime: before.last_edited_time,
+      afterLastEditedTime: after.last_edited_time,
+      message: `Notion page body changed while observing page ${opts.pageId}; all ${NOTION_BODY_OBSERVATION_ATTEMPTS} observation attempts were unstable.`,
+    })
+  })
 
 export const NotionBody = {
   observe,

--- a/packages/@overeng/notion-effect-client/src/body-observation.unit.test.ts
+++ b/packages/@overeng/notion-effect-client/src/body-observation.unit.test.ts
@@ -1,10 +1,21 @@
-import { Effect } from 'effect'
+import type { HttpClientRequest } from '@effect/platform'
+import { Effect, Either } from 'effect'
 import { describe, expect, it } from 'vitest'
 
 import type { Block } from '@overeng/notion-effect-schema'
 
 import type { BlockTree } from './blocks.ts'
-import { observeFromSnapshots } from './body-observation.ts'
+import {
+  NotionBody,
+  NotionBodyObservationChangedError,
+  observeFromSnapshots,
+} from './body-observation.ts'
+import { createTestLayer, type MockResponse } from './test/test-utils.ts'
+
+const pageId = '00000000-0000-4000-8000-000000000020'
+const blockId = '00000000-0000-4000-8000-000000000021'
+const userId = '00000000-0000-4000-8000-000000000010'
+const createdTime = '2026-06-09T00:00:00.000Z'
 
 const block = (opts: {
   readonly id: string
@@ -18,9 +29,9 @@ const block = (opts: {
     parent: { type: 'page_id', page_id: '00000000-0000-4000-8000-000000000000' },
     type: opts.type,
     created_time: '2026-06-09T00:00:00.000Z',
-    created_by: { object: 'user', id: '00000000-0000-4000-8000-000000000010' },
+    created_by: { object: 'user', id: userId },
     last_edited_time: '2026-06-09T00:00:00.000Z',
-    last_edited_by: { object: 'user', id: '00000000-0000-4000-8000-000000000010' },
+    last_edited_by: { object: 'user', id: userId },
     has_children: opts.hasChildren ?? false,
     in_trash: false,
     [opts.type]: opts.payload,
@@ -42,6 +53,105 @@ const text = (content: string) => [
     href: null,
   },
 ]
+
+type ObserveAttempt = {
+  readonly beforeLastEditedTime: string
+  readonly afterLastEditedTime: string
+  readonly markdown: string
+  readonly blockText: string
+}
+
+const pageResponse = (opts: { readonly lastEditedTime: string }) => ({
+  object: 'page',
+  id: pageId,
+  created_time: createdTime,
+  created_by: { object: 'user', id: userId },
+  last_edited_time: opts.lastEditedTime,
+  last_edited_by: { object: 'user', id: userId },
+  icon: null,
+  cover: null,
+  parent: { type: 'workspace', workspace: true },
+  in_trash: false,
+  url: `https://www.notion.so/${pageId}`,
+  public_url: null,
+  properties: {},
+})
+
+const markdownResponse = (opts: { readonly markdown: string }) => ({
+  object: 'page_markdown',
+  markdown: opts.markdown,
+  truncated: false,
+  unknown_block_ids: [],
+})
+
+const blockChildrenResponse = (opts: { readonly blockText: string }) => ({
+  object: 'list',
+  results: [
+    block({
+      id: blockId,
+      type: 'paragraph',
+      payload: { rich_text: text(opts.blockText) },
+    }),
+  ],
+  next_cursor: null,
+  has_more: false,
+})
+
+const makeObserveTestLayer = (attempts: readonly ObserveAttempt[]) => {
+  const requests: Array<{ readonly method: string; readonly path: string }> = []
+  let pageCalls = 0
+  let markdownCalls = 0
+  let blockChildrenCalls = 0
+
+  const attemptAt = (index: number): ObserveAttempt => {
+    const attempt = attempts[index] ?? attempts[attempts.length - 1]
+    if (attempt === undefined) {
+      throw new Error('At least one observe attempt fixture is required')
+    }
+    return attempt
+  }
+
+  const layer = createTestLayer((request: HttpClientRequest.HttpClientRequest): MockResponse => {
+    const url = new URL(request.url)
+    requests.push({ method: request.method, path: `${url.pathname}${url.search}` })
+
+    if (request.method === 'GET' && url.pathname === `/v1/pages/${pageId}`) {
+      const attempt = attemptAt(Math.floor(pageCalls / 2))
+      const lastEditedTime =
+        pageCalls % 2 === 0 ? attempt.beforeLastEditedTime : attempt.afterLastEditedTime
+      pageCalls += 1
+      return { status: 200, body: pageResponse({ lastEditedTime }) }
+    }
+
+    if (request.method === 'GET' && url.pathname === `/v1/pages/${pageId}/markdown`) {
+      const attempt = attemptAt(markdownCalls)
+      markdownCalls += 1
+      return { status: 200, body: markdownResponse({ markdown: attempt.markdown }) }
+    }
+
+    if (request.method === 'GET' && url.pathname === `/v1/blocks/${pageId}/children`) {
+      const attempt = attemptAt(blockChildrenCalls)
+      blockChildrenCalls += 1
+      return { status: 200, body: blockChildrenResponse({ blockText: attempt.blockText }) }
+    }
+
+    return {
+      status: 404,
+      body: {
+        object: 'error',
+        status: 404,
+        code: 'object_not_found',
+        message: `Unexpected request ${request.method} ${url.pathname}${url.search}`,
+      },
+    }
+  })
+
+  return {
+    layer,
+    requests,
+    counts: () => ({ pageCalls, markdownCalls, blockChildrenCalls }),
+  }
+}
 
 describe('NotionBody.observeFromSnapshots', () => {
   it('classifies endpoint Markdown missing rendered content after a divider as lossy', async () => {
@@ -136,5 +246,143 @@ describe('NotionBody.observeFromSnapshots', () => {
       _tag: 'lossy',
       reasons: ['rendered_markdown_has_unobserved_suffix'],
     })
+  })
+})
+
+describe('NotionBody.observe', () => {
+  it('observes a stable metadata window through the HTTP test layer', async () => {
+    const test = makeObserveTestLayer([
+      {
+        beforeLastEditedTime: '2026-06-09T00:00:00.000Z',
+        afterLastEditedTime: '2026-06-09T00:00:00.000Z',
+        markdown: 'Stable body',
+        blockText: 'Stable body',
+      },
+    ])
+
+    const observed = await Effect.runPromise(
+      NotionBody.observe({ pageId }).pipe(Effect.provide(test.layer)),
+    )
+
+    expect(observed.pageId).toBe(pageId)
+    expect(observed.markdown.markdown).toBe('Stable body')
+    expect(observed.inventory.renderedMarkdown).toBe('Stable body')
+    expect(observed.completeness).toEqual({ _tag: 'complete' })
+    expect(test.requests).toEqual([
+      { method: 'GET', path: `/v1/pages/${pageId}` },
+      { method: 'GET', path: `/v1/pages/${pageId}/markdown` },
+      { method: 'GET', path: `/v1/blocks/${pageId}/children?page_size=100` },
+      { method: 'GET', path: `/v1/pages/${pageId}` },
+    ])
+  })
+
+  it('retries changed metadata and returns the retry-attempt observation', async () => {
+    const test = makeObserveTestLayer([
+      {
+        beforeLastEditedTime: '2026-06-09T00:00:00.000Z',
+        afterLastEditedTime: '2026-06-09T00:00:01.000Z',
+        markdown: 'First attempt body',
+        blockText: 'First attempt body',
+      },
+      {
+        beforeLastEditedTime: '2026-06-09T00:00:01.000Z',
+        afterLastEditedTime: '2026-06-09T00:00:01.000Z',
+        markdown: 'Retry attempt body',
+        blockText: 'Retry attempt body',
+      },
+    ])
+
+    const observed = await Effect.runPromise(
+      NotionBody.observe({ pageId }).pipe(Effect.provide(test.layer)),
+    )
+
+    expect(observed.markdown.markdown).toBe('Retry attempt body')
+    expect(observed.inventory.renderedMarkdown).toBe('Retry attempt body')
+    expect(test.counts()).toEqual({
+      pageCalls: 4,
+      markdownCalls: 2,
+      blockChildrenCalls: 2,
+    })
+  })
+
+  it('fails closed with a tagged error when all metadata windows change', async () => {
+    const test = makeObserveTestLayer([
+      {
+        beforeLastEditedTime: '2026-06-09T00:00:00.000Z',
+        afterLastEditedTime: '2026-06-09T00:00:01.000Z',
+        markdown: 'Attempt 1',
+        blockText: 'Attempt 1',
+      },
+      {
+        beforeLastEditedTime: '2026-06-09T00:00:01.000Z',
+        afterLastEditedTime: '2026-06-09T00:00:02.000Z',
+        markdown: 'Attempt 2',
+        blockText: 'Attempt 2',
+      },
+      {
+        beforeLastEditedTime: '2026-06-09T00:00:02.000Z',
+        afterLastEditedTime: '2026-06-09T00:00:03.000Z',
+        markdown: 'Attempt 3',
+        blockText: 'Attempt 3',
+      },
+    ])
+
+    const result = await Effect.runPromise(
+      Effect.either(NotionBody.observe({ pageId }).pipe(Effect.provide(test.layer))),
+    )
+
+    expect(Either.isLeft(result)).toBe(true)
+    if (Either.isLeft(result) === true) {
+      expect(result.left).toBeInstanceOf(NotionBodyObservationChangedError)
+      expect(result.left).toMatchObject({
+        _tag: 'NotionBodyObservationChangedError',
+        pageId,
+        attempts: 3,
+        beforeLastEditedTime: '2026-06-09T00:00:02.000Z',
+        afterLastEditedTime: '2026-06-09T00:00:03.000Z',
+      })
+      expect(result.left.message).toContain('all 3 observation attempts were unstable')
+    }
+  })
+
+  it('bounds unstable observations to three full attempts', async () => {
+    const test = makeObserveTestLayer([
+      {
+        beforeLastEditedTime: '2026-06-09T00:00:00.000Z',
+        afterLastEditedTime: '2026-06-09T00:00:01.000Z',
+        markdown: 'Attempt 1',
+        blockText: 'Attempt 1',
+      },
+      {
+        beforeLastEditedTime: '2026-06-09T00:00:01.000Z',
+        afterLastEditedTime: '2026-06-09T00:00:02.000Z',
+        markdown: 'Attempt 2',
+        blockText: 'Attempt 2',
+      },
+      {
+        beforeLastEditedTime: '2026-06-09T00:00:02.000Z',
+        afterLastEditedTime: '2026-06-09T00:00:03.000Z',
+        markdown: 'Attempt 3',
+        blockText: 'Attempt 3',
+      },
+      {
+        beforeLastEditedTime: '2026-06-09T00:00:03.000Z',
+        afterLastEditedTime: '2026-06-09T00:00:03.000Z',
+        markdown: 'Should not be observed',
+        blockText: 'Should not be observed',
+      },
+    ])
+
+    const result = await Effect.runPromise(
+      Effect.either(NotionBody.observe({ pageId }).pipe(Effect.provide(test.layer))),
+    )
+
+    expect(Either.isLeft(result)).toBe(true)
+    expect(test.counts()).toEqual({
+      pageCalls: 6,
+      markdownCalls: 3,
+      blockChildrenCalls: 3,
+    })
+    expect(test.requests).toHaveLength(12)
   })
 })

--- a/packages/@overeng/notion-effect-client/src/mod.ts
+++ b/packages/@overeng/notion-effect-client/src/mod.ts
@@ -30,6 +30,7 @@ export { type BlockInsertPosition, NotionBlocks } from './blocks.ts'
 export type { NotionBodyObservation } from './body-observation.ts'
 export {
   NotionBody,
+  NotionBodyObservationChangedError,
   observeFromSnapshots as observeNotionBodyFromSnapshots,
 } from './body-observation.ts'
 // Comments


### PR DESCRIPTION
**Problem**

`NotionBody.observe` combined enhanced Markdown and block-tree reads without checking whether the Notion page changed between those separate API observations. A concurrent edit could make the body completeness classifier reason over mixed snapshots.

**Goal**

Make live body observation fail closed when the Markdown and block-tree reads span a page edit, while keeping pure snapshot classification unchanged.

**Decisions**

- Bracket the live Markdown + block-tree observation with `NotionPages.retrieve` calls and compare `last_edited_time`.
- Retry the full observation window up to three total attempts.
- Fail closed with exported `NotionBodyObservationChangedError` when all attempts are unstable.
- Keep `observeFromSnapshots` pure and leave caller-provided metadata reuse out of this PR.
- Capture the durable invariant in the `@overeng/notion-effect-client` VRS requirements and spec without hard-coding the concrete retry mechanism into requirements.

**Verification**

- `CI=1 ./node_modules/.bin/vitest run --config vitest.config.ts src/body-observation.unit.test.ts` from `packages/@overeng/notion-effect-client`: 6 tests passed.
- `CI=1 devenv tasks run check:all --show-output`: passed locally.
- `CI=1 devenv tasks run check:quick --show-output`: passed after the VRS requirements/spec update.

**Complexity**

Small live-observation policy only; no new dependency or new abstraction boundary.

**Concerns**

This adds two page metadata reads per live body observation. `last_edited_time` is also a conservative guard: property-only edits can cause fail-closed retries even when body content did not change, and equal timestamps are not a transactional snapshot token.

**Friction & bottlenecks**

`check:all` reports existing warning-level lint backlog and a FlakeHub cache-info 401 warning, but completed successfully.

**Follow-ups**

- #766 tracks the longer-term content-addressed body observation / guarded settlement model.
- If the extra metadata reads become material before #766, callers that already retrieved page metadata can get an explicit baseline reuse API in a separate small PR.

**References**

Closes #761
Refs #759
Refs #766

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🧋 co1-froth |
| `agent_session_id` | 06c38868-cae2-4cc8-8b92-c3e1dbe8553e |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.131.0 |
| `agent_runtime` | Codex CLI 0.131.0 |
| `agent_model` | unknown |
| `worktree` | effect-utils/schickling/2026-06-09-761 |
| `machine` | mbp2025 |
| `tooling_profile` | dotfiles@1f93e82 |
</details>
<!-- agent-footer:end -->