### PR TITLE
fix(genie): use Starlark headers for Buck outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,9 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **@overeng/genie**: Emit Starlark `#` generated-file headers for Buck2
+  `BUCK`, `.bzl`, and `.bxl` outputs.
+
 - **@overeng/genie**: Tighten package-json export environment validation so
   constrained profiles reject bare Node builtin imports, follow extensionless
   directory entrypoints, and resolve overlapping conditional exports in emitted

--- a/packages/@overeng/genie/src/core/generation.ts
+++ b/packages/@overeng/genie/src/core/generation.ts
@@ -354,7 +354,7 @@ const loadOxfmtConfig = Effect.fn('loadOxfmtConfig')(function* ({
  * ensures consistent output regardless of where genie is invoked, since the `.genie.ts` source
  * file is always a sibling of the generated file.
  */
-const getHeaderComment = ({
+export const getHeaderComment = ({
   targetFilePath,
   sourceFile,
 }: {
@@ -380,6 +380,10 @@ const getHeaderComment = ({
   }
 
   if (ext === '.yml' || ext === '.yaml') {
+    return `# Generated file - DO NOT EDIT\n# Source: ${sourceFile}\n\n`
+  }
+
+  if (basename === 'BUCK' || ext === '.bzl' || ext === '.bxl') {
     return `# Generated file - DO NOT EDIT\n# Source: ${sourceFile}\n\n`
   }
 

--- a/packages/@overeng/genie/src/core/generation.unit.test.ts
+++ b/packages/@overeng/genie/src/core/generation.unit.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { getHeaderComment } from './generation.ts'
+
+describe('getHeaderComment', () => {
+  it.each(['BUCK', 'defs.bzl', 'tooling.bxl'])(
+    'uses Starlark comments for %s',
+    (targetFilePath) => {
+      expect(
+        getHeaderComment({
+          targetFilePath,
+          sourceFile: `${targetFilePath}.genie.ts`,
+        }),
+      ).toBe(`# Generated file - DO NOT EDIT\n# Source: ${targetFilePath}.genie.ts\n\n`)
+    },
+  )
+})


### PR DESCRIPTION
**Problem**

Genie generated-file headers default to JavaScript comment syntax for unknown file types. Buck/Starlark files (`BUCK`, `.bzl`, `.bxl`) use `#` comments, so downstream Buck2-generated files needed a local patch to avoid invalid output.

**Goal**

Make Buck/Starlark generated files first-class in Genie so downstream repos do not carry a private header patch.

**Decisions**

- Keep this PR intentionally narrow: only generated-file header selection for Buck/Starlark outputs.
- Do not include compiled Genie runtime or TypeScript validation changes here. Those need a separate design around Nix-supplied compiler tooling (`tsgo`/`tsc`) rather than staged `node_modules` plumbing.
- Export `getHeaderComment` so the behavior can be covered directly without setting up a full generation fixture.

**Verification**

- `devenv tasks run test:genie --no-tui`
- `devenv tasks run ts:check --no-tui`
- `devenv tasks run lint:check --no-tui`
- `git diff --check`

All commands passed locally.

**Complexity**

No new abstraction. This extends existing header selection with Starlark filename/extension cases and a direct unit test.

**Concerns**

None for the header behavior. The broader compiled-runtime/TypeScript validation question is intentionally excluded from this PR.

**Friction & bottlenecks**

The original combined PR exposed that compiled Genie validation currently wants JS TypeScript module resolution from staged imports. That is a design concern and is split out of this PR.

**Follow-ups**

- Design the package export type-proof validator around explicit Nix/toolchain inputs (`tsgo`/`tsc`) instead of `GENIE_STAGED_NODE_MODULES` or dynamic JS `typescript` resolution.

**References**

- Split from the earlier broad draft of this PR.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🐤 co2-finch |
| `agent_session_id` | 6163ec43-db79-47e5-953d-99f93e419b1d |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.141.0 |
| `agent_runtime` | Codex CLI 0.141.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/j8g5g7wc6hy0r9pfk4gxgpqaq72l74ya-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/159fz94pwvcwdq8a4rycipc0v2w9wd6a-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling/2026-06-29-genie-buck-runtime-fixes |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->