### PR TITLE
feat(genie): catalog duplicate-version gate

### DIFF
--- a/nix/devenv-modules/tasks/shared/pnpm.nix
+++ b/nix/devenv-modules/tasks/shared/pnpm.nix
@@ -7,6 +7,7 @@
 # Provides:
 # - pnpm:install
 # - pnpm:update
+# - pnpm:dedupe
 # - pnpm:clean
 # - pnpm:reset-lock-files
 {
@@ -20,6 +21,7 @@
   preInstall ? "",
   installAfter ? [ ],
   updateAfter ? [ ],
+  dedupeAfter ? [ ],
   cleanAfter ? [ ],
   resetLockFilesAfter ? [ ],
   # Real derivation/path backing the `pnpm` guard. When set, the guard owns
@@ -67,6 +69,8 @@ let
       "${taskNamePrefix}:install:${taskSuffix}";
   updateTaskName =
     if taskSuffix == null then "${taskNamePrefix}:update" else "${taskNamePrefix}:update:${taskSuffix}";
+  dedupeTaskName =
+    if taskSuffix == null then "${taskNamePrefix}:dedupe" else "${taskNamePrefix}:dedupe:${taskSuffix}";
   cleanTaskName =
     if taskSuffix == null then "${taskNamePrefix}:clean" else "${taskNamePrefix}:clean:${taskSuffix}";
   resetLockFilesTaskName =
@@ -611,6 +615,27 @@ let
         ensure_shared_pnpm_files_store
         pnpm install --fix-lockfile --config.confirmModulesPurge=false --pm-on-fail=ignore --config.store-dir="$npm_config_store_dir"
         echo "Repo-root lockfile updated. Refresh Nix FOD hashes with the repo workflow."
+      '';
+    };
+
+    "${dedupeTaskName}" = {
+      guard = "pnpm";
+      # Remediation counterpart to the catalog duplicate-version gate (genie:check):
+      # collapse in-range duplicate versions onto the newest satisfying release.
+      # Upstream-locked duplicates that cannot be collapsed stay and must be
+      # acknowledged via catalogDuplicateExceptions.
+      description = "Collapse in-range duplicate versions in the pnpm lockfile at ${workspaceRoot}";
+      after = (if workspaceRoot == "." then [ "genie:run" ] else [ ]) ++ dedupeAfter;
+      exec = trace.exec dedupeTaskName ''
+        set -euo pipefail
+        cd ${lib.escapeShellArg workspaceRootAbs}
+        ${loadPnpmTaskHelpersFn}
+        ${ensureLocalPnpmHomeFn}
+        ${ensureLocalPnpmStoreDirFn}
+        ${ensureSharedPnpmFilesStoreFn}
+        ensure_shared_pnpm_files_store
+        pnpm dedupe --config.confirmModulesPurge=false --pm-on-fail=ignore --config.store-dir="$npm_config_store_dir"
+        echo "Lockfile deduped. Re-run genie:check to verify the catalog duplicate gate; bless any upstream-locked residuals via catalogDuplicateExceptions."
       '';
     };
 

--- a/nix/oxc-config-plugin.nix
+++ b/nix/oxc-config-plugin.nix
@@ -29,7 +29,7 @@ let
     pnpm = pinnedPnpm;
   };
   packageDir = "packages/@overeng/oxc-config";
-  pnpmDepsHash = "sha256-mZVdZYt5rvavoPGdEbCjva6YnkdELvqS/FAFv+EIESA=";
+  pnpmDepsHash = "sha256-1RJSyOsK/AMqDrEnRNQhL/PukFNeGBwmjmgJlWqNVK4=";
 
   srcPath =
     if builtins.isAttrs src && builtins.hasAttr "outPath" src then

--- a/packages/@overeng/genie/nix/build.nix
+++ b/packages/@overeng/genie/nix/build.nix
@@ -25,7 +25,11 @@ let
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
       "." = {
+<<<<<<< HEAD
         hash = "sha256-VY+bPhN7V12K+Lf7Y99tw3I+expfu7VI8jLM6je5qu4=";
+=======
+        hash = "sha256-sjYWZOHsLd949EKVrQzo4LeljbsbmIik0iaOIUGCXUU=";
+>>>>>>> b9b60ae7 (fix(nix): refresh FOD pnpm-deps hashes after lockfile dedupe)
       };
     };
     nativeNodePackages = opentuiCoreNative.packages;

--- a/packages/@overeng/genie/nix/build.nix
+++ b/packages/@overeng/genie/nix/build.nix
@@ -25,11 +25,7 @@ let
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
       "." = {
-<<<<<<< HEAD
-        hash = "sha256-VY+bPhN7V12K+Lf7Y99tw3I+expfu7VI8jLM6je5qu4=";
-=======
-        hash = "sha256-sjYWZOHsLd949EKVrQzo4LeljbsbmIik0iaOIUGCXUU=";
->>>>>>> b9b60ae7 (fix(nix): refresh FOD pnpm-deps hashes after lockfile dedupe)
+        hash = "sha256-Eg05wg9cDvCgvGJBij3yPNtgPd/SCykvPZPkKBY2TC8=";
       };
     };
     nativeNodePackages = opentuiCoreNative.packages;

