### PR TITLE
fix(tui-react): make xterm CSS import downstream-safe via referenced ambient (#837)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ All notable changes to this project will be documented in this file.
   mismatches in runtime dependencies fail in CI before downstream consumers hit
   them. Mark `pnpm-install-contract.json` as generated in Git attributes.
 
+- **devenv/lint**: Add a `lint:check:asset-import-needs-type-reference` task (wired into
+  `lint:check`) that fails when a compiled, exported source file imports an asset
+  (`import '...css|scss|sass|less'`) without a `/// <reference>` directive to make the ambient
+  `*.css` declaration travel into downstream TS checks (TS2882, #837). It runs out-of-band over
+  tracked + untracked source (an in-oxlint rule would itself be suppressible by an `oxlint-disable`,
+  which is how this regressed), so no disable directive — next-line, same-line, or file-level — can
+  bypass it. Exempts the globs where side-effect imports are allowed and not type-checked downstream
+  (`.storybook/**`, `*.gen.*`, `*.d.ts`, `*.test.*`, `*.stories.*`).
+
 - **Dependency materialization VRS hierarchy**: Move the reusable pnpm install,
   projection, Nix prepared-deps, store-authority, Buck2 evidence, and
   observability contracts into `context/dependency-materialization/` as a
@@ -113,6 +122,17 @@ All notable changes to this project will be documented in this file.
   effect-utils' root workspace config only, so downstream
   `createPnpmPatchedDependencies` consumers do not inherit a pty-only patch and
   trip pnpm's unused-patch validation.
+
+- **@overeng/tui-react**: Fix downstream `TS2882` for `TuiStoryPreview`'s
+  `import '@xterm/xterm/css/xterm.css'`. The `*.css` ambient that types the side-effect import is
+  now referenced from the importing file via a `/// <reference path>` directive (to a shipped
+  `src/storybook/asset-modules.d.ts`), so the declaration travels into every program that compiles
+  the file — including downstream source-linked TS checks. Previously the ambient lived in floating
+  `.d.ts` files loaded only by this repo's own tsconfig `include` globs, so it did not ride along
+  when a downstream consumer compiled the source via `exports`-resolution. Removes those floating
+  declarations (`types/css.d.ts`, `tui-react/src/types/css.d.ts`) and their `include` references
+  across the `genie`, `megarepo`, `notion-cli`, and `tui-stories` tsconfigs. The bundler still
+  injects the stylesheet natively — no runtime or codegen change.
 
 ### Changed
 

--- a/nix/devenv-modules/tasks/shared/lint-oxc.nix
+++ b/nix/devenv-modules/tasks/shared/lint-oxc.nix
@@ -172,6 +172,56 @@ let
       # Intentionally no execIfModified caching: new unmanaged config files are exactly
       # what this task exists to detect.
     };
+    "lint:check:asset-import-needs-type-reference" = {
+      description = "Require a /// <reference> for asset side-effect imports in compiled source";
+      exec = trace.exec "lint:check:asset-import-needs-type-reference" ''
+        set -euo pipefail
+
+        # A bare `import '...css'` (or scss/sass/less) in compiled, exported source needs an ambient
+        # `*.css` declaration to type it. If that ambient lives only in a floating `.d.ts` pulled in
+        # by this package's own tsconfig `include`, it does NOT travel into a downstream consumer
+        # that compiles this source via `exports`-resolution — the side-effect import then fails with
+        # TS2882 (see #837). A `/// <reference path|types ...>` directive in the SAME file is part of
+        # that file's load graph, so the declaration travels into every program that compiles it.
+        #
+        # This guard requires that any compiled-source file with an asset side-effect import also
+        # carries a `/// <reference>`. It runs out-of-band (an inline `oxlint-disable` of
+        # `no-unassigned-import` cannot suppress it). Exempts the globs where side-effect imports are
+        # allowed and not type-checked into downstream graphs: `.storybook/**`, `*.gen.*`, `*.d.ts`,
+        # `*.test.*`, `*.stories.*`.
+        offenders=$(
+          {
+            ${git} ls-files -- 'packages/*/src/**/*.ts' 'packages/*/src/**/*.tsx' \
+              'context/**/*.ts' 'context/**/*.tsx'
+            ${git} ls-files --others --exclude-standard -- \
+              'packages/*/src/**/*.ts' 'packages/*/src/**/*.tsx' \
+              'context/**/*.ts' 'context/**/*.tsx'
+          } | sort -u | while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              */.storybook/*|*.gen.*|*.d.ts|*.test.*|*.stories.*) continue ;;
+            esac
+            ${pkgs.gawk}/bin/awk '
+              /^[[:space:]]*import[[:space:]]+['"'"'"][^'"'"'"]*\.(css|scss|sass|less)['"'"'"]/ { asset = 1 }
+              /^[[:space:]]*\/\/\/[[:space:]]*<reference[[:space:]]/ { ref = 1 }
+              END { if (asset == 1 && ref != 1) print FILENAME }
+            ' "$f"
+          done | sort -u
+        )
+        if [ -n "$offenders" ]; then
+          echo "Asset side-effect import without a travelling type reference in compiled source:"
+          echo "$offenders"
+          echo ""
+          echo "Add a '/// <reference path=\"...\" />' to a shipped '*.css' ambient in the importing"
+          echo "file so the declaration travels into downstream TS checks (see #837), or move the"
+          echo "import under a '.storybook/*' entry that is not type-checked downstream."
+          exit 1
+        fi
+        echo "All asset side-effect imports in compiled source carry a type reference"
+      '';
+      # Intentionally no execIfModified caching: a newly added asset import in any source
+      # file is exactly what this task exists to detect.
+    };
     "lint:check:lockfile" = {
       description = "Verify pnpm-lock.yaml matches package.json specifiers";
       after = [ "pnpm:install" ];
@@ -200,6 +250,7 @@ let
         "lint:check:oxlint"
         "lint:check:genie"
         "lint:check:genie:coverage"
+        "lint:check:asset-import-needs-type-reference"
         "lint:check:lockfile"
       ];
     };

--- a/packages/@overeng/genie/tsconfig.json
+++ b/packages/@overeng/genie/tsconfig.json
@@ -47,13 +47,7 @@
     "types": ["node", "bun"],
     "jsx": "react-jsx"
   },
-  "include": [
-    "src/**/*.ts",
-    "src/**/*.tsx",
-    "bin/**/*.ts",
-    "bin/**/*.tsx",
-    "../../../types/css.d.ts"
-  ],
+  "include": ["src/**/*.ts", "src/**/*.tsx", "bin/**/*.ts", "bin/**/*.tsx"],
   "references": [
     {
       "path": "../otel-contract"

--- a/packages/@overeng/genie/tsconfig.json.genie.ts
+++ b/packages/@overeng/genie/tsconfig.json.genie.ts
@@ -13,13 +13,7 @@ export default tsconfigJson({
     types: ['node', 'bun'],
     jsx: 'react-jsx',
   },
-  include: [
-    'src/**/*.ts',
-    'src/**/*.tsx',
-    'bin/**/*.ts',
-    'bin/**/*.tsx',
-    '../../../types/css.d.ts',
-  ],
+  include: ['src/**/*.ts', 'src/**/*.tsx', 'bin/**/*.ts', 'bin/**/*.tsx'],
   references: [
     { path: '../otel-contract' },
     { path: '../tui-core' },

--- a/packages/@overeng/megarepo/tsconfig.json
+++ b/packages/@overeng/megarepo/tsconfig.json
@@ -47,7 +47,7 @@
     "types": ["node", "bun"],
     "jsx": "react-jsx"
   },
-  "include": ["src/**/*", "test/**/*", "bin/**/*", "../../../types/css.d.ts"],
+  "include": ["src/**/*", "test/**/*", "bin/**/*"],
   "references": [
     {
       "path": "../tui-core"

--- a/packages/@overeng/megarepo/tsconfig.json.genie.ts
+++ b/packages/@overeng/megarepo/tsconfig.json.genie.ts
@@ -14,7 +14,7 @@ export default tsconfigJson({
     ...reactJsx,
     types: ['node', 'bun'],
   },
-  include: ['src/**/*', 'test/**/*', 'bin/**/*', '../../../types/css.d.ts'],
+  include: ['src/**/*', 'test/**/*', 'bin/**/*'],
   references: [
     { path: '../tui-core' },
     { path: '../tui-react' },

--- a/packages/@overeng/notion-cli/tsconfig.json
+++ b/packages/@overeng/notion-cli/tsconfig.json
@@ -46,7 +46,7 @@
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
     "jsx": "react-jsx"
   },
-  "include": ["src/**/*", "bin/**/*.ts", "../../../types/css.d.ts"],
+  "include": ["src/**/*", "bin/**/*.ts"],
   "references": [
     {
       "path": "../effect-path"

--- a/packages/@overeng/notion-cli/tsconfig.json.genie.ts
+++ b/packages/@overeng/notion-cli/tsconfig.json.genie.ts
@@ -11,7 +11,7 @@ export default tsconfigJson({
     ...packageTsconfigCompilerOptions,
     ...reactJsx,
   },
-  include: ['src/**/*', 'bin/**/*.ts', '../../../types/css.d.ts'],
+  include: ['src/**/*', 'bin/**/*.ts'],
   references: [
     { path: '../effect-path' },
     { path: '../notion-effect-client' },

--- a/packages/@overeng/tui-react/src/storybook/TuiStoryPreview.tsx
+++ b/packages/@overeng/tui-react/src/storybook/TuiStoryPreview.tsx
@@ -32,12 +32,17 @@
  * - `ndjson` - Streaming NDJSON
  */
 
+// Types the `*.css` side-effect import below via a referenced ambient (not a floating .d.ts) so the
+// declaration travels into downstream source-linked TS checks. See asset-modules.d.ts and #837.
+// oxlint-disable-next-line typescript-eslint(triple-slash-reference) -- intentional: an ambient-only .d.ts cannot be an ES import
+/// <reference path="./asset-modules.d.ts" />
+
 import { Atom, Registry } from '@effect-atom/atom'
 import { FitAddon } from '@xterm/addon-fit'
 import { WebglAddon } from '@xterm/addon-webgl'
 import { Terminal } from '@xterm/xterm'
 import { Schema } from 'effect'
-// oxlint-disable-next-line eslint-plugin-import(no-unassigned-import) -- CSS side-effect import
+// oxlint-disable-next-line eslint-plugin-import(no-unassigned-import) -- deliberate bundler stylesheet
 import '@xterm/xterm/css/xterm.css'
 import React, { useEffect, useRef, useState, useCallback, useMemo } from 'react'
 

--- a/packages/@overeng/tui-react/src/storybook/asset-modules.d.ts
+++ b/packages/@overeng/tui-react/src/storybook/asset-modules.d.ts
@@ -1,0 +1,13 @@
+/**
+ * Ambient declarations for bundler asset imports (e.g. `import '@xterm/xterm/css/xterm.css'`,
+ * which the bundler injects as a side effect).
+ *
+ * This file is loaded via a `/// <reference path>` directive from each module that imports such an
+ * asset, NOT via a tsconfig `include` glob. That distinction is the fix for #837: a floating
+ * ambient `.d.ts` only enters the program whose tsconfig globs it in, so it does not ride along
+ * when a downstream consumer compiles our source through `exports`-resolution — and the side-effect
+ * import then fails with TS2882. A triple-slash reference is part of the importing file's own load
+ * graph, so the declaration travels into every program that compiles that file.
+ */
+
+declare module '*.css' {}

--- a/packages/@overeng/tui-react/src/types/css.d.ts
+++ b/packages/@overeng/tui-react/src/types/css.d.ts
@@ -1,2 +1,0 @@
-/** Ambient type declaration for CSS side-effect imports (e.g. from @xterm/xterm). */
-declare module '*.css' {}

--- a/packages/@overeng/tui-stories/tsconfig.json
+++ b/packages/@overeng/tui-stories/tsconfig.json
@@ -47,7 +47,7 @@
     "types": ["node"],
     "jsx": "react-jsx"
   },
-  "include": ["src/**/*", "test/**/*", "bin/**/*.ts", "bin/**/*.tsx", "../../../types/css.d.ts"],
+  "include": ["src/**/*", "test/**/*", "bin/**/*.ts", "bin/**/*.tsx"],
   "references": [
     {
       "path": "../megarepo"

--- a/packages/@overeng/tui-stories/tsconfig.json.genie.ts
+++ b/packages/@overeng/tui-stories/tsconfig.json.genie.ts
@@ -13,7 +13,7 @@ export default tsconfigJson({
     ...nodeTypes,
     ...reactJsx,
   },
-  include: ['src/**/*', 'test/**/*', 'bin/**/*.ts', 'bin/**/*.tsx', '../../../types/css.d.ts'],
+  include: ['src/**/*', 'test/**/*', 'bin/**/*.ts', 'bin/**/*.tsx'],
   references: [
     { path: '../megarepo' },
     { path: '../tui-core' },

--- a/types/css.d.ts
+++ b/types/css.d.ts
@@ -1,2 +1,0 @@
-/** Ambient type declaration for CSS side-effect imports (e.g. from @xterm/xterm). */
-declare module '*.css' {}


### PR DESCRIPTION
## Problem

`@overeng/tui-react`'s `TuiStoryPreview` (compiled and exported via `./storybook`) does
`import '@xterm/xterm/css/xterm.css'`. That side-effect import needs a `declare module '*.css'`
ambient. The repo provided one via floating `.d.ts` files — but **a floating ambient `.d.ts` only
enters the program whose tsconfig globs it in; it does not ride along when a downstream consumer
compiles this source via `exports`-resolution.** A downstream aggregate TS check pulling
`TuiStoryPreview.tsx` into its own program through a source-linked workspace finds no ambient →
`TS2882`. Closes #837.

## Fix — make the ambient travel *with the importing file*

The insight: an ambient `declare module` is only in a program if that program loads the *file*
containing it. A floating `.d.ts` is loaded only by its own tsconfig's `include` globs. A
`/// <reference path>` directive **in the importing file** is part of *that file's* load graph, so
the declaration travels into every program that compiles the file — including downstream.

- `TuiStoryPreview.tsx` keeps `import '@xterm/xterm/css/xterm.css'` (the bundler injects the
  stylesheet natively — Vite emits a real `.xterm{…}` CSS asset, unchanged from before), and adds
  `/// <reference path="./asset-modules.d.ts" />`.
- New `src/storybook/asset-modules.d.ts` = `declare module '*.css' {}`, documenting why it is
  referenced rather than glob-included.
- Deleted the floating ambients (`types/css.d.ts`, `tui-react/src/types/css.d.ts`) and their
  `include` references across the `genie`, `megarepo`, `notion-cli`, and `tui-stories` tsconfigs.

This is a **type-only** change: it restores the exact CSS import that worked at runtime before #837
and adds a comment directive — no runtime, codegen, or bundler-output change.

## Enforcement (so the discipline can't lapse)

New shared devenv task `lint:check:asset-import-needs-type-reference` (wired into `lint:check`) fails
when a compiled, exported source file imports an asset (`import '...css|scss|sass|less'`) without a
`/// <reference>` to make its type travel. It runs **out-of-band** over tracked + untracked files —
an in-oxlint rule would itself be suppressible by an `oxlint-disable` — so no disable form
(next-line, same-line, file-level) can bypass it. It exempts the globs where side-effect imports are
allowed and not type-checked downstream (`.storybook/**`, `*.gen.*`, `*.d.ts`, `*.test.*`,
`*.stories.*`), and propagates fleet-wide via the shared lint module.

## Verification

- **Downstream-travel probe (the real proof):** compiling `TuiStoryPreview.tsx` in an isolated
  program (via `files`, so `asset-modules.d.ts` is *not* glob-included) reproduces
  `TS2882: …side-effect import of '@xterm/xterm/css/xterm.css'` **without** the `/// reference`, and
  is clean **with** it. The reference is precisely and solely the fix.
- `dt check:all` green (tsgo: no TS2882; lint incl. the new guard; tests + `nix:test`).
- Guard A/B: an asset import with no `/// reference` fails the task; adding the reference passes.
- `storybook:build` green; Vite bundles `TuiStoryPreview-*.css` containing the xterm `.xterm{…}`
  selectors (the build path is intact).
- The tui-react `*.pw.test.ts` visual e2e is a local-only tool (not CI-gated) and is red at baseline
  in headless CI (the `WebglAddon` needs a GPU) — unrelated to this change, which makes no runtime
  difference to the original working import.

## Tradeoff (honest note)

The bare CSS side-effect import and the triple-slash reference each trip a repo lint rule
(`import/no-unassigned-import` and `typescript-eslint/triple-slash-reference`), so this carries **two
targeted, annotated `oxlint-disable` lines** — the repo lints opinionatedly against both patterns.
An earlier iteration of this fix removed the CSS import entirely (generated CSS-string module +
runtime `<style>` injection), which needed *zero* disables but vendored a copy of the stylesheet and
added a runtime helper. This PR favors the bundler-native build path; the disables are the cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🐇 cl2-hare |
| `agent_session_id` | e489ce06-49f8-4474-a2fc-5df174822162 |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.183 |
| `agent_runtime` | Claude Code 2.1.183 |
| `agent_model` | claude-opus-4-8 |
| `runtime_profile` | /nix/store/ri1wraif9cqyw420wd1ngp0z0a8rnwn7-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/n77xdlvsmwmg1b0kafxnir498z81ijkz-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling/2026-06-25-837 |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->