### PR TITLE
feat(genie): add explicit tsconfig reference composition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- **@overeng/genie**: Add the explicit `@overeng/genie/composition` subpath for
+  reusable cross-artifact composition helpers. The first helper,
+  `tsconfigReferencesFromPackages`, projects TypeScript project references from
+  package workspace metadata while keeping `tsconfigJson(...)` as a thin
+  artifact builder.
+
 - **@overeng/megarepo / CI**: Isolate the cold named-branch GC integration
   matrix into its own CI task and add deterministic git subprocess timeouts
   with OTEL `git.timeout_ms` span attributes so stuck GC probes fail with the

--- a/packages/@overeng/genie/README.md
+++ b/packages/@overeng/genie/README.md
@@ -147,6 +147,24 @@ Each generator has its own documentation:
 - **[oxfmt-config](./src/lib/oxfmt-config/README.md)** - Generate `oxfmt.jsonc` configuration files
 - **[pnpm-workspace](./src/lib/pnpm-workspace/README.md)** - Generate `pnpm-workspace.yaml` files
 
+## Composition Helpers
+
+The canonical `@overeng/genie` export exposes the thin artifact builders. Use
+`@overeng/genie/composition` for reusable cross-artifact helpers that consume
+structured generator metadata explicitly.
+
+```ts
+import { tsconfigJson } from '@overeng/genie'
+import { tsconfigReferencesFromPackages } from '@overeng/genie/composition'
+
+import appPkg from './package.json.genie.ts'
+
+export default tsconfigJson({
+  compilerOptions: { composite: true },
+  references: tsconfigReferencesFromPackages({ from: appPkg }),
+})
+```
+
 ## Features
 
 - **Read-only output** - Generated files are marked read-only by default to prevent accidental edits

--- a/packages/@overeng/genie/docs/.decisions/0001-cross-artifact-composition-helpers.md
+++ b/packages/@overeng/genie/docs/.decisions/0001-cross-artifact-composition-helpers.md
@@ -1,0 +1,92 @@
+# 0001: Cross-artifact composition lives in explicit helpers
+
+## Status
+
+Accepted
+
+## Context
+
+Genie generators should provide principled, non-leaky abstractions over the
+underlying artifact or system they emit. `packageJson(...)` should model package
+manifest authoring, `tsconfigJson(...)` should model TypeScript configuration
+authoring, and each generator should remain understandable without knowing the
+implementation details of unrelated generators.
+
+At the same time, real repositories need clean composition across generated
+artifacts. For example, package manifests expose workspace dependency metadata
+that other projections can consume without reverse-engineering rendered
+`package.json` files.
+
+## Decision
+
+Genie's default long-term shape is:
+
+- individual generators stay focused on one artifact or domain;
+- reusable cross-artifact behavior lives in explicit composition helpers or
+  projection helpers that consume structured `GenieOutput.meta`;
+- the canonical package export `@overeng/genie` remains the thin,
+  unopinionated runtime API;
+- more opinionated reusable composition layers are exposed through dedicated
+  package subpath exports rather than being mixed into the canonical export;
+- the preferred first subpath for reusable cross-artifact helpers is
+  `@overeng/genie/composition`;
+- `GenieOutput.meta` carries stable semantic facts such as identities,
+  relationships, declared capabilities, and normalized authoring intent;
+- project-specific policy lives outside Genie core, usually in repository-local
+  Genie helper modules such as a `./genie` project directory.
+
+Repository-local policy is a valid escape hatch, not the primary abstraction
+boundary for reusable conventions. When a pattern is broadly reusable and can
+remain bootstrap-safe, Genie may provide a shared helper for it. When a pattern
+encodes project-specific policy, the project should own that layer.
+
+Metadata should not store rendered artifact text or target-location-dependent
+relative paths when those values can be computed later by a projection helper
+from semantic facts and render context. Project-shape exceptions such as
+non-Genie-managed workspace members must stay explicit escape hatches rather
+than normal composition inputs.
+
+Admission to `@overeng/genie/composition` requires all of:
+
+- the helper is reusable across repositories;
+- the helper consumes explicit semantic inputs or `GenieOutput.meta`;
+- the helper remains bootstrap-safe when imported by `.genie.ts` sources;
+- the helper does not encode a specific repository's package catalog, patch
+  set, private defaults, Nix/FOD closure policy, or comparable local policy.
+
+## Options
+
+| Option                                                                                       | Result                                                                                                                |
+| -------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| Individual generators plus explicit composition helpers                                      | Selected. Preserves generator boundaries while allowing reusable, typed composition.                                  |
+| Generators infer from each other automatically                                               | Rejected. It maximizes convenience but creates hidden coupling and makes generator behavior harder to reason about.   |
+| Genie core only exposes low-level artifact factories; every repo owns all composition policy | Accepted only as an escape hatch. It is clean locally but causes shared conventions to drift across repositories.     |
+| Same package, dedicated subpath exports for opinionated layers                               | Selected. Keeps import paths semantically explicit without prematurely splitting package lifecycle.                   |
+| Separate opinionated package such as `@overeng/genie-presets`                                | Deferred. It becomes attractive if policy layers grow large or need independent versioning.                           |
+| `@overeng/genie/composition` for reusable cross-artifact helpers                             | Selected. Broad enough for workspace and future projection helpers while still communicating explicit composition.    |
+| `@overeng/genie/presets` for the first opinionated subpath                                   | Rejected for this layer. It implies stronger defaults than principled composition helpers should carry.               |
+| `@overeng/genie/workspace` for the first opinionated subpath                                 | Rejected for now. It is precise for current package/workspace composition but too narrow for the general abstraction. |
+| Strict admission rule for `@overeng/genie/composition`                                       | Selected. Keeps reusable composition separate from project-local policy.                                              |
+| Common effect-utils patterns first, generalized later                                        | Rejected. It risks exporting effect-utils assumptions as accidental Genie API.                                        |
+| Loose experimental admission                                                                 | Rejected for the canonical subpath. Experiments may remain project-local or behind clearly provisional names.         |
+| Stable semantic facts in `meta`; projection data computed later                              | Selected. Keeps metadata portable across target locations and composed repository views.                              |
+| Helper-ready rendered or relative-path projection data in `meta`                             | Rejected by default. It simplifies one helper at the cost of leaking output layout into producer generators.          |
+
+## Consequences
+
+- New cross-artifact features should be designed as explicit helpers rather than
+  hidden behavior inside existing generators.
+- Import paths should communicate abstraction level. Consumers import primitive
+  builders from `@overeng/genie`; they import opinionated shared composition
+  APIs from named subpaths.
+- Helpers that encode effect-utils package defaults, catalog pins, patch sets,
+  or Nix/FOD package-closure policy belong in effect-utils-local Genie modules,
+  not in `@overeng/genie/composition`.
+- Shared helpers must use structured metadata channels, not rendered artifact
+  parsing.
+- Metadata producers should expose stable facts. Projection helpers should own
+  location-specific rendering such as relative paths.
+- The runtime/build boundary still applies: helpers imported by `.genie.ts`
+  sources must stay bootstrap-safe.
+- Project-specific helpers can compose Genie primitives freely, but should not
+  be promoted into Genie core until their policy is reusable beyond one project.

