### PR TITLE
fix(genie): clean compiled import staging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,13 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- **Genie compiled import staging cleanup**: Scope compiled-binary `.genie.ts`
+  import staging directories to the dynamic import lifetime so successful and
+  failing compiled runs no longer leave `genie-import-*` directories in the
+  process temp directory. Add a compiled Genie CLI shell regression test that
+  runs against an isolated `TMPDIR` and verifies the staging directory is
+  removed after repeated runs (#824).
+
 - **OTEL trace-structure contract**: Tighten the offline trace-structure
   negative test so orphan detection uses a syntactically valid but missing
   parent span ID. Invalid span IDs are now left to the helper's input

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,15 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- **Restate integration port allocation**: Bind in-process handler endpoints on
+  port `0` and register the actual kernel-assigned URL, while keeping batch +
+  retry allocation for the native `restate-server` child process ports that must
+  be passed by number.
+
+- **CI test task ordering**: Make `nix:test` wait for `pnpm:install` so
+  source-mode CLI shell tests cannot race dependency materialization under
+  `test:run --mode before`.
+
 - **Genie compiled import staging cleanup**: Scope compiled-binary `.genie.ts`
   import staging directories to the dynamic import lifetime so successful and
   failing compiled runs no longer leave `genie-import-*` directories in the

--- a/devenv.nix
+++ b/devenv.nix
@@ -531,6 +531,10 @@ in
   tasks."genie:run".after = [ "pnpm:install" ];
   tasks."genie:watch".after = [ "pnpm:install" ];
   tasks."genie:check".after = [ "pnpm:install" ];
+  # `nix:test` includes shell e2es for source-mode CLIs (for example compiling
+  # packages/@overeng/genie/bin/genie.tsx), so it must not race dependency
+  # materialization when run as part of `test:run --mode before` in CI.
+  tasks."nix:test".after = [ "pnpm:install" ];
   tasks."lint:check:genie".after = [ "pnpm:install" ];
   tasks."mr:bootstrap".after = [ "pnpm:install" ];
   tasks."mr:fetch-apply".after = [ "pnpm:install" ];

--- a/nix/devenv-modules/tasks/shared/tests/genie-compiled-staging.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/genie-compiled-staging.test.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$TESTS_DIR/../../../../.." && pwd)"
+
+echo "Running Genie compiled import staging cleanup test..."
+echo ""
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+workspace="$tmpdir/workspace"
+tmp_root="$tmpdir/os-tmp"
+compiled_genie="$tmpdir/genie-compiled"
+
+mkdir -p "$workspace/lib" "$tmp_root"
+
+cat > "$workspace/lib/payload.ts" <<'EOF'
+export const payload = { hello: 'compiled' }
+EOF
+
+cat > "$workspace/demo.json.genie.ts" <<'EOF'
+import { payload } from './lib/payload.ts'
+
+export default {
+  data: payload,
+  stringify: () => JSON.stringify(payload, null, 2),
+}
+EOF
+
+echo "Test 1: compiled Genie generates output and exits"
+(
+  cd "$ROOT"
+  bun build packages/@overeng/genie/bin/genie.tsx --compile --outfile "$compiled_genie" >/dev/null
+)
+
+for _ in 1 2 3; do
+  rm -f "$workspace/demo.json"
+  env -u OTEL_EXPORTER_OTLP_ENDPOINT \
+    TMPDIR="$tmp_root" \
+    timeout 20s "$compiled_genie" --cwd "$workspace" --output json >/dev/null
+done
+
+grep -q '"hello": "compiled"' "$workspace/demo.json"
+
+echo "Test 2: compiled import staging dirs are removed after each run"
+leaked_count="$(find "$tmp_root" -maxdepth 1 -mindepth 1 -type d -name 'genie-import-*' | wc -l | tr -d ' ')"
+if [ "$leaked_count" != "0" ]; then
+  find "$tmp_root" -maxdepth 1 -mindepth 1 -type d -name 'genie-import-*' -print >&2
+  echo "Expected 0 leaked genie-import-* dirs, found $leaked_count" >&2
+  exit 1
+fi
+
+echo ""
+echo "Genie compiled import staging cleanup tests passed."

--- a/packages/@overeng/genie/src/core/generation.ts
+++ b/packages/@overeng/genie/src/core/generation.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto'
+import * as nodeFsSync from 'node:fs'
 import nodeFs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
@@ -34,6 +35,11 @@ export type LoadedGenieFile = {
   genieFilePath: string
   output: GenieOutput<unknown>
   ctx: GenieContext
+}
+
+type StagedCompiledBinaryImportGraph = {
+  stagePath: string
+  tempRoot: string
 }
 
 const IMPORT_SPECIFIER_REGEX = /(?:import|export)\s+(?:[\s\S]*?\s+from\s+)?(['"])([^'"]+)\1/g
@@ -110,7 +116,7 @@ const stageCompiledBinaryImportGraph = ({
   entryPath,
 }: {
   entryPath: string
-}): Effect.Effect<string, GenieImportError, FileSystem.FileSystem> =>
+}): Effect.Effect<StagedCompiledBinaryImportGraph, GenieImportError, FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const tempRoot = yield* Effect.tryPromise({
       try: () => nodeFs.mkdtemp(path.join(os.tmpdir(), 'genie-import-')),
@@ -195,8 +201,16 @@ const stageCompiledBinaryImportGraph = ({
         return stagePath
       })
 
-    return yield* stageModule(entryPath)
+    const stagePath = yield* stageModule(entryPath)
+    return { stagePath, tempRoot }
   })
+
+const removeStagedCompiledBinaryImportGraph = ({
+  tempRoot,
+}: StagedCompiledBinaryImportGraph): Effect.Effect<void> =>
+  Effect.sync(() => nodeFsSync.rmSync(tempRoot, { recursive: true, force: true })).pipe(
+    Effect.ignore,
+  )
 
 /**
  * Safely convert error to string.
@@ -504,24 +518,30 @@ export const loadGenieFile = Effect.fn('loadGenieFile')(function* ({
   })
   yield* ensureImportMapResolver
 
-  const importPathBase =
-    isCompiledBinary() === true
-      ? yield* stageCompiledBinaryImportGraph({ entryPath: genieFilePath }).pipe(
-          Effect.map((stagePath) => pathToFileURL(stagePath).href),
-        )
-      : genieFilePath
-  const importPath = `${importPathBase}?import=${Date.now()}`
+  const importModule = (
+    importPath: string,
+  ): Effect.Effect<Record<string, unknown>, GenieImportError> =>
+    Effect.tryPromise({
+      // oxlint-disable-next-line eslint-plugin-import/no-dynamic-require -- dynamic import path required for genie
+      try: () => import(importPath),
+      catch: (error) =>
+        new GenieImportError({
+          genieFilePath,
+          message: `Failed to import ${genieFilePath}: ${safeErrorString(error)}`,
+          cause: error,
+        }),
+    })
 
-  const module = yield* Effect.tryPromise({
-    // oxlint-disable-next-line eslint-plugin-import/no-dynamic-require -- dynamic import path required for genie
-    try: () => import(importPath),
-    catch: (error) =>
-      new GenieImportError({
-        genieFilePath,
-        message: `Failed to import ${genieFilePath}: ${safeErrorString(error)}`,
-        cause: error,
-      }),
-  })
+  const module =
+    isCompiledBinary() === true
+      ? yield* Effect.gen(function* () {
+          const staged = yield* stageCompiledBinaryImportGraph({ entryPath: genieFilePath })
+          const importPath = `${pathToFileURL(staged.stagePath).href}?import=${Date.now()}`
+          return yield* importModule(importPath).pipe(
+            Effect.ensuring(removeStagedCompiledBinaryImportGraph(staged)),
+          )
+        })
+      : yield* importModule(`${genieFilePath}?import=${Date.now()}`)
 
   const exported = module.default
 

--- a/packages/@overeng/restate-effect/src/endpoint/Endpoint.ts
+++ b/packages/@overeng/restate-effect/src/endpoint/Endpoint.ts
@@ -2,7 +2,7 @@ import * as http2 from 'node:http2'
 
 import * as restate from '@restatedev/restate-sdk'
 import { createEndpointHandler } from '@restatedev/restate-sdk/node'
-import type { Config, Schema } from 'effect'
+import type { Config, Schema, Scope } from 'effect'
 import { type ConfigError, Context, Duration, Effect, Exit, Layer, Option, Runtime } from 'effect'
 
 import { RestateContext, type StateSchemas } from '../authoring/RestateContext.ts'
@@ -714,11 +714,28 @@ export interface EndpointOptions<AppR> {
   readonly identityKeys?: ReadonlyArray<string>
 }
 
+/** Runtime binding details for a started endpoint server. */
+export interface EndpointServer {
+  readonly port: number
+  readonly url: string
+}
+
+/** Context service carrying the actual address of a scoped endpoint server. */
+export class BoundEndpoint extends Context.Tag('@overeng/restate-effect/BoundEndpoint')<
+  BoundEndpoint,
+  EndpointServer
+>() {}
+
 /* eslint-disable @typescript-eslint/no-explicit-any -- the services-tuple AppR extractor */
 /**
- * A scoped `Layer` that binds the given service implementations to an h2c
- * (cleartext HTTP/2 prior-knowledge) server on `opts.port` and serves the
- * Restate discovery/invocation protocol.
+ * A scoped `Effect` that binds the given service implementations to an h2c
+ * (cleartext HTTP/2 prior-knowledge) server on `opts.port`, serves the Restate
+ * discovery/invocation protocol, and returns the actual bound address.
+ *
+ * Passing `port: 0` delegates port selection to the kernel and returns the
+ * selected port. That is the race-free pattern for in-process tests: there is no
+ * "ask for a free port, close it, then bind by number" gap for another process
+ * to steal.
  *
  * The shared application runtime is captured once (`Effect.runtime<AppR>()`),
  * each implementation materialized, the server started on acquire, and a
@@ -734,57 +751,87 @@ export interface EndpointOptions<AppR> {
  * `bidirectional` is left UNSET so the SDK negotiates full `BIDI_STREAM` over
  * h2c prior-knowledge (DQ7, docs/vrs/07-endpoint-deploy/spec.md §2).
  */
+export const make = <const S extends ReadonlyArray<AnyImplementation<any>>>(
+  opts: Omit<EndpointOptions<AppROf<S>>, 'services'> & { readonly services: S },
+): Effect.Effect<EndpointServer, RestateError | ConfigError.ConfigError, AppROf<S> | Scope.Scope> =>
+  Effect.gen(function* () {
+    type AppR = AppROf<S>
+    /* Resolve a `Config<number>` port (e.g. `Config.integer('PORT')`) on
+     * acquisition; a literal `number` passes through. A failing Config fails
+     * the layer with a `ConfigError`. */
+    const port = typeof opts.port === 'number' ? opts.port : yield* opts.port
+    const runtime = yield* Effect.runtime<AppR>()
+    const wiring: MaterializeWiring = {
+      hooks: opts.hooks,
+      inboundBridge: opts.inboundBridge,
+      boundaryObserver: opts.boundaryObserver,
+    }
+    const fn = createEndpointHandler({
+      services: opts.services.map((s) =>
+        materializeAny({
+          implementation: s,
+          runtime,
+          ...(wiring !== undefined ? { wiring } : {}),
+        }),
+      ),
+      ...(opts.identityKeys !== undefined ? { identityKeys: [...opts.identityKeys] } : {}),
+    })
+    const server = http2.createServer(fn as Parameters<typeof http2.createServer>[0])
+
+    const bound = yield* Effect.acquireRelease(
+      Effect.async<EndpointServer, RestateError>((resume) => {
+        const onError = (cause: Error) => {
+          server.off('error', onError)
+          resume(
+            Effect.fail(new RestateError({ reason: 'EndpointFailed', method: 'listen', cause })),
+          )
+        }
+        server.once('error', onError)
+        server.listen(port, () => {
+          server.off('error', onError)
+          const address = server.address()
+          if (address === null || typeof address === 'string') {
+            const failure = new RestateError({
+              reason: 'EndpointFailed',
+              method: 'listen',
+              cause: new Error('endpoint did not expose a TCP address'),
+            })
+            server.close(() => resume(Effect.fail(failure)))
+            return
+          }
+          resume(
+            Effect.succeed({
+              port: address.port,
+              url: `http://localhost:${address.port}`,
+            }),
+          )
+        })
+      }),
+      () =>
+        Effect.async<void>((resume) => {
+          server.close(() => resume(Effect.void))
+        }),
+    )
+
+    yield* Effect.logInfo(`restate-effect endpoint listening on ${bound.url}`)
+    return bound
+  })
+
+/** A scoped `Layer` wrapper around {@link make} that exposes the bound address. */
+export const layerWithBoundEndpoint = <const S extends ReadonlyArray<AnyImplementation<any>>>(
+  opts: Omit<EndpointOptions<AppROf<S>>, 'services'> & { readonly services: S },
+): Layer.Layer<BoundEndpoint, RestateError | ConfigError.ConfigError, AppROf<S>> =>
+  Layer.scoped(BoundEndpoint, make(opts))
+
+/**
+ * A scoped `Layer` that starts the endpoint server and discards the bound
+ * address. Use {@link make} or {@link layerWithBoundEndpoint} when a test needs
+ * to register a kernel-selected `port: 0` URL.
+ */
 export const layer = <const S extends ReadonlyArray<AnyImplementation<any>>>(
   opts: Omit<EndpointOptions<AppROf<S>>, 'services'> & { readonly services: S },
 ): Layer.Layer<never, RestateError | ConfigError.ConfigError, AppROf<S>> =>
-  Layer.scopedDiscard(
-    Effect.gen(function* () {
-      type AppR = AppROf<S>
-      /* Resolve a `Config<number>` port (e.g. `Config.integer('PORT')`) on
-       * acquisition; a literal `number` passes through. A failing Config fails
-       * the layer with a `ConfigError`. */
-      const port = typeof opts.port === 'number' ? opts.port : yield* opts.port
-      const runtime = yield* Effect.runtime<AppR>()
-      const wiring: MaterializeWiring = {
-        hooks: opts.hooks,
-        inboundBridge: opts.inboundBridge,
-        boundaryObserver: opts.boundaryObserver,
-      }
-      const fn = createEndpointHandler({
-        services: opts.services.map((s) =>
-          materializeAny({
-            implementation: s,
-            runtime,
-            ...(wiring !== undefined ? { wiring } : {}),
-          }),
-        ),
-        ...(opts.identityKeys !== undefined ? { identityKeys: [...opts.identityKeys] } : {}),
-      })
-      const server = http2.createServer(fn as Parameters<typeof http2.createServer>[0])
-
-      yield* Effect.acquireRelease(
-        Effect.async<typeof server, RestateError>((resume) => {
-          const onError = (cause: Error) => {
-            server.off('error', onError)
-            resume(
-              Effect.fail(new RestateError({ reason: 'EndpointFailed', method: 'listen', cause })),
-            )
-          }
-          server.once('error', onError)
-          server.listen(port, () => {
-            server.off('error', onError)
-            resume(Effect.succeed(server))
-          })
-        }),
-        (s) =>
-          Effect.async<void>((resume) => {
-            s.close(() => resume(Effect.void))
-          }),
-      )
-
-      yield* Effect.logInfo(`restate-effect endpoint listening on http://localhost:${port}`)
-    }),
-  )
+  Layer.scopedDiscard(make(opts))
 
 /**
  * Long-lived production entrypoint: launch the endpoint `layer` and block until

--- a/packages/@overeng/restate-effect/src/mod.ts
+++ b/packages/@overeng/restate-effect/src/mod.ts
@@ -259,13 +259,17 @@ export {
 } from './authoring/Service.ts'
 
 export {
+  BoundEndpoint,
   layer,
+  layerWithBoundEndpoint,
+  make,
   serve,
   materialize,
   materializeObject,
   materializeWorkflow,
   materializeAny,
   type AnyImplementation,
+  type EndpointServer,
   type EndpointOptions,
   type MaterializeWiring,
 } from './endpoint/Endpoint.ts'

--- a/packages/@overeng/restate-effect/src/scheduling/scheduled-durability.integration.test.ts
+++ b/packages/@overeng/restate-effect/src/scheduling/scheduled-durability.integration.test.ts
@@ -16,10 +16,10 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import * as clients from '@restatedev/restate-sdk-clients'
-import { Effect, Exit, Layer, Scope } from 'effect'
+import { Context, Effect, Exit, Layer, Scope } from 'effect'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
-import { freePort } from '@overeng/utils/node'
+import { freePorts } from '@overeng/utils/node'
 
 import {
   installComposedSource,
@@ -32,7 +32,7 @@ import {
   RestateIngress,
   type RestateIngressService,
 } from '../clients/Client.ts'
-import { layer as endpointLayer } from '../endpoint/Endpoint.ts'
+import { BoundEndpoint, layerWithBoundEndpoint } from '../endpoint/Endpoint.ts'
 
 const serverBin = (): string => process.env['RESTATE_SERVER_BIN'] ?? 'restate-server'
 const serverAvailable = (() => {
@@ -130,6 +130,7 @@ describe.skipIf(!serverAvailable)(
     let endpointScope: Scope.CloseableScope
     let ingressUrl: string
     let adminUrl: string
+    let sdkUrl: string
 
     const provideIngress = <X, E, R>(eff: Effect.Effect<X, E, R>) => {
       const svc: RestateIngressService = { ingress: clients.connect({ url: ingressUrl }) }
@@ -144,25 +145,39 @@ describe.skipIf(!serverAvailable)(
       if (serverAvailable === false) return
       resetComposedSources()
       baseDir = await mkdtemp(join(tmpdir(), 'restate-compose-durab-'))
-      const [ingress, admin, node] = await Promise.all([freePort(), freePort(), freePort()])
+      const allocatedPorts = await freePorts(3)
+      const [ingress, admin, node] = [allocatedPorts[0]!, allocatedPorts[1]!, allocatedPorts[2]!]
       ports = { ingress, admin, node }
       ingressUrl = `http://localhost:${ingress}`
       adminUrl = `http://localhost:${admin}`
 
-      const sdkPort = await freePort()
       endpointScope = await Effect.runPromise(Scope.make())
-      await Effect.runPromise(
-        Layer.buildWithScope(
-          endpointLayer({ services: [Daemon.implementation], port: sdkPort }).pipe(
-            Layer.provide(Layer.empty),
+      try {
+        const endpointContext = await Effect.runPromise(
+          Layer.buildWithScope(
+            layerWithBoundEndpoint({ services: [Daemon.implementation], port: 0 }).pipe(
+              Layer.provide(Layer.empty),
+            ),
+            endpointScope,
           ),
-          endpointScope,
-        ),
-      )
+        )
+        sdkUrl = Context.get(endpointContext, BoundEndpoint).url
+      } catch (cause) {
+        await Effect.runPromise(Scope.close(endpointScope, Exit.void))
+        throw cause
+      }
 
       child = spawnServer(baseDir, ports)
-      await waitHealthy(adminUrl)
-      await register(adminUrl, `http://localhost:${sdkPort}`)
+      try {
+        await waitHealthy(adminUrl)
+      } catch (cause) {
+        if (child.exitCode === null) {
+          child.kill('SIGKILL')
+          await sleep(300)
+        }
+        throw cause
+      }
+      await register(adminUrl, sdkUrl)
     }, 90_000)
 
     afterAll(async () => {

--- a/packages/@overeng/restate-effect/src/testing/testing.ts
+++ b/packages/@overeng/restate-effect/src/testing/testing.ts
@@ -33,7 +33,7 @@ import { join } from 'node:path'
 import * as clients from '@restatedev/restate-sdk-clients'
 import { Clock, Context, Effect, Exit, Layer, Option, type Schema, Scope } from 'effect'
 
-import { freePort, freePorts } from '@overeng/utils/node'
+import { freePorts } from '@overeng/utils/node'
 
 import {
   type AdminClientConfig,
@@ -83,7 +83,11 @@ import {
   workflowSubmit as ingressWorkflowSubmit,
 } from '../clients/Client.ts'
 import { contractSerdeFactory } from '../clients/InvocationPolicy.ts'
-import { type AnyImplementation, layer as endpointLayer } from '../endpoint/Endpoint.ts'
+import {
+  BoundEndpoint,
+  type AnyImplementation,
+  layerWithBoundEndpoint,
+} from '../endpoint/Endpoint.ts'
 import { type BoundaryObserver, type EndpointHooks, type HandlerWrap } from '../error/Boundary.ts'
 import { type RedactionCipher, RestateRedaction } from '../schema/Redaction.ts'
 import { RestateError } from '../schema/RestateError.ts'
@@ -753,28 +757,28 @@ export class RestateTestHarness extends Context.Tag('@overeng/restate-effect/Res
           endpointScope: Scope.Scope
         }): Effect.Effect<string, RestateError, RIn2> =>
           Effect.gen(function* () {
-            const port = yield* Effect.promise(() => freePort())
-            yield* endpointLayer({
-              services,
-              port,
-              ...(opts.hooks !== undefined ? { hooks: opts.hooks } : {}),
-              ...(opts.inboundBridge !== undefined ? { inboundBridge: opts.inboundBridge } : {}),
-              ...(opts.boundaryObserver !== undefined
-                ? { boundaryObserver: opts.boundaryObserver }
-                : {}),
-            }).pipe(
-              Layer.provide(appLayer),
+            const endpointContext = yield* Layer.buildWithScope(
+              layerWithBoundEndpoint({
+                services,
+                port: 0,
+                ...(opts.hooks !== undefined ? { hooks: opts.hooks } : {}),
+                ...(opts.inboundBridge !== undefined ? { inboundBridge: opts.inboundBridge } : {}),
+                ...(opts.boundaryObserver !== undefined
+                  ? { boundaryObserver: opts.boundaryObserver }
+                  : {}),
+              }).pipe(Layer.provide(appLayer)),
+              endpointScope,
+            ).pipe(
               /* The endpoint layer's channel is `RestateError | ConfigError`, but
                * the `ConfigError` arm fires ONLY for a `Config<number>` port — here
-               * the port is a literal `number`, so it is structurally impossible.
+               * the port is literal `0`, so it is structurally impossible.
                * Re-fail a real `RestateError` (a bind/listen failure) and die on the
                * unreachable `ConfigError`, keeping the harness channel clean. */
-              Layer.catchAll((cause) =>
-                cause instanceof RestateError ? Layer.fail(cause) : Layer.die(cause),
+              Effect.catchAll((cause) =>
+                cause instanceof RestateError ? Effect.fail(cause) : Effect.die(cause),
               ),
-              Layer.buildWithScope(endpointScope),
             )
-            const uri = `http://localhost:${port}`
+            const uri = Context.get(endpointContext, BoundEndpoint).url
             yield* Effect.tryPromise({
               try: () => server.register(uri),
               catch: (cause) =>


### PR DESCRIPTION
**Problem**

Issue #824: compiled Genie stages runtime `.genie.ts` imports into `genie-import-*` directories under the process temp directory and never removed them.

While verifying the PR, `check:all` exposed two separate flake classes:

- Restate handler endpoints could still use `freePort()` then bind by number, leaving a TOCTOU gap that surfaced locally as `EADDRINUSE :34431`.
- CI unit jobs could start `nix:test` concurrently with `pnpm:install`; the new compiled Genie shell e2e needs source-mode Node deps, so CI could run `packages/@overeng/genie/bin/genie.tsx` before `node_modules` existed.

**Decisions**

The compiled Genie fix keeps the compiled-binary staging path because it is still needed: user `.genie.ts` files are discovered at runtime, and compiled Bun binaries cannot rely on the source-mode import-map plugin path. Instead, the staged import graph now has an explicit lifetime around the dynamic import and a best-effort cleanup finalizer.

For Restate, the principled long-term pattern is: in-process servers bind `port: 0`, read `server.address().port`, and register that exact URL. `freePort()` is only acceptable when a child process needs a number; those paths use `freePorts(...)` plus retry-on-port-collision. This PR exposes `Endpoint.make` / `layerWithBoundEndpoint` so tests can observe the actual bound endpoint, updates the harness and scheduled durability test to use it, and keeps batch allocation for native `restate-server` ports.

For CI, the fix is dependency-ordering, not a timeout bump: `nix:test` now depends on `pnpm:install`, so `test:run --mode before` cannot race source-mode CLI tests against dependency materialization.

**Proof / Verification**

Compiled Genie e2e:

```text
$ bash nix/devenv-modules/tasks/shared/tests/genie-compiled-staging.test.sh
Genie compiled import staging cleanup tests passed.
```

CI failure root cause from PR #825 logs:

```text
nix:test started before pnpm:install completed
error: Could not resolve: "@effect/cli". Maybe you need to "bun install"?
at packages/@overeng/genie/bin/genie.tsx:3:22
```

Local reproduction/ordering proof:

```text
$ devenv tasks run test:run --mode before
# before fix: setup:gate, nix:test, and pnpm:install started together
# after fix: pnpm:install completed before nix:test started
✓ Running nix:test
✓ Running test:run
```

Forced Restate proof:

```text
$ devenv tasks run test:restate-effect --no-tui --show-output --refresh-task-cache
Test Files 35 passed (35)
Tests 170 passed (170)
```

Repo gates:

```text
$ devenv tasks run genie:check --no-tui
✓ Running genie:check

$ devenv tasks run ts:check --no-tui
✓ Running ts:check

$ devenv tasks run lint:check --no-tui
✓ Running lint:check

$ devenv tasks run check:quick --no-tui
✓ Running check:quick

$ devenv tasks run check:all --no-tui
✓ Running check:all
```

**Tradeoffs**

`Endpoint.make` is a small API expansion, but it makes the race-free pattern explicit and reusable. A smaller patch could have wrapped endpoint `freePort()` in retry logic, but that still preserves the bind-by-number gap. Binding `0` and publishing the actual URL removes the gap entirely for in-process endpoints.

The native Restate child process still needs numeric ports. That is why `freePorts(...)` and collision retry remain there. A further cleanup would extract the native Restate server lifecycle into one shared scoped helper with throwaway and persistent-base-dir modes; this PR fixes the flaky surfaces without doing that larger refactor.

**References**

Closes #824.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🐍 co3-viper |
| `agent_session_id` | f890ca75-7e81-4a5a-a9b7-b3e6bbe07cc9 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.141.0 |
| `agent_runtime` | Codex CLI 0.141.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/j1qs1x0327iq8hb9i1gcd9dhrdpbx6ah-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/jdg26gyjsdq4944kipvhrjzdgvj2w1fz-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling/2026-06-22-824 |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@6362d96 |
</details>
<!-- agent-footer:end -->