### PR TITLE
feat(devenv): attribute pnpm install cache misses by component (#809)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,11 +41,16 @@ All notable changes to this project will be documented in this file.
   now names why a live install cache misses instead of a bare `exit 1`. The
   monolithic install-state hash stays the sole hit/miss decision, but on a miss
   the install-state surface is decomposed into four priority-ordered, overlapping
-  components and the highest-severity match is reported: `lockfile`
-  (pnpm-lock.yaml) → `gvs-link` (pnpm version / packageExtensions / allowBuilds /
-  active GVS links projection root) → `policy` (pnpm-workspace.yaml install-policy
-  keys / installFlags / preInstall) → `manifest+config` (root and member
-  manifests, the rest of pnpm-workspace.yaml, .npmrc, injected source trees). Two
+  components and the highest-severity match is reported: `gvs-link` (pnpm version /
+  packageExtensions / allowBuilds / active GVS links projection root) → `lockfile`
+  (pnpm-lock.yaml) → `policy` (pnpm-workspace.yaml install-policy keys /
+  installFlags / preInstall) → `manifest+config` (root and member manifests, the
+  rest of pnpm-workspace.yaml, .npmrc, injected source trees). `gvs-link` is
+  checked before `lockfile` by consequence severity: a steady-state
+  packageExtensions edit also bumps pnpm-lock.yaml, so the higher-severity
+  `links/` purge it forces is reported even when a lockfile bump co-occurs (the
+  gvs-link hash excludes pnpm-lock.yaml, so a pure-lockfile change still reports
+  `lockfile`). Two
   further reasons cover the remaining status miss sites: `bootstrap` (first run /
   missing cache state) and `projection` (stale node_modules links). The reason is
   emitted both to stderr and as the OTEL span attribute `install.miss_reason` on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,29 @@ All notable changes to this project will be documented in this file.
   `tasks.genie` module stays a bare-path standard module — `geniePkg` is an
   optional module argument (threaded via `_module.args.geniePkg`), so downstream
   `imports = [ inputs.effect-utils.devenvModules.tasks.genie ]` is unaffected.
+- **pnpm install cache miss attribution (#809)**: The `pnpm:install` status path
+  now names why a live install cache misses instead of a bare `exit 1`. The
+  monolithic install-state hash stays the sole hit/miss decision, but on a miss
+  the install-state surface is decomposed into four priority-ordered, overlapping
+  components and the highest-severity match is reported: `lockfile`
+  (pnpm-lock.yaml) → `gvs-link` (pnpm version / packageExtensions / allowBuilds /
+  active GVS links projection root) → `policy` (pnpm-workspace.yaml install-policy
+  keys / installFlags / preInstall) → `manifest+config` (root and member
+  manifests, the rest of pnpm-workspace.yaml, .npmrc, injected source trees). Two
+  further reasons cover the remaining status miss sites: `bootstrap` (first run /
+  missing cache state) and `projection` (stale node_modules links). The reason is
+  emitted both to stderr and as the OTEL span attribute `install.miss_reason` on
+  the `<task>:status` span, threaded through a new `otel-span --attr-file` hook so
+  a status body can export runtime-computed span attributes. This documents the
+  invalidation contract: only `gvs-link` forces the wholesale
+  `rm -rf <store>/v11/links` purge plus `pnpm install --force` (pnpm reuses cached
+  GVS link projections without re-resolving packageExtensions —
+  pnpm/pnpm#9739, pnpm/pnpm#11385); every other reason is a plain reinstall. The
+  GVS purge is now logged with its precise cause. Fixed-output Nix dependency prep
+  is unchanged and stays isolated from the live GVS. Known limitation: in this
+  repo package.json, member manifests, and pnpm-workspace.yaml are all
+  genie-generated, so generated config is not cleanly separable from hand edits
+  and is grouped into `manifest+config`.
 
 - **repo dependency/toolchain refresh**: Upgrade the Nix, pnpm, TypeScript, lint,
   test, Storybook/Vite, React, OpenTelemetry, OpenTUI, and Effect 3-line

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,11 +51,13 @@ All notable changes to this project will be documented in this file.
   emitted both to stderr and as the OTEL span attribute `install.miss_reason` on
   the `<task>:status` span, threaded through a new `otel-span --attr-file` hook so
   a status body can export runtime-computed span attributes. This documents the
-  invalidation contract: only `gvs-link` forces the wholesale
-  `rm -rf <store>/v11/links` purge plus `pnpm install --force` (pnpm reuses cached
-  GVS link projections without re-resolving packageExtensions —
-  pnpm/pnpm#9739, pnpm/pnpm#11385); every other reason is a plain reinstall. The
-  GVS purge is now logged with its precise cause. Fixed-output Nix dependency prep
+  invalidation contract: only `gvs-link` can force the wholesale
+  `rm -rf <store>/v11/links` purge plus `pnpm install --force`, and only for its
+  config sub-surface (pnpm version / packageExtensions / allowBuilds), because
+  pnpm reuses cached GVS link projections without re-resolving packageExtensions
+  (pnpm/pnpm#9739, pnpm/pnpm#11385); a links-projection-root change (different
+  effective store-dir) instead forces a fresh-store reinstall. Every other reason
+  is a plain reinstall. The GVS purge is now logged with its precise cause. Fixed-output Nix dependency prep
   is unchanged and stays isolated from the live GVS. Known limitation: in this
   repo package.json, member manifests, and pnpm-workspace.yaml are all
   genie-generated, so generated config is not cleanly separable from hand edits

--- a/nix/devenv-modules/otel/otel-span.nix
+++ b/nix/devenv-modules/otel/otel-span.nix
@@ -56,6 +56,9 @@ pkgs.writeShellScriptBin "otel-span" ''
 
   Options:
     --attr KEY=VALUE      Add a span attribute (repeatable)
+    --attr-file PATH      After the command runs, read KEY=VALUE lines from PATH
+                          (if it exists) and append them as span attributes. Lets
+                          the wrapped command emit runtime-computed attributes.
     --status-attr KEY     Derive bool attribute from exit code (0=true, else=false)
                           and force span status to OK (for status checks, not errors)
     --trace-id ID         Use specific trace ID (default: from TRACEPARENT or random)
@@ -83,6 +86,7 @@ pkgs.writeShellScriptBin "otel-span" ''
       SERVICE_NAME=""
       SPAN_NAME=""
       ATTRS=()
+      ATTR_FILE=""
       STATUS_ATTR=""
       TRACE_ID=""
       SPAN_ID=""
@@ -97,6 +101,10 @@ pkgs.writeShellScriptBin "otel-span" ''
           --help) _run_usage ;;
           --attr)
             ATTRS+=("$2")
+            shift 2
+            ;;
+          --attr-file)
+            ATTR_FILE="$2"
             shift 2
             ;;
           --status-attr)
