### PR TITLE
feat(utils-dev): connect Vitest runner and Effect spans without owning capture lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- **@overeng/utils-dev / Vitest OTEL**: connect native Vitest runner spans to
+  Effect product spans through an explicit parent bridge while keeping otelite
+  assertions deterministic. The shared test module can opt into a root Vitest
+  workspace and enables runner telemetry only in an existing OTLP collector
+  context; package-local downstream behavior remains the default.
 - **@overeng/effect-path**: add Effect 3 cross-major baselines for PathInfo schema
   encoding, convention parser failure partitions, and path operation byte output.
 - **@overeng/tui-stories**: add Effect 3 cross-major baselines for schema-encoded

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ All notable changes to this project will be documented in this file.
   Effect product spans through an explicit parent bridge while keeping otelite
   assertions deterministic. The shared test module can opt into a root Vitest
   workspace and enables runner telemetry only in an existing OTLP collector
-  context; package-local downstream behavior remains the default.
+  context; package-local downstream behavior remains the default. Real otelite
+  end-to-end coverage locks runner parenting, Effect span bridging,
+  assertion-lane suppression, failure status, and bounded drain.
 - **@overeng/effect-path**: add Effect 3 cross-major baselines for PathInfo schema
   encoding, convention parser failure partitions, and path operation byte output.
 - **@overeng/tui-stories**: add Effect 3 cross-major baselines for schema-encoded

--- a/context/vitest-otel/.decisions/0001-two-lane-explicit-bridge.md
+++ b/context/vitest-otel/.decisions/0001-two-lane-explicit-bridge.md
@@ -14,6 +14,14 @@ The question is how to adopt native Vitest OTEL across the megarepo in a way
 that closes the visibility gap without breaking the assertion lane or forcing
 per-package config. Three sub-decisions were load-bearing.
 
+## Options
+
+| Option                         | Tradeoffs                                                                                |
+| ------------------------------ | ---------------------------------------------------------------------------------------- |
+| Global provider                | Automatic parenting, but couples product export and assertion capture to Vitest globals. |
+| Independent explicit bridge    | Preserves provider ownership while connecting traces at the test boundary.               |
+| Independent disconnected trees | Preserves ownership but loses causal navigation between runner and product work.         |
+
 ## Evidence and Argument
 
 ### Explicit bridge, not global-context parenting
@@ -61,6 +69,13 @@ test on every CI run is a large trace volume for little routine value, so they
 remain opt-in (harness `forceOtel` / targeted investigation). Measured runner
 overhead was a small bounded per-file cost with a minimal (no-auto-instrument)
 SDK.
+
+## Decision
+
+Keep the runner and product providers independent and explicitly seed the
+active Vitest span as the Effect parent. Enable runner coverage by default when
+the devenv task supplies collector context, keep product export opt-in, and
+suppress the bridge in otelite assertion capture.
 
 ## Consequences
 

--- a/context/vitest-otel/.decisions/0002-default-safe-root-workspace.md
+++ b/context/vitest-otel/.decisions/0002-default-safe-root-workspace.md
@@ -16,6 +16,21 @@ The observability lifecycle is already owned by
 defines how a test task opts into the native Vitest runner lane when such a
 collector context exists.
 
+## Options
+
+| Option                             | Tradeoffs                                                                                 |
+| ---------------------------------- | ----------------------------------------------------------------------------------------- |
+| Mandatory root workspace           | Centralizes config but breaks consumers without effect-utils' workspace shape.            |
+| Explicit root-workspace capability | Preserves package-local defaults and centralizes telemetry for consumers that opt in.     |
+| Per-package telemetry config       | Avoids root assumptions but duplicates SDK and runner configuration across every package. |
+
+## Evidence and Argument
+
+Package-local execution is an existing downstream contract, while root
+workspace project selection is repository-specific. An explicit capability
+preserves that contract, avoids duplicated package configuration, and composes
+with the observability module that already owns collector lifecycle.
+
 ## Decision
 
 - `devenvModules.tasks.test` keeps package-local execution as its default.

--- a/context/vitest-otel/.decisions/0002-default-safe-root-workspace.md
+++ b/context/vitest-otel/.decisions/0002-default-safe-root-workspace.md
@@ -1,0 +1,38 @@
+# 0002 - Root-workspace runner telemetry is an explicit test-module capability
+
+Status: accepted
+
+## Context
+
+Vitest native OpenTelemetry is configured once in a root workspace config, but
+the reusable devenv test module historically runs each package from its own
+directory and config. Unconditionally changing all package tasks to `--project`
+would require every downstream repository to have effect-utils' root-workspace
+shape and would break consumers that intentionally use only package-local
+configs.
+
+The observability lifecycle is already owned by
+`devenvModules.observability` and its otelite profiles. This decision only
+defines how a test task opts into the native Vitest runner lane when such a
+collector context exists.
+
+## Decision
+
+- `devenvModules.tasks.test` keeps package-local execution as its default.
+- A consumer with a root Vitest workspace explicitly sets
+  `vitestWorkspaceRoot`.
+- In that mode, each package task resolves its package-local Vitest binary
+  before changing directory, then runs the corresponding root `--project`.
+- The task sets `VITEST_OTEL_RUNNER=1` only when the standard
+  `OTEL_EXPORTER_OTLP_ENDPOINT` is present. It does not start, stop, or configure
+  an observability backend.
+- effect-utils self-hosts the capability with `vitestWorkspaceRoot = "."`.
+
+## Consequences
+
+- Downstream consumers retain their existing working directory and
+  package-local config unless they opt in.
+- Native runner telemetry composes with the lifecycle delivered by #970/#973
+  without duplicating otelite or devenv orchestration in the test module.
+- A root workspace must keep project names aligned with the test module's
+  package names.

--- a/context/vitest-otel/.decisions/0003-product-span-flush-budget.md
+++ b/context/vitest-otel/.decisions/0003-product-span-flush-budget.md
@@ -13,6 +13,22 @@ the export failure after the timeout. Its 3-second default can therefore drop a
 product batch silently when a collector is slow even though the independently
 flushed runner spans survive.
 
+## Options
+
+| Option                            | Tradeoffs                                                                                 |
+| --------------------------------- | ----------------------------------------------------------------------------------------- |
+| Shared provider and budget        | Simplifies teardown but couples product attribution and capture to Vitest globals.        |
+| Independent with 3-second budget  | Preserves ownership but can silently drop short-lived product batches on slow collectors. |
+| Independent with 15-second budget | Preserves ownership and improves delivery while retaining a finite upper bound.           |
+
+## Evidence and Argument
+
+Sharing the provider would couple service attribution and assertion capture to
+Vitest's experimental integration. The independent product exporter preserves
+those contracts, but its per-test finalizer is the last opportunity to deliver
+short-lived spans. A 15-second upper bound improves delivery tolerance without
+adding steady-state delay when the collector acknowledges promptly.
+
 ## Decision
 
 - Keep the Effect product exporter per-test and independent from Vitest's

