### PR TITLE
feat(devenv): add git-backed lint file selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- **devenv/lint-oxc**: Add opt-in `fileSelection = "git"` and
-  `changeDetection = "always"` modes so large repos can enumerate lint inputs
-  from tracked plus untracked non-ignored files and skip devenv's expensive
-  `execIfModified` glob walker without overriding shared task bodies.
+- **devenv/lint-oxc**: Make `lintPaths` the single lint surface contract.
+  oxlint/oxfmt tasks now enumerate tracked plus untracked non-ignored files via
+  `git ls-files` and always run instead of delegating change detection to
+  devenv's `execIfModified` glob walker.
 
 - **@overeng/notion-effect-client**: Add `NotionMarkdown.markdownToBlocks`,
   an AST-based selected-GFM Markdown importer that emits Notion append/create

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ All notable changes to this project will be documented in this file.
   `git ls-files` and always run instead of delegating change detection to
   devenv's `execIfModified` glob walker. The shared lint module is kept
   repo-agnostic; effect-utils-specific source policy checks live in local task
-  modules.
+  modules. Per-tool file filters include the broader Oxc-supported extension
+  sets, including `.mts`/`.cts` for oxlint and additional oxfmt-supported
+  formats such as JSON5, SCSS/Less, MDX, GraphQL, and Handlebars.
 
 - **devenv task-module tests**: Add a dedicated `devenv-modules:test` task for
   shell tests colocated under `nix/devenv-modules/tasks/shared/tests`, and wire

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- **devenv/lint-oxc**: Add opt-in `fileSelection = "git"` and
+  `changeDetection = "always"` modes so large repos can enumerate lint inputs
+  from tracked plus untracked non-ignored files and skip devenv's expensive
+  `execIfModified` glob walker without overriding shared task bodies.
+
 - **@overeng/notion-effect-client**: Add `NotionMarkdown.markdownToBlocks`,
   an AST-based selected-GFM Markdown importer that emits Notion append/create
   block payloads for paragraphs, headings, dividers, lists, task lists, code,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,14 @@ All notable changes to this project will be documented in this file.
 - **devenv/lint-oxc**: Make `lintPaths` the single lint surface contract.
   oxlint/oxfmt tasks now enumerate tracked plus untracked non-ignored files via
   `git ls-files` and always run instead of delegating change detection to
-  devenv's `execIfModified` glob walker.
+  devenv's `execIfModified` glob walker. The shared lint module is kept
+  repo-agnostic; effect-utils-specific source policy checks live in local task
+  modules.
+
+- **devenv task-module tests**: Add a dedicated `devenv-modules:test` task for
+  shell tests colocated under `nix/devenv-modules/tasks/shared/tests`, and wire
+  it into `test:run` so shared task-module regressions run in the normal CI unit
+  test job.
 
 - **@overeng/notion-effect-client**: Add `NotionMarkdown.markdownToBlocks`,
   an AST-based selected-GFM Markdown importer that emits Notion append/create
@@ -30,8 +37,8 @@ All notable changes to this project will be documented in this file.
   mismatches in runtime dependencies fail in CI before downstream consumers hit
   them. Mark `pnpm-install-contract.json` as generated in Git attributes.
 