@@ -199,6 +207,20 @@ pkgs.writeShellScriptBin "otel-span" ''
           attrs_json+=',{"key":"'"$key"'","value":{"stringValue":"'"$val"'"}}'
         fi
       done
+      # --attr-file: append KEY=VALUE attributes the wrapped command computed at
+      # runtime (e.g. a cache-miss reason). Same string/bool encoding as --attr.
+      if [[ -n "$ATTR_FILE" ]] && [[ -f "$ATTR_FILE" ]]; then
+        while IFS= read -r attr || [[ -n "$attr" ]]; do
+          [[ -z "$attr" ]] && continue
+          key="''${attr%%=*}"
+          val="''${attr#*=}"
+          if [ "$val" = "true" ] || [ "$val" = "false" ]; then
+            attrs_json+=',{"key":"'"$key"'","value":{"boolValue":'"$val"'}}'
+          else
+            attrs_json+=',{"key":"'"$key"'","value":{"stringValue":"'"$val"'"}}'
+          fi
+        done < "$ATTR_FILE"
+      fi
       # --status-attr: derive bool attribute from exit code (0=true, non-zero=false)
       if [[ -n "$STATUS_ATTR" ]]; then
         if [[ "$exit_code" -eq 0 ]]; then

--- a/nix/devenv-modules/tasks/lib/trace.nix
+++ b/nix/devenv-modules/tasks/lib/trace.nix
@@ -55,14 +55,25 @@ let
   # mr status) inherit TRACEPARENT and produce sub-traces.
   # --status-attr derives task.cached from exit code (0=true, non-zero=false)
   # and forces span status to OK (status checks aren't errors).
+  #
+  # The status body can also export extra span attributes at runtime by writing
+  # `KEY=VALUE` lines to $OTEL_STATUS_ATTR_FILE (e.g. a pnpm cache miss reason).
+  # otel-span reads that sidecar via --attr-file after the body runs. The body
+  # stays branch-agnostic: when OTEL is unavailable OTEL_STATUS_ATTR_FILE is
+  # unset, so writes fall back to /dev/null in the body's own default.
   traceStatus = taskName: method: statusBody: ''
     if command -v otel-span >/dev/null 2>&1 && [ -n "''${OTEL_EXPORTER_OTLP_ENDPOINT:-}" ]; then
       _status_exit=0
+      _status_attr_file="$(mktemp)"
+      export OTEL_STATUS_ATTR_FILE="$_status_attr_file"
       otel-span run "dt-task" "${taskName}:status" \
         --attr "task.phase=status" \
         --attr "status.method=${method}" \
+        --attr-file "$_status_attr_file" \
         --status-attr "task.cached" \
         -- bash -c ${lib.escapeShellArg statusBody} || _status_exit=$?
+      rm -f "$_status_attr_file"
+      unset OTEL_STATUS_ATTR_FILE
 
       exit "$_status_exit"
     else

--- a/nix/devenv-modules/tasks/shared/pnpm-task-helpers.sh
+++ b/nix/devenv-modules/tasks/shared/pnpm-task-helpers.sh
@@ -69,6 +69,139 @@ cache_fingerprint() {
   } | compute_hash
 }
 
