### PR TITLE
Fix Notion generated page type aliases

### DIFF
--- a/packages/@overeng/notion-cli/src/codegen.ts
+++ b/packages/@overeng/notion-cli/src/codegen.ts
@@ -1019,7 +1019,7 @@ export function generateApiCode(opts: GenerateApiCodeOptions): string {
     `    schema: ${pascalName}PageProperties,`,
     `  })`,
     ``,
-    `export type ${pascalName}Page = TypedPage<typeof ${pascalName}PageProperties.Type>`,
+    `export type ${pascalName}Page = TypedPage<${pascalName}PageProperties>`,
   ]
 
   // Add create/update if write schema is enabled


### PR DESCRIPTION
**Problem**
`notion schema generate-config` emits generated API files with page aliases like `TypedPage<typeof FooPageProperties.Type>`. Repositories that gate on Effect-LSP suggestions fail on that generated code because the schema already exports `FooPageProperties` as the decoded property type alias.

**Goal**
Generated Notion API files should reuse the generated property type alias and avoid Effect-LSP `unnecessaryTypeofType` suggestions.

**Decisions**
Changed the API generator to emit `TypedPage<FooPageProperties>` instead of re-querying `typeof FooPageProperties.Type`. This keeps generated code aligned with the schema alias the generator already writes.

**Verification**
```text
devenv tasks run test:notion-cli --no-tui
✓ Running test:notion-cli
✓ Running tasks
```

**Complexity**
No new complexity; this is a one-line generator output cleanup.

**Concerns**
This changes only generated TypeScript surface syntax. It should be type-equivalent for consumers.

**Friction & bottlenecks**
None.

**Follow-ups**
None.

**References**
Follow-up to overengineeringstudio/effect-utils#911.
Needed by schickling/schickling-stiftung#224 schema regeneration.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🎺 co4-brass |
| `agent_session_id` | 355660e0-1bf0-431b-a98b-f1454f90c87c |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.141.0 |
| `agent_runtime` | Codex CLI 0.141.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/5bkm466h121236vcc4sx467hsan9382j-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/fvj9gyni5y0kypcna51kb0bwns7z2kcc-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-10-schickling-assistant-2026-07-10-notion-api-typed-page-alias |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@e9a23d3 |
</details>
<!-- agent-footer:end -->