### PR TITLE
feat(genie): add a system:* label axis; @overeng packages become system:*, effect stays area:

### DIFF
--- a/.github/labels.json
+++ b/.github/labels.json
@@ -206,6 +206,166 @@
       "description": "Needs classification or owner decision · Set: manual"
     },
     {
+      "name": "system:agent-session-ingest",
+      "color": "a371f7",
+      "description": "@overeng/agent-session-ingest package · Set: manual"
+    },
+    {
+      "name": "system:content-address",
+      "color": "a371f7",
+      "description": "@overeng/content-address package · Set: manual"
+    },
+    {
+      "name": "system:effect-ai-claude-cli",
+      "color": "a371f7",
+      "description": "@overeng/effect-ai-claude-cli package · Set: manual"
+    },
+    {
+      "name": "system:effect-path",
+      "color": "a371f7",
+      "description": "@overeng/effect-path package · Set: manual"
+    },
+    {
+      "name": "system:effect-react",
+      "color": "a371f7",
+      "description": "@overeng/effect-react package · Set: manual"
+    },
+    {
+      "name": "system:effect-rpc-tanstack",
+      "color": "a371f7",
+      "description": "@overeng/effect-rpc-tanstack package · Set: manual"
+    },
+    {
+      "name": "system:effect-schema-form",
+      "color": "a371f7",
+      "description": "@overeng/effect-schema-form package · Set: manual"
+    },
+    {
+      "name": "system:effect-schema-form-aria",
+      "color": "a371f7",
+      "description": "@overeng/effect-schema-form-aria package · Set: manual"
+    },
+    {
+      "name": "system:genie",
+      "color": "a371f7",
+      "description": "@overeng/genie package · Set: manual"
+    },
+    {
+      "name": "system:kdl",
+      "color": "a371f7",
+      "description": "@overeng/kdl package · Set: manual"
+    },
+    {
+      "name": "system:kdl-effect",
+      "color": "a371f7",
+      "description": "@overeng/kdl-effect package · Set: manual"
+    },
+    {
+      "name": "system:megarepo",
+      "color": "a371f7",
+      "description": "@overeng/megarepo package · Set: manual"
+    },
+    {
+      "name": "system:notion-cli",
+      "color": "a371f7",
+      "description": "@overeng/notion-cli package · Set: manual"
+    },
+    {
+      "name": "system:notion-core",
+      "color": "a371f7",
+      "description": "@overeng/notion-core package · Set: manual"
+    },
+    {
+      "name": "system:notion-datasource-sync",
+      "color": "a371f7",
+      "description": "@overeng/notion-datasource-sync package · Set: manual"
+    },
+    {
+      "name": "system:notion-effect-client",
+      "color": "a371f7",
+      "description": "@overeng/notion-effect-client package · Set: manual"
+    },
+    {
+      "name": "system:notion-effect-schema",
+      "color": "a371f7",
+      "description": "@overeng/notion-effect-schema package · Set: manual"
+    },
+    {
+      "name": "system:notion-md",
+      "color": "a371f7",
+      "description": "@overeng/notion-md package · Set: manual"
+    },
+    {
+      "name": "system:notion-property-write",
+      "color": "a371f7",
+      "description": "@overeng/notion-property-write package · Set: manual"
+    },
+    {
+      "name": "system:notion-react",
+      "color": "a371f7",
+      "description": "@overeng/notion-react package · Set: manual"
+    },
+    {
+      "name": "system:otel-contract",
+      "color": "a371f7",
+      "description": "@overeng/otel-contract package · Set: manual"
+    },
+    {
+      "name": "system:otelite",
+      "color": "a371f7",
+      "description": "@overeng/otelite package · Set: manual"
+    },
+    {
+      "name": "system:oxc-config",
+      "color": "a371f7",
+      "description": "@overeng/oxc-config package · Set: manual"
+    },
+    {
+      "name": "system:pty-effect",
+      "color": "a371f7",
+      "description": "@overeng/pty-effect package · Set: manual"
+    },
+    {
+      "name": "system:react-inspector",
+      "color": "a371f7",
+      "description": "@overeng/react-inspector package · Set: manual"
+    },
+    {
+      "name": "system:restate-effect",
+      "color": "a371f7",
+      "description": "@overeng/restate-effect package · Set: manual"
+    },
+    {
+      "name": "system:tui-core",
+      "color": "a371f7",
+      "description": "@overeng/tui-core package · Set: manual"
+    },
+    {
+      "name": "system:tui-react",
+      "color": "a371f7",
+      "description": "@overeng/tui-react package · Set: manual"
+    },
+    {
+      "name": "system:tui-stories",
+      "color": "a371f7",
+      "description": "@overeng/tui-stories package · Set: manual"
+    },
+    {
+      "name": "system:utils",
+      "color": "a371f7",
+      "description": "@overeng/utils package · Set: manual"
+    },
+    {
+      "name": "system:utils-dev",
+      "color": "a371f7",
+      "description": "@overeng/utils-dev package · Set: manual"
+    },
+    {
+      "name": "system:workflow-report",
+      "color": "a371f7",
+      "description": "@overeng/workflow-report package · Set: manual"
+    },
+    {
       "name": "type:agent-tooling",
       "color": "1f8fb8",
       "description": "Agent, automation, AI workflow, or developer-agent tooling · Set: manual"

--- a/.github/labels.json.genie.ts
+++ b/.github/labels.json.genie.ts
@@ -1,3 +1,6 @@
+import { readdirSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
 import {
   andonLabels,
   commonLabels,
@@ -47,6 +50,27 @@ const effectUtilsAreaLabels: readonly LabelDef[] = [
   },
 ]
 
+/**
+ * Repo-local `system:*` labels — one per concrete `@overeng/*` package. A
+ * `system:*` value names a thing with its own identity that issues and feedback
+ * are attributed *to*, distinct from the cross-cutting `area:*` concern axis.
+ * Derived from the package directories (derive-don't-author) so the catalog
+ * tracks the workspace automatically; the genie freshness gate regenerates and
+ * diffs `labels.json`, so adding/removing a package is always reflected here.
+ */
+const effectUtilsSystemLabels: readonly LabelDef[] = readdirSync(
+  fileURLToPath(new URL('../packages/@overeng', import.meta.url)),
+  { withFileTypes: true },
+)
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name)
+  .sort()
+  .map((pkg) => ({
+    name: `system:${pkg}`,
+    color: 'a371f7',
+    description: `@overeng/${pkg} package · Set: manual`,
+  }))
+
 /** Repo-local utility labels used by automation in this repo. */
 const effectUtilsAutomationLabels: readonly LabelDef[] = [
   {
@@ -79,6 +103,7 @@ export default githubLabels({
     ...mqLabels,
     ...andonLabels,
     ...effectUtilsAreaLabels,
+    ...effectUtilsSystemLabels,
     ...effectUtilsAutomationLabels,
   ],
   deprecated: [...deprecatedDefaults, ...repoLocalDeprecated],

--- a/genie/labels.ts
+++ b/genie/labels.ts
@@ -177,6 +177,18 @@ const sharedAreaLabels: readonly LabelDef[] = [
 ]
 
 // ============================================================================
+// system:* — named systems/products/packages with their own identity
+//   Distinct from `area:*` (cross-cutting concerns): a `system:*` value names a
+//   thing with its own identity (e.g. a concrete package) that issues and
+//   feedback are attributed *to*. Cross-cutting frameworks such as Effect stay
+//   on `area:*` (`area:effect`) — they are a concern, not a system. There are no
+//   shared `system:*` values; each repo adds its own in its label config.
+//
+//   Color convention: light purple/violet (`a371f7`) so `system:*` chips read
+//   distinctly from the bright-blue `area:*` chips.
+// ============================================================================
+
+// ============================================================================
 // mq:* — Hypermerge / merge-queue lifecycle labels
 //   Must stay loosely aligned with mq_label_color / mq_label_description in
 //   dotfiles/flakes/merge-queue/crates/mq-core/src/gh_client.rs.


### PR DESCRIPTION
## What

Add a `system:*` label axis, distinct from the cross-cutting `area:*` concern axis. A `system:*` value names a thing with its own identity (e.g. a concrete package) that issues and feedback are attributed *to*.

- **Shared catalog** documents the `system:*` convention and its color (light-purple `a371f7`). No shared `system:*` values are added: cross-cutting frameworks such as Effect stay on `area:*` (`area:effect`) because they are a **concern**, not a system.
- **Repo-local** `system:*` labels are derived, one per `packages/@overeng/*` directory (derive-don't-author), so the catalog tracks the workspace automatically.
- `.github/labels.json` is regenerated: 32 `system:*` labels added, `area:effect` retained, no `system:effect`, no migration.

## Why

`effect` is the framework — a cross-cutting concern that belongs on `area:`. The concrete packages are the named systems that get their own `system:*` label. This keeps the two axes orthogonal: an issue reads e.g. `type:bug` + `area:nix` + `system:utils`.

## Notes

- `system:<pkg>` labels are derived from the package directories and sorted, so adding/removing a package is reflected automatically; the genie freshness gate regenerates and diffs `labels.json` on every check.
- Applying these labels to live issues is a separate, gated step (`gh:apply-labels`) and is intentionally not part of this PR.
