### PR TITLE
feat(megarepo): guard worktree archive/reap against in-use worktrees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- **@overeng/megarepo**: Guard the store worktree archive/reap path against
+  in-use worktrees. The cold-GC liveness signal only checks whether a worktree
+  is referenced by some workspace manifest; it never checked whether a live OS
+  process is currently working inside it, so a background `mr store gc` could
+  rename an actively-used worktree into `.archive/` (its cwd silently following
+  the inode) and strip it out from under a live coding-agent session. New
+  `src/lib/store-inuse.ts` adds a Linux `/proc`-based probe — a pure
+  `classifyInUse` seam plus an effectful reader that scans each pid's cwd (and
+  optionally open fds), excludes the gc process and its descendants via a PPid
+  walk, and degrades to "unknown ⇒ keep" on hosts without `/proc`. The probe is
+  wired as an orthogonal veto into all three destructive sites in
+  `mr store gc` (`archiveWorktree`, `archiveRefMismatchWorktree`, `reapArchive`),
+  under the existing `withWorktreeLock` re-check: if a live process holds the
+  worktree the result is `kept` with reason `process-in-use` and a
+  `megarepo/store/gc/inuse-veto` span recording the holding pid/path for
+  attribution. Conservative direction throughout (in doubt → keep).
+
 - **@overeng/genie**: Make `findGenieFiles` return stable repo-relative
   `.genie.ts` paths, with generation/check orchestration resolving them at the
   filesystem boundary. Discovery tests now assert through a canonical-relative

--- a/packages/@overeng/megarepo/src/cli/commands/store/mod.ts
+++ b/packages/@overeng/megarepo/src/cli/commands/store/mod.ts
@@ -36,6 +36,7 @@ import {
   recordObservations,
 } from '../../../lib/store-gc-observations.ts'
 import { validateStoreMembers, fixStoreIssues } from '../../../lib/store-hygiene.ts'
