### PR TITLE
fix(devenv): expose stable Genie module options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **devenv / genie**: replace the shared Genie task module's raw
+  `_module.args.geniePkg` / `_module.args.genieInputGlobs` contract with
+  declared `effectUtils.genie.package` and `effectUtils.genie.extraInputGlobs`
+  options. This keeps packaged Genie consumption on a stable module API and lets
+  downstream repos import the module without compatibility shims.
 - **genie / bootstrap**: narrow the packaged `genie-bootstrap-closure-check`
   derivation to the checker entrypoint, its first-party runtime sources, Bun,
   and the TypeScript tarball declared by `@overeng/genie`. The checker now walks

--- a/devenv.nix
+++ b/devenv.nix
@@ -354,8 +354,6 @@ in
     # Playwright browser drivers and environment setup
     inputs.playwright.devenvModules.default
     # Shared task modules
-    # genie is a standard module; the real is threaded via `_module.args.geniePkg`
-    # below so the guard owns `bin/genie` and exec's it by absolute store path.
     taskModules.genie
     (taskModules.ts { tsBinPkg = effectTsgo; })
     (taskModules.megarepo { mrPkg = mrSourceCli; })
@@ -487,19 +485,16 @@ in
     ./nix/devenv-modules/tasks/local/restate-integration-test.nix
   ];
 
-  # Thread the source-mode `genie` real into the (standard) genie task module so
-  # the cli-guard owns `bin/genie` and exec's it by absolute store path. The
-  # module declares `geniePkg` as an optional arg (defaulting to null → PATH-grep
-  # fallback), so the export stays a bare-path module for downstream consumers.
-  _module.args.geniePkg = genieSourceCli;
+  # The guarded `genie` command dispatches to the source-mode CLI in this repo;
+  # downstream consumers should normally set this to the packaged effect-utils
+  # Genie derivation.
+  effectUtils.genie.package = genieSourceCli;
 
   # Non-`.genie.ts` generator inputs (source-of-truth files a `.genie.ts` reads).
-  # Threaded into the genie task module so a change to one of these busts the
-  # `genie:run` warm-cache fingerprint (which otherwise tracks only `.genie.ts`
-  # sources + generated outputs, silently skipping JSON-only edits). Keep in sync
-  # with the analogous entries in `geniePatterns` below (which cover the
+  # These bust the `genie:run` warm-cache fingerprint. Keep in sync with the
+  # analogous entries in `geniePatterns` below (which cover the
   # `lint:check:genie` gate's `execIfModified`).
