### PR TITLE
feat(ci): add native npm dependency policy audit (#807)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2599,6 +2599,16 @@ jobs:
           EOF
           echo "::warning::Intentional failure for diagnostics validation (#272)"
           exit 1
+      - name: Audit native dependency policy
+        shell: bash
+        run: |
+          set -euo pipefail
+          audit=genie/ci-scripts/native-dep-policy-audit.ts
+          if command -v bun >/dev/null 2>&1; then
+            bun "$audit"
+          else
+            nix run nixpkgs#bun -- "$audit"
+          fi
       - name: Guard pnpm builder contract
         shell: bash
         run: |
@@ -2890,6 +2900,7 @@ jobs:
         run: |
           bash genie/ci-scripts/nix-gc-race-retry.test.sh
           bash genie/ci-scripts/ci-measurement-comparison.test.sh
+          bash genie/ci-scripts/native-dep-policy-audit.test.sh
           bash nix/workspace-tools/lib/mk-pnpm-cli/tests/run.sh --skip-genie --skip-megarepo --skip-devenv-shell --skip-downstream-megarepo
       - name: Save pnpm state
         if: ${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -313,6 +313,24 @@ const cargoJob = {
   ],
 } as const
 
+/**
+ * Audit the native npm dependency policy against the lockfile (issue #807).
+ * Install-free: depends only on `pnpm-lock.yaml` and the genie policy source.
+ */
+const nativeDepPolicyAuditStep = {
+  name: 'Audit native dependency policy',
+  shell: 'bash',
+  run: [
+    'set -euo pipefail',
+    'audit=genie/ci-scripts/native-dep-policy-audit.ts',
+    'if command -v bun >/dev/null 2>&1; then',
+    '  bun "$audit"',
+    'else',
+    '  nix run nixpkgs#bun -- "$audit"',
+    'fi',
+  ].join('\n'),
+} as const
+
 // Jobs keyed by CIJobName for type safety with required status checks
 const jobs: Record<
   CIJobName,
@@ -353,6 +371,10 @@ const jobs: Record<
     step: pnpmBuilderContractStep({
       builderFile: 'nix/workspace-tools/lib/mk-pnpm-deps.nix',
     }),
+    // Audit the native npm dependency policy (issue #807) in the same lane that
+    // guards the pnpm builder contract. Runs install-free against the lockfile
+    // and the genie policy source, both present here without node_modules.
+    extraSteps: [nativeDepPolicyAuditStep],
   }),
   'pnpm-regression': job({
     step: {
@@ -360,6 +382,7 @@ const jobs: Record<
       run: [
         'bash genie/ci-scripts/nix-gc-race-retry.test.sh',
         'bash genie/ci-scripts/ci-measurement-comparison.test.sh',
+        'bash genie/ci-scripts/native-dep-policy-audit.test.sh',
         'bash nix/workspace-tools/lib/mk-pnpm-cli/tests/run.sh --skip-genie --skip-megarepo --skip-devenv-shell --skip-downstream-megarepo',
       ].join('\n'),
     },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,21 @@ All notable changes to this project will be documented in this file.
   test (`ts-diagnostics-parser.test.sh`) against captured real tsgo output and
   an offline `otel:test` assertion for typed `emit-span` output.
 
+- **native dependency policy audit**: Add `nativeDependencyPolicy`, a tagged
+  source-of-truth classification in `genie/external.ts` for every native npm
+  dependency family (nix-grafted, denied-lifecycle-build, fod-accepted-prebuilt).
+  The generated pnpm `allowBuilds` denylist is now derived from it so the
+  denylist and audit cannot drift. A new install-free CI audit
+  (`genie/ci-scripts/native-dep-policy-audit.ts`, wired into the
+  `pnpm-builder-contract` job) diffs the lockfile against the policy and fails
+  on drift: a CPU/OS/libc-gated native family with no policy entry, a
+  non-defensive policy package that disappeared, or a nix-grafted entry whose
+  `via` file is missing. Because pnpm lockfile v9 dropped `requiresBuild` and the
+  builder-contract job restores no `node_modules`, the pnpm build-script ledger
+  is unavailable; detecting a brand-new lifecycle-built package that is neither
+  gated-native nor in the policy is therefore out of scope, with the policy as
+  the source of truth (#807).
+
 ### Changed
 
 - **OTEL trace-structure contract**: Tighten the offline trace-structure

--- a/genie/ci-scripts/native-dep-policy-audit.test.sh
+++ b/genie/ci-scripts/native-dep-policy-audit.test.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+AUDIT="$ROOT/genie/ci-scripts/native-dep-policy-audit.ts"
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+run_bun() {
+  if command -v bun >/dev/null 2>&1; then
+    bun "$@"
+  elif command -v nix >/dev/null 2>&1; then
+    nix run nixpkgs#bun -- "$@"
+  elif [ -n "${DEVENV_BIN:-}" ]; then
+    "$DEVENV_BIN" shell --no-reload -- bash -lc 'bun "$@"' bash "$@"
+  else
+    echo "bun is not available and neither nix nor DEVENV_BIN is set" >&2
+    return 127
+  fi
+}
+
+# Clean fixture: every present family is classified by nativeDependencyPolicy.
+# node-pty resolves via link: (no gated registry key); its nix file is real.
+clean_lock="$tmp_dir/clean.yaml"
+cat >"$clean_lock" <<'YAML'
+lockfileVersion: '9.0'
+packages:
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    cpu: [x64]
+    os: [linux]
+  '@esbuild/linux-x64@0.27.7':
+    cpu: [x64]
+    os: [linux]
+  '@opentui/core-linux-x64@0.4.1':
+    cpu: [x64]
+    os: [linux]
+  '@parcel/watcher-linux-x64-glibc@2.5.1':
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+  '@parcel/watcher@2.5.1': {}
+  '@myobie/pty@0.1.0': {}
+  esbuild@0.27.7: {}
+  fsevents@2.3.3:
+    os: [darwin]
+  msgpackr-extract@3.0.3: {}
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
+    cpu: [x64]
+    os: [linux]
+  node-pty@1.1.0: {}
+YAML
+
+# Failing fixture: an unclassified gated native family (@swc/core-*) appears.
+dirty_lock="$tmp_dir/dirty.yaml"
+cat >"$dirty_lock" <<'YAML'
+lockfileVersion: '9.0'
+packages:
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    cpu: [x64]
+    os: [linux]
+  '@parcel/watcher@2.5.1': {}
+  '@myobie/pty@0.1.0': {}
+  esbuild@0.27.7: {}
+  fsevents@2.3.3:
+    os: [darwin]
+  msgpackr-extract@3.0.3: {}
+  node-pty@1.1.0: {}
+  '@swc/core-linux-x64-gnu@1.13.5':
+    cpu: [x64]
+    os: [linux]
+YAML
+
+# Disappeared fixture: the non-defensive denied family `esbuild` lost its
+# lifecycle-built main package (only the gated @esbuild/* prebuilts remain),
+# which must trip the missing-policy-package check.
+missing_lock="$tmp_dir/missing.yaml"
+cat >"$missing_lock" <<'YAML'
+lockfileVersion: '9.0'
+packages:
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    cpu: [x64]
+    os: [linux]
+  '@esbuild/linux-x64@0.27.7':
+    cpu: [x64]
+    os: [linux]
+  '@opentui/core-linux-x64@0.4.1':
+    cpu: [x64]
+    os: [linux]
+  '@parcel/watcher@2.5.1': {}
+  '@myobie/pty@0.1.0': {}
+  fsevents@2.3.3:
+    os: [darwin]
+  msgpackr-extract@3.0.3: {}
+  node-pty@1.1.0: {}
+YAML
+
+echo "Test 1: clean lockfile passes (exit 0)"
+if ! run_bun "$AUDIT" "$clean_lock" >"$tmp_dir/clean.out" 2>&1; then
+  echo "FAIL: expected clean fixture to pass" >&2
+  cat "$tmp_dir/clean.out" >&2
+  exit 1
+fi
+
+echo "Test 2: unclassified native family fails (nonzero) and names the offender"
+set +e
+run_bun "$AUDIT" "$dirty_lock" >"$tmp_dir/dirty.out" 2>&1
+dirty_exit=$?
+set -e
+if [ "$dirty_exit" -eq 0 ]; then
+  echo "FAIL: expected unclassified @swc/core family to fail the audit" >&2
+  cat "$tmp_dir/dirty.out" >&2
+  exit 1
+fi
+if ! grep -q "@swc/core-linux-x64-gnu" "$tmp_dir/dirty.out"; then
+  echo "FAIL: audit output did not name the offending @swc/core family" >&2
+  cat "$tmp_dir/dirty.out" >&2
+  exit 1
+fi
+
+echo "Test 3: disappeared denied family fails (nonzero) and names the offender"
+set +e
+run_bun "$AUDIT" "$missing_lock" >"$tmp_dir/missing.out" 2>&1
+missing_exit=$?
+set -e
+if [ "$missing_exit" -eq 0 ]; then
+  echo "FAIL: expected a disappeared denied family to fail the audit" >&2
+  cat "$tmp_dir/missing.out" >&2
+  exit 1
+fi
+if ! grep -qE "missing-policy-package\] esbuild" "$tmp_dir/missing.out"; then
+  echo "FAIL: audit output did not flag the missing esbuild family" >&2
+  cat "$tmp_dir/missing.out" >&2
+  exit 1
+fi
+
+echo "Test 4: real repo lockfile passes against the live policy (exit 0)"
+if ! run_bun "$AUDIT" "$ROOT/pnpm-lock.yaml" >"$tmp_dir/real.out" 2>&1; then
+  echo "FAIL: live pnpm-lock.yaml must satisfy nativeDependencyPolicy" >&2
+  cat "$tmp_dir/real.out" >&2
+  exit 1
+fi
+
+echo ""
+echo "native-dep-policy-audit tests passed"

--- a/genie/ci-scripts/native-dep-policy-audit.ts
+++ b/genie/ci-scripts/native-dep-policy-audit.ts
@@ -1,0 +1,217 @@
+#!/usr/bin/env bun
+/**
+ * Native npm dependency policy audit (issue #807).
+ *
+ * Cross-checks the pnpm lockfile against the authoritative
+ * `nativeDependencyPolicy` classification in `genie/external.ts` and fails CI
+ * on drift. This runs install-free: the only inputs are the lockfile and the
+ * genie policy source, which is all the builder-contract CI job has (it
+ * restores no `node_modules`, so the pnpm build-script ledger is unavailable).
+ *
+ * The audit fails when:
+ * - a CPU/OS/libc-gated native family appears in the lockfile with no
+ *   `fod-accepted-prebuilt` or `nix-grafted` policy entry (new native family);
+ * - a non-defensive `denied-lifecycle-build` or a `nix-grafted` family is
+ *   absent from the lockfile (policy entry disappeared / shape changed);
+ * - a `nix-grafted` entry's `via` Nix file is missing.
+ *
+ * Known gap (lockfile v9 dropped `requiresBuild`; ledger unavailable in-job): a
+ * brand-new package that carries a lifecycle build but is neither gated-native
+ * nor already in the policy cannot be auto-detected. The policy is the source
+ * of truth; this audit enforces lockfile-vs-policy drift against it.
+ */
+
+import { existsSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import {
+  type NativeDependencyPolicyEntry,
+  nativeDependencyPolicy,
+} from '../external.ts'
+
+const repoRoot = resolve(import.meta.dir, '../..')
+
+export type AuditOptions = {
+  readonly lockfilePath: string
+  readonly policy?: Record<string, NativeDependencyPolicyEntry>
+  /** Resolve `nix-grafted` `via` files relative to this root (default: repo root). */
+  readonly nixRoot?: string
+}
+
+export type AuditProblem = {
+  readonly kind:
+    | 'unclassified-native-family'
+    | 'missing-policy-package'
+    | 'missing-graft-file'
+  readonly family: string
+  readonly detail: string
+}
+
+type NativePackageMeta = {
+  cpu?: true
+  os?: true
+  libc?: true
+}
+
+const stripYamlQuotes = (value: string): string => {
+  const trimmed = value.trim()
+  if (
+    (trimmed.startsWith("'") === true && trimmed.endsWith("'") === true) ||
+    (trimmed.startsWith('"') === true && trimmed.endsWith('"') === true)
+  ) {
+    return trimmed.slice(1, -1)
+  }
+  return trimmed
+}
+
+/**
+ * Parse the small pnpm-lock.yaml surface the audit needs: package keys plus
+ * cpu/os/libc presence. Avoids coupling CI to Bun.YAML availability.
+ */
+const parseLockfilePackages = (text: string): Record<string, NativePackageMeta> => {
+  const packages: Record<string, NativePackageMeta> = {}
+  let inPackages = false
+  let currentPackage: string | undefined
+
+  for (const line of text.split('\n')) {
+    if (line === 'packages:') {
+      inPackages = true
+      continue
+    }
+
+    if (inPackages === false) continue
+    if (/^[^\s].*:/.test(line) === true) break
+
+    const packageMatch = /^  (.+):(?:\s*\{\})?\s*$/.exec(line)
+    if (packageMatch !== null) {
+      currentPackage = stripYamlQuotes(packageMatch[1]!)
+      packages[currentPackage] = {}
+      continue
+    }
+
+    const platformFieldMatch = /^    (cpu|os|libc):/.exec(line)
+    if (platformFieldMatch !== null && currentPackage !== undefined) {
+      packages[currentPackage]![platformFieldMatch[1] as 'cpu' | 'os' | 'libc'] = true
+    }
+  }
+
+  return packages
+}
+
+/** Strip the trailing `@<version>` from a lockfile package key. */
+const stripVersion = (key: string): string => key.replace(/@[^@]+$/, '')
+
+/**
+ * Map a versioned lockfile package name to its policy family key, if any policy
+ * key is a prefix at a `-`/`/` boundary. Prefix matching keeps `esbuild`
+ * (denied) distinct from `@esbuild/*` (fod-accepted).
+ */
+const familyFor = ({
+  pkgName,
+  policyKeys,
+}: {
+  pkgName: string
+  policyKeys: readonly string[]
+}): string | undefined => {
+  for (const key of policyKeys) {
+    if (pkgName === key) return key
+    if (pkgName.startsWith(`${key}-`) === true || pkgName.startsWith(`${key}/`) === true) {
+      return key
+    }
+  }
+  return undefined
+}
+
+/** A lockfile package is "native-gated" if it carries cpu/os/libc constraints. */
+const isGated = (meta: NativePackageMeta): boolean =>
+  meta.cpu !== undefined || meta.os !== undefined || meta.libc !== undefined
+
+export const auditNativeDependencyPolicy = (opts: AuditOptions): AuditProblem[] => {
+  const policy = opts.policy ?? nativeDependencyPolicy
+  const policyKeys = Object.keys(policy)
+  const nixRoot = opts.nixRoot ?? repoRoot
+  const problems: AuditProblem[] = []
+
+  const packages = parseLockfilePackages(readFileSync(opts.lockfilePath, 'utf8'))
+
+  const presentFamilies = new Set<string>()
+  const gatedFamilies = new Set<string>()
+
+  for (const [key, meta] of Object.entries(packages)) {
+    const name = stripVersion(key)
+    const family = familyFor({ pkgName: name, policyKeys })
+    if (family !== undefined) presentFamilies.add(family)
+    if (isGated(meta) === false) continue
+    if (family === undefined) {
+      // A gated native family with no policy entry: unclassified drift.
+      gatedFamilies.add(name)
+    } else {
+      gatedFamilies.add(family)
+    }
+  }
+
+  // (b) Every gated native family must carry some policy classification. Any
+  // tag counts: a `denied-lifecycle-build` family (e.g. @parcel/watcher,
+  // fsevents) legitimately ships both a lifecycle-built main package and gated
+  // optional prebuilts. Only a wholly unclassified gated family is drift.
+  for (const family of gatedFamilies) {
+    if (policy[family] === undefined) {
+      problems.push({
+        kind: 'unclassified-native-family',
+        family,
+        detail: `gated native package family "${family}" has no nativeDependencyPolicy entry (classify as fod-accepted-prebuilt, nix-grafted, or denied-lifecycle-build)`,
+      })
+    }
+  }
+
+  // (c) Policy entries must still be present / well-shaped.
+  for (const [family, entry] of Object.entries(policy)) {
+    if (entry._tag === 'denied-lifecycle-build') {
+      if (entry.defensive === true) continue
+      if (presentFamilies.has(family) === false) {
+        problems.push({
+          kind: 'missing-policy-package',
+          family,
+          detail: `denied-lifecycle-build family "${family}" is no longer in the lockfile; remove it or mark it defensive`,
+        })
+      }
+    } else if (entry._tag === 'nix-grafted') {
+      if (existsSync(resolve(nixRoot, entry.via)) === false) {
+        problems.push({
+          kind: 'missing-graft-file',
+          family,
+          detail: `nix-grafted family "${family}" references missing graft file "${entry.via}"`,
+        })
+      }
+      if (presentFamilies.has(family) === false) {
+        problems.push({
+          kind: 'missing-policy-package',
+          family,
+          detail: `nix-grafted family "${family}" is no longer in the lockfile; update or remove its policy entry`,
+        })
+      }
+    }
+  }
+
+  return problems
+}
+
+const formatReport = (problems: readonly AuditProblem[]): string => {
+  if (problems.length === 0) return 'native dependency policy audit: OK'
+  const lines = [`native dependency policy audit: ${problems.length} problem(s)`, '']
+  for (const p of problems) {
+    lines.push(`  [${p.kind}] ${p.family}`)
+    lines.push(`    ${p.detail}`)
+  }
+  return lines.join('\n')
+}
+
+if (import.meta.main) {
+  const lockfilePath = process.argv[2] ?? resolve(repoRoot, 'pnpm-lock.yaml')
+  const problems = auditNativeDependencyPolicy({ lockfilePath })
+  const report = formatReport(problems)
+  if (problems.length > 0) {
+    console.error(report)
+    process.exit(1)
+  }
+  console.log(report)
+}

--- a/genie/external.ts
+++ b/genie/external.ts
@@ -309,13 +309,16 @@ export const catalog = defineCatalog({
  *   lifecycle-built native addons per issue #807.
  *
  * Audit gap (documented, not silently dropped): pnpm lockfile v9 no longer
- * emits `requiresBuild`, and the builder-contract CI job restores no
- * `node_modules`, so the build-script ledger (`pendingBuilds`/`ignoredBuilds`)
- * is unavailable and empty under `ignoreScripts: true`. A brand-new package
- * that carries a lifecycle build but is neither CPU/OS/libc-gated nor already
- * in this policy therefore cannot be auto-detected. This policy is the source
- * of truth; the audit enforces lockfile-vs-policy drift (new gated families,
- * disappeared/shape-changed entries) against it.
+ * emits `requiresBuild`. The build-script ledger (`.modules.yaml`
+ * `pendingBuilds`/`ignoredBuilds`) IS populated by a local install even under
+ * `ignoreScripts: true` (it lists packages blocked from building), but it is
+ * unavailable in CI: the builder-contract job runs install-free, and the
+ * Nix pnpm-deps FOD strips `.modules.yaml` from its output for determinism, so
+ * no CI job sees the ledger. A brand-new package that carries a lifecycle
+ * build but is neither CPU/OS/libc-gated nor already in this policy therefore
+ * cannot be auto-detected here. This policy is the source of truth; the audit
+ * enforces lockfile-vs-policy drift (new gated families, disappeared/
+ * shape-changed entries) against it.
  */
 export const nativeDependencyPolicy = {
   // Lifecycle-built native addons denied a pnpm build. Order mirrors the

--- a/genie/external.ts
+++ b/genie/external.ts
@@ -288,6 +288,88 @@ export const catalog = defineCatalog({
 })
 
 /**
+ * Authoritative classification of every native npm dependency family the
+ * workspace tolerates. This is the single source of truth consumed by both the
+ * generated pnpm `allowBuilds` denylist (below) and the CI policy audit
+ * (`genie/ci-scripts/native-dep-policy-audit.ts`), so the two cannot drift.
+ *
+ * Each entry is tagged by how the native code is obtained:
+ *
+ * - `nix-grafted`: the native artifact is supplied by a Nix derivation instead
+ *   of pnpm. `graft: 'link'` builds the addon from source (`node-pty`),
+ *   `graft: 'fetch-only'` grafts prebuilt platform tarballs (`@opentui/core`).
+ *   `via` names the owning Nix file, which the audit verifies exists.
+ * - `denied-lifecycle-build`: a package that ships an install lifecycle build
+ *   script we explicitly refuse to run (pnpm `allowBuilds: false`). `defensive`
+ *   marks entries kept as guard rails even though the family is not currently
+ *   in the lockfile (e.g. `sharp`, `unix-dgram`); their absence is tolerated.
+ * - `fod-accepted-prebuilt`: an optional, CPU/OS/libc-gated prebuilt native
+ *   binary family (Rollup/Rolldown/esbuild/oxc/etc.) that carries no lifecycle
+ *   build and is locked as a fixed-output set. Listed separately from
+ *   lifecycle-built native addons per issue #807.
+ *
+ * Audit gap (documented, not silently dropped): pnpm lockfile v9 no longer
+ * emits `requiresBuild`, and the builder-contract CI job restores no
+ * `node_modules`, so the build-script ledger (`pendingBuilds`/`ignoredBuilds`)
+ * is unavailable and empty under `ignoreScripts: true`. A brand-new package
+ * that carries a lifecycle build but is neither CPU/OS/libc-gated nor already
+ * in this policy therefore cannot be auto-detected. This policy is the source
+ * of truth; the audit enforces lockfile-vs-policy drift (new gated families,
+ * disappeared/shape-changed entries) against it.
+ */
+export const nativeDependencyPolicy = {
+  // Lifecycle-built native addons denied a pnpm build. Order mirrors the
+  // historical `allowBuilds` literal so the derived denylist stays byte-stable.
+  '@parcel/watcher': { _tag: 'denied-lifecycle-build' },
+  '@myobie/pty': { _tag: 'denied-lifecycle-build' },
+  esbuild: { _tag: 'denied-lifecycle-build' },
+  fsevents: { _tag: 'denied-lifecycle-build' },
+  'msgpackr-extract': { _tag: 'denied-lifecycle-build' },
+  'node-pty': { _tag: 'nix-grafted', graft: 'link', via: 'nix/node-pty-native.nix' },
+  sharp: { _tag: 'denied-lifecycle-build', defensive: true },
+  'unix-dgram': { _tag: 'denied-lifecycle-build', defensive: true },
+
+  // Nix-grafted prebuilt native package (not lifecycle-built, so not denied).
+  '@opentui/core': { _tag: 'nix-grafted', graft: 'fetch-only', via: 'nix/opentui-core-native.nix' },
+
+  // FOD-accepted optional prebuilt native families (CPU/OS/libc-gated, no
+  // lifecycle build). Keys are the family prefix shared by every platform
+  // package (e.g. `@rollup/rollup` covers `@rollup/rollup-linux-x64-gnu`).
+  '@rollup/rollup': { _tag: 'fod-accepted-prebuilt' },
+  '@rolldown/binding': { _tag: 'fod-accepted-prebuilt' },
+  '@esbuild': { _tag: 'fod-accepted-prebuilt' },
+  '@msgpackr-extract': { _tag: 'fod-accepted-prebuilt' },
+  lightningcss: { _tag: 'fod-accepted-prebuilt' },
+  '@oxc-parser/binding': { _tag: 'fod-accepted-prebuilt' },
+  '@oxc-resolver/binding': { _tag: 'fod-accepted-prebuilt' },
+  '@tailwindcss/oxide': { _tag: 'fod-accepted-prebuilt' },
+  '@oxlint-tsgolint': { _tag: 'fod-accepted-prebuilt' },
+} as const satisfies Record<string, NativeDependencyPolicyEntry>
+
+/** Tagged classification of a native dependency family. @see nativeDependencyPolicy */
+export type NativeDependencyPolicyEntry =
+  | { readonly _tag: 'nix-grafted'; readonly graft: 'link' | 'fetch-only'; readonly via: string }
+  | { readonly _tag: 'denied-lifecycle-build'; readonly defensive?: boolean }
+  | { readonly _tag: 'fod-accepted-prebuilt' }
+
+/**
+ * Packages whose pnpm lifecycle build is denied. Derived from
+ * `nativeDependencyPolicy` (every `denied-lifecycle-build` entry plus
+ * `nix-grafted` addons built from source via `graft: 'link'`) so the denylist
+ * and the audit share one source of truth. Insertion order is preserved to
+ * keep the generated `pnpm-workspace.yaml` byte-stable.
+ */
+const deniedLifecycleBuilds = Object.fromEntries(
+  Object.entries(nativeDependencyPolicy)
+    .filter(
+      ([, entry]) =>
+        entry._tag === 'denied-lifecycle-build' ||
+        (entry._tag === 'nix-grafted' && entry.graft === 'link'),
+    )
+    .map(([name]) => [name, false as const]),
+)
+
+/**
  * Shared pnpm policy settings for all megarepos.
  *
  * This is the SSOT for pnpm strictness/layout policy. Every megarepo
@@ -336,17 +418,9 @@ export const commonPnpmPolicySettings = {
   // Native binaries are provided by Nix/custom flakes instead of pnpm lifecycle
   // scripts. pnpm 11 removed ignoreDepScripts in favor of allowBuilds; keep
   // known native packages explicit so approval drift is reviewed, but do not
-  // allow any dependency build during install.
-  allowBuilds: {
-    '@parcel/watcher': false,
-    '@myobie/pty': false,
-    esbuild: false,
-    fsevents: false,
-    'msgpackr-extract': false,
-    'node-pty': false,
-    sharp: false,
-    'unix-dgram': false,
-  },
+  // allow any dependency build during install. Derived from
+  // `nativeDependencyPolicy` so the denylist and CI audit cannot drift.
+  allowBuilds: deniedLifecycleBuilds,
 }
 
 /** Common fields for private packages */


### PR DESCRIPTION
Stacked on #805. Closes #807.

## Problem
After the pnpm 11 policy move (`ignoreScripts: true`, explicit `allowBuilds: false`, Nix-grafted native addons), the native-dependency policy lived as tribal knowledge: the `allowBuilds` denylist and the set of accepted prebuilt-optional families were not cross-checked against the lockfile, so drift (a new native family, a denied family changing shape) would pass silently.

## Premise correction
The issue's rule "lockfile package has `requiresBuild: true`" cannot be implemented as written: pnpm v9 lockfiles do not emit `requiresBuild` (zero hits). pnpm's build-script ledger (`node_modules/.modules.yaml` `pendingBuilds`) is populated locally but is unavailable in CI — the builder-contract job is install-free and the pnpm-deps FOD strips `.modules.yaml` for reproducibility. So the durable CI signal is **CPU/OS/libc-gated native families in the lockfile** cross-checked against an explicit policy.

## Change
- **Single source of truth**: `nativeDependencyPolicy` tagged-union in `genie/external.ts` classifying every native family as `nix-grafted` / `denied-lifecycle-build` / `fod-accepted-prebuilt`. The generated `allowBuilds` map is **derived from it**, so the denylist and the audit can't drift (emitted `pnpm-workspace.yaml` is byte-identical).
- **Audit**: `genie/ci-scripts/native-dep-policy-audit.ts` — an install-free Bun script that parses `pnpm-lock.yaml` + the policy and exits nonzero on an unclassified gated family or a denied family that disappeared. Wired as a step in the existing `pnpm-builder-contract` job; `.test.sh` added to `pnpm-regression`.

## Known limitation (tracked in #813)
The gated-family heuristic does not catch an *ungated* node-gyp lifecycle addon (e.g. `bcrypt`) added without a policy entry — covering that needs a `node_modules`-present lane, which the FOD-determinism invariant precludes today. Documented in `external.ts` and filed as #813.

## Verification
- `dt genie:run` / `dt genie:check` clean; `pnpm-workspace.yaml` unchanged (derived `allowBuilds` byte-identical).
- `bun genie/ci-scripts/native-dep-policy-audit.ts` → OK; the 4-fixture `.test.sh` passes incl. two deliberately-failing cases (unclassified `@swc/core`, disappeared `esbuild`).
- `dt ts:check`, `oxlint genie/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🔄 cl2-tide |
| `agent_session_id` | f6325b3c-bcd9-4b16-9af1-96f2233d2d3d |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.179 |
| `agent_runtime` | Claude Code 2.1.179 |
| `agent_model` | claude-opus-4-8 |
| `runtime_profile` | /nix/store/wbb5q5n2gbk751hcyr5ndp0zrmar602x-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/3i12shfqx3wqzq2di3jy1m7f8fn4prmm-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling/2026-06-19-deps |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->