--- a/packages/@overeng/genie/docs/requirements.md
+++ b/packages/@overeng/genie/docs/requirements.md
@@ -72,43 +72,63 @@ may not yet be installed.
 - **R10 Local iteration compatibility:** Cross-repo reuse must still allow
   local source iteration against the active composed worktree rather than
   forcing copy-paste or publish-and-upgrade loops.
+- **R11 Explicit composition layer:** Reusable cross-artifact composition must
+  live behind explicit helper APIs or package subpath exports rather than hidden
+  inference inside artifact-specific generators.
+- **R12 Generator boundary preservation:** Artifact-specific generators must
+  remain principled abstractions over their own target artifact or domain. A
+  generator must not require knowledge of unrelated generators to understand
+  its emitted output.
+- **R13 Project-policy locality:** Project-specific catalogs, defaults, patch
+  sets, Nix/FOD closure policy, and comparable local conventions must live in
+  repository-local Genie helper modules unless they satisfy the reusable
+  composition admission rule.
+- **R14 Composition subpath semantics:** The canonical `@overeng/genie` export
+  must remain the thin runtime API for artifact builders and shared primitives.
+  More opinionated reusable composition helpers must be exposed through
+  semantically named package subpaths such as `@overeng/genie/composition`.
 
 ### Must validate and fail clearly
 
-- **R11 Duplicate-target rejection:** Genie must reject configurations where
+- **R15 Duplicate-target rejection:** Genie must reject configurations where
   multiple sources claim the same generated target.
-- **R12 Repository validation:** Genie must run repository-level validation so
+- **R16 Repository validation:** Genie must run repository-level validation so
   cross-file invariants are checked before reporting a successful run.
-- **R13 Root-cause reporting:** Import cycles, TDZ failures, catalog conflicts,
+- **R17 Root-cause reporting:** Import cycles, TDZ failures, catalog conflicts,
   and comparable configuration errors must surface actionable diagnostics
   instead of opaque incidental stack traces.
-- **R14 File-level reporting:** Batch runs must report per-file outcomes and an
+- **R18 File-level reporting:** Batch runs must report per-file outcomes and an
   aggregate summary suitable for both local use and CI.
-- **R15 Repository-bounded discovery:** Recursive discovery must respect the
+- **R19 Repository-bounded discovery:** Recursive discovery must respect the
   repository's ignore rules so ignored local state, nested agent worktrees, and
   other non-source scratch directories cannot become ambient generation input.
   Untracked but non-ignored `.genie.ts` sources must still be discovered.
 
 ### Must support the main operating modes
 
