### PR TITLE
feat(notion): add markdown block payload conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- **Notion Markdown block payloads**: Add `NotionMarkdown.markdownToBlocks`,
+  an AST-based converter from selected Notion-flavored Markdown and GFM tables
+  into block-children payloads accepted by `NotionBlocks.append`.
+
 - **Bundle smoke CI gate**: Add a Vite/Rollup-based smoke check for
   `@overeng/pty-effect` public entries so bundler-resolution ESM export
   mismatches in runtime dependencies fail in CI before downstream consumers hit

--- a/packages/@overeng/notion-effect-client/src/canonical-markdown.ts
+++ b/packages/@overeng/notion-effect-client/src/canonical-markdown.ts
@@ -1,20 +1,9 @@
-import {
-  gfmStrikethroughFromMarkdown,
-  gfmStrikethroughToMarkdown,
-} from 'mdast-util-gfm-strikethrough'
-import { gfmTableFromMarkdown, gfmTableToMarkdown } from 'mdast-util-gfm-table'
-import {
-  gfmTaskListItemFromMarkdown,
-  gfmTaskListItemToMarkdown,
-} from 'mdast-util-gfm-task-list-item'
-import { gfmStrikethrough } from 'micromark-extension-gfm-strikethrough'
-import { gfmTable } from 'micromark-extension-gfm-table'
-import { gfmTaskListItem } from 'micromark-extension-gfm-task-list-item'
 import remarkParse from 'remark-parse'
 import remarkStringify from 'remark-stringify'
-import { unified, type Processor } from 'unified'
+import { unified } from 'unified'
 import { visit } from 'unist-util-visit'
 
+import { remarkNotionGfm } from './markdown-gfm.ts'
 import { canonicalizeMediaUrlsInMarkdown } from './media-url.ts'
 
 /*
@@ -125,49 +114,6 @@ const markdownStringifyOptions = {
   setext: false,
   tightDefinitions: true,
 } as const
-
-const pushProcessorData = <A>({
-  data,
-  key,
-  extensions,
-}: {
-  data: Record<string, unknown>
-  key: string
-  extensions: ReadonlyArray<A>
-}): void => {
-  const current = (data[key] ??= []) as Array<A>
-  current.push(...extensions)
-}
-
-/*
- * Use only the GFM constructs Notion-flavored Markdown needs here. The bundled
- * `remark-gfm` also enables autolink literals, which rewrites plain URL/email-
- * shaped text into angle autolinks (`https://x.y` -> `<https://x.y>`). That is
- * lossy for Notion preview-link text and makes edge cases like `0@.A`
- * non-idempotent (`<0@.A>` -> `<<0@.A>>`).
- */
-const remarkNotionGfm = function (this: Processor): void {
-  const data = this.data() as Record<string, unknown>
-  pushProcessorData({
-    data,
-    key: 'micromarkExtensions',
-    extensions: [gfmTable(), gfmTaskListItem(), gfmStrikethrough()],
-  })
-  pushProcessorData({
-    data,
-    key: 'fromMarkdownExtensions',
-    extensions: [
-      gfmTableFromMarkdown(),
-      gfmTaskListItemFromMarkdown(),
-      gfmStrikethroughFromMarkdown(),
-    ],
-  })
-  pushProcessorData({
-    data,
-    key: 'toMarkdownExtensions',
-    extensions: [gfmTableToMarkdown(), gfmTaskListItemToMarkdown(), gfmStrikethroughToMarkdown()],
-  })
-}
 
 const processor = unified()
   .use(remarkParse)