--- a/packages/@overeng/genie/src/runtime/catalog-duplicates/catalog-duplicates.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/catalog-duplicates/catalog-duplicates.unit.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseAllResolvedVersionsFromLockfile, validateCatalogDuplicates } from './mod.ts'
+
+const makeLockfileYaml = (packages: string[]) => {
+  const lines = ["lockfileVersion: '9.0'", '', 'packages:', '']
+  for (const spec of packages) {
+    lines.push(spec.startsWith('@') === true ? `  '${spec}':` : `  ${spec}:`)
+    lines.push('    resolution: {integrity: sha512-fake}')
+    lines.push('')
+  }
+  lines.push('snapshots:', '')
+  return lines.join('\n')
+}
+
+describe('parseAllResolvedVersionsFromLockfile', () => {
+  it('collects every version per package, not just the first', () => {
+    const yaml = makeLockfileYaml(['string-width@7.2.0', 'string-width@8.2.0', 'string-width@8.2.1'])
+    const result = parseAllResolvedVersionsFromLockfile(yaml)
+    expect(result.get('string-width')).toEqual(new Set(['7.2.0', '8.2.0', '8.2.1']))
+  })
+
+  it('handles scoped packages and skips parenthesised resolution entries', () => {
+    const lines = [
+      "lockfileVersion: '9.0'",
+      '',
+      'packages:',
+      '',
+      "  '@effect/platform@0.96.0':",
+      '    resolution: {integrity: sha512-a}',
+      '',
+      "  '@effect/platform@0.96.0(effect@3.21.0)':",
+      '    resolution: {integrity: sha512-b}',
+      '',
+      'snapshots:',
+      '',
+    ]
+    const result = parseAllResolvedVersionsFromLockfile(lines.join('\n'))
+    expect(result.get('@effect/platform')).toEqual(new Set(['0.96.0']))
+  })
+})
+
+describe('validateCatalogDuplicates', () => {
+  const catalog = { 'string-width': '8.2.1', effect: '3.21.4', prettier: '3.8.4' }
+
+  it('passes when every catalog package resolves to a single version', () => {
+    const yaml = makeLockfileYaml(['string-width@8.2.1', 'effect@3.21.4', 'prettier@3.8.4'])
+    expect(validateCatalogDuplicates({ catalog, lockfileContent: yaml })).toEqual([])
+  })
+
+  it('errors on an unblessed duplicate of a catalog package', () => {
+    const yaml = makeLockfileYaml(['string-width@7.2.0', 'string-width@8.2.0', 'string-width@8.2.1'])
+    const issues = validateCatalogDuplicates({ catalog, lockfileContent: yaml })
+    expect(issues).toHaveLength(1)
+    expect(issues[0]!.severity).toBe('error')
+    expect(issues[0]!.rule).toBe('catalog-duplicate-version')
+    expect(issues[0]!.dependency).toBe('string-width')
+    /* newest-first ordering */
+    expect(issues[0]!.message).toContain('8.2.1, 8.2.0, 7.2.0')
+  })
+
+  it('ignores duplicates of packages not in the catalog', () => {
+    const yaml = makeLockfileYaml(['lodash@4.17.20', 'lodash@4.17.21'])
+    expect(validateCatalogDuplicates({ catalog, lockfileContent: yaml })).toEqual([])
+  })
+
+  it('downgrades a blessed duplicate to a warning and names the reason', () => {
+    const yaml = makeLockfileYaml(['string-width@7.2.0', 'string-width@8.2.1'])
+    const issues = validateCatalogDuplicates({
+      catalog,
+      lockfileContent: yaml,
+      exceptions: [{ package: 'string-width', reason: '@opentui/core hard-pins 7.2.0', issue: '#820' }],
+    })
+    expect(issues).toHaveLength(1)
+    expect(issues[0]!.severity).toBe('warning')
+    expect(issues[0]!.rule).toBe('catalog-duplicate-version-acknowledged')
+    expect(issues[0]!.message).toContain('@opentui/core hard-pins 7.2.0')
+    expect(issues[0]!.message).toContain('#820')
+  })
+
+  it('flags a stale exception that no longer matches a duplicate', () => {
+    const yaml = makeLockfileYaml(['string-width@8.2.1'])
+    const issues = validateCatalogDuplicates({
+      catalog,
+      lockfileContent: yaml,
+      exceptions: [{ package: 'string-width', reason: 'was locked', issue: '#820' }],
+    })
+    expect(issues).toHaveLength(1)
+    expect(issues[0]!.severity).toBe('warning')
+    expect(issues[0]!.rule).toBe('catalog-duplicate-stale-exception')
+  })
+})