+import { readWorktreeInUse, type InUseHolder } from '../../../lib/store-inuse.ts'
 import {
   collectStoreLiveSet,
   isPathProtected,
@@ -579,6 +580,50 @@ const reReconcileLiveSet = ({
   })
 
 /**
+ * In-use veto re-check for a destructive archive/reap site (orthogonal to the
+ * live-set veto).
+ *
+ * The live-set veto (`isPathProtected`) only asks whether the worktree is in
+ * some workspace's reconciled manifest. This asks the strictly stronger,
+ * independent question — is a live OS process actually working inside it (cwd /
+ * open file) — so a worktree that is absent from every manifest but actively
+ * occupied by a session is still kept.
+ *
+ * Conservative direction: a host without `/proc` reports `unknown`, which is
+ * treated as in-use (KEEP). Returns `Some(holder)` when the site must KEEP and
+ * skip the destructive step; `None` when it is safe to proceed. On a real veto
+ * the holding `pid`/`path` are recorded on a `megarepo/store/gc/inuse-veto` span
+ * for attribution.
+ */
+const inUseVeto = ({
+  worktreePath,
+}: {
+  worktreePath: AbsoluteDirPath
+}): Effect.Effect<Option.Option<InUseHolder>, never, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const result = yield* readWorktreeInUse({ worktreePath })
+    if (result._tag === 'free') return Option.none()
+    const holder: InUseHolder =
+      result._tag === 'in-use'
+        ? result.holder
+        : // `unknown` (no /proc): keep conservatively; attribute the reason as the
+          // holder path so the veto span still carries why we kept.
+          { pid: -1, path: `unknown: ${result.reason}` }
+    yield* LibObservability.withInUseVetoSpan({
+      worktreePath,
+      holderPid: holder.pid,
+      holderPath: holder.path,
+    })(Effect.void)
+    return Option.some(holder)
+  })
+
+/** Render an in-use holder into the free-form `message` detail for a kept result. */
+const inUseMessage = (holder: InUseHolder): string =>
+  holder.pid >= 0
+    ? `live process pid ${holder.pid} has cwd/handle inside the worktree (${holder.path})`
+    : `in-use state could not be determined, kept conservatively (${holder.path})`
+
+/**
  * Cold reclamation for ONE repo's named worktrees (decisions 0001–0010).
  *
  * Fetch the bare first (failure ⇒ keep ALL this repo's named worktrees — the
@@ -779,6 +824,12 @@ const coldReclaimRepo = ({
               ) {
                 return { _tag: 'kept-live' as const }
               }
+              // Orthogonal in-use veto: refuse to move the directory out from
+              // under a live process whose cwd/handle is inside it.
+              const holder = yield* inUseVeto({ worktreePath: worktree.path })
+              if (Option.isSome(holder) === true) {
+                return { _tag: 'kept-in-use' as const, holder: holder.value }
+              }
               const outcome = yield* archiveRefMismatchWorktree({
                 repoRoot: repoFullPath,
                 bareRepoPath,
@@ -806,6 +857,16 @@ const coldReclaimRepo = ({
 
         if (archiveOutcome._tag === 'kept-live') {
           results.push(keepRefMismatch(`HEAD is '${actualHeadBranch}' and path is live`))
+        } else if (archiveOutcome._tag === 'kept-in-use') {
+          results.push(
+            coldResult({
+              target,
+              status: 'kept',
+              reason: 'process-in-use',
+              message: inUseMessage(archiveOutcome.holder),
+              ...refMismatchMeta,
+            }),
+          )
         } else if (archiveOutcome._tag === 'error') {
           results.push(
             coldResult({
@@ -893,6 +954,12 @@ const coldReclaimRepo = ({
             if (isPathProtected({ liveSet: freshLiveSet, path: worktree.path }) === true) {
               return { _tag: 'kept-live' as const }
             }
+            // Orthogonal in-use veto: refuse to archive a worktree a live
+            // process is currently working inside (cwd/handle).
+            const holder = yield* inUseVeto({ worktreePath: worktree.path })
+            if (Option.isSome(holder) === true) {
+              return { _tag: 'kept-in-use' as const, holder: holder.value }
+            }
             const outcome = yield* archiveWorktree({
               repoRoot: repoFullPath,
               bareRepoPath,
@@ -920,6 +987,15 @@ const coldReclaimRepo = ({
 
       if (archiveOutcome._tag === 'kept-live') {
         results.push(coldResult({ target, status: 'kept', reason: 'live' }))
+      } else if (archiveOutcome._tag === 'kept-in-use') {
+        results.push(
+          coldResult({
+            target,
+            status: 'kept',
+            reason: 'process-in-use',
+            message: inUseMessage(archiveOutcome.holder),
+          }),
+        )
       } else if (archiveOutcome._tag === 'error') {
         // Only a PRE-move failure reaches here (post-move steps are best-effort
         // and reported as warnings, never errors), so the original worktree is
@@ -980,6 +1056,13 @@ const coldReclaimRepo = ({
             if (isPathProtected({ liveSet: freshLiveSet, path: entry.path }) === true) {
               return { _tag: 'kept-live' as const }
             }
+            // Orthogonal in-use veto: a session whose cwd followed an earlier
+            // archive rename can be sitting in the `.archive/` entry itself —
+            // reaping it would yank that cwd. Keep if a live process is inside.
+            const holder = yield* inUseVeto({ worktreePath: entry.path })
+            if (Option.isSome(holder) === true) {
+              return { _tag: 'kept-in-use' as const, holder: holder.value }
+            }
             yield* reapArchive({ bareRepoPath, path: entry.path })
             return { _tag: 'reaped' as const }
           }),
@@ -995,6 +1078,15 @@ const coldReclaimRepo = ({
 
       if (reapOutcome._tag === 'kept-live') {
         results.push(coldResult({ target: reapTarget, status: 'kept', reason: 'live' }))
+      } else if (reapOutcome._tag === 'kept-in-use') {
+        results.push(
+          coldResult({
+            target: reapTarget,
+            status: 'kept',
+            reason: 'process-in-use',
+            message: inUseMessage(reapOutcome.holder),
+          }),
+        )
       } else if (reapOutcome._tag === 'error') {
         results.push(
           coldResult({

--- a/packages/@overeng/megarepo/src/lib/observability.ts
+++ b/packages/@overeng/megarepo/src/lib/observability.ts
@@ -765,3 +765,57 @@ export const withAssessLosslessSpan = (worktreePath: string) =>
     operation: assessLosslessOperation,
     attributes: { label: 'lossless', worktreePath },
   })
+
+const inUseProbeAttrs = OtelAttrs.defineSync(
+  Schema.Struct({
+    label: Schema.NonEmptyString.pipe(OtelAttr.spanLabel()),
+    worktreePath: Schema.String.pipe(OtelAttr.key({ key: 'worktreePath' })),
+  }),
+)
+
+const inUseProbeOperation = OtelOperation.define({
+  name: 'megarepo/store/gc/inuse-probe',
+  attributes: inUseProbeAttrs,
+  label: ({ label }) => label,
+})
+
+/** Wrap the live-process in-use probe (`/proc` scan) in a `megarepo/store/gc/inuse-probe` span. */
+export const withInUseProbeSpan = (worktreePath: string) =>
+  trustedWith({
+    operation: inUseProbeOperation,
+    attributes: { label: 'inuse-probe', worktreePath },
+  })
+
+const inUseVetoAttrs = OtelAttrs.defineSync(
+  Schema.Struct({
+    label: Schema.NonEmptyString.pipe(OtelAttr.spanLabel()),
+    worktreePath: Schema.String.pipe(OtelAttr.key({ key: 'worktreePath' })),
+    holderPid: Schema.Number.pipe(OtelAttr.key({ key: 'megarepo.store.inuse.holder_pid' })),
+    holderPath: Schema.String.pipe(OtelAttr.key({ key: 'megarepo.store.inuse.holder_path' })),
+  }),
+)
+
+const inUseVetoOperation = OtelOperation.define({
+  name: 'megarepo/store/gc/inuse-veto',
+  attributes: inUseVetoAttrs,
+  label: ({ label }) => label,
+})
+
+/**
+ * Wrap the in-use VETO of a destructive archive/reap in a
+ * `megarepo/store/gc/inuse-veto` span, carrying the holding `pid` and `path` so
+ * the attribution the RCA needed is queryable.
+ */
+export const withInUseVetoSpan = ({
+  worktreePath,
+  holderPid,
+  holderPath,
+}: {
+  readonly worktreePath: string
+  readonly holderPid: number
+  readonly holderPath: string
+}) =>
+  trustedWith({
+    operation: inUseVetoOperation,
+    attributes: { label: 'inuse-veto', worktreePath, holderPid, holderPath },
+  })