-- **R16 Generate mode:** Genie must write generated targets to disk for normal
+- **R20 Generate mode:** Genie must write generated targets to disk for normal
   repository authoring workflows.
-- **R17 Check mode:** Genie must verify up-to-date state without mutating
+- **R21 Check mode:** Genie must verify up-to-date state without mutating
   targets.
-- **R18 Dry-run mode:** Genie must support previewing prospective changes
+- **R22 Dry-run mode:** Genie must support previewing prospective changes
   without writing files.
-- **R19 Watch mode:** Genie must support an interactive mode that reacts to
+- **R23 Watch mode:** Genie must support an interactive mode that reacts to
   `.genie.ts` source changes and regenerates the affected output set.
 
 ### Must preserve output quality
 
-- **R20 Supported formatting:** Generated outputs must respect the repository's
+- **R24 Supported formatting:** Generated outputs must respect the repository's
   supported formatting conventions so repeated generation does not create
   formatting churn.
-- **R21 Stable metadata channel:** Composition metadata required by other
+- **R25 Stable metadata channel:** Composition metadata required by other
   generators must flow through an explicit structured channel rather than being
   reconstructed from rendered artifact text.
-- **R22 Multi-artifact coverage:** The system must remain capable of generating
+- **R26 Semantic metadata:** `GenieOutput.meta` must carry stable semantic facts
+  such as identities, relationships, declared capabilities, and normalized
+  authoring intent. Target-location-dependent projection values such as
+  relative paths should be computed by projection helpers from metadata and
+  render context instead of stored as producer metadata.
+- **R27 Multi-artifact coverage:** The system must remain capable of generating
   the major repository artifact classes it already serves, including package
   manifests, TypeScript configuration, formatter/linter config, and GitHub
   workflow artifacts.

--- a/packages/@overeng/genie/docs/spec.md
+++ b/packages/@overeng/genie/docs/spec.md
@@ -13,12 +13,16 @@ This spec defines:
 - the public operating modes of the `genie` CLI
 - the source and target file conventions for `.genie.ts` generators
 - the boundary between build-time CLI code and runtime generator code
+- the package export boundary between thin artifact builders and explicit
+  composition helpers
 - import resolution, including megarepo-aware `#mr/...` imports
 - the end-to-end generation and check pipeline
 
 This spec does not define:
 
 - the detailed API contract of each individual runtime factory such as `package-json` or `tsconfig-json`
+- project-specific composition policy such as package catalogs, private
+  defaults, patch sets, or Nix/FOD closure policy
 - the packaging and hash-refresh mechanics of the Nix CLI wrappers outside the `genie` package itself
 - repository-local task wiring beyond the prerequisite boundary that ensures bootstrap members exist before Genie-backed tasks run
 
@@ -32,10 +36,20 @@ The package-level context and current module-boundary docs remain:
 
 Genie exposes two coupled surfaces:
 
-| Surface                                | Role                                                                                         |
-| -------------------------------------- | -------------------------------------------------------------------------------------------- |
-| `genie` CLI                            | discovers `.genie.ts` files, loads them, validates them, renders outputs, and reports status |
-| runtime libraries under `src/runtime/` | provide pure or mostly-pure factories and helpers imported by `.genie.ts` source files       |
+| Surface                                | Role                                                                                                      |
+| -------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `genie` CLI                            | discovers `.genie.ts` files, loads them, validates them, renders outputs, and reports status              |
+| runtime libraries under `src/runtime/` | provide pure or mostly-pure factories and helpers imported by `.genie.ts` source files                    |
+| package subpath exports                | communicate abstraction level for thin builders, explicit composition helpers, node-only helpers, and SDK |
+
+The package export contract is:
+
+| Export                         | Role                                                                                         |
+| ------------------------------ | -------------------------------------------------------------------------------------------- |
+| `@overeng/genie`               | thin runtime API for artifact builders, primitive helpers, and shared types                  |
+| `@overeng/genie/composition`   | explicit reusable cross-artifact composition helpers that consume semantic inputs or `meta`  |
+| `@overeng/genie/node`          | node-resident helpers that may read the filesystem, spawn tools, or otherwise need Node APIs |
+| `@overeng/genie/cli` / `./sdk` | build-time CLI and programmatic SDK surfaces                                                 |
 
 The CLI supports four operating modes:
 
@@ -80,6 +94,60 @@ Genie is split into two execution domains:
 | runtime generator library | `src/runtime/` | dynamically imported by `.genie.ts` modules; npm dependencies are disallowed   |
 
 The runtime layer must stay lightweight and loadable in arbitrary repository contexts because `.genie.ts` files import it directly during evaluation. The build layer may own TUI concerns, CLI option parsing, process orchestration, and other binary-local concerns.
