### PR TITLE
fix(megarepo): canonicalize recursive traversal roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **@overeng/megarepo**: Share canonical nested-megarepo traversal state across
+  recursive commands and key visited roots by resolved worktree identity, so
+  `mr status --all` and `mr ls --all` stop at symlink cycles instead of
+  recursing through ever-growing `repos/` paths.
+
 - **devenv/pnpm**: Keep the cached `pnpm-install-contract.json` writable even
   when the generated source file is read-only, so repeated `pnpm:install` runs
   can update `.devenv/task-cache` instead of failing on the preserved generated

--- a/packages/@overeng/megarepo/src/cli/commands/ls.ts
+++ b/packages/@overeng/megarepo/src/cli/commands/ls.ts
@@ -19,6 +19,7 @@ import {
   readMegarepoConfig,
 } from '../../lib/config.ts'
 import * as Git from '../../lib/git.ts'
+import { type MegarepoTraversal, withMegarepoTraversal } from '../../lib/megarepo-traversal.ts'
 import {
   Cwd,
   detectCurrentMemberPath,
@@ -36,28 +37,28 @@ import type { MemberInfo } from '../renderers/LsOutput/schema.ts'
 const scanMembersRecursive = ({
   megarepoRoot,
   ownerPath,
-  visited = new Set<string>(),
+  traversal,
   all,
+  depth = 0,
 }: {
   megarepoRoot: AbsoluteDirPath
   /** Path to owning megarepo (undefined = root megarepo) */
   ownerPath?: readonly [string, ...string[]]
-  visited?: Set<string>
+  traversal: MegarepoTraversal
   all: boolean
+  depth?: number
 }): Effect.Effect<
   MemberInfo[],
   PlatformError.PlatformError | ParseResult.ParseError | Error,
   FileSystem.FileSystem
 > =>
   Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem
-
-    // Prevent cycles
-    const normalizedRoot = megarepoRoot.replace(/\/$/, '')
-    if (visited.has(normalizedRoot) === true) {
+    const enterResult = yield* traversal.enterRoot({ root: megarepoRoot, depth })
+    if (enterResult._tag === 'Cycle') {
       return []
     }
-    visited.add(normalizedRoot)
+
+    const fs = yield* FileSystem.FileSystem
 
     // Load config
     const configResult = yield* readMegarepoConfig(megarepoRoot).pipe(
@@ -101,8 +102,9 @@ const scanMembersRecursive = ({
         const nestedMembers = yield* scanMembersRecursive({
           megarepoRoot: nestedRoot,
           ownerPath: nestedOwnerPath,
-          visited,
+          traversal,
           all,
+          depth: depth + 1,
         })
         members.push(...nestedMembers)
       }
@@ -145,9 +147,16 @@ export const lsCommand = Cli.Command.make(
             const megarepoName = yield* Git.deriveMegarepoName(root.value)
 
             // Scan members (recursively if --all)
-            const members = yield* scanMembersRecursive({
-              megarepoRoot: root.value,
+            const members = yield* withMegarepoTraversal({
+              purpose: 'ls',
+              root: root.value,
               all,
+              effect: (traversal) =>
+                scanMembersRecursive({
+                  megarepoRoot: root.value,
+                  all,
+                  traversal,
+                }),
             })
 
             // Detect current member path for scope dimming

--- a/packages/@overeng/megarepo/src/cli/commands/status.ts
+++ b/packages/@overeng/megarepo/src/cli/commands/status.ts
@@ -24,6 +24,7 @@ import {
 import * as Git from '../../lib/git.ts'
 import { detectRefMismatch, type RefMismatch } from '../../lib/issues.ts'
 import { checkLockStaleness, LOCK_FILE_NAME, readLockFile } from '../../lib/lock.ts'
+import { type MegarepoTraversal, withMegarepoTraversal } from '../../lib/megarepo-traversal.ts'
 import { extractRefFromSymlinkPath } from '../../lib/ref.ts'
 import { refreshWorkspaceRegistry } from '../../lib/store-liveness.ts'
 import { Store, StoreLayer } from '../../lib/store.ts'
@@ -49,30 +50,30 @@ import type {
  * Recursively scan members and build status tree.
  * @param megarepoRoot - Root path of the megarepo
  * @param all - Whether to recurse into nested megarepos
- * @param visited - Set of visited paths to prevent cycles
+ * @param traversal - Shared traversal state keyed by canonical root identity
  */
 const scanMembersRecursive = ({
   megarepoRoot,
   all,
-  visited = new Set<string>(),
+  traversal,
+  depth = 0,
 }: {
   megarepoRoot: AbsoluteDirPath
   all: boolean
-  visited?: Set<string>
+  traversal: MegarepoTraversal
+  depth?: number
 }): Effect.Effect<
   MemberStatus[],
   PlatformError.PlatformError | ParseResult.ParseError | Error,
   FileSystem.FileSystem | CommandExecutor.CommandExecutor | Store
 > =>
   Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem
-
-    // Prevent cycles
-    const normalizedRoot = megarepoRoot.replace(/\/$/, '')
-    if (visited.has(normalizedRoot) === true) {
+    const enterResult = yield* traversal.enterRoot({ root: megarepoRoot, depth })
+    if (enterResult._tag === 'Cycle') {
       return []
     }
-    visited.add(normalizedRoot)
+
+    const fs = yield* FileSystem.FileSystem
 
     // Load config
     const configResult = yield* readMegarepoConfig(megarepoRoot).pipe(
@@ -134,7 +135,8 @@ const scanMembersRecursive = ({
         nestedMembers = yield* scanMembersRecursive({
           megarepoRoot: nestedRoot,
           all,
-          visited,
+          traversal,
+          depth: depth + 1,
         })
       }
 
@@ -305,9 +307,16 @@ export const statusCommand = Cli.Command.make(
       const { config } = yield* readMegarepoConfig(root.value)
 
       // Scan members (recursively if --all)
-      const members = yield* scanMembersRecursive({
-        megarepoRoot: root.value,
+      const members = yield* withMegarepoTraversal({
+        purpose: 'status',
+        root: root.value,
         all,
+        effect: (traversal) =>
+          scanMembersRecursive({
+            megarepoRoot: root.value,
+            all,
+            traversal,
+          }),
       })
 
       // Get last sync time and lock staleness from lock file

--- a/packages/@overeng/megarepo/src/cli/status.integration.test.ts
+++ b/packages/@overeng/megarepo/src/cli/status.integration.test.ts
@@ -19,7 +19,13 @@ import { EffectPath, type AbsoluteDirPath } from '@overeng/effect-path'
 import { MegarepoConfig } from '../lib/config.ts'
 import { createLockedMember, type LockFile, LOCK_FILE_NAME, writeLockFile } from '../lib/lock.ts'
 import { makeConsoleCapture } from '../test-utils/consoleCapture.ts'
-import { createRepo, getGitRev, initGitRepo, runGitCommand } from '../test-utils/setup.ts'
+import {
+  addCommit,
+  createRepo,
+  getGitRev,
+  initGitRepo,
+  runGitCommand,
+} from '../test-utils/setup.ts'
 import { mrCommand } from './mod.ts'
 import { StatusState } from './renderers/StatusOutput/schema.ts'
 
@@ -503,6 +509,72 @@ describe('mr status --output json', () => {
           // Overall sync needed due to missing remote member
           expect(status!.syncNeeded).toBe(true)
           expect(status!.syncReasons).toContain("Member 'remote-lib' symlink missing")
+        },
+        Effect.provide(NodeContext.layer),
+        Effect.scoped,
+      ),
+    )
+  })
+
+  describe('--all traversal cycles', () => {
+    it.effect(
+      'should stop recursive status at repeated real worktree paths',
+      Effect.fnUntraced(
+        function* () {
+          const fs = yield* FileSystem.FileSystem
+          const tmpDir = EffectPath.unsafe.absoluteDir(`${yield* fs.makeTempDirectoryScoped()}/`)
+          const workspaceA = EffectPath.ops.join(tmpDir, EffectPath.unsafe.relativeDir('a/'))
+          const workspaceB = EffectPath.ops.join(tmpDir, EffectPath.unsafe.relativeDir('b/'))
+
+          yield* fs.makeDirectory(workspaceA, { recursive: true })
+          yield* fs.makeDirectory(workspaceB, { recursive: true })
+          yield* initGitRepo(workspaceA)
+          yield* initGitRepo(workspaceB)
+
+          const writeConfig = (workspacePath: AbsoluteDirPath, members: Record<string, string>) =>
+            Effect.gen(function* () {
+              const configContent = yield* Schema.encode(
+                Schema.parseJson(MegarepoConfig, { space: 2 }),
+              )({ members })
+              yield* fs.writeFileString(
+                EffectPath.ops.join(workspacePath, EffectPath.unsafe.relativeFile('megarepo.json')),
+                `${configContent}\n`,
+              )
+              yield* fs.makeDirectory(
+                EffectPath.ops.join(workspacePath, EffectPath.unsafe.relativeDir('repos/')),
+                { recursive: true },
+              )
+            })
+
+          yield* writeConfig(workspaceA, { b: workspaceB })
+          yield* writeConfig(workspaceB, { a: workspaceA })
+
+          yield* fs.symlink(
+            workspaceB.slice(0, -1),
+            EffectPath.ops.join(workspaceA, EffectPath.unsafe.relativeFile('repos/b')),
+          )
+          yield* fs.symlink(
+            workspaceA.slice(0, -1),
+            EffectPath.ops.join(workspaceB, EffectPath.unsafe.relativeFile('repos/a')),
+          )
+
+          yield* addCommit({ repoPath: workspaceA, message: 'Initialize megarepo A' })
+          yield* addCommit({ repoPath: workspaceB, message: 'Initialize megarepo B' })
+
+          const { status, exitCode } = yield* runStatusCommand({
+            cwd: workspaceA,
+            args: ['--all'],
+          })
+
+          expect(exitCode).toBe(0)
+          expect(status).toBeDefined()
+          const memberB = status!.members.find((member) => member.name === 'b')
+          expect(memberB?.isMegarepo).toBe(true)
+          expect(memberB?.nestedMembers).toHaveLength(1)
+          const cycleClosingMember = memberB?.nestedMembers?.[0]
+          expect(cycleClosingMember?.name).toBe('a')
+          expect(cycleClosingMember?.isMegarepo).toBe(true)
+          expect(cycleClosingMember?.nestedMembers).toEqual([])
         },
         Effect.provide(NodeContext.layer),
         Effect.scoped,

--- a/packages/@overeng/megarepo/src/lib/megarepo-traversal.ts
+++ b/packages/@overeng/megarepo/src/lib/megarepo-traversal.ts
@@ -1,0 +1,151 @@
+/**
+ * Shared traversal state for recursive megarepo walks.
+ *
+ * The important invariant is that a traversal node is identified by its
+ * canonical worktree path, not by the current `repos/<member>` symlink path.
+ * Raw traversal paths can grow forever in symlink cycles.
+ */
+
+import { FileSystem, type Error as PlatformError } from '@effect/platform'
+import { Effect, Ref, Schema, type ParseResult } from 'effect'
+
+import type { AbsoluteDirPath } from '@overeng/effect-path'
+
+import * as Observability from './observability.ts'
+
+/** Known command/operation families that perform nested megarepo traversal. */
+export const MegarepoTraversalPurpose = Schema.Literal('status', 'ls', 'sync').annotations({
+  identifier: 'Megarepo.Traversal.Purpose',
+})
+export type MegarepoTraversalPurpose = typeof MegarepoTraversalPurpose.Type
+
+/** Branded canonical identity for a traversed megarepo root. */
+export const MegarepoTraversalNodeKey = Schema.NonEmptyString.pipe(
+  Schema.brand('Megarepo.Traversal.NodeKey'),
+  Schema.annotations({ identifier: 'Megarepo.Traversal.NodeKey' }),
+)
+export type MegarepoTraversalNodeKey = typeof MegarepoTraversalNodeKey.Type
+
+/** Result of attempting to enter a megarepo root during recursive traversal. */
+export type MegarepoTraversalEnterResult =
+  | {
+      readonly _tag: 'Enter'
+      readonly key: MegarepoTraversalNodeKey
+      readonly resolvedRoot: string
+    }
+  | {
+      readonly _tag: 'Cycle'
+      readonly key: MegarepoTraversalNodeKey
+      readonly resolvedRoot: string
+    }
+
+/** Scalar counters for one traversal span. */
+export interface MegarepoTraversalStats {
+  readonly nodesVisited: number
+  readonly cyclesSkipped: number
+  readonly maxDepth: number
+}
+
+interface MegarepoTraversalState extends MegarepoTraversalStats {
+  readonly visited: ReadonlySet<MegarepoTraversalNodeKey>
+}
+
+/** Stateful traversal guard shared by one recursive megarepo walk. */
+export interface MegarepoTraversal {
+  readonly enterRoot: (args: {
+    readonly root: AbsoluteDirPath
+    readonly depth: number
+  }) => Effect.Effect<
+    MegarepoTraversalEnterResult,
+    PlatformError.PlatformError | ParseResult.ParseError,
+    FileSystem.FileSystem
+  >
+  readonly stats: Effect.Effect<MegarepoTraversalStats>
+}
+
+const canonicalizeRoot = Effect.fn('megarepo/traversal/canonicalize-root')(function* (
+  root: AbsoluteDirPath,
+) {
+  const fs = yield* FileSystem.FileSystem
+  const resolvedRoot = yield* fs.realPath(root.replace(/\/$/, '')).pipe(
+    Effect.map((path) => path.replace(/\/$/, '')),
+    Effect.orElseSucceed(() => root.replace(/\/$/, '')),
+  )
+  const key = yield* Schema.decodeUnknown(MegarepoTraversalNodeKey)(resolvedRoot)
+  return { key, resolvedRoot }
+})
+
+const initialState: MegarepoTraversalState = {
+  visited: new Set(),
+  nodesVisited: 0,
+  cyclesSkipped: 0,
+  maxDepth: 0,
+}
+
+/** Create traversal state keyed by canonical worktree identity. */
+export const makeMegarepoTraversal = Effect.fn('megarepo/traversal/make')(function* () {
+  const stateRef = yield* Ref.make<MegarepoTraversalState>(initialState)
+
+  const enterRoot: MegarepoTraversal['enterRoot'] = Effect.fn('megarepo/traversal/enter-root')(
+    function* ({ root, depth }: { readonly root: AbsoluteDirPath; readonly depth: number }) {
+      const { key, resolvedRoot } = yield* canonicalizeRoot(root)
+      return yield* Ref.modify(
+        stateRef,
+        (state): [MegarepoTraversalEnterResult, MegarepoTraversalState] => {
+          if (state.visited.has(key) === true) {
+            return [
+              { _tag: 'Cycle', key, resolvedRoot },
+              {
+                ...state,
+                cyclesSkipped: state.cyclesSkipped + 1,
+                maxDepth: Math.max(state.maxDepth, depth),
+              },
+            ]
+          }
+
+          const visited = new Set(state.visited)
+          visited.add(key)
+          return [
+            { _tag: 'Enter', key, resolvedRoot },
+            {
+              visited,
+              nodesVisited: state.nodesVisited + 1,
+              cyclesSkipped: state.cyclesSkipped,
+              maxDepth: Math.max(state.maxDepth, depth),
+            },
+          ]
+        },
+      )
+    },
+  )
+
+  const stats = Ref.get(stateRef).pipe(
+    Effect.map(({ nodesVisited, cyclesSkipped, maxDepth }) => ({
+      nodesVisited,
+      cyclesSkipped,
+      maxDepth,
+    })),
+  )
+
+  return { enterRoot, stats } satisfies MegarepoTraversal
+})
+
+/** Run an effect with shared nested traversal state and traversal telemetry. */
+export const withMegarepoTraversal = <A, E, R>({
+  purpose,
+  root,
+  all,
+  effect,
+}: {
+  readonly purpose: MegarepoTraversalPurpose
+  readonly root: AbsoluteDirPath
+  readonly all: boolean
+  readonly effect: (traversal: MegarepoTraversal) => Effect.Effect<A, E, R>
+}): Effect.Effect<A, E, R | FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const traversal = yield* makeMegarepoTraversal()
+    const result = yield* effect(traversal)
+    const stats = yield* traversal.stats
+    yield* Observability.annotateMegarepoTraversalResult(stats)
+    return result
+  }).pipe(Observability.withMegarepoTraversalSpan({ root, purpose, all }))

--- a/packages/@overeng/megarepo/src/lib/megarepo-traversal.ts
+++ b/packages/@overeng/megarepo/src/lib/megarepo-traversal.ts
@@ -50,6 +50,12 @@ interface MegarepoTraversalState extends MegarepoTraversalStats {
   readonly visited: ReadonlySet<MegarepoTraversalNodeKey>
 }
 
+/** Remove trailing slashes from a path without turning the filesystem root into an empty path. */
+export const stripTrailingSlashesPreservingRoot = (path: string): string => {
+  const stripped = path.replace(/\/+$/, '')
+  return stripped === '' ? '/' : stripped
+}
+
 /** Stateful traversal guard shared by one recursive megarepo walk. */
 export interface MegarepoTraversal {
   readonly enterRoot: (args: {
@@ -67,9 +73,10 @@ const canonicalizeRoot = Effect.fn('megarepo/traversal/canonicalize-root')(funct
   root: AbsoluteDirPath,
 ) {
   const fs = yield* FileSystem.FileSystem
-  const resolvedRoot = yield* fs.realPath(root.replace(/\/$/, '')).pipe(
-    Effect.map((path) => path.replace(/\/$/, '')),
-    Effect.orElseSucceed(() => root.replace(/\/$/, '')),
+  const normalizedRoot = stripTrailingSlashesPreservingRoot(root)
+  const resolvedRoot = yield* fs.realPath(normalizedRoot).pipe(
+    Effect.map(stripTrailingSlashesPreservingRoot),
+    Effect.orElseSucceed(() => normalizedRoot),
   )
   const key = yield* Schema.decodeUnknown(MegarepoTraversalNodeKey)(resolvedRoot)
   return { key, resolvedRoot }

--- a/packages/@overeng/megarepo/src/lib/megarepo-traversal.unit.test.ts
+++ b/packages/@overeng/megarepo/src/lib/megarepo-traversal.unit.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+
+import { stripTrailingSlashesPreservingRoot } from './megarepo-traversal.ts'
+
+describe('stripTrailingSlashesPreservingRoot', () => {
+  it('preserves the filesystem root', () => {
+    expect(stripTrailingSlashesPreservingRoot('/')).toBe('/')
+  })
+
+  it('removes trailing slashes from non-root paths', () => {
+    expect(stripTrailingSlashesPreservingRoot('/tmp/megarepo/')).toBe('/tmp/megarepo')
+    expect(stripTrailingSlashesPreservingRoot('/tmp/megarepo//')).toBe('/tmp/megarepo')
+  })
+})

--- a/packages/@overeng/megarepo/src/lib/observability.ts
+++ b/packages/@overeng/megarepo/src/lib/observability.ts
@@ -111,6 +111,27 @@ const workspaceAttrs = OtelAttrs.defineSync(
   }),
 )
 
+const megarepoTraversalAttrs = OtelAttrs.defineSync(
+  Schema.Struct({
+    label: Schema.NonEmptyString.pipe(OtelAttr.spanLabel()),
+    root: Schema.String.pipe(OtelAttr.key({ key: 'megarepo.traversal.root' })),
+    purpose: Schema.NonEmptyString.pipe(OtelAttr.key({ key: 'megarepo.traversal.purpose' })),
+    all: Schema.Boolean.pipe(OtelAttr.key({ key: 'megarepo.traversal.all' })),
+  }),
+)
+
+const megarepoTraversalResultAttrs = OtelAttrs.defineSync(
+  Schema.Struct({
+    nodesVisited: Schema.NonNegativeInt.pipe(
+      OtelAttr.key({ key: 'megarepo.traversal.nodes_visited' }),
+    ),
+    cyclesSkipped: Schema.NonNegativeInt.pipe(
+      OtelAttr.key({ key: 'megarepo.traversal.cycles_skipped' }),
+    ),
+    maxDepth: Schema.NonNegativeInt.pipe(OtelAttr.key({ key: 'megarepo.traversal.max_depth' })),
+  }),
+)
+
 const storeLiveSetAttrs = OtelAttrs.defineSync(
   Schema.Struct({
     label: Schema.NonEmptyString.pipe(OtelAttr.spanLabel()),
@@ -361,6 +382,38 @@ export const withWorkspaceSpan = ({
   readonly workspaceRoot: string
   readonly label?: string
 }) => trustedWith({ operation: workspaceOperation(name), attributes: { label, workspaceRoot } })
+
+const megarepoTraversalOperation = OtelOperation.define({
+  name: 'megarepo/traversal',
+  attributes: megarepoTraversalAttrs,
+  label: ({ label }) => label,
+})
+
+/** Wrap a nested megarepo traversal in a span keyed by its root and purpose.
+ *  Result counters are annotated after traversal completes. */
+export const withMegarepoTraversalSpan = ({
+  root,
+  purpose,
+  all,
+  label = basename(root),
+}: {
+  readonly root: string
+  readonly purpose: string
+  readonly all: boolean
+  readonly label?: string
+}) =>
+  trustedWith({
+    operation: megarepoTraversalOperation,
+    attributes: { label, root, purpose, all },
+  })
+
+/** Annotate the enclosing traversal span with bounded scalar counters. */
+export const annotateMegarepoTraversalResult = (
+  value: Schema.Schema.Type<typeof megarepoTraversalResultAttrs.schema>,
+) =>
+  trustOtelContract<void, never, never>(
+    OtelSpan.annotate({ attributes: megarepoTraversalResultAttrs, value }),
+  )
 
 const storeLiveSetOperation = (name: string) =>
   OtelOperation.define({


### PR DESCRIPTION
## Problem

`mr status --all` and `mr ls --all` could fail to terminate on nested megarepo cycles when traversal reached the same physical worktree through different `repos/<member>` symlink paths. The cycle guard keyed `visited` by the unresolved traversal path, so each pass through the cycle produced a new string identity instead of recognizing the already-seen worktree.

## Goal

Make recursive megarepo traversal terminate deterministically for repeated worktree identities, while standardizing the traversal guard so command implementations do not drift apart.

## Decisions

- Added a shared `megarepo-traversal` module for recursive commands.
- Canonicalized traversal identity with `fs.realPath`, falling back to the raw root only if resolution fails.
- Modeled traversal node keys as a branded non-empty schema value.
- Used `Effect.fn` and `Ref` for the traversal state boundary, matching the repo's Effect conventions.
- Added OpenTelemetry span attributes and traversal result annotations for purpose, root, `--all`, visited nodes, skipped cycles, and max depth.
- Wired `status --all` and `ls --all` through the shared traversal abstraction.
- Added an integration regression with two local megarepos linked through reciprocal `repos/*` symlinks.

## Verification

- `devenv tasks run check:quick --no-tui`
- `devenv tasks run ts:check --no-tui`
- `devenv tasks run lint:check --no-tui`
- `devenv shell -- bash -lc 'DEVENV_TASK_PASSTHROUGH=1 pnpm --filter @overeng/megarepo exec vitest run src/cli/status.integration.test.ts --reporter=dot'`
- Ran the source CLI against the original nested-megarepo reproduction: `status --all --output json` returned bounded JSON with `all: true`; `ls --all --output json` returned `Success` with `all: true`.

## Complexity

This introduces a small shared traversal abstraction instead of keeping per-command `Set<string>` guards. The extra structure is intentional: recursive identity, cycle accounting, and telemetry are now one reusable boundary rather than command-local incidental logic.

## Concerns

- A cycle-closing nested megarepo is currently represented as a megarepo member with empty `nestedMembers`; there is no explicit cycle marker in the JSON shape.
- `realPath` fallback preserves best-effort behavior for unusual filesystem states, but the normal correctness path depends on resolved worktree identity.

## Friction & bottlenecks

A broader `test:megarepo` run hit an unrelated timeout in a store-GC cold integration test. The targeted regression, TypeScript, lint, and quick check gates passed.

## Follow-ups

Optional future work: expose skipped-cycle metadata in command output if users need to distinguish an empty nested megarepo from a cycle boundary.

## References

Closes #852

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🐊 co4-gecko |
| `agent_session_id` | 1ada08a7-e57c-4678-bfa5-e795a48e2b00 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.141.0 |
| `agent_runtime` | Codex CLI 0.141.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/r6ycnx65n3gj1kq9v3a9w0dxgyl4128i-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/jkyy2xvnv888q38a0b5kh08py1ma52pq-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling/2026-06-27-852 |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->