### PR TITLE
Add native status schema planner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,15 @@ All notable changes to this project will be documented in this file.
 
 - **@overeng/notion-cli**: Add a pure native Notion status schema planner for
   additive option convergence and fail-closed drift classification. The planner
-  exposes an explicit safe-apply flag, preserves every live option in candidate
-  apply payloads, and reports colors, renames, removals, and groups as
-  unsupported drift until the Notion API proves safe apply support. (#803)
+  exposes an explicit safe-mutation flag, preserves every live option in
+  candidate apply payloads, and reports colors, renames, removals, and groups as
+  drift until the Notion API proves broader safe apply support. (#803)
+
+- **@overeng/notion-cli**: Add native status schema `status-check` and
+  `status-apply` commands. Apply mode refuses mutation-blocking drift, sends a
+  minimal preserve-live-options payload for additive options only, reports
+  group drift without attempting group convergence, and verifies by reading the
+  data source again so Notion HTTP 200 no-ops cannot pass silently. (#803)
 
 - **@overeng/genie**: Make `findGenieFiles` return stable repo-relative
   `.genie.ts` paths, with generation/check orchestration resolving them at the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- **@overeng/notion-cli**: Add a pure native Notion status schema planner for
+  additive option convergence and fail-closed drift classification. The planner
+  exposes an explicit safe-apply flag, preserves every live option in candidate
+  apply payloads, and reports colors, renames, removals, and groups as
+  unsupported drift until the Notion API proves safe apply support. (#803)
+
 - **@overeng/genie**: Make `findGenieFiles` return stable repo-relative
   `.genie.ts` paths, with generation/check orchestration resolving them at the
   filesystem boundary. Discovery tests now assert through a canonical-relative

--- a/packages/@overeng/notion-cli/docs/requirements.md
+++ b/packages/@overeng/notion-cli/docs/requirements.md
@@ -25,7 +25,8 @@ This document defines package-level requirements for `@overeng/notion-cli`. It i
 - **R03 No legacy aliases:** The root command must not expose `sqlite`, `notion-datasource-sync`, `db dump`, or `db replica` as public compatibility surfaces.
 - **R04 Database namespace:** Database metadata, replica sync, status, conflict, diagnostics, and export workflows must live under `notion db`.
 - **R05 Markdown namespace:** Markdown page workflows must live under `notion md` and be composed from `@overeng/notion-md`.
-- **R06 Schema namespace:** Schema generation, introspection, config generation, and drift detection must live under `notion schema`.
+- **R06 Schema namespace:** Schema generation, introspection, config generation, drift detection, and native status option convergence must live under `notion schema`.
+- **R19 Native status convergence:** `notion schema status-check` must report missing native status options and unsupported drift from generated schema metadata. `notion schema status-apply` must only add missing options, preserve all live options in the update payload, refuse colors/renames/removals, report groups without attempting convergence, and verify by reading the data source again after mutation.
 - **R17 Markdown editor surface:** `notion md` must expose the `@overeng/notion-md` editor commands `cat`, `put`, and `edit` for editor-based two-way page editing (the stateless `cat`/`put` pipes and the engine-backed `edit`).
 - **R18 Editor alias:** The root must expose a top-level `notion edit <page>` alias that delegates to `notion md edit`. This is an intentional marquee verb, not a legacy compatibility alias under R03; it is the only first-level command outside the `md`/`schema`/`db` namespaces.
 

--- a/packages/@overeng/notion-cli/docs/spec.md
+++ b/packages/@overeng/notion-cli/docs/spec.md
@@ -116,18 +116,22 @@ The Nix package smoke test runs `notion db sync --help` through the wrapper. A m
 
 ## Schema Namespace
 
-Trace: R06.
+Trace: R06, R19.
 
 `src/commands/schema/mod.ts` owns schema-oriented Notion database workflows:
 
-| Command           | Implementation responsibility                                     |
-| ----------------- | ----------------------------------------------------------------- |
-| `generate`        | introspect a database and write Effect schema/API code            |
-| `introspect`      | render database/data-source property metadata                     |
-| `generate-config` | generate schemas for configured database sets                     |
-| `diff`            | compare live Notion schema with an existing generated schema file |
+| Command           | Implementation responsibility                                             |
+| ----------------- | ------------------------------------------------------------------------- |
+| `generate`        | introspect a database and write Effect schema/API code                    |
+| `introspect`      | render database/data-source property metadata                             |
+| `generate-config` | generate schemas for configured database sets                             |
+| `diff`            | compare live Notion schema with an existing generated schema file         |
+| `status-check`    | report native status option drift from generated schema metadata          |
+| `status-apply`    | add missing native status options, then verify by reading the source back |
 
 Schema commands resolve the Notion token from `--token` or `NOTION_API_TOKEN`, use typed Notion client services, and render through package TUI components.
+
+Native status apply is intentionally narrower than general schema convergence. It may only add missing options while preserving every live option in the update payload. Colors, renames, and removals are mutation-blocking because applying in their presence risks Notion renames, recolors, or destructive option replacement. Groups are report-only: `status-check --exit-code` treats group drift as drift, but `status-apply` does not attempt group convergence and does not let group-only drift block additive option creation because Notion assigns new options to native groups outside API control. Apply mode must retrieve the data source again after the write and fail if the second plan still shows missing options or mutation-blocking drift.
 
 ## Export Contract
 

--- a/packages/@overeng/notion-cli/src/cli-command.unit.test.ts
+++ b/packages/@overeng/notion-cli/src/cli-command.unit.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest'
 
 import { makeNotionRootCommand } from './cli.ts'
 import { dbCommand } from './commands/db/mod.ts'
+import { schemaCommand } from './commands/schema/mod.ts'
 
 const placeholderCommand = (name: string) =>
   Command.make(name, {}, () => Effect.void).pipe(Command.withDescription(`${name} command`))
@@ -42,5 +43,17 @@ describe('notion db command composition', () => {
     expect(completionText).not.toContain('replica')
     expect(completionText).not.toContain('migrate')
     expect(completionText).not.toContain('repair')
+  })
+})
+
+describe('notion schema command composition', () => {
+  it('exposes native status convergence commands', async () => {
+    const completions = await Effect.runPromise(
+      Command.getBashCompletions(schemaCommand, 'notion schema'),
+    )
+    const completionText = completions.join('\n')
+
+    expect(completionText).toContain('status-check')
+    expect(completionText).toContain('status-apply')
   })
 })

--- a/packages/@overeng/notion-cli/src/commands/schema/mod.ts
+++ b/packages/@overeng/notion-cli/src/commands/schema/mod.ts
@@ -7,7 +7,7 @@ import { fileURLToPath } from 'node:url'
 
 import { Args, Command, Options } from '@effect/cli'
 import { FetchHttpClient, FileSystem } from '@effect/platform'
-import { Effect, Layer, Option, Schema } from 'effect'
+import { Console, Effect, Layer, Option, Schema } from 'effect'
 import React from 'react'
 
 import { EffectPath } from '@overeng/effect-path'
@@ -33,6 +33,12 @@ import { loadConfig } from '../../config.ts'
 import { computeDiff, hasDifferences, parseGeneratedFile } from '../../diff.ts'
 import { introspectDatabase, type PropertyTransformConfig } from '../../introspect.ts'
 import { formatCode, writeSchemaToFile } from '../../output.ts'
+import {
+  applyStatusSchemaConvergenceFromModule,
+  checkStatusSchemaConvergenceFromModule,
+  importStatusSchemaModule,
+} from '../../status-schema-convergence.ts'
+import type { StatusSchemaPlan } from '../../status-schema-plan.ts'
 
 export { resolveNotionToken, tokenOption } from '../shared.ts'
 
@@ -635,6 +641,150 @@ const diffCommand = Command.make(
 )
 
 // -----------------------------------------------------------------------------
+// Native Status Schema Commands
+// -----------------------------------------------------------------------------
+
+const statusSchemaFileOption = Options.file('schema').pipe(
+  Options.withAlias('s'),
+  Options.withDescription(
+    'Path to the generated schema module with notionPropertyMeta annotations',
+  ),
+)
+
+const statusSchemaExportOption = Options.text('schema-export').pipe(
+  Options.withDescription('Generated schema export to inspect, e.g. DeploymentsPageProperties'),
+)
+
+const statusPropertyOption = Options.text('property').pipe(
+  Options.withDescription(
+    'Generated schema field whose Notion metadata is a native status property',
+  ),
+  Options.withDefault('Status'),
+)
+
+const formatStatusPlan = (args: {
+  readonly databaseId: string
+  readonly dataSourceId: string
+  readonly plan: StatusSchemaPlan
+}): string => {
+  const lines = [
+    `Database: ${args.databaseId}`,
+    `Data source: ${args.dataSourceId}`,
+    `Property: ${args.plan.propertyName}`,
+    `Missing options: ${args.plan.missingOptions.length}`,
+    `Unsupported drift: ${args.plan.unsupportedDrift.length}`,
+    `Can apply safely: ${String(args.plan.canApplySafely)}`,
+  ]
+
+  for (const option of args.plan.missingOptions) {
+    lines.push(`  + ${option.name} (${option.id}, ${option.color})`)
+  }
+
+  for (const drift of args.plan.unsupportedDrift) {
+    lines.push(`  ! ${drift.kind}: ${drift.message}`)
+  }
+
+  return lines.join('\n')
+}
+
+const statusCheckCommand = Command.make(
+  'status-check',
+  {
+    databaseId: diffDatabaseIdArg,
+    schema: statusSchemaFileOption,
+    schemaExport: statusSchemaExportOption,
+    property: statusPropertyOption,
+    token: tokenOption,
+    exitCode: exitCodeOption,
+  },
+  ({ databaseId, schema, schemaExport, property, token, exitCode }) =>
+    Effect.gen(function* () {
+      const resolvedToken = yield* resolveNotionToken(token)
+      const schemaModule = yield* importStatusSchemaModule(schema)
+      const result = yield* checkStatusSchemaConvergenceFromModule({
+        databaseId,
+        schemaModule,
+        schemaModulePath: schema,
+        schemaExport,
+        propertyName: property,
+      }).pipe(
+        Effect.provide(
+          Layer.merge(
+            Layer.succeed(NotionConfig, {
+              authToken: resolvedToken,
+            }),
+            FetchHttpClient.layer,
+          ),
+        ),
+      )
+
+      yield* Console.log(
+        formatStatusPlan({
+          databaseId,
+          dataSourceId: result.dataSourceId,
+          plan: result.plan,
+        }),
+      )
+
+      if (
+        exitCode === true &&
+        (result.plan.missingOptions.length > 0 || result.plan.unsupportedDrift.length > 0)
+      ) {
+        return yield* new SchemaDriftDetectedError({
+          databaseId,
+          file: schema,
+          message: 'Native status schema drift detected',
+        })
+      }
+    }),
+).pipe(Command.withDescription('Check native Notion status schema option drift'))
+
+const statusApplyCommand = Command.make(
+  'status-apply',
+  {
+    databaseId: diffDatabaseIdArg,
+    schema: statusSchemaFileOption,
+    schemaExport: statusSchemaExportOption,
+    property: statusPropertyOption,
+    token: tokenOption,
+  },
+  ({ databaseId, schema, schemaExport, property, token }) =>
+    Effect.gen(function* () {
+      const resolvedToken = yield* resolveNotionToken(token)
+      const schemaModule = yield* importStatusSchemaModule(schema)
+      const result = yield* applyStatusSchemaConvergenceFromModule({
+        databaseId,
+        schemaModule,
+        schemaModulePath: schema,
+        schemaExport,
+        propertyName: property,
+      }).pipe(
+        Effect.provide(
+          Layer.merge(
+            Layer.succeed(NotionConfig, {
+              authToken: resolvedToken,
+            }),
+            FetchHttpClient.layer,
+          ),
+        ),
+      )
+
+      yield* Console.log(
+        [
+          `Updated: ${String(result.updated)}`,
+          formatStatusPlan({
+            databaseId,
+            dataSourceId: result.dataSourceId,
+            plan: result.after,
+          }),
+        ].join('\n'),
+      )
+    }),
+).pipe(
+  Command.withDescription('Add missing native Notion status options and verify read-after-write'),
+)
+
+// -----------------------------------------------------------------------------
 // Schema Subcommand
 // -----------------------------------------------------------------------------
 
@@ -645,6 +795,8 @@ export const schemaCommand = Command.make('schema').pipe(
     introspectCommand,
     generateFromConfigCommand,
     diffCommand,
+    statusCheckCommand,
+    statusApplyCommand,
   ]),
   Command.withDescription('Schema generation commands'),
 )

