### PR TITLE
chore: add Hypermerge canary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- **repo**: Add a no-op Hypermerge production canary for schickling/dotfiles#1072.
+
 - **Notion docs**: Ratify the durable Notion DB Markdown Sync VRS decisions into
   `context/notion-db-markdown-sync/decisions/0014` through `0026` and remove the
   provisional `decisions/proposed` ledger.


### PR DESCRIPTION
**Problem**
Hypermerge production rollout needs a real, low-risk PR to exercise enrollment and auto-merge behavior without changing runtime code.

**Goal**
Merge a no-op canary change through the normal PR path so Hypermerge behavior can be observed for schickling/dotfiles#1072.

**Decisions**
Used a changelog-only entry instead of a dependency/catalog bump because effect-utils catalog changes cascade into generated manifests, lockfiles, and Nix package closure hashes. This keeps the canary focused on PR automation rather than dependency freshness.

**Verification**
- `git diff --check` exited 0.
- `devenv tasks run genie:check --no-tui` passed after preparing the devenv/pnpm task environment.

**Complexity**
No new complexity; this is a one-line documentation-only canary.

**Concerns**
This PR intentionally validates automation mechanics rather than product behavior.

**Friction & bottlenecks**
`dt` was not available on PATH in the non-interactive shell, so verification used `devenv tasks run genie:check --no-tui` directly. The devenv setup had to materialize the task environment before running the fast generated-file check.

**Follow-ups**
None for effect-utils.

**References**
Refs schickling/dotfiles#1072.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🦤 co3-ibis |
| `agent_session_id` | fe2634a9-38b5-4541-a749-7a5534c7554e |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.140.0 |
| `agent_runtime` | Codex CLI 0.140.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/9b2jmap9yx7hp360cy9a80mckl3rscwh-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/dmhbngznwx13dnvscz2yzqnf24qyci6b-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-06-18-schickling-2026-06-18-hypermerge-canary |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->