### PR TITLE
fix(pnpm): keep cached install contract writable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ All notable changes to this project will be documented in this file.
   setup as canonical Markdown so downstream packages can delete hand-rolled
   Markdown parsers and consume one block-payload contract.
 
+### Fixed
+
+- **devenv/pnpm**: Keep the cached `pnpm-install-contract.json` writable even
+  when the generated source file is read-only, so repeated `pnpm:install` runs
+  can update `.devenv/task-cache` instead of failing on the preserved generated
+  file mode.
+
 - **Bundle smoke CI gate**: Add a Vite/Rollup-based smoke check for
   `@overeng/pty-effect` public entries so bundler-resolution ESM export
   mismatches in runtime dependencies fail in CI before downstream consumers hit

--- a/nix/devenv-modules/tasks/shared/pnpm.nix
+++ b/nix/devenv-modules/tasks/shared/pnpm.nix
@@ -537,7 +537,9 @@ let
           echo "$_gvs_hash" > "$_gvs_hash_file"
         fi
         if [ -n "''${_pnpm_install_contract_file:-}" ]; then
+          rm -f "$contract_state_file"
           cp "$_pnpm_install_contract_file" "$contract_state_file"
+          chmod u+w "$contract_state_file" 2>/dev/null || true
           if pnpm_contract_supports_dependency_materialization_profile ${pkgs.nodejs}/bin/node "$_pnpm_install_contract_file"; then
             if [ -n "''${CI:-}" ]; then
               _dependency_materialization_trait="ciJobLocal"

--- a/nix/devenv-modules/tasks/shared/tests/pnpm-task-smoke.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/pnpm-task-smoke.test.sh
@@ -194,6 +194,7 @@ cat > "$workspace/pnpm-install-contract.json" <<'EOF'
   }
 }
 EOF
+chmod 444 "$workspace/pnpm-install-contract.json"
 cat > "$workspace/packages/demo/package.json" <<'EOF'
 {"name":"demo","private":true}
 EOF
@@ -386,6 +387,17 @@ echo "Test 2: exec runs fake pnpm and populates cache"
   grep -qxF "install --force --frozen-lockfile --config.confirmModulesPurge=false --ignore-scripts --config.side-effects-cache=false --config.verify-store-integrity=true --config.strict-store-pkg-content-check=true --child-concurrency=1 --network-concurrency=4 --config.package-import-method=clone-or-copy --pm-on-fail=ignore --config.store-dir=$workspace/.devenv/pnpm-store-pure-v1" "$tmpdir/pnpm.log"
   grep -qF ".effect-utils-pnpm-install.lock" "$tmpdir/pnpm-install.exec.sh"
   grep -qF ".effect-utils-pnpm-store.lock" "$tmpdir/pnpm-install.exec.sh"
+  test -w "$workspace/.devenv/task-cache/pnpm-install/pnpm-install-contract.json"
+)
+
+echo "Test 2b: exec replaces a read-only cached generated contract snapshot"
+(
+  cd "$workspace"
+  export HOME="$tmpdir/home"
+  export PNPM_HOME="$workspace/.pnpm-home-a"
+  chmod 444 "$workspace/.devenv/task-cache/pnpm-install/pnpm-install-contract.json"
+  bash "$tmpdir/pnpm-install.exec.sh"
+  test -w "$workspace/.devenv/task-cache/pnpm-install/pnpm-install-contract.json"
 )
 
 echo "Test 3: status hits after install with same GVS path"


### PR DESCRIPTION
## Why

Generated `pnpm-install-contract.json` files are read-only in downstream repos. The shared `pnpm:install` task copied that file into `.devenv/task-cache`, preserving mode `0444`; the next install then failed when `cp` tried to overwrite the cached snapshot.

This surfaced while adopting latest effect-utils in `schickling/dotfiles` for the Effect LSP strict-gates stack.

## What

- Replace the cached contract snapshot before copying the generated source contract.
- Make the cached snapshot user-writable after copying so task cache remains mutable.
- Add smoke coverage for read-only generated source contracts and pre-existing read-only cached snapshots.

## Verification

- `bash nix/devenv-modules/tasks/shared/tests/pnpm-task-smoke.test.sh`
- `devenv tasks run check:quick --mode before --no-tui --show-output`

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🟠 co1-amber |
| `agent_session_id` | 97b37895-a841-433b-8bc4-5f29481e229e |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.141.0 |
| `agent_runtime` | Codex CLI 0.141.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/xy5sp8sgw52wj95vq5v8pza7wnlsdnng-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/na6azhch1msd3dvks1k06yx5m0hqbwjw-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-06-26-fix-pnpm-contract-cache-mode |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@9d3d02e |
</details>
<!-- agent-footer:end -->