-  _module.args.genieInputGlobs = [
+  effectUtils.genie.extraInputGlobs = [
     "context/otel-scrape/telemetry-registry.json"
   ];
 

--- a/flake.nix
+++ b/flake.nix
@@ -236,8 +236,7 @@
         # Shared task modules (parameterized) - meant for reuse in other repos
         tasks = {
           # Simple tasks (no config needed)
-          # genie is a standard module; consumers thread the optional `geniePkg`
-          # real via `_module.args.geniePkg` for deterministic guard ownership.
+          # Configure Genie through the `effectUtils.genie.*` option namespace.
           genie = ./nix/devenv-modules/tasks/shared/genie.nix;
           lint-genie = ./nix/devenv-modules/tasks/shared/lint-genie.nix;
           # Parameterized tasks (pass config)

--- a/nix/devenv-modules/tasks/shared/genie.nix
+++ b/nix/devenv-modules/tasks/shared/genie.nix
@@ -12,27 +12,16 @@
 #   tasks."genie:watch".after = [ "pnpm:install:genie" ];
 #   tasks."genie:check".after = [ "pnpm:install:genie" ];
 #
-# This is a standard devenv module — downstream `imports = [ tasks.genie ]` keeps
-# working because `geniePkg` is an optional module argument defaulting to null.
-# Consumers that want the guard to own `bin/genie` thread the real `genie`
-# derivation by setting `_module.args.geniePkg` in their devenv config. When set,
-# the guard owns `bin/genie` and exec's the real by absolute path under
-# passthrough (see cli-guard.nix). Required for source-mode `genie` (no
-# node_modules/.bin fallback) so passthrough does not exit 127. When unset, the
-# guard falls back to grepping `$PATH`.
+# This is a standard devenv module. Consumers configure it through the
+# `effectUtils.genie.*` option namespace instead of raw `_module.args`.
 {
+  config,
   lib,
   pkgs,
-  geniePkg ? null,
-  # Extra, non-`.genie.ts` generator inputs (git pathspecs/globs) that genie
-  # reads as source-of-truth — e.g. a registry JSON consumed by a `.genie.ts`.
-  # These are folded into the `genie:run` warm-cache fingerprint so a change to
-  # such an input busts the cache and regenerates. Defaults to `[ ]`, so repos
-  # that only have `.genie.ts` inputs (the common case) are unaffected.
-  genieInputGlobs ? [ ],
   ...
 }:
 let
+  cfg = config.effectUtils.genie;
   trace = import ../lib/trace.nix { inherit lib; };
   cliGuard = import ../lib/cli-guard.nix { inherit pkgs; };
   megarepoStoreEnv = builtins.getEnv "MEGAREPO_STORE";
@@ -57,18 +46,18 @@ let
   # Enumerate the extra non-`.genie.ts` generator inputs so their content joins
   # the fingerprint. Mirrors the git-tracked/untracked-non-ignored view used for
   # `.genie.ts` sources, with a find fallback outside a git worktree.
-  enumerateGenieInputGlobs = lib.optionalString (genieInputGlobs != [ ]) ''
+  enumerateGenieInputGlobs = lib.optionalString (cfg.extraInputGlobs != [ ]) ''
     if ${pkgs.git}/bin/git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     ${lib.concatMapStringsSep "\n" (glob: ''
       ${pkgs.git}/bin/git ls-files -z -- ${lib.escapeShellArg glob} | tr '\0' '\n'
       ${pkgs.git}/bin/git ls-files -z --others --exclude-standard -- ${lib.escapeShellArg glob} | tr '\0' '\n'
-    '') genieInputGlobs}
+    '') cfg.extraInputGlobs}
     else
     ${lib.concatMapStringsSep "\n" (glob: ''
       ${pkgs.findutils}/bin/find . -type f -path ${lib.escapeShellArg "./${glob}"} \
         -not -path './.git/*' -not -path './.devenv/*' -not -path './node_modules/*' \
         -print 2>/dev/null || true
-    '') genieInputGlobs}
+    '') cfg.extraInputGlobs}
     fi
   '';
   computeGenieStateHash = ''
@@ -182,9 +171,33 @@ let
   };
 in
 {
-  packages = cliGuard.fromTasks {
-    inherit tasks;
-    reals = lib.optionalAttrs (geniePkg != null) { genie = geniePkg; };
+  options.effectUtils.genie = {
+    package = lib.mkOption {
+      type = lib.types.nullOr lib.types.package;
+      default = null;
+      description = ''
+        Real Genie package used by the guarded `genie` task commands. When set,
+        the module owns `bin/genie` and dispatches to this package by absolute
+        store path under `DEVENV_TASK_PASSTHROUGH=1`. Leave null only for repos
+        that intentionally resolve `genie` from PATH.
+      '';
+    };
+
+    extraInputGlobs = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = ''
+        Extra non-.genie.ts generator inputs, expressed as git pathspecs/globs,
+        that should participate in the `genie:run` warm-cache fingerprint.
+      '';
+    };
   };
-  tasks = cliGuard.stripGuards tasks;
+
+  config = {
+    packages = cliGuard.fromTasks {
+      inherit tasks;
+      reals = lib.optionalAttrs (cfg.package != null) { genie = cfg.package; };
+    };
+    tasks = cliGuard.stripGuards tasks;
+  };
 }

