### PR TITLE
fix(megarepo): add non-mutating setup apply

### DIFF
--- a/.github/repo-settings.json
+++ b/.github/repo-settings.json
@@ -51,6 +51,9 @@
             "context": "test (namespace-profile-macos-arm64)"
           },
           {
+            "context": "test-megarepo-cold-gc"
+          },
+          {
             "context": "nix-check (namespace-profile-linux-x86-64)"
           },
           {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1722,6 +1722,392 @@ jobs:
     concurrency:
       group: "${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '' && format('measurement-baseline-{0}', inputs.measurement_baseline_ref) || (github.event_name == 'workflow_dispatch' && format('manual-run-{0}', github.run_id) || (github.event_name == 'pull_request' && (github.event.action == 'labeled' || github.event.action == 'unlabeled') && format('label-{0}', github.event.label.name) || 'code')) }}-test-${{ strategy.job-index }}"
       cancel-in-progress: ${{ !(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '') && (github.event_name != 'pull_request' || (github.event.action != 'labeled' && github.event.action != 'unlabeled')) }}
+  test-megarepo-cold-gc:
+    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '') }}
+    runs-on:
+      [namespace-profile-linux-x86-64, 'namespace-features:github.run-id=${{ github.run_id }}']
+    timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash
+    env:
+      FORCE_SETUP: '1'
+      CI: 'true'
+      GITHUB_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Checkout CI measurement baseline ref
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '' }}
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.measurement_baseline_ref }}
+      - name: Install Nix
+        uses: DeterminateSystems/determinate-nix-action@v3
+        with:
+          extra-conf: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+            extra-substituters = https://devenv.cachix.org
+            extra-trusted-public-keys = devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
+            access-tokens = github.com=${{ github.token }}
+          summarize: true
+      - name: Provide cachix CLI from nixpkgs
+        shell: bash
+        run: |
+          set -euo pipefail
+          out=$(nix build --no-link --print-out-paths nixpkgs#cachix)
+          echo "$out/bin" >> "$GITHUB_PATH"
+      - name: Enable Cachix cache
+        uses: cachix/cachix-action@v17
+        with:
+          name: overeng-effect-utils
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Use pinned devenv from lock
+        run: |
+          DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
+          if [ -z "$DEVENV_REV" ] || [ "$DEVENV_REV" = "null" ]; then
+            echo '::error::devenv.lock missing .nodes.devenv.locked.rev'
+            exit 1
+          fi
+          echo "DEVENV_REV=$DEVENV_REV" >> "$GITHUB_ENV"
+          echo "Pinned devenv rev: $DEVENV_REV"
+        shell: bash
+      - name: Isolate pnpm state
+        shell: bash
+        run: |
+          echo "PNPM_STORE_DIR=${{ runner.temp }}/pnpm-store/${{ github.job }}" >> "$GITHUB_ENV"
+          echo "PNPM_CONFIG_STORE_DIR=${{ runner.temp }}/pnpm-store/${{ github.job }}" >> "$GITHUB_ENV"
+          echo "PNPM_HOME=${{ github.workspace }}/.pnpm-home" >> "$GITHUB_ENV"
+      - id: restore-pnpm-state
+        name: Restore pnpm state
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ${{ github.workspace }}/.pnpm-home
+            ${{ runner.temp }}/pnpm-store/${{ github.job }}
+          key: "pnpm-state-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
+      - name: Resolve devenv
+        run: |
+          DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
+          if [ -z "$DEVENV_REV" ] || [ "$DEVENV_REV" = "null" ]; then
+            echo '::error::devenv.lock missing .nodes.devenv.locked.rev'
+            exit 1
+          fi
+
+          resolve_devenv() {
+            nix build \
+              --accept-flake-config \
+              --option extra-substituters https://devenv.cachix.org \
+              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
+              --no-link \
+              --print-out-paths \
+              "github:cachix/devenv/$DEVENV_REV#devenv"
+          }
+
+          # Temporary: capture diagnostics dir for #272 root-cause analysis.
+          DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
+          mkdir -p "$DIAG_ROOT"
+          echo "NIX_STORE_DIAGNOSTICS_DIR=$DIAG_ROOT" >> "$GITHUB_ENV"
+
+          {
+            echo "timestamp_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            echo "runner_name=${RUNNER_NAME:-unknown}"
+            echo "runner_os=${RUNNER_OS:-unknown}"
+            echo "runner_arch=${RUNNER_ARCH:-unknown}"
+            echo "github_job=${GITHUB_JOB:-unknown}"
+            echo "github_run_id=${GITHUB_RUN_ID:-unknown}"
+            echo "nix_user_conf_files=${NIX_USER_CONF_FILES:-}"
+            nix --version || true
+          } > "$DIAG_ROOT/environment.txt" 2>&1
+
+          if ! DEVENV_OUT=$(resolve_devenv 2> >(tee "$DIAG_ROOT/resolve-devenv.log" >&2)); then
+            echo "::error::resolve_devenv failed. Last 30 lines of log:"
+            tail -30 "$DIAG_ROOT/resolve-devenv.log" || true
+            exit 1
+          fi
+          DEVENV_BIN="$DEVENV_OUT/bin/devenv"
+
+          # Fast validity check on the devenv store path (~1-2s vs ~25s for devenv info).
+          if ! nix-store --check-validity "$DEVENV_OUT" 2>/dev/null; then
+            echo "::warning::devenv store path invalid, repairing targeted path..."
+            nix-store --repair-path "$DEVENV_OUT" > "$DIAG_ROOT/nix-store-verify-repair.log" 2>&1 || true
+            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}"/nix/eval-cache-* ~/.cache/nix/eval-cache-*
+            if ! DEVENV_OUT=$(resolve_devenv 2> >(tee "$DIAG_ROOT/resolve-devenv-post-repair.log" >&2)); then
+              echo "::error::resolve_devenv failed after repair. Last 30 lines of log:"
+              tail -30 "$DIAG_ROOT/resolve-devenv-post-repair.log" || true
+              exit 1
+            fi
+            DEVENV_BIN="$DEVENV_OUT/bin/devenv"
+          fi
+
+          echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
+          "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"
+        shell: bash
+      - name: Evict cached pnpm deps for oxlint-npm
+        shell: bash
+        run: |
+          targetRef='.#oxlint-npm'
+          entriesJson=$(mktemp)
+          if nix eval --json "$targetRef.passthru.depsBuildEntries" >"$entriesJson" 2>/dev/null; then
+            while IFS=$'\t' read -r attrName drv; do
+              [ -n "$drv" ] || continue
+              while IFS= read -r outPath; do
+                [ -n "$outPath" ] || continue
+                if nix path-info "$outPath" >/dev/null 2>&1; then
+                  echo "evicting cached: $(basename "$outPath")"
+                  if ! nix store delete --ignore-liveness "$outPath" >/dev/null 2>&1; then
+                    echo "::error::failed to evict cached pnpm-deps output: $outPath"
+                    exit 1
+                  fi
+                  if nix path-info "$outPath" >/dev/null 2>&1; then
+                    echo "::error::cached pnpm-deps output still present after eviction: $outPath"
+                    exit 1
+                  fi
+                fi
+              done < <(nix-store -q --outputs "$drv" 2>/dev/null || true)
+            done < <(jq -r '.[] | [.attrName, (.drvPath // "")] | @tsv' "$entriesJson")
+          else
+            topDrv=$(nix path-info --derivation "$targetRef" 2>/dev/null || true)
+            if [ -n "$topDrv" ]; then
+              while IFS= read -r drv; do
+                [ -n "$drv" ] || continue
+                attrName=""
+              while IFS= read -r outPath; do
+                [ -n "$outPath" ] || continue
+                if nix path-info "$outPath" >/dev/null 2>&1; then
+                  echo "evicting cached: $(basename "$outPath")"
+                  if ! nix store delete --ignore-liveness "$outPath" >/dev/null 2>&1; then
+                    echo "::error::failed to evict cached pnpm-deps output: $outPath"
+                    exit 1
+                  fi
+                  if nix path-info "$outPath" >/dev/null 2>&1; then
+                    echo "::error::cached pnpm-deps output still present after eviction: $outPath"
+                    exit 1
+                  fi
+                fi
+              done < <(nix-store -q --outputs "$drv" 2>/dev/null || true)
+              done < <(nix-store -qR "$topDrv" 2>/dev/null | grep "pnpm-deps-[a-z0-9-]*-v[0-9].*\.drv$" || true)
+            fi
+          fi
+          rm -f "$entriesJson"
+      - name: Force diagnostics failure (debug)
+        if: ${{ github.event_name == 'workflow_dispatch' && (inputs.debug_force_nix_diagnostics_failure == true || inputs.debug_force_nix_diagnostics_failure == 'true') }}
+        shell: bash
+        run: |
+          diag_dir="${NIX_STORE_DIAGNOSTICS_DIR:-${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-missing}"
+          mkdir -p "$diag_dir"
+          cat > "$diag_dir/synthetic-signature.log" <<'EOF'
+          Failed to convert config.cachix to JSON
+          ... while evaluating the option `cachix.package`
+          error: path '/nix/store/synthetic-invalid-path' is not valid
+          EOF
+          echo "::warning::Intentional failure for diagnostics validation (#272)"
+          exit 1
+      - name: Megarepo cold-GC tests
+        run: |
+          __nix_gc_retry_helper=$(mktemp)
+          cat > "$__nix_gc_retry_helper" <<'EOF'
+          #!/usr/bin/env bash
+
+          run_nix_gc_race_retry() {
+            local task="$1"
+            local command="$2"
+            local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
+            local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
+            local attempt=1
+            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature saw_daemon_socket_failure had_errexit
+
+            start="$(date +%s)"
+
+            write_summary() {
+              [ -n "${GITHUB_STEP_SUMMARY:-}" ] || return 0
+              {
+                echo "### CI Task"
+                echo "- Task: $task"
+                echo "- Status: $1"
+                echo "- Duration: $elapsed s"
+                echo "- Attempts: $attempt/$max"
+                [ -z "${2:-}" ] || echo "- Note: $2"
+              } >> "$GITHUB_STEP_SUMMARY"
+            }
+
+            repair_nix_daemon() {
+              echo "::warning::Nix daemon socket is unavailable; attempting daemon restart before retry"
+
+              if command -v launchctl >/dev/null 2>&1; then
+                sudo launchctl kickstart -k system/org.nixos.nix-daemon >/dev/null 2>&1 || true
+              fi
+
+              if command -v systemctl >/dev/null 2>&1; then
+                sudo systemctl restart nix-daemon.socket >/dev/null 2>&1 || true
+                sudo systemctl restart nix-daemon.service >/dev/null 2>&1 || true
+                sudo systemctl restart nix-daemon >/dev/null 2>&1 || true
+              fi
+
+              if [ ! -S /nix/var/nix/daemon-socket/socket ] && [ -x /nix/var/nix/profiles/default/bin/nix-daemon ]; then
+                sudo /nix/var/nix/profiles/default/bin/nix-daemon --daemon >/tmp/nix-daemon-restart.log 2>&1 || true
+              fi
+
+              for _ in 1 2 3 4 5; do
+                [ -S /nix/var/nix/daemon-socket/socket ] && return 0
+                sleep 1
+              done
+
+              return 0
+            }
+
+            while [ "$attempt" -le "$max" ]; do
+              echo "::notice::[ci] starting $task (attempt $attempt/$max)"
+              (
+                while sleep "$heartbeat"; do
+                  now=$(date +%s)
+                  elapsed=$((now - start))
+                  echo "::notice::[ci] $task still running after $elapsed s (attempt $attempt/$max)"
+                done
+              ) &
+              hb_pid=$!
+
+              log=$(mktemp)
+              had_errexit=false
+              case $- in
+                *e*) had_errexit=true ;;
+              esac
+              set +e
+              eval "$command" > >(tee -a "$log") 2> >(tee -a "$log" >&2)
+              rc=$?
+              if [ "$had_errexit" = true ]; then
+                set -e
+              fi
+
+              kill "$hb_pid" 2>/dev/null || true
+              wait "$hb_pid" 2>/dev/null || true
+
+              now=$(date +%s)
+              elapsed=$((now - start))
+
+              if [ "$rc" -eq 0 ]; then
+                echo "::notice::[ci] completed $task in $elapsed s"
+                if [ "$attempt" -gt 1 ]; then
+                  write_summary success "Recovered from transient Nix failure after retry"
+                else
+                  write_summary success
+                fi
+                rm -f "$log"
+                return 0
+              fi
+
+              flattened=$(tr '\r\n' '  ' < "$log" | sed -E $'s/\x1B\[[0-9;]*m//g')
+              path=$(printf '%s' "$flattened" |
+                grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" |
+                head -1 |
+                grep -o "/nix/store/[^']*" |
+                tr -d '[:space:]' || true)
+              saw_invalid_path=false
+              saw_cachix_signature=false
+              saw_fetch_signature=false
+              saw_daemon_socket_failure=false
+              [ -n "$path" ] && saw_invalid_path=true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*cannot read file from tarball:[[:space:]]*Truncated tar archive detected while reading data' && saw_fetch_signature=true || true
+              printf '%s' "$flattened" | grep -Eq "error:[[:space:]]*cannot connect to socket at '/nix/var/nix/daemon-socket/socket'" && saw_daemon_socket_failure=true || true
+              rm -f "$log"
+
+              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ] && [ "$saw_fetch_signature" != true ] && [ "$saw_daemon_socket_failure" != true ]; then
+                echo "::warning::[ci] $task failed after $elapsed s without a detected transient Nix failure"
+                write_summary failure "No transient Nix failure signature detected"
+                return "$rc"
+              fi
+
+              if [ "$saw_daemon_socket_failure" = true ]; then
+                repair_nix_daemon
+                echo "::warning::Nix daemon socket failure detected for $task (attempt $attempt/$max); retrying after daemon repair"
+              elif [ "$saw_fetch_signature" = true ]; then
+                echo "::warning::Nix source fetch corruption detected for $task (attempt $attempt/$max); retrying with a refreshed eval cache"
+              elif [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
+                echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
+              elif [ "$saw_cachix_signature" = true ]; then
+                echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
+              else
+                echo "::warning::Nix store validity race detected for $task (attempt $attempt/$max): $path"
+              fi
+
+              [ -z "$path" ] || nix-store --realise "$path" 2>/dev/null || true
+              rm -rf ~/.cache/nix/eval-cache-*
+              attempt=$((attempt + 1))
+            done
+
+            now=$(date +%s)
+            elapsed=$((now - start))
+            echo "::error::Transient Nix retry exhausted for $task ($max attempts)"
+            write_summary failure "Transient Nix retry exhausted"
+            return 1
+          }
+          EOF
+          . "$__nix_gc_retry_helper"
+          rm -f "$__nix_gc_retry_helper"
+          run_nix_gc_race_retry 'devenv tasks run test:megarepo-cold-gc' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" PNPM_CONFIG_STORE_DIR="${PNPM_CONFIG_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DEVENV_TASK_PASSTHROUGH=1 DEVENV_TUI=false "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run test:megarepo-cold-gc'
+      - name: Save pnpm state
+        if: ${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ${{ github.workspace }}/.pnpm-home
+            ${{ runner.temp }}/pnpm-store/${{ github.job }}
+          key: "pnpm-state-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
+      - name: Nix diagnostics summary
+        if: failure()
+        shell: bash
+        run: |
+          diag_dir="${NIX_STORE_DIAGNOSTICS_DIR:-}"
+          if [ -z "$diag_dir" ] || [ ! -d "$diag_dir" ]; then
+            echo "## Nix Store Diagnostics" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "No diagnostics directory found (validation may have failed before capture)." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          {
+            echo "## Nix Store Diagnostics"
+            echo ""
+            echo "Temporary instrumentation for #272; remove after root cause is confirmed and CI is stable."
+            echo ""
+            echo "- Diagnostics directory: \`$diag_dir\`"
+            echo "- Tracking issue: https://github.com/overengineeringstudio/effect-utils/issues/272"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          markers_file="${RUNNER_TEMP:-/tmp}/nix-store-signature-markers.txt"
+          grep -R -n -E "config\\.cachix|cachix\\.package|error: path '/nix/store/.+ is not valid" --exclude="$(basename "$markers_file")" "$diag_dir" > "$markers_file" || true
+
+          if [ -s "$markers_file" ]; then
+            {
+              echo ""
+              echo "### Signature markers"
+              echo '```text'
+              head -n 120 "$markers_file"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "- No signature markers found in captured diagnostics." >> "$GITHUB_STEP_SUMMARY"
+          fi
+      - name: Upload Nix diagnostics artifact
+        if: failure() && env.NIX_STORE_DIAGNOSTICS_DIR != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: 'nix-store-diagnostics-${{ github.job }}-${{ runner.os }}-run-${{ github.run_id }}-attempt-${{ github.run_attempt }}'
+          path: ${{ env.NIX_STORE_DIAGNOSTICS_DIR }}
+          if-no-files-found: ignore
+          retention-days: 14
+      - name: Failure note
+        if: failure()
+        shell: bash
+        run: |
+          echo "If this looks like Namespace runner Nix store corruption (e.g. \"... is not valid\", \"config.cachix\", \"cachix.package\"), add the run link + full nix-store output to:"
+          echo "  https://github.com/overengineeringstudio/effect-utils/issues/201"
+    concurrency:
+      group: "${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '' && format('measurement-baseline-{0}', inputs.measurement_baseline_ref) || (github.event_name == 'workflow_dispatch' && format('manual-run-{0}', github.run_id) || (github.event_name == 'pull_request' && (github.event.action == 'labeled' || github.event.action == 'unlabeled') && format('label-{0}', github.event.label.name) || 'code')) }}-test-megarepo-cold-gc"
+      cancel-in-progress: ${{ !(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '') && (github.event_name != 'pull_request' || (github.event.action != 'labeled' && github.event.action != 'unlabeled')) }}
   nix-check:
     if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '') }}
     strategy:
@@ -9195,6 +9581,7 @@ jobs:
       - typecheck
       - lint
       - test
+      - test-megarepo-cold-gc
       - nix-check
       - nix-fod-check
       - pnpm-builder-contract

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -353,6 +353,12 @@ const jobs: Record<
     name: 'Unit tests',
     run: runDevenvTasksBefore('test:run'),
   }),