--- a/packages/@overeng/notion-cli/src/mod.ts
+++ b/packages/@overeng/notion-cli/src/mod.ts
@@ -49,3 +49,11 @@ export {
 } from './introspect.ts'
 // Output
 export { formatCode, writeSchemaToFile, WriteSchemaToFileError } from './output.ts'
+// Status schema planning
+export {
+  planStatusSchema,
+  type PlanStatusSchemaOptions,
+  type StatusSchemaDrift,
+  type StatusSchemaDriftKind,
+  type StatusSchemaPlan,
+} from './status-schema-plan.ts'

--- a/packages/@overeng/notion-cli/src/mod.ts
+++ b/packages/@overeng/notion-cli/src/mod.ts
@@ -49,8 +49,30 @@ export {
 } from './introspect.ts'
 // Output
 export { formatCode, writeSchemaToFile, WriteSchemaToFileError } from './output.ts'
+// Status schema convergence
+export {
+  applyStatusSchemaConvergence,
+  applyStatusSchemaConvergenceFromModule,
+  checkStatusSchemaConvergenceFromModule,
+  getDesiredStatusPropertyFromSchemaModule,
+  importStatusSchemaModule,
+  makeNotionStatusSchemaGateway,
+  planStatusSchemaConvergence,
+  StatusSchemaApplyVerificationError,
+  StatusSchemaDesiredPropertyNotStatusError,
+  StatusSchemaExportMissingError,
+  StatusSchemaLivePropertyMissingError,
+  StatusSchemaModuleImportError,
+  StatusSchemaUnsupportedDriftError,
+  type StatusSchemaApplyResult,
+  type StatusSchemaConvergenceGateway,
+  type StatusSchemaConvergenceResult,
+  type StatusSchemaModule,
+  type StatusOptionUpdate,
+} from './status-schema-convergence.ts'
 // Status schema planning
 export {
+  isStatusSchemaMutationBlockingDrift,
   planStatusSchema,
   type PlanStatusSchemaOptions,
   type StatusSchemaDrift,

--- a/packages/@overeng/notion-cli/src/status-schema-convergence.ts
+++ b/packages/@overeng/notion-cli/src/status-schema-convergence.ts
@@ -1,0 +1,388 @@
+import { resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+import type { HttpClient } from '@effect/platform'
+import { Effect, Option, Schema } from 'effect'
+
+import {
+  NotionDatabases,
+  NotionDataSources,
+  type NotionApiError,
+  type NotionConfig,
+  SchemaHelpers,
+} from '@overeng/notion-effect-client'
+import type {
+  DataSourceSchema,
+  SelectOptionConfig,
+  StatusPropertySchema,
+} from '@overeng/notion-effect-schema'
+
+import {
+  isStatusSchemaMutationBlockingDrift,
+  planStatusSchema,
+  type StatusSchemaPlan,
+} from './status-schema-plan.ts'
+
+/** Error thrown when a generated schema module cannot be imported. */
+export class StatusSchemaModuleImportError extends Schema.TaggedError<StatusSchemaModuleImportError>()(
+  'StatusSchemaModuleImportError',
+  {
+    path: Schema.String,
+    message: Schema.String,
+    cause: Schema.Unknown,
+  },
+) {}
+
+/** Error thrown when the requested generated schema export is missing. */
+export class StatusSchemaExportMissingError extends Schema.TaggedError<StatusSchemaExportMissingError>()(
+  'StatusSchemaExportMissingError',
+  {
+    exportName: Schema.String,
+    path: Schema.String,
+  },
+) {}
+
+/** Error thrown when the desired generated property is not a native status property. */
+export class StatusSchemaDesiredPropertyNotStatusError extends Schema.TaggedError<StatusSchemaDesiredPropertyNotStatusError>()(
+  'StatusSchemaDesiredPropertyNotStatusError',
+  {
+    propertyName: Schema.String,
+    actualTag: Schema.String,
+  },
+) {}
+
+/** Error thrown when the live Notion schema is missing the desired status property. */
+export class StatusSchemaLivePropertyMissingError extends Schema.TaggedError<StatusSchemaLivePropertyMissingError>()(
+  'StatusSchemaLivePropertyMissingError',
+  {
+    databaseId: Schema.String,
+    propertyName: Schema.String,
+  },
+) {}
+
+/** Error thrown when status drift is present that Notion cannot safely apply. */
+export class StatusSchemaUnsupportedDriftError extends Schema.TaggedError<StatusSchemaUnsupportedDriftError>()(
+  'StatusSchemaUnsupportedDriftError',
+  {
+    databaseId: Schema.String,
+    propertyName: Schema.String,
+    driftCount: Schema.Number,
+    message: Schema.String,
+  },
+) {}
+
+/** Error thrown when read-after-write verification does not prove convergence. */
+export class StatusSchemaApplyVerificationError extends Schema.TaggedError<StatusSchemaApplyVerificationError>()(
+  'StatusSchemaApplyVerificationError',
+  {
+    databaseId: Schema.String,
+    propertyName: Schema.String,
+    missingOptionCount: Schema.Number,
+    driftCount: Schema.Number,
+    message: Schema.String,
+  },
+) {}
+
+/** Imported generated schema module. */
+export type StatusSchemaModule = Readonly<Record<string, unknown>>
+
+/** Minimal Notion status option update DTO. */
+export type StatusOptionUpdate =
+  | {
+      readonly id: string
+      readonly name: string
+    }
+  | {
+      readonly name: string
+      readonly color: SelectOptionConfig['color']
+    }
+
+/** Gateway used by status schema convergence; tests can provide an in-memory implementation. */
+export interface StatusSchemaConvergenceGateway<E = never, R = never> {
+  readonly retrieveStatusProperty: (args: {
+    readonly databaseId: string
+    readonly propertyName: string
+  }) => Effect.Effect<
+    {
+      readonly dataSourceId: string
+      readonly live: StatusPropertySchema
+    },
+    E | StatusSchemaLivePropertyMissingError,
+    R
+  >
+  readonly updateStatusOptions: (args: {
+    readonly dataSourceId: string
+    readonly propertyName: string
+    readonly options: readonly StatusOptionUpdate[]
+  }) => Effect.Effect<void, E, R>
+}
+
+/** Result of checking native status schema convergence. */
+export interface StatusSchemaConvergenceResult {
+  readonly dataSourceId: string
+  readonly desired: StatusPropertySchema
+  readonly live: StatusPropertySchema
+  readonly plan: StatusSchemaPlan
+}
+
+/** Result of applying native status schema convergence. */
+export interface StatusSchemaApplyResult {
+  readonly dataSourceId: string
+  readonly before: StatusSchemaPlan
+  readonly after: StatusSchemaPlan
+  readonly updated: boolean
+}
+
+const formatUnknownErrorMessage = (cause: unknown): string =>
+  cause instanceof Error ? cause.message : String(cause)
+
+const getLiveStatusPropertyFromDataSource = (args: {
+  readonly databaseId: string
+  readonly propertyName: string
+  readonly schema: DataSourceSchema
+}) => {
+  const live = SchemaHelpers.getPropertyByTag({
+    schema: args.schema,
+    name: args.propertyName,
+    tag: 'status',
+  })
+
+  if (Option.isNone(live) === true) {
+    return new StatusSchemaLivePropertyMissingError({
+      databaseId: args.databaseId,
+      propertyName: args.propertyName,
+    })
+  }
+
+  return live.value
+}
+
+const statusOptionUpdatePayload = (args: {
+  readonly live: StatusPropertySchema
+  readonly options: StatusSchemaPlan['applyOptions']
+}): readonly StatusOptionUpdate[] => {
+  const liveOptionIds = new Set(args.live.status.options.map((option) => option.id))
+
+  return args.options.map((option) => {
+    if (liveOptionIds.has(option.id) === true) {
+      return {
+        id: option.id,
+        name: option.name,
+      }
+    }
+
+    return {
+      name: option.name,
+      color: option.color,
+    }
+  })
+}
+
+/** Real Notion gateway for native status schema convergence. */
+export const makeNotionStatusSchemaGateway = (): StatusSchemaConvergenceGateway<
+  NotionApiError,
+  NotionConfig | HttpClient.HttpClient
+> => ({
+  retrieveStatusProperty: (args: { readonly databaseId: string; readonly propertyName: string }) =>
+    Effect.gen(function* () {
+      const target = yield* NotionDatabases.resolveQueryTarget({ databaseId: args.databaseId })
+      const live = getLiveStatusPropertyFromDataSource({
+        databaseId: args.databaseId,
+        propertyName: args.propertyName,
+        schema: target.schemaSource as DataSourceSchema,
+      })
+
+      if (live instanceof StatusSchemaLivePropertyMissingError) {
+        return yield* live
+      }
+
+      return {
+        dataSourceId: target.dataSourceId,
+        live,
+      }
+    }),
+  updateStatusOptions: (args: {
+    readonly dataSourceId: string
+    readonly propertyName: string
+    readonly options: readonly StatusOptionUpdate[]
+  }) =>
+    NotionDataSources.update({
+      dataSourceId: args.dataSourceId,
+      properties: {
+        [args.propertyName]: {
+          status: {
+            options: args.options,
+          },
+        },
+      },
+    }).pipe(Effect.asVoid),
+})
+
+/** Imports a generated schema module by path. */
+export const importStatusSchemaModule = Effect.fnUntraced(function* (path: string) {
+  const absolutePath = resolve(path)
+  const href = pathToFileURL(absolutePath).href
+  return yield* Effect.tryPromise({
+    // oxlint-disable-next-line eslint-plugin-import(no-dynamic-require) -- generated schema modules are selected at runtime
+    try: () => import(href) as Promise<StatusSchemaModule>,
+    catch: (cause) =>
+      new StatusSchemaModuleImportError({
+        path: absolutePath,
+        message: `Failed to import generated schema module: ${formatUnknownErrorMessage(cause)}`,
+        cause,
+      }),
+  })
+})
+
+/** Extracts a desired native status property from generated schema metadata. */
+export const getDesiredStatusPropertyFromSchemaModule = Effect.fn(function* (args: {
+  readonly module: StatusSchemaModule
+  readonly path: string
+  readonly exportName: string
+  readonly propertyName: string
+}) {
+  const schemaExport = args.module[args.exportName]
+  if (schemaExport === undefined) {
+    return yield* new StatusSchemaExportMissingError({
+      path: args.path,
+      exportName: args.exportName,
+    })
+  }
+
+  const meta = yield* SchemaHelpers.getPropertyMetaFromSchema({
+    schema: schemaExport as Schema.Schema.AnyNoContext,
+    propertyName: args.propertyName,
+  })
+
+  if (meta._tag !== 'status') {
+    return yield* new StatusSchemaDesiredPropertyNotStatusError({
+      propertyName: args.propertyName,
+      actualTag: meta._tag,
+    })
+  }
+
+  return meta
+})
+
+/** Plans native status schema convergence using an injected gateway. */
+export const planStatusSchemaConvergence = Effect.fn(function* <E, R>(args: {
+  readonly gateway: StatusSchemaConvergenceGateway<E, R>
+  readonly databaseId: string
+  readonly desired: StatusPropertySchema
+}) {
+  const live = yield* args.gateway.retrieveStatusProperty({
+    databaseId: args.databaseId,
+    propertyName: args.desired.name,
+  })
+  const plan = planStatusSchema({ desired: args.desired, live: live.live })
+  return {
+    dataSourceId: live.dataSourceId,
+    desired: args.desired,
+    live: live.live,
+    plan,
+  } satisfies StatusSchemaConvergenceResult
+})
+
+/** Applies additive native status option convergence and verifies by reading Notion again. */
+export const applyStatusSchemaConvergence = Effect.fn(function* <E, R>(args: {
+  readonly gateway: StatusSchemaConvergenceGateway<E, R>
+  readonly databaseId: string
+  readonly desired: StatusPropertySchema
+}) {
+  const before = yield* planStatusSchemaConvergence(args)
+
+  const beforeMutationBlockingDrift = before.plan.unsupportedDrift.filter(
+    isStatusSchemaMutationBlockingDrift,
+  )
+  if (beforeMutationBlockingDrift.length > 0) {
+    return yield* new StatusSchemaUnsupportedDriftError({
+      databaseId: args.databaseId,
+      propertyName: args.desired.name,
+      driftCount: beforeMutationBlockingDrift.length,
+      message: 'Unsupported native status schema drift blocks safe apply.',
+    })
+  }
+
+  if (before.plan.missingOptions.length === 0) {
+    return {
+      dataSourceId: before.dataSourceId,
+      before: before.plan,
+      after: before.plan,
+      updated: false,
+    } satisfies StatusSchemaApplyResult
+  }
+
+  yield* args.gateway.updateStatusOptions({
+    dataSourceId: before.dataSourceId,
+    propertyName: args.desired.name,
+    options: statusOptionUpdatePayload({
+      live: before.live,
+      options: before.plan.applyOptions,
+    }),
+  })
+
+  const after = yield* planStatusSchemaConvergence(args)
+  const afterMutationBlockingDrift = after.plan.unsupportedDrift.filter(
+    isStatusSchemaMutationBlockingDrift,
+  )
+  if (after.plan.missingOptions.length > 0 || afterMutationBlockingDrift.length > 0) {
+    return yield* new StatusSchemaApplyVerificationError({
+      databaseId: args.databaseId,
+      propertyName: args.desired.name,
+      missingOptionCount: after.plan.missingOptions.length,
+      driftCount: afterMutationBlockingDrift.length,
+      message: 'Status schema apply did not verify after read-after-write.',
+    })
+  }
+
+  return {
+    dataSourceId: before.dataSourceId,
+    before: before.plan,
+    after: after.plan,
+    updated: true,
+  } satisfies StatusSchemaApplyResult
+})
+
+/** Loads desired schema metadata and checks native status schema convergence against Notion. */
+export const checkStatusSchemaConvergenceFromModule = Effect.fn(function* (args: {
+  readonly databaseId: string
+  readonly schemaModule: StatusSchemaModule
+  readonly schemaModulePath: string
+  readonly schemaExport: string
+  readonly propertyName: string
+}) {
+  const desired = yield* getDesiredStatusPropertyFromSchemaModule({
+    module: args.schemaModule,
+    path: args.schemaModulePath,
+    exportName: args.schemaExport,
+    propertyName: args.propertyName,
+  })
+
+  return yield* planStatusSchemaConvergence({
+    gateway: makeNotionStatusSchemaGateway(),
+    databaseId: args.databaseId,
+    desired,
+  })
+})
+
+/** Loads desired schema metadata and applies additive native status option convergence against Notion. */
+export const applyStatusSchemaConvergenceFromModule = Effect.fn(function* (args: {
+  readonly databaseId: string
+  readonly schemaModule: StatusSchemaModule
+  readonly schemaModulePath: string
+  readonly schemaExport: string
+  readonly propertyName: string
+}) {
+  const desired = yield* getDesiredStatusPropertyFromSchemaModule({
+    module: args.schemaModule,
+    path: args.schemaModulePath,
+    exportName: args.schemaExport,
+    propertyName: args.propertyName,
+  })
+
+  return yield* applyStatusSchemaConvergence({
+    gateway: makeNotionStatusSchemaGateway(),
+    databaseId: args.databaseId,
+    desired,
+  })
+})

--- a/packages/@overeng/notion-cli/src/status-schema-convergence.unit.test.ts
+++ b/packages/@overeng/notion-cli/src/status-schema-convergence.unit.test.ts
@@ -1,0 +1,261 @@
+import { Effect, Schema } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import {
+  NotionSchema,
+  notionPropertyMeta,
+  type SelectOptionConfig,
+  type StatusPropertySchema,
+} from '@overeng/notion-effect-schema'
+
+import {
+  applyStatusSchemaConvergence,
+  getDesiredStatusPropertyFromSchemaModule,
+  planStatusSchemaConvergence,
+  StatusSchemaApplyVerificationError,
+  type StatusSchemaConvergenceGateway,
+  type StatusOptionUpdate,
+  StatusSchemaUnsupportedDriftError,
+} from './status-schema-convergence.ts'
+
+const option = ({
+  id,
+  name,
+  color = 'default',
+}: {
+  readonly id: string
+  readonly name: string
+  readonly color?: SelectOptionConfig['color']
+}): SelectOptionConfig => ({ id, name, color })
+
+const statusProperty = ({
+  options,
+  groups = [],
+}: {
+  readonly options: readonly SelectOptionConfig[]
+  readonly groups?: StatusPropertySchema['status']['groups']
+}): StatusPropertySchema => ({
+  id: 'status',
+  name: 'Status',
+  description: null,
+  _tag: 'status',
+  status: {
+    options,
+    groups,
+  },
+})
+
+const makeGateway = (args: {
+  readonly liveResponses: readonly StatusPropertySchema[]
+  readonly updates?: Array<{
+    readonly dataSourceId: string
+    readonly propertyName: string
+    readonly options: readonly StatusOptionUpdate[]
+  }>
+}): StatusSchemaConvergenceGateway => {
+  let retrieveIndex = 0
+
+  return {
+    retrieveStatusProperty: ({ databaseId: _databaseId, propertyName: _propertyName }) =>
+      Effect.sync(() => {
+        const live =
+          args.liveResponses[Math.min(retrieveIndex, args.liveResponses.length - 1)] ??
+          statusProperty({ options: [] })
+        retrieveIndex += 1
+        return {
+          dataSourceId: 'data-source-id',
+          live,
+        }
+      }),
+    updateStatusOptions: ({ dataSourceId, propertyName, options }) =>
+      Effect.sync(() => {
+        args.updates?.push({ dataSourceId, propertyName, options })
+      }),
+  }
+}
+
+describe('status schema convergence', () => {
+  it('check mode reports missing options without mutating', async () => {
+    const livePublished = option({ id: 'published', name: 'Published', color: 'green' })
+    const desiredBlocked = option({ id: 'blocked', name: 'Blocked', color: 'red' })
+    const gateway = makeGateway({
+      liveResponses: [statusProperty({ options: [livePublished] })],
+      updates: [],
+    })
+
+    const result = await Effect.runPromise(
+      planStatusSchemaConvergence({
+        gateway,
+        databaseId: 'database-id',
+        desired: statusProperty({ options: [livePublished, desiredBlocked] }),
+      }),
+    )
+
+    expect(result.plan.missingOptions).toEqual([desiredBlocked])
+    expect(result.plan.canApplySafely).toBe(true)
+  })
+
+  it('apply preserves live options in the update payload and verifies by reading again', async () => {
+    const updates: Array<{
+      readonly dataSourceId: string
+      readonly propertyName: string
+      readonly options: readonly StatusOptionUpdate[]
+    }> = []
+    const livePublished = option({ id: 'published', name: 'Published', color: 'green' })
+    const desiredBlocked = option({ id: 'blocked', name: 'Blocked', color: 'red' })
+    const desired = statusProperty({ options: [livePublished, desiredBlocked] })
+    const gateway = makeGateway({
+      liveResponses: [statusProperty({ options: [livePublished] }), desired],
+      updates,
+    })
+
+    const result = await Effect.runPromise(
+      applyStatusSchemaConvergence({
+        gateway,
+        databaseId: 'database-id',
+        desired,
+      }),
+    )
+
+    expect(result.updated).toBe(true)
+    expect(updates).toEqual([
+      {
+        dataSourceId: 'data-source-id',
+        propertyName: 'Status',
+        options: [
+          { id: 'published', name: 'Published' },
+          { name: 'Blocked', color: 'red' },
+        ],
+      },
+    ])
+    expect(result.after.missingOptions).toEqual([])
+  })
+
+  it('apply tolerates report-only group drift after Notion assigns new options to a group', async () => {
+    const updates: Array<{
+      readonly dataSourceId: string
+      readonly propertyName: string
+      readonly options: readonly StatusOptionUpdate[]
+    }> = []
+    const livePublished = option({ id: 'published', name: 'Published', color: 'green' })
+    const desiredBlocked = option({ id: 'blocked', name: 'Blocked', color: 'red' })
+    const desired = statusProperty({
+      options: [livePublished, desiredBlocked],
+      groups: [
+        { id: 'todo', name: 'To-do', color: 'gray', option_ids: [] },
+        { id: 'done', name: 'Done', color: 'green', option_ids: ['published', 'blocked'] },
+      ],
+    })
+    const gateway = makeGateway({
+      liveResponses: [
+        statusProperty({
+          options: [livePublished],
+          groups: [
+            { id: 'todo', name: 'To-do', color: 'gray', option_ids: [] },
+            { id: 'done', name: 'Done', color: 'green', option_ids: ['published'] },
+          ],
+        }),
+        statusProperty({
+          options: [livePublished, desiredBlocked],
+          groups: [
+            { id: 'todo', name: 'To-do', color: 'gray', option_ids: ['blocked'] },
+            { id: 'done', name: 'Done', color: 'green', option_ids: ['published'] },
+          ],
+        }),
+      ],
+      updates,
+    })
+
+    const result = await Effect.runPromise(
+      applyStatusSchemaConvergence({
+        gateway,
+        databaseId: 'database-id',
+        desired,
+      }),
+    )
+
+    expect(result.updated).toBe(true)
+    expect(result.after.missingOptions).toEqual([])
+    expect(result.after.unsupportedDrift).toMatchObject([{ kind: 'group_changed' }])
+    expect(result.after.canApplySafely).toBe(true)
+    expect(updates).toHaveLength(1)
+  })
+
+  it('apply refuses unsupported drift before updating', async () => {
+    const updates: Array<{
+      readonly dataSourceId: string
+      readonly propertyName: string
+      readonly options: readonly StatusOptionUpdate[]
+    }> = []
+    const gateway = makeGateway({
+      liveResponses: [
+        statusProperty({
+          options: [option({ id: 'published', name: 'Published', color: 'green' })],
+        }),
+      ],
+      updates,
+    })
+
+    const result = await Effect.runPromise(
+      applyStatusSchemaConvergence({
+        gateway,
+        databaseId: 'database-id',
+        desired: statusProperty({
+          options: [option({ id: 'published', name: 'Published', color: 'blue' })],
+        }),
+      }).pipe(Effect.either),
+    )
+
+    expect(result._tag).toBe('Left')
+    if (result._tag === 'Left') {
+      expect(result.left).toBeInstanceOf(StatusSchemaUnsupportedDriftError)
+    }
+    expect(updates).toEqual([])
+  })
+
+  it('apply fails verification when Notion silently no-ops the update', async () => {
+    const livePublished = option({ id: 'published', name: 'Published', color: 'green' })
+    const desiredBlocked = option({ id: 'blocked', name: 'Blocked', color: 'red' })
+    const gateway = makeGateway({
+      liveResponses: [
+        statusProperty({ options: [livePublished] }),
+        statusProperty({ options: [livePublished] }),
+      ],
+      updates: [],
+    })
+
+    const result = await Effect.runPromise(
+      applyStatusSchemaConvergence({
+        gateway,
+        databaseId: 'database-id',
+        desired: statusProperty({ options: [livePublished, desiredBlocked] }),
+      }).pipe(Effect.either),
+    )
+
+    expect(result._tag).toBe('Left')
+    if (result._tag === 'Left') {
+      expect(result.left).toBeInstanceOf(StatusSchemaApplyVerificationError)
+    }
+  })
+
+  it('extracts desired status metadata from a generated schema module export', async () => {
+    const schema = Schema.Struct({
+      Status: NotionSchema.status().annotations({
+        [notionPropertyMeta]: statusProperty({
+          options: [option({ id: 'published', name: 'Published', color: 'green' })],
+        }),
+      }),
+    })
+
+    const desired = await Effect.runPromise(
+      getDesiredStatusPropertyFromSchemaModule({
+        module: { DeploymentsPageProperties: schema },
+        path: 'deployments.gen.ts',
+        exportName: 'DeploymentsPageProperties',
+        propertyName: 'Status',
+      }),
+    )
+
+    expect(desired.status.options.map((statusOption) => statusOption.name)).toEqual(['Published'])
+  })
+})

--- a/packages/@overeng/notion-cli/src/status-schema-plan.ts
+++ b/packages/@overeng/notion-cli/src/status-schema-plan.ts
@@ -15,11 +15,12 @@ export interface StatusSchemaDrift {
   readonly live?: SelectOptionConfig
 }
 
-/** Status schema convergence plan with additive apply candidates and fail-closed drift diagnostics. */
+/** Status schema convergence plan with additive mutation candidates and drift diagnostics. */
 export interface StatusSchemaPlan {
   readonly propertyName: string
   readonly missingOptions: readonly SelectOptionConfig[]
   readonly unsupportedDrift: readonly StatusSchemaDrift[]
+  /** Whether additive option mutation can proceed without mutation-blocking drift. */
   readonly canApplySafely: boolean
   readonly applyOptions: readonly SelectOptionConfig[]
 }
@@ -60,6 +61,10 @@ const sameGroups = ({
     )
   })
 }