--- a/packages/@overeng/genie/src/runtime/catalog-duplicates/catalog-duplicates.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/catalog-duplicates/catalog-duplicates.unit.test.ts
@@ -15,7 +15,11 @@ const makeLockfileYaml = (packages: string[]) => {
 
 describe('parseAllResolvedVersionsFromLockfile', () => {
   it('collects every version per package, not just the first', () => {
-    const yaml = makeLockfileYaml(['string-width@7.2.0', 'string-width@8.2.0', 'string-width@8.2.1'])
+    const yaml = makeLockfileYaml([
+      'string-width@7.2.0',
+      'string-width@8.2.0',
+      'string-width@8.2.1',
+    ])
     const result = parseAllResolvedVersionsFromLockfile(yaml)
     expect(result.get('string-width')).toEqual(new Set(['7.2.0', '8.2.0', '8.2.1']))
   })
@@ -49,7 +53,11 @@ describe('validateCatalogDuplicates', () => {
   })
 
   it('errors on an unblessed duplicate of a catalog package', () => {
-    const yaml = makeLockfileYaml(['string-width@7.2.0', 'string-width@8.2.0', 'string-width@8.2.1'])
+    const yaml = makeLockfileYaml([
+      'string-width@7.2.0',
+      'string-width@8.2.0',
+      'string-width@8.2.1',
+    ])
     const issues = validateCatalogDuplicates({ catalog, lockfileContent: yaml })
     expect(issues).toHaveLength(1)
     expect(issues[0]!.severity).toBe('error')
@@ -69,7 +77,9 @@ describe('validateCatalogDuplicates', () => {
     const issues = validateCatalogDuplicates({
       catalog,
       lockfileContent: yaml,
-      exceptions: [{ package: 'string-width', reason: '@opentui/core hard-pins 7.2.0', issue: '#820' }],
+      exceptions: [
+        { package: 'string-width', reason: '@opentui/core hard-pins 7.2.0', issue: '#820' },
+      ],
     })
     expect(issues).toHaveLength(1)
     expect(issues[0]!.severity).toBe('warning')

--- a/packages/@overeng/genie/src/runtime/catalog-duplicates/mod.ts
+++ b/packages/@overeng/genie/src/runtime/catalog-duplicates/mod.ts
@@ -75,16 +75,6 @@ export const parseAllResolvedVersionsFromLockfile = (
   return result
 }
 
-/** Sort versions newest-first (descending semver, with a string tiebreaker). */
-const byVersionDesc = (a: string, b: string): number => {
-  const [aMajor, aMinor, aPatch] = parseVersion(a)
-  const [bMajor, bMinor, bPatch] = parseVersion(b)
-  if (aMajor !== bMajor) return bMajor - aMajor
-  if (aMinor !== bMinor) return bMinor - aMinor
-  if (aPatch !== bPatch) return bPatch - aPatch
-  return b.localeCompare(a)
-}
-
 // =============================================================================
 // Validation
 // =============================================================================
@@ -139,7 +129,15 @@ export const validateCatalogDuplicates = ({
     const versions = resolved.get(name)
     if (versions === undefined || versions.size <= 1) continue
 
-    const sorted = [...versions].sort(byVersionDesc)
+    /* Newest-first (descending semver, with a string tiebreaker). */
+    const sorted = [...versions].toSorted((a, b) => {
+      const [aMajor, aMinor, aPatch] = parseVersion(a)
+      const [bMajor, bMinor, bPatch] = parseVersion(b)
+      if (aMajor !== bMajor) return bMajor - aMajor
+      if (aMinor !== bMinor) return bMinor - aMinor
+      if (aPatch !== bPatch) return bPatch - aPatch
+      return b.localeCompare(a)
+    })
     const versionList = sorted.join(', ')
     const baseMessage =
       `"${name}" resolves to ${versions.size} versions in the lockfile: ${versionList} ` +

--- a/packages/@overeng/genie/src/runtime/catalog-duplicates/mod.ts
+++ b/packages/@overeng/genie/src/runtime/catalog-duplicates/mod.ts
@@ -1,0 +1,187 @@
+/**
+ * Catalog duplicate-version detection via the pnpm lockfile.
+ *
+ * A catalog-managed package pins a single version, but transitive dependents
+ * can still pull other versions into `pnpm-lock.yaml`, silently creating
+ * duplicate singletons (bundle bloat plus module-identity hazards). This
+ * validator flags any catalog package that resolves to more than one version.
+ *
+ * Remediation, in order of preference:
+ * - in-range duplicates collapse with `pnpm dedupe` (force-newest);
+ * - upstream-locked duplicates — a dependent hard-pins an out-of-range version
+ *   that `pnpm dedupe` cannot collapse — must be acknowledged via
+ *   `catalogDuplicateExceptions` with a reason and tracking issue.
+ *
+ * The exception list is the shared "blessing" primitive: anything unblessed is
+ * an error, a blessing suppresses to a warning, and a blessing that no longer
+ * matches a live duplicate is reported as stale.
+ */
+
+import { parseVersion } from '../semver/mod.ts'
+import type { GenieValidationIssue } from '../validation/mod.ts'
+
+// =============================================================================
+// Lockfile Parser
+// =============================================================================
+
+/**
+ * Collect every resolved version per package name from the `packages:` section
+ * of a `pnpm-lock.yaml`.
+ *
+ * Unlike `parseResolvedVersionsFromLockfile` (which keeps only the first,
+ * canonical entry per name), this retains the full set so duplicates surface.
+ */
+export const parseAllResolvedVersionsFromLockfile = (
+  yamlContent: string,
+): Map<string, Set<string>> => {
+  const result = new Map<string, Set<string>>()
+  const lines = yamlContent.split('\n')
+
+  let inPackages = false
+
+  for (const line of lines) {
+    if (line === 'packages:') {
+      inPackages = true
+      continue
+    }
+    if (inPackages === false) continue
+
+    /* New top-level section ends the current packages block.
+     * Don't break — workspace lockfiles can have multiple `packages:` sections. */
+    if (/^\S/.test(line) === true && line !== 'packages:') {
+      inPackages = false
+      continue
+    }
+
+    /* Package metadata entry: `  'name@version':` or `  name@version:`.
+     * Skip resolution-specific entries containing parentheses. */
+    const pkgMatch = line.match(/^  '?([^'(]+@[^'(]+?)'?:$/)
+    if (pkgMatch === null) continue
+
+    const spec = pkgMatch[1]!
+    const atIdx = spec.startsWith('@') === true ? spec.indexOf('@', 1) : spec.indexOf('@')
+    if (atIdx <= 0) continue
+
+    const name = spec.slice(0, atIdx)
+    const version = spec.slice(atIdx + 1)
+    const existing = result.get(name)
+    if (existing === undefined) {
+      result.set(name, new Set([version]))
+    } else {
+      existing.add(version)
+    }
+  }
+
+  return result
+}
+
+/** Sort versions newest-first (descending semver, with a string tiebreaker). */
+const byVersionDesc = (a: string, b: string): number => {
+  const [aMajor, aMinor, aPatch] = parseVersion(a)
+  const [bMajor, bMinor, bPatch] = parseVersion(b)
+  if (aMajor !== bMajor) return bMajor - aMajor
+  if (aMinor !== bMinor) return bMinor - aMinor
+  if (aPatch !== bPatch) return bPatch - aPatch
+  return b.localeCompare(a)
+}
+
+// =============================================================================
+// Validation
+// =============================================================================
+
+/**
+ * An acknowledged catalog duplicate — the shared blessing primitive.
+ *
+ * Use only for duplicates that cannot be collapsed (a dependent hard-pins an
+ * out-of-range version). In-range duplicates should be fixed with `pnpm dedupe`
+ * rather than blessed.
+ */
+export type CatalogDuplicateException = {
+  /** Catalog package name allowed to resolve to multiple versions. */
+  package: string
+  /** Why the duplicate is unavoidable (e.g. `@opentui/core` hard-pins 7.2.0). */
+  reason: string
+  /** Tracking issue, e.g. `#820`. */
+  issue?: string
+}
+
+/** Input for `validateCatalogDuplicates`. */
+export type CatalogDuplicatesValidationArgs = {
+  /** Catalog entries: package name → version. Defines which packages are gated. */
+  catalog: Record<string, string>
+  /** Raw `pnpm-lock.yaml` content. */
+  lockfileContent: string
+  /** Acknowledged duplicates that suppress the error to a warning. */
+  exceptions?: readonly CatalogDuplicateException[]
+}
+
+/**
+ * Validate that every catalog package resolves to a single version in the
+ * lockfile. Returns validation issues for:
+ *
+ * 1. **Unblessed duplicates** (error): a catalog package with >1 resolved version.
+ * 2. **Blessed duplicates** (warning): the same, but covered by an exception.
+ * 3. **Stale exceptions** (warning): an exception that no longer matches a duplicate.
+ */
+export const validateCatalogDuplicates = ({
+  catalog,
+  lockfileContent,
+  exceptions = [],
+}: CatalogDuplicatesValidationArgs): GenieValidationIssue[] => {
+  const resolved = parseAllResolvedVersionsFromLockfile(lockfileContent)
+  const exceptionByPackage = new Map(exceptions.map((e) => [e.package, e]))
+  const usedExceptions = new Set<string>()
+
+  const issues: GenieValidationIssue[] = []
+
+  for (const [name, catalogVersion] of Object.entries(catalog)) {
+    if (typeof catalogVersion !== 'string') continue
+    const versions = resolved.get(name)
+    if (versions === undefined || versions.size <= 1) continue
+
+    const sorted = [...versions].sort(byVersionDesc)
+    const versionList = sorted.join(', ')
+    const baseMessage =
+      `"${name}" resolves to ${versions.size} versions in the lockfile: ${versionList} ` +
+      `(catalog pins ${catalogVersion}). Run \`pnpm dedupe\` to collapse in-range ` +
+      `duplicates, or acknowledge an upstream-locked duplicate via catalogDuplicateExceptions.`
+
+    const exception = exceptionByPackage.get(name)
+    if (exception !== undefined) {
+      usedExceptions.add(name)
+      issues.push({
+        severity: 'warning',
+        packageName: '(catalog-duplicates)',
+        dependency: name,
+        message: `${baseMessage} (acknowledged: ${exception.reason}${
+          exception.issue !== undefined ? ` — ${exception.issue}` : ''
+        })`,
+        rule: 'catalog-duplicate-version-acknowledged',
+      })
+      continue
+    }
+
+    issues.push({
+      severity: 'error',
+      packageName: '(catalog-duplicates)',
+      dependency: name,
+      message: baseMessage,
+      rule: 'catalog-duplicate-version',
+    })
+  }
+
+  /* Detect stale exceptions */
+  for (const { package: name } of exceptions) {
+    if (usedExceptions.has(name) === false) {
+      issues.push({
+        severity: 'warning',
+        packageName: '(catalogDuplicateExceptions)',
+        dependency: name,
+        message: `catalogDuplicateExceptions entry for "${name}" no longer matches a lockfile duplicate — consider removing it`,
+        rule: 'catalog-duplicate-stale-exception',
+      })
+    }
+  }
+
+  return issues
+}

--- a/packages/@overeng/genie/src/runtime/pnpm-workspace/mod.ts
+++ b/packages/@overeng/genie/src/runtime/pnpm-workspace/mod.ts
@@ -8,9 +8,9 @@
 import { readFileSync } from 'node:fs'
 import path from 'node:path'
 
-import { validateCatalogPeerDeps } from '../catalog-peer-deps/mod.ts'
 import { validateCatalogDuplicates } from '../catalog-duplicates/mod.ts'
 import type { CatalogDuplicateException } from '../catalog-duplicates/mod.ts'
+import { validateCatalogPeerDeps } from '../catalog-peer-deps/mod.ts'
 import { createGenieOutput } from '../core.ts'
 import type { GenieContext } from '../core.ts'
 import { validateCrossInstallRootVersions } from '../cross-install-root/mod.ts'

--- a/packages/@overeng/genie/src/runtime/pnpm-workspace/mod.ts
+++ b/packages/@overeng/genie/src/runtime/pnpm-workspace/mod.ts
@@ -9,6 +9,8 @@ import { readFileSync } from 'node:fs'
 import path from 'node:path'
 
 import { validateCatalogPeerDeps } from '../catalog-peer-deps/mod.ts'
+import { validateCatalogDuplicates } from '../catalog-duplicates/mod.ts'
+import type { CatalogDuplicateException } from '../catalog-duplicates/mod.ts'
 import { createGenieOutput } from '../core.ts'
 import type { GenieContext } from '../core.ts'
 import { validateCrossInstallRootVersions } from '../cross-install-root/mod.ts'
@@ -1185,6 +1187,7 @@ const rootPnpmWorkspaceYaml = ({
   extraMembers = [],
   catalogVersions,
   identityCriticalPackages,
+  catalogDuplicateExceptions,
   ...config
 }: {
   packages: readonly WorkspacePackageLike[]
@@ -1194,6 +1197,8 @@ const rootPnpmWorkspaceYaml = ({
   catalogVersions?: CatalogInput
   /** Package names that must resolve to the same version across all install roots (e.g. `['effect']`). */
   identityCriticalPackages?: readonly string[]
+  /** Acknowledged catalog packages allowed to resolve to multiple lockfile versions (upstream-locked). */
+  catalogDuplicateExceptions?: readonly CatalogDuplicateException[]
 } & Omit<PnpmWorkspaceData, 'packages'>) => {
   const projectedMembers = rootWorkspaceMemberPathsFromPackages({ packages, repoName })
   const allMembers =
@@ -1259,9 +1264,16 @@ const rootPnpmWorkspaceYaml = ({
                 ? { peerDependencyRules: config.peerDependencyRules }
                 : {}),
             }),
+            ...validateCatalogDuplicates({
+              catalog: catalogVersions,
+              lockfileContent,
+              ...(catalogDuplicateExceptions !== undefined
+                ? { exceptions: catalogDuplicateExceptions }
+                : {}),
+            }),
           )
         } catch {
-          /* lockfile not available — skip peer dep validation */
+          /* lockfile not available — skip catalog lockfile validation */
         }
       }
 

--- a/packages/@overeng/megarepo/nix/build.nix
+++ b/packages/@overeng/megarepo/nix/build.nix
@@ -24,11 +24,7 @@ let
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
       "." = {
-<<<<<<< HEAD
-        hash = "sha256-mcaQknTxsiz47In7qd6Y+sdiw046Q2ROmbAdoc9oKW0=";
-=======
-        hash = "sha256-1SIlf6o2oGK3nh6cdGufZrVrwt05trIs5FdUBIbAKaw=";
->>>>>>> b9b60ae7 (fix(nix): refresh FOD pnpm-deps hashes after lockfile dedupe)
+        hash = "sha256-hyD4E59FR+lkSciBR+C0Jv6U/ehc3cHnZTO78S7UFRk=";
       };
     };
     nativeNodePackages = opentuiCoreNative.packages;

--- a/packages/@overeng/megarepo/nix/build.nix
+++ b/packages/@overeng/megarepo/nix/build.nix
@@ -24,7 +24,11 @@ let
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
       "." = {
+<<<<<<< HEAD
         hash = "sha256-mcaQknTxsiz47In7qd6Y+sdiw046Q2ROmbAdoc9oKW0=";
+=======
+        hash = "sha256-1SIlf6o2oGK3nh6cdGufZrVrwt05trIs5FdUBIbAKaw=";
+>>>>>>> b9b60ae7 (fix(nix): refresh FOD pnpm-deps hashes after lockfile dedupe)
       };
     };
     nativeNodePackages = opentuiCoreNative.packages;

--- a/packages/@overeng/notion-cli/nix/build.nix
+++ b/packages/@overeng/notion-cli/nix/build.nix
@@ -33,7 +33,7 @@ let
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
       "." = {
-        hash = "sha256-lB/ITEcEmaSKEG5yrMkrLai+e0OMwvWQgoTmjSCe3N0=";
+        hash = "sha256-I8lMOisGdfUeLjDIH5CxGz1lasR0z5qAq+fbTKLB+PI=";
       };
     };
     nativeNodePackages = opentuiCoreNative.packages;

--- a/packages/@overeng/notion-cli/nix/build.nix
+++ b/packages/@overeng/notion-cli/nix/build.nix
@@ -33,7 +33,7 @@ let
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
       "." = {
-        hash = "sha256-2WFyUnU6IavAOhrHMvb1rN6ix3p4dFJ0OKXqnzfyLjM=";
+        hash = "sha256-lB/ITEcEmaSKEG5yrMkrLai+e0OMwvWQgoTmjSCe3N0=";
       };
     };
     nativeNodePackages = opentuiCoreNative.packages;

--- a/packages/@overeng/notion-md/nix/build.nix
+++ b/packages/@overeng/notion-md/nix/build.nix
@@ -20,7 +20,7 @@ let
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
       "." = {
-        hash = "sha256-T/4BB1hvQmpYYNna8EaqgO6iPgkwq+o6se4BShshbEY=";
+        hash = "sha256-yebsijM8l1yHAn0amEOBuC/7cvPOlYI42PA3GigwClY=";
       };
     };
     smokeTestArgs = [ "--help" ];

--- a/packages/@overeng/notion-md/nix/build.nix
+++ b/packages/@overeng/notion-md/nix/build.nix
@@ -20,7 +20,7 @@ let
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
       "." = {
-        hash = "sha256-5roh9YTUG0Id8nY3aMOyggvsEV/7Dmh3+jFd1iybJZk=";
+        hash = "sha256-T/4BB1hvQmpYYNna8EaqgO6iPgkwq+o6se4BShshbEY=";
       };
     };
     smokeTestArgs = [ "--help" ];

--- a/packages/@overeng/tui-stories/nix/build.nix
+++ b/packages/@overeng/tui-stories/nix/build.nix
@@ -21,7 +21,7 @@ let
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
       "." = {
-        hash = "sha256-7gRdj1rwiPzFHXuBHiJhjxvM55/rXN3+cl/ZhtwLlkk=";
+        hash = "sha256-DSazw0ioWW8VPqYb+RrkiAXEHFxIeCJFDqXcy0ialmI=";
       };
     };
     nativeNodePackages = opentuiCoreNative.packages;

--- a/packages/@overeng/tui-stories/nix/build.nix
+++ b/packages/@overeng/tui-stories/nix/build.nix
@@ -21,7 +21,7 @@ let
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
       "." = {
-        hash = "sha256-DSazw0ioWW8VPqYb+RrkiAXEHFxIeCJFDqXcy0ialmI=";
+        hash = "sha256-ptO53GobgcxUYW25Iz3Eo2M1DGP0bZVV61ppl+2kt7g=";
       };
     };
     nativeNodePackages = opentuiCoreNative.packages;

--- a/packages/@overeng/workflow-report/nix/build.nix
+++ b/packages/@overeng/workflow-report/nix/build.nix
@@ -19,7 +19,7 @@ let
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
       "." = {
-        hash = "sha256-Us/NHCW+PfZ9j6Ut2mp73OMislbcYnivjRyy91HfKUg=";
+        hash = "sha256-Cpt8jb8TB3TdA5FbAo2E4t+HEhqoqZE5oIeJGLf1kfs=";
       };
     };
     smokeTestArgs = [ "--help" ];