--- a/context/vitest-otel/.decisions/0003-product-span-flush-budget.md
+++ b/context/vitest-otel/.decisions/0003-product-span-flush-budget.md
@@ -1,0 +1,32 @@
+# 0003 - Keep product export independent and bound its scope-close flush
+
+Status: accepted
+
+## Context
+
+Vitest runner spans and Effect product spans use independent tracer providers.
+Fast tests often finish before `OtlpTracer`'s periodic exporter runs, so their
+product spans depend on the exporter finalizer at per-test scope close.
+
+`@effect/opentelemetry` bounds that finalizer with `shutdownTimeout` and ignores
+the export failure after the timeout. Its 3-second default can therefore drop a
+product batch silently when a collector is slow even though the independently
+flushed runner spans survive.
+
+## Decision
+
+- Keep the Effect product exporter per-test and independent from Vitest's
+  global provider. This preserves service attribution, explicit parenting, and
+  per-test failure isolation.
+- Set `makeOtelVitestLayer`'s default `shutdownTimeout` to 15 seconds.
+- Keep the native runner SDK teardown independently bounded at 2 seconds so
+  unavailable observability cannot stall Vitest worker shutdown.
+
+## Consequences
+
+- A healthy local otelite/collector acknowledges quickly, so the larger product
+  budget adds no steady-state delay.
+- A slow product exporter can still extend an instrumented test by its actual
+  acknowledgement time, up to 15 seconds. Product export remains opt-in.
+- Runner telemetry may be abandoned earlier than product telemetry when the
+  backend is unavailable; neither lane changes test correctness.

--- a/context/vitest-otel/.experiments/prototype-validation.md
+++ b/context/vitest-otel/.experiments/prototype-validation.md
@@ -5,7 +5,18 @@ Non-normative evidence for [../spec.md](../spec.md) and
 Validated end-to-end in an isolated worktree against the real harness (not a
 throwaway), Vitest pinned `4.1.9`.
 
-## Hypotheses and results
+## Question
+
+Can Vitest's native OpenTelemetry runner tree and Effect product spans compose
+without global-provider coupling or loss of deterministic otelite assertions?
+
+## Method
+
+Run the real utils-dev harness with Vitest `4.1.9`, a minimal native SDK, and
+otelite capture; compare the emitted runner/product trace relationships with
+the bridge enabled, suppressed, and absent.
+
+## Result
 
 | Hypothesis                                         | Method                                                                              | Result                                                                            |
 | -------------------------------------------------- | ----------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
@@ -21,7 +32,13 @@ throwaway), Vitest pinned `4.1.9`.
 - oxlint on the 6 changed files: **0 warnings / 0 errors**; oxfmt clean.
 - `@overeng/utils-dev` full suite (harness lives here): **31/31 pass**.
 