+
+/** Returns whether a drift kind blocks additive option mutation. */
+export const isStatusSchemaMutationBlockingDrift = (drift: StatusSchemaDrift): boolean =>
+  drift.kind !== 'group_changed'
 
 /** Plans additive native Notion status option convergence while reporting unapplyable drift. */
 export const planStatusSchema = ({ desired, live }: PlanStatusSchemaOptions): StatusSchemaPlan => {
@@ -137,7 +142,7 @@ export const planStatusSchema = ({ desired, live }: PlanStatusSchemaOptions): St
     propertyName: desired.name,
     missingOptions,
     unsupportedDrift,
-    canApplySafely: unsupportedDrift.length === 0,
+    canApplySafely: unsupportedDrift.every((drift) => !isStatusSchemaMutationBlockingDrift(drift)),
     applyOptions: [...live.status.options, ...missingOptions],
   }
 }

--- a/packages/@overeng/notion-cli/src/status-schema-plan.ts
+++ b/packages/@overeng/notion-cli/src/status-schema-plan.ts
@@ -1,0 +1,143 @@
+import type { SelectOptionConfig, StatusPropertySchema } from '@overeng/notion-effect-schema'
+
+/** Drift kinds the native Notion status schema planner can classify. */
+export type StatusSchemaDriftKind =
+  | 'color_changed'
+  | 'extra_remote_option'
+  | 'group_changed'
+  | 'rename_or_identity_mismatch'
+
+/** A single status schema drift finding between desired code-owned schema and live Notion schema. */
+export interface StatusSchemaDrift {
+  readonly kind: StatusSchemaDriftKind
+  readonly message: string
+  readonly desired?: SelectOptionConfig
+  readonly live?: SelectOptionConfig
+}
+
+/** Status schema convergence plan with additive apply candidates and fail-closed drift diagnostics. */
+export interface StatusSchemaPlan {
+  readonly propertyName: string
+  readonly missingOptions: readonly SelectOptionConfig[]
+  readonly unsupportedDrift: readonly StatusSchemaDrift[]
+  readonly canApplySafely: boolean
+  readonly applyOptions: readonly SelectOptionConfig[]
+}
+
+/** Inputs for planning native Notion status schema convergence. */
+export interface PlanStatusSchemaOptions {
+  readonly desired: StatusPropertySchema
+  readonly live: StatusPropertySchema
+}
+
+const sameOptionIds = ({
+  left,
+  right,
+}: {
+  readonly left: readonly string[]
+  readonly right: readonly string[]
+}): boolean => left.length === right.length && left.every((value, index) => value === right[index])
+
+const sameGroups = ({
+  desired,
+  live,
+}: {
+  readonly desired: StatusPropertySchema
+  readonly live: StatusPropertySchema
+}): boolean => {
+  if (desired.status.groups.length !== live.status.groups.length) {
+    return false
+  }
+
+  return desired.status.groups.every((desiredGroup, index) => {
+    const liveGroup = live.status.groups[index]
+    return (
+      liveGroup !== undefined &&
+      desiredGroup.id === liveGroup.id &&
+      desiredGroup.name === liveGroup.name &&
+      desiredGroup.color === liveGroup.color &&
+      sameOptionIds({ left: desiredGroup.option_ids, right: liveGroup.option_ids })
+    )
+  })
+}
+
+/** Plans additive native Notion status option convergence while reporting unapplyable drift. */
+export const planStatusSchema = ({ desired, live }: PlanStatusSchemaOptions): StatusSchemaPlan => {
+  const liveById = new Map(live.status.options.map((option) => [option.id, option]))
+  const liveByName = new Map(live.status.options.map((option) => [option.name, option]))
+  const desiredById = new Map(desired.status.options.map((option) => [option.id, option]))
+  const desiredByName = new Map(desired.status.options.map((option) => [option.name, option]))
+
+  const missingOptions: SelectOptionConfig[] = []
+  const unsupportedDrift: StatusSchemaDrift[] = []
+
+  for (const desiredOption of desired.status.options) {
+    const liveBySameId = liveById.get(desiredOption.id)
+    if (liveBySameId !== undefined) {
+      if (liveBySameId.name !== desiredOption.name) {
+        unsupportedDrift.push({
+          kind: 'rename_or_identity_mismatch',
+          message: `Status option id ${desiredOption.id} is named "${liveBySameId.name}" remotely but "${desiredOption.name}" in desired schema.`,
+          desired: desiredOption,
+          live: liveBySameId,
+        })
+      }
+      if (liveBySameId.color !== desiredOption.color) {
+        unsupportedDrift.push({
+          kind: 'color_changed',
+          message: `Status option "${desiredOption.name}" has color "${liveBySameId.color}" remotely but "${desiredOption.color}" in desired schema.`,
+          desired: desiredOption,
+          live: liveBySameId,
+        })
+      }
+      continue
+    }
+
+    const liveBySameName = liveByName.get(desiredOption.name)
+    if (liveBySameName !== undefined) {
+      unsupportedDrift.push({
+        kind: 'rename_or_identity_mismatch',
+        message: `Status option "${desiredOption.name}" exists remotely with id ${liveBySameName.id} but desired schema uses id ${desiredOption.id}.`,
+        desired: desiredOption,
+        live: liveBySameName,
+      })
+      continue
+    }
+
+    missingOptions.push(desiredOption)
+  }
+
+  for (const liveOption of live.status.options) {
+    const desiredBySameId = desiredById.get(liveOption.id)
+    if (desiredBySameId !== undefined) {
+      continue
+    }
+
+    const desiredBySameName = desiredByName.get(liveOption.name)
+    if (desiredBySameName !== undefined) {
+      continue
+    }
+
+    unsupportedDrift.push({
+      kind: 'extra_remote_option',
+      message: `Status option "${liveOption.name}" exists remotely but not in desired schema; removal is not safely applyable.`,
+      live: liveOption,
+    })
+  }
+
+  if (sameGroups({ desired, live }) === false) {
+    unsupportedDrift.push({
+      kind: 'group_changed',
+      message:
+        'Status groups differ between desired and live schema; group convergence is report-only until the Notion API proves safe apply support.',
+    })
+  }
+
+  return {
+    propertyName: desired.name,
+    missingOptions,
+    unsupportedDrift,
+    canApplySafely: unsupportedDrift.length === 0,
+    applyOptions: [...live.status.options, ...missingOptions],
+  }
+}