--- a/packages/@overeng/workflow-report/nix/build.nix
+++ b/packages/@overeng/workflow-report/nix/build.nix
@@ -19,7 +19,7 @@ let
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
       "." = {
-        hash = "sha256-ItcccGCS8p0gYINfyvSRO+wDEVd6gp/uJ4bYszAKjnk=";
+        hash = "sha256-Us/NHCW+PfZ9j6Ut2mp73OMislbcYnivjRyy91HfKUg=";
       };
     };
     smokeTestArgs = [ "--help" ];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1981,6 +1981,7 @@ packages:
   '@babel/parser@7.29.2':
     resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
+    hasBin: true
 
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
@@ -2431,6 +2432,7 @@ packages:
 
   '@myobie/pty@0.10.0':
     resolution: {integrity: sha512-G6DajVZUooexpzR5tcKkGLuea9NbiZ3gWPzVyNNFC3OcrJ68OAAvPW0U2vqcyf8Bvdrb075Zw5ISEQvqbOQ2Xg==}
+    hasBin: true
 
   '@napi-rs/wasm-runtime@1.1.5':
     resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
@@ -3015,6 +3017,7 @@ packages:
   '@playwright/test@1.61.0':
     resolution: {integrity: sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==}
     engines: {node: '>=18'}
+    hasBin: true
 
   '@preact/signals-core@1.14.1':
     resolution: {integrity: sha512-vxPpfXqrwUe9lpjqfYNjAF/0RF/eFGeLgdJzdmIIZjpOnTmGmAB4BjWone562mJGMRP4frU6iZ6ei3PDsu52Ng==}