--- a/packages/@overeng/notion-effect-client/src/markdown-gfm.ts
+++ b/packages/@overeng/notion-effect-client/src/markdown-gfm.ts
@@ -1,0 +1,56 @@
+import {
+  gfmStrikethroughFromMarkdown,
+  gfmStrikethroughToMarkdown,
+} from 'mdast-util-gfm-strikethrough'
+import { gfmTableFromMarkdown, gfmTableToMarkdown } from 'mdast-util-gfm-table'
+import {
+  gfmTaskListItemFromMarkdown,
+  gfmTaskListItemToMarkdown,
+} from 'mdast-util-gfm-task-list-item'
+import { gfmStrikethrough } from 'micromark-extension-gfm-strikethrough'
+import { gfmTable } from 'micromark-extension-gfm-table'
+import { gfmTaskListItem } from 'micromark-extension-gfm-task-list-item'
+import type { Processor } from 'unified'
+
+const pushProcessorData = <TValue>({
+  data,
+  key,
+  extensions,
+}: {
+  data: Record<string, unknown>
+  key: string
+  extensions: ReadonlyArray<TValue>
+}): void => {
+  const current = (data[key] ??= []) as Array<TValue>
+  current.push(...extensions)
+}
+
+/**
+ * Use only the GFM constructs Notion-flavored Markdown needs here. The bundled
+ * `remark-gfm` also enables autolink literals, which rewrites plain URL/email-
+ * shaped text into angle autolinks (`https://x.y` -> `<https://x.y>`). That is
+ * lossy for Notion preview-link text and makes edge cases like `0@.A`
+ * non-idempotent (`<0@.A>` -> `<<0@.A>>`).
+ */
+export const remarkNotionGfm = function (this: Processor): void {
+  const data = this.data() as Record<string, unknown>
+  pushProcessorData({
+    data,
+    key: 'micromarkExtensions',
+    extensions: [gfmTable(), gfmTaskListItem(), gfmStrikethrough()],
+  })
+  pushProcessorData({
+    data,
+    key: 'fromMarkdownExtensions',
+    extensions: [
+      gfmTableFromMarkdown(),
+      gfmTaskListItemFromMarkdown(),
+      gfmStrikethroughFromMarkdown(),
+    ],
+  })
+  pushProcessorData({
+    data,
+    key: 'toMarkdownExtensions',
+    extensions: [gfmTableToMarkdown(), gfmTaskListItemToMarkdown(), gfmStrikethroughToMarkdown()],
+  })
+}

