### PR TITLE
fix(otel-contract): stabilize otel-scrape profile-link otelite inspect (pre-existing 0-row race) (#1232)

### DIFF
--- a/packages/@overeng/otel-contract/src/otel-scrape/profile-link.unit.test.ts
+++ b/packages/@overeng/otel-contract/src/otel-scrape/profile-link.unit.test.ts
@@ -22,7 +22,11 @@ import {
   utf8Bytes,
 } from '@overeng/content-address'
 
-import { OtelScrapeProfileLink, otelScrapeProfileLinkFromDescriptor } from '../mod.ts'
+import {
+  OtelScrapeProfileLink,
+  otelScrapeAttributeKeys,
+  otelScrapeProfileLinkFromDescriptor,
+} from '../mod.ts'
 
 const execFileAsync = promisify(execFile)
 
@@ -255,7 +259,18 @@ describe('otel-scrape profile links', () => {
 
       const inspect = await execFileAsync(
         otelite,
-        ['inspect', captureRoot, '--signal', 'traces', '--name', 'otel_scrape.command'],
+        [
+          'inspect',
+          captureRoot,
+          '--signal',
+          'traces',
+          '--service',
+          'otel-scrape-contract-e2e',
+          '--attr',
+          `${otelScrapeAttributeKeys.otelScrapeSpanOrigin}=otel-scrape`,
+          '--attr',
+          `${otelScrapeAttributeKeys.processExecutableName}=node`,
+        ],
         { maxBuffer: 1024 * 1024 * 10 },
       )
       const rows = inspect.stdout
@@ -267,7 +282,11 @@ describe('otel-scrape profile links', () => {
       expect(rows[0]).toMatchObject({
         schema: 'otelite.span/v1',
         service: 'otel-scrape-contract-e2e',
-        name: 'otel_scrape.command',
+        name: 'node',
+        attrs: {
+          [otelScrapeAttributeKeys.otelScrapeSpanOrigin]: 'otel-scrape',
+          [otelScrapeAttributeKeys.processExecutableName]: 'node',
+        },
       })
 
       const rawCapture = await readFile(join(captureRoot, 'traces.ndjson'), 'utf8')
@@ -278,7 +297,18 @@ describe('otel-scrape profile links', () => {
       const otlpPayload = JSON.parse(firstCaptureLine)
       const span =
         otlpPayload.resourceSpans[0].scopeSpans[0].spans.find(
-          (candidate: { readonly name?: unknown }) => candidate.name === 'otel_scrape.command',
+          (candidate: {
+            readonly attributes?: ReadonlyArray<{
+              readonly key?: unknown
+              readonly value?: Record<string, unknown>
+            }>
+            readonly name?: unknown
+          }) =>
+            candidate.name === 'node' &&
+            attrValue(candidate.attributes ?? [], otelScrapeAttributeKeys.otelScrapeSpanOrigin) ===
+              'otel-scrape' &&
+            attrValue(candidate.attributes ?? [], otelScrapeAttributeKeys.processExecutableName) ===
+              'node',
         ) ?? {}
       const event = span.events.find(
         (candidate: { readonly name?: unknown }) => candidate.name === 'otel_scrape.profile.link',


### PR DESCRIPTION
## Scope

Fixes the pre-existing `@overeng/otel-contract` profile-link e2e failure where `otelite inspect` returned zero rows.

## Root Cause

This was not a capture flush/index timing race. The preserved capture showed `otelite.summary/v1` counted one span, `traces.ndjson` contained that span, and unfiltered `otelite inspect --signal traces` emitted one `otelite.span/v1` row.

The row was filtered out because the test still queried `--name otel_scrape.command`. The current otel-scrape registry/spec names command spans by the wrapped executable basename (`process.executable.name`), so the captured command span for this test is named `node` and carries ownership through `otel_scrape.span.origin=otel-scrape`.

## Fix

The test now selects the command span by service plus generated registry attribute keys:

- `otel_scrape.span.origin=otel-scrape`
- `process.executable.name=node`

It also asserts the current span-name contract (`name=node`) before checking the profile-link event payload.

## RED/GREEN

Before:

- `CI=1 pnpm --filter @overeng/otel-contract exec vitest run src/otel-scrape/profile-link.unit.test.ts` failed at `expect(rows).toHaveLength(1)` because `inspect --name otel_scrape.command` returned `[]`.

After:

- `CI=1 pnpm --filter @overeng/otel-contract exec vitest run src/otel-scrape/profile-link.unit.test.ts` passed: 2 tests passed.
- `CI=1 pnpm --filter @overeng/otel-contract exec vitest run` passed: 118 passed, 2 skipped.
- `devenv tasks run check:quick` passed.
- `devenv tasks run weaver:check` passed.

Refs schickling/dotfiles#1232

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | ✨ co1-quartz |
| `agent_session_id` | 98751094-7fde-42e1-acd1-4149efd78c22 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.141.0 |
| `agent_runtime` | Codex CLI 0.141.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/5bkm466h121236vcc4sx467hsan9382j-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/fvj9gyni5y0kypcna51kb0bwns7z2kcc-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-10-otel-scrape-profile-link-fix |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@e9a23d3 |
</details>
<!-- agent-footer:end -->