### PR TITLE
fix: pass metric reader as non-empty collection

### DIFF
--- a/packages/@overeng/restate-effect/src/observability/otel.ts
+++ b/packages/@overeng/restate-effect/src/observability/otel.ts
@@ -201,7 +201,7 @@ const sharedLayer = (config: OtelLayerConfig): Layer.Layer<never, never, never> 
         )
         const metricReader = resolveMetricReader(config)
         const metricsLayer =
-          metricReader !== undefined ? EffectMetrics.layer(() => metricReader) : Layer.empty
+          metricReader !== undefined ? EffectMetrics.layer(() => [metricReader]) : Layer.empty
         return Layer.merge(tracerLayer, metricsLayer).pipe(Layer.provideMerge(resourceLayer))
       }),
     ),


### PR DESCRIPTION
## Summary

- pass the resolved OTel metric reader to `EffectMetrics.layer` as a non-empty collection

## Rationale

`@effect/opentelemetry` accepts either one `MetricReader` or a non-empty collection of readers, but the lazy callback union can be brittle under newer TypeScript inference. Returning `[metricReader]` chooses the collection branch explicitly while preserving the current single-reader runtime behavior.

This keeps the fix at the upstream Effect/OpenTelemetry boundary instead of requiring downstream source consumers to cast around the `MetricReader` union.

## Verification

- `devenv tasks run ts:check`
- `devenv tasks run test:restate-effect`

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🟠 co1-amber |
| `agent_session_id` | 97b37895-a841-433b-8bc4-5f29481e229e |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.141.0 |
| `agent_runtime` | Codex CLI 0.141.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/xy5sp8sgw52wj95vq5v8pza7wnlsdnng-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/na6azhch1msd3dvks1k06yx5m0hqbwjw-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-06-26-ts6-metric-reader |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@9d3d02e |
</details>
<!-- agent-footer:end -->