--- a/packages/@overeng/megarepo/src/lib/store-inuse.integration.test.ts
+++ b/packages/@overeng/megarepo/src/lib/store-inuse.integration.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Integration tests for the live-process in-use probe (Linux `/proc`).
+ *
+ * Spawns a REAL holder process with its cwd inside a temp "worktree" directory
+ * and asserts {@link readWorktreeInUse} reports it as in-use; moves the holder's
+ * cwd out and asserts it reports free. Skipped on hosts without `/proc`.
+ *
+ * The holder is a child of the vitest runner, so it would be excluded if the
+ * probe were called with the runner (or pid 1 — every process descends from
+ * init) as `selfPid`. We instead pass `selfPid` = the pid of a SIBLING stand-in
+ * process: a sibling is never an ancestor of the holder, so the descendant walk
+ * from the holder climbs its PPid chain and never encounters it — the holder
+ * stays observable. This faithfully models production, where gc is a separate
+ * process tree, not an ancestor of the live session.
+ */
+
+import { spawn, type ChildProcess } from 'node:child_process'
+import { existsSync } from 'node:fs'
+
+import { FileSystem } from '@effect/platform'
+import { NodeContext } from '@effect/platform-node'
+import { describe, it } from '@effect/vitest'
+import { Effect } from 'effect'
+import { expect } from 'vitest'
+
+import { EffectPath } from '@overeng/effect-path'
+
+import { readWorktreeInUse } from './store-inuse.ts'
+
+const hasProc = existsSync('/proc')
+
+/** Spawn a long-lived `sleep` whose cwd is `cwd`; resolve once it is observable. */
+const spawnHolder = (cwd: string): Promise<ChildProcess> =>
+  new Promise((resolve, reject) => {
+    const child = spawn('sleep', ['120'], { cwd, stdio: 'ignore' })
+    child.on('error', reject)
+    if (child.pid === undefined) {
+      reject(new Error('holder failed to spawn'))
+      return
+    }
+    resolve(child)
+  })
+
+/** Poll until `/proc/<pid>/cwd` resolves (the process is scheduled + cwd set). */
+const waitForCwd = (pid: number): Promise<void> =>
+  new Promise((resolve, reject) => {
+    const deadline = Date.now() + 5000
+    const tick = () => {
+      if (existsSync(`/proc/${pid}/cwd`) === true) {
+        resolve()
+        return
+      }
+      if (Date.now() > deadline) {
+        reject(new Error(`holder pid ${pid} never appeared in /proc`))
+        return
+      }
+      setTimeout(tick, 20)
+    }
+    tick()
+  })
+
+const run = <A, E>(effect: Effect.Effect<A, E, FileSystem.FileSystem>) =>
+  Effect.runPromise(effect.pipe(Effect.provide(NodeContext.layer)))
+
+describe.skipIf(hasProc === false)('store-inuse (integration, /proc)', () => {
+  it('reports in-use when a live process holds a descendant as cwd, free once it moves out', async () => {
+    const { worktreePath, sibling, holder } = await run(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem
+        const tmp = yield* fs.makeTempDirectory()
+        const worktreePath = EffectPath.unsafe.absoluteDir(`${tmp}/refs/heads/feature/x/`)
+        const inner = EffectPath.ops.join(worktreePath, EffectPath.unsafe.relativeDir('src/'))
+        // A sibling that shares the worktree's string prefix — must NOT match.
+        const sibling = EffectPath.unsafe.absoluteDir(`${tmp}/refs/heads/feature/x.archive-old/`)
+        yield* fs.makeDirectory(inner, { recursive: true })
+        yield* fs.makeDirectory(sibling, { recursive: true })
+        return { worktreePath, inner, sibling }
+      }),
+    ).then(async ({ worktreePath, inner, sibling }) => {
+      const holder = await spawnHolder(inner)
+      await waitForCwd(holder.pid!)
+      return { worktreePath, sibling, holder }
+    })
+
+    // A SIBLING stand-in (shares the runner as parent, so not an ancestor of the
+    // holder) plays the role of the gc process: passing its pid as `selfPid`
+    // leaves the holder observable, the way real gc would observe a live session.
+    const standIn = await spawnHolder('/')
+    const selfPid = standIn.pid!
+    try {
+      const inUse = await run(readWorktreeInUse({ worktreePath, selfPid }))
+      expect(inUse._tag).toBe('in-use')
+      if (inUse._tag === 'in-use') {
+        expect(inUse.holder.pid).toBe(holder.pid)
+        expect(inUse.holder.path.startsWith(worktreePath.replace(/\/$/, ''))).toBe(true)
+      }
+
+      // A worktree the holder is NOT inside (the .archive-old sibling) reads free.
+      const siblingResult = await run(readWorktreeInUse({ worktreePath: sibling, selfPid }))
+      expect(siblingResult._tag).toBe('free')
+
+      // After the holder dies, the worktree reads free.
+      holder.kill('SIGKILL')
+      await new Promise<void>((resolve) => holder.on('exit', () => resolve()))
+      const afterKill = await run(readWorktreeInUse({ worktreePath, selfPid }))
+      expect(afterKill._tag).toBe('free')
+    } finally {
+      holder.kill('SIGKILL')
+      standIn.kill('SIGKILL')
+    }
+  })
+
+  it('excludes the current process so the gc process never self-vetoes', async () => {
+    // With selfPid = the spawning runner, the holder (its descendant) is excluded.
+    const { worktreePath, holder } = await run(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem
+        const tmp = yield* fs.makeTempDirectory()
+        const worktreePath = EffectPath.unsafe.absoluteDir(`${tmp}/wt/`)
+        yield* fs.makeDirectory(worktreePath, { recursive: true })
+        return { worktreePath }
+      }),
+    ).then(async ({ worktreePath }) => {
+      const holder = await spawnHolder(worktreePath.replace(/\/$/, ''))
+      await waitForCwd(holder.pid!)
+      return { worktreePath, holder }
+    })
+
+    try {
+      const result = await run(readWorktreeInUse({ worktreePath, selfPid: process.pid }))
+      expect(result._tag).toBe('free')
+    } finally {
+      holder.kill('SIGKILL')
+    }
+  })
+})

