### PR TITLE
fix(pnpm): keep install contract cache writable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- **devenv/pnpm**: Keep the cached `pnpm-install-contract.json` writable after
+  copying the generated read-only contract into `.devenv/task-cache`, so repeat
+  `pnpm:install` runs can replace mutable cache state without downstream
+  chmod workarounds.
+
 - **@overeng/notion-effect-client**: Add `NotionMarkdown.markdownToBlocks`,
   an AST-based selected-GFM Markdown importer that emits Notion append/create
   block payloads for paragraphs, headings, dividers, lists, task lists, code,

--- a/nix/devenv-modules/tasks/shared/pnpm.nix
+++ b/nix/devenv-modules/tasks/shared/pnpm.nix
@@ -537,7 +537,9 @@ let
           echo "$_gvs_hash" > "$_gvs_hash_file"
         fi
         if [ -n "''${_pnpm_install_contract_file:-}" ]; then
+          rm -f "$contract_state_file"
           cp "$_pnpm_install_contract_file" "$contract_state_file"
+          chmod u+w "$contract_state_file" 2>/dev/null || true
           if pnpm_contract_supports_dependency_materialization_profile ${pkgs.nodejs}/bin/node "$_pnpm_install_contract_file"; then
             if [ -n "''${CI:-}" ]; then
               _dependency_materialization_trait="ciJobLocal"

--- a/nix/devenv-modules/tasks/shared/tests/pnpm-task-smoke.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/pnpm-task-smoke.test.sh
@@ -388,6 +388,17 @@ echo "Test 2: exec runs fake pnpm and populates cache"
   grep -qF ".effect-utils-pnpm-store.lock" "$tmpdir/pnpm-install.exec.sh"
 )
 
+echo "Test 2b: exec rewrites read-only generated contract cache state"
+(
+  cd "$workspace"
+  export HOME="$tmpdir/home"
+  export PNPM_HOME="$workspace/.pnpm-home-a"
+  contract_state_file="$workspace/.devenv/task-cache/pnpm-install/pnpm-install-contract.json"
+  chmod a-w "$workspace/pnpm-install-contract.json" "$contract_state_file"
+  bash "$tmpdir/pnpm-install.exec.sh"
+  test -w "$contract_state_file"
+)
+
 echo "Test 3: status hits after install with same GVS path"
 (
   cd "$workspace"


### PR DESCRIPTION
## Why

Generated files such as `pnpm-install-contract.json` are read-only. The shared `pnpm:install` task copied that generated contract into `.devenv/task-cache`, preserving the read-only mode. A later install then failed when it tried to replace the cached contract state.

## What

Remove the previous cached contract before copying the generated contract, then make the cache copy user-writable. This keeps generated source artifacts immutable while treating `.devenv/task-cache` as mutable task state.

## Rationale

Downstream repos should not need chmod cleanup around effect-utils task internals. The cache file is derived state and should be safely replaceable on each successful install; the generated source contract remains the authoritative immutable input.

## Verification

- `CI=1 bash nix/devenv-modules/tasks/shared/tests/pnpm-task-smoke.test.sh`
- `CI=1 bash nix/devenv-modules/tasks/shared/tests/pnpm.test.sh`
- `devenv tasks run lint:nix --no-tui`

`devenv tasks run check:quick --no-tui` was also attempted, but this checkout is currently blocked by unrelated megarepo source/member state (`mr:source-policy-check` / missing member symlinks), after `lint:nix` had already passed.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🟠 co1-amber |
| `agent_session_id` | 97b37895-a841-433b-8bc4-5f29481e229e |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.141.0 |
| `agent_runtime` | Codex CLI 0.141.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/xy5sp8sgw52wj95vq5v8pza7wnlsdnng-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/na6azhch1msd3dvks1k06yx5m0hqbwjw-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | 972bbdbca77b8d91d2dcd804a1cc60abbf226b15/schickling-assistant/2026-06-26-pnpm-contract-cache-writable |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@9d3d02e |
</details>
<!-- agent-footer:end -->