### PR TITLE
feat(mk-pnpm-cli): dedupe shared deps FODs by dependency profile

### DIFF
--- a/nix/workspace-tools/lib/mk-pnpm-cli.nix
+++ b/nix/workspace-tools/lib/mk-pnpm-cli.nix
@@ -739,9 +739,26 @@ let
       "root"
     else
       lib.strings.sanitizeDerivationName (lib.replaceStrings [ "/" ] [ "-" ] installDir);
-  installRootDerivationName =
-    installDir:
-    if installDir == "." then name else "${name}-${lib.replaceStrings [ "/" ] [ "-" ] installDir}";
+  # Name the prepared-deps fixed-output derivation by its dependency profile
+  # (install dir + member set) instead of the consumer's CLI name, so that
+  # byte-identical profiles shared by many consumers collapse to one in-store
+  # derivation rather than N consumer-named copies of the same content. The FOD
+  # output hash is content-addressed, so this rename is hash-neutral: only the
+  # store-path name changes, which is exactly what enables the deduplication.
+  #
+  # This assumes member-set identity implies staged-content identity: the
+  # prepared tree also depends on the consumer's root pnpm-lock.yaml /
+  # pnpm-workspace.yaml (staged for patch inheritance) and on the source bound
+  # to each `workspaceSources` entry. That holds when consumers sharing a
+  # profile compose the same source at a fixed root lock — the case in a single
+  # pnpm workspace with one pinned dependency. If a consumer varied the root
+  # lock or the bound source under the same member set, this key would alias
+  # distinct trees and must be widened to fingerprint the staged content.
+  installRootDepsDerivationName =
+    root:
+    "${lib.strings.sanitizeDerivationName (lib.replaceStrings [ "/" ] [ "-" ] root.installDir)}-deps-${
+      builtins.substring 0 12 (installRootProfileKey root)
+    }";
   installRootMemberDirs =
     root:
     if root ? memberDirs then
@@ -1017,7 +1034,7 @@ let
   externalInstallRootDeps = map (
     root:
     let
-      depsSrc = pkgs.runCommand "${installRootDerivationName root.installDir}-pnpm-deps-src" { } (
+      depsSrc = pkgs.runCommand "${installRootDepsDerivationName root}-pnpm-deps-src" { } (
         ''
           set -euo pipefail
           mkdir -p "$out"
@@ -1036,7 +1053,7 @@ let
       );
       lockfilePath = installRootScopedPath root.installDir "pnpm-lock.yaml";
       depsBuild = pnpmDepsHelper.mkDeps {
-        name = installRootDerivationName root.installDir;
+        name = installRootDepsDerivationName root;
         src = depsSrc;
         sourceRoot = ".";
         lockfilePaths = [ lockfilePath ];

--- a/nix/workspace-tools/lib/mk-pnpm-cli/tests/fixtures/downstream/flake.nix
+++ b/nix/workspace-tools/lib/mk-pnpm-cli/tests/fixtures/downstream/flake.nix
@@ -76,6 +76,33 @@
           };
           smokeTestArgs = [ ];
         };
+        # Two consumers that differ ONLY in `name` but share the same external
+        # install-root profile. Their prepared deps for that shared root must
+        # collapse to one in-store derivation (profileKey dedup), while their
+        # consumer-specific root (".") derivations stay distinct.
+        mkProfileDedupConsumer =
+          consumerName:
+          mkPnpmCli {
+            name = consumerName;
+            binaryName = consumerName;
+            entry = "app/src/mod.ts";
+            packageDir = "app";
+            workspaceRoot = ./fixture-workspace;
+            workspaceSources = {
+              "repos/effect-utils" = effectUtilsSource;
+            };
+            depsBuilds = {
+              "." = {
+                hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+              };
+              "repos/effect-utils" = {
+                hash = "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=";
+              };
+            };
+            smokeTestArgs = [ ];
+          };
+        profileDedupConsumerA = mkProfileDedupConsumer "profile-dedup-consumer-alpha";
+        profileDedupConsumerB = mkProfileDedupConsumer "profile-dedup-consumer-bravo";
       in
       {
         packages = {
@@ -129,6 +156,24 @@
               fi
               printf '%s' "$actual" > "$out"
             '';
+        checks.pure-eval-profile-dedup = pkgs.runCommand "mk-pnpm-cli-pure-eval-profile-dedup" { } ''
+          actual='${
+            builtins.toJSON {
+              externalSharedDeduped =
+                profileDedupConsumerA.passthru.depsBuildsByInstallRoot."repos-effect-utils".drvPath
+                == profileDedupConsumerB.passthru.depsBuildsByInstallRoot."repos-effect-utils".drvPath;
+              rootDistinct =
+                profileDedupConsumerA.passthru.depsBuildsByInstallRoot."root".drvPath
+                != profileDedupConsumerB.passthru.depsBuildsByInstallRoot."root".drvPath;
+            }
+          }'
+          expected='{"externalSharedDeduped":true,"rootDistinct":true}'
+          if [ "$actual" != "$expected" ]; then
+            echo "unexpected profile dedup result: $actual" >&2
+            exit 1
+          fi
+          printf '%s' "$actual" > "$out"
+        '';
       }
     );
 }

