### PR TITLE
feat(lib): add mkEffectUtilsInstall for cross-repo source relink

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -292,6 +292,13 @@
       # Usage: effectUtils.lib.mkPnpm { inherit pkgs; }
       lib.mkPnpm = { pkgs }: import ./nix/pnpm.nix { inherit pkgs; };
 
+      # Cross-repo effect-utils source relink install command, with the pnpm
+      # store-dir resolved from the CI-exported env so the relink shares one
+      # store with the root install (avoids a two-store split in deploy jobs).
+      # Usage: effectUtils.lib.mkEffectUtilsInstall { root = config.devenv.root; }
+      lib.mkEffectUtilsInstall =
+        import ./nix/devenv-modules/tasks/lib/effect-utils-install.nix;
+
       # Note: mkSourceCli is internal-only (not exported).
       # For consuming CLIs from other repos, use:
       #   effectUtils.packages.${system}.genie

--- a/nix/devenv-modules/tasks/lib/effect-utils-install.nix
+++ b/nix/devenv-modules/tasks/lib/effect-utils-install.nix
@@ -10,8 +10,9 @@
 # A hardcoded CLI `--config.store-dir` has the highest pnpm precedence and would
 # override the CI env, splitting a single deploy job across two stores and
 # desyncing the root node_modules projection (the `next: command not found`
-# class of failure). `--force` performs the GVS relink; frozen (the default)
-# means a drifted effect-utils lockfile fails loudly rather than being silently
-# rewritten.
+# class of failure). `--force` performs the GVS relink. `--frozen-lockfile` is
+# explicit (not relying on pnpm's CI-only default for frozen) so a drifted
+# effect-utils lockfile fails loudly in both local and CI runs rather than being
+# silently rewritten.
 { root, dir ? "repos/effect-utils" }:
-''DT_PASSTHROUGH=1 pnpm install --force --ignore-scripts --config.confirmModulesPurge=false --config.store-dir="''${PNPM_CONFIG_STORE_DIR:-''${PNPM_STORE_DIR:-${root}/.devenv/pnpm-store-pure-v1}}" --dir ${dir}''
+''DT_PASSTHROUGH=1 pnpm install --force --frozen-lockfile --ignore-scripts --config.confirmModulesPurge=false --config.store-dir="''${PNPM_CONFIG_STORE_DIR:-''${PNPM_STORE_DIR:-${root}/.devenv/pnpm-store-pure-v1}}" --dir ${dir}''

--- a/nix/devenv-modules/tasks/lib/effect-utils-install.nix
+++ b/nix/devenv-modules/tasks/lib/effect-utils-install.nix
@@ -1,0 +1,17 @@
+# Shared pnpm install command for the cross-repo effect-utils source relink.
+#
+# Repos that compose effect-utils as a linked pnpm source workspace must
+# pre-warm `repos/effect-utils`'s own node_modules so TypeScript resolves
+# imports through the cross-repo symlinks. Centralizing the command here keeps
+# the pnpm store-dir resolution in one place: it is sourced from the
+# CI-exported env (PNPM_CONFIG_STORE_DIR / PNPM_STORE_DIR) so the relink shares
+# one store with the root install, falling back to the workspace store locally.
+#
+# A hardcoded CLI `--config.store-dir` has the highest pnpm precedence and would
+# override the CI env, splitting a single deploy job across two stores and
+# desyncing the root node_modules projection (the `next: command not found`
+# class of failure). `--force` performs the GVS relink; frozen (the default)
+# means a drifted effect-utils lockfile fails loudly rather than being silently
+# rewritten.
+{ root, dir ? "repos/effect-utils" }:
+''DT_PASSTHROUGH=1 pnpm install --force --ignore-scripts --config.confirmModulesPurge=false --config.store-dir="''${PNPM_CONFIG_STORE_DIR:-''${PNPM_STORE_DIR:-${root}/.devenv/pnpm-store-pure-v1}}" --dir ${dir}''


### PR DESCRIPTION
## Problem
Repos that compose effect-utils as a linked pnpm source workspace hand-roll a `pnpm install ... --dir repos/effect-utils` relink to pre-warm node_modules. Several inline this with a hardcoded `--config.store-dir=…/.devenv/pnpm-store-pure-v1`. A CLI `--config.store-dir` has the **highest** pnpm precedence and overrides the CI-exported store env (`PNPM_CONFIG_STORE_DIR`), so a deploy job's root install and effect-utils relink land in **two different stores**, and the `--force` GVS relink can desync the root `node_modules` projection — the `next: command not found` failure class seen in `deploy-schickling-dev`.

## Change
Add `effectUtils.lib.mkEffectUtilsInstall { root, dir ? "repos/effect-utils" }` centralizing the relink command with store-dir resolved from `PNPM_CONFIG_STORE_DIR`/`PNPM_STORE_DIR` (shared with the root install; falls back to the workspace store locally), `--force`, `--ignore-scripts`, frozen (default). Consumers call the helper instead of hand-rolling the string, so store-dir handling can't be re-bugged per repo.

## Blast radius
Additive — one new exported lib function + one lib file. No existing behavior changes; members opt in by switching their inline string to the helper.

## Validation
- `nix-instantiate --parse flake.nix` OK.
- Flake-level eval `lib.mkEffectUtilsInstall { root = "/REPO"; }` emits the intended command with shell-level `${PNPM_*}` expansion and Nix-interpolated root/dir.

## Downstream
Consumed by schickling.dev and schickling-stiftung PRs (which drop their inline `effectUtilsInstall` strings). schickling-stiftung currently carries the same latent store-split bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | ⛵ cl1-inlet |
| `agent_session_id` | b4b63d9c-ee73-4edb-961a-7095bfe55445 |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.183 |
| `agent_runtime` | Claude Code 2.1.183 |
| `agent_model` | claude-opus-4-8 |
| `runtime_profile` | /nix/store/m9ybpmqknd74gpy4kga76fgsdsaac7j1-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/akkxsma0kp26y7sm2mlqjqq061zj3xva-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-06-22-2026-06-22-effect-utils-install-helper |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@6936d3a |
</details>
<!-- agent-footer:end -->