@@ -3873,6 +3876,7 @@ packages:
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
+    hasBin: true
 
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
@@ -3932,6 +3936,7 @@ packages:
   baseline-browser-mapping@2.10.21:
     resolution: {integrity: sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA==}
     engines: {node: '>=6.0.0'}
+    hasBin: true
 
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
@@ -3940,6 +3945,7 @@ packages:
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
 
   buffer-image-size@0.6.4:
     resolution: {integrity: sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==}
@@ -4131,6 +4137,7 @@ packages:
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
+    hasBin: true
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -4169,6 +4176,7 @@ packages:
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
+    hasBin: true
 
   esquery@1.7.0:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
@@ -4334,6 +4342,7 @@ packages:
   is-docker@3.0.0:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
 
   is-dom@1.1.0:
     resolution: {integrity: sha512-u82f6mvhYxRPKpw8V1N0W8ce1xXwOrQtgGcxl6UCL5zBmZu3is/18K0rR7uFCnMDuAsS/3W54mGL4vsaFUQlEQ==}
@@ -4353,6 +4362,7 @@ packages:
   is-inside-container@1.0.0:
     resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
     engines: {node: '>=14.16'}
+    hasBin: true
 
   is-object@1.0.2:
     resolution: {integrity: sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==}
@@ -4377,16 +4387,19 @@ packages:
 
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
+    hasBin: true
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
+    hasBin: true
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -4400,9 +4413,11 @@ packages:
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
+    hasBin: true
 
   katex@0.17.0:
     resolution: {integrity: sha512-Vdw0ATsQ9V+LuegM/BTwQqV/6cTl5lbGcIrU+BCgLxyf6bo38ybOr372tuSIxir3CN720flu1meYR6XzNMwQnw==}
