### PR TITLE
fix(genie): keep peer authoring helpers pure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,10 @@ All notable changes to this project will be documented in this file.
 - **@overeng/genie**: Emit Starlark `#` generated-file headers for Buck2
   `BUCK`, `.bzl`, and `.bxl` outputs.
 
+- **@overeng/genie**: Keep peer repo Genie authoring helpers from importing
+  engine-only validation internals by sourcing repo-context helpers directly
+  instead of through the broad node runtime entry.
+
 - **@overeng/genie**: Tighten package-json export environment validation so
   constrained profiles reject bare Node builtin imports, follow extensionless
   directory entrypoints, and resolve overlapping conditional exports in emitted

--- a/genie/external.ts
+++ b/genie/external.ts
@@ -60,13 +60,14 @@ import {
   type WorkspacePackageLike,
 } from '../packages/@overeng/genie/src/runtime/mod.ts'
 /**
- * Repo-context discovery is node-only (reads the filesystem via `import.meta.url`), so it is sourced from the
- * `@overeng/genie/node` entry. Peer repos consume `external.ts` to author genie configs at engine (node) time.
+ * Repo-context discovery is node-only (reads the filesystem via `import.meta.url`), but importing the broad
+ * `@overeng/genie/node` entry also pulls engine validation internals into peer repo Genie files. Import the
+ * repo-context surface directly so downstream authoring helpers stay free of engine-only dependencies.
  */
 import {
   defineRepoContext,
   type RepoContext,
-} from '../packages/@overeng/genie/src/runtime/node/mod.ts'
+} from '../packages/@overeng/genie/src/runtime/repo-context/mod.ts'
 /**
  * Exceptional export: downstream repos that define `workspaceMember()` factories
  * need this type for the optional `pnpmPackageClosure` parameter in `WorkspaceIdentity`.


### PR DESCRIPTION
**Problem**

Peer repos import `genie/external.ts` to author `.genie.ts` files. That helper imported `defineRepoContext` from the broad `@overeng/genie/node` entry, which also re-exports engine-only validation internals. Downstream authoring imports could therefore pull package-json validation code into staged Genie file imports.

**Goal**

Keep peer repo Genie authoring helpers on the narrow authoring/runtime surface while still allowing repo-context discovery where it is needed.

**Decisions**

- Import repo-context directly from `src/runtime/repo-context/mod.ts` instead of through the broad node runtime barrel.
- Keep this PR separate from the Starlark header PR (#870) and the compiler-toolchain design PR (#872).
- Do not introduce a staged `node_modules` workaround; this PR removes an accidental import path instead.

**Verification**

- `devenv tasks run test:genie --no-tui`
- `devenv tasks run ts:check --no-tui`
- `devenv tasks run lint:check --no-tui`
- `git diff --check`

All passed locally.

**Complexity**

No new abstraction. This narrows an import to the module that owns the needed API.

**Concerns**

This does not implement the long-term strict TypeScript proof toolchain. That remains tracked in #871 and designed in #872.

**Friction & bottlenecks**

This was discovered while splitting an overly broad runtime-fix draft. The split clarified that authoring-surface purity and compiler-toolchain choice are separate problems.

**Follow-ups**

- #871: implement `tsgo`-backed strict export type proof.

**References**

Stacked on #870. Refs #871 and #872.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🐤 co2-finch |
| `agent_session_id` | 6163ec43-db79-47e5-953d-99f93e419b1d |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.141.0 |
| `agent_runtime` | Codex CLI 0.141.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/j8g5g7wc6hy0r9pfk4gxgpqaq72l74ya-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/159fz94pwvcwdq8a4rycipc0v2w9wd6a-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-06-29-genie-authoring-boundary |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->