### PR TITLE
fix(notion-cli): default relations to ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,6 +206,11 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- **@overeng/notion-cli**: Default generated Notion relation properties to
+  `relationIds` even when Notion reports `single_property` relation metadata.
+  Explicit single-relation transforms remain available through transform
+  configuration for schemas that intentionally require scalar cardinality.
+
 - **otel-scrape**: Refactored the adapters into a per-tool module framework
   (`src/adapters/`): a `ToolAdapter` trait + `ADAPTERS` registry, with oxlint,
   vitest, and node-cpuprofile each in their own module. `lib.rs` dispatch is now

--- a/packages/@overeng/notion-cli/src/codegen.ts
+++ b/packages/@overeng/notion-cli/src/codegen.ts
@@ -212,10 +212,6 @@ const inferRollupTransform = (property: PropertyInfo): string | undefined => {
 }
 
 const inferDefaultTransform = (property: PropertyInfo): string => {
-  if (property.type === 'relation' && property.relation?.type === 'single_property') {
-    return 'asSingleOption'
-  }
-
   if (property.type === 'rollup') {
     const rollupTransform = inferRollupTransform(property)
     if (rollupTransform !== undefined) return rollupTransform

--- a/packages/@overeng/notion-cli/src/codegen.unit.test.ts
+++ b/packages/@overeng/notion-cli/src/codegen.unit.test.ts
@@ -508,7 +508,7 @@ describe('codegen', () => {
       }
     })
 
-    it('should infer transforms from relation and rollup metadata', () => {
+    it('should infer cardinality-independent relation defaults and rollup metadata transforms', () => {
       const dbInfo: DatabaseInfo = {
         id: 'test',
         name: 'Test',
@@ -542,7 +542,7 @@ describe('codegen', () => {
       }
 
       const code = generateSchemaCode({ dbInfo, schemaName: 'Test' })
-      expect(code).toContain('Owner: NotionSchema.relationSingleOption')
+      expect(code).toContain('Owner: NotionSchema.relationIds')
       expect(code).toContain('Total: NotionSchema.rollupNumber')
     })
 


### PR DESCRIPTION
**Problem**

Notion relation schema metadata reports `single_property` for unidirectional relations. The current Notion codegen interprets that metadata as page-value cardinality and emits `relationSingleOption`, which rejects valid relation arrays containing more than one page id.

**Goal**

Generated relation schemas should preserve valid Notion relation values by default while still allowing callers to opt into scalar relation transforms when they know a property is truly single-valued.

**Decisions**

- Default all relation properties to the existing `relationIds` transform, including relations whose metadata type is `single_property`.
- Keep explicit single-relation transforms (`asSingle`, `asSingleOption`, `asSingleId`, `asSingleIdOption`) available through transform configuration instead of inferring them from direction/sync metadata.
- Add a focused unit-test expectation for cardinality-independent relation defaults.

**Verification**

- `devenv tasks run test:notion-cli --no-tui` passed locally.

**Complexity**

No new complexity. This removes a special-case inference and reuses the existing relation transform surface.

**Concerns**

Generated schemas that were unintentionally relying on scalar relation defaults will become array-valued on regeneration. Those schemas should opt into a single-relation transform explicitly if scalar cardinality is part of their contract.

**Friction & bottlenecks**

The first focused test run had to build the isolated Nix workspace and CLI bundle before Vitest, which took about two minutes locally.

**Follow-ups**

None.

**References**

Closes #242

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🎺 co4-brass |
| `agent_session_id` | 355660e0-1bf0-431b-a98b-f1454f90c87c |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.141.0 |
| `agent_runtime` | Codex CLI 0.141.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/5bkm466h121236vcc4sx467hsan9382j-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/fvj9gyni5y0kypcna51kb0bwns7z2kcc-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | schickling-stiftung/schickling/2026-07-10-qr |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@e9a23d3 |
</details>
<!-- agent-footer:end -->