### PR TITLE
Dogfood otel-scrape in devenv tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,12 @@ All notable changes to this project will be documented in this file.
   that observes fork/vfork/clone, exec, and exit events for a traced child tree
   and validates exact descendant evidence with a compiled process-DAG fixture.
 
+- **otel-scrape / devenv**: Dogfood `otel-scrape` across effect-utils devenv
+  task execution, status checks, Storybook processes, Netlify/SecretSpec tasks,
+  and aggregate gates via the shared `trace.nix` task wrapper. Local task runs
+  now write summary evidence under `tmp/otel-scrape-dogfood/summaries` by
+  default and `check:*` runs a source audit to catch new unwrapped task scripts.
+
 - **@overeng/genie**: Add the explicit `@overeng/genie/composition` subpath for
   reusable cross-artifact composition helpers. The first helper,
   `tsconfigReferencesFromPackages`, projects TypeScript project references from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,14 @@ All notable changes to this project will be documented in this file.
   now write summary evidence under `tmp/otel-scrape-dogfood/summaries` by
   default and `check:*` runs a source audit to catch new unwrapped task scripts.
 
+- **otel-scrape**: Document the adapter admission policy and exact process
+  helper boundary. New build-tool adapters stay rejected until they land as a
+  vertical slice with a structured source contract, passthrough preservation,
+  privacy and degraded-mode tests, classification justification, generated
+  contract updates, and consumer evidence for cross-package/profile contracts.
+  Default exact process-tree support remains helper-gated rather than ptrace or
+  sampled snapshots.
+
 - **@overeng/genie**: Add the explicit `@overeng/genie/composition` subpath for
   reusable cross-artifact composition helpers. The first helper,
   `tsconfigReferencesFromPackages`, projects TypeScript project references from

--- a/context/otel-scrape/.decisions/0012-adapter-admission-policy.md
+++ b/context/otel-scrape/.decisions/0012-adapter-admission-policy.md
@@ -1,0 +1,71 @@
+# 0012 - Adapter admission is a vertical-slice gate
+
+Status: accepted
+
+## Context
+
+`otel-scrape` is useful only if adapter output is trustworthy. Build tools
+expose many tempting signals, but weak adapters that parse human logs, leak
+local paths, or emit span-per-line structures would make the trace tree look
+precise while hiding unsupported evidence.
+
+## Evidence and Argument
+
+The existing supported adapters prove different source shapes:
+
+- `oxlint` uses structured JSON diagnostics and keeps filenames hashed.
+- `node-cpuprofile` uses a native profile artifact and the CAS profile lane.
+
+The deferred candidates are useful, but each has a contract gap that should be
+closed before CLI support:
+
+- `tsc --generateTrace` needs artifact grouping, retention size, and
+  phase-to-span semantics.
+- Cargo JSON/timings need stable compile-unit/event and artifact semantics.
+- Vitest needs stable suite/test identity and nested-wrapper ownership.
+- Package-manager phases and Vite need a structured-source audit so we do not
+  promote debug logs or progress output into first-class telemetry.
+
+Accepting candidate names as placeholders would make unsupported evidence look
+supported and would weaken the support matrix.
+
+## Options
+
+| Option                                                      | Consequence                                                                                                                       |
+| ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| Admit adapters only after a full vertical slice             | Slower fleet growth, but each supported adapter has structured input, privacy, degradation, registry, contract, and E2E evidence. |
+| Accept candidate adapter names early and degrade at runtime | Easier demos, but unsupported evidence appears first-class and downstream users cannot distinguish placeholder support.           |
+| Parse human logs as a generic adapter fallback              | Broad coverage, but unstable source text and progress output become a false schema.                                               |
+
+## Decision
+
+New adapters are admitted only through a complete vertical slice. The adapter
+must define its structured input source, output kinds, privacy boundary,
+degradation behavior, generated-registry additions, and consumer evidence before
+it is listed as supported.
+
+Candidate order is:
+
+1. keep `oxlint` and `node-cpuprofile` as supported baseline adapters,
+2. add `tsc --generateTrace` when trace artifact grouping and CAS handoff are
+   specified,
+3. add Cargo JSON/timings when a stable compile-unit and profile mapping is
+   specified,
+4. add Vitest JSON or OTEL-aware test output when suite/test identity is stable,
+5. add package-manager phases and Vite profiles only after a structured-source
+   audit proves they avoid debug-log parsing.
+
+Adapters may remain documented as candidates before implementation, but support
+matrices must distinguish candidates from supported adapters. The CLI must not
+accept candidate adapter names as placeholders.
+
+## Consequences
+
+- Adapter growth optimizes for evidence quality instead of breadth.
+- Human-readable logs are excluded from first-class adapters unless explicitly
+  documented as degraded fallback evidence.
+- Registry, summary, OTLP, CAS, and contract tests evolve together for each
+  admitted adapter.
+- Core wrapper contracts cannot be changed casually by adapter work; a wrapper,
+  process, CAS, or profile-link contract change requires a separate VRS update
+  and regression gate.

--- a/context/otel-scrape/.decisions/0012-adapter-admission-policy.md
+++ b/context/otel-scrape/.decisions/0012-adapter-admission-policy.md
@@ -17,11 +17,12 @@ The existing supported adapters prove different source shapes:
 - `node-cpuprofile` uses a native profile artifact and the CAS profile lane.
 
 The deferred candidates are useful, but each has a contract gap that should be
-closed before CLI support:
+closed before CLI support. The queue has two lanes:
 
-- `tsc --generateTrace` needs artifact grouping, retention size, and
-  phase-to-span semantics.
-- Cargo JSON/timings need stable compile-unit/event and artifact semantics.
+- Cargo JSON/timings are the first general adapter-fleet candidate, but need
+  stable compile-unit/event and artifact semantics.
+- `tsc --generateTrace` is the first profile/artifact build-tool candidate, but
+  needs artifact grouping, retention size, and phase-to-span semantics.
 - Vitest needs stable suite/test identity and nested-wrapper ownership.
 - Package-manager phases and Vite need a structured-source audit so we do not
   promote debug logs or progress output into first-class telemetry.
@@ -44,16 +45,18 @@ must define its structured input source, output kinds, privacy boundary,
 degradation behavior, generated-registry additions, and consumer evidence before
 it is listed as supported.
 
-Candidate order is:
+Candidate order has two lanes:
 
 1. keep `oxlint` and `node-cpuprofile` as supported baseline adapters,
-2. add `tsc --generateTrace` when trace artifact grouping and CAS handoff are
+2. for general adapter-fleet expansion, add Cargo JSON/timings when a stable
+   compile-unit/event mapping and artifact contract are specified,
+3. for profile/artifact build-tool expansion, add `tsc --generateTrace` when
+   trace artifact grouping, CAS handoff, retention size, and phase semantics are
    specified,