--- a/nix/workspace-tools/lib/mk-pnpm-cli/tests/run.sh
+++ b/nix/workspace-tools/lib/mk-pnpm-cli/tests/run.sh
@@ -244,6 +244,16 @@ run_downstream_pure_eval_regression() {
     --override-input effect-utils "path:$WORKSPACE_REAL/repos/effect-utils" \
     "path:$DOWNSTREAM_DIR#checks.$SYSTEM.pure-eval-derived-workspace-root"
 
+  echo "Build: downstream pure-eval profile-dedup regression (standalone effect-utils path)"
+  nix build --no-link --no-write-lock-file \
+    --override-input effect-utils "path:$WORKSPACE_REAL/effect-utils" \
+    "path:$DOWNSTREAM_DIR#checks.$SYSTEM.pure-eval-profile-dedup"
+
+  echo "Build: downstream pure-eval profile-dedup regression (composed repos/effect-utils path)"
+  nix build --no-link --no-write-lock-file \
+    --override-input effect-utils "path:$WORKSPACE_REAL/repos/effect-utils" \
+    "path:$DOWNSTREAM_DIR#checks.$SYSTEM.pure-eval-profile-dedup"
+
   echo "Check: downstream prepared deps use frozen lockfile mode and skip optional native deps"
   local drv
   drv="$(


### PR DESCRIPTION
## What

Name the prepared-deps fixed-output derivation in `mk-pnpm-cli` by its **dependency profile** (install dir + member set) instead of the consumer's CLI name.

Byte-identical external install-root profiles shared by many consumers (e.g. `repos/effect-utils` composed into N downstream CLIs) currently produce N distinct store paths for identical content, because the derivation name is consumer-prefixed. This collapses them to **one** in-store derivation.

## Why it's safe

The FOD output hash is content-addressed (`pnpmDepsHash`), so renaming the derivation is **hash-neutral** — only the store-path *name* changes, which is exactly what enables the dedup. The consumer-specific root (`.`) derivation is untouched and stays per-consumer.

Proven before/after for two consumers differing only in `name` over a shared `repos/effect-utils` profile:

| | external shared root | root (`.`) |
|---|---|---|
| before | two distinct drvPaths | distinct (correct) |
| after | **one shared drvPath** | distinct (unchanged) |

## Assumption: member-set identity ⟹ staged-content identity

The profile key is `sha256({dir, memberDirs})` — a member *set*, not a full content fingerprint. The prepared tree also depends on the consumer's root `pnpm-lock.yaml`/`pnpm-workspace.yaml` (staged for patch inheritance) and on the source bound to each `workspaceSources` entry. Naming the FOD by this key therefore makes sharing **unconditional** for every downstream — which is correct as long as consumers sharing a profile compose the same source at a fixed root lock (the case in a single pnpm workspace with one pinned dependency). A consumer that varied the root lock or bound source under the same member set would alias distinct trees; the key would then need widening to fingerprint staged content. Documented inline.

## Test

Adds `checks.pure-eval-profile-dedup` (wired into `tests/run.sh`) asserting `{externalSharedDeduped: true, rootDistinct: true}`. Verified building locally; the pre-existing `pure-eval-*` checks (keyed on the preserved `attrName`) still pass.

## Context

Implements the upstream half of decision 0005 of the downstream Evergreen/FOD-maintenance design: the single biggest reduction in hashes to maintain. The downstream repin + per-profile hash-source collapse is follow-up work, gated on verifying the member-set⟹content invariant against the real consumer set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 👁️ cl1-iris |
| `agent_session_id` | 22738f6c-483c-44fe-8a34-27d07b1b390a |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.175 |
| `agent_runtime` | Claude Code 2.1.175 |
| `agent_model` | claude-opus-4-8 |
| `runtime_profile` | /nix/store/vbrylslg57mvx748zfp3isciclxgcdpr-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/fvv30n06w09dxnsd5s6blb6dxzpmk8x4-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | profilekey-fod-dedup/schickling-assistant/profilekey-fod-dedup |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@d0b580e |
</details>
<!-- agent-footer:end -->