### PR TITLE
fix(pnpm): drop redundant ignoreScripts:true that broke bin-shim linking

### DIFF
--- a/genie/external.ts
+++ b/genie/external.ts
@@ -373,7 +373,19 @@ export const commonPnpmPolicySettings = {
   sideEffectsCache: false as const,
   verifyStoreIntegrity: true as const,
   strictStorePkgContentCheck: true as const,
-  ignoreScripts: true as const,
+  // NOTE: `ignoreScripts: true` was intentionally REMOVED here. It is a blanket
+  // switch that disables every dependency lifecycle script, and in pnpm 11 GVS
+  // it has an undocumented side effect: it also suppresses creation of the
+  // `node_modules/.bin` shims for packages whose subtree carries a build (e.g.
+  // vitest/vite/madge/astro), so downstream consumers that resolve tools via
+  // `node_modules/.bin` on PATH get "Executable not found in $PATH". The build
+  // gating we actually want is already provided by `allowBuilds` below (pnpm's
+  // native per-package build allowlist: `false` denies + acknowledges the
+  // build, so nothing builds unless explicitly allowed), which does NOT touch
+  // bin-shim creation. Keeping `ignoreScripts` was therefore redundant for
+  // gating and actively broke bin linking. See overengineeringstudio/effect-utils#917.
+  // This makes the `allowBuilds` allowlist live: `true` entries now actually
+  // build during install (previously ignoreScripts blanket-blocked them too).
   // This dependency refresh intentionally tracks the newest Effect 3 line and
   // Node 26 types. Keep minimum-release-age strict globally, but allow these
   // reviewed packages to advance immediately as part of the coordinated upgrade.

--- a/pnpm-install-contract.json
+++ b/pnpm-install-contract.json
@@ -72,7 +72,6 @@
   },
   "installPolicy": {
     "dedupePeerDependents": true,
-    "ignoreScripts": true,
     "minimumReleaseAgeExclude": ["@effect/platform", "@types/node", "effect"],
     "optimisticRepeatInstall": false,
     "packageImportMethod": "clone-or-copy",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -95,8 +95,6 @@ optimisticRepeatInstall: false
 
 verifyDepsBeforeRun: false
 
-ignoreScripts: true
-
 sideEffectsCache: false
 
 verifyStoreIntegrity: true


### PR DESCRIPTION
## Problem

`commonPnpmPolicySettings.ignoreScripts: true` (genie/external.ts) is a blanket switch that disables every dependency lifecycle script. In pnpm 11 GVS it has an **undocumented side effect**: it also suppresses creation of `node_modules/.bin` shims for packages whose subtree carries a build (e.g. `vitest`, `vite`, `madge`, `astro`, `wrangler`). Downstream consumers that resolve tools via `node_modules/.bin` on `PATH` then fail with `Executable not found in $PATH: "vitest"`.

This was surfaced in livestore CI (livestorejs/livestore#1397, the effect-utils bump), where every red job was a bin-shim miss: test-unit (`vitest`), build-examples/perf (`vite`), lint (`madge`), docs (`astro`).

## Root cause (bisected)

The bump added three `pnpm-workspace.yaml` deltas vs the prior policy: `allowBuilds` native flips, `minimumReleaseAge`, and `ignoreScripts: true`. Local bisection (swap each out, reinstall, check `node_modules/.bin/vitest`):
- remove `ignoreScripts: true` → **bins link** ✅
- remove `minimumReleaseAge` → still broken
- `allowBuilds` all-true → still broken

So `ignoreScripts: true` is the sole cause.

## Why it's redundant (allowBuilds already gates)

`allowBuilds` is pnpm 11's real per-package build gate (stored in `.modules.yaml`; `false` = deny + acknowledge, so nothing builds unless explicitly allowed). Decisive proof: with `ignoreScripts` removed and `allowBuilds` kept, deleting **only** the `esbuild: false` line makes pnpm error `[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: esbuild@…` (esbuild only) — i.e. `allowBuilds: false` actively gates each native. `ignoreScripts` was doing the same gating with a blunter hammer **and** breaking bin-linking.

## Fix

Drop `ignoreScripts: true` from `commonPnpmPolicySettings`. Keep `allowBuilds` (the real gate).

## Validation (this branch, local)

- effect-utils install: **exit 0, no `ERR_PNPM_IGNORED_BUILDS`** — its tree has no build-script package uncovered by the denylist.
- `vitest` bins now **link** in package `.bin` dirs (previously suppressed).
- Gating preserved: effect-utils' `allowBuilds` is all-`false` (natives from Nix), so it still builds **nothing** — this PR is **behavior-neutral** for effect-utils (only bin-linking changes).

## Posture note (for reviewer)

This makes the `allowBuilds` allowlist **live**: `true` entries would now actually build during install (today `ignoreScripts` blanket-blocks them too, so the allowlist's `true` values are dead). effect-utils has **no** `true` entries, so no build-posture change here. Downstream consumers (e.g. livestore) that declare `true` entries for natives they genuinely need built (wa-sqlite, esbuild for vite) will have those become live — intended.

## Follow-ups

- FOD pnpm-deps hashes for packaged CLIs need refreshing (the install output changed — bins now linked); handled by the evergreen FOD closure.
- Upstream pnpm note: `ignoreScripts` suppressing `.bin` shim creation in GVS is arguably a pnpm 11 bug worth reporting.

Refs overengineeringstudio/effect-utils#917.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
