### PR TITLE
Fix Vercel prebuilt deploy workdir for local builds

### DIFF
--- a/packages/@overeng/ci-tools/src/deploy-vercel.e2e.test.ts
+++ b/packages/@overeng/ci-tools/src/deploy-vercel.e2e.test.ts
@@ -318,7 +318,14 @@ exit 1
     apiMode = 'ok'
     const workspace = makeWorkspace()
     const reportFile = join(workspace.root, 'report.jsonl')
-    const workspaceFile = join(workspace.root, 'app', '.next', 'server', 'edge-chunks', 'chunk.wasm')
+    const workspaceFile = join(
+      workspace.root,
+      'app',
+      '.next',
+      'server',
+      'edge-chunks',
+      'chunk.wasm',
+    )
     try {
       mkdirSync(join(workspace.root, 'app', '.next', 'server', 'edge-chunks'), { recursive: true })
       writeFileSync(workspaceFile, 'wasm marker')

--- a/packages/@overeng/ci-tools/src/deploy-vercel.e2e.test.ts
+++ b/packages/@overeng/ci-tools/src/deploy-vercel.e2e.test.ts
@@ -1,5 +1,13 @@
 import { spawn } from 'node:child_process'
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
 import { createServer, type Server } from 'node:http'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
@@ -301,7 +309,7 @@ exit 1
       expect(log).toContain(
         'args=deploy --prebuilt --yes --prod --scope fake-scope --token fake-token',
       )
-      expect(log).toContain(`cwd=${workspace.root} VERCEL_PROJECT_ID=fake-project`)
+      expect(log).toContain(`cwd=${realpathSync(workspace.root)} VERCEL_PROJECT_ID=fake-project`)
       expect(existsSync(join(workspace.root, 'app', 'vercel.json'))).toBe(false)
       expect(existsSync(join(workspace.root, '.vercel'))).toBe(false)
       expect(readRecord(reportFile).data).toMatchObject({
@@ -360,7 +368,7 @@ exit 1
       }
       expect(result.status).toBe(0)
       const log = readFileSync(workspace.logPath, 'utf8')
-      expect(log).toContain(`cwd=${workspace.root} VERCEL_PROJECT_ID=fake-project`)
+      expect(log).toContain(`cwd=${realpathSync(workspace.root)} VERCEL_PROJECT_ID=fake-project`)
       expect(existsSync(join(workspace.root, '.vercel'))).toBe(false)
     } finally {
       rmSync(workspace.root, { recursive: true, force: true })

--- a/packages/@overeng/ci-tools/src/deploy-vercel.e2e.test.ts
+++ b/packages/@overeng/ci-tools/src/deploy-vercel.e2e.test.ts
@@ -157,6 +157,9 @@ if [ "\${1:-}" = "build" ]; then
 fi
 if [ "\${1:-}" = "deploy" ]; then
   test -f .vercel/output/static/index.html
+  if [ -n "\${FAKE_VERCEL_REQUIRE_WORKSPACE_FILE:-}" ]; then
+    test -f "\${FAKE_VERCEL_REQUIRE_WORKSPACE_FILE}"
+  fi
   if [ "\${FAKE_VERCEL_REQUIRE_DOTFILE:-1}" = "1" ]; then
     test -f .vercel/output/static/.well-known
   fi
@@ -298,6 +301,7 @@ exit 1
       expect(log).toContain(
         'args=deploy --prebuilt --yes --prod --scope fake-scope --token fake-token',
       )
+      expect(log).toContain(`cwd=${workspace.root} VERCEL_PROJECT_ID=fake-project`)
       expect(existsSync(join(workspace.root, 'app', 'vercel.json'))).toBe(false)
       expect(existsSync(join(workspace.root, '.vercel'))).toBe(false)
       expect(readRecord(reportFile).data).toMatchObject({
@@ -305,6 +309,52 @@ exit 1
         target: 'app',
         mode: 'prod',
       })
+    } finally {
+      rmSync(workspace.root, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps workspace-relative files available for locally built prebuilt deploys', async () => {
+    apiMode = 'ok'
+    const workspace = makeWorkspace()
+    const reportFile = join(workspace.root, 'report.jsonl')
+    const workspaceFile = join(workspace.root, 'app', '.next', 'server', 'edge-chunks', 'chunk.wasm')
+    try {
+      mkdirSync(join(workspace.root, 'app', '.next', 'server', 'edge-chunks'), { recursive: true })
+      writeFileSync(workspaceFile, 'wasm marker')
+      const result = await runCiTools({
+        workdir: workspace.root,
+        fakeVercelBin: workspace.fakeVercelBin,
+        reportFile,
+        args: [
+          '--target',
+          'app',
+          '--artifact-dir',
+          join(workspace.root, '.vercel', 'output'),
+          '--artifact-kind',
+          'prebuilt-output',
+          '--mode',
+          'prod',
+          '--build-prebuilt-output',
+          '--vercel-root-directory',
+          'app',
+          '--build-env',
+          'BUILD_MARKER=ci-tools',
+          '--scope-env',
+          'VERCEL_SCOPE',
+        ],
+        env: {
+          FAKE_VERCEL_REQUIRE_DOTFILE: '0',
+          FAKE_VERCEL_REQUIRE_WORKSPACE_FILE: 'app/.next/server/edge-chunks/chunk.wasm',
+        },
+      })
+      if (result.status !== 0) {
+        console.error({ stdout: result.stdout, stderr: result.stderr })
+      }
+      expect(result.status).toBe(0)
+      const log = readFileSync(workspace.logPath, 'utf8')
+      expect(log).toContain(`cwd=${workspace.root} VERCEL_PROJECT_ID=fake-project`)
+      expect(existsSync(join(workspace.root, '.vercel'))).toBe(false)
     } finally {
       rmSync(workspace.root, { recursive: true, force: true })
     }

--- a/packages/@overeng/ci-tools/src/deploy-vercel.ts
+++ b/packages/@overeng/ci-tools/src/deploy-vercel.ts
@@ -330,7 +330,12 @@ const preparePrebuiltOutput = Effect.fn('ci-tools.deploy.vercel.prepare-prebuilt
     readonly artifactKind: 'static' | 'prebuilt-output'
     readonly projectId: string
     readonly orgId: string
+    readonly localBuildWorkDir: string | undefined
   }) {
+    if (opts.artifactKind === 'prebuilt-output' && opts.localBuildWorkDir !== undefined) {
+      return { workDir: opts.localBuildWorkDir, cleanupWorkDir: false }
+    }
+
     const workDir = yield* Effect.sync(() => mkdtempSync(join(tmpdir(), 'ci-tools-vercel-')))
     const projectJson = yield* Schema.encode(VercelProjectFileJson)({
       projectId: opts.projectId,
@@ -352,7 +357,7 @@ const preparePrebuiltOutput = Effect.fn('ci-tools.deploy.vercel.prepare-prebuilt
         cpSync(opts.artifactDir, join(workDir, '.vercel', 'output'), { recursive: true })
       })
     }
-    return workDir
+    return { workDir, cleanupWorkDir: true }
   },
 )
 
@@ -975,11 +980,12 @@ export const runVercelDeploy = Effect.fn('ci-tools.deploy.vercel')(function* (
       )
     }
 
-    const workDir = yield* preparePrebuiltOutput({
+    const preparedOutput = yield* preparePrebuiltOutput({
       artifactDir: options.artifactDir,
       artifactKind: options.artifactKind,
       projectId,
       orgId,
+      localBuildWorkDir: options.buildPrebuiltOutput === true ? process.cwd() : undefined,
     })
 
     try {
@@ -990,7 +996,7 @@ export const runVercelDeploy = Effect.fn('ci-tools.deploy.vercel')(function* (
         },
         effect: runVercelCommand({
           vercelBin: options.vercelBin,
-          cwd: workDir,
+          cwd: preparedOutput.workDir,
           args: [
             'deploy',
             '--prebuilt',
@@ -1047,7 +1053,7 @@ export const runVercelDeploy = Effect.fn('ci-tools.deploy.vercel')(function* (
           },
           effect: runVercelCommand({
             vercelBin: options.vercelBin,
-            cwd: workDir,
+            cwd: preparedOutput.workDir,
             args: [
               'alias',
               rawDeployUrl,
@@ -1120,7 +1126,7 @@ export const runVercelDeploy = Effect.fn('ci-tools.deploy.vercel')(function* (
               target: input.target,
               alias,
               allowSharedProject: true,
-              workDir,
+              workDir: preparedOutput.workDir,
               vercelBin: options.vercelBin,
               authToken: authTokenValue,
               projectId,
@@ -1185,7 +1191,9 @@ export const runVercelDeploy = Effect.fn('ci-tools.deploy.vercel')(function* (
         urlEnvKey: options.urlEnvKey,
       })
     } finally {
-      rmSync(workDir, { recursive: true, force: true })
+      if (preparedOutput.cleanupWorkDir === true) {
+        rmSync(preparedOutput.workDir, { recursive: true, force: true })
+      }
     }
   } finally {
     if (cleanupLocalVercel === true) {


### PR DESCRIPTION
## Summary
- deploy locally built Vercel prebuilt output from the original workspace instead of a temp copy
- keep temp workdir packaging for static and externally supplied prebuilt artifacts
- add an e2e regression covering workspace-relative .next edge chunk side files during deploy

## Verification
- `DEVENV_TASK_PASSTHROUGH=1 devenv shell -- packages/@overeng/ci-tools/node_modules/.bin/vitest run packages/@overeng/ci-tools/src/deploy-vercel.e2e.test.ts`

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🎺 co4-brass |
| `agent_session_id` | 355660e0-1bf0-431b-a98b-f1454f90c87c |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.141.0 |
| `agent_runtime` | Codex CLI 0.141.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/5bkm466h121236vcc4sx467hsan9382j-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/fvj9gyni5y0kypcna51kb0bwns7z2kcc-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | schickling-stiftung/schickling/2026-07-10-qr |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@e9a23d3 |
</details>
<!-- agent-footer:end -->