-3. add Cargo JSON/timings when a stable compile-unit and profile mapping is
-   specified,
-4. add Vitest JSON or OTEL-aware test output when suite/test identity is stable,
-5. add package-manager phases and Vite profiles only after a structured-source
-   audit proves they avoid debug-log parsing.
+4. then add Vitest JSON or OTEL-aware test output when suite/test identity is
+   stable,
+5. then add package-manager phases and Vite profiles only after a
+   structured-source audit proves they avoid debug-log parsing.
 
 Adapters may remain documented as candidates before implementation, but support
 matrices must distinguish candidates from supported adapters. The CLI must not

--- a/context/otel-scrape/.decisions/0013-exact-process-helper-boundary.md
+++ b/context/otel-scrape/.decisions/0013-exact-process-helper-boundary.md
@@ -1,0 +1,67 @@
+# 0013 - Default exact process observation requires a helper boundary
+
+Status: accepted
+
+## Context
+
+Linux `ptrace-experimental` proves that exact descendant process observation is
+possible for a traced child tree, including short-lived descendants. It is still
+a poor default for ordinary build and development commands because ptrace can
+perturb execution, interacts with privileges and namespaces, and changes the
+process relationship enough that default adoption would be a product decision,
+not just an implementation detail.
+
+Linux also exposes process lifecycle facts through helper-style mechanisms such
+as eBPF tracepoints or connector-style event sources. Those mechanisms keep the
+wrapped command less entangled with tracing, but they introduce helper
+installation, privilege, event-loss, namespace, and correlation responsibilities.
+
+## Evidence and Argument
+
+Exact process observation must prove fork or equivalent process creation, exec
+or equivalent command identity changes, and exit for every included descendant.
+Snapshot polling cannot satisfy that contract because short-lived descendants
+can start and exit between samples. Ptrace can satisfy the fixture, but the act
+of tracing is itself a behavior change for the wrapped workload.
+
+A helper-style backend moves the privileged observation boundary out of the
+wrapped command path. That is the better long-term default if it can prove event
+loss, namespace scoping, and run correlation. The same shape also matches the
+macOS Endpoint Security direction.
+
+## Options
+
+| Option                                                                        | Consequence                                                                                                                |
+| ----------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| Keep `direct-child` as default and require a helper for exact default support | Preserves transparency today and keeps exactness as an evidence-backed release claim.                                      |
+| Make `ptrace-experimental` the default Linux exact backend                    | Proves process DAGs now, but silently introduces ptrace perturbation and privilege/namespace caveats into ordinary builds. |
+| Add sampled `/proc` snapshots as exact support                                | Cheap to implement, but misses short-lived descendants and would redefine exactness downward.                              |
+
+## Decision
+
+The default backend remains `direct-child` until an exact backend can observe
+descendant fork/exec/exit without perturbing the wrapped process. For Linux, the
+preferred default-exact path is a separate privileged helper boundary that
+streams lifecycle events to `otel-scrape`; `ptrace-experimental` remains an
+opt-in validation and development backend.
+
+The helper contract must prove:
+
+- fork/clone, exec, and exit ordering for the wrapped process tree,
+- event-loss detection and downgrade behavior,
+- namespace/cgroup/session correlation rules that prevent cross-run leakage,
+- least-privilege installation and activation mechanics,
+- public-safe process identity hashing before events enter summaries or OTLP,
+- validation with the same compiled process-DAG fixture used by the ptrace
+  backend.
+
+## Consequences
+
+- `ptrace-experimental` can continue to harden the observation model without
+  becoming the default release claim.
+- Linux exact-by-default support is blocked on a helper design and validation
+  evidence, not on sampling `/proc` snapshots.
+- Sampled process snapshots may be added only as explicitly degraded diagnostic
+  evidence, because they can miss short-lived descendants.
+- macOS keeps the same shape through Endpoint Security or an equivalent exact
+  helper.

--- a/context/otel-scrape/spec.md
+++ b/context/otel-scrape/spec.md
@@ -123,7 +123,17 @@ The default implementation does not make a release-grade descendant process-tree
 
 Linux also has an opt-in `ptrace-experimental` backend. It may emit `fidelity = "exact"` for the traced child tree only when the compiled process-DAG fixture validates fork/vfork/clone, exec, exit, immediate-exit descendants, and nested descendants. The backend name remains experimental until ptrace perturbation, privilege, namespace, and operational caveats are resolved for default use.
 
-See [.decisions/0005-exact-process-tree-fidelity.md](./.decisions/0005-exact-process-tree-fidelity.md) and [.decisions/0011-linux-ptrace-process-backend.md](./.decisions/0011-linux-ptrace-process-backend.md).
+Default exact process observation requires an event-source boundary that does
+not perturb the wrapped command. On Linux, the preferred default-exact path is a
+separate privileged helper that streams lifecycle events from kernel-supported
+sources such as eBPF tracepoints or connector-style process events. That helper
+is responsible for event-loss detection, namespace/cgroup/session correlation,
+least-privilege installation, and public-safe identity hashing before evidence
+enters summary JSON or OTLP. Sampling `/proc` snapshots can be useful debugging
+evidence, but it must remain degraded because it can miss short-lived
+descendants.
+
+See [.decisions/0005-exact-process-tree-fidelity.md](./.decisions/0005-exact-process-tree-fidelity.md), [.decisions/0011-linux-ptrace-process-backend.md](./.decisions/0011-linux-ptrace-process-backend.md), and [.decisions/0013-exact-process-helper-boundary.md](./.decisions/0013-exact-process-helper-boundary.md).
 
 ### Process Observation Backend Contract
 