+
+## Composition Boundary
+
+Artifact-specific generators are responsible for modeling and rendering one
+artifact or domain. For example, `packageJson(...)` models package manifest
+authoring and `tsconfigJson(...)` models TypeScript configuration authoring.
+They must not hide cross-generator inference inside their normal rendering
+path.
+
+Reusable cross-artifact behavior belongs in explicit helpers, exposed through
+named package subpaths. The first shared subpath is
+`@overeng/genie/composition`.
+
+Admission to `@overeng/genie/composition` requires that a helper:
+
+- is reusable across repositories;
+- consumes explicit semantic inputs or `GenieOutput.meta`;
+- remains bootstrap-safe when imported by `.genie.ts` sources;
+- avoids encoding a specific repository's package catalog, patch set, private
+  defaults, Nix/FOD closure policy, or comparable local policy.
+
+`GenieOutput.meta` is the structured channel for non-emitted composition facts.
+It stores stable semantic facts such as workspace identity and dependency
+relationships. Projection helpers compute target-location-dependent output
+values, such as relative paths, from those facts and render context instead of
+requiring producer generators to store rendered projection data.
+
+### TypeScript Reference Composition
+
+`@overeng/genie/composition` provides `tsconfigReferencesFromPackages(...)`.
+The helper projects TypeScript `references` entries from package workspace
+metadata while keeping `tsconfigJson(...)` a thin `tsconfig.json` builder.
+
+The helper accepts:
+
+- a `from` package carrying workspace metadata for the package whose
+  `tsconfig.json` is being authored;
+- an optional package list, defaulting to `from.meta.workspace.deps`;
+- optional `{ package, tsconfig }` entries when the caller wants the helper to
+  apply TypeScript project-reference target eligibility from known tsconfig
+  data;
+- an optional project-local predicate for policy that is not reusable Genie
+  semantics.
+
+The helper must:
+
+- render deterministic, sorted reference paths;
+- compute relative paths from semantic workspace identity and package member
+  paths;
+- route foreign-repo packages through the composed `repos/<repo>/<member>`
+  logical path;
+- skip targets whose supplied tsconfig data explicitly sets
+  `compilerOptions.noEmit: true` or `compilerOptions.composite: false`;
+- avoid filesystem reads so it remains valid in the runtime composition layer.
 
 ## Import Resolution
 

--- a/packages/@overeng/genie/nix/build.nix
+++ b/packages/@overeng/genie/nix/build.nix
@@ -25,7 +25,7 @@ let
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
       "." = {
-        hash = "sha256-eIfCNMUjkWqiFlxWSwKMBLTf6LZNMTJY/O59GXCXoiE=";
+        hash = "sha256-t/DQXXcos62bRzXJx4zlXCC2+JuJDkGueHr4ajScEVI=";
       };
     };
     nativeNodePackages = opentuiCoreNative.packages;

--- a/packages/@overeng/genie/package.json
+++ b/packages/@overeng/genie/package.json
@@ -6,6 +6,7 @@
   "exports": {
     ".": "./src/runtime/mod.ts",
     "./cli": "./src/build/mod.tsx",
+    "./composition": "./src/runtime/composition/mod.ts",
     "./node": "./src/runtime/node/mod.ts",
     "./sdk": "./src/sdk/mod.ts"
   },
@@ -14,6 +15,7 @@
     "exports": {
       ".": "./dist/src/runtime/mod.js",
       "./node": "./dist/src/runtime/node/mod.js",
+      "./composition": "./dist/src/runtime/composition/mod.js",
       "./cli": "./dist/src/build/mod.js",
       "./sdk": "./dist/src/sdk/mod.js"
     }

--- a/packages/@overeng/genie/package.json.genie.ts
+++ b/packages/@overeng/genie/package.json.genie.ts
@@ -62,6 +62,9 @@ export default packageJson(
       // Node-resident entry: re-exports `.` plus the node-only members (nodeGenieIO, actionlint runner,
       // github-ruleset reconcile ops, fs-discovery tsconfigJsonFromPackages, repo-context).
       './node': './src/runtime/node/mod.ts',
+      // Explicit reusable composition layer. Keep `.` focused on thin artifact builders; put cross-artifact
+      // helpers that consume structured Genie metadata here.
+      './composition': './src/runtime/composition/mod.ts',
       './cli': './src/build/mod.tsx',
       './sdk': './src/sdk/mod.ts',
     },
