### PR TITLE
fix(pnpm): keep generated contract cache writable

### DIFF
--- a/nix/devenv-modules/tasks/shared/pnpm.nix
+++ b/nix/devenv-modules/tasks/shared/pnpm.nix
@@ -537,7 +537,9 @@ let
           echo "$_gvs_hash" > "$_gvs_hash_file"
         fi
         if [ -n "''${_pnpm_install_contract_file:-}" ]; then
+          rm -f "$contract_state_file"
           cp "$_pnpm_install_contract_file" "$contract_state_file"
+          chmod u+w "$contract_state_file" 2>/dev/null || true
           if pnpm_contract_supports_dependency_materialization_profile ${pkgs.nodejs}/bin/node "$_pnpm_install_contract_file"; then
             if [ -n "''${CI:-}" ]; then
               _dependency_materialization_trait="ciJobLocal"

--- a/nix/devenv-modules/tasks/shared/tests/pnpm-task-smoke.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/pnpm-task-smoke.test.sh
@@ -400,7 +400,18 @@ echo "Test 3: status hits after install with same GVS path"
   assert_exit_code 0 "$exit_code" "status should hit after install"
 )
 
-echo "Test 4: outer cache hit still misses when projection metadata is missing"
+echo "Test 4: exec can overwrite a cached generated contract with read-only mode"
+(
+  cd "$workspace"
+  export HOME="$tmpdir/home"
+  export PNPM_HOME="$workspace/.pnpm-home-a"
+  contract_cache="$workspace/.devenv/task-cache/pnpm-install/pnpm-install-contract.json"
+  chmod 0444 "$workspace/pnpm-install-contract.json" "$contract_cache"
+  bash "$tmpdir/pnpm-install.exec.sh"
+  test -w "$contract_cache"
+)
+
+echo "Test 5: outer cache hit still misses when projection metadata is missing"
 (
   cd "$workspace"
   export HOME="$tmpdir/home"


### PR DESCRIPTION
**Why**

Downstream repos can generate `pnpm-install-contract.json` as a read-only file. The shared pnpm install task copies that contract into `.devenv/task-cache/pnpm-install/`, preserving mode `0444`. A later install then fails when `cp` tries to overwrite the cached contract.

**What**

Remove the mutable cached contract before copying a fresh one, then make the cached copy owner-writable.

**How**

The generated contract remains immutable at the source, while the task-cache copy is treated as mutable task state. The smoke test now reproduces a read-only source plus read-only previous cache copy and asserts the rerun succeeds with a writable cached copy.

**Verification**

- `CI=1 bash nix/devenv-modules/tasks/shared/tests/pnpm-task-smoke.test.sh`
- `git diff --check`
- GitHub PR checks green on `overengineeringstudio/effect-utils#847`

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🟠 co1-amber |
| `agent_session_id` | 97b37895-a841-433b-8bc4-5f29481e229e |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.141.0 |
| `agent_runtime` | Codex CLI 0.141.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/xy5sp8sgw52wj95vq5v8pza7wnlsdnng-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/na6azhch1msd3dvks1k06yx5m0hqbwjw-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | dotfiles/schickling/2026-06-24-effect-lsp-refactor |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@9d3d02e |
</details>
<!-- agent-footer:end -->