### PR TITLE
fix(otelite): honor traces endpoint env semantics

### DIFF
--- a/packages/@overeng/utils-dev/src/otelite/test-harness.test.ts
+++ b/packages/@overeng/utils-dev/src/otelite/test-harness.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from '@effect/vitest'
 import { Effect } from 'effect'
 
+import { otlpTracesUrl } from '../node-vitest/Vitest.ts'
 import { captureInProcessTrace, OteliteTestHarness } from './test-harness.ts'
 
 describe('OteliteTestHarness', () => {
@@ -105,6 +106,18 @@ describe('OteliteTestHarness', () => {
         expect(process.env.OTELITE_TEST_ENDPOINT).toBe(previousCustomEndpoint)
         expect(process.env.OTELITE_TEST_SERVICE).toBe(previousCustomService)
         expect(process.env.OTELITE_TEST_EXTRA).toBe(previousExtra)
+
+        const previousPerSignalEndpoint = process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+        yield* otel.withEnv(
+          Effect.sync(() => {
+            expect(process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT).toBe(
+              otlpTracesUrl(otel.capture.endpoints.http),
+            )
+          }),
+          { endpointVar: 'OTEL_EXPORTER_OTLP_TRACES_ENDPOINT' },
+        )
+
+        expect(process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT).toBe(previousPerSignalEndpoint)
       }).pipe(Effect.provide(OteliteTestHarness.Default)),
     30_000,
   )

--- a/packages/@overeng/utils-dev/src/otelite/test-harness.ts
+++ b/packages/@overeng/utils-dev/src/otelite/test-harness.ts
@@ -113,6 +113,13 @@ const makeInProcessLayer = (
   )
 }
 
+const endpointEnvValue = (handle: CaptureHandle, endpointVar?: string): string => {
+  if (endpointVar === 'OTEL_EXPORTER_OTLP_TRACES_ENDPOINT') {
+    return otlpTracesUrl(handle.endpoints.http)
+  }
+  return handle.endpoints.http
+}
+
 export class OteliteTestHarness extends Effect.Service<OteliteTestHarness>()(
   '@overeng/utils-dev/otelite/OteliteTestHarness',
   {
@@ -166,8 +173,10 @@ export class OteliteTestHarness extends Effect.Service<OteliteTestHarness>()(
             envSemaphore.withPermits(1)(
               Effect.scoped(
                 scopedEnv({
-                  [envOptions.endpointVar ?? 'OTEL_EXPORTER_OTLP_ENDPOINT']:
-                    captureHandle.endpoints.http,
+                  [envOptions.endpointVar ?? 'OTEL_EXPORTER_OTLP_ENDPOINT']: endpointEnvValue(
+                    captureHandle,
+                    envOptions.endpointVar,
+                  ),
                   [envOptions.serviceNameVar ?? 'OTEL_SERVICE_NAME']: options.serviceName,
                   ...envOptions.extra,
                 }).pipe(Effect.zipRight(effect)),


### PR DESCRIPTION
**Problem**

PR #777 added env-backed otelite test harness support, but review caught one OTLP/HTTP endpoint semantics bug after the PR had already merged: `withEnv({ endpointVar: "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT" })` wrote the otelite base endpoint. Per-signal OTLP endpoint variables are consumed as full URLs, so a subprocess using that variable would POST to the receiver root instead of `/v1/traces`.

**Goal**

Make env-backed harness tests work with the standard per-signal traces endpoint variable while preserving the existing base-endpoint behavior for `OTEL_EXPORTER_OTLP_ENDPOINT` and custom base endpoint variables.

**Decisions**

- Special-case only `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, because that is the standard traces per-signal variable with full-URL semantics.
- Reuse the existing `otlpTracesUrl` helper so the `/v1/traces` suffix stays one source of truth.
- Add regression coverage in the existing environment restoration test rather than introducing a subprocess fixture.

**Verification**

Locally passed:

```
devenv shell env OTEL_MODE=off dt test:utils-dev --no-tui
devenv shell env OTEL_MODE=off dt ts:check --no-tui
devenv shell env OTEL_MODE=off dt lint:check --no-tui
```

The `OTEL_MODE=off` override is local-only: this shell has `OTEL_MODE=system` but no `otel` CLI, which otherwise blocks devenv shell entry before repo tests run.

**Complexity**

No new abstraction beyond a tiny endpoint-value helper in the harness.

**Concerns**

Custom non-standard endpoint variable names still receive the base endpoint. That matches the previous custom-env behavior and avoids guessing semantics from arbitrary names.

**Friction & bottlenecks**

PR #777 merged while the review fix was being prepared, so this is split into a follow-up PR instead of landing on the original branch.

**Follow-ups**

None.

**References**

Follow-up to #777. Addresses the unresolved Codex review thread on #777 about `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` semantics.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🎡 co2-vortex |
| `agent_session_id` | c2daf5cb-6048-4845-8bda-c73ca840df5c |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.137.0 |
| `agent_runtime` | Codex CLI 0.137.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/4p78dsfk8riqcgk91zzjlgraibyf1hd4-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/cly1vi1qvxfyk37gmdk4qw4j33zrfpny-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling/2026-06-11-otelite-test-harness |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@e7e383b |
</details>
<!-- agent-footer:end -->