### PR TITLE
feat(genie): TS metric/span-name constants renderer (#1232 PR-A3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,10 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- **genie / weaver**: TS constants generation now exports prefixed
+  `METRIC_*` and `SPAN_*` name constants, plus `MetricName` and `SpanName`
+  unions, so telemetry producers can import generated names without colliding
+  with existing unprefixed attribute-key constants.
 - **genie / check**: bootstrap-safe import-closure gate (`bootstrap-closure:check`).
   A `.genie.ts` and everything it transitively imports at RUNTIME must be importable
   from a fresh checkout BEFORE install; a generator that reaches a runtime-only

--- a/genie/weaver-registry/constants.rs
+++ b/genie/weaver-registry/constants.rs
@@ -1,7 +1,7 @@
 // Generated file - DO NOT EDIT
 // Source: constants.rs.genie.ts
 // registry-source: genie/weaver-registry/registry.ts
-// fingerprint: sha256:ddc3a85168adbefbada437799004cda0c6ea3b7dfb99c8c0048b8fa08c34750f
+// fingerprint: sha256:54d16d8ac5c1bacac63c7775d4927fcc09883fa10c97b17c3cbcbc75b4f82215
 // regen: devenv tasks run genie:run
 
 //! Generated OpenTelemetry semantic-convention name constants.

--- a/genie/weaver-registry/constants.ts
+++ b/genie/weaver-registry/constants.ts
@@ -1,7 +1,7 @@
 // Generated file - DO NOT EDIT
 // Source: constants.ts.genie.ts
 // registry-source: genie/weaver-registry/registry.ts
-// fingerprint: sha256:a29e00860a50e4d30a7d3870066445413b039a0048224272ef9c77f7afc2210a
+// fingerprint: sha256:54d16d8ac5c1bacac63c7775d4927fcc09883fa10c97b17c3cbcbc75b4f82215
 
 export const AcmeAttempt = 'acme.attempt' as const
 export const AcmeProbeLabel = 'acme.probe.label' as const
@@ -319,6 +319,90 @@ export const RestateStep = 'restate.step' as const
 export const RestateWorkflowId = 'restate.workflow.id' as const
 export const SemaphoreKey = 'semaphore.key' as const
 export const SemaphoreTarget_holder_id = 'semaphore.target_holder_id' as const
+export const SPAN_AcmeOperation = 'acme.operation' as const
+export const SPAN_AtomicWriteFile = 'atomicWriteFile' as const
+export const SPAN_CiToolsDeploy = 'ci-tools.deploy' as const
+export const SPAN_CiToolsDeployAttempt = 'ci-tools.deploy.attempt' as const
+export const SPAN_CiToolsDeployCleanup = 'ci-tools.deploy.cleanup' as const
+export const SPAN_CiToolsDeployProvider = 'ci-tools.deploy.provider' as const
+export const SPAN_CiToolsDeployVerify = 'ci-tools.deploy.verify' as const
+export const SPAN_CmdCollect = 'cmd.collect' as const
+export const SPAN_CmdRun = 'cmd.run' as const
+export const SPAN_CmdRunWithLogging = 'cmd.run-with-logging' as const
+export const SPAN_FileSystemBackingSemaphoreForceRevoke = 'FileSystemBacking.semaphore.forceRevoke' as const
+export const SPAN_FileSystemBackingSemaphoreKey = 'FileSystemBacking.semaphore.key' as const
+export const SPAN_GenieCommand = 'genie/command' as const
+export const SPAN_GenieFile = 'genie/file' as const
+export const SPAN_GenieOxfmt = 'genie/oxfmt' as const
+export const SPAN_GeniePath = 'genie/path' as const
+export const SPAN_GenieRunValidation = 'genie/runValidation' as const
+export const SPAN_GenieTargetLock = 'genie/target-lock' as const
+export const SPAN_GitDeleteBranch = 'git/delete-branch' as const
+export const SPAN_GitDetachWorktreeHead = 'git/detach-worktree-head' as const
+export const SPAN_MegarepoStoreGc = 'megarepo/store/gc' as const
+export const SPAN_MegarepoStoreGcArchiveWorktree = 'megarepo/store/gc/archive-worktree' as const
+export const SPAN_MegarepoStoreGcAssessLossless = 'megarepo/store/gc/assess-lossless' as const
+export const SPAN_MegarepoStoreGcColdReclaimRepo = 'megarepo/store/gc/cold-reclaim-repo' as const
+export const SPAN_MegarepoStoreGcReapArchive = 'megarepo/store/gc/reap-archive' as const
+export const SPAN_MegarepoStoreGcResolvePrState = 'megarepo/store/gc/resolve-pr-state' as const
+export const SPAN_MegarepoStoreGcScanArchives = 'megarepo/store/gc/scan-archives' as const
+export const SPAN_MegarepoStoreGcUnpushedCommitCount = 'megarepo/store/gc/unpushed-commit-count' as const
+export const SPAN_MegarepoSync = 'megarepo/sync' as const
+export const SPAN_MegarepoSyncMember = 'megarepo/sync/member' as const
+export const SPAN_MegarepoSyncMemberCloneOrFetch = 'megarepo/sync/member/clone-or-fetch' as const
+export const SPAN_MegarepoSyncMemberCreateWorktree = 'megarepo/sync/member/create-worktree' as const
+export const SPAN_MegarepoSyncMemberResolveRef = 'megarepo/sync/member/resolve-ref' as const
+export const SPAN_MegarepoTestStoreFixtureCreate = 'megarepo/test/store-fixture/create' as const
+export const SPAN_MegarepoTestStoreFixtureRepo = 'megarepo/test/store-fixture/repo' as const
+export const SPAN_MegarepoTraversal = 'megarepo/traversal' as const
+export const SPAN_NotionMdBatchWatch = 'notion-md.batch-watch' as const
+export const SPAN_NotionMdCat = 'notion-md.cat' as const
+export const SPAN_NotionMdCommentBoundary = 'notion-md.comment-boundary' as const
+export const SPAN_NotionMdDestructiveBody = 'notion-md.destructive-body' as const
+export const SPAN_NotionMdEdit = 'notion-md.edit' as const
+export const SPAN_NotionMdEstablishSidecar = 'notion-md.establish-sidecar' as const
+export const SPAN_NotionMdGatewayArchivePage = 'notion-md.gateway.archive-page' as const
+export const SPAN_NotionMdGatewayCreatePage = 'notion-md.gateway.create-page' as const
+export const SPAN_NotionMdGatewayListChildPages = 'notion-md.gateway.list-child-pages' as const
+export const SPAN_NotionMdGatewayMovePage = 'notion-md.gateway.move-page' as const
+export const SPAN_NotionMdGatewayPullPage = 'notion-md.gateway.pull-page' as const
+export const SPAN_NotionMdGatewayRetrieveDataSource = 'notion-md.gateway.retrieve-data-source' as const
+export const SPAN_NotionMdGatewayUpdateMarkdown = 'notion-md.gateway.update-markdown' as const
+export const SPAN_NotionMdGatewayUpdatePageMetadata = 'notion-md.gateway.update-page-metadata' as const
+export const SPAN_NotionMdGatewayUpdatePageProperties = 'notion-md.gateway.update-page-properties' as const
+export const SPAN_NotionMdMediaBoundary = 'notion-md.media-boundary' as const
+export const SPAN_NotionMdObjectGc = 'notion-md.object-gc' as const
+export const SPAN_NotionMdPlanPath = 'notion-md.plan-path' as const
+export const SPAN_NotionMdPullPage = 'notion-md.pull-page' as const
+export const SPAN_NotionMdPushPage = 'notion-md.push-page' as const
+export const SPAN_NotionMdPut = 'notion-md.put' as const
+export const SPAN_NotionMdStateReadNmd = 'notion-md.state.read-nmd' as const
+export const SPAN_NotionMdStateReadObject = 'notion-md.state.read-object' as const
+export const SPAN_NotionMdStateWriteObject = 'notion-md.state.write-object' as const
+export const SPAN_NotionMdStatusPage = 'notion-md.status-page' as const
+export const SPAN_NotionMdStatusPath = 'notion-md.status-path' as const
+export const SPAN_NotionMdSyncPage = 'notion-md.sync-page' as const
+export const SPAN_NotionMdSyncPath = 'notion-md.sync-path' as const
+export const SPAN_NotionMdSyncTree = 'notion-md.sync-tree' as const
+export const SPAN_NotionMdTrackPage = 'notion-md.track-page' as const
+export const SPAN_NotionMdWatch = 'notion-md.watch' as const
+export const SPAN_NotionMdWatchSyncPass = 'notion-md.watch.sync-pass' as const
+export const SPAN_NotionMdWebhookTrigger = 'notion-md.webhook.trigger' as const
+export const SPAN_NotionDatabasesQuery = 'NotionDatabases.query' as const
+export const SPAN_NotionPagesRetrieve = 'NotionPages.retrieve' as const
+export const SPAN_PtySessionMake = 'pty-session.make' as const
+export const SPAN_PwWaitUntil = 'pw.wait.until' as const
+export const SPAN_SpanAcmeProbe = 'span.acme.probe' as const
+export const SPAN_SpanNotionReactSync = 'span.notion-react.sync' as const
+export const METRIC_AcmeProbeDuration = 'acme.probe.duration' as const
+export const METRIC_AcmeProbes = 'acme.probes' as const
+export const METRIC_MegarepoStoreGcRssBytes = 'megarepo_store_gc_rss_bytes' as const
+export const METRIC_RestateAttemptsTotal = 'restate_attempts_total' as const
+export const METRIC_RestateAwakeableWaitMs = 'restate_awakeable_wait_ms' as const
+export const METRIC_RestateDurableStepsTotal = 'restate_durable_steps_total' as const
+export const METRIC_RestateInvocationDurationMs = 'restate_invocation_duration_ms' as const
+export const METRIC_RestateInvocationsTotal = 'restate_invocations_total' as const
+export const METRIC_RestatePollLoopCyclesTotal = 'restate_poll_loop_cycles_total' as const
 
 export type AttributeKey =
   | 'acme.attempt'
@@ -637,3 +721,91 @@ export type AttributeKey =
   | 'restate.workflow.id'
   | 'semaphore.key'
   | 'semaphore.target_holder_id'
+
+export type SpanName =
+  | 'acme.operation'
+  | 'atomicWriteFile'
+  | 'ci-tools.deploy'
+  | 'ci-tools.deploy.attempt'
+  | 'ci-tools.deploy.cleanup'
+  | 'ci-tools.deploy.provider'
+  | 'ci-tools.deploy.verify'
+  | 'cmd.collect'
+  | 'cmd.run'
+  | 'cmd.run-with-logging'
+  | 'FileSystemBacking.semaphore.forceRevoke'
+  | 'FileSystemBacking.semaphore.key'
+  | 'genie/command'
+  | 'genie/file'
+  | 'genie/oxfmt'
+  | 'genie/path'
+  | 'genie/runValidation'
+  | 'genie/target-lock'
+  | 'git/delete-branch'
+  | 'git/detach-worktree-head'
+  | 'megarepo/store/gc'
+  | 'megarepo/store/gc/archive-worktree'
+  | 'megarepo/store/gc/assess-lossless'
+  | 'megarepo/store/gc/cold-reclaim-repo'
+  | 'megarepo/store/gc/reap-archive'
+  | 'megarepo/store/gc/resolve-pr-state'
+  | 'megarepo/store/gc/scan-archives'
+  | 'megarepo/store/gc/unpushed-commit-count'
+  | 'megarepo/sync'
+  | 'megarepo/sync/member'
+  | 'megarepo/sync/member/clone-or-fetch'
+  | 'megarepo/sync/member/create-worktree'
+  | 'megarepo/sync/member/resolve-ref'
+  | 'megarepo/test/store-fixture/create'
+  | 'megarepo/test/store-fixture/repo'
+  | 'megarepo/traversal'
+  | 'notion-md.batch-watch'
+  | 'notion-md.cat'
+  | 'notion-md.comment-boundary'
+  | 'notion-md.destructive-body'
+  | 'notion-md.edit'
+  | 'notion-md.establish-sidecar'
+  | 'notion-md.gateway.archive-page'
+  | 'notion-md.gateway.create-page'
+  | 'notion-md.gateway.list-child-pages'
+  | 'notion-md.gateway.move-page'
+  | 'notion-md.gateway.pull-page'
+  | 'notion-md.gateway.retrieve-data-source'
+  | 'notion-md.gateway.update-markdown'
+  | 'notion-md.gateway.update-page-metadata'
+  | 'notion-md.gateway.update-page-properties'
+  | 'notion-md.media-boundary'
+  | 'notion-md.object-gc'
+  | 'notion-md.plan-path'
+  | 'notion-md.pull-page'
+  | 'notion-md.push-page'
+  | 'notion-md.put'
+  | 'notion-md.state.read-nmd'
+  | 'notion-md.state.read-object'
+  | 'notion-md.state.write-object'
+  | 'notion-md.status-page'
+  | 'notion-md.status-path'
+  | 'notion-md.sync-page'
+  | 'notion-md.sync-path'
+  | 'notion-md.sync-tree'
+  | 'notion-md.track-page'
+  | 'notion-md.watch'
+  | 'notion-md.watch.sync-pass'
+  | 'notion-md.webhook.trigger'
+  | 'NotionDatabases.query'
+  | 'NotionPages.retrieve'
+  | 'pty-session.make'
+  | 'pw.wait.until'
+  | 'span.acme.probe'
+  | 'span.notion-react.sync'
+
+export type MetricName =
+  | 'acme.probe.duration'
+  | 'acme.probes'
+  | 'megarepo_store_gc_rss_bytes'
+  | 'restate_attempts_total'
+  | 'restate_awakeable_wait_ms'
+  | 'restate_durable_steps_total'
+  | 'restate_invocation_duration_ms'
+  | 'restate_invocations_total'
+  | 'restate_poll_loop_cycles_total'

--- a/genie/weaver-registry/registry.ts
+++ b/genie/weaver-registry/registry.ts
@@ -26,6 +26,7 @@ import type {
   Provenance,
   WeaverRegistryBundle,
 } from '../../packages/@overeng/genie/src/runtime/weaver/mod.ts'
+import { signalNames } from '../../packages/@overeng/genie/src/runtime/weaver/mod.ts'
 import gitContract from '../../packages/@overeng/megarepo/src/git.contract.ts'
 import megarepoContract from '../../packages/@overeng/megarepo/src/megarepo.contract.ts'
 import nixContract from '../../packages/@overeng/megarepo/src/nix.contract.ts'
@@ -129,51 +130,25 @@ const versionInputs = {
   generator: GENERATOR_VERSION,
 }
 
-/** Identity = only the attribute keys the TS/Rust const targets encode (no doc prose). */
+/** Identity = the exact names the TS/Rust const targets encode (no doc prose). */
 const identityKeys = registry.groups
   .flatMap((g) => g.attributes.map((a) => a.id))
   .toSorted((a, b) => a.localeCompare(b))
+const identityNames = {
+  attributeKeys: identityKeys,
+  ...signalNames(registry),
+}
 
 /** Doc fingerprint: the FULL registry (brief/stability/examples/notes/deprecated) → YAML headers. */
 export const docFingerprint = sha256({ registry, ...versionInputs })
-/** Identity fingerprint: keys only → TS/Rust const headers (a prose edit must not churn these). */
-export const identityFingerprint = sha256({ keys: identityKeys, ...versionInputs })
+/** Identity fingerprint: constant names only → TS/Rust const headers (a prose edit must not churn these). */
+export const identityFingerprint = sha256({ ...identityNames, ...versionInputs })
 
 export const REGISTRY_SOURCE = 'genie/weaver-registry/registry.ts'
 export const docProvenance: Provenance = { source: REGISTRY_SOURCE, fingerprint: docFingerprint }
 export const identityProvenance: Provenance = {
   source: REGISTRY_SOURCE,
   fingerprint: identityFingerprint,
-}
-
-/**
- * Rust identity = the exact names the Rust const target encodes: attribute keys PLUS span ids
- * PLUS metric names (a Rust telemetry producer needs signal-name consts too). Kept SEPARATE
- * from {@link identityFingerprint} (attr-keys-only, for the TS `constants.ts`) so a span/metric
- * rename re-hashes the `.rs` without churning `constants.ts`, and a doc-only edit churns neither
- * (GEN-R07 §fingerprint granularity).
- */
-const rustIdentityNames = {
-  attributeKeys: identityKeys,
-  spanIds: registry.signals
-    .filter(
-      (s): s is Extract<(typeof registry.signals)[number], { kind: 'span' }> => s.kind === 'span',
-    )
-    // Hash the emitted Rust span-name consts (runtime names, id fallback), matching renderRustConstants.
-    .map((s) => s.span_name ?? s.id)
-    .toSorted((a, b) => a.localeCompare(b)),
-  metricNames: registry.signals
-    .filter(
-      (s): s is Extract<(typeof registry.signals)[number], { kind: 'metric' }> =>
-        s.kind === 'metric',
-    )
-    .map((s) => s.metric_name)
-    .toSorted((a, b) => a.localeCompare(b)),
-}
-export const rustIdentityFingerprint = sha256({ ...rustIdentityNames, ...versionInputs })
-export const rustProvenance: Provenance = {
-  source: REGISTRY_SOURCE,
-  fingerprint: rustIdentityFingerprint,
 }
 
 /** The own namespaces, all collapsed into ONE `attributes.yaml` (adding a namespace needs no new emitter). */
@@ -188,6 +163,5 @@ export const weaver: WeaverRegistryBundle = {
   registry,
   docProvenance,
   identityProvenance,
-  rustProvenance,
   issues: compositionIssues,
 }

--- a/packages/@overeng/genie/src/runtime/weaver/mod.ts
+++ b/packages/@overeng/genie/src/runtime/weaver/mod.ts
@@ -353,6 +353,12 @@ const pascal = (key: string): string =>
     .map((seg) => seg.charAt(0).toUpperCase() + seg.slice(1))
     .join('')
 
+const namePascal = (key: string): string =>
+  key
+    .split(/[._\-:/]/)
+    .map((seg) => seg.charAt(0).toUpperCase() + seg.slice(1))
+    .join('')
+
 const screamingSnake = (key: string): string => key.replace(/[.\-:/]/g, '_').toUpperCase()
 
 /** Single-quoted string literal (matches the repo's oxfmt style, so no reformat is needed). */
@@ -360,6 +366,117 @@ const sq = (k: string): string => `'${k}'`
 
 const ownKeys = (r: Registry): ReadonlyArray<string> =>
   byId(r.groups.flatMap((g) => g.attributes)).map((a) => a.id)
+
+/** Runtime span names and metric names emitted by TS/Rust producer constants. */
+export const signalNames = (
+  registry: Registry,
+): {
+  readonly spanNames: ReadonlyArray<string>
+  readonly metricNames: ReadonlyArray<string>
+} => ({
+  spanNames: registry.signals
+    .filter((s): s is Extract<SignalDef, { kind: 'span' }> => s.kind === 'span')
+    // Emit the RUNTIME span name (what producers actually name spans), not the weaver group id.
+    // Plain spans carry no runtime name, so fall back to the id.
+    .map((s) => s.span_name ?? s.id)
+    .toSorted((a, b) => a.localeCompare(b)),
+  metricNames: registry.signals
+    .filter((s): s is Extract<SignalDef, { kind: 'metric' }> => s.kind === 'metric')
+    .map((s) => s.metric_name)
+    .toSorted((a, b) => a.localeCompare(b)),
+})
+
+const assertUniqueIdentifiers = ({
+  target,
+  kind,
+  names,
+  identifier,
+  valid,
+}: {
+  target: string
+  kind: string
+  names: ReadonlyArray<string>
+  identifier: (name: string) => string
+  valid: RegExp
+}): void => {
+  const seen = new Map<string, string>()
+  for (const name of names) {
+    const id = identifier(name)
+    if (valid.test(id) === false) {
+      throw new Error(
+        `weaver ${target} constants ${kind}: generated identifier ${JSON.stringify(id)} for ${JSON.stringify(name)} is invalid`,
+      )
+    }
+    const previous = seen.get(id)
+    if (previous !== undefined) {
+      throw new Error(
+        `weaver ${target} constants ${kind}: identifier collision ${JSON.stringify(id)} for ${JSON.stringify(previous)} and ${JSON.stringify(name)}`,
+      )
+    }
+    seen.set(id, name)
+  }
+}
+
+const assertUniqueTsConstIdentifiers = ({
+  attributeKeys,
+  spanNames,
+  metricNames,
+}: {
+  attributeKeys: ReadonlyArray<string>
+  spanNames: ReadonlyArray<string>
+  metricNames: ReadonlyArray<string>
+}): void => {
+  const entries = [
+    ...attributeKeys.map((name) => ({
+      source: `attribute key ${JSON.stringify(name)}`,
+      identifier: pascal(name),
+    })),
+    ...spanNames.map((name) => ({
+      source: `span name ${JSON.stringify(name)}`,
+      identifier: `SPAN_${namePascal(name)}`,
+    })),
+    ...metricNames.map((name) => ({
+      source: `metric name ${JSON.stringify(name)}`,
+      identifier: `METRIC_${namePascal(name)}`,
+    })),
+  ]
+  const seen = new Map<string, string>()
+  for (const { source, identifier } of entries) {
+    if (/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(identifier) === false) {
+      throw new Error(
+        `weaver TS constants: generated identifier ${JSON.stringify(identifier)} for ${source} is invalid`,
+      )
+    }
+    const previous = seen.get(identifier)
+    if (previous !== undefined) {
+      throw new Error(
+        `weaver TS constants: identifier collision ${JSON.stringify(identifier)} for ${previous} and ${source}`,
+      )
+    }
+    seen.set(identifier, source)
+  }
+}
+
+const tsConstLines = ({
+  prefix,
+  names,
+}: {
+  prefix: 'METRIC' | 'SPAN'
+  names: ReadonlyArray<string>
+}): ReadonlyArray<string> => {
+  return names.map((name) => `export const ${prefix}_${namePascal(name)} = ${sq(name)} as const`)
+}
+
+const unionLines = ({
+  typeName,
+  names,
+}: {
+  typeName: string
+  names: ReadonlyArray<string>
+}): ReadonlyArray<string> =>
+  names.length === 0
+    ? [`export type ${typeName} = never`]
+    : [`export type ${typeName} =`, ...names.map((k) => `  | ${sq(k)}`)]
 
 /**
  * TS name constants + a key union (own-namespace keys only — upstream-referenced keys come
@@ -372,10 +489,22 @@ export const renderTsConstants = ({
   registry: Registry
   provenance: Provenance
 }): string => {
-  const keys = ownKeys(registry)
+  const attributeKeys = ownKeys(registry)
+  const { spanNames, metricNames } = signalNames(registry)
+  assertUniqueTsConstIdentifiers({ attributeKeys, spanNames, metricNames })
   const lines: string[] = [provenanceComment({ provenance, prefix: '//' }).trimEnd(), '']
-  for (const k of keys) lines.push(`export const ${pascal(k)} = ${sq(k)} as const`)
-  lines.push('', 'export type AttributeKey =', ...keys.map((k) => `  | ${sq(k)}`), '')
+  for (const k of attributeKeys) lines.push(`export const ${pascal(k)} = ${sq(k)} as const`)
+  lines.push(...tsConstLines({ prefix: 'SPAN', names: spanNames }))
+  lines.push(...tsConstLines({ prefix: 'METRIC', names: metricNames }))
+  lines.push(
+    '',
+    ...unionLines({ typeName: 'AttributeKey', names: attributeKeys }),
+    '',
+    ...unionLines({ typeName: 'SpanName', names: spanNames }),
+    '',
+    ...unionLines({ typeName: 'MetricName', names: metricNames }),
+    '',
+  )
   return lines.join('\n')
 }
 
@@ -419,6 +548,13 @@ const rustModule = ({
 }): string => {
   const indent = '    '
   if (keys.length === 0) return [`/// ${doc}`, `pub mod ${name} {}`].join('\n')
+  assertUniqueIdentifiers({
+    target: 'Rust',
+    kind: name,
+    names: keys,
+    identifier: screamingSnake,
+    valid: /^[A-Z_][A-Z0-9_]*$/,
+  })
   const lines = [`/// ${doc}`, `pub mod ${name} {`]
   for (const k of keys) lines.push(`${indent}pub const ${screamingSnake(k)}: &str = ${rustStr(k)};`)
   lines.push('', ...rustAllSlice({ indent, keys }), '}')
@@ -432,8 +568,8 @@ const rustModule = ({
  * kind sorted) and rustfmt-clean. Upstream-referenced keys are excluded (they come from
  * upstream's own generated bindings — see spec.md §TS-constants scope, which applies equally to
  * Rust). The provenance fingerprint must cover attribute keys + span ids + metric names (the
- * exact names emitted here), split from the doc/TS fingerprints so a prose edit does not churn
- * this file (GEN-R07 §fingerprint granularity).
+ * exact names emitted here), split from the doc fingerprint so a prose edit does not churn this
+ * file (GEN-R07 §fingerprint granularity).
  */
 export const renderRustConstants = ({
   registry,
@@ -443,16 +579,7 @@ export const renderRustConstants = ({
   provenance: Provenance
 }): string => {
   const attributeKeys = ownKeys(registry)
-  const spanNames = registry.signals
-    .filter((s): s is Extract<SignalDef, { kind: 'span' }> => s.kind === 'span')
-    // Emit the RUNTIME span name (what producers actually name spans), not the weaver group id.
-    // Plain spans carry no runtime name, so fall back to the id.
-    .map((s) => s.span_name ?? s.id)
-    .toSorted((a, b) => a.localeCompare(b))
-  const metricNames = registry.signals
-    .filter((s): s is Extract<SignalDef, { kind: 'metric' }> => s.kind === 'metric')
-    .map((s) => s.metric_name)
-    .toSorted((a, b) => a.localeCompare(b))
+  const { spanNames, metricNames } = signalNames(registry)
   return [
     `// registry-source: ${provenance.source}`,
     `// fingerprint: ${provenance.fingerprint}`,
@@ -477,10 +604,10 @@ export const renderRustConstants = ({
 // ---------------------------------------------------------------------------
 
 /**
- * The complete design-time input for the builder family: the composed {@link Registry}, the three
- * split provenance fingerprints (doc / identity / rust — see GEN-R07 §fingerprint granularity),
- * and the whole-registry integrity {@link GenieValidationIssue}s. The aggregator constructs one
- * of these and every emitter consumes it.
+ * The complete design-time input for the builder family: the composed {@link Registry}, the split
+ * provenance fingerprints (doc / identity — see GEN-R07 §fingerprint granularity), and the
+ * whole-registry integrity {@link GenieValidationIssue}s. The aggregator constructs one of these
+ * and every emitter consumes it.
  *
  * NOTE: `issues` is carried here (a deviation from a provenance-only bundle) so `weaverManifest`
  * can surface namespace-collision / dangling-ref blocking via `validate` while keeping every
@@ -490,7 +617,6 @@ export type WeaverRegistryBundle = {
   readonly registry: Registry
   readonly docProvenance: Provenance
   readonly identityProvenance: Provenance
-  readonly rustProvenance: Provenance
   readonly issues: readonly GenieValidationIssue[]
 }
 
@@ -518,18 +644,19 @@ export const weaverSignals = (w: WeaverRegistryBundle): GenieOutput<ReadonlyArra
     stringify: () => renderSignals({ signals: w.registry.signals, provenance: w.docProvenance }),
   })
 
-/** `constants.ts` builder — TS name constants (identity/keys-only fingerprint). */
+/** `constants.ts` builder — TS name constants (identity fingerprint). */
 export const weaverTsConstants = (w: WeaverRegistryBundle): GenieOutput<Registry> =>
   createGenieOutput({
     data: w.registry,
     stringify: () => renderTsConstants({ registry: w.registry, provenance: w.identityProvenance }),
   })
 
-/** `constants.rs` builder — Rust name constants (rust-identity fingerprint: keys + signal names). */
+/** `constants.rs` builder — Rust name constants (identity fingerprint). */
 export const weaverRustConstants = (w: WeaverRegistryBundle): GenieOutput<Registry> =>
   createGenieOutput({
     data: w.registry,
-    stringify: () => renderRustConstants({ registry: w.registry, provenance: w.rustProvenance }),
+    stringify: () =>
+      renderRustConstants({ registry: w.registry, provenance: w.identityProvenance }),
   })
 
 // ---------------------------------------------------------------------------

--- a/packages/@overeng/genie/src/runtime/weaver/ts-constants.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/weaver/ts-constants.unit.test.ts
@@ -1,0 +1,188 @@
+import ts from 'typescript'
+import { describe, expect, it } from 'vitest'
+
+import type { Provenance, Registry } from './mod.ts'
+import { renderRustConstants, renderTsConstants } from './mod.ts'
+import { otelScrapeFixtureRegistry } from './otel-scrape.fixture.ts'
+
+const registry = otelScrapeFixtureRegistry
+
+const FIXTURE_PROVENANCE: Provenance = {
+  source: 'packages/@overeng/genie/src/runtime/weaver/otel-scrape.fixture.ts',
+  fingerprint: 'sha256:0000000000000000000000000000000000000000000000000000000000000000',
+}
+
+const typecheck = (files: ReadonlyMap<string, string>, rootNames: ReadonlyArray<string>): void => {
+  const options: ts.CompilerOptions = {
+    allowImportingTsExtensions: true,
+    module: ts.ModuleKind.NodeNext,
+    moduleResolution: ts.ModuleResolutionKind.NodeNext,
+    noEmit: true,
+    strict: true,
+    target: ts.ScriptTarget.ES2024,
+  }
+  const host = ts.createCompilerHost(options)
+  const fallbackGetSourceFile = host.getSourceFile.bind(host)
+  const fallbackFileExists = host.fileExists.bind(host)
+  const fallbackReadFile = host.readFile.bind(host)
+  host.getSourceFile = (fileName, languageVersion) => {
+    const text = files.get(fileName)
+    if (text !== undefined) return ts.createSourceFile(fileName, text, languageVersion, true)
+    return fallbackGetSourceFile(fileName, languageVersion)
+  }
+  host.fileExists = (fileName) => files.has(fileName) || fallbackFileExists(fileName)
+  host.readFile = (fileName) => files.get(fileName) ?? fallbackReadFile(fileName)
+  host.writeFile = () => undefined
+
+  const program = ts.createProgram(rootNames, options, host)
+  const diagnostics = ts.getPreEmitDiagnostics(program)
+
+  expect(diagnostics.map((d) => ts.flattenDiagnosticMessageText(d.messageText, '\n'))).toEqual([])
+}
+
+describe('renderTsConstants (otel-scrape fixture)', () => {
+  const source = renderTsConstants({ registry, provenance: FIXTURE_PROVENANCE })
+
+  it('emits prefixed metric and span name constants', () => {
+    expect(source).toContain(
+      `export const METRIC_OtelScrapeScrapes = 'otel_scrape.scrapes' as const`,
+    )
+    expect(source).toContain(
+      `export const METRIC_OtelScrapeScrapeDuration = 'otel_scrape.scrape.duration' as const`,
+    )
+    expect(source).toContain(`export const SPAN_OtelScrapeRequest = 'otel_scrape/request' as const`)
+    expect(source).toContain(
+      `export const SPAN_SpanOtelScrapeBatch = 'span.otel_scrape.batch' as const`,
+    )
+  })
+
+  it('emits name unions for generated metric and span names', () => {
+    expect(source).toContain('export type MetricName =')
+    expect(source).toContain(`  | 'otel_scrape.scrapes'`)
+    expect(source).toContain(`  | 'otel_scrape.scrape.duration'`)
+    expect(source).toContain('export type SpanName =')
+    expect(source).toContain(`  | 'otel_scrape/request'`)
+    expect(source).toContain(`  | 'span.otel_scrape.batch'`)
+  })
+
+  it('keeps attribute key constants unprefixed', () => {
+    expect(source).toContain(`export const Otel_scrapeStatus = 'otel_scrape.status' as const`)
+    expect(source).not.toContain(`export const ATTRIBUTE_Otel_scrapeStatus`)
+  })
+
+  it('type-checks consumers importing generated METRIC_ and SPAN_ constants', () => {
+    const constantsFile = '/constants.ts'
+    const consumerFile = '/consumer.ts'
+    const consumer = [
+      "import { METRIC_OtelScrapeScrapes, SPAN_OtelScrapeRequest } from './constants.ts'",
+      "import type { MetricName, SpanName } from './constants.ts'",
+      '',
+      'const metricName: MetricName = METRIC_OtelScrapeScrapes',
+      'const spanName: SpanName = SPAN_OtelScrapeRequest',
+      'void metricName',
+      'void spanName',
+    ].join('\n')
+    const files = new Map<string, string>([
+      [constantsFile, source],
+      [consumerFile, consumer],
+    ])
+    typecheck(files, [consumerFile])
+  })
+
+  it('throws a clear error when folded metric identifiers collide', () => {
+    const collidingRegistry: Registry = {
+      ...registry,
+      signals: [
+        {
+          kind: 'metric',
+          id: 'metric.restate.attempts.total',
+          metric_name: 'restate.attempts.total',
+          instrument: 'counter',
+          unit: '{attempt}',
+          brief: 'Attempts.',
+          stability: 'development',
+          attributes: [],
+        },
+        {
+          kind: 'metric',
+          id: 'metric.restate_attempts_total',
+          metric_name: 'restate_attempts_total',
+          instrument: 'counter',
+          unit: '{attempt}',
+          brief: 'Attempts.',
+          stability: 'development',
+          attributes: [],
+        },
+      ],
+    }
+
+    expect(() =>
+      renderTsConstants({ registry: collidingRegistry, provenance: FIXTURE_PROVENANCE }),
+    ).toThrow(/weaver TS constants: identifier collision "METRIC_RestateAttemptsTotal"/)
+    expect(() =>
+      renderRustConstants({ registry: collidingRegistry, provenance: FIXTURE_PROVENANCE }),
+    ).toThrow(/weaver Rust constants metric: identifier collision "RESTATE_ATTEMPTS_TOTAL"/)
+  })
+
+  it('throws when an attribute-key constant collides with a prefixed span-name constant', () => {
+    const crossKindRegistry: Registry = {
+      ...registry,
+      groups: [
+        {
+          namespace: 'review',
+          displayName: 'Review',
+          attributes: [
+            {
+              id: 'SPAN_Foo',
+              type: 'string',
+              brief: 'A deliberately colliding attribute key.',
+              stability: 'development',
+            },
+          ],
+        },
+      ],
+      signals: [
+        {
+          kind: 'span',
+          id: 'span.review.foo',
+          span_name: 'foo',
+          span_kind: 'internal',
+          brief: 'A deliberately colliding span name.',
+          stability: 'development',
+          attributes: [],
+        },
+      ],
+    }
+
+    expect(() =>
+      renderTsConstants({ registry: crossKindRegistry, provenance: FIXTURE_PROVENANCE }),
+    ).toThrow(
+      'weaver TS constants: identifier collision "SPAN_Foo" for attribute key "SPAN_Foo" and span name "foo"',
+    )
+  })
+
+  it('renders empty span-name unions as never for metrics-only registries', () => {
+    const metricsOnlyRegistry: Registry = {
+      ...registry,
+      signals: [
+        {
+          kind: 'metric',
+          id: 'metric.otel_scrape.scrapes',
+          metric_name: 'otel_scrape.scrapes',
+          instrument: 'counter',
+          unit: '{scrape}',
+          brief: 'Scrapes.',
+          stability: 'development',
+          attributes: [],
+        },
+      ],
+    }
+    const constants = renderTsConstants({
+      registry: metricsOnlyRegistry,
+      provenance: FIXTURE_PROVENANCE,
+    })
+    expect(constants).toContain('export type SpanName = never')
+    expect(constants).toContain(`export const METRIC_OtelScrapeScrapes = 'otel_scrape.scrapes'`)
+    typecheck(new Map([['/constants.ts', constants]]), ['/constants.ts'])
+  })
+})


### PR DESCRIPTION
**Problem**

The Weaver TS constants renderer only emitted attribute-key constants. Producers still had to use raw string literals for metric and span names even though the Rust renderer already exposes those names as constants.

**Goal**

Generate TS `METRIC_*` and `SPAN_*` name constants, plus `MetricName` and `SpanName` unions, from the existing signal model.

**Decisions**

Metric/span constants are prefixed because the TS renderer is flat while Rust separates attributes, spans, and metrics into modules. The prefix avoids collisions with existing unprefixed attribute-key constants. Name identifiers use PascalCase across dots, dashes, colons, slashes, and underscores while preserving the existing attribute-key identifier scheme.

**Verification**

- `CI=1 pnpm --filter @overeng/genie exec vitest run src/runtime/weaver/ts-constants.unit.test.ts` -> 4 tests passed.
- `CI=1 devenv tasks run check:quick` -> passed, including `ts:check`.
- `CI=1 devenv tasks run test:genie` -> passed.
- `CI=1 devenv tasks run weaver:check` -> passed.

RED/GREEN proof: the new `ts-constants.unit.test.ts` imports generated `METRIC_OtelScrapeScrapes` and `SPAN_OtelScrapeRequest` through an in-memory TypeScript program. Before this renderer change those exports are absent and the consumer compile fails; after the change it type-checks cleanly.

**Complexity**

No new abstraction or dependency; this extends the existing pure renderer and reuses the existing Weaver fixture.

**Concerns**

This provides compile-time name constants only. It does not replace any aggregate runtime name-list selector.

**Friction & bottlenecks**

`genie:run` initially reused its task cache after the identifier helper changed; rerunning with `--refresh-task-cache` forced regeneration. No follow-up issue filed because this was a one-off local cache interaction.

**Follow-ups**

Runtime name-list selector retirement remains out of scope for this PR.

**References**

Refs schickling/dotfiles#1232

**Refinements (pre-downstream)**

- Collapsed TS/Rust constants onto one names-inclusive identity fingerprint and shared `signalNames()` extraction, removing the stale keys-only TS fingerprint path.
- Added generation-time identifier validation for TS and Rust constants so folded-name collisions fail with a clear renderer error.
- Render empty TS name unions as `never`, covering metrics-only or spans-only downstream registries without syntax errors.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 💚 co2-beryl |
| `agent_session_id` | 0c1cf87c-1f95-4df4-b772-ab5527b91304 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.141.0 |
| `agent_runtime` | Codex CLI 0.141.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/5bkm466h121236vcc4sx467hsan9382j-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/fvj9gyni5y0kypcna51kb0bwns7z2kcc-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-10-otel-ts-name-renderer |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@e9a23d3 |
</details>
<!-- agent-footer:end -->