### PR TITLE
fix(react-inspector): omit undefined schema metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,10 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **@overeng/react-inspector**: Omit absent schema tooltip and lineage metadata
+  instead of materializing optional fields as `undefined`, so downstream
+  `exactOptionalPropertyTypes` checks can compile the source-linked package.
+
 - **@overeng/notion-effect-client**: Preserve Markdown importer semantics for
   soft-wrapped paragraphs, common JavaScript/TypeScript code-fence aliases, and
   loose list item child blocks when producing Notion append/create payloads.

--- a/packages/@overeng/react-inspector/src/schema/SchemaTooltip.tsx
+++ b/packages/@overeng/react-inspector/src/schema/SchemaTooltip.tsx
@@ -1,6 +1,8 @@
 import React, { useCallback, useEffect, useId, useRef, useState } from 'react'
 import type { FC, ReactNode } from 'react'
 
+import type { Lineage } from '@overeng/utils'
+
 import type { LineageBundle, SchemaInfo } from './effectSchema.tsx'
 
 export interface SchemaTooltipProps {
@@ -427,7 +429,7 @@ const renderSummaryWithPaths = (summary: string): ReactNode => {
   return parts.length > 0 ? parts : summary
 }
 
-const formatFreshness = (freshness: { capturedAt?: string; maxAgeMs?: number }): string => {
+const formatFreshness = (freshness: Lineage.Freshness): string => {
   const parts: string[] = []
   if (freshness.capturedAt !== undefined) parts.push(freshness.capturedAt)
   if (freshness.maxAgeMs !== undefined) parts.push(`≤ ${freshness.maxAgeMs}ms`)

--- a/packages/@overeng/react-inspector/src/schema/effectSchema.tsx
+++ b/packages/@overeng/react-inspector/src/schema/effectSchema.tsx
@@ -752,12 +752,17 @@ export const getSchemaInfo = (schema: S.Schema.AnyNoContext): SchemaInfo => {
   const lineageValue = Lineage.getLineage(schema)
   const lineage: LineageBundle | undefined =
     lineageValue !== undefined
-      ? {
-          display: Lineage.getLineageDisplay(lineageValue),
-          authority: Lineage.getAuthority(schema),
-          freshness: Lineage.getFreshness(schema),
-          reference: Lineage.getReference(schema),
-        }
+      ? (() => {
+          const authority = Lineage.getAuthority(schema)
+          const freshness = Lineage.getFreshness(schema)
+          const reference = Lineage.getReference(schema)
+          return {
+            display: Lineage.getLineageDisplay(lineageValue),
+            ...(authority !== undefined ? { authority } : {}),
+            ...(freshness !== undefined ? { freshness } : {}),
+            ...(reference !== undefined ? { reference } : {}),
+          }
+        })()
       : (() => {
           /* No primary Lineage but companion annotations may still exist. */
           const authority = Lineage.getAuthority(schema)
@@ -774,9 +779,9 @@ export const getSchemaInfo = (schema: S.Schema.AnyNoContext): SchemaInfo => {
               kindLabel: '',
               summary: '',
             },
-            authority,
-            freshness,
-            reference,
+            ...(authority !== undefined ? { authority } : {}),
+            ...(freshness !== undefined ? { freshness } : {}),
+            ...(reference !== undefined ? { reference } : {}),
           }
         })()
 
@@ -793,17 +798,20 @@ export const getSchemaInfo = (schema: S.Schema.AnyNoContext): SchemaInfo => {
     lineage !== undefined
 
   return {
-    displayName,
-    typeKind,
-    description: meaningfulDescription,
-    documentation: annotations.documentation,
-    examples,
-    defaultValue,
-    constraints: constraints.length > 0 ? constraints : undefined,
-    possibleValues: possible?.values,
-    possibleValuesTruncated: possible?.truncated,
-    containerLabel,
-    lineage,
+    ...(displayName !== undefined ? { displayName } : {}),
+    ...(typeKind !== undefined ? { typeKind } : {}),
+    ...(meaningfulDescription !== undefined ? { description: meaningfulDescription } : {}),
+    ...(annotations.documentation !== undefined
+      ? { documentation: annotations.documentation }
+      : {}),
+    ...(examples !== undefined ? { examples } : {}),
+    ...(defaultValue !== undefined ? { defaultValue } : {}),
+    ...(constraints.length > 0 ? { constraints } : {}),
+    ...(possible !== undefined
+      ? { possibleValues: possible.values, possibleValuesTruncated: possible.truncated }
+      : {}),
+    ...(containerLabel !== undefined ? { containerLabel } : {}),
+    ...(lineage !== undefined ? { lineage } : {}),
     hasContent,
   }
 }


### PR DESCRIPTION
## Why

`@overeng/react-inspector` source-linked consumers that enable `exactOptionalPropertyTypes` can fail when schema tooltip metadata objects materialize optional fields with `undefined` values.

## What

- Omit absent `SchemaInfo` and `LineageBundle` optional fields instead of passing `undefined`.
- Type the tooltip freshness formatter against the shared `Lineage.Freshness` type.
- Add a changelog entry.

## Verification

- `pnpm --filter @overeng/react-inspector exec tsc -p tsconfig.json --noEmit --exactOptionalPropertyTypes true --strictNullChecks true`
- `CI=1 pnpm --filter @overeng/react-inspector exec vitest run`
- `devenv tasks run check:quick --no-tui --show-output`

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🟠 co1-amber |
| `agent_session_id` | 97b37895-a841-433b-8bc4-5f29481e229e |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.141.0 |
| `agent_runtime` | Codex CLI 0.141.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/xy5sp8sgw52wj95vq5v8pza7wnlsdnng-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/na6azhch1msd3dvks1k06yx5m0hqbwjw-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-06-25-fix-react-inspector-exact-optional |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@9d3d02e |
</details>
<!-- agent-footer:end -->