### PR TITLE
fix: harden lint format and completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **devenv/lint-oxc, CLI package builders**: Treat an `oxfmt` chunk that becomes
+  empty after formatter config ignores as no work while preserving failures for
+  real formatter errors, and generate packaged CLI completions without assuming
+  every CLI accepts the shared `--log-level none` option.
+
 - **@overeng/megarepo**: Share canonical nested-megarepo traversal state across
   recursive commands and key visited roots by resolved worktree identity, so
   `mr status --all` and `mr ls --all` stop at symlink cycles instead of

--- a/nix/devenv-modules/tasks/shared/lint-oxc.nix
+++ b/nix/devenv-modules/tasks/shared/lint-oxc.nix
@@ -81,6 +81,7 @@ let
     {
       command,
       includeCase,
+      emptySelectionDiagnostic ? null,
     }:
     ''
       set -euo pipefail
@@ -107,7 +108,35 @@ let
         exit 0
       fi
 
-        ${pkgs.findutils}/bin/xargs -0 ${command} < "$files"
+        ${
+          if emptySelectionDiagnostic == null then
+            "${pkgs.findutils}/bin/xargs -0 ${command} < \"$files\""
+          else
+            ''
+              ${pkgs.findutils}/bin/xargs -0 sh -c '
+                empty_selection_diagnostic="$1"
+                shift
+                stderr_file=$(mktemp)
+                trap "rm -f \"$stderr_file\"" EXIT
+
+                if ${command} "$@" 2>"$stderr_file"; then
+                  if [ -s "$stderr_file" ]; then
+                    cat "$stderr_file" >&2
+                  fi
+                  exit 0
+                else
+                  status=$?
+                fi
+
+                if grep -Fq "$empty_selection_diagnostic" "$stderr_file"; then
+                  exit 0
+                fi
+
+                cat "$stderr_file" >&2
+                exit "$status"
+              ' sh ${lib.escapeShellArg emptySelectionDiagnostic} < "$files"
+            ''
+        }
     '';
 
   oxlintIncludeCase = ''
@@ -141,6 +170,7 @@ let
       exec = trace.exec "lint:check:format" (mkLintExec {
         command = "oxfmt --check";
         includeCase = oxfmtIncludeCase;
+        emptySelectionDiagnostic = "Expected at least one target file";
       });
       execIfModified = [ ];
     };