+  'test-megarepo-cold-gc': job({
+    step: {
+      name: 'Megarepo cold-GC tests',
+      run: runDevenvTasksBefore('test:megarepo-cold-gc'),
+    },
+  }),
   // Verify Nix hashes are up-to-date (pnpmDepsHash + localDeps)
   // This catches stale hashes before they break downstream consumers
   'nix-check': multiPlatformJob({

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- **@overeng/megarepo / CI**: Isolate the cold named-branch GC integration
+  matrix into its own CI task and add deterministic git subprocess timeouts
+  with OTEL `git.timeout_ms` span attributes so stuck GC probes fail with the
+  offending command instead of Vitest's generic per-test timeout.
+
 - **@overeng/megarepo / devenv tasks**: Add an explicit `--lock-sync` policy
   to `mr apply` / `mr fetch --apply`, including `--lock-sync off` for
   non-mutating workspace materialization, and add a shared `mr:setup` devenv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ All notable changes to this project will be documented in this file.
   to `mr apply` / `mr fetch --apply`, including `--lock-sync off` for
   non-mutating workspace materialization, and add a shared `mr:setup` devenv
   task that applies committed root members without fetching remotes or rewriting
-  lock files.
+  lock files. `mr:check` now depends on `mr:setup` and points missing-member
+  repair hints at setup instead of the lower-level `mr:apply` task.
 
 - **devenv/lint-oxc**: Make `lintPaths` the single lint surface contract.
   oxlint/oxfmt tasks now enumerate tracked plus untracked non-ignored files via

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- **@overeng/megarepo / devenv tasks**: Add an explicit `--lock-sync` policy
+  to `mr apply` / `mr fetch --apply`, including `--lock-sync off` for
+  non-mutating workspace materialization, and add a shared `mr:setup` devenv
+  task that applies committed root members without fetching remotes or rewriting
+  lock files.
+
 - **devenv/lint-oxc**: Make `lintPaths` the single lint surface contract.
   oxlint/oxfmt tasks now enumerate tracked plus untracked non-ignored files via
   `git ls-files` and always run instead of delegating change detection to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ All notable changes to this project will be documented in this file.
   non-mutating workspace materialization, and add a shared `mr:setup` devenv
   task that applies committed root members without fetching remotes or rewriting
   lock files. `mr:check` now depends on `mr:setup` and points missing-member
-  repair hints at setup instead of the lower-level `mr:apply` task.
+  repair hints at setup instead of the lower-level `mr:apply` task. Source-mode
+  repo wiring now orders `mr:setup` after package installation like the other
+  megarepo tasks.
 
 - **devenv/lint-oxc**: Make `lintPaths` the single lint surface contract.
   oxlint/oxfmt tasks now enumerate tracked plus untracked non-ignored files via

--- a/devenv.nix
+++ b/devenv.nix
@@ -193,6 +193,7 @@ let
     {
       path = "packages/@overeng/megarepo";
       name = "megarepo";
+      vitestArgs = "--exclude src/cli/store-gc-cold.integration.test.ts";
     }
     {
       path = "packages/@overeng/notion-cli";
@@ -531,6 +532,23 @@ in
   };
 
   tasks."test:pty-effect".after = lib.mkAfter [ "pnpm:link-native-node-packages" ];
+
+  tasks."test:megarepo-cold-gc" = {
+    after = [ "pnpm:install" ];
+    description = "Run isolated megarepo cold-GC integration tests";
+    cwd = "packages/@overeng/megarepo";
+    exec = ''
+      set -euo pipefail
+      source ${lib.escapeShellArg pnpmTaskHelpersScript}
+      export MEGAREPO_GIT_COMMAND_TIMEOUT_MS="5000"
+      run_package_bin vitest vitest run src/cli/store-gc-cold.integration.test.ts
+    '';
+    execIfModified = [
+      "packages/@overeng/megarepo/src/**/*.ts"
+      "packages/@overeng/megarepo/src/**/*.tsx"
+      "packages/@overeng/megarepo/vitest.config.ts"
+    ];
+  };
 
   tasks."bundle:smoke" = {
     after = [ "pnpm:install" ];

--- a/devenv.nix
+++ b/devenv.nix
@@ -493,6 +493,7 @@ in
   tasks."genie:check".after = [ "pnpm:install" ];
   tasks."lint:check:genie".after = [ "pnpm:install" ];
   tasks."mr:bootstrap".after = [ "pnpm:install" ];
+  tasks."mr:setup".after = [ "pnpm:install" ];
   tasks."mr:fetch-apply".after = [ "pnpm:install" ];
   tasks."mr:lock".after = [ "pnpm:install" ];
   tasks."mr:apply".after = [ "pnpm:install" ];

--- a/genie/ci.ts
+++ b/genie/ci.ts
@@ -19,6 +19,7 @@ export const CI_JOB_NAMES = [
   'typecheck',
   'lint',
   'test',
+  'test-megarepo-cold-gc',
   'nix-check',
   'nix-fod-check',
   'pnpm-builder-contract',
@@ -44,6 +45,7 @@ export const requiredCIJobs = [
   'cargo',
   // Matrix jobs - GitHub reports these with the matrix value in parentheses
   ...RUNNER_PROFILES.map((runner) => `test (${runner})`),
+  'test-megarepo-cold-gc',
   ...RUNNER_PROFILES.map((runner) => `nix-check (${runner})`),
   ...RUNNER_PROFILES.map((runner) => `nix-fod-check (${runner})`),
   'deploy-storybooks',

--- a/nix/devenv-modules/tasks/shared/megarepo.nix
+++ b/nix/devenv-modules/tasks/shared/megarepo.nix
@@ -4,6 +4,7 @@
 #
 # Tasks:
 # - mr:bootstrap - Materialize the minimal lock-based members needed for local tooling
+# - mr:setup - Materialize committed root members without fetching or rewriting locks
 # - mr:fetch-apply - Fetch latest refs and apply to workspace (mr fetch --apply)
 # - mr:lock - Record the current workspace into megarepo.lock (mr lock)
 # - mr:apply - Apply megarepo.lock exactly (mr apply)
@@ -218,6 +219,22 @@ let
 
         exit 0
       '';
+    };
+
+    "mr:setup" = {
+      guard = "mr";
+      description = "Materialize committed root members without fetching or rewriting locks";
+      exec = trace.exec "mr:setup" ''
+        if [ ! -f ./megarepo.kdl ] && [ ! -f ./megarepo.json ]; then
+          exit 0
+        fi
+
+        ${loadCheckSkipMembersScript}
+        build_mr_skip_args
+        mr apply --lock-sync off "''${MR_SKIP_ARGS[@]}"
+        ${recordWorkspaceMembers}
+      '';
+      status = trace.status "mr:setup" "binary" mrStatusCheck;
     };
 
     "mr:fetch-apply" = {

--- a/nix/devenv-modules/tasks/shared/megarepo.nix
+++ b/nix/devenv-modules/tasks/shared/megarepo.nix
@@ -7,12 +7,13 @@
 # - mr:setup - Materialize committed root members without fetching or rewriting locks
 # - mr:fetch-apply - Fetch latest refs and apply to workspace (mr fetch --apply)
 # - mr:lock - Record the current workspace into megarepo.lock (mr lock)
-# - mr:apply - Apply megarepo.lock exactly (mr apply)
+# - mr:apply - Apply megarepo.lock to the workspace (explicit apply operation)
 # - mr:check - Verify megarepo setup is complete
 # - mr:lock-sync-check - Verify Nix lock files match megarepo.lock revisions (~5ms)
 #
 # Options:
-# - syncAll: Whether to use `--all` (recursive nested sync). Default: true.
+# - syncAll: Whether explicit update/apply tasks use `--all` (recursive nested
+#   sync). Default: true for backwards compatibility.
 #   Set to false in CI where root members are already synced and nested sync
 #   may fail due to credential scoping or version mismatches.
 # - bootstrapMembers: Minimal members that must exist before tooling like genie
@@ -20,7 +21,8 @@
 #   refs. Default: [ ] (task becomes a no-op)
 # NOTE: No pnpm:install:megarepo dependency here — this shared module is used by
 # repos where megarepo may be a Nix package (no pnpm install needed). Repos that
-# use source-mode megarepo via pnpm should add the dependency in their devenv.nix:
+# use source-mode megarepo via pnpm should add dependencies in their devenv.nix:
+#   tasks."mr:setup".after = [ "pnpm:install:megarepo" ];
 #   tasks."mr:fetch-apply".after = [ "pnpm:install:megarepo" ];
 {
   syncAll ? true,
@@ -286,7 +288,7 @@ let
     "mr:check" = {
       guard = "mr";
       description = "Verify megarepo setup is complete";
-      after = [ "mr:apply" ];
+      after = [ "mr:setup" ];
       # Check that repos dir exists and all members have symlinks
       status = trace.status "mr:check" "path" ''
         if [ ! -f ./megarepo.kdl ] && [ ! -f ./megarepo.json ]; then
@@ -304,7 +306,7 @@ let
 
         if [ ! -d ./repos ]; then
           echo "[devenv] Missing repos/ directory." >&2
-          echo "[devenv] Fix: devenv tasks run mr:apply" >&2
+          echo "[devenv] Fix: devenv tasks run mr:setup" >&2
           exit 1
         fi
 
@@ -324,7 +326,7 @@ let
 
         if [ -n "$missing" ]; then
           echo "[devenv] Missing member symlinks:$missing" >&2
-          echo "[devenv] Fix: devenv tasks run mr:apply" >&2
+          echo "[devenv] Fix: devenv tasks run mr:setup" >&2
           exit 1
         fi
       '';

--- a/nix/devenv-modules/tasks/shared/megarepo.nix
+++ b/nix/devenv-modules/tasks/shared/megarepo.nix
@@ -182,7 +182,9 @@ let
     ${checkWorkspaceMembersScript}
 
     status_json=$(mr status --output json 2>/dev/null) || exit 1
-    echo "$status_json" | ${jq} -e '(.workspaceSyncNeeded // false) == false' >/dev/null 2>&1
+    echo "$status_json" \
+      | ${jq} -e '(.syncNeeded // false) == false and (.applyNeeded // false) == false' \
+      >/dev/null 2>&1
   '';
 
   tasks = {

--- a/nix/devenv-modules/tasks/shared/test.nix
+++ b/nix/devenv-modules/tasks/shared/test.nix
@@ -43,10 +43,10 @@ let
   # Do not force preserve-symlinks here. pnpm's projected workspace graph
   # relies on realpath-based resolution, and preserve-symlinks caused Vitest to
   # miss hoisted dependencies in CI.
-  vitestExec = ''
+  vitestExec = extraArgs: ''
     set -euo pipefail
     source ${lib.escapeShellArg pnpmTaskHelpersScript}
-    run_package_bin vitest vitest run
+    run_package_bin vitest vitest run ${extraArgs}
   '';
   vitestWatchExec = ''
     set -euo pipefail
@@ -58,7 +58,7 @@ let
   mkTestTask = pkg: {
     "test:${pkg.name}" = {
       description = "Run tests for ${pkg.name}";
-      exec = trace.exec "test:${pkg.name}" vitestExec;
+      exec = trace.exec "test:${pkg.name}" (vitestExec (pkg.vitestArgs or ""));
       cwd = pkg.path;
       execIfModified = [
         "${pkg.path}/src/**/*.ts"
@@ -79,7 +79,7 @@ let
     "test:run" = {
       guard = "vitest";
       description = "Run all tests";
-      exec = if hasPackages then null else vitestExec;
+      exec = if hasPackages then null else vitestExec "";
       after =
         if hasPackages then map (pkg: "test:${pkg.name}") packages ++ extraTests else [ "genie:run" ];
     };

--- a/nix/devenv-modules/tasks/shared/tests/megarepo-status.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/megarepo-status.test.sh
@@ -60,6 +60,17 @@ run_check() {
   )
 }
 
+run_status_check() {
+  (
+    cd "$workspace"
+    check_workspace_members
+    status_json=$(mr status --output json 2>/dev/null) || exit 1
+    echo "$status_json" \
+      | jq -e '(.syncNeeded // false) == false and (.applyNeeded // false) == false' \
+      >/dev/null 2>&1
+  )
+}
+
 echo "Running megarepo status tests..."
 echo ""
 
@@ -74,12 +85,8 @@ cat > "$tmpdir/bin/mr" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ "$1" != "ls" ] || [ "$2" != "--output" ] || [ "$3" != "json" ]; then
-  echo "unexpected mr invocation: $*" >&2
-  exit 2
-fi
-
-cat <<'JSON'
+if [ "$1" = "ls" ] && [ "$2" = "--output" ] && [ "$3" = "json" ]; then
+  cat <<'JSON'
 {
   "_tag": "Success",
   "members": [
@@ -88,6 +95,22 @@ cat <<'JSON'
   ]
 }
 JSON
+  exit 0
+fi
+
+if [ "$1" = "status" ] && [ "$2" = "--output" ] && [ "$3" = "json" ]; then
+  if [ -n "${MR_STATUS_JSON:-}" ]; then
+    printf '%s\n' "$MR_STATUS_JSON"
+  else
+    cat <<'JSON'
+{"syncNeeded":false,"applyNeeded":false}
+JSON
+  fi
+  exit 0
+fi
+
+echo "unexpected mr invocation: $*" >&2
+exit 2
 EOF
 chmod +x "$tmpdir/bin/mr"
 export PATH="$tmpdir/bin:$PATH"
@@ -119,7 +142,32 @@ set -e
 assert_exit_code 0 "$exit_code" "skipped member is ignored"
 
 echo ""
-echo "Test 4: shared module points setup checks at mr:setup"
+echo "Test 4: status check re-runs when apply or sync is needed"
+mkdir -p "$workspace/repos/two"
+export MR_STATUS_JSON='{"syncNeeded":false,"applyNeeded":false}'
+set +e
+run_status_check
+exit_code=$?
+set -e
+assert_exit_code 0 "$exit_code" "clean status is cacheable"
+
+export MR_STATUS_JSON='{"syncNeeded":true,"applyNeeded":false}'
+set +e
+run_status_check
+exit_code=$?
+set -e
+assert_exit_code 1 "$exit_code" "syncNeeded invalidates cache"
+
+export MR_STATUS_JSON='{"syncNeeded":false,"applyNeeded":true}'
+set +e
+run_status_check
+exit_code=$?
+set -e
+assert_exit_code 1 "$exit_code" "applyNeeded invalidates cache"
+unset MR_STATUS_JSON
+
+echo ""
+echo "Test 5: shared module points setup checks at mr:setup"
 module_file="$(cd "$(dirname "$0")/.." && pwd)/megarepo.nix"
 if ! grep -F 'after = [ "mr:setup" ];' "$module_file" >/dev/null; then
   echo "FAIL: mr:check should depend on mr:setup"

--- a/nix/devenv-modules/tasks/shared/tests/megarepo-status.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/megarepo-status.test.sh
@@ -119,4 +119,21 @@ set -e
 assert_exit_code 0 "$exit_code" "skipped member is ignored"
 
 echo ""
+echo "Test 4: shared module points setup checks at mr:setup"
+module_file="$(cd "$(dirname "$0")/.." && pwd)/megarepo.nix"
+if ! grep -F 'after = [ "mr:setup" ];' "$module_file" >/dev/null; then
+  echo "FAIL: mr:check should depend on mr:setup"
+  exit 1
+fi
+if grep -F '[devenv] Fix: devenv tasks run mr:apply' "$module_file" >/dev/null; then
+  echo "FAIL: setup repair hint should not point at mr:apply"
+  exit 1
+fi
+if ! grep -F '[devenv] Fix: devenv tasks run mr:setup' "$module_file" >/dev/null; then
+  echo "FAIL: setup repair hint should point at mr:setup"
+  exit 1
+fi
+echo "  ok: setup task is the canonical setup dependency"
+
+echo ""
 echo "All megarepo status tests passed"

--- a/packages/@overeng/megarepo/src/cli/commands/apply.ts
+++ b/packages/@overeng/megarepo/src/cli/commands/apply.ts
@@ -7,7 +7,14 @@
 import * as Cli from '@effect/cli'
 
 import { outputOption, verboseOption } from '../context.ts'
-import { runCommand } from './engine.ts'
+import { runCommand, type LockSyncMode } from './engine.ts'
+
+const lockSyncOption = Cli.Options.choice('lock-sync', ['auto', 'off', 'direct', 'recursive']).pipe(
+  Cli.Options.withDescription(
+    'Lock-file rewrite policy during apply: auto, off, direct members only, or recursive nested megarepos',
+  ),
+  Cli.Options.withDefault('auto' as LockSyncMode),
+)
 
 /** `mr apply` — Lock → Workspace: create worktrees, symlink, nix lock sync, generators. */
 export const applyCommand = Cli.Command.make(
@@ -47,9 +54,10 @@ export const applyCommand = Cli.Command.make(
       ),
       Cli.Options.withDefault('auto' as const),
     ),
+    lockSync: lockSyncOption,
     verbose: verboseOption,
   },
-  ({ output, dryRun, force, all, only, skip, gitProtocol, worktreeMode, verbose }) =>
+  ({ output, dryRun, force, all, only, skip, gitProtocol, worktreeMode, lockSync, verbose }) =>
     runCommand({
       mode: 'apply',
       output,
@@ -62,6 +70,7 @@ export const applyCommand = Cli.Command.make(
       createBranches: false,
       verbose,
       worktreeMode,
+      lockSyncMode: lockSync,
     }),
 ).pipe(
   Cli.Command.withDescription(

--- a/packages/@overeng/megarepo/src/cli/commands/engine.ts
+++ b/packages/@overeng/megarepo/src/cli/commands/engine.ts
@@ -74,6 +74,9 @@ import type {
   SyncAction,
 } from '../renderers/SyncOutput/schema.ts'
 
+/** Policy for apply-time lock-file rewrites. */
+export type LockSyncMode = 'auto' | 'off' | 'direct' | 'recursive'
+
 /**
  * Sync a megarepo at the given root path.
  * This is extracted to enable recursive syncing for --all mode.
@@ -104,6 +107,8 @@ export const syncMegarepo = <R = never>({
     applyAfterFetch?: boolean
     /** When true, use commit-based worktrees (refs/commits/<sha>) for deterministic apply. */
     commitMode?: boolean
+    /** Controls whether apply also rewrites Nix/nested megarepo lock files. */
+    lockSyncMode?: LockSyncMode
   }
   depth?: number
   visited?: Set<string>
@@ -426,14 +431,25 @@ export const syncMegarepo = <R = never>({
           lockSyncExplicitSetting === true ||
           (lockSyncExplicitSetting !== false && (devenvLockExists || flakeLockExists))
 
-        if (lockSyncEnabled === true) {
+        const lockSyncMode = options.lockSyncMode ?? 'auto'
+        const cliLockSyncEnabled = lockSyncMode !== 'off'
+        const lockSyncScope =
+          lockSyncMode === 'recursive'
+            ? 'recursive'
+            : lockSyncMode === 'direct' || lockSyncMode === 'off'
+              ? 'direct'
+              : all === true
+                ? 'recursive'
+                : 'direct'
+
+        if (lockSyncEnabled === true && cliLockSyncEnabled === true) {
           const excludeMembers = new Set(config.lockSync?.exclude ?? [])
           nixLockResult = yield* syncNixLocks({
             megarepoRoot,
             config,
             lockFile,
             excludeMembers,
-            scope: all === true ? 'recursive' : 'direct',
+            scope: lockSyncScope,
             recursiveMegarepoMembers: new Set(nestedMegarepos),
           })
           if (nixLockResult.totalUpdates > 0) {
@@ -594,6 +610,7 @@ export const runCommand = ({
   verbose,
   applyAfterFetch = false,
   worktreeMode,
+  lockSyncMode,
 }: {
   mode: SyncMode
   output: OutputModeValue
@@ -609,6 +626,8 @@ export const runCommand = ({
   applyAfterFetch?: boolean
   /** Worktree strategy for apply mode: 'commit', 'tracking', or 'auto' (default). */
   worktreeMode?: 'commit' | 'tracking' | 'auto'
+  /** Controls whether apply also rewrites Nix/nested megarepo lock files. */
+  lockSyncMode?: LockSyncMode
 }) =>
   Effect.gen(function* () {
     const json = output === 'json' || output === 'ndjson'
@@ -679,6 +698,7 @@ export const runCommand = ({
           skip: skipMembers,
           gitProtocol,
           createBranches,
+          ...(lockSyncMode !== undefined ? { lockSyncMode } : {}),
         },
         ...(onMissingRef !== undefined ? { onMissingRef } : {}),
       })
@@ -700,6 +720,7 @@ export const runCommand = ({
           createBranches,
           ...(applyAfterFetch === true ? { applyAfterFetch: true } : {}),
           ...(commitMode === true ? { commitMode: true } : {}),
+          ...(lockSyncMode !== undefined ? { lockSyncMode } : {}),
         },
         ...(progressHandle !== undefined ? { progressHandle } : {}),
         ...(onMissingRef !== undefined ? { onMissingRef } : {}),

--- a/packages/@overeng/megarepo/src/cli/commands/fetch.ts
+++ b/packages/@overeng/megarepo/src/cli/commands/fetch.ts
@@ -8,7 +8,14 @@
 import * as Cli from '@effect/cli'
 
 import { outputOption, verboseOption } from '../context.ts'
-import { runCommand } from './engine.ts'
+import { runCommand, type LockSyncMode } from './engine.ts'
+
+const lockSyncOption = Cli.Options.choice('lock-sync', ['auto', 'off', 'direct', 'recursive']).pipe(
+  Cli.Options.withDescription(
+    'Lock-file rewrite policy for the apply phase: auto, off, direct members only, or recursive nested megarepos',
+  ),
+  Cli.Options.withDefault('auto' as LockSyncMode),
+)
 
 const sharedOptions = {
   output: outputOption,
@@ -45,6 +52,7 @@ const sharedOptions = {
     ),
     Cli.Options.withDefault('auto' as const),
   ),
+  lockSync: lockSyncOption,
   verbose: verboseOption,
 } as const
 
@@ -75,6 +83,7 @@ export const fetchCommand = Cli.Command.make(
     apply: applyAfter,
     createBranches,
     worktreeMode,
+    lockSync,
     verbose,
   }) =>
     runCommand({
@@ -90,6 +99,7 @@ export const fetchCommand = Cli.Command.make(
       verbose,
       applyAfterFetch: applyAfter,
       worktreeMode,
+      lockSyncMode: lockSync,
     }),
 ).pipe(
   Cli.Command.withDescription(

--- a/packages/@overeng/megarepo/src/cli/store-gc-cold.integration.test.ts
+++ b/packages/@overeng/megarepo/src/cli/store-gc-cold.integration.test.ts
@@ -60,13 +60,19 @@ const git = (cwd: string, ...args: ReadonlyArray<string>) =>
     return (yield* Command.string(command)).trim()
   })
 
-/** Deterministic clock so grace/retention decisions are reproducible. */
+const liveClock = Clock.make()
+
+/**
+ * Deterministic decision clock so grace/retention decisions are reproducible.
+ * Sleep delegates to the live clock so command-level timeouts remain real
+ * deadlines instead of firing immediately under the fixed decision time.
+ */
 const fixedClockLayer = (nowMs: number) =>
   Layer.setClock({
     [Clock.ClockTypeId]: Clock.ClockTypeId,
     currentTimeMillis: Effect.succeed(nowMs),
     currentTimeNanos: Effect.succeed(BigInt(nowMs) * 1_000_000n),
-    sleep: () => Effect.void,
+    sleep: (duration) => liveClock.sleep(duration),
     unsafeCurrentTimeMillis: () => nowMs,
     unsafeCurrentTimeNanos: () => BigInt(nowMs) * 1_000_000n,
   })

--- a/packages/@overeng/megarepo/src/cli/sync.integration.test.ts
+++ b/packages/@overeng/megarepo/src/cli/sync.integration.test.ts
@@ -163,6 +163,17 @@ const runFetchCommand = ({
   env?: Record<string, string>
 }) => runMrCommand({ cwd, command: ['fetch'], args, env })
 
+/** Run `mr apply` and capture output. */
+const runApplyCommand = ({
+  cwd,
+  args = [],
+  env = {},
+}: {
+  cwd: AbsoluteDirPath
+  args?: ReadonlyArray<string>
+  env?: Record<string, string>
+}) => runMrCommand({ cwd, command: ['apply'], args, env })
+
 /** Run `mr fetch --apply` (the daily driver, replaces old `mr sync`). */
 const runFetchApplyCommand = ({
   cwd,
@@ -1325,6 +1336,42 @@ const createNestedMegarepoLockRefMatchFixture = () =>
   })
 
 describe('nested megarepo.lock sync scope', () => {
+  it.effect(
+    'should not sync nested megarepo.lock when apply lock sync is disabled',
+    Effect.fnUntraced(
+      function* () {
+        const { parentPath, childPath, storePath, staleNestedCommit } =
+          yield* createNestedWorkspaceFixture()
+
+        const nestedLockPath = EffectPath.ops.join(
+          childPath,
+          EffectPath.unsafe.relativeFile(LOCK_FILE_NAME),
+        )
+        const beforeNestedLockOpt = yield* readLockFile(nestedLockPath)
+        expect(Option.isSome(beforeNestedLockOpt)).toBe(true)
+        const beforeNestedLock = Option.getOrThrow(beforeNestedLockOpt)
+        expect(beforeNestedLock.members['shared']?.commit).toBe(staleNestedCommit)
+
+        const result = yield* runApplyCommand({
+          cwd: parentPath,
+          args: ['--output', 'json', '--lock-sync', 'off'],
+          env: {
+            MEGAREPO_STORE: storePath.slice(0, -1),
+          },
+        })
+        expect(result.exitCode).toBe(0)
+
+        const afterNestedLockOpt = yield* readLockFile(nestedLockPath)
+        expect(Option.isSome(afterNestedLockOpt)).toBe(true)
+        const afterNestedLock = Option.getOrThrow(afterNestedLockOpt)
+        expect(afterNestedLock.members['shared']?.commit).toBe(staleNestedCommit)
+      },
+      Effect.provide(NodeContext.layer),
+      Effect.scoped,
+    ),
+    { timeout: 15_000 },
+  )
+
   it.effect(
     'should not sync nested megarepo.lock in default workspace sync mode',
     Effect.fnUntraced(

--- a/packages/@overeng/megarepo/src/lib/git.ts
+++ b/packages/@overeng/megarepo/src/lib/git.ts
@@ -81,9 +81,47 @@ export class GitCommandError extends Error {
   }
 }
 
+/** Error thrown when a git command exceeds the deterministic command deadline. */
+export class GitCommandTimeoutError extends GitCommandError {
+  readonly timedOut = true
+  readonly timeoutMillis: number
+
+  constructor({ args, timeoutMillis }: { args: ReadonlyArray<string>; timeoutMillis: number }) {
+    super({
+      args,
+      exitCode: 124,
+      stderr: `git ${args.join(' ')} timed out after ${timeoutMillis}ms`,
+    })
+    this.name = 'GitCommandTimeoutError'
+    this.timeoutMillis = timeoutMillis
+  }
+}
+
 // =============================================================================
 // Git Commands
 // =============================================================================
+
+const DEFAULT_GIT_COMMAND_TIMEOUT_MILLIS = 30_000
+
+const gitCommandTimeoutMillis = (): number => {
+  const raw = process.env['MEGAREPO_GIT_COMMAND_TIMEOUT_MS']
+  if (raw === undefined) return DEFAULT_GIT_COMMAND_TIMEOUT_MILLIS
+
+  const parsed = Number.parseInt(raw, 10)
+  return Number.isInteger(parsed) === true && parsed > 0
+    ? parsed
+    : DEFAULT_GIT_COMMAND_TIMEOUT_MILLIS
+}
+
+const withGitCommandTimeout =
+  <A, E, R>({ args, timeoutMillis }: { args: ReadonlyArray<string>; timeoutMillis: number }) =>
+  (effect: Effect.Effect<A, E, R>) =>
+    effect.pipe(
+      Effect.timeoutFail({
+        duration: Duration.millis(timeoutMillis),
+        onTimeout: () => new GitCommandTimeoutError({ args, timeoutMillis }),
+      }),
+    )
 
 /** Decode a chunk of byte buffers into a string with a single O(n) allocation. */
 const decodeChunks = (chunks: Chunk.Chunk<Uint8Array>): string => {
@@ -135,34 +173,41 @@ const startGitProcess = ({ args, cwd }: { args: ReadonlyArray<string>; cwd?: str
  * whose output is unbounded (large `status`/`worktree list`/`rev-list`).
  */
 const runGitCommand = ({ args, cwd }: { args: ReadonlyArray<string>; cwd?: string }) =>
-  Effect.gen(function* () {
-    const process = yield* startGitProcess(cwd !== undefined ? { args, cwd } : { args })
+  (() => {
+    const timeoutMillis = gitCommandTimeoutMillis()
+    return Effect.gen(function* () {
+      const process = yield* startGitProcess(cwd !== undefined ? { args, cwd } : { args })
 
-    // Collect stdout and stderr. Concat is a single O(n) allocation per stream
-    // (sum lengths once, allocate once, copy once) — the previous per-chunk
-    // `reduce` reallocated the whole buffer on every chunk, which is O(n²) in
-    // output size and OOM-killed the host on large `git status` output.
-    const [stdoutChunks, stderrChunks] = yield* Effect.all([
-      Stream.runCollect(process.stdout),
-      Stream.runCollect(process.stderr),
-    ])
+      // Collect stdout and stderr. Concat is a single O(n) allocation per stream
+      // (sum lengths once, allocate once, copy once) — the previous per-chunk
+      // `reduce` reallocated the whole buffer on every chunk, which is O(n²) in
+      // output size and OOM-killed the host on large `git status` output.
+      const [stdoutChunks, stderrChunks] = yield* Effect.all([
+        Stream.runCollect(process.stdout),
+        Stream.runCollect(process.stderr),
+      ])
 
-    const stdout = decodeChunks(stdoutChunks)
-    const stderr = decodeChunks(stderrChunks)
+      const stdout = decodeChunks(stdoutChunks)
+      const stderr = decodeChunks(stderrChunks)
 
-    const exitCode = yield* process.exitCode
+      const exitCode = yield* process.exitCode
 
-    if (exitCode !== 0) {
-      return yield* Effect.fail(new GitCommandError({ args, exitCode, stderr }))
-    }
+      if (exitCode !== 0) {
+        return yield* Effect.fail(new GitCommandError({ args, exitCode, stderr }))
+      }
 
-    yield* Observability.annotateGitCmdOutput({
-      outputBytes: Buffer.byteLength(stdout, 'utf-8'),
-      outputLines: stdout.length === 0 ? 0 : stdout.split('\n').length,
-    })
+      yield* Observability.annotateGitCmdOutput({
+        outputBytes: Buffer.byteLength(stdout, 'utf-8'),
+        outputLines: stdout.length === 0 ? 0 : stdout.split('\n').length,
+      })
 
-    return stdout.trim()
-  }).pipe(Effect.scoped, Observability.withGitCmdSpan({ args, streamed: false }))
+      return stdout.trim()
+    }).pipe(
+      Effect.scoped,
+      withGitCommandTimeout({ args, timeoutMillis }),
+      Observability.withGitCmdSpan({ args, streamed: false, timeoutMs: timeoutMillis }),
+    )
+  })()
 
 /**
  * Run a git command, folding stdout LINE BY LINE through `sink` at constant
@@ -188,45 +233,52 @@ const streamGitCommandLines = <A>({
   cwd?: string
   sink: Sink.Sink<A, string>
 }) =>
-  Effect.gen(function* () {
-    const process = yield* startGitProcess(cwd !== undefined ? { args, cwd } : { args })
+  (() => {
+    const timeoutMillis = gitCommandTimeoutMillis()
+    return Effect.gen(function* () {
+      const process = yield* startGitProcess(cwd !== undefined ? { args, cwd } : { args })
 
-    // SCALAR running counters for the git-cmd output-size span attributes — these
-    // must never accumulate the lines themselves, or we reintroduce the O(n²)
-    // buffering. `Stream.tap` bumps them as each line flows past on its way to the
-    // sink, so memory stays constant.
-    let outputLines = 0
-    let outputBytes = 0
+      // SCALAR running counters for the git-cmd output-size span attributes — these
+      // must never accumulate the lines themselves, or we reintroduce the O(n²)
+      // buffering. `Stream.tap` bumps them as each line flows past on its way to the
+      // sink, so memory stays constant.
+      let outputLines = 0
+      let outputBytes = 0
 
-    const [result, stderrChunks, exitCode] = yield* Effect.all(
-      [
-        process.stdout.pipe(
-          Stream.decodeText('utf-8'),
-          Stream.splitLines,
-          Stream.tap((line) =>
-            Effect.sync(() => {
-              outputLines += 1
-              outputBytes += Buffer.byteLength(line, 'utf-8') + 1 // + newline
-            }),
+      const [result, stderrChunks, exitCode] = yield* Effect.all(
+        [
+          process.stdout.pipe(
+            Stream.decodeText('utf-8'),
+            Stream.splitLines,
+            Stream.tap((line) =>
+              Effect.sync(() => {
+                outputLines += 1
+                outputBytes += Buffer.byteLength(line, 'utf-8') + 1 // + newline
+              }),
+            ),
+            Stream.run(sink),
           ),
-          Stream.run(sink),
-        ),
-        Stream.runCollect(process.stderr),
-        process.exitCode,
-      ],
-      { concurrency: 'unbounded' },
-    )
-
-    if (exitCode !== 0) {
-      return yield* Effect.fail(
-        new GitCommandError({ args, exitCode, stderr: decodeChunks(stderrChunks) }),
+          Stream.runCollect(process.stderr),
+          process.exitCode,
+        ],
+        { concurrency: 'unbounded' },
       )
-    }
 
-    yield* Observability.annotateGitCmdOutput({ outputBytes, outputLines })
+      if (exitCode !== 0) {
+        return yield* Effect.fail(
+          new GitCommandError({ args, exitCode, stderr: decodeChunks(stderrChunks) }),
+        )
+      }
 
-    return result
-  }).pipe(Effect.scoped, Observability.withGitCmdSpan({ args, streamed: true }))
+      yield* Observability.annotateGitCmdOutput({ outputBytes, outputLines })
+
+      return result
+    }).pipe(
+      Effect.scoped,
+      withGitCommandTimeout({ args, timeoutMillis }),
+      Observability.withGitCmdSpan({ args, streamed: true, timeoutMs: timeoutMillis }),
+    )
+  })()
 
 // =============================================================================
 // Transient Error Retry
@@ -240,6 +292,8 @@ const streamGitCommandLines = <A>({
  * identically on every retry.
  */
 export const isTransientGitError = (error: GitCommandError): boolean => {
+  if (error instanceof GitCommandTimeoutError) return false
+
   const stderr = error.stderr.toLowerCase()
   return (
     stderr.includes('http 5') ||

--- a/packages/@overeng/megarepo/src/lib/observability.ts
+++ b/packages/@overeng/megarepo/src/lib/observability.ts
@@ -80,6 +80,7 @@ export const gitCmdAttrs = OtelAttrs.defineSync(
     label: Schema.NonEmptyString.pipe(OtelAttr.spanLabel()),
     subcommand: Schema.String.pipe(OtelAttr.key({ key: 'git.subcommand' })),
     streamed: Schema.Boolean.pipe(OtelAttr.key({ key: 'git.streamed' })),
+    timeoutMs: Schema.optional(Schema.Number.pipe(OtelAttr.key({ key: 'git.timeout_ms' }))),
   }),
 )
 
@@ -278,14 +279,21 @@ const gitCmdOperation = OtelOperation.define({
 export const withGitCmdSpan = ({
   args,
   streamed,
+  timeoutMs,
 }: {
   readonly args: ReadonlyArray<string>
   readonly streamed: boolean
+  readonly timeoutMs?: number
 }) => {
   const subcommand = args[0] ?? 'git'
   return trustedWith({
     operation: gitCmdOperation,
-    attributes: { label: subcommand, subcommand, streamed },
+    attributes: {
+      label: subcommand,
+      subcommand,
+      streamed,
+      ...(timeoutMs === undefined ? {} : { timeoutMs }),
+    },
   })
 }
 


### PR DESCRIPTION
**Problem**

Shell-entry setup had no non-mutating megarepo materialization primitive. Repos that wanted committed members available during setup either called the update path (`mr fetch --apply`) or used apply with default lock-file rewrite behavior, which can turn setup into tracked lock churn.

**Goal**

Provide an explicit setup-safe path that materializes committed root members without fetching remotes or rewriting lock files, while preserving existing update workflows for developers who intentionally refresh locks.

**Decisions**

- Added an explicit `--lock-sync` policy to `mr apply` and the apply phase of `mr fetch --apply`.
- Kept the CLI default policy as `auto` for compatibility. Breaking default changes are tracked separately in #860.
- Added shared `mr:setup` as the canonical non-mutating devenv setup task instead of requiring downstream repos to spell out `mr apply --lock-sync off`.
- Scoped `mr:setup` to root members only. Recursive nested setup remains explicit because recursive setup plus stale child locks can force child lock rewrites.
- Moved shared `mr:check` to depend on `mr:setup`, and updated missing-member repair hints to point at setup instead of the lower-level `mr:apply` task.

**Verification**

- `bash nix/devenv-modules/tasks/shared/tests/megarepo-status.test.sh` passed.
- `DEVENV_TUI=false devenv tasks run test:megarepo --no-tui` passed.
- `DEVENV_TUI=false devenv tasks run check:quick --no-tui` passed.
- `DEVENV_TUI=false devenv tasks run check:all --no-tui` passed.
- `git diff --check` passed.
- Review fix `c933d982` updated the shared status check to use `syncNeeded`/`applyNeeded` and added focused regression coverage for both cache-invalidating states.

**Complexity**

Small CLI option surface plus one shared devenv task. No new dependency or module boundary.

**Concerns**

`mr:setup` intentionally does not recursively prepare nested megarepos. Repos that need nested members ready during root setup should opt into an explicit update/reconcile step rather than making shell entry mutate child locks.

**Friction & bottlenecks**

One direct `bunx vitest` attempt failed because it resolved a transient Vitest outside the workspace. The repo's devenv test tasks are the correct runner.

**Follow-ups**

- #860 tracks the breaking/default-changing cleanup: make recursive lock sync opt-in by default for future major cleanup.
- Downstream dotfiles PR schickling/dotfiles#1215 removes `mr:fetch-apply` from shell entry now. It stays on the existing shared `mr:apply` primitive until this PR lands, because pinning this PR branch directly currently triggers unrelated dotfiles projected FOD churn.

**References**

Refs schickling/dotfiles#1215.
Refs #860.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 📡 co2-pulsar |
| `agent_session_id` | ffe54422-b0c4-421c-9c65-47e09ec72a79 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.141.0 |
| `agent_runtime` | Codex CLI 0.141.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/ynb6b5csz0wgbwqw1c43flnp450v5bjv-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/pqhvj5xhdaw62mi7dm62a7i7pwk9wpjj-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-06-28-fix-megarepo-shell-apply-lock-sync |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@f43f9f1 |
</details>
<!-- agent-footer:end -->