+    hasBin: true
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -4521,6 +4536,7 @@ packages:
   marked@17.0.1:
     resolution: {integrity: sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==}
     engines: {node: '>= 20'}
+    hasBin: true
 
   mdast-util-from-markdown@2.0.3:
     resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
@@ -4621,6 +4637,7 @@ packages:
   mime@3.0.0:
     resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
     engines: {node: '>=10.0.0'}
+    hasBin: true
 
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
@@ -4642,6 +4659,7 @@ packages:
 
   msgpackr-extract@3.0.3:
     resolution: {integrity: sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==}
+    hasBin: true
 
   msgpackr@1.11.10:
     resolution: {integrity: sha512-iCZNq+HszvF+fC3anCm4nBmWEnbeIAfpDs6IStAEKhQ2YSgkjzVG2FF9XJqwwQh5bH3N9OUTUt4QwVN6MLMLtA==}
@@ -4652,6 +4670,7 @@ packages:
   nanoid@3.3.13:
     resolution: {integrity: sha512-sPdqC6ByMVVGvF1ynvvMo0/o+oD1VX7DaHhijt1bFgjvBkHBib4t49GoNDhf2NDta4oeUNlaGbSt5K7qjZ955Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
@@ -4661,6 +4680,7 @@ packages:
 
   node-gyp-build-optional-packages@5.2.2:
     resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
+    hasBin: true
 
   node-pty@1.1.0:
     resolution: {integrity: sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==}
@@ -4695,6 +4715,7 @@ packages:
 
   oxlint-tsgolint@0.23.0:
     resolution: {integrity: sha512-3mBv3CoPbh8dFbzfDGIWa2ytZjn2v+3EX4aKRXjIhsoGFzG8GCjfRirz3rwZf1wYbZzsNLTSgpw8VjQuWdp/jA==}
+    hasBin: true
 
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
@@ -4736,10 +4757,12 @@ packages:
   playwright-core@1.61.0:
     resolution: {integrity: sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==}
     engines: {node: '>=18'}
+    hasBin: true
 
   playwright@1.61.0:
     resolution: {integrity: sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==}
     engines: {node: '>=18'}
+    hasBin: true
 
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
@@ -4749,13 +4772,10 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier@3.8.3:
-    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
-    engines: {node: '>=14'}
-
   prettier@3.8.4:
     resolution: {integrity: sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==}
     engines: {node: '>=14'}
+    hasBin: true
 
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
@@ -4859,10 +4879,12 @@ packages:
   resolve@1.22.12:
     resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
     engines: {node: '>= 0.4'}
+    hasBin: true
 
   rolldown@1.0.3:
     resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
     engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
 
   rollup@4.60.2:
     resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
@@ -4881,10 +4903,12 @@ packages:
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
+    hasBin: true
 
   seroval-plugins@1.5.4:
     resolution: {integrity: sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw==}
@@ -4941,6 +4965,7 @@ packages:
   srvx@0.11.16:
     resolution: {integrity: sha512-bp07zRuycfTY43IjAvvTFnmnJi8ikW0VFiHwOhhYcVW/L4xQ1XY4PAd4Nuum1rsA17C39zL7x+CDhrn5AL32Rw==}
     engines: {node: '>=20.16.0'}
+    hasBin: true
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -4969,10 +4994,6 @@ packages:
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
-
-  string-width@8.2.0:
-    resolution: {integrity: sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==}
-    engines: {node: '>=20'}
 
   string-width@8.2.1:
     resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
@@ -5021,10 +5042,6 @@ packages:
   tinyexec@1.2.4:
     resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
-
-  tinyglobby@0.2.16:
-    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
-    engines: {node: '>=12.0.0'}
 
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
@@ -5080,6 +5097,7 @@ packages:
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
+    hasBin: true
 
   ufo@1.6.3:
     resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
@@ -5133,6 +5151,7 @@ packages:
 
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+    hasBin: true
 
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
@@ -5250,10 +5269,12 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
 
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
+    hasBin: true
 
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
@@ -5265,18 +5286,6 @@ packages:
     peerDependencies:
       bufferutil: ^4.0.1
       utf-8-validate: ^5.0.2
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
     peerDependenciesMeta:
       bufferutil:
         optional: true
@@ -5309,6 +5318,7 @@ packages:
   yaml@2.8.3:
     resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
     engines: {node: '>= 14.6'}
+    hasBin: true
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -5510,7 +5520,7 @@ snapshots:
       '@parcel/watcher': 2.5.6
       effect: 3.21.4
       multipasta: 0.2.7
-      ws: 8.20.0
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -5525,7 +5535,7 @@ snapshots:
       effect: 3.21.4
       mime: 3.0.0
       undici: 7.25.0
-      ws: 8.20.0
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -7025,7 +7035,7 @@ snapshots:
       '@tanstack/virtual-file-routes': 1.162.0
       jiti: 2.7.0
       magic-string: 0.30.21
-      prettier: 3.8.3
+      prettier: 3.8.4
       zod: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -7056,7 +7066,7 @@ snapshots:
       babel-dead-code-elimination: 1.0.12
       diff: 8.0.4
       pathe: 2.0.3
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
     transitivePeerDependencies:
       - supports-color
 
@@ -7086,7 +7096,7 @@ snapshots:
       seroval: 1.5.4
       source-map: 0.7.6
       srvx: 0.11.16
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       ufo: 1.6.3
       vitefu: 1.1.3(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
       xmlbuilder2: 4.0.3
@@ -7305,7 +7315,7 @@ snapshots:
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.7.4
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -7522,7 +7532,7 @@ snapshots:
   cli-truncate@6.0.0:
     dependencies:
       slice-ansi: 9.0.0
-      string-width: 8.2.0
+      string-width: 8.2.1
 
   client-only@0.0.1: {}
 
@@ -8414,8 +8424,6 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier@3.8.3: {}
-
   prettier@3.8.4: {}
 
   pretty-format@27.5.1:
@@ -8694,7 +8702,7 @@ snapshots:
       recast: 0.23.11
       semver: 7.7.4
       use-sync-external-store: 1.6.0(react@19.2.7)
-      ws: 8.20.0
+      ws: 8.21.0
     optionalDependencies:
       '@types/react': 19.2.17
       prettier: 3.8.4
@@ -8728,7 +8736,7 @@ snapshots:
       recast: 0.23.11
       semver: 7.7.4
       use-sync-external-store: 1.6.0(react@19.2.7)
-      ws: 8.20.0
+      ws: 8.21.0
     optionalDependencies:
       '@types/react': 19.2.17
       prettier: 3.8.4
@@ -8748,11 +8756,6 @@ snapshots:
   string-width@7.2.0:
     dependencies:
       emoji-regex: 10.6.0
-      get-east-asian-width: 1.5.0
-      strip-ansi: 7.2.0
-
-  string-width@8.2.0:
-    dependencies:
       get-east-asian-width: 1.5.0
       strip-ansi: 7.2.0
 
@@ -8793,11 +8796,6 @@ snapshots:
   tinybench@2.9.0: {}
 
   tinyexec@1.2.4: {}
-
-  tinyglobby@0.2.16:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
 
   tinyglobby@0.2.17:
     dependencies:
@@ -8959,7 +8957,7 @@ snapshots:
       std-env: 4.1.0
       tinybench: 2.9.0
       tinyexec: 1.2.4
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
@@ -8988,8 +8986,6 @@ snapshots:
   word-wrap@1.2.5: {}
 
   ws@7.5.10: {}
-
-  ws@8.20.0: {}
 
   ws@8.21.0: {}
 

--- a/pnpm-workspace.yaml.genie.ts
+++ b/pnpm-workspace.yaml.genie.ts
@@ -6,5 +6,13 @@ export default pnpmWorkspaceYaml.root({
   packages: rootWorkspacePackages,
   repoName: 'effect-utils',
   catalogVersions: catalog,
+  catalogDuplicateExceptions: [
+    {
+      package: 'string-width',
+      reason:
+        '@opentui/core@0.4.1 pins string-width@7.2.0 exactly, which pnpm dedupe cannot collapse onto the catalog 8.x',
+      issue: '#821',
+    },
+  ],
   ...commonPnpmWorkspaceData,
 })

--- a/pnpm-workspace.yaml.genie.ts
+++ b/pnpm-workspace.yaml.genie.ts
@@ -9,8 +9,15 @@ export default pnpmWorkspaceYaml.root({
   catalogDuplicateExceptions: [
     {
       package: 'string-width',
+      // @opentui/core@0.4.1 (latest) pins string-width@7.2.0 exactly, so pnpm
+      // dedupe cannot collapse it onto the catalog 8.x. We deliberately do NOT
+      // force it via an override: string-width 8 changed wide-char/emoji width
+      // computation (dropped emoji-regex, bumped get-east-asian-width), and
+      // @opentui/core is a terminal renderer that depends on that width logic —
+      // forcing 8.x risks subtle rendering breakage. Blessed instead; revisit
+      // when @opentui/core moves to string-width 8.x. See #821.
       reason:
-        '@opentui/core@0.4.1 pins string-width@7.2.0 exactly, which pnpm dedupe cannot collapse onto the catalog 8.x',
+        '@opentui/core@0.4.1 exact-pins string-width@7.2.0; not force-overridden because string-width 8 changes emoji/wide-char width logic that the TUI renderer relies on',
       issue: '#821',
     },
   ],


### PR DESCRIPTION
## Summary

Adds a **catalog duplicate-version gate** to `genie:check` (the existing CI gate): any catalog-managed package that resolves to more than one version in `pnpm-lock.yaml` fails generation, unless the duplicate is explicitly acknowledged. This catches the class of silent duplicate-version regression that slipped through the deps upgrade (#805) — e.g. `string-width` splitting into 7.2.0/8.2.0/8.2.1.

This is the MVP of the broader "auto-catch upgrade regressions" effort: a **hard invariant gate** built on the repo source-of-truth (genie), sharing a reusable **blessing primitive** (`catalogDuplicateExceptions`) that future gates (orphan catalog entries, etc.) can reuse.

## How it works

- `validateCatalogDuplicates` parses every resolved version per package from the lockfile and flags any **catalog** package with >1 version (scoping to the catalog cleanly excludes unrelated transitive duplicates).
- Wired into the `pnpmWorkspaceYaml.root` validate hook, next to the existing peer-deps check — so it rides `genie:check` with no new CI wiring.
- **Remediation model** (matches "force-newest, bless upstream-locks"):
  - in-range duplicates -> `pnpm dedupe` collapses them to newest;
  - upstream-locked duplicates (a dependent hard-pins an out-of-range version) -> acknowledge via `catalogDuplicateExceptions` with a reason + tracking issue. Unblessed -> error; blessed -> warning; stale blessing -> warning.

## This branch

- `pnpm dedupe` collapsed `prettier` 3.8.3->3.8.4 and `string-width` 8.2.0->8.2.1.
- Blessed the remaining `string-width@7.2.0` (`@opentui/core@0.4.1` exact pin), tracked by #821.

## Verification

- `genie --check` passes (the 2 live duplicates resolved/blessed).
- `check:quick` (ts + lint) passes; `oxfmt`/`oxlint` clean.
- 7 unit tests for the detector + blessing/stale semantics.

## Open follow-up

A `deps:dedupe` fix task (the `lint:fix` counterpart) could make remediation one command. Not included here pending a decision.

Stacked on `schickling/2026-06-19-deps` (#805).

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🗾 cl1-islet |
| `agent_session_id` | 1d71dfbe-fac7-49d0-884e-814d1e68f335 |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.183 |
| `agent_runtime` | Claude Code 2.1.183 |
| `agent_model` | claude-opus-4-8 |
| `runtime_profile` | /nix/store/0q825bibhq9f4wqb2rw8d161dxsiffsi-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/k5g654riadk993gxfq0063gb27k583qn-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-06-21-deps-dup-gate |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@0500194 |
</details>
<!-- agent-footer:end -->