### PR TITLE
Support Vercel production domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **ci-tools / Vercel**: add first-class production-domain support to the shared
+  Vercel deploy path. `ci-tools deploy vercel --production-domain <host>` now
+  aliases production deployments to canonical custom domains, reports those
+  domains in workflow-report evidence, and uses the canonical domain as the
+  final URL for live verification. The devenv Vercel task module threads
+  `deployment.productionDomains` through to `ci-tools`, so downstream repos can
+  keep custom domains in generated deploy-surface config instead of one-off
+  dashboard state.
 - **devenv / genie**: replace the shared Genie task module's raw
   `_module.args.geniePkg` / `_module.args.genieInputGlobs` contract with
   declared `effectUtils.genie.package` and `effectUtils.genie.extraInputGlobs`

--- a/nix/devenv-modules/tasks/shared/tests/deploy-task-e2e.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/deploy-task-e2e.test.sh
@@ -131,6 +131,7 @@ extract_vercel_static_task_script() {
                 projectIdEnv = \"VERCEL_PROJECT_ID_WEB\";
                 scopeEnv = \"VERCEL_SCOPE_WEB\";
                 aliasPrefix = \"web-preview\";
+                productionDomains = [ \"app.example.com\" ];
                 afterTask = null;
               }
             ];
@@ -174,6 +175,7 @@ extract_vercel_build_task_script() {
                 projectIdEnv = \"VERCEL_PROJECT_ID_APP\";
                 scopeEnv = \"VERCEL_SCOPE_APP\";
                 aliasPrefix = \"app-preview\";
+                productionDomains = [ \"app.example.com\" ];
               }
             ];
           }) {
@@ -465,6 +467,7 @@ assert_contains "$vercel_static_args" "--scope-env VERCEL_SCOPE_WEB" "Vercel sta
 assert_contains "$vercel_static_args" "--github-output-file $vercel_github_output" "Vercel static wrapper should pass GitHub output path"
 assert_contains "$vercel_static_args" "--url-env-key VERCEL_DEPLOY_URL_WEB" "Vercel static wrapper should pass default URL env key"
 assert_contains "$vercel_static_args" "--github-env-file $vercel_github_env" "Vercel static wrapper should pass GitHub env path"
+assert_contains "$vercel_static_args" "--production-domain app.example.com" "Vercel static wrapper should pass production domains"
 assert_json_field "https://web-preview-pr-123-team.vercel.app/" "$vercel_output_file" "value => value.devenv.env.VERCEL_DEPLOY_URL_WEB" "Vercel task output should be delegated through ci-tools"
 assert_json_field "vercel" "$vercel_report_file" "value => value.data.provider" "Vercel report record should be delegated through ci-tools"
 assert_contains "$(cat "$vercel_github_output")" "workflow_report_path=$vercel_report_file" "Vercel GitHub outputs should include report path from ci-tools"

--- a/nix/devenv-modules/tasks/shared/vercel.nix
+++ b/nix/devenv-modules/tasks/shared/vercel.nix
@@ -50,6 +50,7 @@ let
       scopeEnv = deployment.scopeEnv or null;
       protectionBypassEnv = deployment.protectionBypassEnv or null;
       aliasPrefix = deployment.aliasPrefix or null;
+      productionDomains = deployment.productionDomains or [ ];
       urlEnvKey =
         deployment.urlEnvKey or "VERCEL_DEPLOY_URL_${
           lib.toUpper (builtins.replaceStrings [ "-" "." "/" ] [ "_" "_" "_" ] name)
@@ -102,6 +103,9 @@ let
           ${lib.optionalString (aliasPrefix != null) ''
             args+=(--alias-prefix ${lib.escapeShellArg aliasPrefix})
           ''}
+          ${lib.concatStringsSep "\n          " (
+            map (domain: "args+=(--production-domain ${lib.escapeShellArg domain})") productionDomains
+          )}
           ${lib.optionalString (teamIdEnv != null) ''
             args+=(--team-id-env ${lib.escapeShellArg teamIdEnv})
           ''}

--- a/packages/@overeng/ci-tools/src/cli-command.ts
+++ b/packages/@overeng/ci-tools/src/cli-command.ts
@@ -401,6 +401,10 @@ const vercelDeployCommand = Command.make(
       Options.withDescription('Optional suffix appended to Vercel aliases'),
       Options.optional,
     ),
+    productionDomain: Options.text('production-domain').pipe(
+      Options.withDescription('Production hostname to alias to the deployment (repeatable)'),
+      Options.repeated,
+    ),
     projectIdEnv: Options.text('project-id-env').pipe(
       Options.withDescription('Environment variable containing the Vercel project id'),
       Options.withDefault('VERCEL_PROJECT_ID'),
@@ -496,6 +500,7 @@ const vercelDeployCommand = Command.make(
       artifactKind: opts.artifactKind,
       aliasPrefix: optionToUndefined(opts.aliasPrefix),
       aliasSuffix: optionToUndefined(opts.aliasSuffix),
+      productionDomains: opts.productionDomain,
       teamIdEnv: optionToUndefined(opts.teamIdEnv),
       scopeEnv: optionToUndefined(opts.scopeEnv),
       protectionBypassEnv: optionToUndefined(opts.protectionBypassEnv),

--- a/packages/@overeng/ci-tools/src/deploy-domain.ts
+++ b/packages/@overeng/ci-tools/src/deploy-domain.ts
@@ -50,6 +50,14 @@ export const DeployAlias = Schema.NonEmptyTrimmedString.pipe(
 )
 export type DeployAlias = typeof DeployAlias.Type
 
+export const DeployHostname = Schema.NonEmptyTrimmedString.pipe(
+  Schema.pattern(
+    /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)+$/u,
+  ),
+  Schema.annotations({ identifier: 'CiTools.Deploy.Hostname' }),
+)
+export type DeployHostname = typeof DeployHostname.Type
+
 export const EnvVarName = Schema.NonEmptyTrimmedString.pipe(
   Schema.pattern(/^[A-Z_][A-Z0-9_]*$/u),
   Schema.annotations({ identifier: 'CiTools.Deploy.EnvVarName' }),
@@ -122,6 +130,7 @@ export const DeployInputV1 = Schema.TaggedStruct('DeployInput', {
   mode: DeployMode,
   artifactDir: Schema.NonEmptyTrimmedString,
   alias: Schema.optional(DeployAlias),
+  productionDomains: Schema.optional(Schema.Array(DeployHostname)),
   pr: Schema.optional(PositiveInt),
   gitSha: Schema.optional(Schema.NonEmptyTrimmedString),
   runId: Schema.optional(Schema.NonEmptyTrimmedString),
@@ -146,6 +155,7 @@ export const DeployResultV1 = Schema.TaggedStruct('DeployResult', {
   rawDeployUrl: HttpsUrl,
   finalUrl: HttpsUrl,
   alias: Schema.optional(DeployAlias),
+  productionDomains: Schema.optional(Schema.Array(DeployHostname)),
   startedAtUtc: Schema.DateTimeUtc,
   endedAtUtc: Schema.DateTimeUtc,
   attempts: PositiveInt,
@@ -428,6 +438,9 @@ export const deploySuccessRecord = (
       mode: opts.input.mode,
       attempts: opts.result.attempts,
       ...(opts.result.alias === undefined ? {} : { alias: opts.result.alias }),
+      ...(opts.result.productionDomains === undefined || opts.result.productionDomains.length === 0
+        ? {}
+        : { productionDomains: opts.result.productionDomains }),
       rawDeployUrl: opts.result.rawDeployUrl.toString(),
       finalUrl: opts.result.finalUrl.toString(),
       deployedAtUtc: encodeDateTimeUtc(opts.result.endedAtUtc),

--- a/packages/@overeng/ci-tools/src/deploy-vercel.e2e.test.ts
+++ b/packages/@overeng/ci-tools/src/deploy-vercel.e2e.test.ts
@@ -285,6 +285,8 @@ exit 1
           'prebuilt-output',
           '--mode',
           'prod',
+          '--production-domain',
+          'app.example.com',
           '--build-prebuilt-output',
           '--vercel-root-directory',
           'app',
@@ -309,6 +311,9 @@ exit 1
       expect(log).toContain(
         'args=deploy --prebuilt --yes --prod --scope fake-scope --token fake-token',
       )
+      expect(log).toContain(
+        'args=alias https://deploy-web.vercel.app app.example.com --scope fake-scope',
+      )
       expect(log).toContain(`cwd=${realpathSync(workspace.root)} VERCEL_PROJECT_ID=fake-project`)
       expect(existsSync(join(workspace.root, 'app', 'vercel.json'))).toBe(false)
       expect(existsSync(join(workspace.root, '.vercel'))).toBe(false)
@@ -316,6 +321,8 @@ exit 1
         provider: 'vercel',
         target: 'app',
         mode: 'prod',
+        finalUrl: 'https://app.example.com/',
+        productionDomains: ['app.example.com'],
       })
     } finally {
       rmSync(workspace.root, { recursive: true, force: true })

--- a/packages/@overeng/ci-tools/src/deploy-vercel.ts
+++ b/packages/@overeng/ci-tools/src/deploy-vercel.ts
@@ -55,6 +55,7 @@ export type VercelDeployCommandOptions = {
   readonly pr?: number | undefined
   readonly aliasPrefix?: string | undefined
   readonly aliasSuffix?: string | undefined
+  readonly productionDomains: readonly string[]
   readonly projectIdEnv: string
   readonly orgIdEnv: string
   readonly authTokenEnv: string
@@ -122,6 +123,11 @@ const vercelAlias = Effect.fn('ci-tools.deploy.vercel.alias')(function* (opts: {
       return undefined
   }
 })
+
+const vercelProductionDomains = (opts: {
+  readonly mode: 'prod' | 'pr' | 'preview'
+  readonly domains: readonly string[]
+}) => (opts.mode === 'prod' ? opts.domains : [])
 
 const decodeDeployInput = Effect.fn('ci-tools.deploy.vercel.decode-input')(function* (
   value: unknown,
@@ -813,6 +819,10 @@ export const runVercelDeploy = Effect.fn('ci-tools.deploy.vercel')(function* (
     pr: options.pr,
     aliasSuffix: options.aliasSuffix,
   })
+  const productionDomains = vercelProductionDomains({
+    mode: options.mode,
+    domains: options.productionDomains,
+  })
 
   const input = yield* decodeDeployInput({
     _tag: 'DeployInput',
@@ -823,6 +833,7 @@ export const runVercelDeploy = Effect.fn('ci-tools.deploy.vercel')(function* (
     mode: options.mode,
     artifactDir: options.artifactDir,
     alias,
+    productionDomains,
     pr: options.pr,
     workflowReportOutputFile: options.workflowReportOutputFile,
     e2e: {
@@ -1084,6 +1095,47 @@ export const runVercelDeploy = Effect.fn('ci-tools.deploy.vercel')(function* (
         finalUrl = `https://${aliasHost}`
       }
 
+      for (const productionDomain of productionDomains) {
+        const domainResult = yield* DeployProviderOperation.with({
+          attributes: {
+            provider: 'vercel',
+            target: input.target,
+          },
+          effect: runVercelCommand({
+            vercelBin: options.vercelBin,
+            cwd: preparedOutput.workDir,
+            args: [
+              'alias',
+              rawDeployUrl,
+              productionDomain,
+              ...vercelScopeArgs(scope),
+              '--token',
+              authTokenValue,
+            ],
+            env: {
+              VERCEL_PROJECT_ID: projectId,
+              VERCEL_ORG_ID: orgId,
+              ...(teamId === undefined ? {} : { VERCEL_TEAM_ID: teamId }),
+            },
+          }),
+        })
+        if (domainResult.status !== 0) {
+          return yield* failWithRecord(
+            classifyVercelFailure({
+              target: options.target,
+              status: domainResult.status,
+              stdout: domainResult.stdout,
+              stderr: domainResult.stderr,
+              authToken: authTokenValue,
+              operation: 'alias',
+            }),
+          )
+        }
+      }
+      if (productionDomains.length > 0) {
+        finalUrl = `https://${productionDomains[0]}`
+      }
+
       const preliminary = decodeResultEither({
         _tag: 'DeployResult',
         schemaVersion: 1,
@@ -1093,6 +1145,7 @@ export const runVercelDeploy = Effect.fn('ci-tools.deploy.vercel')(function* (
         rawDeployUrl,
         finalUrl,
         alias,
+        productionDomains,
         startedAtUtc: createdAtUtc,
         endedAtUtc: isoNow(),
         attempts: 1,
@@ -1145,6 +1198,7 @@ export const runVercelDeploy = Effect.fn('ci-tools.deploy.vercel')(function* (
         rawDeployUrl,
         finalUrl,
         alias,
+        productionDomains,
         startedAtUtc: createdAtUtc,
         endedAtUtc: isoNow(),
         attempts: 1,


### PR DESCRIPTION
## Summary
- add first-class Vercel production domain support to ci-tools deploys
- thread deployment.productionDomains through the shared devenv Vercel task module
- report production domains in workflow-report deploy evidence

## Verification
- devenv shell --no-reload -- bun test packages/@overeng/ci-tools/src/deploy-vercel.e2e.test.ts packages/@overeng/ci-tools/src/deploy-domain.test.ts
- bash nix/devenv-modules/tasks/shared/tests/deploy-task-e2e.test.sh

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🎺 co4-brass |
| `agent_session_id` | 355660e0-1bf0-431b-a98b-f1454f90c87c |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.141.0 |
| `agent_runtime` | Codex CLI 0.141.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/5bkm466h121236vcc4sx467hsan9382j-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/fvj9gyni5y0kypcna51kb0bwns7z2kcc-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | 61b0ad8a2615b4bf390c635c4091e3bf7ba4a269/schickling/2026-07-10-vercel-prod-domains |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@e9a23d3 |
</details>
<!-- agent-footer:end -->