@@ -70,6 +73,7 @@ export default packageJson(
       exports: {
         '.': './dist/src/runtime/mod.js',
         './node': './dist/src/runtime/node/mod.js',
+        './composition': './dist/src/runtime/composition/mod.js',
         './cli': './dist/src/build/mod.js',
         './sdk': './dist/src/sdk/mod.js',
       },

--- a/packages/@overeng/genie/src/runtime/README.md
+++ b/packages/@overeng/genie/src/runtime/README.md
@@ -19,3 +19,15 @@ The returned default export is a `GenieOutput<TData, TMeta>` with:
 
 Projection helpers should consume `meta` explicitly instead of re-deriving the
 same information from generated files.
+
+## Composition Layer
+
+The canonical `@overeng/genie` export is the thin runtime surface for
+artifact-focused builders. Reusable cross-artifact helpers live under
+dedicated subpath exports so the import path states the abstraction level.
+
+Use `@overeng/genie/composition` for explicit helpers that consume semantic
+metadata from generated artifacts. For example,
+`tsconfigReferencesFromPackages(...)` projects TypeScript project references
+from package workspace dependency metadata without making `tsconfigJson(...)`
+know about `packageJson(...)`.

--- a/packages/@overeng/genie/src/runtime/composition/composition.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/composition/composition.unit.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest'
+
+import type { WorkspacePackageLike } from '../package-json/mod.ts'
+import { isTsconfigReferenceTarget, tsconfigReferencesFromPackages } from './mod.ts'
+
+const pkg = ({
+  repoName = 'repo',
+  name,
+  memberPath,
+  deps = [],
+}: {
+  repoName?: string
+  name: string
+  memberPath: string
+  deps?: readonly WorkspacePackageLike[]
+}): WorkspacePackageLike => ({
+  data: { name },
+  meta: {
+    workspace: {
+      repoName,
+      memberPath,
+      deps,
+    },
+  },
+})
+
+describe('tsconfigReferencesFromPackages', () => {
+  it('projects sorted direct references from package workspace deps', () => {
+    const utils = pkg({ name: '@test/utils', memberPath: 'packages/utils' })
+    const core = pkg({ name: '@test/core', memberPath: 'packages/core' })
+    const app = pkg({
+      name: '@test/app',
+      memberPath: 'packages/app',
+      deps: [utils, core],
+    })
+
+    expect(tsconfigReferencesFromPackages({ from: app })).toEqual([
+      { path: '../core' },
+      { path: '../utils' },
+    ])
+  })
+
+  it('projects foreign-repo dependencies through the composed repos path', () => {
+    const shared = pkg({
+      repoName: 'shared-repo',
+      name: '@shared/core',
+      memberPath: 'packages/core',
+    })
+    const app = pkg({
+      name: '@test/app',
+      memberPath: 'packages/app',
+      deps: [shared],
+    })
+
+    expect(tsconfigReferencesFromPackages({ from: app })).toEqual([
+      { path: '../../repos/shared-repo/packages/core' },
+    ])
+  })
+
+  it('deduplicates explicit packages after path projection', () => {
+    const utils = pkg({ name: '@test/utils', memberPath: 'packages/utils' })
+    const app = pkg({ name: '@test/app', memberPath: 'packages/app' })
+
+    expect(tsconfigReferencesFromPackages({ from: app, packages: [utils, utils] })).toEqual([
+      { path: '../utils' },
+    ])
+  })
+
+  it('skips packages with supplied ineligible tsconfig data', () => {
+    const buildable = pkg({ name: '@test/buildable', memberPath: 'packages/buildable' })
+    const noEmit = pkg({ name: '@test/no-emit', memberPath: 'packages/no-emit' })
+    const nonComposite = pkg({
+      name: '@test/non-composite',
+      memberPath: 'packages/non-composite',
+    })
+    const app = pkg({ name: '@test/app', memberPath: 'packages/app' })
+
+    expect(
+      tsconfigReferencesFromPackages({
+        from: app,
+        packages: [
+          { package: noEmit, tsconfig: { compilerOptions: { composite: true, noEmit: true } } },
+          { package: nonComposite, tsconfig: { compilerOptions: { composite: false } } },
+          { package: buildable, tsconfig: { compilerOptions: { composite: true } } },
+        ],
+      }),
+    ).toEqual([{ path: '../buildable' }])
+  })
+
+  it('supports project-local include predicates', () => {
+    const app = pkg({ name: '@test/app', memberPath: 'packages/app' })
+    const generated = pkg({ name: '@test/generated', memberPath: 'packages/generated' })
+    const runtime = pkg({ name: '@test/runtime', memberPath: 'packages/runtime' })
+
+    expect(
+      tsconfigReferencesFromPackages({
+        from: app,
+        packages: [generated, runtime],
+        include: (entry) => entry.data.name !== '@test/generated',
+      }),
+    ).toEqual([{ path: '../runtime' }])
+  })
+})
+
+describe('isTsconfigReferenceTarget', () => {
+  it('accepts default and composite configs', () => {
+    expect(isTsconfigReferenceTarget({})).toBe(true)
+    expect(isTsconfigReferenceTarget({ compilerOptions: { composite: true } })).toBe(true)
+  })
+
+  it('rejects explicit TypeScript project-reference opt-outs', () => {
+    expect(isTsconfigReferenceTarget({ compilerOptions: { composite: false } })).toBe(false)
+    expect(isTsconfigReferenceTarget({ compilerOptions: { noEmit: true } })).toBe(false)
+  })
+})

--- a/packages/@overeng/genie/src/runtime/composition/mod.ts
+++ b/packages/@overeng/genie/src/runtime/composition/mod.ts
@@ -1,0 +1,105 @@
+import type { GenieOutput } from '../core.ts'
+import type { WorkspacePackageLike } from '../package-json/mod.ts'
+import type { TSConfigArgs } from '../tsconfig-json/mod.ts'
+import { relativeRepoPath } from '../workspace-graph.ts'
+
+type TsconfigReference = NonNullable<TSConfigArgs['references']>[number]
+
+type TsconfigReferencePackage =
+  | WorkspacePackageLike
+  | {
+      package: WorkspacePackageLike
+      tsconfig?: TSConfigArgs | GenieOutput<TSConfigArgs>
+    }
+
+export type TsconfigReferencesFromPackagesArgs = {
+  /**
+   * Package whose tsconfig is receiving references.
+   *
+   * When `packages` is omitted, the helper projects the direct workspace deps
+   * declared in this package's workspace metadata.
+   */
+  from: WorkspacePackageLike
+  /** Packages to reference. Defaults to `from.meta.workspace.deps`. */
+  packages?: readonly TsconfigReferencePackage[]
+  /**
+   * Additional package predicate for project-local policy.
+   *
+   * Use this for rules that are not reusable Genie semantics. TypeScript's
+   * generic project-reference target rules are handled from `tsconfig` data
+   * when each package entry provides it.
+   */
+  include?: (pkg: WorkspacePackageLike) => boolean
+}
+
+const unwrapPackage = (entry: TsconfigReferencePackage): WorkspacePackageLike =>
+  'package' in entry ? entry.package : entry
+
+const unwrapTsconfig = (entry: TsconfigReferencePackage): TSConfigArgs | undefined => {
+  if ('package' in entry === false) return undefined
+  const tsconfig = entry.tsconfig
+  if (tsconfig === undefined) return undefined
+  return 'data' in tsconfig ? tsconfig.data : tsconfig
+}
+
+/**
+ * Whether a tsconfig can be targeted by a TypeScript project reference.
+ *
+ * TypeScript rejects referenced projects that explicitly disable emit. Genie
+ * also treats `composite: false` as an opt-out from project-reference targets.
+ */
+export const isTsconfigReferenceTarget = (tsconfig: TSConfigArgs): boolean =>
+  tsconfig.compilerOptions?.composite !== false && tsconfig.compilerOptions?.noEmit !== true
+
+const logicalWorkspaceMemberPath = ({
+  fromRepoName,
+  pkg,
+}: {
+  fromRepoName: string
+  pkg: WorkspacePackageLike
+}): string =>
+  pkg.meta.workspace.repoName === fromRepoName
+    ? pkg.meta.workspace.memberPath
+    : `repos/${pkg.meta.workspace.repoName}/${pkg.meta.workspace.memberPath}`
+
+const formatReferencePath = (relativePath: string): string =>
+  relativePath === '.' || relativePath.startsWith('.') === true ? relativePath : `./${relativePath}`
+
+/**
+ * Project TypeScript project references from package workspace metadata.
+ *
+ * This helper is an explicit cross-artifact composition layer: package
+ * generators provide semantic workspace dependency metadata, while this
+ * function renders the location-specific `references` entries for a tsconfig.
+ */
+export const tsconfigReferencesFromPackages = ({
+  from,
+  packages = from.meta.workspace.deps,
+  include,
+}: TsconfigReferencesFromPackagesArgs): TsconfigReference[] => {
+  const fromWorkspace = from.meta.workspace
+  const references = new Map<string, TsconfigReference>()
+
+  for (const entry of packages) {
+    const pkg = unwrapPackage(entry)
+    if (include?.(pkg) === false) continue
+
+    const tsconfig = unwrapTsconfig(entry)
+    if (tsconfig !== undefined && isTsconfigReferenceTarget(tsconfig) === false) continue
+
+    const targetPath = logicalWorkspaceMemberPath({
+      fromRepoName: fromWorkspace.repoName,
+      pkg,
+    })
+    const path = formatReferencePath(
+      relativeRepoPath({
+        from: fromWorkspace.memberPath,
+        to: targetPath,
+      }),
+    )
+
+    references.set(path, { path })
+  }
+
+  return [...references.values()].toSorted((a, b) => a.path.localeCompare(b.path))
+}

--- a/packages/@overeng/genie/src/runtime/tsconfig-json/README.md
+++ b/packages/@overeng/genie/src/runtime/tsconfig-json/README.md
@@ -25,6 +25,42 @@ export default tsconfigJSON({
 - **Complete coverage**: Supports all tsconfig fields including watch options and ts-node configuration
 - **Reference support**: Project references for monorepo setups
 
+## Workspace References
+
+Keep `tsconfigJson(...)` as a direct model of `tsconfig.json`. For reusable
+cross-artifact composition, import helpers from `@overeng/genie/composition`:
+
+```ts
+import { tsconfigJson } from '@overeng/genie'
+import { tsconfigReferencesFromPackages } from '@overeng/genie/composition'
+
+import appPkg from './package.json.genie.ts'
+
+export default tsconfigJson({
+  compilerOptions: {
+    composite: true,
+    rootDir: '.',
+    outDir: './dist',
+  },
+  include: ['src/**/*.ts'],
+  references: tsconfigReferencesFromPackages({ from: appPkg }),
+})
+```
+
+When target tsconfig data is available, pass it with each package entry so the
+helper can apply TypeScript project-reference target rules such as skipping
+`noEmit: true` targets:
+
+```ts
+import utilsPkg from '../utils/package.json.genie.ts'
+import utilsTsconfig from '../utils/tsconfig.json.genie.ts'
+
+references: tsconfigReferencesFromPackages({
+  from: appPkg,
+  packages: [{ package: utilsPkg, tsconfig: utilsTsconfig }],
+})
+```
+
 ## Type Reference
 
 See [TypeScript tsconfig reference](https://www.typescriptlang.org/tsconfig) for detailed documentation on all compiler options.

--- a/packages/@overeng/genie/src/runtime/tsconfig-json/tsconfig-json.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/tsconfig-json/tsconfig-json.unit.test.ts
@@ -88,6 +88,70 @@ describe('tsconfigJson', () => {
       expect(warnSpy).not.toHaveBeenCalled()
     })
   })
+
+  describe('workspace reference validation', () => {
+    const workspacePackages = [
+      {
+        name: '@test/app',
+        path: 'packages/app',
+        dependencies: { '@test/lib': 'workspace:^' },
+        devDependencies: {},
+      },
+      {
+        name: '@test/lib',
+        path: 'packages/lib',
+        dependencies: {},
+        devDependencies: {},
+      },
+    ]
+
+    const context = ({ tsconfig }: { tsconfig: string }): GenieContext => ({
+      location: 'packages/app',
+      cwd: '/workspace',
+      workspace: {
+        packages: workspacePackages,
+        byName: new Map(workspacePackages.map((pkg) => [pkg.name, pkg])),
+      },
+      io: {
+        fileExists: (filePath) => filePath === '/workspace/packages/lib/tsconfig.json',
+        readText: (filePath) =>
+          filePath === '/workspace/packages/lib/tsconfig.json' ? tsconfig : undefined,
+      },
+      parseJsonc: ({ text }) => JSON.parse(text),
+    })
+
+    it('requires references for workspace deps that can be project reference targets', () => {
+      const result = tsconfigJson({ compilerOptions: {}, include: ['src/**/*.ts'] })
+
+      expect(
+        result.validate?.(
+          context({
+            tsconfig: JSON.stringify({ compilerOptions: { composite: true } }),
+          }),
+        ),
+      ).toEqual([
+        {
+          severity: 'error',
+          packageName: '@test/app',
+          dependency: '@test/lib',
+          message: 'Missing tsconfig reference "../lib" for workspace dependency "@test/lib"',
+          rule: 'tsconfig-references',
+        },
+      ])
+    })
+
+    it('skips workspace deps whose tsconfig disables emit', () => {
+      const result = tsconfigJson({ compilerOptions: {}, include: ['src/**/*.ts'] })
+
+      expect(
+        result.validate?.(
+          context({
+            tsconfig: JSON.stringify({ compilerOptions: { composite: true, noEmit: true } }),
+          }),
+        ),
+      ).toEqual([])
+    })
+  })
 })
 
 describe('tsconfigJsonFromPackages', () => {

--- a/packages/@overeng/genie/src/runtime/tsconfig-json/validators/references.ts
+++ b/packages/@overeng/genie/src/runtime/tsconfig-json/validators/references.ts
@@ -80,9 +80,12 @@ export const validateTsconfigReferences = ({
     // Skip deps that can't be valid project reference targets:
     // - No tsconfig.json (e.g. meta-packages like peer-deps)
     // - composite: false (e.g. Astro sites, CLI tools)
+    // - noEmit: true (TypeScript rejects referenced projects that disable emit)
     const depTsconfigPath = joinPath(ctx.cwd, depPkg.path, 'tsconfig.json')
     if (io.fileExists(depTsconfigPath) === false) continue
-    if (isCompositeProject({ tsconfigPath: depTsconfigPath, io, parseJsonc }) === false) continue
+    if (isReferenceTargetProject({ tsconfigPath: depTsconfigPath, io, parseJsonc }) === false) {
+      continue
+    }
 
     const expectedRef = computeRelativeRef({ from: ctx.location, to: depPkg.path })
     if (currentRefs.has(expectedRef) === false) {
@@ -104,14 +107,14 @@ export const validateTsconfigReferences = ({
 }
 
 /**
- * Check if a tsconfig.json has composite: true (required for project reference targets).
+ * Check if a tsconfig.json can be used as a project reference target.
  *
  * Reads the file via the injected {@link GenieIO} and parses it with the injected {@link GenieJsoncParser}
  * (the engine backs it with the same TypeScript JSONC parser the previous `ts.readConfigFile` impl used, so
  * comment-headed/JSONC tsconfigs parse identically). An unreadable or unparseable file yields `false` —
  * matching the prior `catch → false` behavior, conservatively skipping the dep as a reference target.
  */
-const isCompositeProject = ({
+const isReferenceTargetProject = ({
   tsconfigPath,
   io,
   parseJsonc,
@@ -124,7 +127,8 @@ const isCompositeProject = ({
   if (text === undefined) return false
   const config = parseJsonc({ path: tsconfigPath, text })
   if (config === undefined) return false
-  return (
-    (config as { compilerOptions?: { composite?: boolean } }).compilerOptions?.composite !== false
-  )
+  const compilerOptions = (
+    config as { compilerOptions?: { composite?: boolean; noEmit?: boolean } }
+  ).compilerOptions
+  return compilerOptions?.composite !== false && compilerOptions?.noEmit !== true
 }


### PR DESCRIPTION
## Problem

Genie's tsconfig reference validator handled one correctness bug but still left the long-term authoring model underspecified: package dependency metadata and `tsconfig.json` project references could drift because references were still normally hand-authored.

The validator also treated `composite !== false` as enough to require a project reference. TypeScript rejects referenced projects that disable emit, so `compilerOptions.noEmit: true` packages were impossible to satisfy cleanly.

## Goal

Keep `tsconfigJson(...)` as a thin artifact builder while adding an explicit reusable composition path for TypeScript project references derived from package workspace metadata.

## Decisions

- `tsconfigJson(...)` remains unaware of `packageJson(...)`; cross-artifact behavior lives in `@overeng/genie/composition`.
- The new `tsconfigReferencesFromPackages(...)` helper consumes package `meta.workspace` and renders deterministic relative `references` entries.
- TypeScript target eligibility is applied from supplied tsconfig data via `isTsconfigReferenceTarget(...)`; the helper stays runtime-safe and does not read the filesystem.
- The original validator fix remains: workspace deps whose on-disk tsconfig has `noEmit: true` are not required as references.
- The Genie VRS requirements and spec now record the long-term boundary: thin canonical export, explicit composition subpath, project-specific policy outside Genie core, semantic metadata, and tsconfig reference composition behavior.
- Adding the package export changes the Genie prepared-deps fixed output, so the Genie FOD hash was refreshed after local proof.

## Verification

- `DEVENV_TUI=false devenv tasks run genie:run --no-tui --show-output`
- `DEVENV_TUI=false devenv tasks run lint:check:genie --no-tui --show-output`
- `DEVENV_TUI=false devenv tasks run lint:check:format --no-tui --show-output`
- `DEVENV_TUI=false devenv tasks run ts:check --no-tui --show-output`
- `DEVENV_TUI=false devenv tasks run test:genie --no-tui --show-output` — 20 test files, 295 tests passed
- `DEVENV_TUI=false devenv tasks run check:quick --no-tui --show-output`
- `nix build .#genie-pnpm-deps --no-link`
- `DEVENV_TUI=false devenv tasks run nix:check:quick:genie --no-tui --show-output`
- `DEVENV_TUI=false devenv tasks run lint:nix:format --no-tui --show-output`
- `git diff --check`

## Complexity

Adds one explicit composition subpath and one helper module. The abstraction is intentional: it prevents hidden coupling between individual generators while giving repos a reusable way to avoid duplicated project-reference lists.

## Concerns

`tsconfigReferencesFromPackages(...)` assumes a package is referenceable unless corresponding tsconfig data is supplied. That keeps the helper bootstrap-safe; callers that need `noEmit` / `composite` filtering should pass `{ package, tsconfig }` entries or a project-local predicate.

## Friction & bottlenecks

Evergreen was invoked for the FOD refresh path, but both `evergreen fod reconcile` and `evergreen fod refresh` rejected the existing CLI package hash shape (`{ hash = "..."; }`) as unrecognized. The hash was therefore updated mechanically to the exact value printed by CI and then proved locally with `nix build .#genie-pnpm-deps --no-link`.

## Follow-ups

Downstream repos can adopt `@overeng/genie/composition` helpers incrementally. Project-specific wrappers should remain in repo-local Genie modules unless they satisfy the reusable composition admission rule.

A tooling follow-up is tracked in #865 to teach Evergreen to repair the current CLI package `depsBuilds = { "." = { hash = "..."; }; }` shape or migrate those files to its supported `mkSharedHash` / `mkHash` form.

## References

Refs the downstream megarepo/dotfiles investigation that exposed the tsconfig reference validator and authoring-model gap.