--- a/nix/devenv-modules/tasks/shared/tests/genie-module-options.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/genie-module-options.test.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$TESTS_DIR/../../../../.." && pwd)"
+
+eval_genie_module_attr() {
+  local module_config="$1"
+  local attr_expr="$2"
+
+  nix eval --impure --raw --expr "
+    let
+      flake = builtins.getFlake (toString $ROOT);
+      pkgs = import flake.inputs.nixpkgs { system = builtins.currentSystem; };
+      evaluated = pkgs.lib.evalModules {
+        modules = [
+          ({ ... }: {
+            options.tasks = pkgs.lib.mkOption { type = pkgs.lib.types.attrsOf pkgs.lib.types.anything; default = { }; };
+            options.packages = pkgs.lib.mkOption { type = pkgs.lib.types.listOf pkgs.lib.types.anything; default = [ ]; };
+          })
+          $ROOT/nix/devenv-modules/tasks/shared/genie.nix
+          ({ ... }: $module_config)
+        ];
+        specialArgs = { inherit pkgs; lib = pkgs.lib; };
+      };
+    in $attr_expr
+  "
+}
+
+echo "Running Genie module option smoke test..."
+
+default_globs="$(eval_genie_module_attr "{ }" 'builtins.toJSON evaluated.config.effectUtils.genie.extraInputGlobs')"
+if [ "$default_globs" != "[]" ]; then
+  echo "FAIL: default extraInputGlobs should be empty"
+  echo "  actual: $default_globs"
+  exit 1
+fi
+
+package_count="$(eval_genie_module_attr "{ effectUtils.genie.package = pkgs.hello; }" 'builtins.toString (builtins.length evaluated.config.packages)')"
+if [ "$package_count" != "1" ]; then
+  echo "FAIL: setting effectUtils.genie.package should add one guarded package"
+  echo "  actual package count: $package_count"
+  exit 1
+fi
+
+configured_globs="$(eval_genie_module_attr "{ effectUtils.genie.extraInputGlobs = [ \"registry.json\" ]; }" 'builtins.toJSON evaluated.config.effectUtils.genie.extraInputGlobs')"
+if [ "$configured_globs" != '["registry.json"]' ]; then
+  echo "FAIL: extraInputGlobs option should accept repo-specific generator inputs"
+  echo "  actual: $configured_globs"
+  exit 1
+fi
+
+echo "Genie module option smoke test passed."


### PR DESCRIPTION
**Problem**

The shared Genie devenv task module accepted repo-specific configuration through raw `_module.args` (`geniePkg`, `genieInputGlobs`). That is a leaky module contract: consumers can import the module successfully only if they know the private argument names and how this module is implemented.

**Goal**

Make packaged Genie consumption and extra generator-input tracking a stable devenv module API, so downstream repos configure Genie through declared options rather than compatibility shims.

**Decisions**

- Added `effectUtils.genie.package` as the stable package-first configuration surface for the guarded `genie` command.
- Added `effectUtils.genie.extraInputGlobs` for non-`.genie.ts` generator inputs that should participate in the `genie:run` warm-cache fingerprint.
- Updated effect-utils itself to use those options with its source-mode Genie CLI.
- Added a focused module-evaluation smoke test for the default import, package option, and extra input globs.

**Verification**

- `nix/devenv-modules/tasks/shared/tests/genie-module-options.test.sh`
  - passed; validates default import, `effectUtils.genie.package`, and `effectUtils.genie.extraInputGlobs`.
- `devenv tasks list | rg 'genie:run|genie:check|devenv-modules:test|check:(quick|all)'`
  - passed; task evaluation succeeds and Genie/check tasks are present.
- `devenv tasks run devenv-modules:test --no-tui`
  - passed; shared devenv module test suite completed successfully.

**Complexity**

No new runtime complexity. This moves existing configuration from raw module arguments into declared module options.

**Concerns**

Repos still need to set `effectUtils.genie.package` when they want deterministic guarded ownership of `bin/genie`. Leaving it unset preserves PATH fallback for intentional source-mode users.

**Friction & bottlenecks**

The previous `_module.args` contract made downstream evaluation failures look like missing compatibility glue rather than an upstream API issue. This PR makes that boundary explicit.

**Follow-ups**

Adopt the new options in downstream repos that currently set raw Genie module arguments.

**References**

Refs https://github.com/overengineeringstudio/effect-utils/issues/884

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🔥 co2-flint |
| `agent_session_id` | 62f5cabc-d4b3-4110-b244-be9aba37588f |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.141.0 |
| `agent_runtime` | Codex CLI 0.141.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/9mf1jnhnb7mybyy8pyl6nl411fsqr3ns-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/p4qvkb2rwfls2wb11v2vz2ccmf3s8a63-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils-genie-module-options/schickling-assistant/2026-07-09-genie-module-options |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@1d945c8 |
</details>
<!-- agent-footer:end -->