--- a/packages/@overeng/megarepo/src/lib/store-inuse.ts
+++ b/packages/@overeng/megarepo/src/lib/store-inuse.ts
@@ -1,0 +1,281 @@
+/**
+ * In-use guard for store worktrees.
+ *
+ * The cold-GC liveness signal (`store-liveness.ts` / `classifyStoreWorktreePolicy`)
+ * answers "is this worktree referenced by some workspace's reconciled manifest?".
+ * That is NOT the same as "is a live OS process currently working inside it":
+ * a freshly-created or repinned-but-unregistered worktree can be absent from
+ * every manifest while a coding-agent session sits in it with its cwd there.
+ *
+ * Archiving such a worktree is a directory rename, and on Linux a rename is
+ * transparent to a process already in that directory — its cwd silently follows
+ * the inode into `.archive/`, and the subsequent `git` bookkeeping (detach +
+ * branch free, then a `mr apply` re-checkout) breaks the session mid-flight.
+ * This module is the orthogonal, strictly stronger guard: before any destructive
+ * archive/reap, refuse if a live process has the worktree (or a descendant) as
+ * its cwd (or, optionally, an open file handle).
+ *
+ * Two seams, mirroring `store-gc-observations.ts` (pure `nextObservationLedger`
+ * vs effectful IO):
+ * - {@link classifyInUse} — PURE: given the worktree path, the already-read
+ *   `{ pid, path }` list, and the pids to exclude, return the FIRST matching
+ *   holder (`Option`) so the caller can attribute the veto. Unit-tested.
+ * - {@link readWorktreeInUse} — the effectful Linux `/proc` reader that produces
+ *   that list and computes the exclude set (current process + its descendants),
+ *   then calls the pure classifier under an OTel span.
+ *
+ * Conservative direction (in doubt → KEEP): on a host without `/proc` (e.g.
+ * macOS) the reader returns `{ _tag: 'unknown' }`, which the caller MUST treat
+ * as in-use (do not archive). Per-pid permission/race errors (`EACCES`/`ESRCH`)
+ * skip that pid; they never fail the whole check.
+ */
+
+import { FileSystem } from '@effect/platform'
+import { Effect, Option } from 'effect'
+
+import type { AbsoluteDirPath } from '@overeng/effect-path'
+
+import * as Observability from './observability.ts'
+
+/** One process's path of interest (its cwd, or an open file/fd target). */
+export interface ProcPath {
+  /** The owning process id. */
+  readonly pid: number
+  /** An absolute path the process holds (cwd or an open file), as read from `/proc`. */
+  readonly path: string
+}
+
+/** A live process found holding the worktree (or a descendant) — the veto's attribution. */
+export interface InUseHolder {
+  /** The pid working inside the worktree. */
+  readonly pid: number
+  /** The held path (cwd or open file) that falls under the worktree. */
+  readonly path: string
+}
+
+/**
+ * Result of the in-use probe.
+ *
+ * - `in-use` — a live, non-excluded process holds the worktree; carries the
+ *   first {@link InUseHolder} for attribution.
+ * - `free` — no live process holds it (safe to archive, w.r.t. this guard).
+ * - `unknown` — the probe could not run (no `/proc` on this host); the caller
+ *   MUST treat this conservatively as KEEP.
+ */
+export type InUseResult =
+  | { readonly _tag: 'in-use'; readonly holder: InUseHolder }
+  | { readonly _tag: 'free' }
+  | { readonly _tag: 'unknown'; readonly reason: string }
+
+const stripTrailingSlashes = (path: string): string => path.replace(/\/+$/u, '')
+
+/**
+ * True if `candidate` is the worktree itself or strictly nested under it.
+ *
+ * Both sides are normalized to a no-trailing-slash form, then the test is
+ * `candidate === wt || candidate.startsWith(wt + '/')`. The explicit `+ '/'`
+ * boundary is what keeps a sibling like `<wt>.archive-old` (or `<wt>-2`) from
+ * matching by raw string prefix.
+ */
+export const isPathInsideWorktree = ({
+  worktreePath,
+  candidate,
+}: {
+  readonly worktreePath: string
+  readonly candidate: string
+}): boolean => {
+  const wt = stripTrailingSlashes(worktreePath)
+  const cand = stripTrailingSlashes(candidate)
+  return cand === wt || cand.startsWith(`${wt}/`)
+}
+
+/**
+ * Pure in-use classifier (the unit-tested seam).
+ *
+ * Returns the FIRST `{ pid, path }` whose `path` is the worktree or a descendant
+ * and whose `pid` is not in `excludePids`. `excludePids` is supplied by the
+ * caller (the IO layer computes "current process + its descendants") so this
+ * stays pure AND so a test can drive it with an explicit exclude set — the IO
+ * reader must NOT bake the exclusion in, or an integration test's holder process
+ * (itself a descendant of the test runner) would be silently excluded.
+ */
+export const classifyInUse = ({
+  worktreePath,
+  procPaths,
+  excludePids,
+}: {
+  readonly worktreePath: string
+  readonly procPaths: ReadonlyArray<ProcPath>
+  readonly excludePids: ReadonlySet<number>
+}): Option.Option<InUseHolder> => {
+  for (const { pid, path } of procPaths) {
+    if (excludePids.has(pid) === true) continue
+    if (isPathInsideWorktree({ worktreePath, candidate: path }) === true) {
+      return Option.some({ pid, path })
+    }
+  }
+  return Option.none()
+}
+
+const PROC_ROOT = '/proc'
+
+/** Parse a `/proc` directory entry name into a numeric pid (non-numeric ⇒ none). */
+const parsePid = (name: string): Option.Option<number> => {
+  if (/^\d+$/u.test(name) === false) return Option.none()
+  const pid = Number.parseInt(name, 10)
+  return Number.isInteger(pid) === true && pid > 0 ? Option.some(pid) : Option.none()
+}
+
+/**
+ * Read one `/proc/<pid>` process's paths of interest.
+ *
+ * Always reads `cwd` (the load-bearing signal that matches the incident: a cwd
+ * that follows the archive rename). When `scanOpenFiles` is set, also reads the
+ * `fd/*` symlink targets so a process with an open file handle inside the
+ * worktree (but cwd elsewhere) is still caught. Every read is tolerant: a
+ * vanished/permission-denied pid yields no paths rather than failing.
+ */
+const readProcPaths = ({
+  pid,
+  scanOpenFiles,
+}: {
+  readonly pid: number
+  readonly scanOpenFiles: boolean
+}): Effect.Effect<ReadonlyArray<ProcPath>, never, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem
+    const paths: Array<ProcPath> = []
+
+    const cwd = yield* fs
+      .readLink(`${PROC_ROOT}/${pid}/cwd`)
+      .pipe(Effect.catchAll(() => Effect.succeed(null)))
+    if (cwd !== null) paths.push({ pid, path: cwd })
+
+    if (scanOpenFiles === true) {
+      const fdDir = `${PROC_ROOT}/${pid}/fd`
+      const fds = yield* fs
+        .readDirectory(fdDir)
+        .pipe(Effect.catchAll(() => Effect.succeed([] as ReadonlyArray<string>)))
+      for (const fd of fds) {
+        const target = yield* fs
+          .readLink(`${fdDir}/${fd}`)
+          .pipe(Effect.catchAll(() => Effect.succeed(null)))
+        // Only absolute filesystem paths matter; `/proc` fd links can point at
+        // sockets/pipes (`socket:[…]`) etc., which never fall under a worktree.
+        if (target !== null && target.startsWith('/') === true) paths.push({ pid, path: target })
+      }
+    }
+
+    return paths
+  })
+
+/** Read `PPid:` from `/proc/<pid>/status` (the only field we need for the chain walk). */
+const readPpid = ({
+  pid,
+}: {
+  readonly pid: number
+}): Effect.Effect<Option.Option<number>, never, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem
+    const content = yield* fs
+      .readFileString(`${PROC_ROOT}/${pid}/status`)
+      .pipe(Effect.catchAll(() => Effect.succeed(null)))
+    if (content === null) return Option.none()
+    const match = content.match(/^PPid:\s*(\d+)$/mu)
+    if (match?.[1] === undefined) return Option.none()
+    const ppid = Number.parseInt(match[1], 10)
+    return Number.isInteger(ppid) === true ? Option.some(ppid) : Option.none()
+  })
+
+/**
+ * Decide whether `pid` is the current process or one of its descendants.
+ *
+ * Walks the PPid chain UPWARD from `pid`: hit `selfPid` ⇒ exclude (it is us or
+ * our child); hit pid 0/1 or an unreadable link ⇒ keep (an unrelated process).
+ * Walking up from a single matched pid is far cheaper than materializing the
+ * whole process tree, and the walk only runs for the rare in-worktree matches.
+ * A `seen` set guards against a pathological cycle.
+ */
+const isSelfOrDescendant = ({
+  pid,
+  selfPid,
+}: {
+  readonly pid: number
+  readonly selfPid: number
+}): Effect.Effect<boolean, never, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const seen = new Set<number>()
+    let current = pid
+    while (current > 1 && seen.has(current) === false) {
+      if (current === selfPid) return true
+      seen.add(current)
+      const ppid = yield* readPpid({ pid: current })
+      if (Option.isNone(ppid) === true) return false
+      current = ppid.value
+    }
+    return current === selfPid
+  })
+
+/**
+ * Effectful in-use probe for one worktree (the IO seam).
+ *
+ * On Linux: enumerate `/proc`, read each pid's cwd (and optionally open files),
+ * run the pure {@link classifyInUse} with an EMPTY exclude set to find any
+ * candidate holder, then — only if a candidate exists — exclude the current
+ * process and its descendants via a PPid-chain walk so the gc process itself
+ * (and the git children it may have spawned with a cwd inside the worktree)
+ * never self-veto. The first surviving holder ⇒ `in-use`.
+ *
+ * On a host without `/proc` ⇒ `{ _tag: 'unknown' }` (caller treats as KEEP).
+ *
+ * `selfPid` defaults to `process.pid`; it is injectable so a test can pin it.
+ */
+export const readWorktreeInUse = ({
+  worktreePath,
+  scanOpenFiles = false,
+  selfPid = process.pid,
+}: {
+  readonly worktreePath: AbsoluteDirPath
+  readonly scanOpenFiles?: boolean
+  readonly selfPid?: number
+}): Effect.Effect<InUseResult, never, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem
+
+    const procExists = yield* fs
+      .exists(PROC_ROOT)
+      .pipe(Effect.catchAll(() => Effect.succeed(false)))
+    if (procExists === false) {
+      return { _tag: 'unknown' as const, reason: 'no /proc on this host' }
+    }
+
+    const entries = yield* fs
+      .readDirectory(PROC_ROOT)
+      .pipe(Effect.catchAll(() => Effect.succeed([] as ReadonlyArray<string>)))
+    const pids = entries.flatMap((name) => Option.getOrElse(parsePid(name), () => [] as never))
+
+    // Read all candidate paths. Self-exclusion is NOT applied here (it is the
+    // classifier's `excludePids`), so the read stays a pure enumeration.
+    const procPaths: Array<ProcPath> = []
+    for (const pid of pids) {
+      const paths = yield* readProcPaths({ pid, scanOpenFiles })
+      for (const p of paths) procPaths.push(p)
+    }
+
+    // Find the first in-worktree candidate ignoring nobody, then walk only that
+    // (and any subsequent) candidate's ancestry to drop self+descendants. This
+    // keeps the expensive PPid walk off the common no-match path.
+    const excludePids = new Set<number>()
+    for (;;) {
+      const candidate = classifyInUse({ worktreePath, procPaths, excludePids })
+      if (Option.isNone(candidate) === true) break
+      const holder = candidate.value
+      const excluded = yield* isSelfOrDescendant({ pid: holder.pid, selfPid })
+      if (excluded === false) {
+        return { _tag: 'in-use' as const, holder }
+      }
+      excludePids.add(holder.pid)
+    }
+
+    return { _tag: 'free' as const }
+  }).pipe(Observability.withInUseProbeSpan(worktreePath))