--- a/packages/@overeng/notion-effect-client/src/markdown-to-blocks.ts
+++ b/packages/@overeng/notion-effect-client/src/markdown-to-blocks.ts
@@ -1,0 +1,242 @@
+import remarkParse from 'remark-parse'
+import { unified } from 'unified'
+
+import { remarkNotionGfm } from './markdown-gfm.ts'
+
+/** Rich-text payload accepted inside Notion block-children write requests. */
+export type NotionRichTextCreate = {
+  readonly type: 'text'
+  readonly text: {
+    readonly content: string
+    readonly link?: { readonly url: string }
+  }
+  readonly annotations?: {
+    readonly bold?: boolean
+    readonly italic?: boolean
+    readonly strikethrough?: boolean
+    readonly code?: boolean
+  }
+}
+
+/** Block-child payload accepted by `NotionBlocks.append`. */
+export type NotionBlockCreate = Readonly<Record<string, unknown>>
+
+type RichTextMarks = NonNullable<NotionRichTextCreate['annotations']>
+
+type MdastNode = {
+  readonly type: string
+  readonly value?: string
+  readonly url?: string
+  readonly depth?: number
+  readonly ordered?: boolean
+  readonly checked?: boolean | null
+  readonly children?: readonly MdastNode[]
+}
+
+const processor = unified().use(remarkParse).use(remarkNotionGfm)
+
+const normalizeInput = (markdown: string): string =>
+  markdown
+    .replace(/\r\n/g, '\n')
+    .replace(/\r/g, '\n')
+    .replace(/<br\s*\/?>\s*/gi, '\n')
+
+const hasMarks = (marks: RichTextMarks): boolean =>
+  marks.bold === true ||
+  marks.italic === true ||
+  marks.strikethrough === true ||
+  marks.code === true
+
+const text = ({
+  content,
+  marks = {},
+  url,
+}: {
+  content: string
+  marks?: RichTextMarks
+  url?: string
+}): NotionRichTextCreate => ({
+  type: 'text',
+  text: url === undefined ? { content } : { content, link: { url } },
+  ...(hasMarks(marks) === true ? { annotations: marks } : {}),
+})
+
+const markedText = ({
+  content,
+  marks,
+  url,
+}: {
+  content: string
+  marks: RichTextMarks
+  url: string | undefined
+}): NotionRichTextCreate => text({ content, marks, ...(url === undefined ? {} : { url }) })
+
+const richTextFromNodes = (
+  nodes: readonly MdastNode[] | undefined,
+): readonly NotionRichTextCreate[] => {
+  const segments: NotionRichTextCreate[] = []
+
+  const visit = ({
+    node,
+    marks = {},
+    linkUrl,
+  }: {
+    node: MdastNode
+    marks?: RichTextMarks
+    linkUrl?: string
+  }): void => {
+    switch (node.type) {
+      case 'text':
+        segments.push(markedText({ content: node.value ?? '', marks, url: linkUrl }))
+        return
+      case 'strong':
+        node.children?.forEach((child) =>
+          visitChild({ node: child, marks: { ...marks, bold: true }, linkUrl }),
+        )
+        return
+      case 'emphasis':
+        node.children?.forEach((child) =>
+          visitChild({ node: child, marks: { ...marks, italic: true }, linkUrl }),
+        )
+        return
+      case 'delete':
+        node.children?.forEach((child) =>
+          visitChild({ node: child, marks: { ...marks, strikethrough: true }, linkUrl }),
+        )
+        return
+      case 'inlineCode':
+        segments.push(
+          markedText({ content: node.value ?? '', marks: { ...marks, code: true }, url: linkUrl }),
+        )
+        return
+      case 'break':
+        segments.push(markedText({ content: '\n', marks, url: linkUrl }))
+        return
+      case 'link':
+        node.children?.forEach((child) =>
+          visitChild({ node: child, marks, linkUrl: node.url ?? linkUrl }),
+        )
+        return
+      case 'image':
+        segments.push(markedText({ content: node.url ?? '', marks, url: node.url }))
+        return
+      default:
+        if (node.children !== undefined) {
+          node.children.forEach((child) => visitChild({ node: child, marks, linkUrl }))
+        }
+    }
+  }
+  const visitChild = ({
+    node,
+    marks,
+    linkUrl,
+  }: {
+    node: MdastNode
+    marks: RichTextMarks
+    linkUrl: string | undefined
+  }): void => visit({ node, marks, ...(linkUrl === undefined ? {} : { linkUrl }) })
+
+  nodes?.forEach((node) => visit({ node }))
+  return segments.length > 0 ? segments : [text({ content: '' })]
+}
+
+const blockWithRichText = ({
+  type,
+  richText,
+}: {
+  type: string
+  richText: readonly NotionRichTextCreate[]
+}): NotionBlockCreate => ({
+  type,
+  [type]: { rich_text: richText },
+})
+
+const tableCellRichText = (node: MdastNode | undefined): readonly NotionRichTextCreate[] =>
+  richTextFromNodes(node?.children)
+
+const tableBlock = (node: MdastNode): NotionBlockCreate => {
+  const rows = node.children ?? []
+  const tableWidth = Math.max(...rows.map((row) => row.children?.length ?? 0), 1)
+
+  return {
+    type: 'table',
+    table: {
+      table_width: tableWidth,
+      has_column_header: true,
+      has_row_header: false,
+      children: rows.map((row) => ({
+        type: 'table_row',
+        table_row: {
+          cells: Array.from({ length: tableWidth }, (_, index) =>
+            tableCellRichText(row.children?.[index]),
+          ),
+        },
+      })),
+    },
+  }
+}
+
+const listItemRichText = (node: MdastNode): readonly NotionRichTextCreate[] => {
+  const children = node.children ?? []
+  const paragraph = children.find((child) => child.type === 'paragraph')
+  return richTextFromNodes(
+    paragraph?.children ?? children.flatMap((child) => child.children ?? [child]),
+  )
+}
+
+const listBlocks = (node: MdastNode): readonly NotionBlockCreate[] => {
+  const type = node.ordered === true ? 'numbered_list_item' : 'bulleted_list_item'
+  return (node.children ?? []).map((item) => {
+    if (item.checked !== null && item.checked !== undefined) {
+      return {
+        type: 'to_do',
+        to_do: {
+          rich_text: listItemRichText(item),
+          checked: item.checked,
+        },
+      }
+    }
+
+    return blockWithRichText({ type, richText: listItemRichText(item) })
+  })
+}
+
+const rootBlockFromNode = (node: MdastNode): readonly NotionBlockCreate[] => {
+  switch (node.type) {
+    case 'paragraph':
+      return [blockWithRichText({ type: 'paragraph', richText: richTextFromNodes(node.children) })]
+    case 'heading': {
+      const type = `heading_${Math.min(Math.max(node.depth ?? 1, 1), 3)}`
+      return [blockWithRichText({ type, richText: richTextFromNodes(node.children) })]
+    }
+    case 'thematicBreak':
+      return [{ type: 'divider', divider: {} }]
+    case 'list':
+      return listBlocks(node)
+    case 'table':
+      return [tableBlock(node)]
+    case 'code':
+      return [
+        {
+          type: 'code',
+          code: {
+            rich_text: richTextFromNodes([{ type: 'text', value: node.value ?? '' }]),
+            language: 'plain text',
+          },
+        },
+      ]
+    default:
+      return node.children === undefined
+        ? []
+        : [blockWithRichText({ type: 'paragraph', richText: richTextFromNodes(node.children) })]
+  }
+}
+
+/**
+ * Convert Notion-flavored Markdown into block children payloads accepted by
+ * `NotionBlocks.append`.
+ */
+export const markdownToBlocks = (markdown: string): readonly NotionBlockCreate[] => {
+  const tree = processor.parse(normalizeInput(markdown)) as MdastNode
+  return tree.children?.flatMap(rootBlockFromNode) ?? []
+}

