### PR TITLE
fix(devenv): make cli-guards own command names deterministically (#808)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- **devenv cli-guard ownership**: Make the cli-guard nudge-wrappers the
+  deterministic owners of their command names so the devenv buildEnv no longer
+  emits nondeterministic `collision between ...` warnings (#808). Each guard now
+  exec's the real binary by absolute store path under `DT_PASSTHROUGH=1` instead
+  of grepping `$PATH`, so the real packages (`genie`, `mr`, `oxlint`, `oxfmt`,
+  `nixfmt`, `deadnix`, `tsgo`, `pnpm`) no longer need to be competing top-level
+  profile providers. Reals are threaded into the task modules via `*Pkg` args
+  (`tsBinPkg`, `oxlintPkg`, `mrPkg`, `pnpmPkg`, `geniePkg`). `effect-tsgo`
+  and `pnpm` stay on `$PATH` at `lib.lowPrio` to keep their `effect-tsgo`/`pnpx`
+  siblings reachable. `realBin` is optional with the previous `$PATH`-grep
+  retained as the fallback, so the `fromTasks`/`mkCliGuard` API and unthreaded
+  guards (`vitest`, `playwright`) are backward compatible. The exported
+  `tasks.genie` module stays a bare-path standard module — `geniePkg` is an
+  optional module argument (threaded via `_module.args.geniePkg`), so downstream
+  `imports = [ inputs.effect-utils.devenvModules.tasks.genie ]` is unaffected.
+
 - **repo dependency/toolchain refresh**: Upgrade the Nix, pnpm, TypeScript, lint,
   test, Storybook/Vite, React, OpenTelemetry, OpenTUI, and Effect 3-line
   dependency set to current major-compatible versions while deliberately not

--- a/devenv.nix
+++ b/devenv.nix
@@ -56,6 +56,21 @@ let
   # Use bun source entrypoints for in-repo CLIs in devenv (flake builds stay strict).
   mkSourceCli = import ./nix/devenv-modules/lib/mk-source-cli.nix { inherit pkgs; };
 
+  # Real packages backing guarded command names. The cli-guards own bin/<name>
+  # and exec these via absolute store path under passthrough, so they are passed
+  # as `*Pkg` reals to the task modules instead of also being top-level profile
+  # providers (which would collide with the guards in buildEnv). See cli-guard.nix.
+  effectTsgo = inputs.tsgo.packages.${currentSystem}.effect-tsgo;
+  pnpmPkg = import ./nix/pnpm.nix { inherit pkgs; };
+  genieSourceCli = mkSourceCli {
+    name = "genie";
+    entry = "packages/@overeng/genie/bin/genie.tsx";
+  };
+  mrSourceCli = mkSourceCli {
+    name = "mr";
+    entry = "packages/@overeng/megarepo/bin/mr.ts";
+  };
+
   # CLI packages built with Nix (for hash management)
   nixCliPackages = [
     {
@@ -312,9 +327,11 @@ in
     # Playwright browser drivers and environment setup
     inputs.playwright.devenvModules.default
     # Shared task modules
+    # genie is a standard module; the real is threaded via `_module.args.geniePkg`
+    # below so the guard owns `bin/genie` and exec's it by absolute store path.
     taskModules.genie
-    (taskModules.ts { })
-    (taskModules.megarepo { })
+    (taskModules.ts { tsBinPkg = effectTsgo; })
+    (taskModules.megarepo { mrPkg = mrSourceCli; })
     (taskModules.lint-nix { })
     (taskModules.check {
       extraChecks = [
@@ -326,7 +343,10 @@ in
     (taskModules.clean { packages = allPackages; })
     # Repo-root pnpm install task
     # NOTE: Using pnpm temporarily. See: context/workarounds/bun-issues.md
-    (taskModules.pnpm { packages = allPackages; })
+    (taskModules.pnpm {
+      packages = allPackages;
+      inherit pnpmPkg;
+    })
     # Self-contained test tasks: each package uses its own vitest from node_modules
     (taskModules.test {
       packages = packagesWithTests;
@@ -346,6 +366,7 @@ in
       }) packagesWithNetlifyPreview;
     })
     (taskModules.lint-oxc {
+      oxlintPkg = oxlintWithPlugins;
       lintPaths = [
         "packages"
         "scripts"
@@ -442,29 +463,47 @@ in
     ./nix/devenv-modules/tasks/local/restate-integration-test.nix
   ];
 
+  # Thread the source-mode `genie` real into the (standard) genie task module so
+  # the cli-guard owns `bin/genie` and exec's it by absolute store path. The
+  # module declares `geniePkg` as an optional arg (defaulting to null → PATH-grep
+  # fallback), so the export stays a bare-path module for downstream consumers.
+  _module.args.geniePkg = genieSourceCli;
+
+  # Guarded-command ownership (issue #808):
+  #   Each cli-guard owns its `bin/<name>` and exec's the real binary by absolute
+  #   store path under DT_PASSTHROUGH=1 (see nix/devenv-modules/tasks/lib/cli-guard.nix).
+  #   The reals are therefore threaded into the task modules as `*Pkg` args
+  #   rather than listed here as competing top-level providers, which removes the
+  #   nondeterministic buildEnv `collision between ...` warnings.
+  #
+  #   command  owner (real exec'd by guard)        why not a top-level package
+  #   -------  ---------------------------------    --------------------------------
+  #   genie    genieSourceCli  (mkSourceCli)        guard owns it; sole bin
+  #   mr       mrSourceCli     (mkSourceCli)        guard owns it; sole bin
+  #   oxlint   oxlintWithPlugins                    guard owns it; sole bin
+  #   oxfmt    pkgs.oxfmt                           guard owns it (in lint-oxc.nix); sole bin
+  #   nixfmt   pkgs.nixfmt-rfc-style                guard owns it (in lint-nix.nix); sole bin
+  #   deadnix  pkgs.deadnix                         guard owns it (in lint-nix.nix); sole bin
+  #   tsgo     effectTsgo                           lowPrio below: keeps `effect-tsgo` sibling
+  #   pnpm     pnpmPkg (nix/pnpm.nix)               lowPrio below: keeps `pnpx` sibling
+  #
+  #   tsc/tsserver stay real-owned via `pkgs.typescript` (no guard, no collision).
+  #   tui-stories is real-owned via mkSourceCli (no guard, no collision).
   packages = [
-    inputs.tsgo.packages.${currentSystem}.effect-tsgo
-    (import ./nix/pnpm.nix { inherit pkgs; })
+    # lowPrio: the tsgo guard owns `bin/tsgo`; keep this for the `effect-tsgo` bin.
+    (lib.lowPrio effectTsgo)
+    # lowPrio: the pnpm guard owns `bin/pnpm`; keep this for the `pnpx` bin.
+    (lib.lowPrio pnpmPkg)
     pkgs.nodejs_24
     pkgs.bun
     pkgs.typescript
     pkgs.flock # Cross-process locking for setup tasks (see setup.nix)
-    oxlintWithPlugins
-    pkgs.oxfmt
     # restate-server (+ restate CLI) on $PATH for restate-effect integration tests.
     restate
     # Use the packaged wrapper so `notion db ...` runs on Node 24 with node:sqlite.
     repoFlake.packages.${currentSystem}.notion-cli
     # otelite binary on PATH so @overeng/utils-dev/otelite tests run the real CLI.
     repoFlake.packages.${currentSystem}.otelite
-    (mkSourceCli {
-      name = "genie";
-      entry = "packages/@overeng/genie/bin/genie.tsx";
-    })
-    (mkSourceCli {
-      name = "mr";
-      entry = "packages/@overeng/megarepo/bin/mr.ts";
-    })
     cliBuildStamp.package
     (mkSourceCli {
       name = "tui-stories";

--- a/flake.nix
+++ b/flake.nix
@@ -208,6 +208,8 @@
         # Shared task modules (parameterized) - meant for reuse in other repos
         tasks = {
           # Simple tasks (no config needed)
+          # genie is a standard module; consumers thread the optional `geniePkg`
+          # real via `_module.args.geniePkg` for deterministic guard ownership.
           genie = ./nix/devenv-modules/tasks/shared/genie.nix;
           lint-genie = ./nix/devenv-modules/tasks/shared/lint-genie.nix;
           # Parameterized tasks (pass config)

--- a/nix/devenv-modules/tasks/lib/cli-guard.nix
+++ b/nix/devenv-modules/tasks/lib/cli-guard.nix
@@ -11,11 +11,32 @@
 #   - dt wrapper re-sets it before calling devenv tasks run
 #   - CI helper (runDevenvTasksBefore) sets it
 #
+# Ownership and the `realBin` arg:
+#   A guard wrapper is itself a `writeShellScriptBin <cli>`, i.e. it provides
+#   `bin/<cli>`. When the real binary for `<cli>` also sits in the same
+#   buildEnv (the devenv profile), buildEnv keeps only one `bin/<cli>` and the
+#   winner is nondeterministic — the guard might shadow the real, or vice
+#   versa, breaking "CI and local resolve the same command paths".
+#
+#   To make the guard the deterministic owner, pass `realBin` (a derivation or
+#   an absolute path). Under passthrough the guard then `exec`s the real binary
+#   by its ABSOLUTE store path instead of grepping $PATH. This is load-bearing:
+#   once the guard owns `bin/<cli>`, the real is no longer reachable under its
+#   own name on $PATH, so the PATH-grep would find nothing and exit 127. The
+#   absolute reference also pulls the real into the closure, so the real package
+#   can be dropped from (or `lib.lowPrio`'d in) the profile's `packages` list to
+#   silence the collision warning while staying reachable.
+#
+#   When `realBin` is null (e.g. CLIs whose real lives in node_modules/.bin and
+#   is not a profile collision), the guard falls back to the PATH-grep lookup.
+#
 # Usage in task modules:
 #
 #   let cliGuard = import ../lib/cli-guard.nix { inherit pkgs; };
 #   in {
-#     packages = cliGuard.fromTasks guardedTasks;
+#     # `reals` maps cli name -> real derivation/path for guards that own
+#     # their command name (collide with a profile-level real).
+#     packages = cliGuard.fromTasks { tasks = guardedTasks; reals = { oxlint = oxlintPkg; }; };
 #     tasks = cliGuard.stripGuards (guardedTasks // otherTasks);
 #   }
 #
@@ -29,6 +50,7 @@
 #   packages = [
 #     (cliGuard.mkCliGuard {
 #       cli = "oxlint";
+#       realBin = oxlintPkg; # optional; absolute-path exec under passthrough
 #       tasks = [
 #         { task = "lint:check:oxlint"; description = "Check lint"; }
 #       ];
@@ -36,9 +58,26 @@
 #   ];
 { pkgs }:
 let
+  lib = pkgs.lib;
+
+  # Resolve a realBin arg (derivation or absolute path) to an absolute
+  # `bin/<cli>` path string, or null when no real was provided.
+  resolveRealBin =
+    cli: realBin:
+    if realBin == null then
+      null
+    else if lib.isDerivation realBin then
+      lib.getExe' realBin cli
+    else
+      toString realBin;
+
   # Build a single guard wrapper script for one CLI
   mkCliGuard =
-    { cli, tasks }:
+    {
+      cli,
+      tasks,
+      realBin ? null,
+    }:
     let
       taskLines = builtins.concatStringsSep "\n" (
         map (
@@ -49,32 +88,41 @@ let
           ''printf "  ${desc}  devenv tasks run ${t.task} --mode before --no-tui\n\n" >&2''
         ) tasks
       );
+      realPath = resolveRealBin cli realBin;
+      # When the real binary is known, exec it by absolute store path. See the
+      # header comment for why PATH-grep cannot work once the guard owns the name.
+      passthroughBody =
+        if realPath != null then
+          ''exec ${lib.escapeShellArg realPath} "$@"''
+        else
+          ''
+            _self="$(cd "''${0%/*}" && pwd -P)"
+            _real=""
+            IFS=: read -ra _dirs <<< "$PATH"
+            for _d in "''${_dirs[@]}"; do
+              [ -z "$_d" ] && continue
+              _resolved="$(cd "$_d" 2>/dev/null && pwd -P)" || continue
+              [ "$_resolved" = "$_self" ] && continue
+              if [ -x "$_d/${cli}" ]; then
+                if grep -q '^# cli-guard-wrapper:${cli}$' "$_d/${cli}" 2>/dev/null; then
+                  continue
+                fi
+                _real="$_d/${cli}"
+                break
+              fi
+            done
+            if [ -z "$_real" ]; then
+              echo "cli-guard: '${cli}' not found on PATH (after removing guard)" >&2
+              exit 127
+            fi
+            exec "$_real" "$@"'';
     in
     pkgs.writeShellScriptBin cli ''
       # cli-guard-wrapper:${cli}
       set -euo pipefail
 
       if [ "''${DT_PASSTHROUGH:-}" = "1" ]; then
-        _self="$(cd "''${0%/*}" && pwd -P)"
-        _real=""
-        IFS=: read -ra _dirs <<< "$PATH"
-        for _d in "''${_dirs[@]}"; do
-          [ -z "$_d" ] && continue
-          _resolved="$(cd "$_d" 2>/dev/null && pwd -P)" || continue
-          [ "$_resolved" = "$_self" ] && continue
-          if [ -x "$_d/${cli}" ]; then
-            if grep -q '^# cli-guard-wrapper:${cli}$' "$_d/${cli}" 2>/dev/null; then
-              continue
-            fi
-            _real="$_d/${cli}"
-            break
-          fi
-        done
-        if [ -z "$_real" ]; then
-          echo "cli-guard: '${cli}' not found on PATH (after removing guard)" >&2
-          exit 127
-        fi
-        exec "$_real" "$@"
+        ${passthroughBody}
       fi
 
       echo "" >&2
@@ -92,9 +140,16 @@ let
   # Extract guard packages from a tasks attrset.
   # Tasks with a `guard = "cli-name"` attribute are grouped by CLI name
   # and a guard wrapper is generated for each group.
+  #
+  # Accepts either a bare tasks attrset (backward compatible) or
+  # `{ tasks, reals }` where `reals` maps a cli name to its real
+  # derivation/path. Reals make the guard own `bin/<cli>` deterministically by
+  # exec'ing the real via absolute path under passthrough (see header comment).
   fromTasks =
-    tasks:
+    arg:
     let
+      tasks = arg.tasks or arg;
+      reals = arg.reals or { };
       # Collect { cli, task, description } from tasks that have a guard attr
       guardEntries = builtins.filter (e: e != null) (
         builtins.attrValues (
@@ -125,6 +180,7 @@ let
         in
         mkCliGuard {
           inherit cli;
+          realBin = reals.${cli} or null;
           tasks = map (e: { inherit (e) task description; }) entries;
         };
     in

--- a/nix/devenv-modules/tasks/shared/genie.nix
+++ b/nix/devenv-modules/tasks/shared/genie.nix
@@ -11,7 +11,21 @@
 #   tasks."genie:run".after = [ "pnpm:install:genie" ];
 #   tasks."genie:watch".after = [ "pnpm:install:genie" ];
 #   tasks."genie:check".after = [ "pnpm:install:genie" ];
-{ lib, pkgs, ... }:
+#
+# This is a standard devenv module — downstream `imports = [ tasks.genie ]` keeps
+# working because `geniePkg` is an optional module argument defaulting to null.
+# Consumers that want the guard to own `bin/genie` thread the real `genie`
+# derivation by setting `_module.args.geniePkg` in their devenv config. When set,
+# the guard owns `bin/genie` and exec's the real by absolute path under
+# passthrough (see cli-guard.nix). Required for source-mode `genie` (no
+# node_modules/.bin fallback) so passthrough does not exit 127. When unset, the
+# guard falls back to grepping `$PATH`.
+{
+  lib,
+  pkgs,
+  geniePkg ? null,
+  ...
+}:
 let
   trace = import ../lib/trace.nix { inherit lib; };
   cliGuard = import ../lib/cli-guard.nix { inherit pkgs; };
@@ -144,6 +158,9 @@ let
   };
 in
 {
-  packages = cliGuard.fromTasks tasks;
+  packages = cliGuard.fromTasks {
+    inherit tasks;
+    reals = lib.optionalAttrs (geniePkg != null) { genie = geniePkg; };
+  };
   tasks = cliGuard.stripGuards tasks;
 }

--- a/nix/devenv-modules/tasks/shared/lint-nix.nix
+++ b/nix/devenv-modules/tasks/shared/lint-nix.nix
@@ -91,10 +91,16 @@ let
   };
 in
 {
-  packages = [
-    pkgs.nixfmt-rfc-style
-    pkgs.deadnix
-  ]
-  ++ cliGuard.fromTasks guardedTasks;
+  # The nixfmt/deadnix guards own their command names by exec'ing the real
+  # binaries via absolute path (see cli-guard.nix), so the reals no longer need
+  # to be competing top-level providers — dropping them from `packages` removes
+  # the buildEnv collision while the guards keep them reachable.
+  packages = cliGuard.fromTasks {
+    tasks = guardedTasks;
+    reals = {
+      nixfmt = pkgs.nixfmt-rfc-style;
+      deadnix = pkgs.deadnix;
+    };
+  };
   tasks = cliGuard.stripGuards (guardedTasks // otherTasks);
 }

--- a/nix/devenv-modules/tasks/shared/lint-oxc.nix
+++ b/nix/devenv-modules/tasks/shared/lint-oxc.nix
@@ -51,6 +51,11 @@
   # Whether to treat warnings as errors. Set to false for repos with many
   # existing warnings that can't be fixed immediately.
   denyWarnings ? true,
+  # Real derivation/path backing the `oxlint` guard (e.g. the plugin-injecting
+  # oxlint wrapper). When set, the guard owns `bin/oxlint` and exec's this by
+  # absolute path under passthrough (see cli-guard.nix). The `oxfmt` guard uses
+  # pkgs.oxfmt directly since that is in-module.
+  oxlintPkg ? null,
 }:
 { lib, pkgs, ... }:
 let
@@ -208,8 +213,20 @@ let
   };
 in
 {
-  # Provide tsgolint when type-aware linting is enabled
-  packages = lib.optionals (tsconfig != null) [ pkgs.tsgolint ] ++ cliGuard.fromTasks guardedTasks;
+  # Provide tsgolint when type-aware linting is enabled.
+  # The oxlint/oxfmt guards own their command names (exec the reals via absolute
+  # path, see cli-guard.nix), so oxfmt is dropped as a top-level provider here and
+  # oxlint is dropped from the consumer's `packages` — removing the buildEnv
+  # collision while keeping both reachable under passthrough.
+  packages =
+    lib.optionals (tsconfig != null) [ pkgs.tsgolint ]
+    ++ cliGuard.fromTasks {
+      tasks = guardedTasks;
+      reals = {
+        oxfmt = pkgs.oxfmt;
+      }
+      // lib.optionalAttrs (oxlintPkg != null) { oxlint = oxlintPkg; };
+    };
 
   tasks = cliGuard.stripGuards (guardedTasks // otherTasks);
 }

--- a/nix/devenv-modules/tasks/shared/megarepo.nix
+++ b/nix/devenv-modules/tasks/shared/megarepo.nix
@@ -24,6 +24,11 @@
 {
   syncAll ? true,
   bootstrapMembers ? [ ],
+  # Real derivation/path backing the `mr` guard. When set, the guard owns
+  # `bin/mr` and exec's this by absolute path under passthrough (see
+  # cli-guard.nix). Required for source-mode `mr` (no node_modules/.bin
+  # fallback) so passthrough does not exit 127.
+  mrPkg ? null,
 }:
 { lib, pkgs, ... }:
 let
@@ -397,7 +402,10 @@ in
     pkgs.git
     pkgs.openssh
   ]
-  ++ cliGuard.fromTasks tasks;
+  ++ cliGuard.fromTasks {
+    inherit tasks;
+    reals = lib.optionalAttrs (mrPkg != null) { mr = mrPkg; };
+  };
 
   tasks =
     cliGuard.stripGuards tasks

--- a/nix/devenv-modules/tasks/shared/pnpm.nix
+++ b/nix/devenv-modules/tasks/shared/pnpm.nix
@@ -22,6 +22,11 @@
   updateAfter ? [ ],
   cleanAfter ? [ ],
   resetLockFilesAfter ? [ ],
+  # Real derivation/path backing the `pnpm` guard. When set, the guard owns
+  # `bin/pnpm` and exec's this by absolute path under passthrough (see
+  # cli-guard.nix). The real package may ship siblings (e.g. `pnpx`) that the
+  # consumer keeps on PATH separately.
+  pnpmPkg ? null,
 }:
 {
   lib,
@@ -612,7 +617,10 @@ let
 
 in
 {
-  packages = cliGuard.fromTasks allTasks;
+  packages = cliGuard.fromTasks {
+    tasks = allTasks;
+    reals = lib.optionalAttrs (pnpmPkg != null) { pnpm = pnpmPkg; };
+  };
 
   enterShell = lib.mkIf (globalCache && workspaceRoot == ".") ''
     export PNPM_HOME="''${PNPM_HOME:-${config.devenv.root}/.devenv/pnpm-home}"

--- a/nix/devenv-modules/tasks/shared/ts.nix
+++ b/nix/devenv-modules/tasks/shared/ts.nix
@@ -44,6 +44,10 @@
   tsconfigFile ? "tsconfig.all.json",
   tsBin ? "tsgo",
   tscBin ? "tsc",
+  # Real derivation/path backing the `tsBin` guard. When set, the guard owns
+  # `bin/<tsBin>` and exec's this by absolute path under passthrough so the real
+  # need not be a competing top-level provider (see cli-guard.nix).
+  tsBinPkg ? null,
 }:
 {
   lib,
@@ -328,7 +332,10 @@ in
   packages = [
     pkgs.bc
   ]
-  ++ cliGuard.fromTasks guardedTasks;
+  ++ cliGuard.fromTasks {
+    tasks = guardedTasks;
+    reals = lib.optionalAttrs (tsBinPkg != null) { ${tsBin} = tsBinPkg; };
+  };
 
   tasks = cliGuard.stripGuards (guardedTasks // otherTasks);
 }


### PR DESCRIPTION
Stacked on #805. Closes #808.

## Problem
The cli-guard nudge-wrappers (which steer interactive use toward `dt` tasks) and the real binaries collided in the devenv buildEnv profile for `genie`, `mr`, `oxlint`, `oxfmt`, `pnpm`, `tsgo`, `nixfmt`, `deadnix`. buildEnv keeps only one `bin/<name>`, and **which one won was nondeterministic** (guard won some, real won others) — that nondeterminism is the real bug and threatens the "CI and local resolve the same command paths" criterion.

## Change (Option B — guard owns the name, execs the real)
Each guard deterministically owns its command name and, under `DT_PASSTHROUGH=1`, execs the real binary by **absolute store path** instead of grepping `$PATH`. This keeps the dt-task nudge, makes ownership deterministic, and removes the warning.

- `cli-guard.nix`: `mkCliGuard`/`fromTasks` gain an optional `realBin`; PATH-grep retained as the `realBin == null` fallback (backward-compatible).
- Reals threaded into task modules as optional `*Pkg` args (`geniePkg`/`tsBinPkg`/`mrPkg`/`pnpmPkg`/`oxlintPkg`, plus in-module nixfmt/deadnix/oxfmt) rather than as competing top-level profile providers.
- `tsgo`/`pnpm` keep their siblings (`effect-tsgo`, `pnpx`) reachable via `lib.lowPrio`; sole-bin reals (genie/mr/oxlint/oxfmt/nixfmt/deadnix) are removed from the top-level list. `tsc`/`tsserver` and `tui-stories` stay real-owned (no guard emitted — the scoping-suspected "9th tsc collision" does not exist: ts.nix guards use `tsBin`=tsgo, `tscBin` only appears in unguarded tasks).
- The chosen owner per command is documented in a table in `devenv.nix`.

## Non-breaking for downstream
`geniePkg` is an optional **module argument** (null default), so the exported `devenvModules.tasks.genie` stays a bare-path standard module — downstream `imports = [ tasks.genie ]` keeps working (falls back to PATH-grep). No flake-export shape change.

## Verification
- Profile realized (non-vacuous rebuild): `grep -c "collision between"` = **0**.
- Bin owners deterministic: guarded names → cli-guard wrappers exec'ing reals by absolute `/nix/store/...` path; `effect-tsgo`/`pnpx`/`tsc`/`tsserver`/`tui-stories` reals reachable; no dropped bins (78 present).
- `DT_PASSTHROUGH=1 <cmd> --version` rc=0 for oxlint/oxfmt/nixfmt/deadnix/pnpm/tsgo/tsc.
- `devenv assemble` / `tasks list` eval clean; `tasks.genie` confirmed a standard module (non-breaking); `nixfmt --check` + `deadnix` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🔄 cl2-tide |
| `agent_session_id` | f6325b3c-bcd9-4b16-9af1-96f2233d2d3d |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.179 |
| `agent_runtime` | Claude Code 2.1.179 |
| `agent_model` | claude-opus-4-8 |
| `runtime_profile` | /nix/store/wbb5q5n2gbk751hcyr5ndp0zrmar602x-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/3i12shfqx3wqzq2di3jy1m7f8fn4prmm-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling/2026-06-19-deps |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->