### PR TITLE
fix(notion-effect-client): nest create-database properties under initial_data_source

### DIFF
--- a/packages/@overeng/notion-effect-client/src/databases.ts
+++ b/packages/@overeng/notion-effect-client/src/databases.ts
@@ -84,8 +84,14 @@ export interface CreateDatabaseOptions {
     | { readonly type: 'workspace'; readonly workspace: true }
   /** Database title rich text */
   readonly title: readonly unknown[]
-  /** Property schema definitions */
+  /**
+   * Property schema definitions. In API 2026-03-11 these live on the database's
+   * initial data source, not on the database object; `create` nests them under
+   * `initial_data_source` for you (see {@link create}).
+   */
   readonly properties: Record<string, unknown>
+  /** Optional title for the initial data source (defaults to the database title) */
+  readonly initialDataSourceTitle?: readonly unknown[]
   /** Database description rich text */
   readonly description?: readonly unknown[]
   /** Whether the database should be displayed inline */
@@ -170,13 +176,23 @@ export const retrieve = Effect.fn('NotionDatabases.retrieve')(function* (
 /**
  * Create a database.
  *
+ * In API 2026-03-11 the property schema lives on the database's **initial data
+ * source**, not on the database object: a top-level `properties` key is silently
+ * dropped, yielding an empty `Name`-only database. This nests `opts.properties`
+ * under `initial_data_source` so callers keep passing a flat property map.
+ *
  * @see https://developers.notion.com/reference/create-a-database
  */
 export const create = Effect.fn('NotionDatabases.create')(function* (opts: CreateDatabaseOptions) {
+  const initialDataSource: Record<string, unknown> = { properties: opts.properties }
+  if (opts.initialDataSourceTitle !== undefined) {
+    initialDataSource.title = opts.initialDataSourceTitle
+  }
+
   const body: Record<string, unknown> = {
     parent: opts.parent,
     title: opts.title,
-    properties: opts.properties,
+    initial_data_source: initialDataSource,
   }
 
   if (opts.description !== undefined) body.description = opts.description

--- a/packages/@overeng/notion-effect-client/src/databases.unit.test.ts
+++ b/packages/@overeng/notion-effect-client/src/databases.unit.test.ts
@@ -1,0 +1,79 @@
+import type { HttpClientRequest } from '@effect/platform'
+import { Effect } from 'effect'
+import { expect } from 'vitest'
+
+import { Vitest } from '@overeng/utils-dev/node-vitest'
+
+import { NotionDatabases } from './databases.ts'
+import { createTestLayer, sampleResponses } from './test/test-utils.ts'
+
+/** Decode a JSON request body regardless of the underlying HttpBody encoding. */
+const decodeJsonBody = (req: HttpClientRequest.HttpClientRequest): Record<string, unknown> => {
+  const raw = (req.body as { readonly body?: unknown }).body
+  if (raw instanceof Uint8Array) return JSON.parse(new TextDecoder().decode(raw))
+  if (typeof raw === 'string') return JSON.parse(raw)
+  throw new Error(`unexpected request body shape: ${JSON.stringify(req.body)}`)
+}
+
+Vitest.describe('NotionDatabases.create', () => {
+  Vitest.it.effect(
+    'nests properties under initial_data_source (API 2026-03-11 data_source split)',
+    () =>
+      Effect.gen(function* () {
+        let captured: HttpClientRequest.HttpClientRequest | undefined
+
+        // Effect.either: the response-decode result is irrelevant here — we assert the
+        // outbound request body, which the handler captures before any decode.
+        yield* NotionDatabases.create({
+          parent: { type: 'page_id', page_id: 'page-1' },
+          title: [{ type: 'text', text: { content: 'Items' } }],
+          properties: { Name: { title: {} }, Stage: { status: {} } },
+        }).pipe(
+          Effect.either,
+          Effect.provide(
+            createTestLayer((req) => {
+              captured = req
+              return { status: 200, body: sampleResponses.database }
+            }),
+          ),
+        )
+
+        const body = decodeJsonBody(captured!)
+
+        // The schema must NOT be at the top level (silently dropped by the API),
+        // and MUST live under initial_data_source.properties.
+        expect(body.properties).toBeUndefined()
+        expect(body.initial_data_source).toEqual({
+          properties: { Name: { title: {} }, Stage: { status: {} } },
+        })
+        expect(body.parent).toEqual({ type: 'page_id', page_id: 'page-1' })
+      }),
+  )
+
+  Vitest.it.effect('passes initialDataSourceTitle through to initial_data_source', () =>
+    Effect.gen(function* () {
+      let captured: HttpClientRequest.HttpClientRequest | undefined
+
+      const dsTitle = [{ type: 'text', text: { content: 'Items DS' } }]
+      yield* NotionDatabases.create({
+        parent: { type: 'page_id', page_id: 'page-1' },
+        title: [{ type: 'text', text: { content: 'Items' } }],
+        properties: { Name: { title: {} } },
+        initialDataSourceTitle: dsTitle,
+      }).pipe(
+        Effect.either,
+        Effect.provide(
+          createTestLayer((req) => {
+            captured = req
+            return { status: 200, body: sampleResponses.database }
+          }),
+        ),
+      )
+
+      const body = decodeJsonBody(captured!) as {
+        readonly initial_data_source: Record<string, unknown>
+      }
+      expect(body.initial_data_source.title).toEqual(dsTitle)
+    }),
+  )
+})


### PR DESCRIPTION
## Problem

Notion API `2026-03-11` split `database` and `data_source`: a database's property schema now lives on its **initial data source**, not the database object. A top-level `properties` key on `POST /databases` is **silently dropped** — `NotionDatabases.create` succeeds but produces an empty `Name`-only database with no error. (Confirmed live against the current API.)

## Fix

`NotionDatabases.create` nests `opts.properties` under `initial_data_source` in the request body. Callers keep passing a flat property map (no API break); added an optional `initialDataSourceTitle`. `NotionDataSources.create` already used the data_source shape — this aligns database creation with it.

## Tests

New `databases.unit.test.ts` (mock HttpClient) asserts the outbound body: no top-level `properties`, schema present under `initial_data_source.properties`, and `initialDataSourceTitle` passthrough. Verified: `vitest` 2/2 pass, `tsc -b` clean, oxlint/oxfmt clean.

## Why

Unblocks programmatic multi-DB provisioning (surfaced while de-risking the Info Diet system, which provisions Items/Sources/Topics from an Effect schema).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 💎 cl1-zenith |
| `agent_session_id` | efe92103-4d47-43a0-a448-d5a043e7fe52 |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.165 |
| `agent_runtime` | Claude Code 2.1.165 |
| `agent_model` | claude-opus-4-8 |
| `runtime_profile` | /nix/store/h2fzkx1acfyaidg5bmdamarf7856a2s8-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/3v899lwjyzgkr7x7h4m5hlbbpn1jkbds-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-06-10-notion-create-data-source |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->