--- a/packages/@overeng/notion-effect-client/src/markdown-to-blocks.unit.test.ts
+++ b/packages/@overeng/notion-effect-client/src/markdown-to-blocks.unit.test.ts
@@ -1,0 +1,142 @@
+import { describe, it } from '@effect/vitest'
+import { expect } from 'vitest'
+
+import { markdownToBlocks } from './markdown-to-blocks.ts'
+
+const block = (markdown: string, index = 0) =>
+  markdownToBlocks(markdown)[index] as Record<string, unknown>
+
+describe('markdownToBlocks', () => {
+  it('converts paragraphs and normalizes HTML line breaks within paragraph text', () => {
+    expect(markdownToBlocks('one<br>two')).toEqual([
+      {
+        type: 'paragraph',
+        paragraph: {
+          rich_text: [{ type: 'text', text: { content: 'one\ntwo' } }],
+        },
+      },
+    ])
+  })
+
+  it('uses normalized HTML line breaks to split adjacent block starts', () => {
+    expect(markdownToBlocks('## Acme<br>### Growth').map((item) => item.type)).toEqual([
+      'heading_2',
+      'heading_3',
+    ])
+  })
+
+  it('converts headings and caps deeper headings at Notion heading_3', () => {
+    expect(markdownToBlocks('# One\n\n## Two\n\n#### Four').map((item) => item.type)).toEqual([
+      'heading_1',
+      'heading_2',
+      'heading_3',
+    ])
+  })
+
+  it('converts thematic breaks to dividers', () => {
+    expect(markdownToBlocks('---')).toEqual([{ type: 'divider', divider: {} }])
+  })
+
+  it('converts inline rich text marks', () => {
+    const paragraph = block('**bold** *italic* `code` ~~gone~~') as {
+      readonly paragraph: { readonly rich_text: readonly unknown[] }
+    }
+
+    expect(paragraph.paragraph.rich_text).toEqual([
+      { type: 'text', text: { content: 'bold' }, annotations: { bold: true } },
+      { type: 'text', text: { content: ' ' } },
+      { type: 'text', text: { content: 'italic' }, annotations: { italic: true } },
+      { type: 'text', text: { content: ' ' } },
+      { type: 'text', text: { content: 'code' }, annotations: { code: true } },
+      { type: 'text', text: { content: ' ' } },
+      { type: 'text', text: { content: 'gone' }, annotations: { strikethrough: true } },
+    ])
+  })
+
+  it('preserves explicit markdown links in rich text', () => {
+    const paragraph = block('[Example](https://example.com)') as {
+      readonly paragraph: { readonly rich_text: readonly unknown[] }
+    }
+
+    expect(paragraph.paragraph.rich_text).toEqual([
+      {
+        type: 'text',
+        text: { content: 'Example', link: { url: 'https://example.com' } },
+      },
+    ])
+  })
+
+  it('expands bullet, ordered, and task-list items to appendable blocks', () => {
+    expect(
+      markdownToBlocks('- a\n- **b**\n\n1. one\n2. two\n\n- [x] done').map((item) => item.type),
+    ).toEqual([
+      'bulleted_list_item',
+      'bulleted_list_item',
+      'numbered_list_item',
+      'numbered_list_item',
+      'to_do',
+    ])
+  })
+
+  it('converts GFM tables with rich text cells', () => {
+    const table = block('| Item | Amount |\n|---|---|\n| **Total** | *1.309,00 EUR* |') as {
+      readonly table: {
+        readonly table_width: number
+        readonly has_column_header: boolean
+        readonly has_row_header: boolean
+        readonly children: ReadonlyArray<{
+          readonly table_row: { readonly cells: readonly (readonly unknown[])[] }
+        }>
+      }
+    }
+
+    expect(table.table.table_width).toBe(2)
+    expect(table.table.has_column_header).toBe(true)
+    expect(table.table.has_row_header).toBe(false)
+    expect(table.table.children).toHaveLength(2)
+    expect(table.table.children[1]?.table_row.cells[0]).toEqual([
+      { type: 'text', text: { content: 'Total' }, annotations: { bold: true } },
+    ])
+    expect(table.table.children[1]?.table_row.cells[1]).toEqual([
+      { type: 'text', text: { content: '1.309,00 EUR' }, annotations: { italic: true } },
+    ])
+  })
+
+  it('pads missing table cells to the table width', () => {
+    const table = block('| A | B | C |\n|---|---|---|\n| 1 |') as {
+      readonly table: {
+        readonly table_width: number
+        readonly children: ReadonlyArray<{
+          readonly table_row: { readonly cells: readonly (readonly unknown[])[] }
+        }>
+      }
+    }
+
+    expect(table.table.table_width).toBe(3)
+    expect(table.table.children[1]?.table_row.cells).toHaveLength(3)
+    expect(table.table.children[1]?.table_row.cells[2]).toEqual([
+      { type: 'text', text: { content: '' } },
+    ])
+  })
+
+  it('leaves non-table pipe content as a paragraph', () => {
+    expect(markdownToBlocks('acme | 123 Main St | 90210 Springfield')).toEqual([
+      {
+        type: 'paragraph',
+        paragraph: {
+          rich_text: [
+            { type: 'text', text: { content: 'acme | 123 Main St | 90210 Springfield' } },
+          ],
+        },
+      },
+    ])
+  })
+
+  it('converts mixed heading, table, and paragraph content in order', () => {
+    expect(
+      markdownToBlocks(
+        '## Balance\n\n| Item | Amount |\n|---|---|\n| Assets | 63.087 |\n\nText after table.',
+      ).map((item) => item.type),
+    ).toEqual(['heading_2', 'table', 'paragraph'])
+  })
+})