-- **devenv/lint**: Add a `lint:check:asset-import-needs-type-reference` task (wired into
-  `lint:check`) that fails when a compiled, exported source file imports an asset
+- **devenv/lint**: Add a local `lint:check:asset-import-needs-type-reference`
+  task (wired into `lint:check`) that fails when a compiled, exported source file imports an asset
   (`import '...css|scss|sass|less'`) without a `/// <reference>` directive to make the ambient
   `*.css` declaration travel into downstream TS checks (TS2882, #837). It runs out-of-band over
   tracked + untracked source (an in-oxlint rule would itself be suppressible by an `oxlint-disable`,
@@ -192,7 +199,7 @@ All notable changes to this project will be documented in this file.
   retry allocation for the native `restate-server` child process ports that must
   be passed by number.
 
-- **CI test task ordering**: Make `nix:test` wait for `pnpm:install` so
+- **CI test task ordering**: Make shared devenv task-module tests wait for `pnpm:install` so
   source-mode CLI shell tests cannot race dependency materialization under
   `test:run --mode before`.
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -52,6 +52,8 @@ let
     nix-cli = import ./nix/devenv-modules/tasks/shared/nix-cli.nix;
     secretspec = import ./nix/devenv-modules/tasks/shared/secretspec.nix;
     context = ./nix/devenv-modules/tasks/shared/context.nix;
+    devenv-module-tests = ./nix/devenv-modules/tasks/local/devenv-module-tests.nix;
+    asset-import-type-reference = ./nix/devenv-modules/tasks/local/asset-import-type-reference.nix;
   };
   # Use bun source entrypoints for in-repo CLIs in devenv (flake builds stay strict).
   mkSourceCli = import ./nix/devenv-modules/lib/mk-source-cli.nix { inherit pkgs; };
@@ -348,7 +350,7 @@ in
     # Self-contained test tasks: each package uses its own vitest from node_modules
     (taskModules.test {
       packages = packagesWithTests;
-      extraTests = [ "nix:test" ];
+      extraTests = [ "devenv-modules:test" ];
     })
     (taskModules.storybook {
       packages = packagesWithStorybook;
@@ -412,6 +414,8 @@ in
     (taskModules.secretspec { })
     # Local task: Validate allPackages matches filesystem packages (effect-utils specific)
     ./nix/devenv-modules/tasks/local/workspace-check.nix
+    taskModules.devenv-module-tests
+    taskModules.asset-import-type-reference
     # Notion integration tests (requires NOTION_API_TOKEN)
     ./nix/devenv-modules/tasks/local/notion-integration-test.nix
     # Restate integration tests (native restate-server via RESTATE_SERVER_BIN)
@@ -486,10 +490,6 @@ in
   tasks."genie:run".after = [ "pnpm:install" ];
   tasks."genie:watch".after = [ "pnpm:install" ];
   tasks."genie:check".after = [ "pnpm:install" ];
-  # `nix:test` includes shell e2es for source-mode CLIs (for example compiling
-  # packages/@overeng/genie/bin/genie.tsx), so it must not race dependency
-  # materialization when run as part of `test:run` in CI.
-  tasks."nix:test".after = [ "pnpm:install" ];
   tasks."lint:check:genie".after = [ "pnpm:install" ];
   tasks."mr:bootstrap".after = [ "pnpm:install" ];
   tasks."mr:fetch-apply".after = [ "pnpm:install" ];

--- a/devenv.nix
+++ b/devenv.nix
@@ -365,6 +365,8 @@ in
     })
     (taskModules.lint-oxc {
       oxlintPkg = oxlintWithPlugins;
+      fileSelection = "git";
+      changeDetection = "always";
       lintPaths = [
         "packages"
         "scripts"

--- a/devenv.nix
+++ b/devenv.nix
@@ -365,55 +365,10 @@ in
     })
     (taskModules.lint-oxc {
       oxlintPkg = oxlintWithPlugins;
-      fileSelection = "git";
-      changeDetection = "always";
       lintPaths = [
         "packages"
         "scripts"
         "context"
-      ];
-      # Explicit patterns that avoid node_modules traversal
-      # Key insight: patterns like "packages/*/src/**" are safe because src/ never contains node_modules
-      execIfModifiedPatterns = [
-        # packages: src directories (safe - no node_modules inside src)
-        "packages/@overeng/*/src/**/*.ts"
-        "packages/@overeng/*/src/**/*.tsx"
-        "packages/@overeng/*/src/**/*.js"
-        "packages/@overeng/*/src/**/*.jsx"
-        # packages: root level config files
-        "packages/@overeng/*/*.ts"
-        "packages/@overeng/*/*.js"
-        # packages: bin, .storybook, stories, stress-test directories
-        "packages/@overeng/*/bin/*.ts"
-        "packages/@overeng/*/.storybook/*.ts"
-        "packages/@overeng/*/.storybook/*.tsx"
-        "packages/@overeng/*/stories/**/*.ts"
-        "packages/@overeng/*/stories/**/*.tsx"
-        "packages/@overeng/*/stress-test/**/*.ts"
-        # packages: test directories and setup files
-        "packages/@overeng/*/test/**/*.ts"
-        "packages/@overeng/*/test/**/*.tsx"
-        "packages/@overeng/*/vitest.setup.ts"
-        # packages/examples: specific paths (examples/basic has node_modules)
-        "packages/@overeng/*/examples/*/*.ts"
-        "packages/@overeng/*/examples/*/*.tsx"
-        "packages/@overeng/*/examples/*/src/**/*.ts"
-        "packages/@overeng/*/examples/*/src/**/*.tsx"
-        "packages/@overeng/*/examples/*/tests/*.ts"
-        # scripts
-        "scripts/*.ts"
-        "scripts/commands/**/*.ts"
-        # context: specific safe paths
-        "context/cli-design/*.ts"
-        "context/effect/socket/*.genie.ts"
-        "context/effect/socket/examples/*.ts"
-        "context/opentui/*.genie.ts"
-        # context: docs/config (safe; no node_modules under context/)
-        "context/**/*.md"
-        "context/**/*.json"
-        # linter config files (changes should trigger lint)
-        ".oxfmtrc.json"
-        ".oxlintrc.json"
       ];
       # Genie file patterns for caching genie:check tasks
       geniePatterns = [

--- a/nix/devenv-modules/tasks/README.md
+++ b/nix/devenv-modules/tasks/README.md
@@ -13,6 +13,11 @@ imports = [
   (inputs.effect-utils.devenvModules.tasks.ts {})
   (inputs.effect-utils.devenvModules.tasks.lint-oxc {
     execIfModifiedPatterns = [ "src/**/*.ts" ];
+    # For large repos where devenv's glob-based change detection is too
+    # expensive, let the task always run and enumerate lint inputs through git.
+    changeDetection = "always";
+    fileSelection = "git";
+    lintPaths = [ "src" "test" ];
   })
 ];
 ```
@@ -30,10 +35,12 @@ imports = [
 - `clean.nix` - Clean tasks
 - `genie.nix` - Genie config generation tasks
 - `lint-oxc.nix` - Linting tasks (oxlint, oxfmt)
-  - Note: `lint:check:format`/`lint:fix:format` run oxfmt on an explicit file list
-    (git-tracked files) instead of `oxfmt <dir>...` directory walking. This avoids
-    flaky "File not found" errors when pnpm is concurrently mutating/symlinking
-    `node_modules` during CI.
+  - `fileSelection = "git"` resolves `lintPaths` via `git ls-files`, including
+    untracked non-ignored files, before calling oxlint/oxfmt. Use it for large
+    repos where direct directory arguments risk walking ignored dependency trees.
+  - `changeDetection = "always"` disables devenv's `execIfModified` cache for
+    lint tasks. This is useful when devenv's glob walker is more expensive than
+    simply running the focused lint command.
 - `megarepo.nix` - Megarepo workspace tasks
 - `nix-cli.nix` - Nix CLI build/check tasks
 - `pnpm.nix` - pnpm install tasks

--- a/nix/devenv-modules/tasks/README.md
+++ b/nix/devenv-modules/tasks/README.md
@@ -68,6 +68,8 @@ They assume the effect-utils repo structure and are not exported in flake.nix.
 
 ### Available Modules:
 
+- `asset-import-type-reference.nix` - effect-utils package export policy check for asset side-effect imports
+- `devenv-module-tests.nix` - CI task that runs shell tests for reusable task modules
 - `workspace-check.nix` - Validates `allPackages` in devenv.nix matches filesystem
 
 ## `lib/` - Shared Utilities

--- a/nix/devenv-modules/tasks/README.md
+++ b/nix/devenv-modules/tasks/README.md
@@ -12,12 +12,9 @@ imports = [
   (inputs.effect-utils.devenvModules.tasks.check {})
   (inputs.effect-utils.devenvModules.tasks.ts {})
   (inputs.effect-utils.devenvModules.tasks.lint-oxc {
-    execIfModifiedPatterns = [ "src/**/*.ts" ];
-    # For large repos where devenv's glob-based change detection is too
-    # expensive, let the task always run and enumerate lint inputs through git.
-    changeDetection = "always";
-    fileSelection = "git";
     lintPaths = [ "src" "test" ];
+    geniePatterns = [ "*.genie.ts" ];
+    genieCoverageDirs = [ "." ];
   })
 ];
 ```
@@ -35,12 +32,9 @@ imports = [
 - `clean.nix` - Clean tasks
 - `genie.nix` - Genie config generation tasks
 - `lint-oxc.nix` - Linting tasks (oxlint, oxfmt)
-  - `fileSelection = "git"` resolves `lintPaths` via `git ls-files`, including
-    untracked non-ignored files, before calling oxlint/oxfmt. Use it for large
-    repos where direct directory arguments risk walking ignored dependency trees.
-  - `changeDetection = "always"` disables devenv's `execIfModified` cache for
-    lint tasks. This is useful when devenv's glob walker is more expensive than
-    simply running the focused lint command.
+  - `lintPaths` are Git pathspecs. The lint tasks enumerate tracked and untracked
+    non-ignored files through `git ls-files` before calling oxlint/oxfmt, and do
+    not use devenv's `execIfModified` glob walker.
 - `megarepo.nix` - Megarepo workspace tasks
 - `nix-cli.nix` - Nix CLI build/check tasks
 - `pnpm.nix` - pnpm install tasks

--- a/nix/devenv-modules/tasks/local/asset-import-type-reference.nix
+++ b/nix/devenv-modules/tasks/local/asset-import-type-reference.nix
@@ -1,0 +1,57 @@
+{ lib, pkgs, ... }:
+let
+  trace = import ../lib/trace.nix { inherit lib; };
+  git = "${pkgs.git}/bin/git";
+in
+{
+  tasks."lint:check:asset-import-needs-type-reference" = {
+    description = "Require a /// <reference> for asset side-effect imports in compiled source";
+    exec = trace.exec "lint:check:asset-import-needs-type-reference" ''
+      set -euo pipefail
+
+      # A bare `import '...css'` (or scss/sass/less) in compiled, exported source needs an ambient
+      # `*.css` declaration to type it. If that ambient lives only in a floating `.d.ts` pulled in
+      # by this package's own tsconfig `include`, it does NOT travel into a downstream consumer
+      # that compiles this source via `exports`-resolution — the side-effect import then fails with
+      # TS2882 (see #837). A `/// <reference path|types ...>` directive in the SAME file is part of
+      # that file's load graph, so the declaration travels into every program that compiles it.
+      #
+      # This guard requires that any compiled-source file with an asset side-effect import also
+      # carries a `/// <reference>`. It runs out-of-band (an inline `oxlint-disable` of
+      # `no-unassigned-import` cannot suppress it). Exempts the globs where side-effect imports are
+      # allowed and not type-checked into downstream graphs: `.storybook/**`, `*.gen.*`, `*.d.ts`,
+      # `*.test.*`, `*.stories.*`.
+      offenders=$(
+        {
+          ${git} ls-files -- 'packages/*/src/**/*.ts' 'packages/*/src/**/*.tsx' \
+            'context/**/*.ts' 'context/**/*.tsx'
+          ${git} ls-files --others --exclude-standard -- \
+            'packages/*/src/**/*.ts' 'packages/*/src/**/*.tsx' \
+            'context/**/*.ts' 'context/**/*.tsx'
+        } | sort -u | while IFS= read -r f; do
+          [ -z "$f" ] && continue
+          case "$f" in
+            */.storybook/*|*.gen.*|*.d.ts|*.test.*|*.stories.*) continue ;;
+          esac
+          ${pkgs.gawk}/bin/awk '
+            /^[[:space:]]*import[[:space:]]+['"'"'"][^'"'"'"]*\.(css|scss|sass|less)['"'"'"]/ { asset = 1 }
+            /^[[:space:]]*\/\/\/[[:space:]]*<reference[[:space:]]/ { ref = 1 }
+            END { if (asset == 1 && ref != 1) print FILENAME }
+          ' "$f"
+        done | sort -u
+      )
+      if [ -n "$offenders" ]; then
+        echo "Asset side-effect import without a travelling type reference in compiled source:"
+        echo "$offenders"
+        echo ""
+        echo "Add a '/// <reference path=\"...\" />' to a shipped '*.css' ambient in the importing"
+        echo "file so the declaration travels into downstream TS checks (see #837), or move the"
+        echo "import under a '.storybook/*' entry that is not type-checked downstream."
+        exit 1
+      fi
+      echo "All asset side-effect imports in compiled source carry a type reference"
+    '';
+  };
+
+  tasks."lint:check".after = lib.mkAfter [ "lint:check:asset-import-needs-type-reference" ];
+}

--- a/nix/devenv-modules/tasks/local/devenv-module-tests.nix
+++ b/nix/devenv-modules/tasks/local/devenv-module-tests.nix
@@ -1,0 +1,34 @@
+{ lib, pkgs, ... }:
+let
+  trace = import ../lib/trace.nix { inherit lib; };
+
+  devenvModuleTestsScript = pkgs.writeShellScript "devenv-module-tests" ''
+    set -euo pipefail
+
+    testDir="${toString ../shared/tests}"
+    if [ ! -d "$testDir" ]; then
+      echo "No devenv module tests found (missing $testDir)"
+      exit 1
+    fi
+
+    found=false
+    for testFile in "$testDir"/*.test.sh; do
+      [ -f "$testFile" ] || continue
+      found=true
+      echo "Running $testFile"
+      bash "$testFile"
+    done
+
+    if [ "$found" != true ]; then
+      echo "No devenv module tests found in $testDir"
+      exit 1
+    fi
+  '';
+in
+{
+  tasks."devenv-modules:test" = {
+    description = "Run shell tests for shared devenv task modules";
+    exec = trace.exec "devenv-modules:test" "${devenvModuleTestsScript}";
+    after = [ "pnpm:install" ];
+  };
+}

--- a/nix/devenv-modules/tasks/shared/lint-oxc.nix
+++ b/nix/devenv-modules/tasks/shared/lint-oxc.nix
@@ -30,6 +30,14 @@
 #       tsconfig = "tsconfig.all.json";  # optional
 #       # Whether to fail on warnings (default: true for CI strictness)
 #       # denyWarnings = false;  # optional
+#       # How lint file arguments are assembled:
+#       # - "argv" passes lintPaths directly to oxlint/oxfmt (default).
+#       # - "git" resolves lintPaths through git ls-files, including untracked
+#       #   non-ignored files, and avoids filesystem walks through ignored trees.
+#       # fileSelection = "git";  # optional
+#       # Whether devenv should cache the lint task based on execIfModifiedPatterns.
+#       # Set to "always" for megarepos where devenv's glob walker is too expensive.
+#       # changeDetection = "always";  # optional
 #     })
 #   ];
 #
@@ -45,6 +53,14 @@
     "tsconfig.json"
   ],
   lintPaths ? [ "." ],
+  # File selection for the lint tool invocation.
+  # - "argv": pass lintPaths directly (backward-compatible default).
+  # - "git": enumerate tracked + untracked non-ignored files via git pathspecs.
+  fileSelection ? "argv",
+  # Task change detection:
+  # - "devenv": use execIfModifiedPatterns (backward-compatible default).
+  # - "always": disable devenv's execIfModified cache for these lint tasks.
+  changeDetection ? "devenv",
   # Type-aware linting: provide tsconfig to enable --type-aware flag.
   # Requires pkgs.tsgolint in devenv packages (auto-discovered on PATH by oxlint).
   tsconfig ? null,
@@ -66,6 +82,26 @@ let
     MEGAREPO_STORE = megarepoStoreEnv;
   };
   git = "${pkgs.git}/bin/git";
+  fileSelectionMode =
+    if
+      builtins.elem fileSelection [
+        "argv"
+        "git"
+      ]
+    then
+      fileSelection
+    else
+      throw "lint-oxc: fileSelection must be one of: argv, git";
+  changeDetectionMode =
+    if
+      builtins.elem changeDetection [
+        "devenv"
+        "always"
+      ]
+    then
+      changeDetection
+    else
+      throw "lint-oxc: changeDetection must be one of: devenv, always";
   scanDirsSetup = builtins.concatStringsSep "\n" (
     map (dir: "scan_dir_args+=(${builtins.toJSON dir})") genieCoverageDirs
   );
@@ -79,6 +115,35 @@ let
     ]) genieCoverageFiles
   );
   lintPathsArg = builtins.concatStringsSep " " lintPaths;
+  lintPathspecsSetup = builtins.concatStringsSep "\n" (
+    map (pathspec: "lint_pathspec_args+=(${builtins.toJSON pathspec})") lintPaths
+  );
+  lintExecIfModified = if changeDetectionMode == "always" then [ ] else execIfModifiedPatterns;
+
+  mkGitFileSelectionExec = command: ''
+    set -euo pipefail
+
+    lint_pathspec_args=()
+    ${lintPathspecsSetup}
+
+    files=$(mktemp)
+    trap 'rm -f "$files"' EXIT
+      {
+        ${git} ls-files -z -- "''${lint_pathspec_args[@]}"
+        ${git} ls-files -z --others --exclude-standard -- "''${lint_pathspec_args[@]}"
+      } | ${pkgs.coreutils}/bin/sort -zu > "$files"
+
+    if [ ! -s "$files" ]; then
+      echo "No lint files matched"
+      exit 0
+    fi
+
+      ${pkgs.findutils}/bin/xargs -0 ${command} < "$files"
+  '';
+
+  mkLintExec =
+    command:
+    if fileSelectionMode == "git" then mkGitFileSelectionExec command else command + " ${lintPathsArg}";
 
   # Type-aware linting flags (enabled when tsconfig is provided)
   typeAwareFlags = if tsconfig != null then "--type-aware --tsconfig ${tsconfig}" else "";
@@ -92,20 +157,20 @@ let
     let
       flags = "${warningsFlag} ${extraFlags}";
     in
-    "oxlint --import-plugin ${flags} ${typeAwareFlags} ${lintPathsArg}";
+    mkLintExec "oxlint --import-plugin ${flags} ${typeAwareFlags}";
 
   guardedTasks = {
     "lint:check:format" = {
       guard = "oxfmt";
       description = "Check code formatting with oxfmt";
-      exec = trace.exec "lint:check:format" "oxfmt --check ${lintPathsArg}";
-      execIfModified = execIfModifiedPatterns;
+      exec = trace.exec "lint:check:format" (mkLintExec "oxfmt --check");
+      execIfModified = lintExecIfModified;
     };
     "lint:check:oxlint" = {
       guard = "oxlint";
       description = "Run oxlint linter";
       exec = trace.exec "lint:check:oxlint" (mkOxlintCmd "");
-      execIfModified = execIfModifiedPatterns;
+      execIfModified = lintExecIfModified;
     }
     // lib.optionalAttrs (tsconfig != null) {
       after = [ "pnpm:install" ];
@@ -113,7 +178,7 @@ let
     "lint:fix:format" = {
       guard = "oxfmt";
       description = "Fix code formatting with oxfmt";
-      exec = trace.exec "lint:fix:format" "oxfmt ${lintPathsArg}";
+      exec = trace.exec "lint:fix:format" (mkLintExec "oxfmt");
     };
     "lint:fix:oxlint" = {
       guard = "oxlint";

--- a/nix/devenv-modules/tasks/shared/lint-oxc.nix
+++ b/nix/devenv-modules/tasks/shared/lint-oxc.nix
@@ -111,10 +111,10 @@ let
     '';
 
   oxlintIncludeCase = ''
-    *.js|*.jsx|*.mjs|*.cjs|*.ts|*.tsx)
+    *.js|*.jsx|*.mjs|*.cjs|*.ts|*.tsx|*.mts|*.cts|*.vue|*.svelte|*.astro)
   '';
   oxfmtIncludeCase = ''
-    *.js|*.jsx|*.mjs|*.cjs|*.ts|*.tsx|*.json|*.jsonc|*.yaml|*.yml|*.toml|*.html|*.css|*.md|*.markdown)
+    *.js|*.jsx|*.mjs|*.cjs|*.ts|*.tsx|*.mts|*.cts|*.json|*.jsonc|*.json5|*.yaml|*.yml|*.toml|*.html|*.vue|*.css|*.scss|*.sass|*.less|*.md|*.markdown|*.mdx|*.graphql|*.gql|*.hbs|*.handlebars)
   '';
 
   # Type-aware linting flags (enabled when tsconfig is provided)

--- a/nix/devenv-modules/tasks/shared/lint-oxc.nix
+++ b/nix/devenv-modules/tasks/shared/lint-oxc.nix
@@ -6,15 +6,8 @@
 # Usage in devenv.nix:
 #   imports = [
 #     (inputs.effect-utils.devenvModules.tasks.lint-oxc {
-#       # Explicit glob patterns for execIfModified.
-#       # Use negation patterns to exclude vendored/generated trees globally.
-#       execIfModifiedPatterns = [
-#         "packages/*/src/**/*.ts"
-#         "packages/*/src/**/*.tsx"
-#         "packages/*/*.ts"  # root config files including *.genie.ts
-#         "!**/node_modules/**"
-#         "!**/dist/**"
-#       ];
+#       # Git pathspecs that define the lint surface.
+#       lintPaths = [ "packages" "scripts" ];
 #       # Glob patterns for .genie.ts files (for genie check caching)
 #       # Should match all *.genie.ts files without traversing node_modules
 #       geniePatterns = [
@@ -30,21 +23,12 @@
 #       tsconfig = "tsconfig.all.json";  # optional
 #       # Whether to fail on warnings (default: true for CI strictness)
 #       # denyWarnings = false;  # optional
-#       # How lint file arguments are assembled:
-#       # - "argv" passes lintPaths directly to oxlint/oxfmt (default).
-#       # - "git" resolves lintPaths through git ls-files, including untracked
-#       #   non-ignored files, and avoids filesystem walks through ignored trees.
-#       # fileSelection = "git";  # optional
-#       # Whether devenv should cache the lint task based on execIfModifiedPatterns.
-#       # Set to "always" for megarepos where devenv's glob walker is too expensive.
-#       # changeDetection = "always";  # optional
 #     })
 #   ];
 #
 # Provides: lint:check, lint:check:format, lint:check:oxlint, lint:check:genie, lint:check:genie:coverage
 #           lint:fix, lint:fix:format, lint:fix:oxlint
 {
-  execIfModifiedPatterns,
   geniePatterns,
   genieCoverageDirs,
   genieCoverageExcludes ? [ ],
@@ -52,15 +36,10 @@
     "package.json"
     "tsconfig.json"
   ],
+  # Git pathspecs that define the lint surface. Lint tasks enumerate tracked and
+  # untracked non-ignored files below these paths, so ignored dependency/build
+  # trees are never walked by devenv or the lint tools.
   lintPaths ? [ "." ],
-  # File selection for the lint tool invocation.
-  # - "argv": pass lintPaths directly (backward-compatible default).
-  # - "git": enumerate tracked + untracked non-ignored files via git pathspecs.
-  fileSelection ? "argv",
-  # Task change detection:
-  # - "devenv": use execIfModifiedPatterns (backward-compatible default).
-  # - "always": disable devenv's execIfModified cache for these lint tasks.
-  changeDetection ? "devenv",
   # Type-aware linting: provide tsconfig to enable --type-aware flag.
   # Requires pkgs.tsgolint in devenv packages (auto-discovered on PATH by oxlint).
   tsconfig ? null,
@@ -82,26 +61,6 @@ let
     MEGAREPO_STORE = megarepoStoreEnv;
   };
   git = "${pkgs.git}/bin/git";
-  fileSelectionMode =
-    if
-      builtins.elem fileSelection [
-        "argv"
-        "git"
-      ]
-    then
-      fileSelection
-    else
-      throw "lint-oxc: fileSelection must be one of: argv, git";
-  changeDetectionMode =
-    if
-      builtins.elem changeDetection [
-        "devenv"
-        "always"
-      ]
-    then
-      changeDetection
-    else
-      throw "lint-oxc: changeDetection must be one of: devenv, always";
   scanDirsSetup = builtins.concatStringsSep "\n" (
     map (dir: "scan_dir_args+=(${builtins.toJSON dir})") genieCoverageDirs
   );
@@ -114,13 +73,11 @@ let
       ''"$f" == */${f}''
     ]) genieCoverageFiles
   );
-  lintPathsArg = builtins.concatStringsSep " " lintPaths;
   lintPathspecsSetup = builtins.concatStringsSep "\n" (
     map (pathspec: "lint_pathspec_args+=(${builtins.toJSON pathspec})") lintPaths
   );
-  lintExecIfModified = if changeDetectionMode == "always" then [ ] else execIfModifiedPatterns;
 
-  mkGitFileSelectionExec = command: ''
+  mkLintExec = command: ''
     set -euo pipefail
 
     lint_pathspec_args=()
@@ -141,10 +98,6 @@ let
       ${pkgs.findutils}/bin/xargs -0 ${command} < "$files"
   '';
 
-  mkLintExec =
-    command:
-    if fileSelectionMode == "git" then mkGitFileSelectionExec command else command + " ${lintPathsArg}";
-
   # Type-aware linting flags (enabled when tsconfig is provided)
   typeAwareFlags = if tsconfig != null then "--type-aware --tsconfig ${tsconfig}" else "";
   warningsFlag = if denyWarnings then "--deny-warnings" else "";
@@ -164,13 +117,13 @@ let
       guard = "oxfmt";
       description = "Check code formatting with oxfmt";
       exec = trace.exec "lint:check:format" (mkLintExec "oxfmt --check");
-      execIfModified = lintExecIfModified;
+      execIfModified = [ ];
     };
     "lint:check:oxlint" = {
       guard = "oxlint";
       description = "Run oxlint linter";
       exec = trace.exec "lint:check:oxlint" (mkOxlintCmd "");
-      execIfModified = lintExecIfModified;
+      execIfModified = [ ];
     }
     // lib.optionalAttrs (tsconfig != null) {
       after = [ "pnpm:install" ];

--- a/nix/devenv-modules/tasks/shared/lint-oxc.nix
+++ b/nix/devenv-modules/tasks/shared/lint-oxc.nix
@@ -88,7 +88,11 @@ let
       {
         ${git} ls-files -z -- "''${lint_pathspec_args[@]}"
         ${git} ls-files -z --others --exclude-standard -- "''${lint_pathspec_args[@]}"
-      } | ${pkgs.coreutils}/bin/sort -zu > "$files"
+      } | ${pkgs.coreutils}/bin/sort -zu | while IFS= read -r -d "" path; do
+        if [ -e "$path" ] || [ -L "$path" ]; then
+          printf '%s\0' "$path"
+        fi
+      done > "$files"
 
     if [ ! -s "$files" ]; then
       echo "No lint files matched"

--- a/nix/devenv-modules/tasks/shared/lint-oxc.nix
+++ b/nix/devenv-modules/tasks/shared/lint-oxc.nix
@@ -218,56 +218,6 @@ let
       # Intentionally no execIfModified caching: new unmanaged config files are exactly
       # what this task exists to detect.
     };
-    "lint:check:asset-import-needs-type-reference" = {
-      description = "Require a /// <reference> for asset side-effect imports in compiled source";
-      exec = trace.exec "lint:check:asset-import-needs-type-reference" ''
-        set -euo pipefail
-
-        # A bare `import '...css'` (or scss/sass/less) in compiled, exported source needs an ambient
-        # `*.css` declaration to type it. If that ambient lives only in a floating `.d.ts` pulled in
-        # by this package's own tsconfig `include`, it does NOT travel into a downstream consumer
-        # that compiles this source via `exports`-resolution — the side-effect import then fails with
-        # TS2882 (see #837). A `/// <reference path|types ...>` directive in the SAME file is part of
-        # that file's load graph, so the declaration travels into every program that compiles it.
-        #
-        # This guard requires that any compiled-source file with an asset side-effect import also
-        # carries a `/// <reference>`. It runs out-of-band (an inline `oxlint-disable` of
-        # `no-unassigned-import` cannot suppress it). Exempts the globs where side-effect imports are
-        # allowed and not type-checked into downstream graphs: `.storybook/**`, `*.gen.*`, `*.d.ts`,
-        # `*.test.*`, `*.stories.*`.
-        offenders=$(
-          {
-            ${git} ls-files -- 'packages/*/src/**/*.ts' 'packages/*/src/**/*.tsx' \
-              'context/**/*.ts' 'context/**/*.tsx'
-            ${git} ls-files --others --exclude-standard -- \
-              'packages/*/src/**/*.ts' 'packages/*/src/**/*.tsx' \
-              'context/**/*.ts' 'context/**/*.tsx'
-          } | sort -u | while IFS= read -r f; do
-            [ -z "$f" ] && continue
-            case "$f" in
-              */.storybook/*|*.gen.*|*.d.ts|*.test.*|*.stories.*) continue ;;
-            esac
-            ${pkgs.gawk}/bin/awk '
-              /^[[:space:]]*import[[:space:]]+['"'"'"][^'"'"'"]*\.(css|scss|sass|less)['"'"'"]/ { asset = 1 }
-              /^[[:space:]]*\/\/\/[[:space:]]*<reference[[:space:]]/ { ref = 1 }
-              END { if (asset == 1 && ref != 1) print FILENAME }
-            ' "$f"
-          done | sort -u
-        )
-        if [ -n "$offenders" ]; then
-          echo "Asset side-effect import without a travelling type reference in compiled source:"
-          echo "$offenders"
-          echo ""
-          echo "Add a '/// <reference path=\"...\" />' to a shipped '*.css' ambient in the importing"
-          echo "file so the declaration travels into downstream TS checks (see #837), or move the"
-          echo "import under a '.storybook/*' entry that is not type-checked downstream."
-          exit 1
-        fi
-        echo "All asset side-effect imports in compiled source carry a type reference"
-      '';
-      # Intentionally no execIfModified caching: a newly added asset import in any source
-      # file is exactly what this task exists to detect.
-    };
     "lint:check:lockfile" = {
       description = "Verify pnpm-lock.yaml matches package.json specifiers";
       after = [ "pnpm:install" ];
@@ -296,7 +246,6 @@ let
         "lint:check:oxlint"
         "lint:check:genie"
         "lint:check:genie:coverage"
-        "lint:check:asset-import-needs-type-reference"
         "lint:check:lockfile"
       ];
     };

--- a/nix/devenv-modules/tasks/shared/lint-oxc.nix
+++ b/nix/devenv-modules/tasks/shared/lint-oxc.nix
@@ -77,29 +77,44 @@ let
     map (pathspec: "lint_pathspec_args+=(${builtins.toJSON pathspec})") lintPaths
   );
 
-  mkLintExec = command: ''
-    set -euo pipefail
+  mkLintExec =
+    {
+      command,
+      includeCase,
+    }:
+    ''
+      set -euo pipefail
 
-    lint_pathspec_args=()
-    ${lintPathspecsSetup}
+      lint_pathspec_args=()
+      ${lintPathspecsSetup}
 
-    files=$(mktemp)
-    trap 'rm -f "$files"' EXIT
-      {
-        ${git} ls-files -z -- "''${lint_pathspec_args[@]}"
-        ${git} ls-files -z --others --exclude-standard -- "''${lint_pathspec_args[@]}"
-      } | ${pkgs.coreutils}/bin/sort -zu | while IFS= read -r -d "" path; do
-        if [ -e "$path" ] || [ -L "$path" ]; then
-          printf '%s\0' "$path"
-        fi
-      done > "$files"
+      files=$(mktemp)
+      trap 'rm -f "$files"' EXIT
+        {
+          ${git} ls-files -z -- "''${lint_pathspec_args[@]}"
+          ${git} ls-files -z --others --exclude-standard -- "''${lint_pathspec_args[@]}"
+        } | ${pkgs.coreutils}/bin/sort -zu | while IFS= read -r -d "" path; do
+          [ -e "$path" ] || [ -L "$path" ] || continue
+          case "$path" in
+            ${includeCase}
+              printf '%s\0' "$path"
+              ;;
+          esac
+        done > "$files"
 
-    if [ ! -s "$files" ]; then
-      echo "No lint files matched"
-      exit 0
-    fi
+      if [ ! -s "$files" ]; then
+        echo "No lint files matched"
+        exit 0
+      fi
 
-      ${pkgs.findutils}/bin/xargs -0 ${command} < "$files"
+        ${pkgs.findutils}/bin/xargs -0 ${command} < "$files"
+    '';
+
+  oxlintIncludeCase = ''
+    *.js|*.jsx|*.mjs|*.cjs|*.ts|*.tsx)
+  '';
+  oxfmtIncludeCase = ''
+    *.js|*.jsx|*.mjs|*.cjs|*.ts|*.tsx|*.json|*.jsonc|*.yaml|*.yml|*.toml|*.html|*.css|*.md|*.markdown)
   '';
 
   # Type-aware linting flags (enabled when tsconfig is provided)
@@ -114,13 +129,19 @@ let
     let
       flags = "${warningsFlag} ${extraFlags}";
     in
-    mkLintExec "oxlint --import-plugin ${flags} ${typeAwareFlags}";
+    mkLintExec {
+      command = "oxlint --import-plugin ${flags} ${typeAwareFlags}";
+      includeCase = oxlintIncludeCase;
+    };
 
   guardedTasks = {
     "lint:check:format" = {
       guard = "oxfmt";
       description = "Check code formatting with oxfmt";
-      exec = trace.exec "lint:check:format" (mkLintExec "oxfmt --check");
+      exec = trace.exec "lint:check:format" (mkLintExec {
+        command = "oxfmt --check";
+        includeCase = oxfmtIncludeCase;
+      });
       execIfModified = [ ];
     };
     "lint:check:oxlint" = {
@@ -135,7 +156,10 @@ let
     "lint:fix:format" = {
       guard = "oxfmt";
       description = "Fix code formatting with oxfmt";
-      exec = trace.exec "lint:fix:format" (mkLintExec "oxfmt");
+      exec = trace.exec "lint:fix:format" (mkLintExec {
+        command = "oxfmt";
+        includeCase = oxfmtIncludeCase;
+      });
     };
     "lint:fix:oxlint" = {
       guard = "oxlint";

--- a/nix/devenv-modules/tasks/shared/nix-cli.nix
+++ b/nix/devenv-modules/tasks/shared/nix-cli.nix
@@ -296,25 +296,6 @@ let
     echo "✓ $name: lockfile and deps unchanged"
   '';
 
-  # Script to run nix-cli tests colocated with this module
-  nixTestsScript = pkgs.writeShellScript "nix-cli-tests" ''
-    set -euo pipefail
-    testDir="${toString ./tests}"
-    if [ ! -d "$testDir" ]; then
-      echo "No nix-cli tests found (missing $testDir)"
-      exit 1
-    fi
-
-    for testFile in "$testDir"/*.test.sh; do
-      if [ ! -f "$testFile" ]; then
-        echo "No nix-cli tests found in $testDir"
-        exit 1
-      fi
-      echo "Running $testFile"
-      bash "$testFile"
-    done
-  '';
-
   mkBuildTask = pkg: {
     "nix:build:${pkg.name}" = {
       description = "Build ${pkg.name} Nix package";
@@ -374,11 +355,6 @@ lib.mkIf hasPackages {
       # Aggregate tasks
       [
         {
-          "nix:test" = {
-            description = "Run nix-cli tooling tests";
-            exec = trace.exec "nix:test" "${nixTestsScript}";
-          };
-
           "nix:build" = {
             description = "Build all CLI Nix packages";
             after = map (p: "nix:build:${p.name}") cliPackages;

--- a/nix/devenv-modules/tasks/shared/tests/lint-oxc-file-list.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/lint-oxc-file-list.test.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$TESTS_DIR/../../../../.." && pwd)"
+
+assert_contains() {
+  local needle="$1"
+  local file="$2"
+  local label="$3"
+
+  if ! grep -Fxq "$needle" "$file"; then
+    echo "FAIL: $label"
+    echo "  missing: $needle"
+    echo "  file contents:"
+    sed -n '1,120p' "$file"
+    exit 1
+  fi
+  echo "  ok: $label"
+}
+
+assert_not_contains() {
+  local needle="$1"
+  local file="$2"
+  local label="$3"
+
+  if grep -Fxq "$needle" "$file"; then
+    echo "FAIL: $label"
+    echo "  unexpected: $needle"
+    echo "  file contents:"
+    sed -n '1,120p' "$file"
+    exit 1
+  fi
+  echo "  ok: $label"
+}
+
+extract_lint_task_script() {
+  local task_name="$1"
+  local output_path="$2"
+
+  nix eval --impure --raw --expr "
+    let
+      flake = builtins.getFlake (toString $ROOT);
+      pkgs = import flake.inputs.nixpkgs { system = builtins.currentSystem; };
+      evaluated = pkgs.lib.evalModules {
+        modules = [
+          ({ ... }: {
+            options.tasks = pkgs.lib.mkOption { type = pkgs.lib.types.attrsOf pkgs.lib.types.anything; default = { }; };
+            options.processes = pkgs.lib.mkOption { type = pkgs.lib.types.attrsOf pkgs.lib.types.anything; default = { }; };
+            options.packages = pkgs.lib.mkOption { type = pkgs.lib.types.listOf pkgs.lib.types.anything; default = [ ]; };
+          })
+          ((import $ROOT/nix/devenv-modules/tasks/shared/lint-oxc.nix {
+            lintPaths = [ \"*.ts\" ];
+            geniePatterns = [ ];
+            genieCoverageDirs = [ \".\" ];
+          }) {
+            pkgs = pkgs;
+            lib = pkgs.lib;
+            config = { };
+          })
+        ];
+      };
+    in evaluated.config.tasks.\"${task_name}\".exec
+  " > "$output_path"
+  chmod +x "$output_path"
+}
+
+echo "Running lint-oxc file list tests..."
+echo ""
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+workspace="$tmpdir/workspace"
+mkdir -p "$workspace/node_modules/pkg" "$tmpdir/bin"
+
+cat > "$tmpdir/bin/oxlint" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$@" > "${TEST_OXLINT_ARGS:?}"
+EOF
+chmod +x "$tmpdir/bin/oxlint"
+
+cat > "$workspace/keep.ts" <<'EOF'
+export const keep = true
+EOF
+cat > "$workspace/deleted.ts" <<'EOF'
+export const deleted = true
+EOF
+cat > "$workspace/new.ts" <<'EOF'
+export const fresh = true
+EOF
+cat > "$workspace/.gitignore" <<'EOF'
+node_modules/
+EOF
+cat > "$workspace/node_modules/pkg/ignored.ts" <<'EOF'
+export const ignored = true
+EOF
+
+(
+  cd "$workspace"
+  git init --quiet
+  git add .gitignore keep.ts deleted.ts
+  rm deleted.ts
+)
+
+extract_lint_task_script "lint:check:oxlint" "$tmpdir/lint-check-oxlint.sh"
+
+export PATH="$tmpdir/bin:$PATH"
+export TEST_OXLINT_ARGS="$tmpdir/oxlint-args.txt"
+
+echo "Test 1: lint task skips tracked paths deleted from the worktree"
+(
+  cd "$workspace"
+  bash "$tmpdir/lint-check-oxlint.sh"
+)
+
+assert_contains "keep.ts" "$TEST_OXLINT_ARGS" "tracked existing file is linted"
+assert_contains "new.ts" "$TEST_OXLINT_ARGS" "untracked non-ignored file is linted"
+assert_not_contains "deleted.ts" "$TEST_OXLINT_ARGS" "tracked deleted file is filtered"
+assert_not_contains "node_modules/pkg/ignored.ts" "$TEST_OXLINT_ARGS" "ignored file is not linted"
+
+echo ""
+echo "All lint-oxc file list tests passed"

--- a/nix/devenv-modules/tasks/shared/tests/lint-oxc-file-list.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/lint-oxc-file-list.test.sh
@@ -114,11 +114,45 @@ EOF
 cat > "$workspace/config.json" <<'EOF'
 {"supported": true}
 EOF
+cat > "$workspace/module.mts" <<'EOF'
+export const module = true
+EOF
+cat > "$workspace/common.cts" <<'EOF'
+export const common = true
+EOF
+cat > "$workspace/view.vue" <<'EOF'
+<script setup lang="ts">const view = true</script>
+EOF
+cat > "$workspace/card.svelte" <<'EOF'
+<script lang="ts">const card = true</script>
+EOF
+cat > "$workspace/page.astro" <<'EOF'
+---
+const page = true
+---
+EOF
+cat > "$workspace/config.json5" <<'EOF'
+{supported: true}
+EOF
+cat > "$workspace/styles.scss" <<'EOF'
+.supported { color: red; }
+EOF
+cat > "$workspace/notes.mdx" <<'EOF'
+# Supported by oxfmt
+EOF
+cat > "$workspace/query.graphql" <<'EOF'
+query Supported { node { id } }
+EOF
+cat > "$workspace/template.hbs" <<'EOF'
+<p>{{supported}}</p>
+EOF
 
 (
   cd "$workspace"
   git init --quiet
-  git add .gitignore keep.ts deleted.ts fixture.kdl lib.rs readme.md config.json
+  git add .gitignore keep.ts deleted.ts fixture.kdl lib.rs readme.md config.json \
+    module.mts common.cts view.vue card.svelte page.astro config.json5 styles.scss \
+    notes.mdx query.graphql template.hbs
   rm deleted.ts
 )
 
@@ -137,12 +171,22 @@ echo "Test 1: lint task skips tracked paths deleted from the worktree"
 
 assert_contains "keep.ts" "$TEST_OXLINT_ARGS" "tracked existing file is linted"
 assert_contains "new.ts" "$TEST_OXLINT_ARGS" "untracked non-ignored file is linted"
+assert_contains "module.mts" "$TEST_OXLINT_ARGS" "MTS file is linted by oxlint"
+assert_contains "common.cts" "$TEST_OXLINT_ARGS" "CTS file is linted by oxlint"
+assert_contains "view.vue" "$TEST_OXLINT_ARGS" "Vue file is linted by oxlint"
+assert_contains "card.svelte" "$TEST_OXLINT_ARGS" "Svelte file is linted by oxlint"
+assert_contains "page.astro" "$TEST_OXLINT_ARGS" "Astro file is linted by oxlint"
 assert_not_contains "deleted.ts" "$TEST_OXLINT_ARGS" "tracked deleted file is filtered"
 assert_not_contains "node_modules/pkg/ignored.ts" "$TEST_OXLINT_ARGS" "ignored file is not linted"
 assert_not_contains "fixture.kdl" "$TEST_OXLINT_ARGS" "unsupported KDL fixture is not linted by oxlint"
 assert_not_contains "lib.rs" "$TEST_OXLINT_ARGS" "unsupported Rust file is not linted by oxlint"
 assert_not_contains "readme.md" "$TEST_OXLINT_ARGS" "Markdown file is not linted by oxlint"
 assert_not_contains "config.json" "$TEST_OXLINT_ARGS" "JSON file is not linted by oxlint"
+assert_not_contains "config.json5" "$TEST_OXLINT_ARGS" "JSON5 file is not linted by oxlint"
+assert_not_contains "styles.scss" "$TEST_OXLINT_ARGS" "SCSS file is not linted by oxlint"
+assert_not_contains "notes.mdx" "$TEST_OXLINT_ARGS" "MDX file is not linted by oxlint"
+assert_not_contains "query.graphql" "$TEST_OXLINT_ARGS" "GraphQL file is not linted by oxlint"
+assert_not_contains "template.hbs" "$TEST_OXLINT_ARGS" "Handlebars file is not linted by oxlint"
 
 echo ""
 echo "Test 2: format task keeps oxfmt-supported files and skips unsupported paths"
@@ -153,8 +197,16 @@ echo "Test 2: format task keeps oxfmt-supported files and skips unsupported path
 
 assert_contains "keep.ts" "$TEST_OXFMT_ARGS" "tracked TypeScript file is formatted"
 assert_contains "new.ts" "$TEST_OXFMT_ARGS" "untracked TypeScript file is formatted"
+assert_contains "module.mts" "$TEST_OXFMT_ARGS" "MTS file is formatted"
+assert_contains "common.cts" "$TEST_OXFMT_ARGS" "CTS file is formatted"
+assert_contains "view.vue" "$TEST_OXFMT_ARGS" "Vue file is formatted"
 assert_contains "readme.md" "$TEST_OXFMT_ARGS" "Markdown file is formatted"
 assert_contains "config.json" "$TEST_OXFMT_ARGS" "JSON file is formatted"
+assert_contains "config.json5" "$TEST_OXFMT_ARGS" "JSON5 file is formatted"
+assert_contains "styles.scss" "$TEST_OXFMT_ARGS" "SCSS file is formatted"
+assert_contains "notes.mdx" "$TEST_OXFMT_ARGS" "MDX file is formatted"
+assert_contains "query.graphql" "$TEST_OXFMT_ARGS" "GraphQL file is formatted"
+assert_contains "template.hbs" "$TEST_OXFMT_ARGS" "Handlebars file is formatted"
 assert_not_contains "deleted.ts" "$TEST_OXFMT_ARGS" "tracked deleted file is filtered for oxfmt"
 assert_not_contains "fixture.kdl" "$TEST_OXFMT_ARGS" "unsupported KDL fixture is not formatted"
 assert_not_contains "lib.rs" "$TEST_OXFMT_ARGS" "unsupported Rust file is not formatted"

--- a/nix/devenv-modules/tasks/shared/tests/lint-oxc-file-list.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/lint-oxc-file-list.test.sh
@@ -50,7 +50,7 @@ extract_lint_task_script() {
             options.packages = pkgs.lib.mkOption { type = pkgs.lib.types.listOf pkgs.lib.types.anything; default = [ ]; };
           })
           ((import $ROOT/nix/devenv-modules/tasks/shared/lint-oxc.nix {
-            lintPaths = [ \"*.ts\" ];
+            lintPaths = [ \".\" ];
             geniePatterns = [ ];
             genieCoverageDirs = [ \".\" ];
           }) {
@@ -79,6 +79,12 @@ cat > "$tmpdir/bin/oxlint" <<'EOF'
 set -euo pipefail
 printf '%s\n' "$@" > "${TEST_OXLINT_ARGS:?}"
 EOF
+cat > "$tmpdir/bin/oxfmt" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$@" > "${TEST_OXFMT_ARGS:?}"
+EOF
+chmod +x "$tmpdir/bin/oxfmt"
 chmod +x "$tmpdir/bin/oxlint"
 
 cat > "$workspace/keep.ts" <<'EOF'
@@ -96,18 +102,32 @@ EOF
 cat > "$workspace/node_modules/pkg/ignored.ts" <<'EOF'
 export const ignored = true
 EOF
+cat > "$workspace/fixture.kdl" <<'EOF'
+node "unsupported"
+EOF
+cat > "$workspace/lib.rs" <<'EOF'
+pub fn unsupported() {}
+EOF
+cat > "$workspace/readme.md" <<'EOF'
+# Supported by oxfmt
+EOF
+cat > "$workspace/config.json" <<'EOF'
+{"supported": true}
+EOF
 
 (
   cd "$workspace"
   git init --quiet
-  git add .gitignore keep.ts deleted.ts
+  git add .gitignore keep.ts deleted.ts fixture.kdl lib.rs readme.md config.json
   rm deleted.ts
 )
 
 extract_lint_task_script "lint:check:oxlint" "$tmpdir/lint-check-oxlint.sh"
+extract_lint_task_script "lint:check:format" "$tmpdir/lint-check-format.sh"
 
 export PATH="$tmpdir/bin:$PATH"
 export TEST_OXLINT_ARGS="$tmpdir/oxlint-args.txt"
+export TEST_OXFMT_ARGS="$tmpdir/oxfmt-args.txt"
 
 echo "Test 1: lint task skips tracked paths deleted from the worktree"
 (
@@ -119,6 +139,26 @@ assert_contains "keep.ts" "$TEST_OXLINT_ARGS" "tracked existing file is linted"
 assert_contains "new.ts" "$TEST_OXLINT_ARGS" "untracked non-ignored file is linted"
 assert_not_contains "deleted.ts" "$TEST_OXLINT_ARGS" "tracked deleted file is filtered"
 assert_not_contains "node_modules/pkg/ignored.ts" "$TEST_OXLINT_ARGS" "ignored file is not linted"
+assert_not_contains "fixture.kdl" "$TEST_OXLINT_ARGS" "unsupported KDL fixture is not linted by oxlint"
+assert_not_contains "lib.rs" "$TEST_OXLINT_ARGS" "unsupported Rust file is not linted by oxlint"
+assert_not_contains "readme.md" "$TEST_OXLINT_ARGS" "Markdown file is not linted by oxlint"
+assert_not_contains "config.json" "$TEST_OXLINT_ARGS" "JSON file is not linted by oxlint"
+
+echo ""
+echo "Test 2: format task keeps oxfmt-supported files and skips unsupported paths"
+(
+  cd "$workspace"
+  bash "$tmpdir/lint-check-format.sh"
+)
+
+assert_contains "keep.ts" "$TEST_OXFMT_ARGS" "tracked TypeScript file is formatted"
+assert_contains "new.ts" "$TEST_OXFMT_ARGS" "untracked TypeScript file is formatted"
+assert_contains "readme.md" "$TEST_OXFMT_ARGS" "Markdown file is formatted"
+assert_contains "config.json" "$TEST_OXFMT_ARGS" "JSON file is formatted"
+assert_not_contains "deleted.ts" "$TEST_OXFMT_ARGS" "tracked deleted file is filtered for oxfmt"
+assert_not_contains "fixture.kdl" "$TEST_OXFMT_ARGS" "unsupported KDL fixture is not formatted"
+assert_not_contains "lib.rs" "$TEST_OXFMT_ARGS" "unsupported Rust file is not formatted"
+assert_not_contains "node_modules/pkg/ignored.ts" "$TEST_OXFMT_ARGS" "ignored file is not formatted"
 
 echo ""
 echo "All lint-oxc file list tests passed"


### PR DESCRIPTION
**Problem**

Large repos sometimes cannot use the shared `lint-oxc` task cleanly because the old surface split the lint command from devenv's `execIfModified` glob-based change detection. Consumers ended up maintaining duplicated path lists or overriding shared task bodies when the change detector was more expensive than the lint command.

**Goal**

Make `lintPaths` the single durable lint surface. The shared module should own file enumeration, avoid ignored dependency/build trees, and keep consumers from overriding lint task bodies.

**Decisions**

- Make `lintPaths` Git pathspecs and always enumerate lint inputs with `git ls-files`.
- Include tracked files plus untracked non-ignored files, so new files are linted before commit while ignored trees stay out of scope.
- Filter Git-listed paths that no longer exist in the worktree, so unstaged deletes/renames do not make oxlint/oxfmt fail on stale cached paths.
- Filter enumerated files per tool before `xargs`: oxlint receives JS/TS-family files plus supported framework files; oxfmt receives Oxc-supported JS/TS, JSON/JSON5/YAML/TOML, HTML/Vue/CSS/SCSS/Less, Markdown/MDX, GraphQL, and Handlebars-family files.
- Disable devenv `execIfModified` for oxlint/oxfmt tasks. Once enumeration is Git-backed, always running is simpler than maintaining a second cache surface.
- Remove the opt-in `fileSelection` / `changeDetection` compatibility knobs and dogfood the lean contract in effect-utils' own `devenv.nix`.
- Keep `lint-oxc` reusable: effect-utils-specific source policy checks now live in local task modules instead of the shared lint module.
- Wire shared devenv task-module shell tests through a dedicated `devenv-modules:test` task included by `test:run`, so they run in the normal CI unit-test job.

**Verification**

On the updated PR branch `d5dcb524`:

```text
nixfmt --check nix/devenv-modules/tasks/shared/lint-oxc.nix
nix-instantiate --parse nix/devenv-modules/tasks/shared/lint-oxc.nix
# passed: parse-ok
```

```text
bash nix/devenv-modules/tasks/shared/tests/lint-oxc-file-list.test.sh
# passed: tracked existing files and untracked non-ignored files are linted;
# deleted, ignored, and unsupported paths are filtered; oxlint/oxfmt receive
# different supported file sets, including .mts/.cts and broader oxfmt formats.
```

```text
devenv tasks run lint:check:format --mode before --no-tui
# passed
```

```text
devenv tasks run lint:check:oxlint --mode before --no-tui
# passed
```

Earlier on this branch:

```text
devenv tasks run lint:check --mode before --no-tui
# passed
```

```text
devenv tasks run lint:check:asset-import-needs-type-reference --mode before --no-tui
# passed
```

```text
devenv tasks run devenv-modules:test --mode before --no-tui
# failed locally in the existing OTel assertion: "devenv.task.exec should be the root task span"
# CI later passed the unit-test jobs on 842d083b; focused lint-oxc coverage passes directly.
```

**Complexity**

This removes config surface and task-body duplication. The remaining shared lint complexity is one Git-backed file-list helper shared by oxlint and oxfmt, plus focused shell regression coverage for deleted tracked paths, unsupported file types, and Oxc-supported extensions. Repo-specific policy stays local to effect-utils.

**Concerns**

This is a breaking module API change for consumers that still pass `execIfModifiedPatterns` to `lint-oxc`. The intended migration is to delete that argument and express the lint surface with `lintPaths`.

`lintPaths` now require a Git worktree. That matches devenv task usage in these repos; non-Git consumers should not use this shared module.

The module now owns file-type allowlists for oxlint and oxfmt. New tool-supported file types should be added there deliberately with test coverage.

`xargs` may split very large file lists into multiple oxlint/oxfmt invocations, so tools can print repeated startup warnings. That avoids shell argument-length failures.

**Follow-ups**

- Downstream repos should remove local `lint:check:oxlint`/`lint:check:format` body overrides and configure only `lintPaths` plus `oxlintPkg` where custom oxlint packaging is needed.

**References**

Refs cachix/devenv#2588.
Refs cachix/devenv#2966.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🏺 co4-clay |
| `agent_session_id` | 66b7ef57-1e28-403a-b3fe-7e9d7d400492 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.141.0 |
| `agent_runtime` | Codex CLI 0.141.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/r6ycnx65n3gj1kq9v3a9w0dxgyl4128i-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/jkyy2xvnv888q38a0b5kh08py1ma52pq-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils-lint-oxc-pr/schickling/lint-oxc-git-file-selection-pr |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->