### PR TITLE
fix(notion-cli): let schema generate -o write a file (--output-mode for TUI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **notion-cli**: `schema generate <id> -o schema.gen.ts` now writes the file
+  again. The `generate` command registered both a file `--output`/`-o` option
+  and the shared TUI render-mode option, which also claimed `--output`/`-o`, so
+  the render-mode choice validator shadowed the file path and rejected it. The
+  TUI render mode on `generate` now uses a distinct `--output-mode` flag (no
+  `-o` alias), leaving `--output`/`-o` for the output file. Added a parse-level
+  test asserting `-o` resolves to the file path. (`introspect`/`diff`/
+  `generate-config` keep the shared render-mode `--output`/`-o`; they have no
+  file option to collide with.)
 - **CI / cargo**: move standalone Rust crate build/test/clippy/fmt semantics into
   the `cargo:check` devenv task and make the generated cargo CI lane call that
   task, ensuring the `node-cpuprofile` integration test runs with the devenv

--- a/packages/@overeng/notion-cli/src/commands/schema/mod.ts
+++ b/packages/@overeng/notion-cli/src/commands/schema/mod.ts
@@ -13,7 +13,11 @@ import React from 'react'
 import { EffectPath } from '@overeng/effect-path'
 import { NotionConfig, NotionDatabases, NotionDataSources } from '@overeng/notion-effect-client'
 import { run } from '@overeng/tui-react'
-import { outputOption as tuiOutputOption, outputModeLayer } from '@overeng/tui-react/node'
+import {
+  OUTPUT_MODE_VALUES,
+  outputOption as tuiOutputOption,
+  outputModeLayer,
+} from '@overeng/tui-react/node'
 
 import { getDiffApp } from '../../renderers/DiffOutput/app.ts'
 import { DiffView } from '../../renderers/DiffOutput/view.tsx'
@@ -88,6 +92,17 @@ const outputOption = Options.file('output').pipe(
   ),
 )
 
