### PR TITLE
test(utils): cover hash helper contract

### DIFF
--- a/packages/@overeng/utils/src/isomorphic/hash.unit.test.ts
+++ b/packages/@overeng/utils/src/isomorphic/hash.unit.test.ts
@@ -1,0 +1,18 @@
+import { expect } from 'vitest'
+
+import { Vitest } from '@overeng/utils-dev/node-vitest'
+
+import { sha1Hex, sha256Hex } from './hash.ts'
+
+Vitest.describe('hash helpers', () => {
+  Vitest.it('computes stable SHA-1 and SHA-256 hex digests for string input', () => {
+    expect(sha1Hex('abc')).toBe('a9993e364706816aba3e25717850c26c9cd0d89d')
+    expect(sha256Hex('abc')).toBe(
+      'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad',
+    )
+  })
+
+  Vitest.it('computes the same SHA-256 hex digest for equivalent byte input', () => {
+    expect(sha256Hex(new TextEncoder().encode('abc'))).toBe(sha256Hex('abc'))
+  })
+})


### PR DESCRIPTION
## Summary
- adds direct unit coverage for the owned `@overeng/utils` SHA-1/SHA-256 helper contract
- codifies that consumers should depend on `sha1Hex`/`sha256Hex` instead of reaching into `@noble/hashes` package internals
- keeps `@noble/hashes` at the current `2.2.0` dependency already declared by `@overeng/utils`

## Testing
- `pnpm --filter @overeng/utils exec vitest run src/isomorphic/hash.unit.test.ts`

## Risk
- low: test-only change for existing exported helpers

## Rollback
- revert this PR to remove the added unit coverage

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 👑 co2-crest |
| `agent_session_id` | db5eb4b8-cace-4e02-9ee7-b837b126cbb7 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.141.0 |
| `agent_runtime` | Codex CLI 0.141.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/ri1wraif9cqyw420wd1ngp0z0a8rnwn7-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/n77xdlvsmwmg1b0kafxnir498z81ijkz-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | ea27ba8e7e64b04ce035427a5a1239261e6a33c0/schickling/2026-06-25-utils-hash-contract |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->