--- a/packages/@overeng/notion-cli/src/status-schema-plan.unit.test.ts
+++ b/packages/@overeng/notion-cli/src/status-schema-plan.unit.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest'
+
+import type { SelectOptionConfig, StatusPropertySchema } from '@overeng/notion-effect-schema'
+
+import { planStatusSchema } from './status-schema-plan.ts'
+
+const option = ({
+  id,
+  name,
+  color = 'default',
+}: {
+  readonly id: string
+  readonly name: string
+  readonly color?: SelectOptionConfig['color']
+}): SelectOptionConfig => ({ id, name, color })
+
+const statusProperty = ({
+  options,
+  groups = [],
+}: {
+  readonly options: readonly SelectOptionConfig[]
+  readonly groups?: StatusPropertySchema['status']['groups']
+}): StatusPropertySchema => ({
+  id: 'status',
+  name: 'Status',
+  description: null,
+  _tag: 'status',
+  status: {
+    options,
+    groups,
+  },
+})
+
+describe('planStatusSchema', () => {
+  it('plans missing options as additive candidates while preserving all live options', () => {
+    const livePublished = option({ id: 'live-published', name: 'Published', color: 'green' })
+    const desiredBlocked = option({ id: 'desired-blocked', name: 'Blocked', color: 'red' })
+
+    const plan = planStatusSchema({
+      live: statusProperty({ options: [livePublished] }),
+      desired: statusProperty({ options: [livePublished, desiredBlocked] }),
+    })
+
+    expect(plan.missingOptions).toEqual([desiredBlocked])
+    expect(plan.unsupportedDrift).toEqual([])
+    expect(plan.canApplySafely).toBe(true)
+    expect(plan.applyOptions).toEqual([livePublished, desiredBlocked])
+  })
+
+  it('reports color drift instead of treating it as applyable', () => {
+    const plan = planStatusSchema({
+      live: statusProperty({
+        options: [option({ id: 'published', name: 'Published', color: 'green' })],
+      }),
+      desired: statusProperty({
+        options: [option({ id: 'published', name: 'Published', color: 'blue' })],
+      }),
+    })
+
+    expect(plan.missingOptions).toEqual([])
+    expect(plan.unsupportedDrift).toMatchObject([{ kind: 'color_changed' }])
+    expect(plan.canApplySafely).toBe(false)
+    expect(plan.applyOptions).toEqual([
+      option({ id: 'published', name: 'Published', color: 'green' }),
+    ])
+  })
+
+  it('reports same-id name drift as an unsupported rename', () => {
+    const plan = planStatusSchema({
+      live: statusProperty({
+        options: [option({ id: 'running', name: 'Running' })],
+      }),
+      desired: statusProperty({
+        options: [option({ id: 'running', name: 'Wird veroeffentlicht' })],
+      }),
+    })
+
+    expect(plan.missingOptions).toEqual([])
+    expect(plan.unsupportedDrift).toMatchObject([{ kind: 'rename_or_identity_mismatch' }])
+    expect(plan.canApplySafely).toBe(false)
+  })
+
+  it('reports same-name id drift as an identity mismatch', () => {
+    const plan = planStatusSchema({
+      live: statusProperty({
+        options: [option({ id: 'remote-running', name: 'Running' })],
+      }),
+      desired: statusProperty({
+        options: [option({ id: 'desired-running', name: 'Running' })],
+      }),
+    })
+
+    expect(plan.missingOptions).toEqual([])
+    expect(plan.unsupportedDrift).toMatchObject([{ kind: 'rename_or_identity_mismatch' }])
+    expect(plan.canApplySafely).toBe(false)
+    expect(plan.applyOptions).toEqual([option({ id: 'remote-running', name: 'Running' })])
+  })
+
+  it('reports extra remote options instead of omitting them from the apply payload', () => {
+    const remoteExtra = option({ id: 'remote-extra', name: 'Legacy' })
+    const desiredPublished = option({ id: 'published', name: 'Published' })
+
+    const plan = planStatusSchema({
+      live: statusProperty({ options: [desiredPublished, remoteExtra] }),
+      desired: statusProperty({ options: [desiredPublished] }),
+    })
+
+    expect(plan.unsupportedDrift).toMatchObject([{ kind: 'extra_remote_option' }])
+    expect(plan.canApplySafely).toBe(false)
+    expect(plan.applyOptions).toEqual([desiredPublished, remoteExtra])
+  })
+
+  it('reports group drift as report-only', () => {
+    const published = option({ id: 'published', name: 'Published' })
+    const plan = planStatusSchema({
+      live: statusProperty({
+        options: [published],
+        groups: [{ id: 'group-1', name: 'Complete', color: 'green', option_ids: ['published'] }],
+      }),
+      desired: statusProperty({
+        options: [published],
+        groups: [{ id: 'group-1', name: 'Done', color: 'green', option_ids: ['published'] }],
+      }),
+    })
+
+    expect(plan.missingOptions).toEqual([])
+    expect(plan.unsupportedDrift).toMatchObject([{ kind: 'group_changed' }])
+    expect(plan.canApplySafely).toBe(false)
+  })
+
+  it('preserves live options and blocks safe apply when missing options mix with unsupported drift', () => {
+    const livePublished = option({ id: 'published', name: 'Published', color: 'green' })
+    const liveLegacy = option({ id: 'legacy', name: 'Legacy', color: 'yellow' })
+    const desiredBlocked = option({ id: 'blocked', name: 'Blocked', color: 'red' })
+
+    const plan = planStatusSchema({
+      live: statusProperty({ options: [livePublished, liveLegacy] }),
+      desired: statusProperty({ options: [livePublished, desiredBlocked] }),
+    })
+
+    expect(plan.missingOptions).toEqual([desiredBlocked])
+    expect(plan.unsupportedDrift).toMatchObject([{ kind: 'extra_remote_option' }])
+    expect(plan.canApplySafely).toBe(false)
+    expect(plan.applyOptions).toEqual([livePublished, liveLegacy, desiredBlocked])
+  })
+})

