### PR TITLE
fix(ci): skip fork-only reporting writes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6178,6 +6178,12 @@ jobs:
             fi
 
             can_render_pr_comment=true
+            is_fork_pr=false
+            if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+              echo "::notice::CI measurement PR comment skipped for fork pull request; summary and artifacts remain available"
+              can_render_pr_comment=false
+              is_fork_pr=true
+            fi
 
             ensure_ci_measurement_tool() {
               tool_name="$1"
@@ -6226,7 +6232,9 @@ jobs:
             fi
 
             if [ "$can_render_pr_comment" != "true" ]; then
-              exit 1
+              if [ "$is_fork_pr" != "true" ]; then
+                exit 1
+              fi
             fi
 
             if [ "$can_render_pr_comment" = "true" ]; then
@@ -7194,6 +7202,22 @@ jobs:
 
                 node "$renderer_script" "$comparison_file" "$comments_json" "$comment_body" "$comment_id_file" "$chart_file" "$chart_dark_file"
 
+                rerender_ci_measurement_comment() {
+                  node "$renderer_script" "$comparison_file" "$comments_json" "$comment_body" "$comment_id_file" "$chart_file" "$chart_dark_file"
+                }
+
+                drop_ci_measurement_chart_source() {
+                  export CI_MEASUREMENT_PR_COMMENT_CHART_SOURCE_URL=""
+                  rerender_ci_measurement_comment
+                }
+
+                drop_ci_measurement_chart_images() {
+                  export CI_MEASUREMENT_PR_COMMENT_CHART_URL=""
+                  export CI_MEASUREMENT_PR_COMMENT_CHART_DARK_URL=""
+                  export CI_MEASUREMENT_PR_COMMENT_CHART_SOURCE_URL=""
+                  rerender_ci_measurement_comment
+                }
+
                 if [ -s "$chart_file" ]; then
                   if [ "$require_public_asset" = "true" ] && [ -z "$public_asset_command" ]; then
                     echo "::error::CI measurement chart was rendered for a private repository, but CI_MEASUREMENT_PR_COMMENT_PUBLIC_ASSET_COMMAND is not configured. Private raw GitHub URLs cannot be embedded in PR comments."
@@ -7232,7 +7256,7 @@ jobs:
                   if ! gh api "repos/$repo/contents/$asset_svg_path" --method PUT --field message="Update CI measurement chart SVG for PR #$pr_number" --field content="$chart_content" --field branch="$asset_branch" >/dev/null; then
                     echo "::notice::unable to upload CI measurement chart SVG asset"
                     if [ -z "$public_asset_command" ]; then
-                      sed -i.bak '/\[SVG source\]/d' "$comment_body"
+                      drop_ci_measurement_chart_source
                     fi
                   fi
                   if [ -s "$chart_png_file" ]; then
@@ -7240,11 +7264,11 @@ jobs:
                     if ! gh api "repos/$repo/contents/$asset_png_path" --method PUT --field message="Update CI measurement chart PNG for PR #$pr_number" --field content="$chart_png_content" --field branch="$asset_branch" >/dev/null; then
                       echo "::notice::unable to upload CI measurement chart PNG asset"
                       if [ -z "$public_asset_command" ]; then
-                        sed -i.bak '/!\[Measurement change vs baseline chart\]/d; /!\[Perf change vs baseline chart\]/d; /<picture>/,/<\\/picture>/d' "$comment_body"
+                        drop_ci_measurement_chart_images
                       fi
                     fi
                   else
-                    sed -i.bak '/!\[Measurement change vs baseline chart\]/d; /!\[Perf change vs baseline chart\]/d; /<picture>/,/<\\/picture>/d' "$comment_body"
+                    drop_ci_measurement_chart_images
                   fi
                   if [ -s "$chart_dark_png_file" ]; then
                     chart_dark_png_content="$(base64 <"$chart_dark_png_file" | tr -d '\n')"
@@ -7252,7 +7276,7 @@ jobs:
                       echo "::notice::unable to upload dark CI measurement chart PNG asset"
                       if [ -z "$public_asset_command" ]; then
                         export CI_MEASUREMENT_PR_COMMENT_CHART_DARK_URL=""
-                        node "$renderer_script" "$comparison_file" "$comments_json" "$comment_body" "$comment_id_file" "$chart_file" "$chart_dark_file"
+                        rerender_ci_measurement_comment
                       fi
                     fi
                   fi
@@ -8790,7 +8814,7 @@ jobs:
       - pnpm-regression
       - cargo
       - deploy-storybooks
-    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '') }}
+    if: (github.ref == 'refs/heads/main') && github.event_name == 'push'
     steps:
       - name: Dispatch alignment to coordinator
         env:

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -904,7 +904,6 @@ export default ciWorkflow({
           'namespace-features:github.run-id=${{ github.run_id }}',
         ],
       }),
