### PR TITLE
chore(labels): axis-consistent coloring (origin/state unified)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,8 @@ tsconfig.*.json linguist-generated=true
 .github/workflows/*.yml linguist-generated=true
 .oxlintrc.json linguist-generated=true
 .oxfmtrc.json linguist-generated=true
+.github/labels.json linguist-generated=true
+.github/repo-settings.json linguist-generated=true
 pnpm-workspace.yaml linguist-generated=true
 
 # Lock files - collapse in GitHub PR diffs

--- a/.github/labels.json
+++ b/.github/labels.json
@@ -182,7 +182,7 @@
     },
     {
       "name": "origin:agent",
-      "color": "a371f7",
+      "color": "6f42c1",
       "description": "Filed or primarily produced by an AI agent · Set: AI agent or manual"
     },
     {
@@ -192,17 +192,17 @@
     },
     {
       "name": "state:blocked",
-      "color": "e99695",
+      "color": "6e7781",
       "description": "Blocked on an external dependency or decision · Set: manual"
     },
     {
       "name": "state:needs-research",
-      "color": "1f8fb8",
+      "color": "6e7781",
       "description": "Needs research / investigation before scope or approach is clear · Set: manual"
     },
     {
       "name": "state:triage",
-      "color": "fbca04",
+      "color": "6e7781",
       "description": "Needs classification or owner decision · Set: manual"
     },
     {

--- a/genie/labels.ts
+++ b/genie/labels.ts
@@ -44,6 +44,8 @@ const colors = {
   grey: 'bfd4e2',
   lightGrey: 'ededed',
   pale: 'bfd4f2',
+  /* Neutral slate used as the single, axis-consistent color for all `state:*` labels. */
+  slate: '6e7781',
 } as const
 
 // ============================================================================
@@ -100,17 +102,17 @@ const typeLabels: readonly LabelDef[] = [
 const stateLabels: readonly LabelDef[] = [
   {
     name: 'state:triage',
-    color: colors.yellow,
+    color: colors.slate,
     description: 'Needs classification or owner decision · Set: manual',
   },
   {
     name: 'state:blocked',
-    color: colors.pink,
+    color: colors.slate,
     description: 'Blocked on an external dependency or decision · Set: manual',
   },
   {
     name: 'state:needs-research',
-    color: colors.lightBlue,
+    color: colors.slate,
     description: 'Needs research / investigation before scope or approach is clear · Set: manual',
   },
 ]
@@ -122,7 +124,7 @@ const stateLabels: readonly LabelDef[] = [
 const originLabels: readonly LabelDef[] = [
   {
     name: 'origin:agent',
-    color: colors.lightPurple,
+    color: colors.darkPurple,
     description: 'Filed or primarily produced by an AI agent · Set: AI agent or manual',
   },
   {


### PR DESCRIPTION
## Problem

Two label axes use multiple colors within the axis, so neither reads as a single visual group at a glance:

- `origin:*` — `origin:agent` is `a371f7` (lightPurple), `origin:janitor` is `6f42c1` (darkPurple).
- `state:*` — `state:triage` `fbca04`, `state:blocked` `e99695`, `state:needs-research` `1f8fb8`.

## Goal

Each of `origin:*` and `state:*` is one consistent color, so the axis is recognizable at a glance. `type:*` (semantic palette) and `andon:*` (severity ramp) keep their meaningful per-label colors.

## Decisions

- `origin:*` → `6f42c1` (darkPurple) for both. Keeps the existing purple identity of the origin axis; only `origin:agent` moves.
- `state:*` → `6e7781`, a new neutral `slate` palette constant. Chosen to be distinct from every axis it could be confused with: area-blue (`1d76db`), origin-purple (`6f42c1`), the `type:*` semantic colors, and the `andon:*` red/orange/yellow/green ramp. A neutral grey reads as "lifecycle state" without competing with the semantic axes.
- `type:*` and `andon:*` left untouched — their per-label colors carry meaning.

## Verification

- `genie:run` regenerates `.github/labels.json`; the only diff is the 4 changed color lines (`origin:agent` + 3 `state:*`), confirming source and generated artifact stay in sync.
- `lint:check:genie` (generated-artifact freshness) → green.
- `oxfmt --check genie/labels.ts` → clean.

Full `check:all` was deferred to PR CI (data-only color change, low risk).

## Complexity

No new complexity. One palette constant added; four `LabelDef` color fields repointed to existing/new constants.

## Concerns

These are shared `commonLabels` reused across primary megarepo members, so this is a fleet-wide change. Dependent repos show the new colors only after they repin this rev and run their own `gh:apply-labels`; until then a repo's live labels and its committed `labels.json` may briefly differ across the fleet. This is expected for a shared-catalog color change.

## Follow-ups

- After merge, effect-utils' own live labels need `gh:apply-labels` to reflect the new colors (this PR only updates the committed `labels.json`).
- dotfiles must repin effect-utils to the merge commit and regenerate its `labels.json`; other first-party members pick up the new colors on their next `gh:apply-labels`.

## References

Fleet-wide label-axis coloring consistency. No tracked issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🌲 cl1-pine |
| `agent_session_id` | 3daebbe0-b4d1-49e1-a0af-ff3146b68c5d |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.179 |
| `agent_runtime` | Claude Code 2.1.179 |
| `agent_model` | claude-opus-4-8 |
| `runtime_profile` | /nix/store/wbb5q5n2gbk751hcyr5ndp0zrmar602x-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/3i12shfqx3wqzq2di3jy1m7f8fn4prmm-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | dotfiles/schickling-assistant/2026-06-19-misc3 |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->