--- a/packages/@overeng/notion-effect-client/src/markdown.ts
+++ b/packages/@overeng/notion-effect-client/src/markdown.ts
@@ -20,7 +20,10 @@ import {
   NotionBlocks,
   type RetrieveNestedOptions,
 } from './blocks.ts'
+import { markdownToBlocks } from './markdown-to-blocks.ts'
 import { canonicalizeMediaUrl } from './media-url.ts'
+
+export { markdownToBlocks } from './markdown-to-blocks.ts'
 
 // -----------------------------------------------------------------------------
 // Types
@@ -679,4 +682,5 @@ export const NotionMarkdown = {
   pageToMarkdown,
   treeToMarkdown,
   blocksToMarkdown,
+  markdownToBlocks,
 } as const

--- a/packages/@overeng/notion-effect-client/src/mod.ts
+++ b/packages/@overeng/notion-effect-client/src/mod.ts
@@ -130,6 +130,7 @@ export type {
   BlockWithData,
   PageToMarkdownOptions,
 } from './markdown.ts'
+export type { NotionBlockCreate, NotionRichTextCreate } from './markdown-to-blocks.ts'
 export {
   BlockHelpers,
   getBlockCaption,
@@ -143,6 +144,7 @@ export {
   getEquationExpression,
   getTableRowCells,
   isTodoChecked,
+  markdownToBlocks,
   NotionMarkdown,
 } from './markdown.ts'
 export { canonicalizeBlockMarkdown, canonicalizeSemanticMarkdown } from './canonical-markdown.ts'


### PR DESCRIPTION
## Why

Downstream consumers need to turn selected Notion-flavored Markdown into block children payloads for `NotionBlocks.append`. `dotfiles` currently carries a local parser for this in `notion-scan`, which duplicates Markdown and block-payload policy that belongs in `@overeng/notion-effect-client`.

## What

Adds `NotionMarkdown.markdownToBlocks` and the standalone `markdownToBlocks` export. The converter produces append-compatible block child payloads for paragraphs, headings, dividers, lists, task lists, code blocks, links/rich text marks, and GFM tables.

## How

The implementation parses Markdown through the same selected GFM extension setup already used by canonical Markdown, now factored into `markdown-gfm.ts`. It then maps the mdast root nodes to Notion block-children write payloads. Retrieved Notion blocks remain typed by the schema package; these write payloads intentionally use a create/append payload type compatible with the existing `NotionBlocks.append` surface.

## Rationale

Using the existing remark/GFM parser path avoids adding another line-oriented Markdown parser and keeps table/list semantics aligned with the package's canonical Markdown policy. A full schema-backed write-block union would be a useful follow-up, but it is larger than this reuse milestone because `NotionBlocks.append` currently accepts `readonly unknown[]`.

## Verification

- `devenv tasks run lint:check --no-tui`
- `devenv tasks run test:notion-effect-client --no-tui`
- `devenv tasks run ts:check --no-tui`

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🦪 co2-pearl |
| `agent_session_id` | 5182684b-6aa2-411c-b6fd-51b9bdd85dff |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.141.0 |
| `agent_runtime` | Codex CLI 0.141.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/dlw6ln1sp2mzhavrp31s0crndlb4hrb6-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/3155hc5z7ifx113vjm28czbihi7phimw-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling/2026-06-25-markdown-to-blocks |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->