### PR TITLE
feat(otel-contract): dated deprecation lifecycle fields (#1232 PR-A1)

### DIFF
--- a/packages/@overeng/genie/src/runtime/weaver/mod.ts
+++ b/packages/@overeng/genie/src/runtime/weaver/mod.ts
@@ -179,6 +179,48 @@ export type RegistryFragment = {
 
 const POLICY_ANNOTATION_NS = 'overeng_policy'
 
+const deprecatedToNormativeObject = (deprecated: Deprecated): Record<string, unknown> =>
+  deprecated.reason === 'renamed'
+    ? { reason: deprecated.reason, renamed_to: deprecated.renamed_to }
+    : { reason: deprecated.reason, note: deprecated.note }
+
+const deprecatedToLifecycleAnnotation = (
+  deprecated: Deprecated,
+): Record<string, unknown> | undefined => {
+  const annotation = {
+    ...(deprecated.since !== undefined ? { since: deprecated.since } : {}),
+    ...(deprecated.remove_after !== undefined ? { remove_after: deprecated.remove_after } : {}),
+  }
+  return Object.keys(annotation).length > 0 ? annotation : undefined
+}
+
+const addPolicyAnnotation = ({
+  annotations,
+  fields,
+}: {
+  annotations: Record<string, unknown>
+  fields: Record<string, unknown>
+}): void => {
+  const existing = annotations[POLICY_ANNOTATION_NS] as Record<string, unknown> | undefined
+  annotations[POLICY_ANNOTATION_NS] = existing === undefined ? fields : { ...existing, ...fields }
+}
+
+const addDeprecatedToObject = ({
+  out,
+  annotations,
+  deprecated,
+}: {
+  out: Record<string, unknown>
+  annotations: Record<string, unknown>
+  deprecated: Deprecated
+}): void => {
+  out['deprecated'] = deprecatedToNormativeObject(deprecated)
+  const lifecycle = deprecatedToLifecycleAnnotation(deprecated)
+  if (lifecycle !== undefined) {
+    addPolicyAnnotation({ annotations, fields: { deprecated: lifecycle } })
+  }
+}
+
 const attrDefToObject = (a: AttrDef): Record<string, unknown> => {
   const out: Record<string, unknown> = {
     id: a.id,
@@ -199,13 +241,18 @@ const attrDefToObject = (a: AttrDef): Record<string, unknown> => {
   }
   if (a.note !== undefined) out['note'] = a.note
   if (a.examples !== undefined && a.examples.length > 0) out['examples'] = [...a.examples]
-  if (a.deprecated !== undefined) out['deprecated'] = { ...a.deprecated }
   const annotations: Record<string, unknown> = {}
+  if (a.deprecated !== undefined) {
+    addDeprecatedToObject({ out, annotations, deprecated: a.deprecated })
+  }
   if (a.policy?.cardinality !== undefined || a.policy?.encode !== undefined) {
-    annotations[POLICY_ANNOTATION_NS] = {
-      ...(a.policy.cardinality !== undefined ? { cardinality: a.policy.cardinality } : {}),
-      ...(a.policy.encode !== undefined ? { encode: a.policy.encode } : {}),
-    }
+    addPolicyAnnotation({
+      annotations,
+      fields: {
+        ...(a.policy.cardinality !== undefined ? { cardinality: a.policy.cardinality } : {}),
+        ...(a.policy.encode !== undefined ? { encode: a.policy.encode } : {}),
+      },
+    })
   }
   if (a.bridge !== undefined) {
     annotations['bridge'] = {
@@ -231,11 +278,6 @@ const attrRefToObject = (r: AttrRef): Record<string, unknown> => {
 const byId = <T extends { id: string }>(xs: ReadonlyArray<T>): ReadonlyArray<T> =>
   xs.toSorted((a, b) => a.id.localeCompare(b.id))
 
-const deprecatedToNormativeObject = (deprecated: Deprecated): Record<string, unknown> =>
-  deprecated.reason === 'renamed'
-    ? { reason: deprecated.reason, renamed_to: deprecated.renamed_to }
-    : { reason: deprecated.reason, note: deprecated.note }
-
 const attributeGroupToObject = (g: AttributeGroup): Record<string, unknown> => ({
   id: `registry.${g.namespace}`,
   type: 'attribute_group',
@@ -254,19 +296,11 @@ const signalToObject = (sig: SignalDef): Record<string, unknown> => {
   }
   base['stability'] = sig.stability
   base['brief'] = sig.brief
+  const annotations: Record<string, unknown> = {}
   if (sig.deprecated !== undefined) {
-    base['deprecated'] = deprecatedToNormativeObject(sig.deprecated)
-    if (sig.deprecated.since !== undefined || sig.deprecated.remove_after !== undefined) {
-      base['annotations'] = {
-        deprecated: {
-          ...(sig.deprecated.since !== undefined ? { since: sig.deprecated.since } : {}),
-          ...(sig.deprecated.remove_after !== undefined
-            ? { remove_after: sig.deprecated.remove_after }
-            : {}),
-        },
-      }
-    }
+    addDeprecatedToObject({ out: base, annotations, deprecated: sig.deprecated })
   }
+  if (Object.keys(annotations).length > 0) base['annotations'] = annotations
   base['attributes'] = sig.attributes.map(attrRefToObject)
   return base
 }

--- a/packages/@overeng/genie/src/runtime/weaver/mod.ts
+++ b/packages/@overeng/genie/src/runtime/weaver/mod.ts
@@ -50,10 +50,17 @@ export type WeaverType =
   | { readonly members: ReadonlyArray<EnumMember> }
   | `template[${string}]`
 
+type DeprecationLifecycle = {
+  readonly since?: string
+  readonly remove_after?: string
+}
+
 /** weaver 0.23+ STRUCTURED deprecation (the string form was removed). */
-export type Deprecated =
-  | { readonly reason: 'renamed'; readonly renamed_to: string }
-  | { readonly reason: 'obsoleted' | 'uncategorized'; readonly note: string }
+export type Deprecated = DeprecationLifecycle &
+  (
+    | { readonly reason: 'renamed'; readonly renamed_to: string }
+    | { readonly reason: 'obsoleted' | 'uncategorized'; readonly note: string }
+  )
 
 /** How strongly an attribute reference is required on a signal (weaver `requirement_level`). */
 export type RequirementLevel =
@@ -114,6 +121,7 @@ export type SignalDef =
       readonly span_kind: SpanKind
       readonly brief: string
       readonly stability: Stability
+      readonly deprecated?: Deprecated
       readonly attributes: ReadonlyArray<AttrRef>
     }
   | {
@@ -124,6 +132,7 @@ export type SignalDef =
       readonly unit: string
       readonly brief: string
       readonly stability: Stability
+      readonly deprecated?: Deprecated
       readonly attributes: ReadonlyArray<AttrRef>
     }
 
@@ -222,6 +231,11 @@ const attrRefToObject = (r: AttrRef): Record<string, unknown> => {
 const byId = <T extends { id: string }>(xs: ReadonlyArray<T>): ReadonlyArray<T> =>
   xs.toSorted((a, b) => a.id.localeCompare(b.id))
 
+const deprecatedToNormativeObject = (deprecated: Deprecated): Record<string, unknown> =>
+  deprecated.reason === 'renamed'
+    ? { reason: deprecated.reason, renamed_to: deprecated.renamed_to }
+    : { reason: deprecated.reason, note: deprecated.note }
+
 const attributeGroupToObject = (g: AttributeGroup): Record<string, unknown> => ({
   id: `registry.${g.namespace}`,
   type: 'attribute_group',
@@ -240,6 +254,19 @@ const signalToObject = (sig: SignalDef): Record<string, unknown> => {
   }
   base['stability'] = sig.stability
   base['brief'] = sig.brief
+  if (sig.deprecated !== undefined) {
+    base['deprecated'] = deprecatedToNormativeObject(sig.deprecated)
+    if (sig.deprecated.since !== undefined || sig.deprecated.remove_after !== undefined) {
+      base['annotations'] = {
+        deprecated: {
+          ...(sig.deprecated.since !== undefined ? { since: sig.deprecated.since } : {}),
+          ...(sig.deprecated.remove_after !== undefined
+            ? { remove_after: sig.deprecated.remove_after }
+            : {}),
+        },
+      }
+    }
+  }
   base['attributes'] = sig.attributes.map(attrRefToObject)
   return base
 }

--- a/packages/@overeng/genie/src/runtime/weaver/rust-constants.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/weaver/rust-constants.unit.test.ts
@@ -5,8 +5,8 @@ import path from 'node:path'
 
 import { describe, expect, it } from 'vitest'
 
-import type { Provenance, SignalDef } from './mod.ts'
-import { renderRustConstants, renderSignals } from './mod.ts'
+import type { AttrDef, Provenance, Registry, SignalDef } from './mod.ts'
+import { renderAttributes, renderRustConstants, renderSignals } from './mod.ts'
 import { otelScrapeFixtureRegistry } from './otel-scrape.fixture.ts'
 
 // The synthetic otel-scrape registry is authored directly as dep-free Layer-1 data
@@ -85,6 +85,55 @@ describe('renderSignals signal deprecation', () => {
     expect(yaml.slice(deprecatedStart, annotationsStart).trimEnd()).toBe(
       '  deprecated:\n      reason: renamed\n      renamed_to: otel_scrape.new',
     )
+    expect(yaml.slice(annotationsStart)).toContain('overeng_policy:')
+    expect(yaml.slice(annotationsStart)).toContain('deprecated:')
+    expect(yaml.slice(annotationsStart)).toContain('since: 2026-07-10')
+    expect(yaml.slice(annotationsStart)).toContain('remove_after: 2026-10-10')
+  })
+})
+
+describe('renderAttributes attribute deprecation', () => {
+  it('keeps lifecycle dates in namespaced annotations and out of normative deprecated YAML', () => {
+    const attribute: AttrDef = {
+      id: 'otel_scrape.old_attribute',
+      type: 'string',
+      brief: 'Old scrape attribute.',
+      stability: 'development',
+      deprecated: {
+        reason: 'renamed',
+        renamed_to: 'otel_scrape.new_attribute',
+        since: '2026-07-10',
+        remove_after: '2026-10-10',
+      },
+    }
+    const registry: Registry = {
+      name: 'otel-scrape-test',
+      description: 'Test registry.',
+      schemaUrl: 'https://example.invalid/schema',
+      dependencies: [],
+      groups: [
+        {
+          namespace: 'otel_scrape',
+          displayName: 'OTel Scrape',
+          attributes: [attribute],
+        },
+      ],
+      signals: [],
+    }
+
+    const yaml = renderAttributes({ registry, provenance: FIXTURE_PROVENANCE })
+    const deprecatedStart = yaml.indexOf('      deprecated:')
+    const annotationsStart = yaml.indexOf('      annotations:')
+
+    expect(deprecatedStart).toBeGreaterThan(-1)
+    expect(annotationsStart).toBeGreaterThan(deprecatedStart)
+    expect(yaml.match(/\bsince:/g)).toHaveLength(1)
+    expect(yaml.match(/\bremove_after:/g)).toHaveLength(1)
+    expect(yaml.slice(deprecatedStart, annotationsStart).trimEnd()).toBe(
+      '      deprecated:\n          reason: renamed\n          renamed_to: otel_scrape.new_attribute',
+    )
+    expect(yaml.slice(annotationsStart)).toContain('overeng_policy:')
+    expect(yaml.slice(annotationsStart)).toContain('deprecated:')
     expect(yaml.slice(annotationsStart)).toContain('since: 2026-07-10')
     expect(yaml.slice(annotationsStart)).toContain('remove_after: 2026-10-10')
   })

--- a/packages/@overeng/genie/src/runtime/weaver/rust-constants.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/weaver/rust-constants.unit.test.ts
@@ -5,8 +5,8 @@ import path from 'node:path'
 
 import { describe, expect, it } from 'vitest'
 
-import type { Provenance } from './mod.ts'
-import { renderRustConstants } from './mod.ts'
+import type { Provenance, SignalDef } from './mod.ts'
+import { renderRustConstants, renderSignals } from './mod.ts'
 import { otelScrapeFixtureRegistry } from './otel-scrape.fixture.ts'
 
 // The synthetic otel-scrape registry is authored directly as dep-free Layer-1 data
@@ -54,6 +54,41 @@ const ALL_EXPECTED_NAMES = [
   ...EXPECTED_SPAN_IDS,
   ...EXPECTED_METRIC_NAMES,
 ]
+
+describe('renderSignals signal deprecation', () => {
+  it('keeps lifecycle dates in annotations and out of normative deprecated YAML', () => {
+    const signal: SignalDef = {
+      kind: 'metric',
+      id: 'metric.otel_scrape.old',
+      metric_name: 'otel_scrape.old',
+      instrument: 'counter',
+      unit: '1',
+      brief: 'Old scrape metric.',
+      stability: 'development',
+      deprecated: {
+        reason: 'renamed',
+        renamed_to: 'otel_scrape.new',
+        since: '2026-07-10',
+        remove_after: '2026-10-10',
+      },
+      attributes: [],
+    }
+
+    const yaml = renderSignals({ signals: [signal], provenance: FIXTURE_PROVENANCE })
+    const deprecatedStart = yaml.indexOf('  deprecated:')
+    const annotationsStart = yaml.indexOf('  annotations:')
+
+    expect(deprecatedStart).toBeGreaterThan(-1)
+    expect(annotationsStart).toBeGreaterThan(deprecatedStart)
+    expect(yaml.match(/\bsince:/g)).toHaveLength(1)
+    expect(yaml.match(/\bremove_after:/g)).toHaveLength(1)
+    expect(yaml.slice(deprecatedStart, annotationsStart).trimEnd()).toBe(
+      '  deprecated:\n      reason: renamed\n      renamed_to: otel_scrape.new',
+    )
+    expect(yaml.slice(annotationsStart)).toContain('since: 2026-07-10')
+    expect(yaml.slice(annotationsStart)).toContain('remove_after: 2026-10-10')
+  })
+})
 
 /** Resolve a binary from `$PATH` (rust tooling is provided by devenv/CI, absent in some sandboxes). */
 const onPath = (bin: string): string | undefined => {

--- a/packages/@overeng/otel-contract/src/registry.ts
+++ b/packages/@overeng/otel-contract/src/registry.ts
@@ -69,10 +69,17 @@ export type WeaverType =
   | { readonly members: ReadonlyArray<EnumMember> }
   | `template[${string}]`
 
+type DeprecationLifecycle = {
+  readonly since?: string
+  readonly remove_after?: string
+}
+
 /** Weaver structured deprecation (the pre-0.23 string form was removed). */
-export type Deprecated =
-  | { readonly reason: 'renamed'; readonly renamed_to: string }
-  | { readonly reason: 'obsoleted' | 'uncategorized'; readonly note: string }
+export type Deprecated = DeprecationLifecycle &
+  (
+    | { readonly reason: 'renamed'; readonly renamed_to: string }
+    | { readonly reason: 'obsoleted' | 'uncategorized'; readonly note: string }
+  )
 
 /** Weaver attribute-ref requirement level (incl. the object forms). */
 export type RequirementLevel =
@@ -128,6 +135,7 @@ export type SignalDef =
       readonly span_kind: SpanKind
       readonly brief: string
       readonly stability: Stability
+      readonly deprecated?: Deprecated
       readonly attributes: ReadonlyArray<AttrRef>
     }
   | {
@@ -138,6 +146,7 @@ export type SignalDef =
       readonly unit: string
       readonly brief: string
       readonly stability: Stability
+      readonly deprecated?: Deprecated
       readonly attributes: ReadonlyArray<AttrRef>
     }
 
@@ -488,6 +497,7 @@ export const span = (o: {
   kind: SpanKind
   brief: string
   stability: Stability
+  deprecated?: Deprecated
   attributes: Record<string, FieldSpec>
 }): SpanContract => {
   const { fields, refList, refs } = buildFields(o.attributes)
@@ -503,6 +513,7 @@ export const span = (o: {
       span_kind: o.kind,
       brief: o.brief,
       stability: o.stability,
+      ...(o.deprecated !== undefined ? { deprecated: o.deprecated } : {}),
       attributes: refList,
     }),
   }
@@ -530,6 +541,7 @@ export const metric = (o: {
   unit: string
   brief: string
   stability: Stability
+  deprecated?: Deprecated
   boundaries?: ReadonlyArray<number>
   labels: Record<string, FieldSpec>
 }): MetricContract => {
@@ -576,6 +588,7 @@ export const metric = (o: {
       unit: o.unit,
       brief: o.brief,
       stability: o.stability,
+      ...(o.deprecated !== undefined ? { deprecated: o.deprecated } : {}),
       attributes: refList,
     }),
   }

--- a/packages/@overeng/otel-contract/src/registry.unit.test.ts
+++ b/packages/@overeng/otel-contract/src/registry.unit.test.ts
@@ -95,6 +95,51 @@ describe('Layer 2 → runtime encoder derivation (SC-R13/R14)', () => {
       }),
     ).toThrow(WeaverUnsupportedInstrumentError)
   })
+
+  it('carries full dated deprecation on metric and span SignalDefs', () => {
+    const label = attr.string({
+      key: 'acme.lifecycle.label',
+      cardinality: 'low',
+      brief: 'Lifecycle label.',
+      stability: 'development',
+      examples: ['x'],
+    })
+    const deprecated = {
+      reason: 'renamed',
+      renamed_to: 'acme.lifecycle.new',
+      since: '2026-07-10',
+      remove_after: '2026-10-10',
+    } as const
+    const contract = defineOtelContract({
+      memberPath: 'packages/acme/lifecycle',
+      displayName: 'Acme Lifecycle',
+      signals: [
+        metric({
+          id: 'metric.acme.lifecycle.old',
+          name: 'acme.lifecycle.old',
+          instrument: 'counter',
+          unit: '1',
+          brief: 'Old lifecycle metric.',
+          stability: 'development',
+          deprecated,
+          labels: { label: required(label) },
+        }),
+        span({
+          id: 'span.acme.lifecycle.old',
+          kind: 'internal',
+          brief: 'Old lifecycle span.',
+          stability: 'development',
+          deprecated,
+          attributes: { label: required(label) },
+        }),
+      ],
+    })
+
+    expect(fragment(contract).signals.map((signal) => signal.deprecated)).toEqual([
+      deprecated,
+      deprecated,
+    ])
+  })
 })
 
 describe('derived namespace + catalog (decision 0006)', () => {


### PR DESCRIPTION
**Problem**
OTel contract deprecation metadata only carried Weaver's structured reason/note fields, and signal builders did not accept deprecation metadata at all. Dotfiles needs machine-readable dated deprecation lifecycle data on metric/span signals for schickling/dotfiles#1232.

**Goal**
Allow the OTel contract DSL to carry `since` and `remove_after` dates on structured deprecation metadata, including metric and span signals, while keeping emitted Weaver YAML compatible with Weaver 0.24.2.

**Decisions**
`Deprecated` keeps the existing tagged shape and adds optional `since` / `remove_after` lifecycle fields across variants.

Metric and span builders now accept `deprecated` and preserve the complete object on the typed `SignalDef` data.

`renderSignals` emits only Weaver-known fields under normative `deprecated:` (`reason`, `renamed_to` or `note`). The dated lifecycle fields are emitted under non-normative `annotations.overeng_policy.deprecated`, so Weaver ignores them while downstream consumers can still single-source from typed signal data.

**Refinement (pre-merge)**
Attribute deprecations now route through the same strip-and-annotate helper as signal deprecations, so dated attribute deprecations are Weaver-safe and retain lifecycle dates in YAML. The non-normative deprecation lifecycle annotation is namespaced under `overeng_policy.deprecated`, and a regression test covers the attribute path.

**Verification**
- RED proof: pre-change `metric({ deprecated })` produced TS2353 because `deprecated` was not accepted by the metric builder.
- GREEN proof: post-change fixture typechecked and `fragment(contract).signals` carries the full deprecation object for metric and span signals.
- `CI=1 pnpm --filter @overeng/otel-contract exec vitest run src/registry.unit.test.ts` passed.
- `CI=1 pnpm --filter @overeng/genie exec vitest run src/runtime/weaver/rust-constants.unit.test.ts` passed.
- `devenv tasks run check:quick` passed.
- `devenv tasks run weaver:check` passed.

Pre-existing gate note: after locally building both `packages/@overeng/otelite` and `packages/@overeng/otel-scrape`, `src/otel-scrape/profile-link.unit.test.ts` still fails at the same `otelite inspect` 0-row assertion with the A1 files path-limited stashed via `git stash push --key a1-verify -- ...`. That proves the failure is pre-existing/environmental and unrelated to this typed deprecation/rendering diff.

**Complexity**
No new dependency or broad abstraction. The shared renderer helper strips non-Weaver lifecycle fields from the normative deprecated block and routes them through namespaced annotations for both attributes and signals.

**Concerns**
The pre-existing `profile-link.unit.test.ts` failure prevents claiming the full `@overeng/otel-contract` suite is green locally, but it reproduces on the base tree with this PR's files stashed.

**Friction & bottlenecks**
Fresh worktree Rust test binaries were missing, so `otelite` and `otel-scrape` had to be built locally before the profile-link classification could be trusted.

**Follow-ups**
Investigate the pre-existing `profile-link.unit.test.ts` / `otelite inspect` 0-row failure separately.

**References**
Refs schickling/dotfiles#1232

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | ✨ co1-quartz |
| `agent_session_id` | 98751094-7fde-42e1-acd1-4149efd78c22 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.141.0 |
| `agent_runtime` | Codex CLI 0.141.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/5bkm466h121236vcc4sx467hsan9382j-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/fvj9gyni5y0kypcna51kb0bwns7z2kcc-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-10-otel-deprecation-lifecycle |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@e9a23d3 |
</details>
<!-- agent-footer:end -->