-## Known costs and open items
+## Conclusion
+
+The explicit bridge connects independent runner and product providers, while
+the suppression marker keeps assertion capture deterministic. Native runner
+telemetry remains inert when collector context is absent.
+
+## VRS Impact
 
 - Adding `@opentelemetry/exporter-trace-otlp-http` changed `pnpm-lock.yaml`,
   invalidating the nix pnpm-deps FOD hashes for workspace CLIs (oxc-config,

--- a/context/vitest-otel/requirements.md
+++ b/context/vitest-otel/requirements.md
@@ -94,7 +94,7 @@
 
 - **R10 Capture-lane suppression:** When the otelite in-process capture is
   active for a test, the runner-parent seed is suppressed, so captured product
-  spans stay root and their shape (including root-ness) is independent of
+  spans stay inside the capture-owned trace and their shape is independent of
   whether native Vitest OTEL is enabled for the run.
 - **R11 Suppression is structural, not per-test:** Suppression is provided by
   the capture layer itself, requiring no change to individual assertion tests.
@@ -109,3 +109,16 @@
 - **R14 Ungoverned names are declared:** `vitest.*` runner span names are
   explicitly recorded as external/ungoverned, so their absence from the
   telemetry registry is intentional, not an oversight (T03).
+
+### Run outcomes and export completion stay trustworthy
+
+- **R15 Failure status:** A failed test preserves the Vitest process failure and
+  marks the corresponding native callback span as an OpenTelemetry error.
+- **R16 Bounded drain:** Success and failure runs drain pending runner and
+  product telemetry within their configured teardown bounds; an unavailable
+  receiver cannot turn telemetry teardown into an unbounded test run.
+- **R17 OTLP interoperability:** A standards-conforming OTLP receiver accepts
+  both native runner and Effect product telemetry without rejected records, and
+  the decoded records preserve the collector gate, ambient task parenting,
+  Vitest-to-Effect parent bridge, assertion-lane suppression, successful drain,
+  and failed-callback status.

--- a/context/vitest-otel/spec.md
+++ b/context/vitest-otel/spec.md
@@ -17,6 +17,7 @@ Defines:
 - Capture-lane suppression (R10–R12).
 - Independent runner/product teardown budgets (decision
   [0003](./.decisions/0003-product-span-flush-budget.md)).
+- Outcome and end-to-end conformance for both lanes (R15–R17).
 
 Does not define:
 
@@ -78,7 +79,11 @@ export default provider // Vitest calls .shutdown() to flush
 - No `getNodeAutoInstrumentations()` — the process is not instrumented (R04).
 - `.mjs`, loaded by Vitest outside the TS transform pipeline.
 - The exporter honors standard `OTEL_EXPORTER_OTLP_ENDPOINT` env; runner spans
-  root under the ambient `TRACEPARENT` (R03).
+  root under the ambient `TRACEPARENT` (R03). Vitest itself extracts
+  `TRACEPARENT`/`TRACESTATE` with the registered W3C propagator when it creates
+  `vitest.start`, then propagates that context to workers. The sdkPath module
+  must not perform a second extraction or manufacture an ambient process-wide
+  context.
 
 Emitted tree (observed): `vitest.worker → vitest.runtime.run →
 vitest.test.runner.run.{module,spec,test} → vitest.test.runner.test.callback`,
@@ -136,7 +141,32 @@ makeOteliteCaptureLayer()
   (lower layer) and provided by the otelite capture layer (upper layer) — no
   circular dependency, no per-test change (R11).
 - `bridgeVitestParent` checks it via `Effect.serviceOption`; when present the
-  seed is skipped and captured product spans stay root (R10).
+  seed is skipped and captured product spans stay under the capture-owned
+  `otelite-capture-file` root instead of joining the ambient runner trace (R10).
+
+The bridge executes inside the context supplied by `combinedLayer`, so the
+capture layer's marker is visible before the parent decision. Exporter
+finalizers remain owned by the outer `Effect.scoped` boundary.
+
+## End-to-end conformance (R15–R17)
+
+`vitest-otelite-e2e.test.sh` runs focused fixtures through the real Vitest
+runner and an ephemeral real otelite OTLP receiver. otelite owns receiver
+readiness and post-child drain; assertions consume its decoded summary and span
+rows rather than sleeping or implementing another receiver.
+
+| Scenario                                | Structural assertion                                                                                       |
+| --------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| Endpoint, runner switch absent          | Zero native spans; child succeeds                                                                          |
+| Runner switch + inherited `TRACEPARENT` | Every span uses the inherited trace ID; `vitest.start` points to the inherited span                        |
+| Effect product export                   | Product span's parent is the active `vitest.test.runner.test.callback`                                     |
+| otelite assertion capture               | Exactly one product under the capture-owned root; outer receiver contains runner spans but not the product |
+| Failing test                            | Child exits non-zero; callback has OTEL error status; receiver reports zero rejects after drain            |
+
+The shared-task smoke test separately proves the genuinely distinct config
+discovery behavior: package-local execution is the default, while a configured
+`vitestWorkspaceRoot` selects the package by manifest name and enables native
+OTEL only when the endpoint is present.
 
 ## Design questions
 

--- a/context/vitest-otel/spec.md
+++ b/context/vitest-otel/spec.md
@@ -3,9 +3,10 @@ Effect product spans under it. It builds on [requirements.md](./requirements.md)
 
 ## Status
 
-Draft. Validated end-to-end in an isolated prototype (see
-[.experiments/prototype-validation.md](./.experiments/prototype-validation.md));
-not yet landed on the mainline harness.
+Implemented by the shared test module, root Vitest config, and
+`@overeng/utils-dev` bridge. The original behavior was validated end-to-end in
+an isolated prototype (see
+[.experiments/prototype-validation.md](./.experiments/prototype-validation.md)).
 
 ## Scope
 
@@ -14,14 +15,16 @@ Defines:
 - The shared Vitest `sdkPath` module and how native OTEL is enabled (R01–R05).
 - The Vitest→Effect parent bridge and its placement in `withTestCtx` (R06–R09).
 - Capture-lane suppression (R10–R12).
+- Independent runner/product teardown budgets (decision
+  [0003](./.decisions/0003-product-span-flush-budget.md)).
 
 Does not define:
 
 - The Effect-native `OtlpTracer` / `makeOtelVitestLayer` export path — see
   `@overeng/utils-dev` `node-vitest`.
 - The otelite receiver / assertion API — see `@overeng/utils-dev` `otelite`.
-- The devenv OTEL collector, endpoint, or `TRACEPARENT` injection — see
-  `nix/devenv-modules/otel.nix`.
+- The observability backend lifecycle, endpoint, or `TRACEPARENT` injection —
+  see `devenvModules.observability` and its otelite profiles.
 
 ## Two lanes
 
@@ -45,12 +48,16 @@ root vitest.config.ts
     : (absent)
 ```
 
-- `VITEST_OTEL_RUNNER` is the collector-context switch (R01, R03); the devenv
-  test task sets it when `OTEL_EXPORTER_OTLP_ENDPOINT` is configured. Bare local
-  and watch runs leave it unset → native OTEL absent (A03). It is also the
+- `VITEST_OTEL_RUNNER` is the collector-context switch (R01, R03). A consumer
+  opts its shared test module into root-workspace execution with
+  `vitestWorkspaceRoot`; those tasks set the switch when
+  `OTEL_EXPORTER_OTLP_ENDPOINT` is configured. Package-local tasks, bare local
+  runs, and watch runs leave it unset → native OTEL absent (A03). It is also the
   single disable switch (R05).
-- Enablement is global config, applied to every project run with no per-package
-  edit (R02).
+- Enablement is global config, applied to every opted-in project run with no
+  per-package config edit (R02). Package-local execution remains the reusable
+  module's default (decision
+  [0002](./.decisions/0002-default-safe-root-workspace.md)).
 
 ### sdkPath module (R04)
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -387,6 +387,10 @@ in
       extraTests = [ "devenv-modules:test" ];
       packageConcurrency = 4;
       retainVitestJson = true;
+      # This repository has a root Vitest workspace, so package tasks can opt
+      # into native runner telemetry without imposing that structure on users
+      # of the reusable test module.
+      vitestWorkspaceRoot = ".";
     })
     (taskModules.storybook {
       packages = packagesWithStorybook;

--- a/genie/external.ts
+++ b/genie/external.ts
@@ -260,6 +260,7 @@ export const catalog = defineCatalog({
   // which @restatedev/restate-sdk-opentelemetry@1.14.5 requires as a peer.
   // @effect/opentelemetry@0.63 accepts ^2.0.0, so utils + restate-effect both stay compatible.
   '@opentelemetry/api': '1.9.1',
+  '@opentelemetry/exporter-trace-otlp-http': '0.219.0',
   '@opentelemetry/resources': '2.8.0',
   '@opentelemetry/sdk-logs': '0.219.0',
   '@opentelemetry/sdk-metrics': '2.8.0',

--- a/nix/devenv-modules/tasks/shared/test.nix
+++ b/nix/devenv-modules/tasks/shared/test.nix
@@ -22,6 +22,13 @@
 #   # Bound package-level fan-out for large repos / constrained CI runners:
 #   imports = [ (inputs.effect-utils.devenvModules.tasks.test { packageConcurrency = 4; }) ];
 #
+#   # Optional: run package tasks through a root Vitest workspace. The default
+#   # remains package-local so downstream repos do not need a root config:
+#   imports = [ (inputs.effect-utils.devenvModules.tasks.test {
+#     packages = [ { path = "packages/demo"; name = "demo"; } ];
+#     vitestWorkspaceRoot = ".";
+#   }) ];
+#
 # Each package must have:
 #   - vitest as a devDependency in package.json
 #   - vitest.config.ts in the package root
@@ -37,6 +44,7 @@
   extraTests ? [ ],
   packageConcurrency ? null,
   retainVitestJson ? false,
+  vitestWorkspaceRoot ? null,
 }:
 { lib, pkgs, ... }:
 let
@@ -86,6 +94,7 @@ let
     {
       name,
       extraArgs ? "",
+      rootWorkspace ? false,
     }:
     ''
       set -euo pipefail
@@ -104,7 +113,22 @@ let
           "--outputFile.json=$_vitest_collection_dir/${taskFileStem name}.vitest.json"
         )
       ''}
-      "''${_otel_instr[@]}" "$(resolve_package_bin vitest vitest)" run --testTimeout 30000 --hookTimeout 30000 "''${_vitest_collection_args[@]}" ${extraArgs}
+      ${
+        if rootWorkspace == false then
+          ''
+            "''${_otel_instr[@]}" "$(resolve_package_bin vitest vitest)" run --testTimeout 30000 --hookTimeout 30000 "''${_vitest_collection_args[@]}" ${extraArgs}
+          ''
+        else
+          ''
+            _vitest_bin="$(resolve_package_bin vitest vitest)"
+            _project_name="$("''${NODE_BIN:-node}" -p "require('$PWD/package.json').name")"
+            if [ -n "''${OTEL_EXPORTER_OTLP_ENDPOINT:-}" ]; then
+              export VITEST_OTEL_RUNNER=1
+            fi
+            cd "''${DEVENV_ROOT:?}/${vitestWorkspaceRoot}"
+            "''${_otel_instr[@]}" "$_vitest_bin" run --testTimeout 30000 --hookTimeout 30000 "''${_vitest_collection_args[@]}" --project "$_project_name" ${extraArgs}
+          ''
+      }
     '';
   vitestWatchExec = ''
     set -euo pipefail
@@ -135,6 +159,7 @@ let
         exec = trace.exec "test:${pkg.name}" (vitestExec {
           name = "test:${pkg.name}";
           extraArgs = pkg.vitestArgs or "";
+          rootWorkspace = vitestWorkspaceRoot != null;
         });
         cwd = pkg.path;
         execIfModified = [

--- a/nix/devenv-modules/tasks/shared/tests/pnpm-task-smoke.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/pnpm-task-smoke.test.sh
@@ -142,6 +142,7 @@ extract_shared_task_script() {
   local package_path="$3"
   local package_name="$4"
   local output_path="$5"
+  local module_extra="${6:-}"
 
   nix-instantiate --eval --strict --json --expr "
     let
@@ -166,6 +167,7 @@ extract_shared_task_script() {
                 port = 6006;
               }
             ];
+            $module_extra
           }) {
             pkgs = pkgsForTest;
             lib = lib;
@@ -365,6 +367,9 @@ EOF
 chmod +x "$workspace/packages/demo/node_modules/vitest/bin/vitest.js"
 cat > "$workspace/packages/demo/node_modules/.bin/vitest" <<'EOF'
 #!/usr/bin/env bash
+if [ -n "${TEST_VITEST_CONTEXT_LOG:-}" ]; then
+  printf 'pwd=%s\nrunner=%s\n' "$PWD" "${VITEST_OTEL_RUNNER:-}" > "$TEST_VITEST_CONTEXT_LOG"
+fi
 printf 'vitest-shim:%s\n' "$*"
 EOF
 chmod +x "$workspace/packages/demo/node_modules/.bin/vitest"
@@ -410,6 +415,13 @@ extract_shared_task_script \
   "demo" \
   "$tmpdir/test-demo.exec.sh"
 extract_shared_task_script \
+  "nix/devenv-modules/tasks/shared/test.nix" \
+  "test:demo" \
+  "packages/demo" \
+  "demo" \
+  "$tmpdir/test-demo-workspace.exec.sh" \
+  'vitestWorkspaceRoot = ".";'
+extract_shared_task_script \
   "nix/devenv-modules/tasks/shared/storybook.nix" \
   "storybook:build:demo" \
   "packages/demo" \
@@ -436,6 +448,7 @@ rewrite_unrealized_tool_paths "$tmpdir/pnpm-install-impure-ignore-scripts.exec.s
 rewrite_unrealized_tool_paths "$tmpdir/pnpm-install-impure-ignore-dep-scripts.exec.sh"
 rewrite_unrealized_tool_paths "$tmpdir/pnpm-install-impure-gvs.exec.sh"
 rewrite_unrealized_tool_paths "$tmpdir/test-demo.exec.sh"
+rewrite_unrealized_tool_paths "$tmpdir/test-demo-workspace.exec.sh"
 rewrite_unrealized_tool_paths "$tmpdir/storybook-demo.exec.sh"
 
 export PATH="$tmpdir/bin:$PATH"
@@ -1015,7 +1028,23 @@ echo "Test 29: generated storybook task runs storybook without pnpm exec"
   [ "$output" = "storybook-shim:build" ]
 )
 
-echo "Test 30: clean removes only root-owned topology and leaves shared content intact"
+echo "Test 30: root-workspace test mode is opt-in and enables runner OTEL only with a collector"
+(
+  cd "$workspace/packages/demo"
+  export DEVENV_ROOT="$workspace"
+  export TEST_VITEST_CONTEXT_LOG="$tmpdir/vitest-context.log"
+  output="$(OTEL_SCRAPE_ENABLED=0 OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318 bash "$tmpdir/test-demo-workspace.exec.sh")"
+  [ "$output" = "vitest-shim:run --testTimeout 30000 --hookTimeout 30000 --project demo" ]
+  grep -qF "pwd=$workspace" "$TEST_VITEST_CONTEXT_LOG"
+  grep -qF "runner=1" "$TEST_VITEST_CONTEXT_LOG"
+
+  output="$(OTEL_SCRAPE_ENABLED=0 OTEL_EXPORTER_OTLP_ENDPOINT= bash "$tmpdir/test-demo-workspace.exec.sh")"
+  [ "$output" = "vitest-shim:run --testTimeout 30000 --hookTimeout 30000 --project demo" ]
+  grep -qF "runner=" "$TEST_VITEST_CONTEXT_LOG"
+  ! grep -qF "runner=1" "$TEST_VITEST_CONTEXT_LOG"
+)
+
+echo "Test 31: clean removes only root-owned topology and leaves shared content intact"
 (
   cd "$workspace"
   export HOME="$tmpdir/home"

--- a/nix/devenv-modules/tasks/shared/tests/vitest-otelite-e2e.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/vitest-otelite-e2e.test.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Exercises Vitest's native OTEL lane and the Effect parent bridge through a
+# real otelite OTLP receiver. otelite owns readiness and drain; assertions read
+# decoded capture rows, so no receiver sleeps or hand-rolled HTTP server exist.
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$TESTS_DIR/../../../../.." && pwd)"
+FIXTURE="$ROOT/packages/@overeng/utils-dev/src/node-vitest/fixtures/otel-e2e"
+VITEST="$ROOT/packages/@overeng/utils-dev/node_modules/.bin/vitest"
+TRACE_ID="0af7651916cd43dd8448eb211c80319c"
+PARENT_SPAN_ID="b7ad6b7169203331"
+TRACEPARENT="00-$TRACE_ID-$PARENT_SPAN_ID-01"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+resolve_otelite() {
+  if [ -n "${OTELITE_BIN:-}" ]; then
+    printf '%s\n' "$OTELITE_BIN"
+  elif command -v otelite >/dev/null 2>&1; then
+    command -v otelite
+  else
+    printf '%s/bin/otelite\n' "$(nix build --no-link --print-out-paths "$ROOT#otelite")"
+  fi
+}
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+otelite_bin="$(resolve_otelite)"
+
+run_fixture() {
+  local label="$1"
+  local enabled="$2"
+  local file="$3"
+  local expect_exit="$4"
+  local capture="$tmpdir/$label.capture"
+  local stdout="$tmpdir/$label.stdout"
+  local stderr="$tmpdir/$label.stderr"
+  local actual_exit
+
+  set +e
+  if [ "$enabled" = 1 ]; then
+    TRACEPARENT="$TRACEPARENT" VITEST_OTEL_RUNNER=1 \
+      "$otelite_bin" run --out "$capture" --protocol http/json --drain-idle 100 -- \
+      "$VITEST" run --config "$FIXTURE/vitest.config.mjs" "$file" \
+      >"$stdout" 2>"$stderr"
+  else
+    env -u TRACEPARENT -u OTEL_TASK_TRACEPARENT -u VITEST_OTEL_RUNNER \
+      "$otelite_bin" run --out "$capture" --protocol http/json --drain-idle 100 -- \
+      "$VITEST" run --config "$FIXTURE/vitest.config.mjs" "$file" \
+      >"$stdout" 2>"$stderr"
+  fi
+  actual_exit=$?
+  set -e
+
+  [ "$actual_exit" -eq "$expect_exit" ] \
+    || fail "$label: expected exit $expect_exit, got $actual_exit ($(cat "$stderr"))"
+
+  "$otelite_bin" inspect "$capture" --signal traces >"$tmpdir/$label.spans.ndjson"
+}
+
+echo "Running Vitest OTEL otelite e2e test..."
+
+# Endpoint availability alone is not enablement: no switch means no SDK and no
+# native Vitest spans. This is the negative control for collector gating.
+run_fixture disabled 0 success.fixture.test.ts 0
+jq -e '.counts.spans == 0 and .counts.rejected == 0 and .child.exit_code == 0' \
+  "$tmpdir/disabled.stdout" >/dev/null \
+  || fail "disabled: endpoint-only run should capture zero spans and preserve success"
+
+# The positive half of the inherited-context regression: the same real runner
+# joins the supplied W3C trace and its top span points at the external parent.
+run_fixture bridge 1 bridge.fixture.test.ts 0
+jq -e '.counts.spans > 0 and .counts.rejected == 0 and .child.exit_code == 0' \
+  "$tmpdir/bridge.stdout" >/dev/null \
+  || fail "bridge: enabled run should drain accepted spans and preserve success"
+jq -s -e --arg trace "$TRACE_ID" 'all(.[]; .trace_id == $trace)' \
+  "$tmpdir/bridge.spans.ndjson" >/dev/null \
+  || fail "bridge: every runner and product span should join the inherited trace"
+jq -s -e --arg parent "$PARENT_SPAN_ID" '
+  any(.[]; .name == "vitest.start" and .parent_span_id == $parent)
+' "$tmpdir/bridge.spans.ndjson" >/dev/null \
+  || fail "bridge: vitest.start should parent directly to inherited TRACEPARENT"
+product_parent="$(
+  jq -r 'select(.name == "vitest-otel-e2e.product") | .parent_span_id' \
+    "$tmpdir/bridge.spans.ndjson"
+)"
+[ -n "$product_parent" ] && [ "$product_parent" != null ] \
+  || fail "bridge: missing Effect product span parent"
+jq -s -e --arg parent "$product_parent" '
+  any(.[]; .span_id == $parent and .name == "vitest.test.runner.test.callback")
+' "$tmpdir/bridge.spans.ndjson" >/dev/null \
+  || fail "bridge: Effect product span should parent to the active Vitest callback"
+
+# The assertion lane uses its own otelite receiver. Its fixture asserts the
+# captured product is one root span; the outer receiver must see native runner
+# spans but never that capture-owned product tree, proving suppression and
+# exporter isolation.
+run_fixture suppression 1 suppression.fixture.test.ts 0
+jq -e '.counts.spans > 0 and .counts.rejected == 0 and .child.exit_code == 0' \
+  "$tmpdir/suppression.stdout" >/dev/null \
+  || fail "suppression: outer runner capture should drain without rejects"
+jq -s -e '
+  any(.[]; .name == "vitest.test.runner.test.callback")
+  and all(.[]; .name != "vitest-otel-e2e.captured-product")
+' "$tmpdir/suppression.spans.ndjson" >/dev/null \
+  || fail "suppression: outer receiver should contain runner spans, not assertion product spans"
+
+# A failing child still completes the otelite drain and exports an ERROR
+# callback. No timing assertion is involved: the summary and decoded rows are
+# the deterministic completion evidence.
+run_fixture failure 1 failure.fixture.test.ts 1
+jq -e '.counts.spans > 0 and .counts.rejected == 0 and .child.exit_code == 1' \
+  "$tmpdir/failure.stdout" >/dev/null \
+  || fail "failure: summary should preserve child failure after draining accepted spans"
+jq -s -e '
+  any(.[]; .name == "vitest.test.runner.test.callback" and .status_code == 2)
+' "$tmpdir/failure.spans.ndjson" >/dev/null \
+  || fail "failure: failed callback should export OTEL error status"
+
+echo "Vitest OTEL otelite e2e test passed"

--- a/nix/oxc-config-plugin.nix
+++ b/nix/oxc-config-plugin.nix
@@ -29,7 +29,7 @@ let
     pnpm = pinnedPnpm;
   };
   packageDir = "packages/@overeng/oxc-config";
-  pnpmDepsHash = "sha256-0EpX7HQHfu4XyZjO/0N4QjOKaFXNB3F/iEUzGesURjM=";
+  pnpmDepsHash = "sha256-ybOGoqdL6zInSyi6bbuL9VhRlOFYAqnrb7fmTB0RiIk=";
 
   srcPath =
     if builtins.isAttrs src && builtins.hasAttr "outPath" src then

--- a/packages/@overeng/ci-tools/nix/build.nix
+++ b/packages/@overeng/ci-tools/nix/build.nix
@@ -19,7 +19,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-KOHU2Wf4qIAeis7nZKdJRBA192SYTpgn+ztjCEbSVVk=";
+      "." = mkSharedHash "sha256-47UQH5TtYdFKfDcSUmvmZYmAeOokKfSKfSntidTf0qE=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/genie/nix/build.nix
+++ b/packages/@overeng/genie/nix/build.nix
@@ -26,7 +26,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-DbFTw0rg9x++24H73gC0mh6Hio480Vzw4DcciBiFWj8=";
+      "." = mkSharedHash "sha256-1yz4KV9npmlT469mw8EWetY+VQffWjnirelFZjRzIYY=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/megarepo/nix/build.nix
+++ b/packages/@overeng/megarepo/nix/build.nix
@@ -24,7 +24,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-qC8Zwf/5v9EOEplQe7nYC0ZsbIBqBPun5Qo/cUEsiDo=";
+      "." = mkSharedHash "sha256-0bwUPElP0eGna7KuO8D87+8N+VRvYuA5Ma9qBz1Ow64=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     smokeTestArgs = [ "--help" ];

--- a/packages/@overeng/notion-cli/nix/build.nix
+++ b/packages/@overeng/notion-cli/nix/build.nix
@@ -33,7 +33,7 @@ let
     installRuntimeWorkspace = true;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-h4QW7C8huONRRAoB7S0mN4+DCzbvLd/onGyz7G9O83I=";
+      "." = mkSharedHash "sha256-pSFIhS3LNFCMAM9Ugmm7sogEqK8YRRveCNdzzEnAI1s=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/notion-md/nix/build.nix
+++ b/packages/@overeng/notion-md/nix/build.nix
@@ -20,7 +20,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-LAC9pK+sG1r5o5fUea8XNQexsl4gda0JpVzOYndD5EU=";
+      "." = mkSharedHash "sha256-43aQNrndDwz79m1iioSfQeLsLsNTKr+4gmu5J68cWeA=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/tui-stories/nix/build.nix
+++ b/packages/@overeng/tui-stories/nix/build.nix
@@ -21,7 +21,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-LK4w3JOeRzBwcVNzCpcMFv7nv2dEOX6yPVnvGJNXxG8=";
+      "." = mkSharedHash "sha256-wKz5ga1irMZwvZxf0gapj72rTyXFy3qrI6gsFPoE66I=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/utils-dev/package.json
+++ b/packages/@overeng/utils-dev/package.json
@@ -16,6 +16,12 @@
       "./otelite": "./dist/otelite/mod.js"
     }
   },
+  "dependencies": {
+    "@opentelemetry/api": "1.9.1",
+    "@opentelemetry/exporter-trace-otlp-http": "0.219.0",
+    "@opentelemetry/sdk-trace-base": "2.8.0",
+    "@opentelemetry/sdk-trace-node": "2.8.0"
+  },
   "devDependencies": {
     "@effect/opentelemetry": "0.63.0",
     "@effect/platform": "0.96.2",

--- a/packages/@overeng/utils-dev/package.json.genie.ts
+++ b/packages/@overeng/utils-dev/package.json.genie.ts
@@ -17,8 +17,18 @@ const peerDepNames = [
   'vitest',
 ] as const
 
+const otelRuntimeDepNames = [
+  '@opentelemetry/api',
+  '@opentelemetry/exporter-trace-otlp-http',
+  '@opentelemetry/sdk-trace-base',
+  '@opentelemetry/sdk-trace-node',
+] as const
+
 const deps = catalog.compose({
   workspace: workspaceMember({ memberPath: 'packages/@overeng/utils-dev' }),
+  dependencies: {
+    external: catalog.pick(...otelRuntimeDepNames),
+  },
   devDependencies: {
     external: {
       ...catalog.pick(...peerDepNames, '@types/node', 'typescript'),

--- a/packages/@overeng/utils-dev/src/node-vitest/Vitest.ts
+++ b/packages/@overeng/utils-dev/src/node-vitest/Vitest.ts
@@ -12,15 +12,19 @@
 import * as inspector from 'node:inspector'
 
 import { OtlpSerialization, OtlpTracer } from '@effect/opentelemetry'
+import * as OtelTracer from '@effect/opentelemetry/Tracer'
 import { FetchHttpClient } from '@effect/platform'
 import type * as Vitest from '@effect/vitest'
+import { trace } from '@opentelemetry/api'
 import type { Duration } from 'effect'
 import {
   type Cause,
+  Context,
   Effect,
   type FastCheck as FC,
   identity,
   Layer,
+  Option,
   Predicate,
   type Schema,
   type Scope,
@@ -59,6 +63,8 @@ export interface OtelVitestConfig {
   endpoint?: string
   /** Tracer export interval in milliseconds. @default 250 */
   exportInterval?: number
+  /** Exporter shutdown/flush timeout in milliseconds. @default 15000 */
+  shutdownTimeout?: number
 }
 
 export { otlpTracesUrl } from '../otelite/otlp-url.ts'
@@ -79,6 +85,7 @@ export const makeOtelVitestLayer = (
     endpointEnvVar = 'OTEL_EXPORTER_OTLP_ENDPOINT',
     endpoint: explicitEndpoint,
     exportInterval = 250,
+    shutdownTimeout = 15_000,
     rootSpanName,
   } = config
 
@@ -96,6 +103,9 @@ export const makeOtelVitestLayer = (
       url: otlpTracesUrl(endpoint),
       resource: { serviceName },
       exportInterval,
+      // Product spans flush at per-test scope close. Keep this above the native
+      // runner SDK's export budget so a slow collector does not drop only one lane.
+      shutdownTimeout,
     }).pipe(
       Layer.provideMerge(FetchHttpClient.layer),
       Layer.provideMerge(OtlpSerialization.layerJson),
@@ -107,6 +117,34 @@ export const makeOtelVitestLayer = (
 
 /** Dummy OTEL layer that does nothing (for when OTEL is disabled). */
 export const OtelVitestDummy: Layer.Layer<never> = Layer.empty
+
+/**
+ * Marker used by deterministic otelite capture tests to keep captured product
+ * spans independent of an ambient native Vitest runner span.
+ */
+export class SuppressVitestParentBridge extends Context.Tag(
+  '@overeng/utils-dev/node-vitest/SuppressVitestParentBridge',
+)<SuppressVitestParentBridge, true>() {}
+
+/**
+ * Seeds Vitest's active callback span as the explicit Effect parent.
+ *
+ * The two tracer providers remain independent; only trace identity and parent
+ * identity cross this boundary.
+ */
+const bridgeVitestParent = <A, E, R>(self: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
+  Effect.suspend(() => {
+    const spanContext = trace.getActiveSpan()?.spanContext()
+    if (spanContext === undefined) return self
+
+    return Effect.serviceOption(SuppressVitestParentBridge).pipe(
+      Effect.flatMap((suppressed) =>
+        Option.isSome(suppressed) === true
+          ? self
+          : Effect.withParentSpan(self, OtelTracer.makeExternalSpan(spanContext)),
+      ),
+    )
+  })
 
 // ============================================================================
 // withTestCtx - Test Context Wrapper
@@ -194,11 +232,13 @@ export const withTestCtx =
 
       const combinedLayer = layer.pipe(Layer.provideMerge(otelLayer))
 
-      return self.pipe(
-        DEBUGGER_ACTIVE === true ? identity : Effect.timeout(timeout),
-        Effect.provide(combinedLayer),
-        Effect.scoped, // We need to scope the effect manually here because otherwise the span is not closed
-        Effect.annotateLogs({ suffix }),
+      return bridgeVitestParent(
+        self.pipe(
+          DEBUGGER_ACTIVE === true ? identity : Effect.timeout(timeout),
+          Effect.provide(combinedLayer),
+          Effect.scoped, // We need to scope the effect manually here because otherwise the span is not closed
+          Effect.annotateLogs({ suffix }),
+        ),
       ) as any
     }
 

--- a/packages/@overeng/utils-dev/src/node-vitest/Vitest.ts
+++ b/packages/@overeng/utils-dev/src/node-vitest/Vitest.ts
@@ -232,13 +232,17 @@ export const withTestCtx =
 
       const combinedLayer = layer.pipe(Layer.provideMerge(otelLayer))
 
+      // Keep the bridge inside the provided context: capture layers contribute
+      // SuppressVitestParentBridge, so the decision must run after that marker
+      // is available. The outer scope still owns every provided-layer finalizer.
       return bridgeVitestParent(
         self.pipe(
           DEBUGGER_ACTIVE === true ? identity : Effect.timeout(timeout),
-          Effect.provide(combinedLayer),
-          Effect.scoped, // We need to scope the effect manually here because otherwise the span is not closed
           Effect.annotateLogs({ suffix }),
         ),
+      ).pipe(
+        Effect.provide(combinedLayer),
+        Effect.scoped, // We need to scope the effect manually here because otherwise the span is not closed
       ) as any
     }
 

--- a/packages/@overeng/utils-dev/src/node-vitest/fixtures/otel-e2e/bridge.fixture.test.ts
+++ b/packages/@overeng/utils-dev/src/node-vitest/fixtures/otel-e2e/bridge.fixture.test.ts
@@ -1,0 +1,13 @@
+import { Effect } from 'effect'
+
+import { Vitest } from '../../mod.ts'
+
+const PRODUCT_SPAN_NAME = 'vitest-otel-e2e.product'
+
+Vitest.scopedLive('bridges an Effect product span', (test) =>
+  Effect.void.pipe(
+    // oxlint-disable-next-line overeng/no-raw-otel-primitives -- direct probe of the generic Vitest-to-Effect bridge
+    Effect.withSpan(PRODUCT_SPAN_NAME),
+    Vitest.withTestCtx(test, { forceOtel: true }),
+  ),
+)

--- a/packages/@overeng/utils-dev/src/node-vitest/fixtures/otel-e2e/failure.fixture.test.ts
+++ b/packages/@overeng/utils-dev/src/node-vitest/fixtures/otel-e2e/failure.fixture.test.ts
@@ -1,0 +1,5 @@
+import { expect, test } from 'vitest'
+
+test('exports a failed callback', () => {
+  expect('actual').toBe('expected')
+})

--- a/packages/@overeng/utils-dev/src/node-vitest/fixtures/otel-e2e/success.fixture.test.ts
+++ b/packages/@overeng/utils-dev/src/node-vitest/fixtures/otel-e2e/success.fixture.test.ts
@@ -1,0 +1,5 @@
+import { expect, test } from 'vitest'
+
+test('completes successfully', () => {
+  expect('vitest-otel').toContain('otel')
+})

--- a/packages/@overeng/utils-dev/src/node-vitest/fixtures/otel-e2e/suppression.fixture.test.ts
+++ b/packages/@overeng/utils-dev/src/node-vitest/fixtures/otel-e2e/suppression.fixture.test.ts
@@ -1,0 +1,31 @@
+import { Effect } from 'effect'
+
+import {
+  flushCaptureSpans,
+  makeOteliteCaptureLayer,
+  OteliteCapture,
+} from '../../../otelite/vitest-bridge.ts'
+import { Vitest } from '../../mod.ts'
+
+const CAPTURED_SPAN_NAME = 'vitest-otel-e2e.captured-product'
+
+const exportInterval = 100
+const CaptureLayer = makeOteliteCaptureLayer({ exportInterval })
+
+Vitest.scopedLive('keeps the assertion product span root and singular', (test) =>
+  Effect.gen(function* () {
+    const capture = yield* OteliteCapture
+
+    yield* Effect.void.pipe(
+      // oxlint-disable-next-line overeng/no-raw-otel-primitives -- direct probe of capture-lane bridge suppression
+      Effect.withSpan(CAPTURED_SPAN_NAME),
+    )
+    yield* flushCaptureSpans({ exportInterval })
+
+    const spans = yield* capture.inspect({ signal: 'traces', name: CAPTURED_SPAN_NAME })
+    Vitest.expect(spans).toHaveLength(1)
+    const inheritedTraceId = process.env.TRACEPARENT?.split('-')[1]
+    Vitest.expect(inheritedTraceId).toBeDefined()
+    Vitest.expect(spans[0]?.trace_id).not.toBe(inheritedTraceId)
+  }).pipe(Vitest.withTestCtx(test, { makeLayer: () => CaptureLayer })),
+)

--- a/packages/@overeng/utils-dev/src/node-vitest/fixtures/otel-e2e/vitest.config.mjs
+++ b/packages/@overeng/utils-dev/src/node-vitest/fixtures/otel-e2e/vitest.config.mjs
@@ -1,0 +1,23 @@
+import { fileURLToPath } from 'node:url'
+
+const runnerEnabled = process.env.VITEST_OTEL_RUNNER === '1'
+
+export default {
+  root: fileURLToPath(new URL('.', import.meta.url)),
+  test: {
+    include: ['*.fixture.test.ts'],
+    pool: 'forks',
+    maxWorkers: 1,
+    fileParallelism: false,
+    ...(runnerEnabled === true
+      ? {
+          experimental: {
+            openTelemetry: {
+              enabled: true,
+              sdkPath: '../../otel-sdk.mjs',
+            },
+          },
+        }
+      : {}),
+  },
+}

--- a/packages/@overeng/utils-dev/src/node-vitest/otel-sdk.mjs
+++ b/packages/@overeng/utils-dev/src/node-vitest/otel-sdk.mjs
@@ -1,0 +1,37 @@
+/**
+ * Minimal SDK for Vitest's native OpenTelemetry runner spans.
+ *
+ * Vitest loads this module outside the TypeScript transform pipeline and awaits
+ * the default export's `shutdown()`. Registering the provider also installs the
+ * AsyncLocalStorage context manager used by the Effect parent bridge.
+ */
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
+import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base'
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node'
+
+const shutdownBudgetMs = 2_000
+
+export default (() => {
+  const provider = new NodeTracerProvider({
+    spanProcessors: [
+      new BatchSpanProcessor(new OTLPTraceExporter({ timeoutMillis: shutdownBudgetMs }), {
+        exportTimeoutMillis: shutdownBudgetMs,
+      }),
+    ],
+  })
+  provider.register()
+
+  // Runner telemetry must not turn an unavailable collector into a failed or
+  // minute-long test teardown. Vitest awaits this seam, so bound it explicitly.
+  const realShutdown = provider.shutdown.bind(provider)
+  provider.shutdown = () =>
+    Promise.race([
+      realShutdown().catch(() => {}),
+      new Promise((resolve) => {
+        const timer = setTimeout(resolve, shutdownBudgetMs)
+        timer.unref()
+      }),
+    ])
+
+  return provider
+})()

--- a/packages/@overeng/utils-dev/src/otelite/vitest-bridge.test.ts
+++ b/packages/@overeng/utils-dev/src/otelite/vitest-bridge.test.ts
@@ -47,8 +47,8 @@ layer(CaptureLayer, { excludeTestServices: true })('OteliteCapture bridge', (it)
       yield* flushCaptureSpans({ exportInterval })
 
       const rows = yield* cap.inspect({ signal: 'traces', name: spanName })
-      expect(rows.length).toBeGreaterThanOrEqual(1)
-      const span = rows.find((r) => r.name === spanName)!
+      expect(rows).toHaveLength(1)
+      const span = rows[0]!
       expect(span.schema).toBe('otelite.span/v1')
       expect(span.service).toBe('otelite-capture-bridge')
 
@@ -71,7 +71,7 @@ layer(CaptureLayer, { excludeTestServices: true })('OteliteCapture bridge', (it)
 
       const rows = yield* cap.inspect({ signal: 'traces', name: spanName })
       expect(rows.every((r) => r.name === spanName)).toBe(true)
-      expect(rows.length).toBeGreaterThanOrEqual(1)
+      expect(rows).toHaveLength(1)
     }),
   )
 })

--- a/packages/@overeng/utils-dev/src/otelite/vitest-bridge.ts
+++ b/packages/@overeng/utils-dev/src/otelite/vitest-bridge.ts
@@ -25,7 +25,7 @@
 import { NodeContext } from '@effect/platform-node'
 import { Context, Effect, Layer } from 'effect'
 
-import { makeOtelVitestLayer } from '../node-vitest/Vitest.ts'
+import { makeOtelVitestLayer, SuppressVitestParentBridge } from '../node-vitest/Vitest.ts'
 import type { OteliteCliError, OteliteDecodeError, OteliteSpawnError } from './errors.ts'
 import { Otelite } from './Otelite.ts'
 import type { CaptureHandle, CaptureOptions } from './Otelite.ts'
@@ -110,7 +110,12 @@ export const makeOteliteCaptureLayer = (
     ),
   )
 
-  return exporterLayer.pipe(Layer.provideMerge(handleLayer))
+  return exporterLayer.pipe(
+    Layer.provideMerge(handleLayer),
+    // A capture assertion must not change shape depending on whether the outer
+    // Vitest run happened to enable native runner telemetry.
+    Layer.provideMerge(Layer.succeed(SuppressVitestParentBridge, true as const)),
+  )
 }
 
 /**

--- a/packages/@overeng/utils-dev/vitest.config.ts
+++ b/packages/@overeng/utils-dev/vitest.config.ts
@@ -3,7 +3,11 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     include: ['src/**/*.test.ts'],
-    exclude: ['src/**/*.integration.test.ts', 'src/**/*.pw.test.ts'],
+    exclude: [
+      'src/**/*.integration.test.ts',
+      'src/**/*.pw.test.ts',
+      'src/node-vitest/fixtures/**/*.test.ts',
+    ],
     server: { deps: { inline: ['@effect/vitest'] } },
     // The otelite tests (src/otelite) spawn the real nix-built otelite binary;
     // give them headroom.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1927,6 +1927,19 @@ importers:
         version: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)
 
   packages/@overeng/utils-dev:
+    dependencies:
+      '@opentelemetry/api':
+        specifier: 1.9.1
+        version: 1.9.1
+      '@opentelemetry/exporter-trace-otlp-http':
+        specifier: 0.219.0
+        version: 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base':
+        specifier: 2.8.0
+        version: 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-node':
+        specifier: 2.8.0
+        version: 2.8.0(@opentelemetry/api@1.9.1)
     devDependencies:
       '@effect/opentelemetry':
         specifier: 0.63.0
@@ -2540,6 +2553,24 @@ packages:
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/exporter-trace-otlp-http@0.219.0':
+    resolution: {integrity: sha512-9t6SvBXXBEjOBcIzgozvBbd3jWrv3Gt3ngGhl1fhdZ/zRc7oZDVOFEqbi2zlBpW9BXhgDMKv422J0DL/3iQWfw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-exporter-base@0.219.0':
+    resolution: {integrity: sha512-zvIxQX/AZUVKDU+hCuYx+7UkiP7GRdnk1ZbFQRYzHvYp47cAWR4j3IhoPhV9KaeXEv2xdGq3IA6PnpzDmLcmSA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-transformer@0.219.0':
+    resolution: {integrity: sha512-aaYKAyXhw9VchKZVGOopD3Gw/kPsyrX2c6IQ0AW32mTjqmZOh5Y6Gf5OYqTNqVktAeBjmFinhyFaCwW6GYK9YQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
 
   '@opentelemetry/resources@2.8.0':
     resolution: {integrity: sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==}
@@ -5714,6 +5745,31 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/exporter-trace-otlp-http@0.219.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-exporter-base@0.219.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.219.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-transformer@0.219.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.219.0
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1)':
     dependencies:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,11 @@ import { existsSync, readdirSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import { defineConfig } from 'vitest/config'
+import type { ViteUserConfig } from 'vitest/config'
+
+// Package-local Vitest binaries load this root workspace config, so avoid a
+// runtime import that would be resolved from the dependency-less repo root.
+const defineConfig = (config: ViteUserConfig): ViteUserConfig => config
 
 const rootDir = fileURLToPath(new URL('.', import.meta.url))
 const packagesRoot = resolve(rootDir, 'packages', '@overeng')
@@ -26,11 +30,23 @@ const projects = projectRoots.map((root) =>
     : { root, test: { exclude, server: { deps: { inline: inlineDeps } } } },
 )
 
+const otelRunnerEnabled = process.env.VITEST_OTEL_RUNNER === '1'
+
 // We mostly have this file for VSC test explorer support
 export default defineConfig({
   test: {
     exclude,
     server: { deps: { inline: inlineDeps } },
+    ...(otelRunnerEnabled === true
+      ? {
+          experimental: {
+            openTelemetry: {
+              enabled: true,
+              sdkPath: './packages/@overeng/utils-dev/src/node-vitest/otel-sdk.mjs',
+            },
+          },
+        }
+      : {}),
     projects,
   },
 })


### PR DESCRIPTION
## Problem

Vitest test tasks appear as opaque command spans: runner startup, collection,
file execution, and callbacks are not visible. Effect product spans emitted by
the test harness use an independent tracer and therefore do not automatically
inherit Vitest's active callback span.

The original version of this PR also carried observability orchestration that
has since landed in #970 and #973. Keeping both implementations would duplicate
the devenv/otelite lifecycle and make downstream test-module behavior depend on
effect-utils' root-workspace shape.

## Goal

Keep the narrow missing seam: emit native Vitest runner spans and explicitly
connect Effect product spans to the active Vitest callback, while composing with
the observability lifecycle already owned by `devenvModules.observability` and
otelite.

## Decisions

- **Explicit parent bridge.** `withTestCtx` reads Vitest's active OTEL span at
  execution time and seeds it as an external Effect parent. The bridge executes
  inside the supplied Effect layer so layer-provided suppression and tracers are
  visible at the boundary.
- **Vitest owns W3C extraction.** Vitest extracts `TRACEPARENT`/`TRACESTATE`
  through its registered propagator when it creates `vitest.start`, then carries
  that context through workers. The SDK does not duplicate that process-global
  responsibility.
- **Deterministic capture lane.** `makeOteliteCaptureLayer` provides a typed
  `SuppressVitestParentBridge` marker, so assertion capture owns a separate trace
  and does not depend on ambient runner instrumentation.
- **Default-safe task composition.** The shared test module keeps package-local
  execution by default. Repositories with a root Vitest workspace explicitly
  set `vitestWorkspaceRoot`; effect-utils self-hosts that option.
- **Existing lifecycle only.** The test task consumes the standard
  `OTEL_EXPORTER_OTLP_ENDPOINT` and sets `VITEST_OTEL_RUNNER=1`. It does not
  start or configure otelite, a Collector, Tempo, or Grafana.
- **Bounded teardown.** The minimal native SDK abandons unavailable runner
  export after 2 seconds. Effect product export keeps a separate 15-second
  scope-close budget because fast tests often flush only in that finalizer.

## End-to-end evidence

The new shell gate starts the real Nix-built otelite receiver and decodes its
OTLP rows. It proves:

1. no native spans when the runner switch is absent;
2. inherited W3C trace and direct `vitest.start` parentage when enabled;
3. an Effect product span parented to the active Vitest callback;
4. assertion-capture suppression produces exactly one product span on its own
   trace while runner spans remain on the inherited trace;
5. failing tests still export an error-status callback; and
6. every tested export drains within a bounded otelite-owned lifecycle with no
   rejected spans.

Red/green validation also caught a real ordering bug: with the old
`withTestCtx` composition, the product span was not parented to the active
callback and the suppression marker was outside the bridge environment.
Providing the combined layer around the bridge makes both contracts observable.

## Verification

- `OTELITE_BIN="$(nix build --no-link --print-out-paths .#otelite)/bin/otelite" bash nix/devenv-modules/tasks/shared/tests/vitest-otelite-e2e.test.sh`
  - pass.
- Focused utils-dev Vitest run for the otelite bridge and flush suites
  - 2 files, 5 tests passed.
- `axe vrs check --profile strict context/vitest-otel`
  - pass. Requirements now explicitly cover failure status, bounded drain, and
    OTLP interoperability; accepted decisions and experiment records satisfy
    strict record shape.
- `devenv tasks run lint:fix lint:nix:fix:format --no-tui`
  - pass.
- `devenv tasks run check:quick --no-tui`
  - pass.
- `devenv tasks run devenv-modules:test --no-tui`
  - pass.
- `devenv tasks run check:all --no-tui`
  - the changed OTEL contract boundary, Nix flake, Cargo, strict TypeScript,
    devenv-module, Weaver, and preceding package gates passed. The run then
    failed in three pre-existing `@overeng/restate-effect` observability tests
    (missing attempt spans); a separate `test:restate-effect` run reproduces
    those failures without this PR touching that package. The orchestrator
    skipped the downstream utils-dev batch, which is why the changed package
    and real otelite E2E are also run directly above.

## Complexity and trade-offs

The implementation adds one minimal `.mjs` Vitest SDK module, dedicated E2E
fixtures, and direct OpenTelemetry dependencies in `@overeng/utils-dev`. The
reusable Nix surface is one nullable option; no backend process or profile
module is added.

Vitest's OpenTelemetry API remains experimental. Disabling
`VITEST_OTEL_RUNNER` removes the runner lane without changing test behavior or
otelite product-span assertions. High-volume product export remains opt-in.

## Follow-ups

- Consider attaching reusable `evergreen.fodGraph.v1` metadata so future lock
  changes can use `chase-fod-closure` without explicit hash-source routing.
- The open design questions in `context/vitest-otel/spec.md` remain out of
  scope, especially default-on high-volume product export.

## References

- Superseded lifecycle scope: #970, #973
- VRS: `context/vitest-otel/`