+/**
+ * TUI render-mode option for commands that also take a file `--output`/`-o`.
+ * Uses a distinct `--output-mode` flag (no `-o` alias) so the file-output option
+ * keeps `--output`/`-o`; the shared tui `outputOption` claims those and would
+ * otherwise shadow the file path, making `generate <id> -o file.ts` fail.
+ */
+const tuiOutputModeOption = Options.choice('output-mode', OUTPUT_MODE_VALUES).pipe(
+  Options.withDescription('TUI render mode (auto, pretty, ci-plain, json, ...)'),
+  Options.withDefault('auto' as (typeof OUTPUT_MODE_VALUES)[number]),
+)
+
 const nameOption = Options.text('name').pipe(
   Options.withAlias('n'),
   Options.withDescription('Name for the generated schema (defaults to database title)'),
@@ -143,7 +158,8 @@ const writableOption = Options.boolean('writable').pipe(
   Options.withDefault(false),
 )
 
-const generateCommand = Command.make(
+/** Exported for parse-level testing of option resolution (see mod.unit.test.ts). */
+export const generateCommand = Command.make(
   'generate',
   {
     databaseId: generateDatabaseIdArg,
@@ -158,7 +174,7 @@ const generateCommand = Command.make(
     noSchemaMeta: noSchemaMetaOption,
     includeApi: includeApiOption,
     writable: writableOption,
-    tuiOutput: tuiOutputOption,
+    tuiOutput: tuiOutputModeOption,
   },
   ({
     databaseId,

--- a/packages/@overeng/notion-cli/src/commands/schema/mod.unit.test.ts
+++ b/packages/@overeng/notion-cli/src/commands/schema/mod.unit.test.ts
@@ -1,0 +1,44 @@
+import { Command } from '@effect/cli'
+import { NodeContext } from '@effect/platform-node'
+import { describe, it } from '@effect/vitest'
+import { Effect } from 'effect'
+import { expect } from 'vitest'
+
+import { generateCommand } from './mod.ts'
+
+/**
+ * `schema generate` exposes both a file `--output`/`-o` option and the shared
+ * TUI render-mode option. These used to collide: the render-mode option also
+ * claimed `--output`/`-o`, so its choice validator shadowed the file path and
+ * `generate <id> -o schema.gen.ts` was rejected as an invalid mode. The
+ * render-mode flag now lives on `--output-mode` (no `-o` alias), leaving
+ * `--output`/`-o` free for the file path.
+ *
+ * This is a parse-level test: we swap in a capturing handler so the real Args/
+ * Options (where any collision lives) are exercised without touching the Notion
+ * API or the network.
+ */
+describe('schema generate option resolution', () => {
+  it.effect('parses -o as the output file path (no --output-mode collision)', () =>
+    Effect.gen(function* () {
+      let captured: { output?: string; tuiOutput?: string } | undefined
+
+      const testCommand = Command.withHandler(generateCommand, (parsed) =>
+        Effect.sync(() => {
+          captured = parsed
+        }),
+      )
+
+      const runCli = Command.run(testCommand, { name: 'notion', version: 'test' })
+
+      // argv[0]/argv[1] are dropped by Command.run; the rest is parsed by the
+      // command: a synthetic database-id positional plus the file `-o` flag.
+      yield* runCli(['node', 'notion', 'db-id-123', '-o', 'schema.gen.ts'])
+
+      expect(captured).toBeDefined()
+      expect(captured!.output).toBe('schema.gen.ts')
+      // The TUI render mode falls back to its default rather than swallowing `-o`.
+      expect(captured!.tuiOutput).toBe('auto')
+    }).pipe(Effect.provide(NodeContext.layer)),
+  )
+})


### PR DESCRIPTION
## Problem

`notion schema generate <id> -o schema.gen.ts` fails. In
`packages/@overeng/notion-cli/src/commands/schema/mod.ts` the `generate`
command registered **two** options that both claimed `--output`/`-o`:

- the schema file-output option — `Options.file('output').pipe(Options.withAlias('o'), …)`
- the shared TUI render-mode option imported from `@overeng/tui-react/node` —
  `Options.choice('output', OUTPUT_MODE_VALUES).pipe(Options.withAlias('o'), …)`

Because both used `--output`/`-o`, the choice validator shadowed the file
path: passing `-o schema.gen.ts` was rejected by the render-mode validator
("Expected one of the following cases: auto, tty, …"). This made the primary
single-command codegen path unusable — users had to fall back to
`generate-config`.

## Goal

`schema generate <id> -o schema.gen.ts` writes the file again, with the TUI
render mode still selectable via a distinct flag.

## Fix

- Keep `--output`/`-o` for the **file path** on `generate`.
- Give the TUI render mode its own `--output-mode` flag (no `-o` alias) on
  `generate` only.
- `introspect` / `diff` / `generate-config` keep the shared render-mode
  `--output`/`-o` — they have no file option to collide with, so they are
  unchanged.

`OUTPUT_MODE_VALUES` was already exported from `@overeng/tui-react/node`; no
changes to that package were needed. `generateCommand` is now exported so the
test can exercise its real Args/Options.

## Decisions

- **Flag name `--output-mode` on `generate` only.** The other subcommands keep
  the ergonomic `-o`/`--output` render-mode flag; only `generate` has a
  competing file option, so scoping the rename there minimizes surface change
  and keeps the collision impossible without a broader flag migration.

## Verification

- `bun packages/@overeng/notion-cli/src/cli.ts schema generate --help` now
  lists both distinctly:
  - `(-o, --output file)` — "Output file path for generated schema …"
  - `--output-mode auto | tty | alt-screen | ci | ci-plain | log | json | ndjson`
- **New parse-level test** `mod.unit.test.ts` (`@effect/vitest`): swaps in a
  capturing handler via `Command.withHandler` so the real command's
  Args/Options are parsed in isolation (no Notion API / network), then asserts
  `-o schema.gen.ts` resolves to `output` and the render mode falls back to its
  `auto` default. **Confirmed it fails before the fix**: reintroducing the
  collision makes the run fail with `InvalidValue` — "Expected one of the
  following cases: auto, tty, …" — proving the test catches the regression.
- Checks run against this tree: `vitest run` (green), `oxfmt --check` +
  `oxlint` (0 warnings / 0 errors on both changed files), `tsgo --noEmit` over
  `notion-cli` src (clean). No `.genie.ts` inputs touched and no generated
  files in the diff, so `genie:check` is unaffected.

## Complexity

No new complexity — a flag rename scoped to one subcommand plus a focused parse
test.

## Concerns

Minor user-facing change: on `generate`, the TUI render-mode flag moves from
`--output`/`-o` to `--output-mode`. `-o` now unambiguously means the output
file. Called out in `CHANGELOG.md` under `[Unreleased]`.

## Follow-ups

None.

## References

Standalone bug fix; no tracking issue.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 💜 cl1-violet |
| `agent_session_id` | 5ce468e2-a077-44ee-a724-bca1fb992e1c |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.202 |
| `agent_runtime` | Claude Code 2.1.202 |
| `agent_model` | claude-opus-4-8 |
| `runtime_profile` | /nix/store/34v4ljmkjh4sgzax68wwgggmzf69zmfk-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/92pwq9mx1byj8nl9an05dyh4baykvf1d-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | pr-wt/fix/notion-cli-schema-generate-output-file |
| `machine` | mbp2025 |
| `tooling_profile` | dotfiles@unknown |
</details>
<!-- agent-footer:end -->