### PR TITLE
fix(devenv): call real oxfmt from lint tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -615,6 +615,11 @@ jobs:
             }
 
             repair_nix_daemon() {
+              if [ "${NIX_GC_RACE_SKIP_DAEMON_REPAIR:-0}" = 1 ]; then
+                echo "::warning::Nix daemon repair skipped by NIX_GC_RACE_SKIP_DAEMON_REPAIR=1"
+                return 0
+              fi
+
               echo "::warning::Nix daemon socket is unavailable; attempting daemon restart before retry"
 
               if command -v launchctl >/dev/null 2>&1; then
@@ -770,6 +775,11 @@ jobs:
             }
 
             repair_nix_daemon() {
+              if [ "${NIX_GC_RACE_SKIP_DAEMON_REPAIR:-0}" = 1 ]; then
+                echo "::warning::Nix daemon repair skipped by NIX_GC_RACE_SKIP_DAEMON_REPAIR=1"
+                return 0
+              fi
+
               echo "::warning::Nix daemon socket is unavailable; attempting daemon restart before retry"
 
               if command -v launchctl >/dev/null 2>&1; then
@@ -1156,6 +1166,11 @@ jobs:
             }
 
             repair_nix_daemon() {
+              if [ "${NIX_GC_RACE_SKIP_DAEMON_REPAIR:-0}" = 1 ]; then
+                echo "::warning::Nix daemon repair skipped by NIX_GC_RACE_SKIP_DAEMON_REPAIR=1"
+                return 0
+              fi
+
               echo "::warning::Nix daemon socket is unavailable; attempting daemon restart before retry"
 
               if command -v launchctl >/dev/null 2>&1; then
@@ -1545,6 +1560,11 @@ jobs:
             }
 
             repair_nix_daemon() {
+              if [ "${NIX_GC_RACE_SKIP_DAEMON_REPAIR:-0}" = 1 ]; then
+                echo "::warning::Nix daemon repair skipped by NIX_GC_RACE_SKIP_DAEMON_REPAIR=1"
+                return 0
+              fi
+
               echo "::warning::Nix daemon socket is unavailable; attempting daemon restart before retry"
 
               if command -v launchctl >/dev/null 2>&1; then
@@ -1931,6 +1951,11 @@ jobs:
             }
 
             repair_nix_daemon() {
+              if [ "${NIX_GC_RACE_SKIP_DAEMON_REPAIR:-0}" = 1 ]; then
+                echo "::warning::Nix daemon repair skipped by NIX_GC_RACE_SKIP_DAEMON_REPAIR=1"
+                return 0
+              fi
+
               echo "::warning::Nix daemon socket is unavailable; attempting daemon restart before retry"
 
               if command -v launchctl >/dev/null 2>&1; then
@@ -2320,6 +2345,11 @@ jobs:
             }
 
             repair_nix_daemon() {
+              if [ "${NIX_GC_RACE_SKIP_DAEMON_REPAIR:-0}" = 1 ]; then
+                echo "::warning::Nix daemon repair skipped by NIX_GC_RACE_SKIP_DAEMON_REPAIR=1"
+                return 0
+              fi
+
               echo "::warning::Nix daemon socket is unavailable; attempting daemon restart before retry"
 
               if command -v launchctl >/dev/null 2>&1; then
@@ -2626,6 +2656,11 @@ jobs:
             }
 
             repair_nix_daemon() {
+              if [ "${NIX_GC_RACE_SKIP_DAEMON_REPAIR:-0}" = 1 ]; then
+                echo "::warning::Nix daemon repair skipped by NIX_GC_RACE_SKIP_DAEMON_REPAIR=1"
+                return 0
+              fi
+
               echo "::warning::Nix daemon socket is unavailable; attempting daemon restart before retry"
 
               if command -v launchctl >/dev/null 2>&1; then
@@ -3558,6 +3593,11 @@ jobs:
             }
 
             repair_nix_daemon() {
+              if [ "${NIX_GC_RACE_SKIP_DAEMON_REPAIR:-0}" = 1 ]; then
+                echo "::warning::Nix daemon repair skipped by NIX_GC_RACE_SKIP_DAEMON_REPAIR=1"
+                return 0
+              fi
+
               echo "::warning::Nix daemon socket is unavailable; attempting daemon restart before retry"
 
               if command -v launchctl >/dev/null 2>&1; then
@@ -8336,6 +8376,11 @@ jobs:
             }
 
             repair_nix_daemon() {
+              if [ "${NIX_GC_RACE_SKIP_DAEMON_REPAIR:-0}" = 1 ]; then
+                echo "::warning::Nix daemon repair skipped by NIX_GC_RACE_SKIP_DAEMON_REPAIR=1"
+                return 0
+              fi
+
               echo "::warning::Nix daemon socket is unavailable; attempting daemon restart before retry"
 
               if command -v launchctl >/dev/null 2>&1; then
@@ -8725,6 +8770,11 @@ jobs:
             }
 
             repair_nix_daemon() {
+              if [ "${NIX_GC_RACE_SKIP_DAEMON_REPAIR:-0}" = 1 ]; then
+                echo "::warning::Nix daemon repair skipped by NIX_GC_RACE_SKIP_DAEMON_REPAIR=1"
+                return 0
+              fi
+
               echo "::warning::Nix daemon socket is unavailable; attempting daemon restart before retry"
 
               if command -v launchctl >/dev/null 2>&1; then
@@ -9142,6 +9192,11 @@ jobs:
             }
 
             repair_nix_daemon() {
+              if [ "${NIX_GC_RACE_SKIP_DAEMON_REPAIR:-0}" = 1 ]; then
+                echo "::warning::Nix daemon repair skipped by NIX_GC_RACE_SKIP_DAEMON_REPAIR=1"
+                return 0
+              fi
+
               echo "::warning::Nix daemon socket is unavailable; attempting daemon restart before retry"
 
               if command -v launchctl >/dev/null 2>&1; then
@@ -9285,6 +9340,11 @@ jobs:
             }
 
             repair_nix_daemon() {
+              if [ "${NIX_GC_RACE_SKIP_DAEMON_REPAIR:-0}" = 1 ]; then
+                echo "::warning::Nix daemon repair skipped by NIX_GC_RACE_SKIP_DAEMON_REPAIR=1"
+                return 0
+              fi
+
               echo "::warning::Nix daemon socket is unavailable; attempting daemon restart before retry"
 
               if command -v launchctl >/dev/null 2>&1; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,10 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **CI**: Keep the standalone Nix retry helper aligned with the generated
+  workflow helper for missing daemon-socket failures, and cover the daemon
+  retry path in helper tests.
+
 - **@overeng/genie**: Emit Starlark `#` generated-file headers for Buck2
   `BUCK`, `.bzl`, and `.bxl` outputs.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,10 @@ All notable changes to this project will be documented in this file.
   workflow helper for missing daemon-socket failures, and cover the daemon
   retry path in helper tests.
 
+- **@overeng/pty-effect**: Stabilize the daemon env override live test on macOS
+  by keeping the short-lived PTY session alive long enough for peek/attach
+  assertions.
+
 - **@overeng/genie**: Emit Starlark `#` generated-file headers for Buck2
   `BUCK`, `.bzl`, and `.bxl` outputs.
 

--- a/genie/ci-scripts/nix-gc-race-retry.sh
+++ b/genie/ci-scripts/nix-gc-race-retry.sh
@@ -6,7 +6,7 @@ run_nix_gc_race_retry() {
   local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
   local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
   local attempt=1
-  local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature had_errexit
+  local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature saw_daemon_socket_failure had_errexit
 
   start="$(date +%s)"
 
@@ -20,6 +20,36 @@ run_nix_gc_race_retry() {
       echo "- Attempts: $attempt/$max"
       [ -z "${2:-}" ] || echo "- Note: $2"
     } >> "$GITHUB_STEP_SUMMARY"
+  }
+
+  repair_nix_daemon() {
+    if [ "${NIX_GC_RACE_SKIP_DAEMON_REPAIR:-0}" = 1 ]; then
+      echo "::warning::Nix daemon repair skipped by NIX_GC_RACE_SKIP_DAEMON_REPAIR=1"
+      return 0
+    fi
+
+    echo "::warning::Nix daemon socket is unavailable; attempting daemon restart before retry"
+
+    if command -v launchctl >/dev/null 2>&1; then
+      sudo launchctl kickstart -k system/org.nixos.nix-daemon >/dev/null 2>&1 || true
+    fi
+
+    if command -v systemctl >/dev/null 2>&1; then
+      sudo systemctl restart nix-daemon.socket >/dev/null 2>&1 || true
+      sudo systemctl restart nix-daemon.service >/dev/null 2>&1 || true
+      sudo systemctl restart nix-daemon >/dev/null 2>&1 || true
+    fi
+
+    if [ ! -S /nix/var/nix/daemon-socket/socket ] && [ -x /nix/var/nix/profiles/default/bin/nix-daemon ]; then
+      sudo /nix/var/nix/profiles/default/bin/nix-daemon --daemon >/tmp/nix-daemon-restart.log 2>&1 || true
+    fi
+
+    for _ in 1 2 3 4 5; do
+      [ -S /nix/var/nix/daemon-socket/socket ] && return 0
+      sleep 1
+    done
+
+    return 0
   }
 
   while [ "$attempt" -le "$max" ]; do
@@ -62,7 +92,7 @@ run_nix_gc_race_retry() {
       return 0
     fi
 
-    flattened=$(tr '\r\n' '  ' < "$log" | sed -E $'s/\x1B\\[[0-9;]*m//g')
+    flattened=$(tr '\r\n' '  ' < "$log" | sed -E $'s/\x1B\[[0-9;]*m//g')
     path=$(printf '%s' "$flattened" |
       grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" |
       head -1 |
@@ -71,19 +101,24 @@ run_nix_gc_race_retry() {
     saw_invalid_path=false
     saw_cachix_signature=false
     saw_fetch_signature=false
+    saw_daemon_socket_failure=false
     [ -n "$path" ] && saw_invalid_path=true
     printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
     printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
     printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*cannot read file from tarball:[[:space:]]*Truncated tar archive detected while reading data' && saw_fetch_signature=true || true
+    printf '%s' "$flattened" | grep -Eq "error:[[:space:]]*cannot connect to socket at '/nix/var/nix/daemon-socket/socket'" && saw_daemon_socket_failure=true || true
     rm -f "$log"
 
-    if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ] && [ "$saw_fetch_signature" != true ]; then
+    if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ] && [ "$saw_fetch_signature" != true ] && [ "$saw_daemon_socket_failure" != true ]; then
       echo "::warning::[ci] $task failed after $elapsed s without a detected transient Nix failure"
       write_summary failure "No transient Nix failure signature detected"
       return "$rc"
     fi
 
-    if [ "$saw_fetch_signature" = true ]; then
+    if [ "$saw_daemon_socket_failure" = true ]; then
+      repair_nix_daemon
+      echo "::warning::Nix daemon socket failure detected for $task (attempt $attempt/$max); retrying after daemon repair"
+    elif [ "$saw_fetch_signature" = true ]; then
       echo "::warning::Nix source fetch corruption detected for $task (attempt $attempt/$max); retrying with a refreshed eval cache"
     elif [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
       echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"

--- a/genie/ci-scripts/nix-gc-race-retry.test.sh
+++ b/genie/ci-scripts/nix-gc-race-retry.test.sh
@@ -37,7 +37,34 @@ trap 'rm -rf "$test_dir"' EXIT
 echo "Running nix GC race retry helper tests..."
 echo ""
 
-echo "Test 1: retries invalid-store-path failures and succeeds on the next attempt"
+echo "Test 1: standalone helper stays aligned with workflow helper source"
+node - "$ROOT" <<'NODE'
+const { readFileSync } = require('node:fs')
+const { join } = require('node:path')
+
+const root = process.argv[2]
+const standalone = readFileSync(
+  join(root, 'genie/ci-scripts/nix-gc-race-retry.sh'),
+  'utf8',
+).trimEnd()
+const sharedSource = readFileSync(join(root, 'genie/ci-workflow/shared.ts'), 'utf8')
+const match = sharedSource.match(
+  /const nixGcRaceRetryScript = String\.raw`([\s\S]*?)`\n\n\/\*\*/,
+)
+
+if (match === null) {
+  console.error('FAIL: unable to locate nixGcRaceRetryScript in shared.ts')
+  process.exit(1)
+}
+
+const embedded = match[1].replaceAll('${dollar}', '$').trimEnd()
+if (standalone !== embedded) {
+  console.error('FAIL: standalone helper drifted from workflow helper source')
+  process.exit(1)
+}
+NODE
+
+echo "Test 2: retries invalid-store-path failures and succeeds on the next attempt"
 retry_fixture="$test_dir/retry-fixture.sh"
 cat > "$retry_fixture" <<EOF
 #!/usr/bin/env bash
@@ -58,7 +85,7 @@ chmod +x "$retry_fixture"
 CI_PROGRESS_HEARTBEAT_SECONDS=1 NIX_GC_RACE_MAX_RETRIES=2 run_nix_gc_race_retry "retry-fixture" "$retry_fixture" >/dev/null
 assert_eq "2" "$(cat "$test_dir/retry-attempt")" "invalid-store-path retry count"
 
-echo "Test 2: retries cachix wrapper failures without an extracted store path"
+echo "Test 3: retries cachix wrapper failures without an extracted store path"
 cachix_fixture="$test_dir/cachix-fixture.sh"
 cat > "$cachix_fixture" <<EOF
 #!/usr/bin/env bash
@@ -80,7 +107,7 @@ chmod +x "$cachix_fixture"
 CI_PROGRESS_HEARTBEAT_SECONDS=1 NIX_GC_RACE_MAX_RETRIES=2 run_nix_gc_race_retry "cachix-fixture" "$cachix_fixture" >/dev/null
 assert_eq "2" "$(cat "$test_dir/cachix-attempt")" "cachix wrapper retry count"
 
-echo "Test 3: retries truncated Nix input tarball failures"
+echo "Test 4: retries truncated Nix input tarball failures"
 fetch_fixture="$test_dir/fetch-fixture.sh"
 cat > "$fetch_fixture" <<EOF
 #!/usr/bin/env bash
@@ -101,13 +128,35 @@ chmod +x "$fetch_fixture"
 CI_PROGRESS_HEARTBEAT_SECONDS=1 NIX_GC_RACE_MAX_RETRIES=2 run_nix_gc_race_retry "fetch-fixture" "$fetch_fixture" >/dev/null
 assert_eq "2" "$(cat "$test_dir/fetch-attempt")" "truncated tarball retry count"
 
-echo "Test 4: does not retry when literal signature strings appear outside Nix error context"
+echo "Test 5: retries missing Nix daemon socket failures"
+daemon_fixture="$test_dir/daemon-fixture.sh"
+cat > "$daemon_fixture" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+attempt_file="$test_dir/daemon-attempt"
+attempt=1
+if [ -f "\$attempt_file" ]; then
+  attempt=\$(cat "\$attempt_file")
+fi
+if [ "\$attempt" -eq 1 ]; then
+  echo 2 > "\$attempt_file"
+  echo "error: cannot connect to socket at '/nix/var/nix/daemon-socket/socket': No such file or directory" >&2
+  exit 1
+fi
+echo "daemon recovered"
+EOF
+chmod +x "$daemon_fixture"
+CI_PROGRESS_HEARTBEAT_SECONDS=1 NIX_GC_RACE_MAX_RETRIES=2 NIX_GC_RACE_SKIP_DAEMON_REPAIR=1 run_nix_gc_race_retry "daemon-fixture" "$daemon_fixture" >/dev/null
+assert_eq "2" "$(cat "$test_dir/daemon-attempt")" "Nix daemon socket retry count"
+
+echo "Test 6: does not retry when literal signature strings appear outside Nix error context"
 false_positive_fixture="$test_dir/false-positive-fixture.sh"
 cat > "$false_positive_fixture" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 echo "AssertionError: expected source to contain Failed to convert config.cachix to JSON" >&2
 echo "source snippet: while evaluating the option cachix.package" >&2
+echo "source snippet: cannot connect to socket at '/nix/var/nix/daemon-socket/socket'" >&2
 exit 9
 EOF
 chmod +x "$false_positive_fixture"
@@ -117,7 +166,7 @@ exit_code=$?
 set -e
 assert_exit_code 9 "$exit_code" "non-error-context strings do not trigger retries"
 
-echo "Test 5: preserves the original exit code when no retry signature is present"
+echo "Test 7: preserves the original exit code when no retry signature is present"
 non_retry_fixture="$test_dir/non-retry-fixture.sh"
 cat > "$non_retry_fixture" <<'EOF'
 #!/usr/bin/env bash

--- a/genie/ci-workflow/shared.ts
+++ b/genie/ci-workflow/shared.ts
@@ -376,6 +376,11 @@ run_nix_gc_race_retry() {
   }
 
   repair_nix_daemon() {
+    if [ "${dollar}{NIX_GC_RACE_SKIP_DAEMON_REPAIR:-0}" = 1 ]; then
+      echo "::warning::Nix daemon repair skipped by NIX_GC_RACE_SKIP_DAEMON_REPAIR=1"
+      return 0
+    fi
+
     echo "::warning::Nix daemon socket is unavailable; attempting daemon restart before retry"
 
     if command -v launchctl >/dev/null 2>&1; then

--- a/megarepo.lock
+++ b/megarepo.lock
@@ -4,9 +4,9 @@
     "effect": {
       "url": "https://github.com/effect-ts/effect",
       "ref": "main",
-      "commit": "05d72eab7bac3444ca20d871d4c65a272200ef0e",
+      "commit": "cfa2bbf7f290e88e2c57480eb9b2d7b058389cda",
       "pinned": false,
-      "lockedAt": "2026-06-07T10:49:55.434Z"
+      "lockedAt": "2026-06-29T16:03:20.461Z"
     }
   }
 }

--- a/nix/devenv-modules/tasks/shared/lint-oxc.nix
+++ b/nix/devenv-modules/tasks/shared/lint-oxc.nix
@@ -169,7 +169,7 @@ let
       guard = "oxfmt";
       description = "Check code formatting with oxfmt";
       exec = trace.exec "lint:check:format" (mkLintExec {
-        command = "oxfmt --check";
+        command = "${pkgs.oxfmt}/bin/oxfmt --check";
         includeCase = oxfmtIncludeCase;
         emptySelectionDiagnostic = "Expected at least one target file";
       });
@@ -188,7 +188,7 @@ let
       guard = "oxfmt";
       description = "Fix code formatting with oxfmt";
       exec = trace.exec "lint:fix:format" (mkLintExec {
-        command = "oxfmt";
+        command = "${pkgs.oxfmt}/bin/oxfmt";
         includeCase = oxfmtIncludeCase;
         emptySelectionDiagnostic = "Expected at least one target file";
       });

--- a/nix/devenv-modules/tasks/shared/lint-oxc.nix
+++ b/nix/devenv-modules/tasks/shared/lint-oxc.nix
@@ -46,10 +46,13 @@
   # Whether to treat warnings as errors. Set to false for repos with many
   # existing warnings that can't be fixed immediately.
   denyWarnings ? true,
+  # Real derivation/path backing the formatter guard. Defaults to pkgs.oxfmt but
+  # stays injectable so module tests can prove absolute-path execution without
+  # depending on PATH shadowing.
+  oxfmtPkg ? null,
   # Real derivation/path backing the `oxlint` guard (e.g. the plugin-injecting
   # oxlint wrapper). When set, the guard owns `bin/oxlint` and exec's this by
-  # absolute path under passthrough (see cli-guard.nix). The `oxfmt` guard uses
-  # pkgs.oxfmt directly since that is in-module.
+  # absolute path under passthrough (see cli-guard.nix).
   oxlintPkg ? null,
 }:
 { lib, pkgs, ... }:
@@ -150,6 +153,7 @@ let
   # Type-aware linting flags (enabled when tsconfig is provided)
   typeAwareFlags = if tsconfig != null then "--type-aware --tsconfig ${tsconfig}" else "";
   warningsFlag = if denyWarnings then "--deny-warnings" else "";
+  resolvedOxfmtPkg = if oxfmtPkg == null then pkgs.oxfmt else oxfmtPkg;
 
   # Plugin injection is handled by oxlint-with-plugins wrapper on PATH.
   # Consumers should add oxlint-with-plugins to devenv packages instead of
@@ -169,7 +173,7 @@ let
       guard = "oxfmt";
       description = "Check code formatting with oxfmt";
       exec = trace.exec "lint:check:format" (mkLintExec {
-        command = "${pkgs.oxfmt}/bin/oxfmt --check";
+        command = "${resolvedOxfmtPkg}/bin/oxfmt --check";
         includeCase = oxfmtIncludeCase;
         emptySelectionDiagnostic = "Expected at least one target file";
       });
@@ -188,7 +192,7 @@ let
       guard = "oxfmt";
       description = "Fix code formatting with oxfmt";
       exec = trace.exec "lint:fix:format" (mkLintExec {
-        command = "${pkgs.oxfmt}/bin/oxfmt";
+        command = "${resolvedOxfmtPkg}/bin/oxfmt";
         includeCase = oxfmtIncludeCase;
         emptySelectionDiagnostic = "Expected at least one target file";
       });
@@ -301,7 +305,7 @@ in
     ++ cliGuard.fromTasks {
       tasks = guardedTasks;
       reals = {
-        oxfmt = pkgs.oxfmt;
+        oxfmt = resolvedOxfmtPkg;
       }
       // lib.optionalAttrs (oxlintPkg != null) { oxlint = oxlintPkg; };
     };

--- a/nix/devenv-modules/tasks/shared/tests/lint-oxc-file-list.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/lint-oxc-file-list.test.sh
@@ -42,6 +42,7 @@ extract_lint_task_script() {
     let
       flake = builtins.getFlake (toString $ROOT);
       pkgs = import flake.inputs.nixpkgs { system = builtins.currentSystem; };
+      oxfmtPkg = builtins.getEnv \"TEST_FAKE_OXFMT_PKG\";
       evaluated = pkgs.lib.evalModules {
         modules = [
           ({ ... }: {
@@ -53,6 +54,7 @@ extract_lint_task_script() {
             lintPaths = [ \".\" ];
             geniePatterns = [ ];
             genieCoverageDirs = [ \".\" ];
+            oxfmtPkg = oxfmtPkg;
           }) {
             pkgs = pkgs;
             lib = pkgs.lib;
@@ -99,6 +101,7 @@ printf '%s\n' "$@" > "${TEST_OXFMT_ARGS:?}"
 EOF
 chmod +x "$tmpdir/bin/oxfmt"
 chmod +x "$tmpdir/bin/oxlint"
+export TEST_FAKE_OXFMT_PKG="$tmpdir"
 
 cat > "$workspace/keep.ts" <<'EOF'
 export const keep = true

--- a/packages/@overeng/pty-effect/src/client.test.ts
+++ b/packages/@overeng/pty-effect/src/client.test.ts
@@ -188,7 +188,7 @@ describe('PtyClient', () => {
           yield* client.spawnDaemon({
             name,
             command: 'sh',
-            args: ['-c', 'echo "ENV:$PTY_EFFECT_TEST_VALUE" && sleep 0.05'],
+            args: ['-c', 'echo "ENV:$PTY_EFFECT_TEST_VALUE" && sleep 0.5'],
             env: { PTY_EFFECT_TEST_VALUE: marker },
           })
 


### PR DESCRIPTION
**Problem**

The devenv OXC/oxfmt lint task wrapper could recursively resolve to the task wrapper itself instead of the real formatter executable. While validating the PR, CI also exposed two separate reliability issues in the test lane:

- The Namespace Linux test job hit a runner-side missing Nix daemon socket during its shell self-test.
- The macOS test job later exposed a real test race in `@overeng/pty-effect`: the env override live test used a 50ms session lifetime and could exit before `peek`/`attach` observed the session.

**Goal**

Make the formatter task call the intended `oxfmt` binary and leave the PR with durable CI coverage rather than relying on reruns for flaky surfaces.

**Decisions**

- Keep the formatter task on an explicit package path instead of ambient PATH lookup.
- Treat the Nix daemon socket failure as runner instability, but harden the reusable CI helper anyway: the standalone helper now matches the generated workflow helper, includes daemon-socket retry/repair behavior, and has an alignment test to prevent future drift.
- Stabilize the macOS pty live test by keeping the spawned session alive for 0.5s, matching nearby live tests that assert post-spawn screen state.

Flaky options considered:

- Rerun only: rejected because it would not cover the daemon-socket retry helper drift or the pty test race.
- Add broad sleeps/retries around all pty client calls: rejected as too blunt.
- Chosen: make the specific short-lived live test exercise the intended behavior with a sufficient session lifetime, and add focused retry-helper coverage.

**Verification**

Local:

- `bash genie/ci-scripts/nix-gc-race-retry.test.sh` passed.
- `devenv tasks run genie:check --no-tui` passed.
- `devenv tasks run check:quick --no-tui` passed.
- `devenv tasks run test:pty-effect --no-tui` passed.
- `devenv tasks run test:run --no-tui` passed.

CI:

- CI run 4079 passed: https://github.com/overengineeringstudio/effect-utils/actions/runs/28430606156

**Complexity**

Small increase in test coverage and one injectable formatter package parameter for module tests. The production path still defaults to `pkgs.oxfmt` and remains explicit.

**Concerns**

The Nix daemon socket incident is runner-side. This PR improves recovery/test coverage for that failure mode, but it does not eliminate possible future runner daemon outages.

**Friction & bottlenecks**

GitHub error summaries for the failed jobs surfaced echoed workflow shell source as `::error::` lines, obscuring the actual failure. Pulling raw job logs was required to distinguish runner failure from product test failure.

**Follow-ups**

A deeper cleanup would make the retry helper truly single-source generated instead of inline-plus-standalone with an alignment test. This PR keeps the smaller durable guard because downstream Genie imports currently need the inline helper to remain bootstrap-safe.

**References**

- Latest proving commit: `a739d4e43`
- Green CI run: https://github.com/overengineeringstudio/effect-utils/actions/runs/28430606156

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | ♨️ co3-ember |
| `agent_session_id` | 87fe29bd-11be-4978-b6d2-912995b155b4 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.141.0 |
| `agent_runtime` | Codex CLI 0.141.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/ynb6b5csz0wgbwqw1c43flnp450v5bjv-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/pqhvj5xhdaw62mi7dm62a7i7pwk9wpjj-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | 025eab9f587c5843e6e47512b816cab3ddfeb0cb/schickling/2026-06-29-devenv-oxfmt-guard |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@f43f9f1 |
</details>
<!-- agent-footer:end -->