--- a/packages/@overeng/notion-cli/src/status-schema-plan.unit.test.ts
+++ b/packages/@overeng/notion-cli/src/status-schema-plan.unit.test.ts
@@ -125,7 +125,7 @@ describe('planStatusSchema', () => {
 
     expect(plan.missingOptions).toEqual([])
     expect(plan.unsupportedDrift).toMatchObject([{ kind: 'group_changed' }])
-    expect(plan.canApplySafely).toBe(false)
+    expect(plan.canApplySafely).toBe(true)
   })
 
   it('preserves live options and blocks safe apply when missing options mix with unsupported drift', () => {

--- a/packages/@overeng/notion-effect-client/src/schema-helpers.ts
+++ b/packages/@overeng/notion-effect-client/src/schema-helpers.ts
@@ -211,6 +211,78 @@ export const getRequiredPropertiesFromSchema = Effect.fn(
   return required
 })
 
+/** Extracts full Notion property metadata annotations from a Schema.Struct. */
+export const getPropertyMetasFromSchema = Effect.fn('SchemaHelpers.getPropertyMetasFromSchema')(
+  function* (schema: Schema.Schema.AnyNoContext) {
+    const ast = schema.ast
+    if (ast._tag !== 'TypeLiteral') {
+      return yield* new SchemaMetaMissingError({
+        message: 'Schema must be a Struct to extract Notion property metadata',
+        missing: [],
+      })
+    }
+
+    const metas: Array<{ fieldName: string; meta: NotionPropertyMeta }> = []
+    const missing: string[] = []
+
+    for (const prop of ast.propertySignatures) {
+      if (typeof prop.name !== 'string') {
+        continue
+      }
+
+      const annotation = SchemaAST.getAnnotation<NotionPropertyMeta>(prop.type, notionPropertyMeta)
+      if (Option.isSome(annotation) === true) {
+        metas.push({ fieldName: prop.name, meta: annotation.value })
+      } else {
+        missing.push(prop.name)
+      }
+    }
+
+    if (missing.length > 0) {
+      return yield* new SchemaMetaMissingError({
+        message: `Schema is missing Notion property metadata for: ${missing.join(', ')}`,
+        missing,
+      })
+    }
+
+    return metas
+  },
+)
+
+/** Extracts one Notion property metadata annotation from a Schema.Struct field. */
+export const getPropertyMetaFromSchema = Effect.fn('SchemaHelpers.getPropertyMetaFromSchema')(
+  function* (args: { schema: Schema.Schema.AnyNoContext; propertyName: string }) {
+    const ast = args.schema.ast
+    if (ast._tag !== 'TypeLiteral') {
+      return yield* new SchemaMetaMissingError({
+        message: 'Schema must be a Struct to extract Notion property metadata',
+        missing: [],
+      })
+    }
+
+    for (const prop of ast.propertySignatures) {
+      if (prop.name !== args.propertyName) {
+        continue
+      }
+
+      const annotation = SchemaAST.getAnnotation<NotionPropertyMeta>(prop.type, notionPropertyMeta)
+      if (Option.isSome(annotation) === true) {
+        return annotation.value
+      }
+
+      return yield* new SchemaMetaMissingError({
+        message: `Schema is missing Notion property metadata for: ${args.propertyName}`,
+        missing: [args.propertyName],
+      })
+    }
+
+    return yield* new SchemaMetaMissingError({
+      message: `Schema is missing field: ${args.propertyName}`,
+      missing: [args.propertyName],
+    })
+  },
+)
+
 /** Validates database properties using metadata extracted from a Schema.Struct */
 export const validatePropertiesFromSchema = Effect.fn('SchemaHelpers.validatePropertiesFromSchema')(
   function* (args: {
@@ -462,6 +534,8 @@ export const SchemaHelpers = {
   getPropertyByTag,
   validateProperties,
   getRequiredPropertiesFromSchema,
+  getPropertyMetasFromSchema,
+  getPropertyMetaFromSchema,
   validatePropertiesFromSchema,
   getSelectOptions,
   getMultiSelectOptions,

--- a/packages/@overeng/notion-effect-client/src/schema-helpers.unit.test.ts
+++ b/packages/@overeng/notion-effect-client/src/schema-helpers.unit.test.ts
@@ -187,6 +187,73 @@ Vitest.describe('SchemaHelpers', () => {
     )
   })
 
+  Vitest.describe('getPropertyMetaFromSchema', () => {
+    Vitest.it.effect('returns the full Notion property metadata for a schema field', () =>
+      Effect.gen(function* () {
+        const meta = yield* SchemaHelpers.getPropertyMetaFromSchema({
+          schema: Schema.Struct({
+            Status: NotionSchema.status().annotations({
+              [notionPropertyMeta]: {
+                _tag: 'status',
+                id: 'status',
+                name: 'Status',
+                description: null,
+                status: {
+                  options: [{ id: 'done', name: 'Done', color: 'green', description: null }],
+                  groups: [],
+                },
+              },
+            }),
+          }),
+          propertyName: 'Status',
+        })
+
+        expect(meta._tag).toBe('status')
+        if (meta._tag === 'status') {
+          expect(meta.status.options.map((option) => option.name)).toEqual(['Done'])
+        }
+      }),
+    )
+
+    Vitest.it.effect('does not require unrelated schema fields to be annotated', () =>
+      Effect.gen(function* () {
+        const meta = yield* SchemaHelpers.getPropertyMetaFromSchema({
+          schema: Schema.Struct({
+            Status: NotionSchema.status().annotations({
+              [notionPropertyMeta]: {
+                _tag: 'status',
+                id: 'status',
+                name: 'Status',
+                description: null,
+                status: {
+                  options: [{ id: 'done', name: 'Done', color: 'green', description: null }],
+                  groups: [],
+                },
+              },
+            }),
+            Unannotated: Schema.String,
+          }),
+          propertyName: 'Status',
+        })
+
+        expect(meta._tag).toBe('status')
+      }),
+    )
+
+    Vitest.it.effect('fails when the schema field is not annotated', () =>
+      Effect.gen(function* () {
+        const result = yield* SchemaHelpers.getPropertyMetaFromSchema({
+          schema: Schema.Struct({
+            Status: Schema.String,
+          }),
+          propertyName: 'Status',
+        }).pipe(Effect.either)
+
+        expect(result._tag).toBe('Left')
+      }),
+    )
+  })
+
   Vitest.describe('getRelationTargetOrFail', () => {
     Vitest.it.effect('returns relation target when available', () =>
       Effect.gen(function* () {


### PR DESCRIPTION
## Summary
- add a pure native Notion status schema planner for additive option convergence
- classify colors, renames, removals, and groups as unsupported drift
- preserve live options in candidate apply payloads and expose a safe-apply flag

## Verification
- devenv tasks run test:notion-cli --no-tui
- devenv tasks run ts:check --no-tui
- CI=1 devenv tasks run check:all --no-tui

Closes #803

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🔭 co2-reach |
| `agent_session_id` | 4d9a3e19-f884-47ec-ae33-97c3a2745f8a |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.140.0 |
| `agent_runtime` | Codex CLI 0.140.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/wbb5q5n2gbk751hcyr5ndp0zrmar602x-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/3i12shfqx3wqzq2di3jy1m7f8fn4prmm-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/main |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->