### PR TITLE
fix(labels): encode label path segments

### DIFF
--- a/nix/devenv-modules/gh-labels.nix
+++ b/nix/devenv-modules/gh-labels.nix
@@ -35,6 +35,10 @@ let
       MIGRATIONS=$(jq -c '.legacyMigrations // [] | .[]' .github/labels.json)
       LIVE=$(gh api "repos/$REPO/labels" --paginate)
 
+      label_path_segment() {
+        jq -rn --arg label "$1" '$label | @uri'
+      }
+
       # 1. Upsert each desired label (create or patch on color/description drift)
       while IFS= read -r d; do
         name=$(jq -r .name <<<"$d")
@@ -44,7 +48,7 @@ let
         if [ -z "$existing" ]; then
           gh api "repos/$REPO/labels" --method POST -f name="$name" -f color="$color" -f description="$desc"
         elif [ "$(jq -r .color <<<"$existing")" != "$color" ] || [ "$(jq -r .description <<<"$existing")" != "$desc" ]; then
-          gh api "repos/$REPO/labels/$name" --method PATCH -f color="$color" -f description="$desc"
+          gh api "repos/$REPO/labels/$(label_path_segment "$name")" --method PATCH -f color="$color" -f description="$desc"
         fi
       done <<<"$LABELS"
 
@@ -53,9 +57,9 @@ let
         [ -z "$m" ] && continue
         from=$(jq -r .from <<<"$m")
         to=$(jq -r .to <<<"$m")
-        gh api "repos/$REPO/issues?labels=$from&state=all" --paginate --jq '.[].number' | while read -r n; do
+        gh api "repos/$REPO/issues?labels=$(label_path_segment "$from")&state=all" --paginate --jq '.[].number' | while read -r n; do
           gh api "repos/$REPO/issues/$n/labels" --method POST -f "labels[]=$to"
-          gh api "repos/$REPO/issues/$n/labels/$from" --method DELETE 2>/dev/null || true
+          gh api "repos/$REPO/issues/$n/labels/$(label_path_segment "$from")" --method DELETE 2>/dev/null || true
         done
       done <<<"$MIGRATIONS"
 
@@ -65,7 +69,7 @@ let
         if jq -e --arg n "$name" 'select(.from == $n)' <<<"$MIGRATIONS" >/dev/null 2>&1; then
           echo "skip delete $name - still has pending migration"
         else
-          gh api "repos/$REPO/labels/$name" --method DELETE 2>/dev/null || true
+          gh api "repos/$REPO/labels/$(label_path_segment "$name")" --method DELETE 2>/dev/null || true
         fi
       done <<<"$DEPRECATED"
 
@@ -85,6 +89,10 @@ let
       DEPRECATED=$(jq -r '.deprecated // [] | .[]' .github/labels.json)
       MIGRATIONS=$(jq -c '.legacyMigrations // [] | .[]' .github/labels.json)
       LIVE=$(gh api "repos/$REPO/labels" --paginate)
+
+      label_path_segment() {
+        jq -rn --arg label "$1" '$label | @uri'
+      }
 
       drift=0
 
@@ -108,7 +116,7 @@ let
         [ -z "$m" ] && continue
         from=$(jq -r .from <<<"$m")
         to=$(jq -r .to <<<"$m")
-        count=$(gh api "repos/$REPO/issues?labels=$from&state=all" --paginate --jq '.[].number' | wc -l | tr -d ' ')
+        count=$(gh api "repos/$REPO/issues?labels=$(label_path_segment "$from")&state=all" --paginate --jq '.[].number' | wc -l | tr -d ' ')
         if [ "$count" -gt 0 ]; then
           printf 'would-migrate %s -> %s (%d issues)\n' "$from" "$to" "$count"
           drift=$((drift + 1))


### PR DESCRIPTION
**Problem**
GitHub label names can contain `/`, but the shared `gh-labels` devenv module interpolated raw label names into REST path segments for PATCH/DELETE operations. That makes strict Hypermerge labels such as `hy:req/enroll` and `hy:state/ci-admitted` unsafe for label reconciliation.

**Goal**
Make `.github/labels.json` reconciliation handle slash-containing labels consistently for upsert, migration, and deprecated-label deletion.

**Decisions**
Encode label names with jq `@uri` only where they are used as URL path or query components. Keep POST bodies unchanged so GitHub stores the canonical human-readable label name.

**Verification**
- `git diff --check origin/main...HEAD -- nix/devenv-modules/gh-labels.nix` passed.
- `nix eval --impure --expr ...` confirmed the module exposes `gh:apply-labels` and `gh:check-labels`.
- `nix build --impure --expr ... --no-link` forced both generated task executables to build successfully.

**Complexity**
No new abstraction beyond a tiny local URI-encoding helper in each generated shell application.

**Concerns**
The module still relies on the GitHub REST label migration path and `gh api`; this PR only fixes escaping, not broader reconciliation semantics.

**Friction & bottlenecks**
The repository does not expose a default dev shell in this checkout, so validation used direct Nix evaluation/build of the generated task executables.

**Follow-ups**
Use this upstream SHA in the Hypermerge rollout branch before relying on slash-label deletion in downstream label cleanup.

**References**
Refs schickling/dotfiles#1072
Refs schickling/dotfiles#1075

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🗻 co2-peak |
| `agent_session_id` | e9966c75-0cc7-4a0b-a8e0-a6b2f5c164f0 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.140.0 |
| `agent_runtime` | Codex CLI 0.140.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/wbb5q5n2gbk751hcyr5ndp0zrmar602x-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/3i12shfqx3wqzq2di3jy1m7f8fn4prmm-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | 1d5846a92beadd899cc321b98d77ef0467434678/schickling/2026-06-20-gh-labels-slash-encoding |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->