+# ── Install-state component hashes (miss attribution) ─────────────────────────
+#
+# The monolithic install-state hash stays the sole hit/miss decision. These
+# narrower component hashes are a diagnostic computed only after that monolithic
+# hash already mismatched, so a miss can name WHICH surface changed instead of a
+# bare `exit 1`. See pnpm.nix for the invalidation contract these encode.
+#
+# Components are deliberately overlapping (one edit can touch several), so the
+# reported reason is the highest-severity first match in this order:
+#   lockfile -> gvs-link -> policy -> manifest+config
+# That order also IS the invalidation contract: gvs-link forces a GVS-link purge
+# plus a forced reinstall; lockfile/policy/manifest force a plain reinstall.
+#
+# All components read files from $PWD (the workspace root). Callers parameterize
+# the version, install flags, pre-install hook, manifest paths, and resolved GVS
+# links dir via the PNPM_COMPONENT_* environment variables so the same helper
+# bodies run in task scripts and in the sourced shell tests.
+
+# lockfile: the resolved dependency graph (pnpm-lock.yaml).
+compute_component_lockfile_hash() {
+  {
+    if [ -f pnpm-lock.yaml ]; then
+      cat pnpm-lock.yaml
+    fi
+  } | compute_hash
+}
+
+# gvs-link: the narrow surface that forces a pnpm 11 GVS `links/` purge. pnpm
+# reuses existing GVS link projections without re-resolving packageExtensions,
+# so this surface (pnpm version + packageExtensions + allowBuilds + the active
+# links projection root, which pnpm bakes into absolute paths) must invalidate
+# the link cache, not just node_modules. This is the same fingerprint the exec
+# path uses to decide whether to drop `links/`.
+#
+# Note: the issue's literal taxonomy grouped packageExtensions/allowBuilds/version
+# under `policy`. They live in `gvs-link` here instead because only that lets a
+# packageExtensions edit be reported as the GVS-link purge it actually triggers;
+# `policy` below is the install-policy surface MINUS this gvs-link surface.
+compute_component_gvs_link_hash() {
+  {
+    printf '%s\n' "${PNPM_COMPONENT_PNPM_VERSION:-}"
+    sed -n '/^packageExtensions:/,/^[a-zA-Z]/p' pnpm-workspace.yaml 2>/dev/null || true
+    sed -n '/^allowBuilds:/,/^[a-zA-Z]/p' pnpm-workspace.yaml 2>/dev/null || true
+    printf '%s\n' "${PNPM_COMPONENT_GVS_LINKS_DIR:-}"
+  } | compute_hash
+}
+
+# policy: the install-policy surface that is NOT already covered by gvs-link.
+# pnpm-workspace.yaml spells these knobs in camelCase; PNPM_COMPONENT_POLICY_KEYS
+# carries that key list (kept beside pnpm-install-policy.nix). installFlags and
+# preInstall complete the per-task policy surface. Hashing the workspace.yaml
+# keys keeps this component a faithful subset of the monolithic install-state
+# inputs, so it stays reachable in real installs and not just in unit tests.
+compute_component_policy_hash() {
+  {
+    local key
+    for key in ${PNPM_COMPONENT_POLICY_KEYS:-}; do
+      grep -E "^${key}:" pnpm-workspace.yaml 2>/dev/null || true
+    done
+    printf '%s\n' "${PNPM_COMPONENT_INSTALL_FLAGS:-}"
+    printf '%s\n' "${PNPM_COMPONENT_PRE_INSTALL:-}"
+  } | compute_hash
+}
+
+# manifest+config: the catch-all for everything else (root + member manifests,
+# the rest of pnpm-workspace.yaml, .npmrc, injected source trees). pnpm-lock.yaml
+# is deliberately excluded (it is the `lockfile` component) so a lockfile-only
+# change is never misreported here.
+#
+# In this repo package.json, member manifests, and pnpm-workspace.yaml are all
+# genie-generated from `.genie.ts` sources, so the generated-config surface is
+# not separable from the manifest surface today; they are grouped together and
+# this limitation is documented in pnpm.nix.
+compute_component_manifest_config_hash() {
+  {
+    if [ -f package.json ]; then
+      cat package.json
+    fi
+    if [ -f pnpm-workspace.yaml ]; then
+      cat pnpm-workspace.yaml
+    fi
+    if [ -f .npmrc ]; then
+      cat .npmrc
+    fi
+
+    local manifest
+    for manifest in ${PNPM_COMPONENT_MANIFEST_PATHS:-}; do
+      if [ -f "$manifest" ]; then
+        cat "$manifest"
+      fi
+    done
+
+    local injected_dir
+    for injected_dir in ${PNPM_COMPONENT_INJECTED_DIRS:-}; do
+      emit_dir_state "$injected_dir"
+    done
+  } | compute_hash
+}
+
+# Compare each component hash against its stored value and print the
+# highest-severity component that changed. Stored values come from the
+# matching PNPM_STORED_* environment variables. Prints nothing (and returns 1)
+# when every component matches, which means the install-state mismatch is caused
+# by an input outside this decomposition.
+classify_install_state_miss() {
+  if [ "$(compute_component_lockfile_hash)" != "${PNPM_STORED_LOCKFILE_HASH:-}" ]; then
+    printf '%s\n' "lockfile"
+    return 0
+  fi
+  if [ "$(compute_component_gvs_link_hash)" != "${PNPM_STORED_GVS_LINK_HASH:-}" ]; then
+    printf '%s\n' "gvs-link"
+    return 0
+  fi
+  if [ "$(compute_component_policy_hash)" != "${PNPM_STORED_POLICY_HASH:-}" ]; then
+    printf '%s\n' "policy"
+    return 0
+  fi
+  if [ "$(compute_component_manifest_config_hash)" != "${PNPM_STORED_MANIFEST_CONFIG_HASH:-}" ]; then
+    printf '%s\n' "manifest+config"
+    return 0
+  fi
+  return 1
+}
+
+# Emit a miss reason to stderr and to the OTEL status attribute sidecar. The
+# /dev/null fallback keeps this byte-identical on the OTEL and non-OTEL branches
+# so callers need no `if OTEL` guard. See trace.nix for the --attr-file plumbing.
+report_install_miss_reason() {
+  local reason="$1"
+  echo "[pnpm] install cache miss: $reason" >&2
+  printf 'install.miss_reason=%s\n' "$reason" > "${OTEL_STATUS_ATTR_FILE:-/dev/null}"
+}
+
 check_node_modules_links_healthy() {
   local node_bin="$1"
   local projection_script="$2"

--- a/nix/devenv-modules/tasks/shared/pnpm-task-helpers.sh
+++ b/nix/devenv-modules/tasks/shared/pnpm-task-helpers.sh
@@ -78,9 +78,14 @@ cache_fingerprint() {
 #
 # Components are deliberately overlapping (one edit can touch several), so the
 # reported reason is the highest-severity first match in this order:
-#   lockfile -> gvs-link -> policy -> manifest+config
+#   gvs-link -> lockfile -> policy -> manifest+config
 # That order also IS the invalidation contract: gvs-link forces a GVS-link purge
 # plus a forced reinstall; lockfile/policy/manifest force a plain reinstall.
+# gvs-link is checked before lockfile because a steady-state packageExtensions
+# edit also bumps pnpm-lock.yaml, and the higher-severity `links/` purge it
+# triggers must win the report. This is safe because the gvs-link hash EXCLUDES
+# pnpm-lock.yaml, so a pure-lockfile change does not trip gvs-link and still
+# correctly reports `lockfile`.
 #
 # All components read files from $PWD (the workspace root). Callers parameterize
 # the version, install flags, pre-install hook, manifest paths, and resolved GVS
@@ -174,12 +179,12 @@ compute_component_manifest_config_hash() {
 # when every component matches, which means the install-state mismatch is caused
 # by an input outside this decomposition.
 classify_install_state_miss() {
-  if [ "$(compute_component_lockfile_hash)" != "${PNPM_STORED_LOCKFILE_HASH:-}" ]; then
-    printf '%s\n' "lockfile"
-    return 0
-  fi
   if [ "$(compute_component_gvs_link_hash)" != "${PNPM_STORED_GVS_LINK_HASH:-}" ]; then
     printf '%s\n' "gvs-link"
+    return 0
+  fi
+  if [ "$(compute_component_lockfile_hash)" != "${PNPM_STORED_LOCKFILE_HASH:-}" ]; then
+    printf '%s\n' "lockfile"
     return 0
   fi
   if [ "$(compute_component_policy_hash)" != "${PNPM_STORED_POLICY_HASH:-}" ]; then

--- a/nix/devenv-modules/tasks/shared/pnpm.nix
+++ b/nix/devenv-modules/tasks/shared/pnpm.nix
@@ -9,6 +9,44 @@
 # - pnpm:update
 # - pnpm:clean
 # - pnpm:reset-lock-files
+#
+# Install-state invalidation contract
+# ------------------------------------
+# A live pnpm install uses a global virtual store (GVS). The status path keeps a
+# single monolithic install-state hash as the hit/miss decision, but on a miss it
+# attributes the change to one of four overlapping COMPONENTS (a single edit can
+# touch several; the reported reason is the highest-severity first match):
+#
+#   lockfile         pnpm-lock.yaml changed                -> plain reinstall
+#   gvs-link         pnpm version / packageExtensions /    -> GVS `links/` purge
+#                    allowBuilds / active links projection     + forced reinstall
+#   policy           install-policy knobs (pnpm-workspace   -> plain reinstall
+#                    .yaml policy keys) / installFlags /
+#                    preInstall changed
+#   manifest+config  any other manifest or config surface  -> plain reinstall
+#                    (root + member package.json, the rest
+#                    of pnpm-workspace.yaml, .npmrc,
+#                    injected source trees)
+#
+# Two further status miss reasons exist outside the install-state decomposition:
+#   bootstrap        node_modules / cache files / .modules.yaml absent (first run)
+#   projection       node_modules projection-state hash changed (stale links)
+#
+# Only `gvs-link` forces the wholesale `rm -rf <store>/v11/links` purge plus a
+# `pnpm install --force`; every other reason is a plain reinstall. The purge is
+# necessary because pnpm 11 reuses cached GVS link projections without
+# re-resolving packageExtensions (pnpm/pnpm#9739, pnpm/pnpm#11385).
+#
+# The reported reason is also emitted as the OTEL span attribute
+# `install.miss_reason` on the `<task>:status` span (see tasks/lib/trace.nix).
+#
+# Component decomposition note: the issue's literal taxonomy placed
+# packageExtensions/allowBuilds/pnpm.version under `policy`. They live in
+# `gvs-link` here so a packageExtensions edit is reported as the GVS-link purge it
+# actually triggers; `policy` is the install-policy surface MINUS that gvs-link
+# surface. The genie-generated config (package.json, member manifests,
+# pnpm-workspace.yaml are all `.genie.ts`-generated) is not cleanly separable
+# from hand edits, so generated config is grouped into `manifest+config`.
 {
   packages,
   workspaceRoot ? ".",
@@ -254,6 +292,59 @@ let
       } | compute_hash
     }
   '';
+  # Export the inputs the component-hash helpers in pnpm-task-helpers.sh need.
+  # Keeping them in one place lets the exec and status paths classify install
+  # misses with the exact same surface. The policy key list is the camelCase
+  # pnpm-workspace.yaml mirror of the shared install policy, so a policy-key edit
+  # is a reachable subset of the monolithic install-state inputs (not only the
+  # abstract Nix flag list, which the workspace.yaml does not spell).
+  setComponentHashInputsFn = ''
+    export PNPM_COMPONENT_PNPM_VERSION=${lib.escapeShellArg pkgs.pnpm.version}
+    export PNPM_COMPONENT_INSTALL_FLAGS=${lib.escapeShellArg (builtins.toJSON installFlags)}
+    export PNPM_COMPONENT_PRE_INSTALL=${lib.escapeShellArg preInstall}
+    export PNPM_COMPONENT_POLICY_KEYS=${lib.escapeShellArg (lib.concatStringsSep " " pnpmInstallPolicy.workspaceYamlPolicyKeys)}
+    export PNPM_COMPONENT_MANIFEST_PATHS=${
+      lib.escapeShellArg (lib.concatMapStringsSep " " (path: "${path}/package.json") packages)
+    }
+    export PNPM_COMPONENT_INJECTED_DIRS=${lib.escapeShellArg (lib.concatStringsSep " " injectedSourcePaths)}
+    PNPM_COMPONENT_GVS_LINKS_DIR="$(resolve_gvs_links_dir)"
+    export PNPM_COMPONENT_GVS_LINKS_DIR
+  '';
+
+  # Persist each component hash beside the monolithic install-state hash so the
+  # status path can name which component changed without re-deriving the stored
+  # baseline. Written only after a successful install.
+  writeComponentHashesFn = ''
+    write_component_hashes() {
+      local components_file="$1"
+      {
+        printf 'lockfile %s\n' "$(compute_component_lockfile_hash)"
+        printf 'gvs-link %s\n' "$(compute_component_gvs_link_hash)"
+        printf 'policy %s\n' "$(compute_component_policy_hash)"
+        printf 'manifest+config %s\n' "$(compute_component_manifest_config_hash)"
+      } > "$components_file"
+    }
+  '';
+
+  # Load stored component hashes into the PNPM_STORED_* variables the classifier
+  # compares against, then classify and report the highest-severity miss.
+  classifyAndReportMissFn = ''
+    classify_and_report_install_miss() {
+      local components_file="$1"
+      local reason="manifest+config"
+      if [ -f "$components_file" ]; then
+        PNPM_STORED_LOCKFILE_HASH="$(awk '$1=="lockfile"{print $2}' "$components_file")"
+        PNPM_STORED_GVS_LINK_HASH="$(awk '$1=="gvs-link"{print $2}' "$components_file")"
+        PNPM_STORED_POLICY_HASH="$(awk '$1=="policy"{print $2}' "$components_file")"
+        PNPM_STORED_MANIFEST_CONFIG_HASH="$(awk '$1=="manifest+config"{print $2}' "$components_file")"
+        export PNPM_STORED_LOCKFILE_HASH PNPM_STORED_GVS_LINK_HASH \
+          PNPM_STORED_POLICY_HASH PNPM_STORED_MANIFEST_CONFIG_HASH
+        reason="$(classify_install_state_miss || printf '%s' "manifest+config")"
+      fi
+      report_install_miss_reason "$reason"
+    }
+  '';
+
   computeProjectionStateHashFn = ''
     compute_projection_state_hash() {
       # Keep the warm-path fingerprint semantics identical while avoiding the
@@ -411,6 +502,9 @@ let
         # root because pnpm 11 bakes absolute paths into `links/`.
         hash_file="${cacheRoot}/install-state.hash"
         projection_hash_file="${cacheRoot}/projection-state.hash"
+        components_file="${cacheRoot}/install-state.components"
+        ${setComponentHashInputsFn}
+        ${writeComponentHashesFn}
 
         lockfile="${cacheRoot}/pnpm-install.lock"
         exec 200>"$lockfile"
@@ -467,7 +561,10 @@ let
           _gvs_hash_file="$(dirname "$_gvs_links_dir")/.effect-utils-gvs-links.hash"
           mkdir -p "$(dirname "$_gvs_links_dir")"
           if [ ! -f "$_gvs_hash_file" ] || [ "$(cat "$_gvs_hash_file")" != "$_gvs_hash" ]; then
-            echo "[pnpm] GVS config changed, forcing current workspace relink"
+            # Invalidation contract: only the gvs-link component (pnpm version /
+            # packageExtensions / allowBuilds / links projection root) forces the
+            # wholesale links/ purge below. Log the precise cause.
+            echo "[pnpm] GVS config changed (component: gvs-link), forcing current workspace relink and purging $_gvs_links_dir"
             purge_node_modules node_modules ${nodeModulesPaths}
             # A workspace relink only rewrites node_modules. If the broken
             # package projection is already cached under v11/links, pnpm can
@@ -520,6 +617,10 @@ let
 
         cache_value="$(compute_projection_state_hash)"
         ${cache.writeCacheFile ''"$projection_hash_file"''}
+
+        # Persist the per-component baseline so the status path can attribute a
+        # future install-state miss to a specific component.
+        write_component_hashes "$components_file"
       '';
       status = trace.status installTaskName "hash" ''
         set -euo pipefail
@@ -531,8 +632,12 @@ let
         ensure_shared_pnpm_files_store
         hash_file="${cacheRoot}/install-state.hash"
         projection_hash_file="${cacheRoot}/projection-state.hash"
+        components_file="${cacheRoot}/install-state.components"
+        ${setComponentHashInputsFn}
+        ${classifyAndReportMissFn}
 
         if [ ! -d node_modules ] || [ ! -f pnpm-lock.yaml ] || [ ! -f "$hash_file" ] || [ ! -f "$projection_hash_file" ] || [ ! -f node_modules/.modules.yaml ]; then
+          report_install_miss_reason "bootstrap"
           exit 1
         fi
 
@@ -545,6 +650,7 @@ let
           current_projection_hash="$(compute_projection_state_hash)"
           stored_projection_hash="$(cat "$projection_hash_file")"
           if [ "$current_projection_hash" != "$stored_projection_hash" ]; then
+            report_install_miss_reason "projection"
             exit 1
           fi
           exit 0
@@ -558,9 +664,13 @@ let
         stored_hash="$(cat "$hash_file")"
         stored_projection_hash="$(cat "$projection_hash_file")"
         if [ "$current_hash" != "$stored_hash" ]; then
+          # The monolithic install-state hash stays the hit/miss decision; only
+          # now do we classify which component changed for the miss reason.
+          classify_and_report_install_miss "$components_file"
           exit 1
         fi
         if [ "$current_projection_hash" != "$stored_projection_hash" ]; then
+          report_install_miss_reason "projection"
           exit 1
         fi
         exit 0

--- a/nix/devenv-modules/tasks/shared/pnpm.nix
+++ b/nix/devenv-modules/tasks/shared/pnpm.nix
@@ -32,10 +32,16 @@
 #   bootstrap        node_modules / cache files / .modules.yaml absent (first run)
 #   projection       node_modules projection-state hash changed (stale links)
 #
-# Only `gvs-link` forces the wholesale `rm -rf <store>/v11/links` purge plus a
-# `pnpm install --force`; every other reason is a plain reinstall. The purge is
-# necessary because pnpm 11 reuses cached GVS link projections without
-# re-resolving packageExtensions (pnpm/pnpm#9739, pnpm/pnpm#11385).
+# Of the four, only `gvs-link` can force the wholesale `rm -rf <store>/v11/links`
+# purge plus a `pnpm install --force`; every other reason is a plain reinstall.
+# `gvs-link` has two sub-surfaces with different consequences:
+#   - config (pnpm version / packageExtensions / allowBuilds): forces the `links/`
+#     purge + forced reinstall, because pnpm 11 reuses cached GVS link projections
+#     without re-resolving packageExtensions (pnpm/pnpm#9739, pnpm/pnpm#11385).
+#   - links projection root (effective store-dir / links-dir): a different store
+#     has its own (possibly empty) `links/`, so the exec path takes the forced
+#     reinstall via the missing per-store gvs hash file rather than deleting an
+#     existing `links/` directory.
 #
 # The reported reason is also emitted as the OTEL span attribute
 # `install.miss_reason` on the `<task>:status` span (see tasks/lib/trace.nix).

--- a/nix/devenv-modules/tasks/shared/pnpm.nix
+++ b/nix/devenv-modules/tasks/shared/pnpm.nix
@@ -17,9 +17,9 @@
 # attributes the change to one of four overlapping COMPONENTS (a single edit can
 # touch several; the reported reason is the highest-severity first match):
 #
-#   lockfile         pnpm-lock.yaml changed                -> plain reinstall
 #   gvs-link         pnpm version / packageExtensions /    -> GVS `links/` purge
 #                    allowBuilds / active links projection     + forced reinstall
+#   lockfile         pnpm-lock.yaml changed                -> plain reinstall
 #   policy           install-policy knobs (pnpm-workspace   -> plain reinstall
 #                    .yaml policy keys) / installFlags /
 #                    preInstall changed
@@ -27,6 +27,12 @@
 #                    (root + member package.json, the rest
 #                    of pnpm-workspace.yaml, .npmrc,
 #                    injected source trees)
+#
+# gvs-link precedes lockfile by consequence severity: a steady-state
+# packageExtensions edit also bumps pnpm-lock.yaml, so the higher-severity
+# `links/` purge must be reported even when a lockfile bump co-occurs. The
+# gvs-link hash excludes pnpm-lock.yaml, so a pure-lockfile change still reports
+# `lockfile`.
 #
 # Two further status miss reasons exist outside the install-state decomposition:
 #   bootstrap        node_modules / cache files / .modules.yaml absent (first run)

--- a/nix/devenv-modules/tasks/shared/tests/pnpm.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/pnpm.test.sh
@@ -422,5 +422,125 @@ exit_code=$?
 set -e
 assert_exit_code 0 "$exit_code" "projection health ignores optional subpath exports"
 
+# ── Install-state miss attribution ────────────────────────────────────────────
+#
+# These tests source the real component-hash helpers, build a baseline, then
+# mutate exactly one surface and assert that classify_install_state_miss reports
+# the highest-severity component. They also assert report_install_miss_reason
+# writes the OTEL sidecar attribute, which is how install.miss_reason reaches the
+# status span.
+
+make_install_state_fixture() {
+  local root="$1"
+
+  mkdir -p "$root/pkg-a"
+  cat > "$root/pnpm-lock.yaml" <<'EOF'
+lockfileVersion: '9.0'
+importers: {}
+packages: {}
+EOF
+  cat > "$root/package.json" <<'EOF'
+{"name":"root","private":true}
+EOF
+  cat > "$root/pkg-a/package.json" <<'EOF'
+{"name":"pkg-a","private":true}
+EOF
+  cat > "$root/pnpm-workspace.yaml" <<'EOF'
+packages:
+  - pkg-a
+
+packageExtensions:
+  some-pkg:
+    dependencies:
+      extra-dep: '1.0.0'
+
+allowBuilds:
+  - esbuild
+
+enableGlobalVirtualStore: true
+ignoreScripts: true
+verifyStoreIntegrity: true
+EOF
+}
+
+# Mirror the env the task scripts export so the sourced helpers see the same
+# surface. Policy keys mirror pnpm-install-policy.nix workspaceYamlPolicyKeys.
+set_component_env() {
+  export PNPM_COMPONENT_PNPM_VERSION="11.0.0"
+  export PNPM_COMPONENT_INSTALL_FLAGS='[]'
+  export PNPM_COMPONENT_PRE_INSTALL=""
+  export PNPM_COMPONENT_POLICY_KEYS="enableGlobalVirtualStore ignoreScripts verifyStoreIntegrity"
+  export PNPM_COMPONENT_MANIFEST_PATHS="pkg-a/package.json"
+  export PNPM_COMPONENT_INJECTED_DIRS=""
+  export PNPM_COMPONENT_GVS_LINKS_DIR="/stable/store/v11/links"
+}
+
+store_component_baseline() {
+  export PNPM_STORED_LOCKFILE_HASH="$(compute_component_lockfile_hash)"
+  export PNPM_STORED_GVS_LINK_HASH="$(compute_component_gvs_link_hash)"
+  export PNPM_STORED_POLICY_HASH="$(compute_component_policy_hash)"
+  export PNPM_STORED_MANIFEST_CONFIG_HASH="$(compute_component_manifest_config_hash)"
+}
+
+echo "Test 23: lockfile-only change reports miss_reason lockfile"
+(
+  state_dir="$test_dir/miss-lockfile"
+  make_install_state_fixture "$state_dir"
+  cd "$state_dir"
+  set_component_env
+  store_component_baseline
+  printf 'packages: { changed }\n' >> pnpm-lock.yaml
+  assert_eq "lockfile" "$(classify_install_state_miss)" "lockfile change reports lockfile"
+)
+
+echo "Test 24: policy-only change reports miss_reason policy"
+(
+  state_dir="$test_dir/miss-policy"
+  make_install_state_fixture "$state_dir"
+  cd "$state_dir"
+  set_component_env
+  store_component_baseline
+  # Flip a workspace.yaml install-policy key that is not part of the gvs-link
+  # surface (packageExtensions/allowBuilds) so the reason is uniquely policy.
+  sed -i 's/^ignoreScripts: true/ignoreScripts: false/' pnpm-workspace.yaml
+  assert_eq "policy" "$(classify_install_state_miss)" "policy key change reports policy"
+)
+
+echo "Test 25: manifest change reports miss_reason manifest+config"
+(
+  state_dir="$test_dir/miss-manifest"
+  make_install_state_fixture "$state_dir"
+  cd "$state_dir"
+  set_component_env
+  store_component_baseline
+  # A non-policy manifest field: only the manifest+config catch-all should fire.
+  cat > pkg-a/package.json <<'EOF'
+{"name":"pkg-a","private":true,"description":"changed"}
+EOF
+  assert_eq "manifest+config" "$(classify_install_state_miss)" "manifest change reports manifest+config"
+)
+
+echo "Test 26: gvs-policy change reports miss_reason gvs-link"
+(
+  state_dir="$test_dir/miss-gvs"
+  make_install_state_fixture "$state_dir"
+  cd "$state_dir"
+  set_component_env
+  store_component_baseline
+  # packageExtensions also trips manifest+config (whole workspace.yaml is hashed
+  # there); priority ordering must still report the GVS-link purge it triggers.
+  sed -i "s/extra-dep: '1.0.0'/extra-dep: '2.0.0'/" pnpm-workspace.yaml
+  assert_eq "gvs-link" "$(classify_install_state_miss)" "packageExtensions change reports gvs-link"
+)
+
+echo "Test 27: report_install_miss_reason writes the OTEL sidecar attribute"
+(
+  attr_file="$test_dir/miss-attr-file"
+  export OTEL_STATUS_ATTR_FILE="$attr_file"
+  report_install_miss_reason "gvs-link" 2>/dev/null
+  unset OTEL_STATUS_ATTR_FILE
+  assert_eq "install.miss_reason=gvs-link" "$(cat "$attr_file")" "miss reason written to sidecar"
+)
+
 echo ""
 echo "All pnpm task helper tests passed"

--- a/nix/devenv-modules/tasks/shared/tests/pnpm.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/pnpm.test.sh
@@ -542,5 +542,20 @@ echo "Test 27: report_install_miss_reason writes the OTEL sidecar attribute"
   assert_eq "install.miss_reason=gvs-link" "$(cat "$attr_file")" "miss reason written to sidecar"
 )
 
+echo "Test 28: steady-state packageExtensions co-change reports miss_reason gvs-link"
+(
+  state_dir="$test_dir/miss-gvs-cochange"
+  make_install_state_fixture "$state_dir"
+  cd "$state_dir"
+  set_component_env
+  store_component_baseline
+  # The realistic steady-state shape: a packageExtensions edit ALSO bumps the
+  # lockfile. gvs-link must win over lockfile by consequence severity (it forces
+  # the `links/` purge), so the priority order is gvs-link before lockfile.
+  sed -i "s/extra-dep: '1.0.0'/extra-dep: '2.0.0'/" pnpm-workspace.yaml
+  printf 'packages: { changed }\n' >> pnpm-lock.yaml
+  assert_eq "gvs-link" "$(classify_install_state_miss)" "packageExtensions+lockfile co-change reports gvs-link"
+)
+
 echo ""
 echo "All pnpm task helper tests passed"


### PR DESCRIPTION
Stacked on #805. Closes #809.

## Problem
The pnpm install task computed a single monolithic state-hash folding lockfile + policy + manifests + generated-config together. On a miss the status path just `exit 1` with no reason, and a GVS-config change triggered a wholesale `rm -rf <store>/v11/links` purge — both consequences of the same opaque digest.

## Change
Decompose the state-hash into labeled component hashes computed only after the monolithic hash mismatches (the monolithic hash stays the sole hit/miss gate), and report which component moved.

- Components, priority-ordered first-match: `gvs-link` → `lockfile` → `policy` → `manifest+config` (plus `bootstrap` for first-run, `projection` for stale links).
- `gvs-link` is checked before `lockfile` on purpose: a `packageExtensions` edit also bumps the lockfile, so reporting by consequence severity (gvs-link forces the purge) matches what actually happens. `gvs-link`'s hash excludes the lockfile, so a pure-lockfile change still reports `lockfile`.
- Miss-reason is emitted to stderr and as OTEL `install.miss_reason` on the `<task>:status` span (new `trace.nix` attr-file sidecar + `otel-span.nix` `--attr-file` hook).
- The wholesale GVS purge is unchanged but now logged with its precise cause. The invalidation contract is documented in the `pnpm.nix` header + CHANGELOG.

## Scope decision
The full hash-partitioned GVS cache the issue floats is deliberately not built: it only helps when oscillating between previously-seen policy states, costs unbounded disk, and pnpm bakes absolute paths into `v11/links` so safe reuse is unproven. The component decomposition is the principled prerequisite. FOD prep (`mk-pnpm-deps.nix`) is untouched; its leak guard is preserved as a regression guard.

## Limitation
genie-generated config is not separable from hand edits today, so it's grouped into `manifest+config` and documented.

## Verification
- `tests/pnpm.test.sh` 28/28 and `tests/pnpm-task-smoke.test.sh` 30/30 pass (production classifier). Reorder verified red-green; `bash -n` + `nixfmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🔄 cl2-tide |
| `agent_session_id` | f6325b3c-bcd9-4b16-9af1-96f2233d2d3d |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.179 |
| `agent_runtime` | Claude Code 2.1.179 |
| `agent_model` | claude-opus-4-8 |
| `runtime_profile` | /nix/store/wbb5q5n2gbk751hcyr5ndp0zrmar602x-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/3i12shfqx3wqzq2di3jy1m7f8fn4prmm-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling/2026-06-19-deps |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->