### PR TITLE
fix(devenv): drop guarded tool profile boilerplate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ All notable changes to this project will be documented in this file.
   Effect 4 instance through a peer dependency instead of bundling a private
   Effect runtime, preventing cross-major schema AST crashes in LiveStore
   Devtools.
+- **devenv cli-guard ownership**: drop the remaining self-consumer
+  `lib.lowPrio effectTsgo` / `lib.lowPrio pnpmPkg` boilerplate. Passing
+  `tsBinPkg` / `pnpmPkg` to the task modules is sufficient because the guards
+  exec the real binaries by absolute store path under passthrough.
 - **ci-tools / Vercel**: add first-class production-domain support to the shared
   Vercel deploy path. `ci-tools deploy vercel --production-domain <host>` now
   aliases production deployments to canonical custom domains, reports those

--- a/devenv.nix
+++ b/devenv.nix
@@ -498,26 +498,6 @@ in
     "context/otel-scrape/telemetry-registry.json"
   ];
 
-  # Guarded-command ownership (issue #808):
-  #   Each cli-guard owns its `bin/<name>` and exec's the real binary by absolute
-  #   store path under DEVENV_TASK_PASSTHROUGH=1 (see nix/devenv-modules/tasks/lib/cli-guard.nix).
-  #   The reals are therefore threaded into the task modules as `*Pkg` args
-  #   rather than listed here as competing top-level providers, which removes the
-  #   nondeterministic buildEnv `collision between ...` warnings.
-  #
-  #   command  owner (real exec'd by guard)        contract
-  #   -------  ---------------------------------    --------------------------------
-  #   genie    genieSourceCli  (mkSourceCli)        guard owns it; sole bin
-  #   mr       mrSourceCli     (mkSourceCli)        guard owns it; sole bin
-  #   oxlint   oxlintWithPlugins                    guard owns it; sole bin
-  #   oxfmt    pkgs.oxfmt                           guard owns it (in lint-oxc.nix); sole bin
-  #   nixfmt   pkgs.nixfmt-rfc-style                guard owns it (in lint-nix.nix); sole bin
-  #   deadnix  pkgs.deadnix                         guard owns it (in lint-nix.nix); sole bin
-  #   tsgo     effectTsgo                           pass tsBinPkg; no lib.lowPrio package
-  #   pnpm     pnpmPkg (nix/pnpm.nix)               pass pnpmPkg; no lib.lowPrio package
-  #
-  #   tsc/tsserver stay real-owned via `pkgs.typescript` (no guard, no collision).
-  #   tui-stories is real-owned via mkSourceCli (no guard, no collision).
   packages = [
     pkgs.nodejs_24
     pkgs.bun

--- a/devenv.nix
+++ b/devenv.nix
@@ -505,7 +505,7 @@ in
   #   rather than listed here as competing top-level providers, which removes the
   #   nondeterministic buildEnv `collision between ...` warnings.
   #
-  #   command  owner (real exec'd by guard)        why not a top-level package
+  #   command  owner (real exec'd by guard)        contract
   #   -------  ---------------------------------    --------------------------------
   #   genie    genieSourceCli  (mkSourceCli)        guard owns it; sole bin
   #   mr       mrSourceCli     (mkSourceCli)        guard owns it; sole bin
@@ -513,16 +513,12 @@ in
   #   oxfmt    pkgs.oxfmt                           guard owns it (in lint-oxc.nix); sole bin
   #   nixfmt   pkgs.nixfmt-rfc-style                guard owns it (in lint-nix.nix); sole bin
   #   deadnix  pkgs.deadnix                         guard owns it (in lint-nix.nix); sole bin
-  #   tsgo     effectTsgo                           lowPrio below: keeps `effect-tsgo` sibling
-  #   pnpm     pnpmPkg (nix/pnpm.nix)               lowPrio below: keeps `pnpx` sibling
+  #   tsgo     effectTsgo                           pass tsBinPkg; no lib.lowPrio package
+  #   pnpm     pnpmPkg (nix/pnpm.nix)               pass pnpmPkg; no lib.lowPrio package
   #
   #   tsc/tsserver stay real-owned via `pkgs.typescript` (no guard, no collision).
   #   tui-stories is real-owned via mkSourceCli (no guard, no collision).
   packages = [
-    # lowPrio: the tsgo guard owns `bin/tsgo`; keep this for the `effect-tsgo` bin.
-    (lib.lowPrio effectTsgo)
-    # lowPrio: the pnpm guard owns `bin/pnpm`; keep this for the `pnpx` bin.
-    (lib.lowPrio pnpmPkg)
     pkgs.nodejs_24
     pkgs.bun
     pkgs.typescript

--- a/nix/devenv-modules/tasks/shared/pnpm.nix
+++ b/nix/devenv-modules/tasks/shared/pnpm.nix
@@ -25,8 +25,8 @@
   cleanAfter ? [ ],
   resetLockFilesAfter ? [ ],
   # Real derivation/path backing the `pnpm` guard. When set, the guard owns
-  # `bin/pnpm` and exec's this by absolute path under passthrough, so consumers
-  # do not need to list the real package with `lib.lowPrio`.
+  # `bin/pnpm` and exec's this by absolute path under passthrough (see
+  # cli-guard.nix).
   pnpmPkg ? null,
 }:
 {

--- a/nix/devenv-modules/tasks/shared/pnpm.nix
+++ b/nix/devenv-modules/tasks/shared/pnpm.nix
@@ -25,9 +25,8 @@
   cleanAfter ? [ ],
   resetLockFilesAfter ? [ ],
   # Real derivation/path backing the `pnpm` guard. When set, the guard owns
-  # `bin/pnpm` and exec's this by absolute path under passthrough (see
-  # cli-guard.nix). The real package may ship siblings (e.g. `pnpx`) that the
-  # consumer keeps on PATH separately.
+  # `bin/pnpm` and exec's this by absolute path under passthrough, so consumers
+  # do not need to list the real package with `lib.lowPrio`.
   pnpmPkg ? null,
 }:
 {

--- a/nix/devenv-modules/tasks/shared/tests/pnpm-task-smoke.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/pnpm-task-smoke.test.sh
@@ -80,6 +80,23 @@ extract_task_script() {
   chmod +x "$output_path"
 }
 
+eval_pnpm_package_count() {
+  nix eval --impure --raw --expr "
+    let
+      flake = builtins.getFlake (toString $ROOT);
+      pkgs = import flake.inputs.nixpkgs { system = builtins.currentSystem; };
+      module = (import $ROOT/nix/devenv-modules/tasks/shared/pnpm.nix {
+        packages = [ ];
+        pnpmPkg = pkgs.writeShellScriptBin \"pnpm\" \"exit 0\";
+      }) {
+        pkgs = pkgs;
+        lib = pkgs.lib;
+        config = { devenv.root = \"$workspace\"; };
+      };
+    in builtins.toString (builtins.length module.packages)
+  "
+}
+
 extract_shared_task_script() {
   local module_path="$1"
   local task_name="$2"
@@ -145,6 +162,9 @@ trap 'rm -rf "$tmpdir"' EXIT
 
 workspace="$tmpdir/workspace"
 mkdir -p "$workspace/.devenv/task-cache" "$workspace/.pnpm-home-a/store/v11" "$workspace/.pnpm-home-b/store/v11" "$tmpdir/bin" "$workspace/packages/demo/node_modules/.bin" "$workspace/nested/pkg"
+
+echo "Preflight: pnpmPkg is exec-only guard backing, not a profile package"
+assert_eq 1 "$(eval_pnpm_package_count)" "pnpm module packages should contain the pnpm guard only"
 
 cat > "$workspace/package.json" <<'EOF'
 {"name":"smoke-workspace","private":true}

--- a/nix/devenv-modules/tasks/shared/tests/ts-task-smoke.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/ts-task-smoke.test.sh
@@ -17,6 +17,19 @@ assert_exit_code() {
   fi
 }
 
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+
+  if [ "$expected" != "$actual" ]; then
+    echo "FAIL: $label"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+    exit 1
+  fi
+}
+
 extract_ts_emit_script() {
   local attr="$1"
   local output_path="$2"
@@ -45,6 +58,22 @@ extract_ts_emit_script() {
     in evaluated.config.tasks.\"ts:emit\".${attr}
   " > "$output_path"
   chmod +x "$output_path"
+}
+
+eval_ts_package_count() {
+  nix eval --impure --raw --expr "
+    let
+      flake = builtins.getFlake (toString $ROOT);
+      pkgs = import flake.inputs.nixpkgs { system = builtins.currentSystem; };
+      module = (import $ROOT/nix/devenv-modules/tasks/shared/ts.nix {
+        tsBinPkg = pkgs.writeShellScriptBin \"tsgo\" \"exit 0\";
+      }) {
+        pkgs = pkgs;
+        lib = pkgs.lib;
+        config = { };
+      };
+    in builtins.toString (builtins.length module.packages)
+  "
 }
 
 echo "Running ts task smoke test..."
@@ -213,6 +242,9 @@ echo "Test 1: ts:emit exec filters noEmit refs even with inline comments"
   bash "$tmpdir/ts-emit.exec.sh"
 )
 test -f "$TEST_CAPTURED_TSCONFIG"
+
+echo "Preflight: tsBinPkg is exec-only guard backing, not a profile package"
+assert_eq 2 "$(eval_ts_package_count)" "ts module packages should be bc plus tsgo guard only"
 
 echo "Test 2: ts:emit status uses the same filtered graph"
 (

--- a/nix/devenv-modules/tasks/shared/ts.nix
+++ b/nix/devenv-modules/tasks/shared/ts.nix
@@ -60,8 +60,8 @@
   tsBin ? "tsgo",
   tscBin ? "tsc",
   # Real derivation/path backing the `tsBin` guard. When set, the guard owns
-  # `bin/<tsBin>` and exec's this by absolute path under passthrough, so
-  # consumers do not need to list the real package with `lib.lowPrio`.
+  # `bin/<tsBin>` and exec's this by absolute path under passthrough (see
+  # cli-guard.nix).
   tsBinPkg ? null,
 }:
 {

--- a/nix/devenv-modules/tasks/shared/ts.nix
+++ b/nix/devenv-modules/tasks/shared/ts.nix
@@ -60,8 +60,8 @@
   tsBin ? "tsgo",
   tscBin ? "tsc",
   # Real derivation/path backing the `tsBin` guard. When set, the guard owns
-  # `bin/<tsBin>` and exec's this by absolute path under passthrough so the real
-  # need not be a competing top-level provider (see cli-guard.nix).
+  # `bin/<tsBin>` and exec's this by absolute path under passthrough, so
+  # consumers do not need to list the real package with `lib.lowPrio`.
   tsBinPkg ? null,
 }:
 {


### PR DESCRIPTION
**Problem**

Consumers of the shared tsgo and pnpm task modules had to repeat guard-ownership boilerplate by passing the real package to the module and also listing the real package in `packages` with `lib.lowPrio`. That leaked the profile collision policy into every consumer.

**Goal**

Make `tsBinPkg` / `pnpmPkg` the complete consumer contract. The task-module guard owns the command name and execs the real binary by absolute store path under passthrough, so consumers do not need to list the real package separately.

**Decisions**

- Dropped `effectTsgo` from this repo's profile. `effect-tsgo` only needs to back the `tsgo` guard here; the guard's absolute store reference keeps the real binary reachable for task passthrough.
- Dropped `pnpmPkg` from this repo's profile. The `pnpx` gate found no real `pnpx` PATH call sites in effect-utils or the checked downstream members, so preserving `pnpx` on the profile is not needed.
- Added smoke-test assertions for the contract: passing `tsBinPkg` / `pnpmPkg` contributes guard packages only, not the real package as a top-level profile provider.

**Verification**

- `CI=1 bash nix/devenv-modules/tasks/shared/tests/ts-task-smoke.test.sh` passed.
- `CI=1 bash nix/devenv-modules/tasks/shared/tests/pnpm-task-smoke.test.sh` passed.
- `CI=1 devenv tasks run genie:check --no-tui` passed.
- `CI=1 devenv tasks run ts:check:strict --no-tui` passed.
- `CI=1 devenv tasks run check:quick --no-tui` passed.
- `CI=1 devenv tasks run check:all --no-tui` reached unrelated `test:restate-effect` failure in `scheduled-compose.integration.test.ts` wake-id rotation. This is pre-existing and tracked by #768; the diff here is Nix/devenv-module only and touches zero Restate source. CI is the authority for the full suite.

**Complexity**

No new abstraction. This removes self-consumer profile boilerplate and pins the existing guard contract with focused tests.

**Concerns**

The `pnpm` DROP decision depends on the current `pnpx` usage scan. If a future consumer needs `pnpx` from the profile, the policy should be centralized in `taskModules.pnpm` rather than restored per consumer.

**Friction & bottlenecks**

The full local suite was affected by a known timing-sensitive Restate integration flake (#768), aggravated by current dev-machine load.

**Follow-ups**

- #768 tracks hardening the unrelated wake-id rotation assertion.

**References**

Closes #924
Refs #768

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 💚 co1-beryl |
| `agent_session_id` | 659cacbd-052d-4d23-b839-0ed4bea3b54b |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.144.1 |
| `agent_runtime` | Codex CLI 0.144.1 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/1n76sy6i9y3ki3k4w04jksqvygw67sj0-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/jn6r0r7r59x3a525jch4pwzwykszqp60-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-17-tsgo-924-hub |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@4eac376 |
</details>
<!-- agent-footer:end -->