--- a/packages/@overeng/megarepo/src/lib/store-inuse.unit.test.ts
+++ b/packages/@overeng/megarepo/src/lib/store-inuse.unit.test.ts
@@ -1,0 +1,99 @@
+import { Option } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import { classifyInUse, isPathInsideWorktree, type ProcPath } from './store-inuse.ts'
+
+const WT = '/store/github.com/acme/widget/refs/heads/feature/x'
+
+describe('store-inuse', () => {
+  describe('isPathInsideWorktree', () => {
+    it('matches the worktree path itself', () => {
+      expect(isPathInsideWorktree({ worktreePath: WT, candidate: WT })).toBe(true)
+    })
+
+    it('matches a descendant', () => {
+      expect(isPathInsideWorktree({ worktreePath: WT, candidate: `${WT}/src/lib` })).toBe(true)
+    })
+
+    it('does not match an outside path', () => {
+      expect(isPathInsideWorktree({ worktreePath: WT, candidate: '/store/other' })).toBe(false)
+    })
+
+    it('does not match a sibling that shares the string prefix (.archive-old)', () => {
+      // The `+ '/'` boundary is load-bearing: a raw startsWith would wrongly match.
+      expect(isPathInsideWorktree({ worktreePath: WT, candidate: `${WT}.archive-old` })).toBe(false)
+      expect(isPathInsideWorktree({ worktreePath: WT, candidate: `${WT}-2` })).toBe(false)
+    })
+
+    it('normalizes trailing slashes on both sides', () => {
+      expect(isPathInsideWorktree({ worktreePath: `${WT}/`, candidate: WT })).toBe(true)
+      expect(isPathInsideWorktree({ worktreePath: WT, candidate: `${WT}/` })).toBe(true)
+      expect(isPathInsideWorktree({ worktreePath: `${WT}/`, candidate: `${WT}/src/` })).toBe(true)
+    })
+  })
+
+  describe('classifyInUse', () => {
+    const procPaths = (entries: ReadonlyArray<ProcPath>) => entries
+
+    it('returns none when no process path is inside the worktree', () => {
+      const result = classifyInUse({
+        worktreePath: WT,
+        procPaths: procPaths([
+          { pid: 10, path: '/store/other' },
+          { pid: 11, path: '/' },
+        ]),
+        excludePids: new Set(),
+      })
+      expect(Option.isNone(result)).toBe(true)
+    })
+
+    it('returns the first holder whose path is at or under the worktree', () => {
+      const result = classifyInUse({
+        worktreePath: WT,
+        procPaths: procPaths([
+          { pid: 10, path: '/elsewhere' },
+          { pid: 42, path: `${WT}/src` },
+          { pid: 43, path: WT },
+        ]),
+        excludePids: new Set(),
+      })
+      expect(Option.isSome(result)).toBe(true)
+      if (Option.isSome(result) === true) {
+        expect(result.value).toEqual({ pid: 42, path: `${WT}/src` })
+      }
+    })
+
+    it('skips excluded pids (self/descendant) and reports the next holder', () => {
+      const result = classifyInUse({
+        worktreePath: WT,
+        procPaths: procPaths([
+          { pid: 42, path: `${WT}/src` },
+          { pid: 99, path: `${WT}/docs` },
+        ]),
+        excludePids: new Set([42]),
+      })
+      expect(Option.isSome(result)).toBe(true)
+      if (Option.isSome(result) === true) {
+        expect(result.value.pid).toBe(99)
+      }
+    })
+
+    it('returns none when the only holder is excluded', () => {
+      const result = classifyInUse({
+        worktreePath: WT,
+        procPaths: procPaths([{ pid: 42, path: `${WT}/src` }]),
+        excludePids: new Set([42]),
+      })
+      expect(Option.isNone(result)).toBe(true)
+    })
+
+    it('does not flag a sibling .archive-old path as in-use', () => {
+      const result = classifyInUse({
+        worktreePath: WT,
+        procPaths: procPaths([{ pid: 7, path: `${WT}.archive-old/src` }]),
+        excludePids: new Set(),
+      })
+      expect(Option.isNone(result)).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
## Problem

`mr store gc`'s cold-reclaim path decides a worktree is "cold" purely from
absence in the workspace liveness manifests (`store-liveness.ts` /
`classifyStoreWorktreePolicy`). It never checks whether a **live OS process is
currently working inside the worktree**.

This is not theoretical — it caused a real incident. A background store-reclaim
renamed an actively-used worktree into `.archive/` while a coding-agent session
had its shell cwd inside it. On Linux a directory rename is transparent to a
process already in that directory: its cwd silently followed the inode into
`.archive/`, and the subsequent git bookkeeping (detach HEAD + free branch, then
a re-`apply` checkout) stripped the worktree out from under the live session.
`git` started reporting "not a git repository" mid-task and untracked work was
orphaned in the archive.

Even current `main` (with the lossless + grace cold GC from #780) has this gap:
the under-lock veto re-check only re-runs the manifest liveness test. A
freshly-created or repinned-but-unregistered worktree can be absent from every
manifest while a session is actively in it.

## Goal

Before any destructive archive/reap, additionally refuse if a live process has
the worktree (or a descendant) as its cwd or open file handle. "Cold" must mean
*no process is in it*, not just *absent from a manifest*. Conservative direction
throughout: in doubt → keep.

## Decisions

- **Orthogonal veto, not a replacement.** The new check is ANDed with the
  existing manifest liveness veto (keep if EITHER protects the worktree). The
  two reasons stay distinguishable: manifest protection keeps as before; the
  process check keeps with a new `reason: process-in-use` and a dedicated
  `megarepo/store/gc/inuse-veto` span carrying the holding pid/path (the
  attribution the incident lacked).
- **Pure/IO seam, mirroring `store-gc-observations.ts`.** `classifyInUse`
  (pure, unit-tested) takes the already-read `{ pid, path }` list plus an
  explicit `excludePids` set and returns the first matching holder. The
  effectful `readWorktreeInUse` does the `/proc` scan and computes the exclude
  set. Keeping `excludePids` a parameter (not baked into the reader) is what
  lets the classifier be unit-tested AND lets the integration test observe a
  spawned holder.
- **Self/descendant exclusion via PPid walk.** The gc process (and any git
  child it spawns with a cwd inside the worktree) must never self-veto. From
  each in-worktree match we climb its PPid chain; if we reach the gc pid it is
  excluded. Walking up from the rare matches is cheaper than materializing the
  whole process tree.
- **Path boundary.** `candidate === wt || candidate.startsWith(wt + '/')` with
  both sides slash-normalized, so a sibling like `<wt>.archive-old` never
  matches by raw string prefix.
- **Non-Linux → keep (see Concerns).** No `/proc` ⇒ `unknown` ⇒ the caller
  treats it as in-use and keeps.

## Verification

Scoped to the changed package (avoided a full-repo `check:all` to stay light on
shared build/CI capacity).

- `dt ts:check` (workspace `tsc --build`): green.
- `dt test:megarepo` (full package suite): green (exit 0).
- Targeted re-run of the touched/related suites:
  - `store-inuse.unit.test.ts`: 10 passed
  - `store-inuse.integration.test.ts`: 2 passed (spawns a real holder process
    with cwd inside a temp worktree, asserts in-use; a sibling `.archive-old`
    dir reads free; post-kill reads free; and the gc-self-veto case reads free)
  - `store-archive.integration.test.ts`: 8 passed
  - `store-gc-observations.unit.test.ts`: 12 passed
  - `cli/store.integration.test.ts`: 21 passed
- `oxlint` + `oxfmt --check` on all changed files: clean (0/0).

## Complexity

One new lib module with a clean pure/IO split and three small call-site veto
blocks reusing the existing lock + outcome plumbing. No new dependencies (uses
`@effect/platform` `FileSystem.readLink`/`readDirectory`, already used by
`store-liveness.ts`). The new module is justified: the probe is distinct,
testable logic that does not belong inside the gc orchestration.

## Concerns

- **macOS (no `/proc`) behavior change.** On a host without `/proc` the probe
  returns `unknown`, which the caller treats as in-use, so `mr store gc`
  archives/reaps nothing there. This is a deliberate conservative choice
  (keep > delete), but it is a real behavior change for non-Linux gc, not a
  silent no-op. A best-effort `lsof` fallback could restore macOS gc later if
  wanted (see Follow-ups). The incident class lives on the Linux hosts.
- **`--dry-run` does not reflect the in-use veto.** Dry-run short-circuits the
  decision before the lock/probe, so a preview may show `archived` for a
  worktree a real run would keep. The real run is the safe one; the preview is
  advisory.
- Open-fd scanning is implemented but defaulted off; cwd is the load-bearing
  signal that matches the incident.

## Follow-ups

- Optional `lsof`-based fallback so macOS `mr store gc` keeps functioning
  instead of degrading to keep-everything.
- Broader fleet attribution/audit work (kernel-level command audit) is tracked
  separately and out of scope here.

## References

Fixes the worktree-archival incident (RCA captured locally). Related: #780
(lossless + grace cold GC), which this hardens.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🥉 cl1-bronze |
| `agent_session_id` | ddfcde53-424d-4e20-9b32-3374c0698f0c |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.179 |
| `agent_runtime` | Claude Code 2.1.179 |
| `agent_model` | claude-opus-4-8 |
| `runtime_profile` | /nix/store/wbb5q5n2gbk751hcyr5ndp0zrmar602x-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/3i12shfqx3wqzq2di3jy1m7f8fn4prmm-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-06-20-2026-06-20-guard-worktree-inuse |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->