### PR TITLE
Fix Restate metrics layer reader shape

### DIFF
--- a/packages/@overeng/restate-effect/src/observability/otel.ts
+++ b/packages/@overeng/restate-effect/src/observability/otel.ts
@@ -201,7 +201,7 @@ const sharedLayer = (config: OtelLayerConfig): Layer.Layer<never, never, never> 
         )
         const metricReader = resolveMetricReader(config)
         const metricsLayer =
-          metricReader !== undefined ? EffectMetrics.layer(() => metricReader) : Layer.empty
+          metricReader !== undefined ? EffectMetrics.layer(() => [metricReader]) : Layer.empty
         return Layer.merge(tracerLayer, metricsLayer).pipe(Layer.provideMerge(resourceLayer))
       }),
     ),


### PR DESCRIPTION
## Problem

`@effect/opentelemetry` now types `Metrics.layer` as accepting either a lazy `MetricReader` or a non-empty readonly array of readers. In downstream TS6/source-consumer checks, `@overeng/restate-effect` currently passes the resolved reader directly and hits the stricter layer input shape.

## Solution

Wrap the resolved reader in a one-element array when constructing the metrics layer. This preserves the existing runtime behavior: a configured exporter still registers exactly one reader; the no-reader branch remains `Layer.empty`.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @overeng/restate-effect exec tsc --build tsconfig.json --pretty false`
- `pnpm --filter @overeng/restate-effect exec oxlint packages/@overeng/restate-effect/src/observability/otel.ts`

I also ran `CI=1 pnpm --filter @overeng/restate-effect exec vitest run --passWithNoTests`; it failed because this shell does not provide the `restate-server` binary required by `src/testing/test-env.integration.test.ts`, while the rest of the package tests passed before that integration fixture timed out.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🟠 co1-amber |
| `agent_session_id` | 97b37895-a841-433b-8bc4-5f29481e229e |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.141.0 |
| `agent_runtime` | Codex CLI 0.141.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/xy5sp8sgw52wj95vq5v8pza7wnlsdnng-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/na6azhch1msd3dvks1k06yx5m0hqbwjw-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-06-26-fix-restate-metric-reader-layer |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@9d3d02e |
</details>
<!-- agent-footer:end -->