### PR TITLE
feat(genie): support pnpm hoisting limits

### DIFF
--- a/packages/@overeng/genie/src/runtime/pnpm-workspace/mod.ts
+++ b/packages/@overeng/genie/src/runtime/pnpm-workspace/mod.ts
@@ -99,6 +99,12 @@ export interface PnpmSettings {
   publicHoistPattern?: readonly string[]
 
   /**
+   * Limit how far dependencies are hoisted when using `nodeLinker: hoisted`.
+   * @see https://pnpm.io/settings#hoistinglimits
+   */
+  hoistingLimits?: 'none' | 'workspaces' | 'dependencies'
+
+  /**
    * Hoist all dependencies matching hoistPattern to the root node_modules.
    * @see https://pnpm.io/settings#shamefully-hoist
    */
@@ -709,6 +715,12 @@ export interface PnpmWorkspaceData {
   publicHoistPattern?: readonly string[]
 
   /**
+   * Limit how far dependencies are hoisted when using `nodeLinker: hoisted`.
+   * @see https://pnpm.io/settings#hoistinglimits
+   */
+  hoistingLimits?: 'none' | 'workspaces' | 'dependencies'
+
+  /**
    * The node_modules layout.
    * @see https://pnpm.io/settings#node-linker
    */
@@ -1002,6 +1014,10 @@ const buildPnpmWorkspaceYaml = <T extends PnpmWorkspaceData>({
 
   if (data.publicHoistPattern !== undefined) {
     result.publicHoistPattern = [...data.publicHoistPattern]
+  }
+
+  if (data.hoistingLimits !== undefined) {
+    result.hoistingLimits = data.hoistingLimits
   }
 
   if (data.nodeLinker !== undefined) {

--- a/packages/@overeng/genie/src/runtime/pnpm-workspace/pnpm-workspace.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/pnpm-workspace/pnpm-workspace.unit.test.ts
@@ -192,6 +192,17 @@ describe('metadata-based workspace projections', () => {
     expect(workspaceFile.stringify(mockGenieContext)).toContain('storeDir: .pnpm-store')
   })
 
+  it('serializes hoistingLimits for hoisted pnpm workspaces', () => {
+    const workspaceFile = pnpmWorkspaceYaml.root({
+      packages: [app],
+      repoName: repo.repoName,
+      nodeLinker: 'hoisted',
+      hoistingLimits: 'workspaces',
+    })
+
+    expect(workspaceFile.stringify(mockGenieContext)).toContain('hoistingLimits: workspaces')
+  })
+
   it('projects workspace root workspaces from package metadata', () => {
     const workspaceRoot = packageJson.aggregateFromPackages({
       packages: [app],


### PR DESCRIPTION
## Why

Dotfiles needs pnpm 11 `hoistingLimits: workspaces` with `nodeLinker: hoisted` so a published package can resolve linked workspace-style dependencies from the consuming package scope instead of the workspace root.

## What

Adds `hoistingLimits` to the Genie pnpm-workspace settings/types and serializes it into generated `pnpm-workspace.yaml`.

## Verification

- `pnpm --dir repos/effect-utils --filter @overeng/genie exec vitest run src/runtime/pnpm-workspace/pnpm-workspace.unit.test.ts --reporter=dot`

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🟠 co1-amber |
| `agent_session_id` | 97b37895-a841-433b-8bc4-5f29481e229e |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.141.0 |
| `agent_runtime` | Codex CLI 0.141.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/xy5sp8sgw52wj95vq5v8pza7wnlsdnng-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/na6azhch1msd3dvks1k06yx5m0hqbwjw-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | 85a70236360e418a8277400e94dda00156185ef9/schickling-assistant/2026-06-26-genie-hoisting-limits |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@9d3d02e |
</details>
<!-- agent-footer:end -->