-      if: normalCiIf,
     },
   },
 } satisfies GitHubWorkflowArgs)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,15 @@ All notable changes to this project will be documented in this file.
   source-mode CLI shell tests cannot race dependency materialization under
   `test:run --mode before`.
 
+- **CI alignment notification**: Keep the `notify-alignment` dispatch limited to
+  trusted push events so fork pull requests without `MEGAREPO_ALIGNMENT_TOKEN`
+  do not run the coordinator dispatch job and fail with GitHub `401`.
+
+- **CI measurement reporting**: Skip PR comment publication for fork pull
+  requests that cannot write comments/assets, while keeping measurement summaries
+  and artifacts. Chart asset fallbacks now re-render the comment from structured
+  URLs instead of editing Markdown with brittle `sed` ranges.
+
 - **Genie compiled import staging cleanup**: Scope compiled-binary `.genie.ts`
   import staging directories to the dynamic import lifetime so successful and
   failing compiled runs no longer leave `genie-import-*` directories in the

--- a/genie/ci-workflow/measurements.ts
+++ b/genie/ci-workflow/measurements.ts
@@ -2476,6 +2476,12 @@ ${
   fi
 
   can_render_pr_comment=true
+  is_fork_pr=false
+  if [ "${dollar}{{ github.event.pull_request.head.repo.full_name }}" != "${dollar}{{ github.repository }}" ]; then
+    echo "::notice::CI measurement PR comment skipped for fork pull request; summary and artifacts remain available"
+    can_render_pr_comment=false
+    is_fork_pr=true
+  fi
 
   ensure_ci_measurement_tool() {
     tool_name="$1"
@@ -2524,7 +2530,9 @@ ${
   fi
 
   if [ "$can_render_pr_comment" != "true" ]; then
-    exit 1
+    if [ "$is_fork_pr" != "true" ]; then
+      exit 1
+    fi
   fi
 
   if [ "$can_render_pr_comment" = "true" ]; then
@@ -3492,6 +3500,22 @@ EOF
 
       node "$renderer_script" "$comparison_file" "$comments_json" "$comment_body" "$comment_id_file" "$chart_file" "$chart_dark_file"
 
+      rerender_ci_measurement_comment() {
+        node "$renderer_script" "$comparison_file" "$comments_json" "$comment_body" "$comment_id_file" "$chart_file" "$chart_dark_file"
+      }
+
+      drop_ci_measurement_chart_source() {
+        export CI_MEASUREMENT_PR_COMMENT_CHART_SOURCE_URL=""
+        rerender_ci_measurement_comment
+      }
+
+      drop_ci_measurement_chart_images() {
+        export CI_MEASUREMENT_PR_COMMENT_CHART_URL=""
+        export CI_MEASUREMENT_PR_COMMENT_CHART_DARK_URL=""
+        export CI_MEASUREMENT_PR_COMMENT_CHART_SOURCE_URL=""
+        rerender_ci_measurement_comment
+      }
+
       if [ -s "$chart_file" ]; then
         if [ "$require_public_asset" = "true" ] && [ -z "$public_asset_command" ]; then
           echo "::error::CI measurement chart was rendered for a private repository, but CI_MEASUREMENT_PR_COMMENT_PUBLIC_ASSET_COMMAND is not configured. Private raw GitHub URLs cannot be embedded in PR comments."
@@ -3530,7 +3554,7 @@ EOF
         if ! gh api "repos/$repo/contents/$asset_svg_path" --method PUT --field message="Update CI measurement chart SVG for PR #$pr_number" --field content="$chart_content" --field branch="$asset_branch" >/dev/null; then
           echo "::notice::unable to upload CI measurement chart SVG asset"
           if [ -z "$public_asset_command" ]; then
-            sed -i.bak '/\[SVG source\]/d' "$comment_body"
+            drop_ci_measurement_chart_source
           fi
         fi
         if [ -s "$chart_png_file" ]; then
@@ -3538,11 +3562,11 @@ EOF
           if ! gh api "repos/$repo/contents/$asset_png_path" --method PUT --field message="Update CI measurement chart PNG for PR #$pr_number" --field content="$chart_png_content" --field branch="$asset_branch" >/dev/null; then
             echo "::notice::unable to upload CI measurement chart PNG asset"
             if [ -z "$public_asset_command" ]; then
-              sed -i.bak '/!\[Measurement change vs baseline chart\]/d; /!\[Perf change vs baseline chart\]/d; /<picture>/,/<\\/picture>/d' "$comment_body"
+              drop_ci_measurement_chart_images
             fi
           fi
         else
-          sed -i.bak '/!\[Measurement change vs baseline chart\]/d; /!\[Perf change vs baseline chart\]/d; /<picture>/,/<\\/picture>/d' "$comment_body"
+          drop_ci_measurement_chart_images
         fi
         if [ -s "$chart_dark_png_file" ]; then
           chart_dark_png_content="$(base64 <"$chart_dark_png_file" | tr -d '\n')"
@@ -3550,7 +3574,7 @@ EOF
             echo "::notice::unable to upload dark CI measurement chart PNG asset"
             if [ -z "$public_asset_command" ]; then
               export CI_MEASUREMENT_PR_COMMENT_CHART_DARK_URL=""
-              node "$renderer_script" "$comparison_file" "$comments_json" "$comment_body" "$comment_id_file" "$chart_file" "$chart_dark_file"
+              rerender_ci_measurement_comment
             fi
           fi
         fi


### PR DESCRIPTION
**Problem**

PR #833 fixed the Restate SDK log capture path and its product/test jobs passed, but the run still failed in CI control-plane jobs that require write privileges unavailable to fork pull requests. `notify-alignment` attempted to dispatch with an unavailable secret, and `ci/measurements-report` treated fork PR comment/chart upload failures as fatal.

**Goal**

Fork pull requests should keep product CI meaningful: write-only reporting integrations should either skip or degrade to summaries/artifacts without failing otherwise green validation.

**Decisions**

- Let `notify-alignment` keep its source-level main-push guard instead of overriding it with the normal PR CI condition in the generated workflow.
- Detect fork PRs before CI measurement PR comment rendering and skip the GitHub-write comment path while leaving summaries and artifacts available.
- Replace brittle generated `sed` rewrites for measurement chart fallback with explicit rerender helpers, so upload failures remove chart inputs structurally.

**Verification**

- `devenv shell -- dt check:quick --no-tui` passed on commit `bbafbb56`.
- `devenv shell -- dt check:all --no-tui` passed on commit `bbafbb56`.
- Confirmed generated `.github/workflows/ci.yml` contains the fork PR measurement skip and `notify-alignment` is guarded by `github.ref == refs/heads/main && github.event_name == push`.

**Complexity**

No new runtime complexity. The change is limited to generated CI behavior and the generator source that owns it.

**Concerns**

Fork PRs will no longer receive the measurement PR comment from this job. They still retain step summaries and artifacts, which is the least-privilege behavior available without granting write tokens to forked code.

**Friction & bottlenecks**

PR #833 was merged while the follow-up CI-control commit was being prepared, so this had to be rebased as a separate follow-up PR. The local `genie:run` task cache did not notice helper-only workflow source changes until the generator was run directly with the repo-supported passthrough.

**Follow-ups**

None.

**References**

Refs #833.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 💪 co2-grit |
| `agent_session_id` | 1b788b62-b3ce-4b5b-a281-5ad76f16dd99 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.141.0 |
| `agent_runtime` | Codex CLI 0.141.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/g1a0105g1bnsbl26qx0207gc52zs74i9-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/9jcbgsa9v5q2bj8jd7n7ml448xihc1k1-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling/2026-06-22-dmp-e2e |
| `machine` | mbp2025 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->