@@ -159,6 +189,7 @@ let
       exec = trace.exec "lint:fix:format" (mkLintExec {
         command = "oxfmt";
         includeCase = oxfmtIncludeCase;
+        emptySelectionDiagnostic = "Expected at least one target file";
       });
     };
     "lint:fix:oxlint" = {

--- a/nix/devenv-modules/tasks/shared/lint-oxc.nix
+++ b/nix/devenv-modules/tasks/shared/lint-oxc.nix
@@ -128,11 +128,12 @@ let
                   status=$?
                 fi
 
-                if grep -Fq "$empty_selection_diagnostic" "$stderr_file"; then
+                stderr="$(cat "$stderr_file")"
+                if [ "$stderr" = "$empty_selection_diagnostic" ]; then
                   exit 0
                 fi
 
-                cat "$stderr_file" >&2
+                printf "%s\n" "$stderr" >&2
                 exit "$status"
               ' sh ${lib.escapeShellArg emptySelectionDiagnostic} < "$files"
             ''

--- a/nix/devenv-modules/tasks/shared/tests/lint-oxc-file-list.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/lint-oxc-file-list.test.sh
@@ -82,6 +82,14 @@ EOF
 cat > "$tmpdir/bin/oxfmt" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
+if [ "${TEST_OXFMT_EMPTY_TARGET_ERROR:-0}" = 1 ]; then
+  echo "Expected at least one target file" >&2
+  exit 1
+fi
+if [ "${TEST_OXFMT_OTHER_ERROR:-0}" = 1 ]; then
+  echo "parse error" >&2
+  exit 1
+fi
 printf '%s\n' "$@" > "${TEST_OXFMT_ARGS:?}"
 EOF
 chmod +x "$tmpdir/bin/oxfmt"
@@ -211,6 +219,27 @@ assert_not_contains "deleted.ts" "$TEST_OXFMT_ARGS" "tracked deleted file is fil
 assert_not_contains "fixture.kdl" "$TEST_OXFMT_ARGS" "unsupported KDL fixture is not formatted"
 assert_not_contains "lib.rs" "$TEST_OXFMT_ARGS" "unsupported Rust file is not formatted"
 assert_not_contains "node_modules/pkg/ignored.ts" "$TEST_OXFMT_ARGS" "ignored file is not formatted"
+
+echo ""
+echo "Test 3: format task treats an oxfmt all-ignored chunk as empty work"
+export TEST_OXFMT_EMPTY_TARGET_ERROR=1
+(
+  cd "$workspace"
+  bash "$tmpdir/lint-check-format.sh"
+)
+unset TEST_OXFMT_EMPTY_TARGET_ERROR
+
+echo ""
+echo "Test 4: format task still fails real oxfmt errors"
+export TEST_OXFMT_OTHER_ERROR=1
+if (
+  cd "$workspace"
+  bash "$tmpdir/lint-check-format.sh"
+); then
+  echo "FAIL: non-empty oxfmt errors must fail"
+  exit 1
+fi
+unset TEST_OXFMT_OTHER_ERROR
 
 echo ""
 echo "All lint-oxc file list tests passed"

--- a/nix/devenv-modules/tasks/shared/tests/lint-oxc-file-list.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/lint-oxc-file-list.test.sh
@@ -90,6 +90,11 @@ if [ "${TEST_OXFMT_OTHER_ERROR:-0}" = 1 ]; then
   echo "parse error" >&2
   exit 1
 fi
+if [ "${TEST_OXFMT_MIXED_EMPTY_TARGET_ERROR:-0}" = 1 ]; then
+  echo "Expected at least one target file" >&2
+  echo "parse error" >&2
+  exit 1
+fi
 printf '%s\n' "$@" > "${TEST_OXFMT_ARGS:?}"
 EOF
 chmod +x "$tmpdir/bin/oxfmt"
@@ -240,6 +245,18 @@ if (
   exit 1
 fi
 unset TEST_OXFMT_OTHER_ERROR
+
+echo ""
+echo "Test 5: format task does not hide mixed empty-target and real errors"
+export TEST_OXFMT_MIXED_EMPTY_TARGET_ERROR=1
+if (
+  cd "$workspace"
+  bash "$tmpdir/lint-check-format.sh"
+); then
+  echo "FAIL: mixed empty-target and real oxfmt errors must fail"
+  exit 1
+fi
+unset TEST_OXFMT_MIXED_EMPTY_TARGET_ERROR
 
 echo ""
 echo "All lint-oxc file list tests passed"

--- a/nix/workspace-tools/lib/mk-bun-cli.nix
+++ b/nix/workspace-tools/lib/mk-bun-cli.nix
@@ -286,13 +286,39 @@ pkgs.stdenv.mkDerivation {
     mkdir -p "$out/bin"
     cp ".bun-build/${binaryName}" "$out/bin/${binaryName}"
 
-    # Generate shell completions (Effect CLI built-in support)
+    # Generate shell completions. Effect CLIs commonly support `--log-level none`,
+    # but package builders must also work for CLIs that expose completions without
+    # that logging flag.
     mkdir -p "$out/share/fish/vendor_completions.d"
     mkdir -p "$out/share/bash-completion/completions"
     mkdir -p "$out/share/zsh/site-functions"
-    $out/bin/${binaryName} --log-level none --completions fish > "$out/share/fish/vendor_completions.d/${binaryName}.fish" || true
-    $out/bin/${binaryName} --log-level none --completions bash > "$out/share/bash-completion/completions/${binaryName}" || true
-    $out/bin/${binaryName} --log-level none --completions zsh > "$out/share/zsh/site-functions/_${binaryName}" || true
+
+    generate_completion() {
+      shell_name="$1"
+      target="$2"
+      output_file="$(mktemp)"
+      stderr_file="$(mktemp)"
+
+      if "$out/bin/${binaryName}" --log-level none --completions "$shell_name" > "$output_file" 2>"$stderr_file"; then
+        mv "$output_file" "$target"
+        rm -f "$stderr_file"
+        return 0
+      fi
+
+      if "$out/bin/${binaryName}" --completions "$shell_name" > "$output_file" 2>"$stderr_file"; then
+        mv "$output_file" "$target"
+        rm -f "$stderr_file"
+        return 0
+      fi
+
+      echo "mk-bun-cli: warning: failed to generate $shell_name completions for ${binaryName}" >&2
+      cat "$stderr_file" >&2
+      rm -f "$output_file" "$stderr_file"
+    }
+
+    generate_completion fish "$out/share/fish/vendor_completions.d/${binaryName}.fish"
+    generate_completion bash "$out/share/bash-completion/completions/${binaryName}"
+    generate_completion zsh "$out/share/zsh/site-functions/_${binaryName}"
 
     runHook postInstall
   '';

--- a/nix/workspace-tools/lib/mk-bun-cli/tests/fixtures/app/src/cli.ts
+++ b/nix/workspace-tools/lib/mk-bun-cli/tests/fixtures/app/src/cli.ts
@@ -3,6 +3,19 @@ import { sharedMessage } from 'shared-lib'
 const buildVersion = '__CLI_VERSION__'
 
 const main = () => {
+  const args = process.argv.slice(2)
+  if (args.includes('--log-level')) {
+    console.error('unknown option: --log-level')
+    process.exit(2)
+  }
+
+  const completionsIndex = args.indexOf('--completions')
+  if (completionsIndex !== -1) {
+    const shell = args[completionsIndex + 1] ?? 'unknown'
+    console.log(`# ${shell} completions for app-cli`)
+    return
+  }
+
   console.log(`app-cli ${buildVersion}: ${sharedMessage}`)
 }
 

--- a/nix/workspace-tools/lib/mk-bun-cli/tests/run.sh
+++ b/nix/workspace-tools/lib/mk-bun-cli/tests/run.sh
@@ -168,12 +168,41 @@ run_build() {
   local label="$1"
   local target="$2"
   local extra_args="${3:-}"
+  local bin_name="${4:-}"
   local start
   start="$(now)"
   echo "Build: $label"
   # shellcheck disable=SC2086
-  nix build --no-link --no-write-lock-file -L $extra_args "$target"
+  local out
+  out="$(nix build --impure --no-link --no-write-lock-file --print-out-paths -L $extra_args "$target")"
+  if [ -n "$bin_name" ]; then
+    check_completions "$out" "$bin_name"
+  fi
   print_timing "$label" "$start"
+}
+
+check_completions() {
+  local out="$1"
+  local bin_name="$2"
+
+  echo "Check: $bin_name shell completions"
+  local fish_file="$out/share/fish/vendor_completions.d/${bin_name}.fish"
+  local bash_file="$out/share/bash-completion/completions/${bin_name}"
+  local zsh_file="$out/share/zsh/site-functions/_${bin_name}"
+  for f in "$fish_file" "$bash_file" "$zsh_file"; do
+    if [ ! -f "$f" ] && [ ! -L "$f" ]; then
+      echo "error: missing completion file: $f" >&2
+      exit 1
+    fi
+    if [ ! -s "$f" ]; then
+      echo "error: empty completion file: $f" >&2
+      exit 1
+    fi
+    if ! grep -q "completions for $bin_name" "$f"; then
+      echo "error: completion file was not generated via fallback: $f" >&2
+      exit 1
+    fi
+  done
 }
 
 run_devenv() {
@@ -251,9 +280,9 @@ fi
 
 if [ "$SKIP_PEER" -eq 0 ]; then
   run_build "peer app (from repos)" "path:$WORKSPACE_REAL/repos/app#app-cli" \
-    "--override-input effect-utils path:$WORKSPACE_REAL/repos/effect-utils"
+    "--override-input effect-utils path:$WORKSPACE_REAL/repos/effect-utils" "app-cli"
   run_build "peer app (standalone)" "path:$WORKSPACE_REAL/app#app-cli" \
-    "--override-input effect-utils path:$WORKSPACE_REAL/effect-utils"
+    "--override-input effect-utils path:$WORKSPACE_REAL/effect-utils" "app-cli"
 fi
 
 if [ "$SKIP_DEVENV" -eq 0 ]; then

--- a/nix/workspace-tools/lib/mk-pnpm-cli.nix
+++ b/nix/workspace-tools/lib/mk-pnpm-cli.nix
@@ -1597,13 +1597,39 @@ pkgs.stdenv.mkDerivation {
     echo "cli-build: phase=install cli=${binaryName} package=${packageDir} duration=$(install_timer_elapsed "$installStartedAt")s installed_size=$(install_format_bytes "$installedBytes")"
 
     ${lib.optionalString generateCompletions ''
-      # Generate shell completions (Effect CLI built-in support)
+      # Generate shell completions. Effect CLIs commonly support `--log-level none`,
+      # but package builders must also work for CLIs that expose completions without
+      # that logging flag.
       mkdir -p "$out/share/fish/vendor_completions.d"
       mkdir -p "$out/share/bash-completion/completions"
       mkdir -p "$out/share/zsh/site-functions"
-      $out/bin/${binaryName} --log-level none --completions fish > "$out/share/fish/vendor_completions.d/${binaryName}.fish" || true
-      $out/bin/${binaryName} --log-level none --completions bash > "$out/share/bash-completion/completions/${binaryName}" || true
-      $out/bin/${binaryName} --log-level none --completions zsh > "$out/share/zsh/site-functions/_${binaryName}" || true
+
+      generate_completion() {
+        shell_name="$1"
+        target="$2"
+        output_file="$(mktemp)"
+        stderr_file="$(mktemp)"
+
+        if "$out/bin/${binaryName}" --log-level none --completions "$shell_name" > "$output_file" 2>"$stderr_file"; then
+          mv "$output_file" "$target"
+          rm -f "$stderr_file"
+          return 0
+        fi
+
+        if "$out/bin/${binaryName}" --completions "$shell_name" > "$output_file" 2>"$stderr_file"; then
+          mv "$output_file" "$target"
+          rm -f "$stderr_file"
+          return 0
+        fi
+
+        echo "mk-pnpm-cli: warning: failed to generate $shell_name completions for ${binaryName}" >&2
+        cat "$stderr_file" >&2
+        rm -f "$output_file" "$stderr_file"
+      }
+
+      generate_completion fish "$out/share/fish/vendor_completions.d/${binaryName}.fish"
+      generate_completion bash "$out/share/bash-completion/completions/${binaryName}"
+      generate_completion zsh "$out/share/zsh/site-functions/_${binaryName}"
     ''}
     runHook postInstall
   '';


### PR DESCRIPTION
## Why

Two downstream contracts were too strict for real consumers:

- `lint:check:format` treated an `oxfmt` invocation whose selected chunk became empty after formatter config ignores as a task failure.
- `mk-pnpm-cli` / `mk-bun-cli` assumed packaged CLIs accept `--log-level none` when generating completions.

## What

- Tolerate only the specific `oxfmt` empty-target diagnostic for format check/fix chunks while preserving real formatter failures.
- Generate completions atomically by trying the quiet Effect CLI form first and falling back to plain `--completions <shell>`.
- Add focused regression coverage for the `oxfmt` empty-target case and a fixture CLI that rejects `--log-level` while supporting completions.

## Rationale

This keeps file selection git-backed and config-driven instead of duplicating formatter ignore semantics in shell. Completion generation stays best-effort, but no longer writes directly to final files from a failing command or assumes every CLI has the same logging option.

## Verification

- `bash nix/devenv-modules/tasks/shared/tests/lint-oxc-file-list.test.sh`
- `CI=1 devenv tasks run lint:check:format --no-tui`
- `CI=1 devenv tasks run check:quick --no-tui`

Note: `bash nix/workspace-tools/lib/mk-bun-cli/tests/run.sh --skip-effect-utils --skip-devenv --skip-nested` currently fails before reaching completion generation in the existing mk-bun local-dependency fixture evaluation (`package.json` source path issue). The PR keeps the completion fixture shape in place but does not broaden into that separate mk-bun harness issue.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🎄 co1-fir |
| `agent_session_id` | 25d961b2-a802-486b-add6-86fcaf813528 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.141.0 |
| `agent_runtime` | Codex CLI 0.141.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/r6ycnx65n3gj1kq9v3a9w0dxgyl4128i-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/jkyy2xvnv888q38a0b5kh08py1ma52pq-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | 6496693d37fa6644be7e380add6a02c00121cce5/schickling-assistant/fix-lint-format-completions |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->