### PR TITLE
feat(workspace-tools): share external install-root deps FOD by member-set profile

### DIFF
--- a/nix/workspace-tools/lib/mk-pnpm-cli.nix
+++ b/nix/workspace-tools/lib/mk-pnpm-cli.nix
@@ -766,6 +766,79 @@ let
     );
 
   /**
+    Extract the top-level `patchedDependencies:` block from a lockfile string.
+
+    Root patches are folded into an external install root's lockfile at build
+    time by `inheritRootPatchedDependenciesScript`, so they affect the prepared
+    deps even though they are not part of the install root's own staged
+    lockfile. The fingerprint below therefore has to account for them. We only
+    keep the `patchedDependencies` section (not the whole root lockfile) so an
+    unrelated root dependency bump does not invalidate the external install
+    root's prepared deps, preserving the reuse boundary documented at
+    `externalInstallRootDeps`.
+  */
+  rootPatchedDependenciesSection =
+    lockfileContent:
+    let
+      lines = lib.splitString "\n" lockfileContent;
+      startIndex = lib.lists.findFirstIndex (line: line == "patchedDependencies:") null lines;
+    in
+    if startIndex == null then
+      ""
+    else
+      let
+        rest = lib.lists.drop (startIndex + 1) lines;
+        # The section ends at the next top-level key (a non-indented,
+        # non-blank line). Default to consuming the rest of the file when this
+        # is the last section.
+        endOffset = lib.lists.findFirstIndex (
+          line: line != "" && !(lib.hasPrefix " " line)
+        ) (builtins.length rest) rest;
+        sectionLines = lib.lists.take endOffset rest;
+      in
+      builtins.concatStringsSep "\n" sectionLines;
+
+  /**
+    Content-derived, consumer-invariant fingerprint for an external install
+    root's prepared deps.
+
+    The default `mk-pnpm-deps` fingerprint is the staged-source store-path
+    basename, which is consumer-specific (each consumer stages the same content
+    under its own derivation name). That keeps byte-identical prepared deps on
+    distinct output store paths. This fingerprint instead hashes the staged
+    content itself:
+
+    - the external install root's own lockfile (which records dependency
+      versions and `patchedDependencies` content hashes for that workspace), and
+    - the root lockfile's `patchedDependencies` section (root patches inherited
+      into this install root at build time).
+
+    Both are read through the eval workspace root (no import-from-derivation).
+    The result changes whenever the prepared tree would change, preserving the
+    stale-cache protection of the default fingerprint, but is identical across
+    consumers that compose the same member set, so their FODs collapse onto one
+    output store path.
+  */
+  externalInstallRootContentFingerprint =
+    root:
+    let
+      installRootLockfile = builtins.readFile (
+        resolveEvalSourceFor (installRootScopedPath root.installDir "pnpm-lock.yaml")
+      );
+      rootLockfile = builtins.readFile (resolveEvalSourceFor "pnpm-lock.yaml");
+    in
+    builtins.substring 0 8 (
+      builtins.hashString "sha256" (
+        builtins.toJSON {
+          inherit (root) installDir;
+          memberDirs = installRootMemberDirs root;
+          inherit installRootLockfile;
+          rootPatchedDependencies = rootPatchedDependenciesSection rootLockfile;
+        }
+      )
+    );
+
+  /**
     `depsBuilds` is the canonical source of truth for prepared pnpm artifacts.
 
     Each install root gets one fixed-output derivation, and the downstream CLI
@@ -1036,7 +1109,19 @@ let
       );
       lockfilePath = installRootScopedPath root.installDir "pnpm-lock.yaml";
       depsBuild = pnpmDepsHelper.mkDeps {
-        name = installRootDerivationName root.installDir;
+        # Name the prepared-deps FOD by the install root (its directory plus a
+        # short member-set profile key) instead of the consumer prefix, so
+        # consumers that compose the same external install root share a single
+        # FOD output store path (one build, one cache entry) instead of N
+        # byte-identical copies. The directory tag keeps the derivation
+        # debuggable; the profile key disambiguates different member sets that
+        # share a directory.
+        name = "${lib.replaceStrings [ "/" ] [ "-" ] root.installDir}-deps-${
+          builtins.substring 0 12 (installRootProfileKey root)
+        }";
+        # Use a content-derived, consumer-invariant fingerprint so the shared
+        # name still changes whenever the prepared tree would change.
+        nameFingerprint = externalInstallRootContentFingerprint root;
         src = depsSrc;
         sourceRoot = ".";
         lockfilePaths = [ lockfilePath ];

--- a/nix/workspace-tools/lib/mk-pnpm-deps.nix
+++ b/nix/workspace-tools/lib/mk-pnpm-deps.nix
@@ -432,6 +432,21 @@ in
       lockfilePaths ? [ "pnpm-lock.yaml" ],
       pnpmFilters ? [ ],
       includeOptionalDependencies ? false,
+      # Optional explicit, content-derived fingerprint for the derivation name.
+      #
+      # By default the fingerprint is the first 8 chars of `src`'s store-path
+      # basename. That hash is consumer-specific for shared install roots
+      # (each consumer stages `src` under its own derivation name), so two
+      # consumers with byte-identical prepared deps still get distinct FOD names
+      # and therefore distinct output store paths even though the recursive
+      # output hash is identical.
+      #
+      # Callers that want byte-identical prepared deps to collapse onto one FOD
+      # output (one build, one cache entry) can pass a fingerprint derived from
+      # the staged content itself rather than the consumer-named `src` path. It
+      # must still change whenever the prepared tree would change, to preserve
+      # the stale-cache protection documented below.
+      nameFingerprint ? null,
     }:
     let
       # Embed a fingerprint of the FOD's inputs (lockfile, package.json, etc.)
@@ -456,9 +471,11 @@ in
       # experimental feature is production-ready and binary cache support is
       # complete. CA derivations eliminate manually-maintained FOD hashes entirely.
       # Track: NixOS/nix#6623
-      srcFingerprint = builtins.substring 0 8 (
-        builtins.unsafeDiscardStringContext (baseNameOf (toString src))
-      );
+      srcFingerprint =
+        if nameFingerprint != null then
+          nameFingerprint
+        else
+          builtins.substring 0 8 (builtins.unsafeDiscardStringContext (baseNameOf (toString src)));
       pnpmPackageImportMethod =
         /*
           Self-hosted darwin rebuild-checks compare a trusted realized output with


### PR DESCRIPTION
## Problem

Each downstream consumer that composes the same external install root (e.g. `repos/effect-utils`) builds its own prepared-deps FOD. Consumers with the same member set produce **byte-identical** prepared deps and already declare the same recursive output hash (`mkSharedHash`), but get **distinct store paths** purely because the derivation is named by the consumer prefix (`scg-runtime-…` vs `scg-runtime-host-…`). An FOD output path is a function of `(name, outputHash)` only, so the differing name forces N redundant store paths and cache entries for identical content.

## Change

Name the external install-root deps FOD by the install root's **member-set profile key** (`installRootProfileKey`, plus the directory tag for readability) instead of the consumer prefix, and key its fingerprint on a **content-derived, consumer-invariant** value instead of the consumer-named staged-source path.

- New `mkDeps` arg `nameFingerprint` (opt-in; aggregate root keeps default behavior).
- Fingerprint = `hash(install-root lockfile + root lockfile \`patchedDependencies\` section)`, read at eval (no IFD). It still moves on any output-relevant change (deps version, in-workspace patch hash, inherited root patch), preserving the stale-cache protection of the default fingerprint, while ignoring inert root changes (e.g. unrelated `importers`) so the root-only-change reuse boundary is preserved.
- depsSrc and all source staging are untouched (output path = f(name, hash); depsSrc no longer influences the name).

## Proof (against a downstream repo with 17 effect-utils consumers)

- FOD output collapses to one store path per member-set profile: **17 → 11** distinct outputs.
  - Profile A: 5 consumers → 1 path.
  - Profile B: 3 consumers → 1 path.
  - 9 singletons unchanged.
- **Safety:** all 11 collapse groups are declared-hash-uniform (no group mixes two distinct `mkSharedHash` values) — a collapse can only ever unify consumers that already declared byte-identical content.
- **Stale detection control:** perturbing the install-root lockfile or the root `patchedDependencies` changes the fingerprint; perturbing only the inert root `importers` section does not.
- The shared FOD and a full downstream consumer build green end-to-end against the unchanged declared hash; `genie` (aggregate-root path) still builds with its default consumer-named fingerprint.

## Notes

- Output-hash values are unchanged; this only relocates store paths, so no FOD hash refresh is needed.
- Downstream repos can shrink per-consumer effect-utils stanzas to per-profile shared stanzas (separate follow-up; not in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🪺 cl2-robin |
| `agent_session_id` | 53672103-2c3c-4165-9fc6-7a06d168a461 |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.165 |
| `agent_runtime` | Claude Code 2.1.165 |
| `agent_model` | claude-opus-4-8 |
| `runtime_profile` | /nix/store/gqsx6k18v9d5fj0n1yd15b84vyjzkw38-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/fvv30n06w09dxnsd5s6blb6dxzpmk8x4-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | eu/schickling-assistant/fod-profile-dedup |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@38a9419 |
</details>
<!-- agent-footer:end -->