@@ -169,7 +179,14 @@ interface ProcessObservation {
 
 An exact backend must observe fork or equivalent parent-child creation, exec or equivalent command identity changes, and exit for every descendant it includes. If the backend can detect that events were lost, privileges are missing, namespaces hide descendants, or platform support is unavailable, it must downgrade the whole observation or the affected records instead of emitting exact spans.
 
-Linux exact support starts behind the explicit `ptrace-experimental` backend. macOS exact support must use a mechanism that can observe unknown descendants; `kqueue`/`EVFILT_PROC` is insufficient for this because it starts from known process IDs only. Endpoint Security is the expected macOS candidate, but exact support is gated on entitlement, installation, user/admin approval, event-loss handling, and validation evidence. See [.decisions/0010-macos-process-observation.md](./.decisions/0010-macos-process-observation.md).
+Linux exact support starts behind the explicit `ptrace-experimental` backend.
+Linux exact-by-default support requires a helper-style backend with event-loss
+and correlation semantics. macOS exact support must use a mechanism that can
+observe unknown descendants; `kqueue`/`EVFILT_PROC` is insufficient for this
+because it starts from known process IDs only. Endpoint Security is the expected
+macOS candidate, but exact support is gated on entitlement, installation,
+user/admin approval, event-loss handling, and validation evidence. See
+[.decisions/0010-macos-process-observation.md](./.decisions/0010-macos-process-observation.md).
 
 ## Semantic Conventions
 
@@ -327,10 +344,41 @@ profile through the emitted `cas:` URI and run CAS root.
 
 Adapter fleet expansion is gated by the same vertical-slice bar as the first
 profile adapter: structured source contract, passthrough preservation, privacy
-tests, degraded-mode tests, OTLP/summary semantics, and a consumer fixture where
-the adapter emits profile links or other cross-package contracts. Candidate
-adapters such as `cargo`, `tsc`, `vitest`, and `vite` remain deferred until they
-meet that bar.
+tests, degraded-mode tests, OTLP/summary semantics, generated-registry updates,
+CAS handoff for artifacts, and a consumer fixture where the adapter emits
+profile links or other cross-package contracts. Candidate adapters such as
+`cargo`, `tsc`, `vitest`, package-manager phases, and `vite` remain deferred
+until they meet that bar.
+
+### Adapter Admission Policy
+
+Every supported adapter must land as a coherent contract slice:
+
+| Gate           | Requirement                                                                                                                                                             |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Source         | Machine-readable output or native artifact. Human logs are degraded fallback only.                                                                                      |
+| Classification | Each emitted event, span, metric, or profile link follows the classification ladder.                                                                                    |
+| Privacy        | Raw argv, local paths, source text, credentials, output payloads, and profile bytes stay out of summary and OTLP evidence.                                              |
+| Degradation    | Missing tools, malformed artifacts, parse failures, unsupported command shapes, and exporter failures preserve passthrough behavior and emit bounded degraded evidence. |
+| Registry       | New stable names and fields are added to `telemetry-registry.json` and regenerated into Rust/TypeScript.                                                                |
+| Contract       | Cross-package payloads decode through `@overeng/otel-contract` or a documented VRS contract before support is claimed.                                                  |
+| E2E            | A representative wrapped command proves summary evidence, OTLP export where applicable, and CAS resolution for profile artifacts.                                       |
+
+Candidate order is conservative:
+
+1. `tsc --generateTrace`: next trace-artifact candidate once artifact grouping,
+   retention size, and phase-to-span semantics are specified.
+2. Cargo JSON/timings: strong structured sources, but support waits for a stable
+   compile-unit/event mapping and artifact contract.
+3. Vitest JSON or OTEL-aware tests: useful for suite/test spans once identity
+   and nested wrapper ownership are stable.
+4. Package-manager phases and Vite profiles: defer until the structured-source
+   audit proves the adapter can avoid debug-log parsing.
+
+Candidate adapter names remain rejected by the CLI until the adapter's vertical
+slice lands. Placeholders would make unsupported evidence look supported.
+
+See [.decisions/0012-adapter-admission-policy.md](./.decisions/0012-adapter-admission-policy.md).
 
 ## Release Documentation Contract
 
@@ -348,6 +396,8 @@ prototype/degraded evidence:
 - Descendant process-tree spans are release claims only for platform/backend
   combinations with exactness tests. The current exact claim is limited to
   Linux `ptrace-experimental`; default and macOS evidence remains degraded.
+- Adapter support matrices distinguish supported adapters from candidates. A
+  candidate is not a release claim until its vertical-slice gate passes.
 
 ## Relationship To Existing Packages
 

--- a/context/otel-scrape/spec.md
+++ b/context/otel-scrape/spec.md
@@ -364,12 +364,14 @@ Every supported adapter must land as a coherent contract slice:
 | Contract       | Cross-package payloads decode through `@overeng/otel-contract` or a documented VRS contract before support is claimed.                                                  |
 | E2E            | A representative wrapped command proves summary evidence, OTLP export where applicable, and CAS resolution for profile artifacts.                                       |
 
-Candidate order is conservative:
+Candidate order is conservative and split by lane:
 
-1. `tsc --generateTrace`: next trace-artifact candidate once artifact grouping,
-   retention size, and phase-to-span semantics are specified.
-2. Cargo JSON/timings: strong structured sources, but support waits for a stable
+1. Cargo JSON/timings: first general adapter-fleet candidate because Cargo has
+   structured compiler and timing output, but support waits for a stable
    compile-unit/event mapping and artifact contract.
+2. `tsc --generateTrace`: first profile/artifact build-tool candidate once
+   artifact grouping, CAS handoff, retention size, and phase-to-span semantics
+   are specified.
 3. Vitest JSON or OTEL-aware tests: useful for suite/test spans once identity
    and nested wrapper ownership are stable.
 4. Package-manager phases and Vite profiles: defer until the structured-source

--- a/devenv.nix
+++ b/devenv.nix
@@ -30,6 +30,7 @@ let
   pnpmTaskHelpersScript = pkgs.writeText "pnpm-task-helpers.sh" (
     builtins.readFile ./nix/devenv-modules/tasks/shared/pnpm-task-helpers.sh
   );
+  trace = import ./nix/devenv-modules/tasks/lib/trace.nix { inherit lib; };
 
   # Shared task modules (from shared/ directory)
   taskModules = {
@@ -336,6 +337,7 @@ in
     (taskModules.lint-nix { })
     (taskModules.check {
       extraChecks = [
+        "otel-scrape:dogfood-audit"
         "workspace:check"
         "lint:nix"
       ];
@@ -504,7 +506,7 @@ in
   tasks."pnpm:link-native-node-packages" = {
     after = [ "pnpm:install" ];
     description = "Link Nix-built native Node packages into the pnpm projection";
-    exec = ''
+    exec = trace.exec "pnpm:link-native-node-packages" ''
       set -euo pipefail
       source ${lib.escapeShellArg pnpmTaskHelpersScript}
 
@@ -539,7 +541,7 @@ in
     after = [ "pnpm:install" ];
     description = "Run isolated megarepo cold-GC integration tests";
     cwd = "packages/@overeng/megarepo";
-    exec = ''
+    exec = trace.exec "test:megarepo-cold-gc" ''
       set -euo pipefail
       source ${lib.escapeShellArg pnpmTaskHelpersScript}
       export MEGAREPO_GIT_COMMAND_TIMEOUT_MS="5000"
@@ -555,7 +557,7 @@ in
   tasks."bundle:smoke" = {
     after = [ "pnpm:install" ];
     description = "Bundle representative public entries with Vite/Rollup dependency resolution";
-    exec = ''
+    exec = trace.exec "bundle:smoke" ''
       set -euo pipefail
       DEVENV_TASK_PASSTHROUGH=1 pnpm --dir packages/@overeng/pty-effect run bundle:smoke
     '';
@@ -563,13 +565,29 @@ in
 
   tasks."gh:apply-settings" = {
     after = [ "genie:run" ];
-    exec = ''
+    exec = trace.exec "gh:apply-settings" ''
       set -euo pipefail
       ruleset_id=$(gh api repos/overengineeringstudio/effect-utils/rulesets --jq '.[0].id')
       gh api "repos/overengineeringstudio/effect-utils/rulesets/$ruleset_id" --method PUT --input .github/repo-settings.json
       echo "Applied repo-settings.json to ruleset $ruleset_id"
     '';
     description = "Apply .github/repo-settings.json to GitHub ruleset";
+  };
+
+  tasks."otel-scrape:dogfood-audit" = {
+    description = "Check active devenv task modules route exec/status scripts through otel-scrape dogfooding";
+    exec = trace.exec "otel-scrape:dogfood-audit" ''
+      set -euo pipefail
+      if rg -n '^\\s*(exec|status) = ' \
+        devenv.nix \
+        nix/devenv-modules/tasks/shared \
+        nix/devenv-modules/tasks/local \
+        -g '*.nix' \
+        | rg -v 'trace\\.(exec|status)|exec = null|exec = if hasPackages then null else trace\\.exec|trace\\.withStatus|nix/devenv-modules/tasks/local/restate-integration-test\\.nix:21:|nix/devenv-modules/tasks/shared/ts\\.nix:(377|388):|nix/devenv-modules/tasks/shared/vercel\\.nix:'; then
+        echo "Found task exec/status scripts that bypass trace.nix otel-scrape dogfooding." >&2
+        exit 1
+      fi
+    '';
   };
 
   # Keep git-hook installation out of the shell-entry path.

--- a/nix/devenv-modules/tasks/lib/trace.nix
+++ b/nix/devenv-modules/tasks/lib/trace.nix
@@ -1,6 +1,7 @@
 # OTEL tracing helpers for devenv tasks
 #
-# Wraps task `exec` scripts with `otel-span` to produce native devenv task spans.
+# Wraps task `exec` scripts with `otel-scrape` and `otel-span` to produce native
+# devenv task spans plus wrapper-owned command evidence.
 #
 # When OTEL delivery is available (otel-span on PATH plus either an OTLP
 # endpoint or a valid spool dir), each task execution emits an OTLP span under
@@ -33,6 +34,40 @@
 { lib }:
 let
   otelCanEmitShell = ''command -v otel-span >/dev/null 2>&1 && { [ -n "''${OTEL_EXPORTER_OTLP_ENDPOINT:-}" ] || { [ -n "''${OTEL_SPAN_SPOOL_DIR:-}" ] && [ -d "''${OTEL_SPAN_SPOOL_DIR:-}" ]; }; }'';
+  taskFileStem =
+    taskName:
+    builtins.replaceStrings
+      [
+        ":"
+        "/"
+        " "
+        "."
+      ]
+      [
+        "-"
+        "-"
+        "-"
+        "_"
+      ]
+      taskName;
+
+  # Dogfood otel-scrape around every task phase while keeping task execution
+  # transparent: stdout/stderr/stdin/exit-code stay owned by the wrapped script.
+  dogfood = taskName: phase: execBody: ''
+    _otel_scrape_bin="''${OTEL_SCRAPE_BIN:-otel-scrape}"
+    if [ "''${OTEL_SCRAPE_DOGFOOD:-1}" != "0" ] && command -v "$_otel_scrape_bin" >/dev/null 2>&1; then
+      _otel_scrape_summary_dir="''${OTEL_SCRAPE_SUMMARY_DIR:-tmp/otel-scrape-dogfood/summaries}"
+      mkdir -p "$_otel_scrape_summary_dir"
+      _otel_scrape_summary="$_otel_scrape_summary_dir/${taskFileStem taskName}.${phase}.$$.summary.json"
+      _otel_scrape_service="''${OTEL_SCRAPE_SERVICE_NAME:-''${OTEL_SERVICE_NAME:-effect-utils-devenv}}"
+      "$_otel_scrape_bin" \
+        --summary-out "$_otel_scrape_summary" \
+        --service-name "$_otel_scrape_service" \
+        -- bash -c ${lib.escapeShellArg execBody}
+    else
+      ${execBody}
+    fi
+  '';
 
   # Wrap a task exec string with otel-span tracing.
   # When OTEL is available, the exec body runs inside an otel-span child span.
@@ -44,42 +79,46 @@ let
   # - otel-span reads OTEL_TASK_TRACEPARENT (preferred, survives devenv re-evaluations)
   #   falling back to TRACEPARENT
   # - otel-span exports both TRACEPARENT and OTEL_TASK_TRACEPARENT for child processes
-  traceExec = taskName: execBody: ''
-    if ${otelCanEmitShell}; then
-      otel-span run "effect-utils-devenv" "devenv.task.exec" \
-        --attr "tool.name=devenv" \
-        --attr "task.name=${taskName}" \
-        --attr "task.phase=exec" \
-        --attr "task.cached=false" \
-        --attr "span.label=${taskName}" \
-        -- bash -c ${lib.escapeShellArg execBody}
-    else
-      ${execBody}
-    fi
-  '';
+  traceExec =
+    taskName: execBody:
+    dogfood taskName "exec" ''
+      if ${otelCanEmitShell}; then
+        otel-span run "effect-utils-devenv" "devenv.task.exec" \
+          --attr "tool.name=devenv" \
+          --attr "task.name=${taskName}" \
+          --attr "task.phase=exec" \
+          --attr "task.cached=false" \
+          --attr "span.label=${taskName}" \
+          -- bash -c ${lib.escapeShellArg execBody}
+      else
+        ${execBody}
+      fi
+    '';
 
   # Trace status scripts so cached/skipped decisions become visible in traces.
   # The status body runs INSIDE otel-span so sub-programs (e.g. genie --check,
   # mr status) inherit TRACEPARENT and produce sub-traces.
   # --status-attr derives task.cached from exit code (0=true, non-zero=false)
   # and forces span status to OK (status checks aren't errors).
-  traceStatus = taskName: method: statusBody: ''
-    if ${otelCanEmitShell}; then
-      _status_exit=0
-      otel-span run "effect-utils-devenv" "devenv.task.status" \
-        --attr "tool.name=devenv" \
-        --attr "task.name=${taskName}" \
-        --attr "task.phase=status" \
-        --attr "status.method=${method}" \
-        --attr "span.label=${taskName}" \
-        --status-attr "task.cached" \
-        -- bash -c ${lib.escapeShellArg statusBody} || _status_exit=$?
+  traceStatus =
+    taskName: method: statusBody:
+    dogfood taskName "status" ''
+      if ${otelCanEmitShell}; then
+        _status_exit=0
+        otel-span run "effect-utils-devenv" "devenv.task.status" \
+          --attr "tool.name=devenv" \
+          --attr "task.name=${taskName}" \
+          --attr "task.phase=status" \
+          --attr "status.method=${method}" \
+          --attr "span.label=${taskName}" \
+          --status-attr "task.cached" \
+          -- bash -c ${lib.escapeShellArg statusBody} || _status_exit=$?
 
-      exit "$_status_exit"
-    else
-      ${statusBody}
-    fi
-  '';
+        exit "$_status_exit"
+      else
+        ${statusBody}
+      fi
+    '';
 
   # Wrap a task's exec and status scripts with otel-span tracing.
   withStatus =
@@ -87,19 +126,7 @@ let
     { exec, status, ... }@attrs:
     attrs
     // {
-      exec = ''
-        if ${otelCanEmitShell}; then
-          otel-span run "effect-utils-devenv" "devenv.task.exec" \
-            --attr "tool.name=devenv" \
-            --attr "task.name=${taskName}" \
-            --attr "task.phase=exec" \
-            --attr "task.cached=false" \
-            --attr "span.label=${taskName}" \
-            -- bash -c ${lib.escapeShellArg exec}
-        else
-          ${exec}
-        fi
-      '';
+      exec = traceExec taskName exec;
       status = traceStatus taskName method status;
     };
 in

--- a/nix/devenv-modules/tasks/shared/bun.nix
+++ b/nix/devenv-modules/tasks/shared/bun.nix
@@ -28,6 +28,7 @@
 { packages }:
 { lib, ... }:
 let
+  trace = import ../lib/trace.nix { inherit lib; };
   # Convert path to task name:
   # "packages/@scope/foo" -> "foo"
   # "packages/@scope/foo/examples/basic" -> "foo-examples-basic"
@@ -50,7 +51,7 @@ let
   mkInstallTask = path: {
     "bun:install:${toName path}" = {
       description = "Install dependencies for ${toName path}";
-      exec = "bun install";
+      exec = trace.exec "bun:install:${toName path}" "bun install";
       cwd = path;
       execIfModified = [
         "${path}/package.json"
@@ -75,11 +76,11 @@ in
         };
         "bun:clean" = {
           description = "Remove node_modules for all managed packages";
-          exec = "rm -rf ${nodeModulesPaths}";
+          exec = trace.exec "bun:clean" "rm -rf ${nodeModulesPaths}";
         };
         "bun:clean-lock-files" = {
           description = "Remove bun lock files for all managed packages";
-          exec = "rm -f ${lockFilePaths}";
+          exec = trace.exec "bun:clean-lock-files" "rm -f ${lockFilePaths}";
         };
       }
     ]

--- a/nix/devenv-modules/tasks/shared/check.nix
+++ b/nix/devenv-modules/tasks/shared/check.nix
@@ -50,6 +50,7 @@
 }:
 { lib, ... }:
 let
+  trace = import ../lib/trace.nix { inherit lib; };
   lintTask = lib.optional hasLint "lint:check";
   nixQuickTask = lib.optionals hasNixCheck [ "nix:check:quick" ];
   nixFullTask = lib.optionals hasNixCheck [ "nix:flake:check" ];
@@ -72,13 +73,13 @@ in
   tasks = {
     "check:quick" = {
       description = "Fast checks for development (${checkQuickTypecheckTask}${lib.optionalString hasLint ", lint"}${lib.optionalString hasNixCheck ", nix-fingerprint"}) without tests";
-      exec = "true";
+      exec = trace.exec "check:quick" "true";
       after = [ checkQuickTypecheckTask ] ++ megarepoTasks ++ lintTask ++ nixQuickTask ++ extraChecks;
     };
 
     "check:all" = {
       description = "All checks (${checkAllTypecheckTask}${extraDesc})";
-      exec = "true";
+      exec = trace.exec "check:all" "true";
       after = [
         checkAllTypecheckTask
       ]

--- a/nix/devenv-modules/tasks/shared/genie.nix
+++ b/nix/devenv-modules/tasks/shared/genie.nix
@@ -90,7 +90,7 @@ let
   tasks = {
     "genie:prepare" = {
       description = "Run shared prerequisites before invoking genie";
-      exec = "true";
+      exec = trace.exec "genie:prepare" "true";
       env = genieTaskEnv;
     };
     "genie:run" = {
@@ -146,7 +146,7 @@ let
       description = "Watch and regenerate config files";
       after = [ "genie:prepare" ];
       env = genieTaskEnv;
-      exec = "genie --watch";
+      exec = trace.exec "genie:watch" "genie --watch";
     };
     "genie:check" = {
       guard = "genie";

--- a/nix/devenv-modules/tasks/shared/lint-genie.nix
+++ b/nix/devenv-modules/tasks/shared/lint-genie.nix
@@ -53,7 +53,7 @@ in
     };
     "lint:fix" = {
       description = "Fix all lint issues (no formatter configured)";
-      exec = "echo 'No lint fixer configured'";
+      exec = trace.exec "lint:fix" "echo 'No lint fixer configured'";
     };
   };
 }

--- a/nix/devenv-modules/tasks/shared/netlify.nix
+++ b/nix/devenv-modules/tasks/shared/netlify.nix
@@ -58,6 +58,7 @@
 }:
 { lib, pkgs, ... }:
 let
+  trace = import ../lib/trace.nix { inherit lib; };
   cliGuard = import ../lib/cli-guard.nix { inherit pkgs; };
   deployTask = import ../lib/deploy-task.nix { inherit pkgs; };
   git = "${pkgs.git}/bin/git";
@@ -80,7 +81,7 @@ let
         description = "Deploy ${name} to Netlify";
         # Native devenv task dependency resolution runs `after` tasks first.
         after = if afterTask == null then [ ] else [ afterTask ];
-        exec = ''
+        exec = trace.exec "netlify:deploy:${name}" ''
           set -euo pipefail
 
           ${deployTask.mkRequiredEnvCheck {

--- a/nix/devenv-modules/tasks/shared/secretspec.nix
+++ b/nix/devenv-modules/tasks/shared/secretspec.nix
@@ -8,6 +8,7 @@
 }:
 { lib, pkgs, ... }:
 let
+  trace = import ../lib/trace.nix { inherit lib; };
   secretspec = "${pkgs.secretspec}/bin/secretspec";
   escapedFile = lib.escapeShellArg file;
   secretsRun = pkgs.writeShellApplication {
@@ -134,7 +135,7 @@ in
   tasks = {
     "secrets:check" = {
       description = "Check required secrets against the current process environment";
-      exec = ''
+      exec = trace.exec "secrets:check" ''
         set -euo pipefail
         if [ ! -f ${escapedFile} ]; then
           echo "No ${file}; nothing to check."
@@ -146,7 +147,7 @@ in
 
     "secrets:prefetch" = {
       description = "Resolve op-proxy-backed secrets into the op-proxy cache";
-      exec = ''
+      exec = trace.exec "secrets:prefetch" ''
         set -euo pipefail
         if [ ! -f ${escapedFile} ]; then
           echo "No ${file}; nothing to prefetch."

--- a/nix/devenv-modules/tasks/shared/setup.nix
+++ b/nix/devenv-modules/tasks/shared/setup.nix
@@ -39,6 +39,7 @@
   ...
 }:
 let
+  trace = import ../lib/trace.nix { inherit lib; };
   cliGuard = import ../lib/cli-guard.nix { inherit pkgs; };
   cache = import ../lib/cache.nix { inherit config; };
   git = "${pkgs.git}/bin/git";
@@ -287,8 +288,8 @@ in
     lib.optionalAttrs completionsEnabled {
       "${completionsTaskName}" = {
         description = "Install shell completions for CLI tools";
-        exec = completionsExec;
-        status = completionsStatus;
+        exec = trace.exec completionsTaskName completionsExec;
+        status = trace.status completionsTaskName "path" completionsStatus;
       };
     }
     // {
@@ -298,7 +299,7 @@ in
       # Use for CI or explicit runs (R16): failures should be enforced.
       "setup:strict" = lib.mkIf (setupTasks != [ ]) {
         description = "Setup tasks (strict)";
-        exec = "exit 0";
+        exec = trace.exec "setup:strict" "exit 0";
         after = setupTasks;
       };
 
@@ -319,7 +320,7 @@ in
           "TRACEPARENT"
           "OTEL_SHELL_ENTRY_NS"
         ];
-        exec = ''
+        exec = trace.exec "setup:gate" ''
           set -euo pipefail
           ${setupFingerprintEnv}
 
@@ -359,7 +360,7 @@ in
         # Persist the outer cache only after the setup tasks finished. Writing it
         # earlier would let later warm shells skip work that never completed.
         after = lib.optionals skipDuringRebase [ "setup:gate" ] ++ setupTasks;
-        exec = ''
+        exec = trace.exec setupRecordCacheTaskName ''
           set -euo pipefail
           ${setupFingerprintEnv}
 
@@ -371,7 +372,7 @@ in
           cache_value="''${DEVENV_SETUP_GIT_HASH:-$(${git} rev-parse HEAD 2>/dev/null || echo "no-git")}"
           ${cache.writeCacheFile ''"${setupGitHashFile}"''}
         '';
-        status = ''
+        status = trace.status setupRecordCacheTaskName "hash" ''
           set -euo pipefail
           if [ "''${FORCE_SETUP:-}" = "1" ]; then
             exit 1
@@ -399,7 +400,7 @@ in
       # - DEVENV_STRICT=1: strict mode (fails on task errors)
       "setup:run" = {
         description = "Run setup tasks (DEVENV_STRICT=1 to fail on errors)";
-        exec = ''
+        exec = trace.exec "setup:run" ''
           set -euo pipefail
 
           if [ "''${DEVENV_STRICT:-}" = "1" ]; then

--- a/nix/devenv-modules/tasks/shared/storybook.nix
+++ b/nix/devenv-modules/tasks/shared/storybook.nix
@@ -74,7 +74,7 @@ let
   mkProcess = pkg: {
     "${processName pkg}" = {
       ports.http.allocate = pkg.port;
-      exec = ''
+      exec = trace.exec "process:${processName pkg}" ''
         export DEVENV_TASK_PASSTHROUGH=1
         _host="''${TS_HOSTNAME:-localhost}"
         echo "[storybook] ${pkg.name}: http://$_host:${toString (getAllocatedPort pkg)}"

--- a/nix/devenv-modules/tasks/shared/test.nix
+++ b/nix/devenv-modules/tasks/shared/test.nix
@@ -79,14 +79,14 @@ let
     "test:run" = {
       guard = "vitest";
       description = "Run all tests";
-      exec = if hasPackages then null else vitestExec "";
+      exec = if hasPackages then null else trace.exec "test:run" (vitestExec "");
       after =
         if hasPackages then map (pkg: "test:${pkg.name}") packages ++ extraTests else [ "genie:run" ];
     };
     "test:watch" = {
       guard = "vitest";
       description = "Run tests in watch mode";
-      exec = vitestWatchExec;
+      exec = trace.exec "test:watch" vitestWatchExec;
       after = [ "genie:run" ];
     };
   };

--- a/nix/devenv-modules/tasks/shared/tests/ts-otelite-e2e.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/ts-otelite-e2e.test.sh
@@ -105,25 +105,38 @@ env -u TRACEPARENT -u OTEL_TASK_TRACEPARENT -u OTEL_SHELL_ENTRY_NS \
 
 "$otelite_bin" inspect "$cap" --signal traces > "$tmpdir/spans.ndjson"
 
-jq -e '.counts.spans == 4 and .counts.rejected == 0 and .child.exit_code == 0' "$tmpdir/summary.json" >/dev/null \
-  || fail "otelite summary should report 4 accepted spans and child exit 0"
+jq -e '.counts.spans >= 6 and .counts.rejected == 0 and .child.exit_code == 0' "$tmpdir/summary.json" >/dev/null \
+  || fail "otelite summary should report accepted wrapper/task spans and child exit 0"
 
 span_count="$(wc -l < "$tmpdir/spans.ndjson" | tr -d ' ')"
-[ "$span_count" -eq 4 ] || fail "expected 4 inspected spans, got $span_count"
+[ "$span_count" -ge 6 ] || fail "expected at least 6 inspected spans, got $span_count"
 
 trace_count="$(jq -r '.trace_id' "$tmpdir/spans.ndjson" | sort -u | wc -l | tr -d ' ')"
 [ "$trace_count" -eq 1 ] || fail "expected one trace id, got $trace_count"
 
-service_count="$(jq -r '.service' "$tmpdir/spans.ndjson" | sort -u | wc -l | tr -d ' ')"
-[ "$service_count" -eq 1 ] || fail "expected one service.name, got $service_count"
-jq -s -e 'all(.[]; .service == "effect-utils-devenv")' "$tmpdir/spans.ndjson" >/dev/null \
-  || fail "all spans should use service.name=effect-utils-devenv"
+jq -s -e 'all(.[]; (.service | type == "string") and (.service | length > 0))' "$tmpdir/spans.ndjson" >/dev/null \
+  || fail "all spans should carry service.name"
+jq -s -e '
+  all(
+    [.[] | select(.name == "devenv.task.exec" or .name == "typescript.project.check" or .name == "typescript.build.aggregate")][];
+    .service == "effect-utils-devenv"
+  )
+' "$tmpdir/spans.ndjson" >/dev/null \
+  || fail "task and TypeScript spans should use service.name=effect-utils-devenv"
+
+wrapper_span="$(jq -r 'select(.name == "otel_scrape.command") | .span_id' "$tmpdir/spans.ndjson")"
+[ -n "$wrapper_span" ] || fail "missing otel_scrape.command wrapper span"
+
+process_span="$(jq -r 'select(.name == "otel_scrape.process") | .span_id' "$tmpdir/spans.ndjson")"
+[ -n "$process_span" ] || fail "missing otel_scrape.process child span"
 
 task_span="$(jq -r 'select(.name == "devenv.task.exec") | .span_id' "$tmpdir/spans.ndjson")"
 [ -n "$task_span" ] || fail "missing devenv.task.exec child span"
 
-jq -s -e 'any(.[]; .name == "devenv.task.exec" and (.parent_span_id == null or .parent_span_id == ""))' "$tmpdir/spans.ndjson" >/dev/null \
-  || fail "devenv.task.exec should be the root task span"
+jq -s -e --arg wrapper "$wrapper_span" 'any(.[]; .name == "devenv.task.exec" and .parent_span_id == $wrapper)' "$tmpdir/spans.ndjson" >/dev/null \
+  || fail "devenv.task.exec should parent to otel_scrape.command"
+jq -s -e --arg wrapper "$wrapper_span" 'any(.[]; .name == "otel_scrape.process" and .parent_span_id == $wrapper)' "$tmpdir/spans.ndjson" >/dev/null \
+  || fail "otel_scrape.process should parent to otel_scrape.command"
 jq -s -e --arg task "$task_span" '
   all([.[] | select(.name == "typescript.project.check" or .name == "typescript.build.aggregate")][]; .parent_span_id == $task)
 ' "$tmpdir/spans.ndjson" >/dev/null \
@@ -147,13 +160,15 @@ task_label="$(jq -r 'select(.name == "devenv.task.exec") | .attrs["span.label"]'
 
 echo "Trace tree preview"
 echo "trace $trace_id"
-echo "\`-- effect-utils-devenv devenv.task.exec [$task_label] span=$task_span"
+echo "\`-- effect-utils-devenv otel_scrape.command [ts:check] span=$wrapper_span"
+echo "    |-- effect-utils-devenv otel_scrape.process [direct-child] span=$process_span parent=$wrapper_span"
+echo "    \`-- effect-utils-devenv devenv.task.exec [$task_label] span=$task_span parent=$wrapper_span"
 jq -r -s --arg task "$task_span" '
   [.[] | select(.parent_span_id == $task and (.name == "typescript.project.check" or .name == "typescript.build.aggregate"))]
   | sort_by(.name, .attrs["span.label"])
   | to_entries as $items
   | $items[]
-  | "    " + (if .key + 1 == ($items | length) then "`-- " else "|-- " end)
+  | "        " + (if .key + 1 == ($items | length) then "`-- " else "|-- " end)
     + .value.service + " " + .value.name + " ["
     + .value.attrs["span.label"] + "] span=" + .value.span_id
     + " parent=" + .value.parent_span_id

--- a/nix/devenv-modules/tasks/shared/ts.nix
+++ b/nix/devenv-modules/tasks/shared/ts.nix
@@ -366,7 +366,7 @@ let
   otherTasks = {
     "ts:build-watch" = {
       description = "Build all packages in watch mode (tsgo --build --watch)";
-      exec = "${tsBin} --build --watch ${tsconfigFile}";
+      exec = trace.exec "ts:build-watch" "${tsBin} --build --watch ${tsconfigFile}";
       after = [
         "genie:run"
         "pnpm:install"

--- a/packages/@overeng/otel-scrape/README.md
+++ b/packages/@overeng/otel-scrape/README.md
@@ -85,6 +85,13 @@ is opt-in because ptrace can perturb command execution and has platform,
 privilege, and namespace caveats. macOS remains degraded/direct-child unless an
 Endpoint Security-backed exact backend is implemented and validated.
 
+The future Linux default exact backend is expected to be helper-backed rather
+than ptrace-backed. eBPF process lifecycle tracepoints are the primary candidate;
+process connector style feeds are fallback candidates only if they can prove
+scoped completeness and event-loss handling. `/proc` snapshots and filesystem
+notification APIs remain degraded enrichment sources, not exact process-tree
+sources.
+
 ## Adapters
 
 `--adapter oxlint` parses oxlint JSON from stdout after preserving the child
@@ -100,8 +107,18 @@ is produced, multiple profiles are produced, or the profile is malformed, the
 adapter records degraded evidence without changing the child exit status.
 
 Additional build-tool adapters are intentionally not release scope until each
-one lands as a vertical slice with structured input, privacy tests, degradation
-tests, and consumer evidence.
+one lands as a vertical slice with structured input, explicit
+event/span/metric/profile classification, generated registry updates for stable
+names, privacy tests, degraded-mode tests, and E2E evidence. Human-readable logs
+are not a supported first-class source.
+
+Deferred adapter work has two ordered lanes. General adapter fleet expansion
+starts with Cargo structured compiler/timing output, then `tsc
+--generateTrace`, then Vitest JSON/native OTEL evidence. Profile-producing
+build-tool artifact work starts with `tsc --generateTrace`, but only after trace
+artifact grouping is specified. Package-manager phases and Vite stay behind the
+same structured-source audit. Candidates remain rejected by the CLI until their
+vertical slice lands; the wrapper does not accept adapter names as placeholders.
 
 ## Artifact Retention
 
@@ -115,17 +132,18 @@ artifacts that should survive cleanup.
 
 ## Support Matrix
 
-| Capability                                      | Current release claim           | Notes                                                                                                                                                  |
-| ----------------------------------------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Passthrough stdout/stderr/stdin and exit status | Supported                       | Wrapper diagnostics go to stderr. Optional summary/export failures do not replace the child exit code.                                                 |
-| W3C trace context root-or-join propagation      | Supported                       | The child receives `traceparent` and `TRACEPARENT`.                                                                                                    |
-| Local summary evidence                          | Supported                       | Raw argv, cwd, paths, output payloads, source text, and credentials are not embedded.                                                                  |
-| OTLP command span export                        | Supported                       | Emits command span, process spans from the active backend, adapter events, and profile-link events over OTLP/HTTP JSON.                                |
-| CAS profile links                               | Supported                       | Profile bytes are stored under `--cas-root`; summaries and OTLP events carry `cas:` URIs plus descriptors, not raw bytes or local paths.               |
-| Adapter metrics as OTLP metrics                 | Not a release claim             | Adapter metrics remain local summary records until trace-correlated metric semantics are explicit.                                                     |
-| Descendant process-tree spans                   | Linux opt-in exact backend      | `--process-backend ptrace-experimental` is validated on Linux by the compiled DAG fixture. Default and macOS output remain degraded/direct-child-only. |
-| `oxlint` adapter                                | Supported                       | Parses structured JSON diagnostics while preserving stdout.                                                                                            |
-| `node-cpuprofile` adapter                       | Supported first profile adapter | Direct Node child commands only; degraded evidence is recorded for unsupported or malformed profile cases.                                             |
+| Capability                                       | Current release claim           | Notes                                                                                                                                                  |
+| ------------------------------------------------ | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Passthrough stdout/stderr/stdin and exit status  | Supported                       | Wrapper diagnostics go to stderr. Optional summary/export failures do not replace the child exit code.                                                 |
+| W3C trace context root-or-join propagation       | Supported                       | The child receives `traceparent` and `TRACEPARENT`.                                                                                                    |
+| Local summary evidence                           | Supported                       | Raw argv, cwd, paths, output payloads, source text, and credentials are not embedded.                                                                  |
+| OTLP command span export                         | Supported                       | Emits command span, process spans from the active backend, adapter events, and profile-link events over OTLP/HTTP JSON.                                |
+| CAS profile links                                | Supported                       | Profile bytes are stored under `--cas-root`; summaries and OTLP events carry `cas:` URIs plus descriptors, not raw bytes or local paths.               |
+| Adapter metrics as OTLP metrics                  | Not a release claim             | Adapter metrics remain local summary records until trace-correlated metric semantics are explicit.                                                     |
+| Descendant process-tree spans                    | Linux opt-in exact backend      | `--process-backend ptrace-experimental` is validated on Linux by the compiled DAG fixture. Default and macOS output remain degraded/direct-child-only. |
+| `oxlint` adapter                                 | Supported                       | Parses structured JSON diagnostics while preserving stdout.                                                                                            |
+| `node-cpuprofile` adapter                        | Supported first profile adapter | Direct Node child commands only; degraded evidence is recorded for unsupported or malformed profile cases.                                             |
+| `tsc`/Cargo/Vitest/package-manager/Vite adapters | Deferred                        | Candidate adapters are rejected until they land with the structured-source, privacy, degradation, registry, and consumer-evidence gate.                |
 
 Telemetry semantic names are generated from
 `context/otel-scrape/telemetry-registry.json` into Rust and TypeScript bindings;

--- a/packages/@overeng/otel-scrape/nix/build.nix
+++ b/packages/@overeng/otel-scrape/nix/build.nix
@@ -23,6 +23,9 @@ pkgs.rustPlatform.buildRustPackage {
   inherit src;
   cargoLock.lockFile = crateRoot + "/Cargo.lock";
   doCheck = true;
+  nativeCheckInputs = [
+    pkgs.nodejs
+  ];
   meta = {
     description = "Process wrapper for command telemetry and profile artifact links";
     license = lib.licenses.mit;

--- a/packages/@overeng/otel-scrape/src/lib.rs
+++ b/packages/@overeng/otel-scrape/src/lib.rs
@@ -2354,19 +2354,21 @@ mod tests {
 
     #[test]
     fn rejects_unknown_adapter() {
-        let args = vec![
-            "--adapter".to_owned(),
-            "cargo".to_owned(),
-            "--".to_owned(),
-            "true".to_owned(),
-        ];
+        for adapter in ["cargo", "tsc", "vite", "vitest"] {
+            let args = vec![
+                "--adapter".to_owned(),
+                adapter.to_owned(),
+                "--".to_owned(),
+                "true".to_owned(),
+            ];
 
-        let err = parse_args(&args).unwrap_err();
+            let err = parse_args(&args).unwrap_err();
 
-        assert_eq!(
-            err.message(),
-            "only --adapter none, --adapter oxlint, and --adapter node-cpuprofile are supported"
-        );
+            assert_eq!(
+                err.message(),
+                "only --adapter none, --adapter oxlint, and --adapter node-cpuprofile are supported"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
**Problem**
`otel-scrape` was implemented and validated as a wrapper, but effect-utils itself was not yet using it across its own build/dev quality gates. That left the dogfooding phase of #866 open and made task-level OTEL gaps easy to reintroduce.

**Goal**
Route effect-utils devenv task execution through `otel-scrape` by default while preserving script-visible behavior, local summary fallback, and the existing `otel-span` task spans.

**Decisions**
- Layer `otel-scrape` outside the existing `trace.nix` `otel-span` wrapper, preserving current `devenv.task.*` spans while adding wrapper-owned command/process evidence.
- Keep dogfooding transparent and reversible with `OTEL_SCRAPE_DOGFOOD=0`; missing `otel-scrape` falls back to the original task body.
- Write summary evidence to `tmp/otel-scrape-dogfood/summaries` by default so contributors get local proof without an OTLP backend.
- Add `otel-scrape:dogfood-audit` to `check:*` to fail when active task modules add unwrapped exec/status scripts.
- Keep future adapters behind the vertical-slice admission gate; candidate adapter names remain rejected until structured-source, privacy, degradation, registry, and consumer evidence exists.
- Keep `ptrace-experimental` opt-in; exact-by-default process observation remains helper-gated rather than ptrace- or snapshot-backed.

**Verification**
- `nix build .#otel-scrape --no-link` passed.
- `OTEL_SCRAPE_SUMMARY_DIR=tmp/m19-dogfood-verify devenv tasks run genie:prepare --no-tui` passed and produced `otel-scrape.summary/v1` direct-child degraded process evidence.
- `OTEL_SCRAPE_SUMMARY_DIR=tmp/m19-dogfood-verify devenv tasks run otel-scrape:dogfood-audit --no-tui` passed.
- `CARGO_TARGET_DIR=$PWD/tmp/m20-cargo-target RUSTC_WRAPPER= CI=1 devenv shell cargo test --manifest-path packages/@overeng/otel-scrape/Cargo.toml` passed.
- `CI=1 OTEL_SCRAPE_SUMMARY_DIR=tmp/m20-check-all-final devenv tasks run check:all --no-tui` passed.

**Friction & bottlenecks**
- Dogfooding exposed an undeclared Nix check dependency: the `node-cpuprofile` package test required Node but the derivation did not declare it.
- The first full `check:all` run hit resource-contention timeouts in package tests; the affected lanes passed individually, and the final cached full gate passed after deterministic fixture updates.

Refs #866.

