### PR TITLE
fix(labels): encode GitHub label path segments

### DIFF
--- a/nix/devenv-modules/gh-labels.nix
+++ b/nix/devenv-modules/gh-labels.nix
@@ -35,6 +35,10 @@ let
       MIGRATIONS=$(jq -c '.legacyMigrations // [] | .[]' .github/labels.json)
       LIVE=$(gh api "repos/$REPO/labels" --paginate)
 
+      label_path_segment() {
+        jq -rn --arg label "$1" '$label | @uri'
+      }
+
       # 1. Upsert each desired label (create or patch on color/description drift)
       while IFS= read -r d; do
         name=$(jq -r .name <<<"$d")
@@ -44,7 +48,7 @@ let
         if [ -z "$existing" ]; then
           gh api "repos/$REPO/labels" --method POST -f name="$name" -f color="$color" -f description="$desc"
         elif [ "$(jq -r .color <<<"$existing")" != "$color" ] || [ "$(jq -r .description <<<"$existing")" != "$desc" ]; then
-          gh api "repos/$REPO/labels/$name" --method PATCH -f color="$color" -f description="$desc"
+          gh api "repos/$REPO/labels/$(label_path_segment "$name")" --method PATCH -f color="$color" -f description="$desc"
         fi
       done <<<"$LABELS"
 
@@ -53,9 +57,9 @@ let
         [ -z "$m" ] && continue
         from=$(jq -r .from <<<"$m")
         to=$(jq -r .to <<<"$m")
-        gh api "repos/$REPO/issues?labels=$from&state=all" --paginate --jq '.[].number' | while read -r n; do
+        gh api "repos/$REPO/issues?labels=$(label_path_segment "$from")&state=all" --paginate --jq '.[].number' | while read -r n; do
           gh api "repos/$REPO/issues/$n/labels" --method POST -f "labels[]=$to"
-          gh api "repos/$REPO/issues/$n/labels/$from" --method DELETE 2>/dev/null || true
+          gh api "repos/$REPO/issues/$n/labels/$(label_path_segment "$from")" --method DELETE 2>/dev/null || true
         done
       done <<<"$MIGRATIONS"
 
@@ -65,7 +69,7 @@ let
         if jq -e --arg n "$name" 'select(.from == $n)' <<<"$MIGRATIONS" >/dev/null 2>&1; then
           echo "skip delete $name - still has pending migration"
         else
-          gh api "repos/$REPO/labels/$name" --method DELETE 2>/dev/null || true
+          gh api "repos/$REPO/labels/$(label_path_segment "$name")" --method DELETE 2>/dev/null || true
         fi
       done <<<"$DEPRECATED"
 
@@ -85,6 +89,10 @@ let
       DEPRECATED=$(jq -r '.deprecated // [] | .[]' .github/labels.json)
       MIGRATIONS=$(jq -c '.legacyMigrations // [] | .[]' .github/labels.json)
       LIVE=$(gh api "repos/$REPO/labels" --paginate)
+
+      label_path_segment() {
+        jq -rn --arg label "$1" '$label | @uri'
+      }
 
       drift=0
 
@@ -108,7 +116,7 @@ let
         [ -z "$m" ] && continue
         from=$(jq -r .from <<<"$m")
         to=$(jq -r .to <<<"$m")
-        count=$(gh api "repos/$REPO/issues?labels=$from&state=all" --paginate --jq '.[].number' | wc -l | tr -d ' ')
+        count=$(gh api "repos/$REPO/issues?labels=$(label_path_segment "$from")&state=all" --paginate --jq '.[].number' | wc -l | tr -d ' ')
         if [ "$count" -gt 0 ]; then
           printf 'would-migrate %s -> %s (%d issues)\n' "$from" "$to" "$count"
           drift=$((drift + 1))


### PR DESCRIPTION
**Problem**

The reusable GitHub label IaC tasks build REST paths with raw label names for PATCH/DELETE and issue-label removal. Labels with `/`, such as `hy:req/enroll` and `hy:state/ci-admitted`, are valid GitHub labels but unsafe as raw path segments.

**Goal**

Make `gh:apply-labels` and `gh:check-labels` work correctly for slash-containing labels while preserving existing create/update/delete/migration behavior.

**Decisions**

Use `jq @uri` inside the generated shell scripts to encode label names only when they are used as URL path/query segments. Label creation still sends the raw name as form data.

**Verification**

- `git diff --check`
- `devenv tasks list | rg "gh:(apply|check)-labels"` built both `gh-apply-labels` and `gh-check-labels` successfully.

**Complexity**

No new abstraction; this is a small encoding helper in each generated shell script.

**Concerns**

Live reconciliation was not run from this PR. The change is intended to support the Hypermerge strict-label rollout where slash labels become canonical.

**Friction & bottlenecks**

The label-IaC module lives in effect-utils while the rollout is in dotfiles, so the fix must land cross-repo rather than inside the dotfiles PR.

**Follow-ups**

- Use this fix during the Hypermerge label migration in `schickling/dotfiles#1075`.

**References**

Refs schickling/dotfiles#1072
Refs schickling/dotfiles#1075

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🗻 co2-peak |
| `agent_session_id` | e9966c75-0cc7-4a0b-a8e0-a6b2f5c164f0 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.140.0 |
| `agent_runtime` | Codex CLI 0.140.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/wbb5q5n2gbk751hcyr5ndp0zrmar602x-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/3i12shfqx3wqzq2di3jy1m7f8fn4prmm-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | dotfiles/schickling/2026-06-17-hypermerge-rollout |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->