### PR TITLE
fix(react-inspector): support Effect 4 consumer schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **react-inspector / Effect 4**: migrate schema inspection, Lineage annotations,
+  and Storybook fixtures to Effect 4. The package now consumes the application's
+  Effect 4 instance through a peer dependency instead of bundling a private
+  Effect runtime, preventing cross-major schema AST crashes in LiveStore
+  Devtools.
 - **ci-tools / Vercel**: add first-class production-domain support to the shared
   Vercel deploy path. `ci-tools deploy vercel --production-domain <host>` now
   aliases production deployments to canonical custom domains, reports those

--- a/nix/oxc-config-plugin.nix
+++ b/nix/oxc-config-plugin.nix
@@ -29,7 +29,7 @@ let
     pnpm = pinnedPnpm;
   };
   packageDir = "packages/@overeng/oxc-config";
-  pnpmDepsHash = "sha256-KZtdAGoB9h/3/kRbCyTS4PuIO30BXMB3PHxU8MLkkKg=";
+  pnpmDepsHash = "sha256-9uq6/ZPFEBWEOc6HuwF//wD7VQSNyPgv2geKpxnpgF8=";
 
   srcPath =
     if builtins.isAttrs src && builtins.hasAttr "outPath" src then

--- a/packages/@overeng/genie/nix/build.nix
+++ b/packages/@overeng/genie/nix/build.nix
@@ -26,7 +26,7 @@ let
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
       "." = {
-        hash = "sha256-+/J9pav88LNVFEYz1LtDMWppGyO/PscDQFG+vKZ/bXs=";
+        hash = "sha256-m0npmLuVudv2MyaQ/n2E3QcrcIbdqhA5A4Sku2iHgVM=";
       };
     };
     nativeNodePackages = opentuiCoreNative.packages;

--- a/packages/@overeng/megarepo/nix/build.nix
+++ b/packages/@overeng/megarepo/nix/build.nix
@@ -24,7 +24,7 @@ let
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
       "." = {
-        hash = "sha256-7GIuaFRe7q7SHHHtZsSGbUTtVi+oDCSrrMUKEyCadJU=";
+        hash = "sha256-bDhzSYZWT2wzBfEdrtTYYhU5lsRjevS5xyXJ6Sqo82s=";
       };
     };
     nativeNodePackages = opentuiCoreNative.packages;

--- a/packages/@overeng/notion-cli/nix/build.nix
+++ b/packages/@overeng/notion-cli/nix/build.nix
@@ -33,7 +33,7 @@ let
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
       "." = {
-        hash = "sha256-1wPReRAcDJFYcivSKUiE4YKDcGWSADTpfbzZjILAx1w=";
+        hash = "sha256-8CjJctxPCWz4JMGQ8atEttSr5r2bkk9OcsZS6EbS7K0=";
       };
     };
     nativeNodePackages = opentuiCoreNative.packages;

--- a/packages/@overeng/notion-md/nix/build.nix
+++ b/packages/@overeng/notion-md/nix/build.nix
@@ -20,7 +20,7 @@ let
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
       "." = {
-        hash = "sha256-2v7EzhJUvH1S3zTvcMXw6nqnykrvCqtZgbYbkQUQvOc=";
+        hash = "sha256-rSh+tO4hJY56irWLjTNQmL1t+uFosbzXDyIjy98V7UU=";
       };
     };
     smokeTestArgs = [ "--help" ];

--- a/packages/@overeng/react-inspector/.storybook/main.ts
+++ b/packages/@overeng/react-inspector/.storybook/main.ts
@@ -1,3 +1,16 @@
-import { createDomStorybookConfig } from '@overeng/utils/node/storybook/config'
+import type { StorybookConfig } from '@storybook/react-vite'
 
-export default createDomStorybookConfig({ stories: ['../stories/*.*'], disableMinify: true })
+export default {
+  stories: ['../stories/*.*'],
+  framework: { name: '@storybook/react-vite', options: {} },
+  viteFinal: (config) => ({
+    ...config,
+    build: { ...config.build, minify: false },
+    server: {
+      ...config.server,
+      host: '0.0.0.0',
+      allowedHosts: true,
+      watch: { ...config.server?.watch, useFsEvents: false },
+    },
+  }),
+} satisfies StorybookConfig

--- a/packages/@overeng/react-inspector/FORK_CHANGELOG.md
+++ b/packages/@overeng/react-inspector/FORK_CHANGELOG.md
@@ -42,6 +42,14 @@ Each entry should include:
 
 ### Added
 
+#### Effect 4 Schema Support (2026-07-17, tracks #925)
+
+Migrated the schema-aware inspector and its Lineage annotations from Effect 3
+to Effect 4. `effect` is now a peer dependency, with the exact supported beta
+used only for package development, so consumer-created schemas are inspected by
+the same Effect runtime instance that created them. The Effect schema Storybook
+fixtures now use Effect 4 constructors, checks, and annotations throughout.
+
 #### Lineage Annotations (2026-05-25, addresses #687)
 
 New `Lineage` annotation namespace describing the epistemic status of a

--- a/packages/@overeng/react-inspector/package.json
+++ b/packages/@overeng/react-inspector/package.json
@@ -24,7 +24,6 @@
     "is-dom": "1.1.0"
   },
   "devDependencies": {
-    "@overeng/utils": "workspace:^",
     "@storybook/react": "10.4.6",
     "@storybook/react-vite": "10.4.6",
     "@testing-library/react": "16.3.2",
@@ -32,7 +31,7 @@
     "@types/is-dom": "1.1.2",
     "@types/react": "19.2.17",
     "@vitejs/plugin-react": "6.0.2",
-    "effect": "3.21.4",
+    "effect": "4.0.0-beta.98",
     "happy-dom": "20.10.6",
     "react": "19.2.7",
     "react-dom": "19.2.7",
@@ -42,31 +41,14 @@
     "vitest": "4.1.9"
   },
   "peerDependencies": {
-    "@effect/cluster": "^0.59.0",
-    "@effect/experimental": "^0.60.0",
-    "@effect/opentelemetry": "^0.63.0",
-    "@effect/platform": "^0.96.2",
-    "@effect/platform-node": "^0.107.0",
-    "@effect/rpc": "^0.75.1",
-    "@effect/workflow": "^0.18.2",
-    "@playwright/test": "^1.61.0",
-    "effect": "^3.21.4",
+    "effect": "^4.0.0-beta.97",
     "react": "^19.2.7"
-  },
-  "peerDependenciesMeta": {
-    "effect": {
-      "optional": true
-    }
   },
   "$genie": {
     "source": "package.json.genie.ts",
     "warning": "DO NOT EDIT - changes will be overwritten",
     "workspaceClosureDirs": [
-      "packages/@overeng/content-address",
-      "packages/@overeng/otel-contract",
-      "packages/@overeng/react-inspector",
-      "packages/@overeng/utils",
-      "packages/@overeng/utils-dev"
+      "packages/@overeng/react-inspector"
     ]
   }
 }

--- a/packages/@overeng/react-inspector/package.json.genie.ts
+++ b/packages/@overeng/react-inspector/package.json.genie.ts
@@ -1,12 +1,33 @@
 // @genie-bootstrap
 import {
-  catalog,
+  catalog as repoCatalog,
+  defineCatalog,
   workspaceMember,
   exportEntry,
   packageJson,
   type PackageJsonInputData,
 } from '../../../genie/internal.ts'
-import utilsPkg from '../utils/package.json.genie.ts'
+
+const catalog = defineCatalog({
+  ...repoCatalog.pick(
+    'is-dom',
+    'react',
+    '@storybook/react',
+    '@storybook/react-vite',
+    '@testing-library/react',
+    '@testing-library/user-event',
+    '@types/is-dom',
+    '@types/react',
+    '@vitejs/plugin-react',
+    'happy-dom',
+    'react-dom',
+    'storybook',
+    'typescript',
+    'vite',
+    'vitest',
+  ),
+  effect: '4.0.0-beta.98',
+})
 
 const peerDepNames = ['effect', 'react'] as const
 const workspaceDeps = catalog.compose({
@@ -17,7 +38,6 @@ const workspaceDeps = catalog.compose({
     },
   },
   devDependencies: {
-    workspace: [utilsPkg],
     external: {
       ...catalog.pick(
         ...peerDepNames,
@@ -38,8 +58,10 @@ const workspaceDeps = catalog.compose({
     },
   },
   peerDependencies: {
-    workspace: [utilsPkg],
-    external: catalog.pick(...peerDepNames),
+    external: {
+      effect: '^4.0.0-beta.97',
+      ...catalog.pick('react'),
+    },
   },
 })
 
@@ -66,11 +88,6 @@ export default packageJson(
     scripts: {
       storybook: 'storybook dev -p 6011',
       'storybook:build': 'storybook build',
-    },
-    peerDependenciesMeta: {
-      effect: {
-        optional: true,
-      },
     },
   } satisfies PackageJsonInputData,
   workspaceDeps,

--- a/packages/@overeng/react-inspector/src/schema/SchemaAwareNodeRenderer.tsx
+++ b/packages/@overeng/react-inspector/src/schema/SchemaAwareNodeRenderer.tsx
@@ -76,7 +76,7 @@ export const createSchemaAwareNodeRenderer = ({
        * For arrays whose schema describes the element type, render
        * `Array<Element>(N)` instead of the default `Array(N)`. The array
        * schema's own `title`/`identifier` (e.g. `Schema.Array(Item)
-       * .annotations({ identifier: 'OrderItems' })`) wins over the
+       * .annotate({ identifier: 'OrderItems' })`) wins over the
        * constructed `Array<Element>` label.
        */
       const schemaDisplayName = schemaCtx.getDisplayName()
@@ -95,7 +95,7 @@ export const createSchemaAwareNodeRenderer = ({
 
     /*
      * Map/Set runtime values: when the schema describes the container (e.g.
-     * `Schema.Map({ key, value })` -> `Map<string, Money>`), surface the
+     * `Schema.ReadonlyMap(key, value)` -> `ReadonlyMap<string, Money>`), surface the
      * schema label in the type-badge slot followed by the runtime size.
      * Mirrors the array branch but reads `.size` instead of `.length`.
      */

--- a/packages/@overeng/react-inspector/src/schema/SchemaAwareObjectInspector.tsx
+++ b/packages/@overeng/react-inspector/src/schema/SchemaAwareObjectInspector.tsx
@@ -1,4 +1,4 @@
-import type { Schema as S } from 'effect'
+import type { Schema } from 'effect'
 import React, { useMemo } from 'react'
 import type { ComponentProps, FC } from 'react'
 
@@ -31,14 +31,14 @@ export const withSchemaSupport = <TInspector extends FC<any>>(
   deps: SchemaAwareObjectInspectorDeps,
 ): FC<
   ComponentProps<TInspector> & {
-    schema?: S.Schema.AnyNoContext
-    schemas?: S.Schema.AnyNoContext[]
+    schema?: Schema.Top
+    schemas?: Schema.Top[]
   }
 > => {
   const SchemaAwareObjectInspector: FC<
     ComponentProps<TInspector> & {
-      schema?: S.Schema.AnyNoContext
-      schemas?: S.Schema.AnyNoContext[]
+      schema?: Schema.Top
+      schemas?: Schema.Top[]
     }
   > = ({ schema, schemas, nodeRenderer, ...props }) => {
     const schemaNodeRenderer = useMemo(() => createSchemaAwareNodeRenderer(deps), [])
@@ -50,7 +50,7 @@ export const withSchemaSupport = <TInspector extends FC<any>>(
        * Forward `data` as `rootData` so the SchemaProvider can narrow
        * tagged unions at intermediate path segments using the runtime
        * value. Without this, only the leaf union narrows and children
-       * under a `Schema.Union(A, B, C)` field lose their variant schema.
+       * under a `Schema.Union([A, B, C])` field lose their variant schema.
        */
       const rootData = (props as { data?: unknown }).data
       return (
@@ -74,14 +74,14 @@ export const withSchemaContext = <TInspector extends FC<any>>(
   ObjectInspector: TInspector,
 ): FC<
   ComponentProps<TInspector> & {
-    schema?: S.Schema.AnyNoContext
-    schemas?: S.Schema.AnyNoContext[]
+    schema?: Schema.Top
+    schemas?: Schema.Top[]
   }
 > => {
   const SchemaAwareObjectInspector: FC<
     ComponentProps<TInspector> & {
-      schema?: S.Schema.AnyNoContext
-      schemas?: S.Schema.AnyNoContext[]
+      schema?: Schema.Top
+      schemas?: Schema.Top[]
     }
   > = ({ schema, schemas, ...props }) => {
     const inspector = <ObjectInspector {...(props as ComponentProps<TInspector>)} />

--- a/packages/@overeng/react-inspector/src/schema/SchemaContext.tsx
+++ b/packages/@overeng/react-inspector/src/schema/SchemaContext.tsx
@@ -1,5 +1,3 @@
-import type { Schema as S } from 'effect'
-import { pipe } from 'effect'
 import React, { createContext, useContext, useMemo } from 'react'
 import type { FC, ReactNode } from 'react'
 
@@ -7,6 +5,7 @@ import {
   type SchemaAnnotations,
   type SchemaInfo,
   type SchemaRegistry,
+  type SchemaView,
   getAnnotations,
   getFieldSchema,
   getArrayElementSchema,
@@ -21,9 +20,9 @@ import {
 
 export interface SchemaContextValue {
   /** The current schema for the data being inspected */
-  schema: S.Schema.AnyNoContext | undefined
+  schema: SchemaView | undefined
   /** The root schema (stays constant during tree traversal) */
-  rootSchema: S.Schema.AnyNoContext | undefined
+  rootSchema: SchemaView | undefined
   /** Registry of schemas for looking up by constructor name */
   registry: SchemaRegistry
   /** Get annotations for the current schema */
@@ -41,9 +40,9 @@ export interface SchemaContextValue {
   /** Get schema context for array elements */
   getElementContext: () => SchemaContextValue
   /** Look up a schema by name from registry */
-  lookupByName: (name: string) => S.Schema.AnyNoContext | undefined
+  lookupByName: (name: string) => SchemaView | undefined
   /** Get schema for a path like "$.address.street" or "$[0].name" */
-  getSchemaForPath: (path: string) => S.Schema.AnyNoContext | undefined
+  getSchemaForPath: (path: string) => SchemaView | undefined
   /** Get schema context for a path */
   getContextForPath: (path: string) => SchemaContextValue
   /**
@@ -81,13 +80,13 @@ const SchemaContext = createContext<SchemaContextValue>(defaultContextValue)
 export interface SchemaProviderProps {
   children: ReactNode
   /** Schema for the data being inspected */
-  schema?: S.Schema.AnyNoContext | undefined
+  schema?: SchemaView | undefined
   /** Additional schemas to register for lookup by name */
-  schemas?: S.Schema.AnyNoContext[] | undefined
+  schemas?: SchemaView[] | undefined
   /**
    * Root runtime value being inspected. When provided, path-based context
    * lookups walk the value in lockstep with the schema and narrow any
-   * intermediate tagged-union (`Schema.Union(A, B, C)` with `_tag`
+   * intermediate tagged-union (`Schema.Union([A, B, C])` with `_tag`
    * literals) to the matching variant. Without this, only the leaf union
    * gets narrowed.
    *
@@ -119,13 +118,13 @@ const parsePathSegments = (path: string): string[] => {
  * @see https://github.com/overengineeringstudio/effect-utils/issues/686
  */
 const resolveSchemaForSegments = (
-  rootSchema: S.Schema.AnyNoContext | undefined,
+  rootSchema: SchemaView | undefined,
   segments: string[],
   rootData: unknown,
   hasData: boolean,
-): S.Schema.AnyNoContext | undefined => {
+): SchemaView | undefined => {
   if (rootSchema === undefined) return undefined
-  let current: S.Schema.AnyNoContext | undefined = rootSchema
+  let current: SchemaView | undefined = rootSchema
   let value: unknown = rootData
 
   for (const segment of segments) {
@@ -134,7 +133,7 @@ const resolveSchemaForSegments = (
     if (hasData === true) {
       const narrowedAst = narrowUnionByTag(current.ast, value)
       if (narrowedAst !== current.ast) {
-        current = { ast: narrowedAst } as S.Schema.AnyNoContext
+        current = { ast: narrowedAst }
       }
     }
 
@@ -161,9 +160,9 @@ const resolveSchemaForSegments = (
 
 /** Create a context value for a given schema and registry */
 const createContextValue = (
-  schema: S.Schema.AnyNoContext | undefined,
+  schema: SchemaView | undefined,
   registry: SchemaRegistry,
-  rootSchema: S.Schema.AnyNoContext | undefined,
+  rootSchema: SchemaView | undefined,
   rootDataHolder: { hasData: boolean; data: unknown },
 ): SchemaContextValue => {
   const effectiveRootSchema = rootSchema ?? schema
@@ -174,7 +173,7 @@ const createContextValue = (
     registry,
     getAnnotations: () => (schema !== undefined ? getAnnotations(schema) : {}),
     getDisplayName: () =>
-      schema !== undefined ? pipe(schema, getAnnotations, getDisplayName) : undefined,
+      schema !== undefined ? getDisplayName(getAnnotations(schema)) : undefined,
     getDescription: () => (schema !== undefined ? getAnnotations(schema).description : undefined),
     getSchemaInfo: () => (schema !== undefined ? getSchemaInfo(schema) : undefined),
     formatValue: (value: unknown) =>
@@ -223,10 +222,7 @@ const createContextValue = (
         return createContextValue(undefined, registry, effectiveRootSchema, rootDataHolder)
       }
       const narrowedAst = narrowUnionByTag(pathSchema.ast, value)
-      const narrowedSchema =
-        narrowedAst === pathSchema.ast
-          ? pathSchema
-          : ({ ast: narrowedAst } as S.Schema.AnyNoContext)
+      const narrowedSchema = narrowedAst === pathSchema.ast ? pathSchema : { ast: narrowedAst }
       return createContextValue(narrowedSchema, registry, effectiveRootSchema, rootDataHolder)
     },
   }

--- a/packages/@overeng/react-inspector/src/schema/SchemaTooltip.tsx
+++ b/packages/@overeng/react-inspector/src/schema/SchemaTooltip.tsx
@@ -1,9 +1,8 @@
 import React, { useCallback, useEffect, useId, useRef, useState } from 'react'
 import type { FC, ReactNode } from 'react'
 
-import type { Lineage } from '@overeng/utils'
-
 import type { LineageBundle, SchemaInfo } from './effectSchema.tsx'
+import type * as Lineage from './lineage.ts'
 
 export interface SchemaTooltipProps {
   /** Display-ready schema info; pass undefined to render children without a tooltip. */

--- a/packages/@overeng/react-inspector/src/schema/effect4.unit.test.tsx
+++ b/packages/@overeng/react-inspector/src/schema/effect4.unit.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen } from '@testing-library/react'
+import { Schema } from 'effect'
+import React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { ObjectInspector } from '../object-inspector/ObjectInspector.tsx'
+import { ObjectLabel } from '../object-inspector/ObjectLabel.tsx'
+import { ObjectPreview } from '../object-inspector/ObjectPreview.tsx'
+import { ObjectRootLabel } from '../object-inspector/ObjectRootLabel.tsx'
+import { ObjectName } from '../object/ObjectName.tsx'
+import { ObjectValue } from '../object/ObjectValue.tsx'
+import { formatWithPretty, getAnnotations, getSchemaInfo } from './effectSchema.tsx'
+import * as Lineage from './lineage.ts'
+import { withSchemaSupport } from './SchemaAwareObjectInspector.tsx'
+import { SchemaProvider, useSchemaContext } from './SchemaContext.tsx'
+
+const ConsumerSchema = Schema.Struct({
+  id: Schema.Number.annotate({ description: 'Consumer-created identifier' }),
+  name: Schema.String.annotate({ title: 'Display name' }),
+}).annotate({ identifier: 'Consumer.Record' })
+
+const ConsumerSchemaInspector = withSchemaSupport(ObjectInspector, {
+  ObjectRootLabel,
+  ObjectLabel,
+  ObjectName,
+  ObjectValue,
+  ObjectPreview,
+})
+
+const SchemaProbe = () => {
+  const schema = useSchemaContext()
+  return (
+    <output>
+      {schema.getDisplayName()}:{schema.getFieldContext('id').getDescription()}
+    </output>
+  )
+}
+
+describe('Effect 4 consumer schema compatibility', () => {
+  it('inspects a schema created by the consuming Effect instance without runtime errors', () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    expect(() =>
+      render(
+        <ConsumerSchemaInspector
+          data={{ id: 1, name: 'Ada' }}
+          schema={ConsumerSchema}
+          expandLevel={2}
+        />,
+      ),
+    ).not.toThrow()
+
+    expect(screen.getByText('id')).toBeTruthy()
+    expect(document.body.textContent).toContain('Ada')
+    expect(error).not.toHaveBeenCalled()
+    error.mockRestore()
+  })
+
+  it('traverses Effect 4 annotations supplied by the consumer', () => {
+    render(
+      <SchemaProvider schema={ConsumerSchema} rootData={{ id: 1, name: 'Ada' }}>
+        <SchemaProbe />
+      </SchemaProvider>,
+    )
+
+    expect(screen.getByText('Consumer.Record:Consumer-created identifier')).toBeTruthy()
+  })
+
+  it('preserves custom pretty annotations and extracts Effect 4 check metadata', () => {
+    const schema = Schema.Number.pipe(
+      Schema.check(Schema.isInt()),
+      Schema.check(Schema.isBetween({ minimum: 0, maximum: 150 })),
+    ).annotate({ pretty: (value) => `${value} years` })
+
+    expect(formatWithPretty(42, getAnnotations(schema))).toBe('42 years')
+    expect(getSchemaInfo(schema).constraints).toEqual([
+      { label: '≥', value: '0' },
+      { label: '≤', value: '150' },
+      { label: 'integer', value: 'yes' },
+    ])
+
+    const handle = Schema.String.pipe(
+      Schema.check(Schema.isMinLength(1)),
+      Schema.check(Schema.isMaxLength(20)),
+      Schema.check(Schema.isPattern(/^[a-z]+$/i)),
+    )
+    expect(getSchemaInfo(handle).constraints).toEqual([
+      { label: 'min length', value: '1' },
+      { label: 'max length', value: '20' },
+      { label: 'pattern', value: '/^[a-z]+$/i' },
+    ])
+  })
+
+  it('attaches and reads Effect 4 lineage annotations with shorthand derivation kinds', () => {
+    const schema = Schema.Number.pipe(
+      Lineage.derivedFrom({ from: ['subtotal', 'tax'], how: 'Pure', pure: true }),
+    )
+
+    expect(Lineage.getLineage(schema)).toEqual({
+      _tag: 'Derived',
+      from: [
+        { _tag: 'Field', path: '$.subtotal' },
+        { _tag: 'Field', path: '$.tax' },
+      ],
+      how: { _tag: 'Pure' },
+      pure: true,
+    })
+  })
+})

--- a/packages/@overeng/react-inspector/src/schema/effect4.unit.test.tsx
+++ b/packages/@overeng/react-inspector/src/schema/effect4.unit.test.tsx
@@ -15,7 +15,7 @@ import { withSchemaSupport } from './SchemaAwareObjectInspector.tsx'
 import { SchemaProvider, useSchemaContext } from './SchemaContext.tsx'
 
 const ConsumerSchema = Schema.Struct({
-  id: Schema.Number.annotate({ description: 'Consumer-created identifier' }),
+  id: Schema.Finite.annotate({ description: 'Consumer-created identifier' }),
   name: Schema.String.annotate({ title: 'Display name' }),
 }).annotate({ identifier: 'Consumer.Record' })
 
@@ -67,7 +67,7 @@ describe('Effect 4 consumer schema compatibility', () => {
   })
 
   it('preserves custom pretty annotations and extracts Effect 4 check metadata', () => {
-    const schema = Schema.Number.pipe(
+    const schema = Schema.Finite.pipe(
       Schema.check(Schema.isInt()),
       Schema.check(Schema.isBetween({ minimum: 0, maximum: 150 })),
     ).annotate({ pretty: (value) => `${value} years` })
@@ -92,7 +92,7 @@ describe('Effect 4 consumer schema compatibility', () => {
   })
 
   it('attaches and reads Effect 4 lineage annotations with shorthand derivation kinds', () => {
-    const schema = Schema.Number.pipe(
+    const schema = Schema.Finite.pipe(
       Lineage.derivedFrom({ from: ['subtotal', 'tax'], how: 'Pure', pure: true }),
     )
 

--- a/packages/@overeng/react-inspector/src/schema/effectSchema.tsx
+++ b/packages/@overeng/react-inspector/src/schema/effectSchema.tsx
@@ -94,7 +94,7 @@ export const getAnnotationsFromAST = (ast: SchemaAST.AST): SchemaAnnotations => 
       ? { description: annotations.description }
       : {}),
     ...(pretty === undefined ? {} : { pretty }),
-    ...(Array.isArray(annotations.examples) ? { examples: annotations.examples } : {}),
+    ...(Array.isArray(annotations.examples) === true ? { examples: annotations.examples } : {}),
     ...('default' in annotations ? { default: annotations.default } : {}),
     ...(asRecord(annotations.jsonSchema) === undefined
       ? {}
@@ -274,7 +274,10 @@ export const getPossibleValuesFromAST = (
   if (ast._tag === 'Literal') collected.push(stringifyShort(ast.literal))
   else if (ast._tag === 'Enum') {
     for (const value of ast.enums) collected.push(stringifyShort(value))
-  } else if (ast._tag === 'Union' && ast.types.every((member) => member._tag === 'Literal')) {
+  } else if (
+    ast._tag === 'Union' &&
+    ast.types.every((member) => member._tag === 'Literal') === true
+  ) {
     for (const member of ast.types) {
       if (member._tag === 'Literal') collected.push(stringifyShort(member.literal))
     }
@@ -318,7 +321,9 @@ const getContainerLabelForAST = (rawAst: SchemaAST.AST): string | undefined => {
     }
     if (ast.elements.length > 0) {
       const labels = ast.elements.map(getElementLabelForAST)
-      return labels.every((label) => label !== undefined) ? `[${labels.join(', ')}]` : undefined
+      return labels.every((label) => label !== undefined) === true
+        ? `[${labels.join(', ')}]`
+        : undefined
     }
   }
   if (ast._tag === 'Objects' && ast.propertySignatures.length === 0) {
@@ -424,7 +429,8 @@ export const getSchemaInfo = (schema: SchemaView): SchemaInfo => {
           ...(reference === undefined ? {} : { reference }),
         }
   const description =
-    annotations.description !== undefined && TRIVIAL_DESCRIPTIONS.has(annotations.description)
+    annotations.description !== undefined &&
+    TRIVIAL_DESCRIPTIONS.has(annotations.description) === true
       ? undefined
       : annotations.description
   const hasContent =

--- a/packages/@overeng/react-inspector/src/schema/effectSchema.tsx
+++ b/packages/@overeng/react-inspector/src/schema/effectSchema.tsx
@@ -1,24 +1,10 @@
-import type { Schema as S, SchemaAST } from 'effect'
+import type { SchemaAST } from 'effect'
 
-import { Lineage } from '@overeng/utils'
+import * as Lineage from './lineage.ts'
 
-/** Symbols used by Effect Schema for annotations */
-const IdentifierAnnotationId = Symbol.for('effect/annotation/Identifier')
-const TitleAnnotationId = Symbol.for('effect/annotation/Title')
-const DescriptionAnnotationId = Symbol.for('effect/annotation/Description')
-const PrettyAnnotationId = Symbol.for('effect/annotation/Pretty')
-const ExamplesAnnotationId = Symbol.for('effect/annotation/Examples')
-const DefaultAnnotationId = Symbol.for('effect/annotation/Default')
-const JSONSchemaAnnotationId = Symbol.for('effect/annotation/JSONSchema')
-const DocumentationAnnotationId = Symbol.for('effect/annotation/Documentation')
-/**
- * Effect tags `Schema.MapFromSelf` / `Schema.SetFromSelf` (and the transform
- * variants `Schema.Map` / `Schema.Set` / `Schema.ReadonlyMap` /
- * `Schema.ReadonlySet`) with this annotation so consumers can distinguish
- * Map/Set declarations from arbitrary `Declaration` ASTs without string-
- * matching on descriptions.
- */
-const TypeConstructorAnnotationId = Symbol.for('effect/annotation/TypeConstructor')
+export interface SchemaView {
+  readonly ast: SchemaAST.AST
+}
 
 export interface SchemaAnnotations {
   identifier?: string | undefined
@@ -31,18 +17,11 @@ export interface SchemaAnnotations {
   documentation?: string | undefined
 }
 
-/** A constraint extracted from a JSON Schema annotation, ready for display. */
 export interface SchemaConstraint {
   label: string
   value: string
 }
 
-/**
- * Aggregated, display-ready schema information for a single tree node.
- *
- * `hasContent` is true when at least one field beyond `displayName`/`typeKind`
- * has content — callers use it to decide whether to render a tooltip at all.
- */
 export interface SchemaInfo {
   displayName?: string
   typeKind?: string
@@ -53,29 +32,11 @@ export interface SchemaInfo {
   constraints?: ReadonlyArray<SchemaConstraint>
   possibleValues?: ReadonlyArray<string>
   possibleValuesTruncated?: number
-  /**
-   * Schema-derived container label for arrays / records / tuples, e.g.
-   * `Array<Order Item>`, `Record<string, Money>`, `[A, B, C]`. Prefer this
-   * over the runtime constructor name (`Array`, `Object`) when rendering the
-   * type badge for a container. Falls back to `undefined` when the schema
-   * doesn't carry enough info.
-   */
   containerLabel?: string
-  /**
-   * Lineage annotation bundle, when present on the schema.
-   *
-   * @see https://github.com/overengineeringstudio/effect-utils/issues/687
-   */
   lineage?: LineageBundle
   hasContent: boolean
 }
 
-/**
- * Pre-resolved Lineage annotations for a single schema, paired with the
- * companion annotations (Authority, Freshness, Reference) when set.
- *
- * @see https://github.com/overengineeringstudio/effect-utils/issues/687
- */
 export interface LineageBundle {
   display: Lineage.LineageDisplay
   authority?: Lineage.Authority
@@ -83,174 +44,105 @@ export interface LineageBundle {
   reference?: Lineage.Reference
 }
 
-const isNullishAst = (ast: SchemaAST.AST): boolean => {
-  if (ast._tag === 'UndefinedKeyword' || ast._tag === 'VoidKeyword') return true
-  return ast._tag === 'Literal' && ast.literal === null
-}
+const view = (ast: SchemaAST.AST): SchemaView => ({ ast })
+
+const isNullishAst = (ast: SchemaAST.AST): boolean =>
+  ast._tag === 'Null' || ast._tag === 'Undefined' || ast._tag === 'Void'
 
 const unwrapAstForDisplay = (ast: SchemaAST.AST): SchemaAST.AST => {
-  switch (ast._tag) {
-    case 'Transformation':
-      return unwrapAstForDisplay(ast.to)
-    case 'Refinement':
-      return unwrapAstForDisplay(ast.from)
-    case 'Suspend':
-      return unwrapAstForDisplay(ast.f())
-    case 'Union': {
-      const nonNullish = ast.types.filter((member) => !isNullishAst(member))
-      if (nonNullish.length === 1) {
-        const [only] = nonNullish
-        if (only !== undefined) return unwrapAstForDisplay(only)
-      }
-      return ast
+  if (ast._tag === 'Suspend') return unwrapAstForDisplay(ast.thunk())
+  if (ast._tag === 'Union') {
+    const nonNullish = ast.types.filter((member) => isNullishAst(member) === false)
+    if (nonNullish.length === 1 && nonNullish[0] !== undefined) {
+      return unwrapAstForDisplay(nonNullish[0])
     }
-    default:
-      return ast
   }
+  return ast
 }
 
-/** Extract annotations from a Schema AST node */
+const asRecord = (value: unknown): Record<string, unknown> | undefined =>
+  value !== null && typeof value === 'object' ? (value as Record<string, unknown>) : undefined
+
 export const getAnnotationsFromAST = (ast: SchemaAST.AST): SchemaAnnotations => {
-  const annotations = ast.annotations
+  const annotations: Record<string, unknown> = {
+    ...ast.context?.annotations,
+    ...ast.annotations,
+  }
+  for (const check of ast.checks ?? []) Object.assign(annotations, check.annotations)
+  const customPretty = annotations.pretty
+  const formatterFactory = annotations.toFormatter
+  let pretty: ((value: unknown) => string) | undefined
+  if (typeof customPretty === 'function') {
+    pretty = (value) => {
+      const formatted = customPretty(value)
+      if (typeof formatted !== 'string')
+        throw new TypeError('pretty annotation must return a string')
+      return formatted
+    }
+  } else if (typeof formatterFactory === 'function') {
+    try {
+      const formatter = formatterFactory([])
+      if (typeof formatter === 'function') pretty = formatter
+    } catch {
+      // Some declaration formatters require type-parameter formatters.
+    }
+  }
   return {
-    identifier: annotations[IdentifierAnnotationId] as string | undefined,
-    title: annotations[TitleAnnotationId] as string | undefined,
-    description: annotations[DescriptionAnnotationId] as string | undefined,
-    pretty: annotations[PrettyAnnotationId] as ((value: unknown) => string) | undefined,
-    examples: annotations[ExamplesAnnotationId] as ReadonlyArray<unknown> | undefined,
-    default: annotations[DefaultAnnotationId],
-    jsonSchema: annotations[JSONSchemaAnnotationId] as Record<string, unknown> | undefined,
-    documentation: annotations[DocumentationAnnotationId] as string | undefined,
+    ...(typeof annotations.identifier === 'string' ? { identifier: annotations.identifier } : {}),
+    ...(typeof annotations.title === 'string' ? { title: annotations.title } : {}),
+    ...(typeof annotations.description === 'string'
+      ? { description: annotations.description }
+      : {}),
+    ...(pretty === undefined ? {} : { pretty }),
+    ...(Array.isArray(annotations.examples) ? { examples: annotations.examples } : {}),
+    ...('default' in annotations ? { default: annotations.default } : {}),
+    ...(asRecord(annotations.jsonSchema) === undefined
+      ? {}
+      : { jsonSchema: asRecord(annotations.jsonSchema) }),
+    ...(typeof annotations.documentation === 'string'
+      ? { documentation: annotations.documentation }
+      : {}),
   }
 }
 
-/** Extract annotations from a Schema */
-export const getAnnotations = (schema: S.Schema.AnyNoContext): SchemaAnnotations => {
-  return getAnnotationsFromAST(unwrapAstForDisplay(schema.ast))
-}
+export const getAnnotations = (schema: SchemaView): SchemaAnnotations =>
+  getAnnotationsFromAST(unwrapAstForDisplay(schema.ast))
 
-/** Get display name from schema annotations (prefer title, fallback to identifier) */
-export const getDisplayName = (annotations: SchemaAnnotations): string | undefined => {
-  return annotations.title ?? annotations.identifier
-}
+export const getDisplayName = (annotations: SchemaAnnotations): string | undefined =>
+  annotations.title ?? annotations.identifier
 
-/** Format a value using the schema's pretty annotation if available */
 export const formatWithPretty = (
   value: unknown,
   annotations: SchemaAnnotations,
 ): string | undefined => {
-  if (annotations.pretty !== undefined) {
-    try {
-      const result = annotations.pretty(value)
-      // Effect's built-in schemas may have pretty annotations that return functions (hooks)
-      // rather than formatted strings. Only return the result if it's actually a string.
-      if (typeof result === 'string') {
-        return result
-      }
-      return undefined
-    } catch {
-      return undefined
-    }
+  try {
+    return annotations.pretty?.(value)
+  } catch {
+    return undefined
   }
-  return undefined
 }
 
-/** Check if an object might be an Effect Schema (duck typing for optional dependency) */
-export const isEffectSchema = (obj: unknown): obj is S.Schema.AnyNoContext => {
-  return (
-    obj !== null &&
-    typeof obj === 'object' &&
-    'ast' in obj &&
-    typeof (obj as { ast: unknown }).ast === 'object' &&
-    (obj as { ast: { annotations?: unknown } }).ast !== null &&
-    'annotations' in ((obj as { ast: { annotations?: unknown } }).ast ?? {})
-  )
+export const isEffectSchema = (obj: unknown): obj is SchemaView => {
+  if (obj === null || typeof obj !== 'object' || !('ast' in obj)) return false
+  const ast = (obj as { readonly ast?: unknown }).ast
+  return ast !== null && typeof ast === 'object' && '_tag' in ast
 }
 
-/**
- * Apply field/property-level annotations on top of the field type's annotations.
- *
- * Why: Effect Schema lets users put `.annotations({ description: ... })` on
- * either the field itself (via `Schema.propertySignature(...).annotations(...)`)
- * or on the field's value type. We merge so the field-level annotations win,
- * which matches user intent — a field-specific description shouldn't be hidden
- * by a generic one on the value type.
- */
-const mergeAnnotations = (
-  base: SchemaAST.AST,
-  overrides: SchemaAST.AST['annotations'] | undefined,
-): SchemaAST.AST => {
-  if (overrides === undefined || Object.getOwnPropertySymbols(overrides).length === 0) {
-    return base
-  }
-  return {
-    ...base,
-    annotations: { ...base.annotations, ...overrides },
-  } as SchemaAST.AST
-}
-
-/**
- * Try to find a matching schema for a Struct field.
- *
- * Returns the field type's *raw* AST (with the PropertySignature's own
- * annotations merged on top). Refinement/Transformation/Union wrappers are
- * preserved so callers like {@link getSchemaInfo} can read user-supplied
- * annotations that live on those wrappers. Downstream traversals
- * (`getFieldSchema`, `getArrayElementSchema`) re-apply `unwrapAstForDisplay`
- * before pattern-matching, so the preserved wrapper doesn't block deeper
- * lookups.
- */
-export const getFieldSchema = (
-  schema: S.Schema.AnyNoContext,
-  fieldName: string,
-): S.Schema.AnyNoContext | undefined => {
+export const getFieldSchema = (schema: SchemaView, fieldName: string): SchemaView | undefined => {
   const ast = unwrapAstForDisplay(schema.ast)
-
-  if (ast._tag === 'TypeLiteral') {
-    const typeLiteralAst = ast as SchemaAST.TypeLiteral
-    const propSig = typeLiteralAst.propertySignatures.find((sig) => sig.name === fieldName)
-    if (propSig !== undefined) {
-      return {
-        ast: mergeAnnotations(propSig.type, propSig.annotations),
-      } as S.Schema.AnyNoContext
-    }
-    /*
-     * Record / `Schema.Record({ key, value })` case — no explicit
-     * propertySignature, but the index signature gives us the value type.
-     * Without this fallback, fields inside records would render without
-     * schema context (tooltip, pretty formatting, etc.).
-     */
-    const indexSig = typeLiteralAst.indexSignatures[0]
-    if (indexSig !== undefined) {
-      return { ast: indexSig.type } as S.Schema.AnyNoContext
-    }
-  }
-
-  return undefined
+  if (ast._tag !== 'Objects') return undefined
+  const property = ast.propertySignatures.find((signature) => signature.name === fieldName)
+  if (property !== undefined) return view(property.type)
+  const index = ast.indexSignatures[0]
+  return index === undefined ? undefined : view(index.type)
 }
 
-/** Get schema for array elements if the schema is an array/tuple. */
-export const getArrayElementSchema = (
-  schema: S.Schema.AnyNoContext,
-): S.Schema.AnyNoContext | undefined => {
+export const getArrayElementSchema = (schema: SchemaView): SchemaView | undefined => {
   const ast = unwrapAstForDisplay(schema.ast)
-
-  if (ast._tag === 'TupleType' && 'rest' in ast) {
-    const tupleAst = ast as SchemaAST.TupleType
-    if (tupleAst.rest.length > 0) {
-      const [firstRest] = tupleAst.rest
-      if (firstRest !== undefined) {
-        return { ast: firstRest.type } as S.Schema.AnyNoContext
-      }
-    }
-  }
-
-  return undefined
+  if (ast._tag !== 'Arrays') return undefined
+  const element = ast.rest[0] ?? ast.elements[0]
+  return element === undefined ? undefined : view(element)
 }
-
-/* --------------------------------------------------------------------------
- * Display-ready schema info (used by the tooltip)
- * -------------------------------------------------------------------------- */
 
 const stringifyShort = (value: unknown): string => {
   if (typeof value === 'string') return JSON.stringify(value)
@@ -266,58 +158,44 @@ const stringifyShort = (value: unknown): string => {
   }
 }
 
-const formatValueForDisplay = (value: unknown, annotations: SchemaAnnotations): string => {
-  return formatWithPretty(value, annotations) ?? stringifyShort(value)
-}
-
-/**
- * Human-friendly label for the AST kind. Surfaced as the small caps subtitle
- * in the tooltip header when no `title`/`identifier` is set, and as a hint
- * alongside `displayName` when one is set.
- */
-const getTypeKind = (rawAst: SchemaAST.AST): string | undefined => {
-  // Note: we read off the *raw* AST (before unwrap) so wrapper kinds like
-  // Refinement/Union are visible to the user when they would otherwise be
-  // silently unwrapped.
-  switch (rawAst._tag) {
-    case 'StringKeyword':
+const getTypeKind = (ast: SchemaAST.AST): string | undefined => {
+  switch (ast._tag) {
+    case 'String':
       return 'string'
-    case 'NumberKeyword':
+    case 'Number':
       return 'number'
-    case 'BooleanKeyword':
+    case 'Boolean':
       return 'boolean'
-    case 'BigIntKeyword':
+    case 'BigInt':
       return 'bigint'
-    case 'SymbolKeyword':
+    case 'Symbol':
       return 'symbol'
     case 'ObjectKeyword':
       return 'object'
-    case 'UnknownKeyword':
+    case 'Unknown':
       return 'unknown'
-    case 'AnyKeyword':
+    case 'Any':
       return 'any'
-    case 'NeverKeyword':
+    case 'Never':
       return 'never'
-    case 'VoidKeyword':
+    case 'Void':
       return 'void'
-    case 'UndefinedKeyword':
+    case 'Undefined':
       return 'undefined'
+    case 'Null':
+      return 'null'
     case 'Literal':
       return 'literal'
-    case 'Enums':
+    case 'Enum':
       return 'enum'
     case 'TemplateLiteral':
       return 'template literal'
-    case 'TupleType':
+    case 'Arrays':
       return 'array'
-    case 'TypeLiteral':
+    case 'Objects':
       return 'struct'
     case 'Union':
       return 'union'
-    case 'Refinement':
-      return 'refinement'
-    case 'Transformation':
-      return 'transform'
     case 'Suspend':
       return 'suspend'
     case 'Declaration':
@@ -327,146 +205,88 @@ const getTypeKind = (rawAst: SchemaAST.AST): string | undefined => {
   }
 }
 
-/* JSON Schema -> human constraint extraction.
- *
- * We deliberately only surface keys that have an obvious one-line rendering;
- * unknown keys are dropped rather than dumped as raw JSON. */
-const jsonSchemaConstraintRules: ReadonlyArray<
+const constraintRules: ReadonlyArray<
   [key: string, render: (value: unknown) => SchemaConstraint | undefined]
 > = [
-  ['minLength', (v) => ({ label: 'min length', value: String(v) })],
-  ['maxLength', (v) => ({ label: 'max length', value: String(v) })],
-  ['minItems', (v) => ({ label: 'min items', value: String(v) })],
-  ['maxItems', (v) => ({ label: 'max items', value: String(v) })],
-  ['minimum', (v) => ({ label: '≥', value: String(v) })],
-  ['maximum', (v) => ({ label: '≤', value: String(v) })],
-  ['exclusiveMinimum', (v) => ({ label: '>', value: String(v) })],
-  ['exclusiveMaximum', (v) => ({ label: '<', value: String(v) })],
-  ['multipleOf', (v) => ({ label: 'multiple of', value: String(v) })],
-  ['uniqueItems', (v) => (v === true ? { label: 'unique items', value: '' } : undefined)],
-  ['pattern', (v) => ({ label: 'pattern', value: `/${String(v)}/` })],
-  ['format', (v) => ({ label: 'format', value: String(v) })],
+  ['minLength', (value) => ({ label: 'min length', value: String(value) })],
+  ['maxLength', (value) => ({ label: 'max length', value: String(value) })],
+  ['minimum', (value) => ({ label: '≥', value: String(value) })],
+  ['maximum', (value) => ({ label: '≤', value: String(value) })],
+  ['exclusiveMinimum', (value) => ({ label: '>', value: String(value) })],
+  ['exclusiveMaximum', (value) => ({ label: '<', value: String(value) })],
+  ['multipleOf', (value) => ({ label: 'multiple of', value: String(value) })],
+  [
+    'pattern',
+    (value) => ({
+      label: 'pattern',
+      value: value instanceof RegExp ? value.toString() : `/${String(value)}/`,
+    }),
+  ],
+  ['integer', () => ({ label: 'integer', value: 'yes' })],
+  ['format', (value) => ({ label: 'format', value: String(value) })],
 ]
 
-/**
- * Walk Refinement chain to collect JSON Schema annotations, then map known
- * keys to human-readable constraints.
- *
- * Refinements stack (e.g. `Int.pipe(positive(), between(0, 10))`) and each
- * link can contribute its own JSON Schema fragment. We merge with later
- * (outer) refinements winning, since those are the user's most specific
- * intent.
- */
 export const getConstraintsFromJSONSchema = (
-  rawAst: SchemaAST.AST,
+  ast: SchemaAST.AST,
 ): ReadonlyArray<SchemaConstraint> => {
-  const fragments: Record<string, unknown> = {}
-  /*
-   * Guard against self-referential Suspend chains (e.g. recursive schemas
-   * defined via `Schema.suspend(() => SomeSchema)`). Without this guard,
-   * `collect` would recurse infinitely on identity-cycle schemas — try/catch
-   * around `ast.f()` wouldn't catch it because it's not a thrown error.
-   */
-  const seen = new WeakSet<SchemaAST.AST>()
+  const constraints: Record<string, unknown> = {
+    ...getAnnotationsFromAST(ast).jsonSchema,
+  }
+  for (const check of ast.checks ?? []) {
+    const arbitrary = asRecord(check.annotations?.arbitrary)
+    const constraint = asRecord(arbitrary?.constraint)
+    if (constraint !== undefined) Object.assign(constraints, constraint)
 
-  /*
-   * Recurse first, then write — so outer refinements win on duplicate keys.
-   * Example: `Schema.Number.pipe(between(0, 100), between(10, 50))`. The
-   * outermost refinement is `between(10, 50)`; the user's most specific
-   * intent. Walking inner→outer and using last-write-wins via Object.assign
-   * preserves that intent. Writing first (outer) then recursing into inner
-   * would let `between(0, 100)` clobber the tighter `between(10, 50)`.
-   */
-  const collect = (ast: SchemaAST.AST): void => {
-    if (seen.has(ast) === true) return
-    seen.add(ast)
-
-    if (ast._tag === 'Refinement') {
-      collect(ast.from)
-    } else if (ast._tag === 'Transformation') {
-      collect(ast.to)
-    } else if (ast._tag === 'Suspend') {
-      try {
-        collect(ast.f())
-      } catch {
-        /* ignore — Suspend may not be safe to evaluate eagerly */
-      }
-    }
-
-    const fragment = ast.annotations[JSONSchemaAnnotationId] as Record<string, unknown> | undefined
-    if (fragment !== undefined) {
-      Object.assign(fragments, fragment)
+    const meta = asRecord(check.annotations?.meta)
+    switch (meta?._tag) {
+      case 'isMinLength':
+        constraints.minLength = meta.minLength
+        break
+      case 'isMaxLength':
+        constraints.maxLength = meta.maxLength
+        break
+      case 'isPattern':
+        constraints.pattern = meta.regExp
+        break
+      case 'isInt':
+        constraints.integer = true
+        break
+      case 'isBetween':
+        constraints[meta.exclusiveMinimum === true ? 'exclusiveMinimum' : 'minimum'] = meta.minimum
+        constraints[meta.exclusiveMaximum === true ? 'exclusiveMaximum' : 'maximum'] = meta.maximum
+        break
     }
   }
-
-  collect(rawAst)
-
-  const out: SchemaConstraint[] = []
-  for (const [key, render] of jsonSchemaConstraintRules) {
-    if (key in fragments) {
-      const constraint = render(fragments[key])
-      if (constraint !== undefined) out.push(constraint)
-    }
-  }
-  return out
+  return constraintRules.flatMap(([key, render]) => {
+    if (!(key in constraints)) return []
+    const rendered = render(constraints[key])
+    return rendered === undefined ? [] : [rendered]
+  })
 }
 
 const MAX_POSSIBLE_VALUES = 12
 
-/** Detect literal/enum/union-of-literal ASTs and surface their allowed values. */
 export const getPossibleValuesFromAST = (
   rawAst: SchemaAST.AST,
 ): { values: ReadonlyArray<string>; truncated: number } | undefined => {
   const ast = unwrapAstForDisplay(rawAst)
-
   const collected: string[] = []
-  let valid = false
-
-  if (ast._tag === 'Literal') {
-    collected.push(stringifyShort(ast.literal))
-    valid = true
-  } else if (ast._tag === 'Enums') {
-    valid = true
-    for (const [, value] of ast.enums) {
-      collected.push(stringifyShort(value))
+  if (ast._tag === 'Literal') collected.push(stringifyShort(ast.literal))
+  else if (ast._tag === 'Enum') {
+    for (const value of ast.enums) collected.push(stringifyShort(value))
+  } else if (ast._tag === 'Union' && ast.types.every((member) => member._tag === 'Literal')) {
+    for (const member of ast.types) {
+      if (member._tag === 'Literal') collected.push(stringifyShort(member.literal))
     }
-  } else if (ast._tag === 'Union') {
-    valid = ast.types.every((m) => m._tag === 'Literal')
-    if (valid === true) {
-      for (const member of ast.types) {
-        if (member._tag === 'Literal') {
-          collected.push(stringifyShort(member.literal))
-        }
-      }
-    }
-  } else if (ast._tag === 'TemplateLiteral') {
-    valid = true
-    collected.push(`\`${ast.toString()}\``)
+  } else if (ast._tag === 'TemplateLiteral') collected.push(`\`${ast.toString()}\``)
+  if (collected.length === 0) return undefined
+  return {
+    values: collected.slice(0, MAX_POSSIBLE_VALUES),
+    truncated: Math.max(0, collected.length - MAX_POSSIBLE_VALUES),
   }
-
-  if (valid === false || collected.length === 0) return undefined
-
-  if (collected.length > MAX_POSSIBLE_VALUES) {
-    return {
-      values: collected.slice(0, MAX_POSSIBLE_VALUES),
-      truncated: collected.length - MAX_POSSIBLE_VALUES,
-    }
-  }
-  return { values: collected, truncated: 0 }
 }
 
-/**
- * Effect's built-in primitive schemas (Schema.String, Schema.Number, etc.)
- * ship with trivial descriptions like "a string", "a number". These are
- * useless in a tooltip — they just repeat what the rendered value already
- * conveys. We exclude them from the `hasContent` decision so that fields
- * without any user-supplied annotations don't get a tooltip affordance.
- *
- * User-supplied descriptions that happen to match these strings are also
- * suppressed; that's an acceptable false negative for keeping the surface
- * clean.
- */
-const TRIVIAL_DESCRIPTIONS: ReadonlySet<string> = new Set([
+const TRIVIAL_DESCRIPTIONS = new Set([
   'a string',
   'a number',
   'a boolean',
@@ -479,365 +299,174 @@ const TRIVIAL_DESCRIPTIONS: ReadonlySet<string> = new Set([
   'void',
   'undefined',
   'null',
-  'a Date',
-  'a Date from a string',
-  'a Date from a number',
-  'an integer',
-  'a finite number',
 ])
 
-const isTrivialDescription = (description: string | undefined): boolean =>
-  description !== undefined && TRIVIAL_DESCRIPTIONS.has(description)
+const getElementLabelForAST = (rawAst: SchemaAST.AST): string | undefined => {
+  const displayName = getDisplayName(getAnnotationsFromAST(rawAst))
+  if (displayName !== undefined) return displayName
+  const ast = unwrapAstForDisplay(rawAst)
+  if (ast._tag === 'Literal') return stringifyShort(ast.literal)
+  return getTypeKind(ast)
+}
 
-/**
- * Build a schema-derived label for container kinds. Returns `undefined` when
- * the schema doesn't describe a container, or doesn't carry enough info to
- * produce a useful label (no named element / value).
- *
- * Examples:
- * - `Schema.Array(OrderItem)` → `Array<Order Item>`
- * - `Schema.Record({ key: String, value: Money })` → `Record<string, Money>`
- * - `Schema.Tuple(String, Number, Boolean)` → `[string, number, boolean]`
- */
 const getContainerLabelForAST = (rawAst: SchemaAST.AST): string | undefined => {
   const ast = unwrapAstForDisplay(rawAst)
-
-  if (ast._tag === 'TupleType') {
-    const tupleAst = ast as SchemaAST.TupleType
-    /* Array (TupleType with rest-only and no positional elements). */
-    if (tupleAst.elements.length === 0 && tupleAst.rest.length > 0) {
-      const restType = tupleAst.rest[0]?.type
-      if (restType === undefined) return undefined
-      const elementName = getElementLabelForAST(restType)
-      return elementName !== undefined ? `Array<${elementName}>` : undefined
+  if (ast._tag === 'Arrays') {
+    if (ast.elements.length === 0 && ast.rest[0] !== undefined) {
+      const label = getElementLabelForAST(ast.rest[0])
+      return label === undefined ? undefined : `Array<${label}>`
     }
-    /* Fixed tuple — render positional element labels. */
-    if (tupleAst.elements.length > 0) {
-      const parts: string[] = []
-      for (const el of tupleAst.elements) {
-        const label = getElementLabelForAST(el.type)
-        if (label === undefined) return undefined
-        parts.push(label)
-      }
-      return `[${parts.join(', ')}]`
-    }
-    return undefined
-  }
-
-  if (ast._tag === 'TypeLiteral') {
-    const typeLit = ast as SchemaAST.TypeLiteral
-    /* Record (only index signatures, no explicit properties). */
-    if (typeLit.propertySignatures.length === 0 && typeLit.indexSignatures.length > 0) {
-      const indexSig = typeLit.indexSignatures[0]!
-      const keyLabel = getElementLabelForAST(indexSig.parameter) ?? 'string'
-      const valueLabel = getElementLabelForAST(indexSig.type)
-      if (valueLabel === undefined) return undefined
-      return `Record<${keyLabel}, ${valueLabel}>`
+    if (ast.elements.length > 0) {
+      const labels = ast.elements.map(getElementLabelForAST)
+      return labels.every((label) => label !== undefined) ? `[${labels.join(', ')}]` : undefined
     }
   }
-
-  /*
-   * Map / Set declarations: identified by the `typeConstructor` annotation
-   * Effect attaches to `Schema.MapFromSelf` / `Schema.SetFromSelf` (and the
-   * transform variants `Schema.Map` / `Schema.Set` / `Schema.ReadonlyMap` /
-   * `Schema.ReadonlySet`, which `unwrapAstForDisplay` collapses to their
-   * `to` declaration). The annotation only carries `_tag: 'ReadonlyMap' |
-   * 'ReadonlySet'` — the mutable vs readonly distinction has to be inferred
-   * from the description string Effect produces (`Map<...>` /
-   * `ReadonlyMap<...>` / `Set<...>` / `ReadonlySet<...>`).
-   *
-   * @see https://github.com/overengineeringstudio/effect-utils/issues/686
-   */
+  if (ast._tag === 'Objects' && ast.propertySignatures.length === 0) {
+    const index = ast.indexSignatures[0]
+    if (index !== undefined) {
+      const key = getElementLabelForAST(index.parameter) ?? 'string'
+      const value = getElementLabelForAST(index.type)
+      return value === undefined ? undefined : `Record<${key}, ${value}>`
+    }
+  }
   if (ast._tag === 'Declaration') {
-    const declAst = ast as SchemaAST.Declaration
-    const typeCtor = declAst.annotations[TypeConstructorAnnotationId] as
-      | { _tag?: unknown }
-      | undefined
-    const ctorTag = typeCtor?._tag
-    if (ctorTag === 'ReadonlyMap' || ctorTag === 'ReadonlySet') {
-      const description = declAst.annotations[DescriptionAnnotationId] as string | undefined
-      if (ctorTag === 'ReadonlyMap' && declAst.typeParameters.length === 2) {
-        const [keyAst, valueAst] = declAst.typeParameters
-        if (keyAst !== undefined && valueAst !== undefined) {
-          const keyLabel = getElementLabelForAST(keyAst)
-          const valueLabel = getElementLabelForAST(valueAst)
-          if (keyLabel !== undefined && valueLabel !== undefined) {
-            const prefix = description?.startsWith('ReadonlyMap<') === true ? 'ReadonlyMap' : 'Map'
-            return `${prefix}<${keyLabel}, ${valueLabel}>`
-          }
-        }
-      }
-      if (ctorTag === 'ReadonlySet' && declAst.typeParameters.length === 1) {
-        const [valueAst] = declAst.typeParameters
-        if (valueAst !== undefined) {
-          const valueLabel = getElementLabelForAST(valueAst)
-          if (valueLabel !== undefined) {
-            const prefix = description?.startsWith('ReadonlySet<') === true ? 'ReadonlySet' : 'Set'
-            return `${prefix}<${valueLabel}>`
-          }
-        }
-      }
+    const typeConstructor = asRecord(ast.annotations?.typeConstructor)
+    if (typeConstructor?._tag === 'ReadonlyMap' && ast.typeParameters.length === 2) {
+      const key =
+        ast.typeParameters[0] === undefined
+          ? undefined
+          : getElementLabelForAST(ast.typeParameters[0])
+      const value =
+        ast.typeParameters[1] === undefined
+          ? undefined
+          : getElementLabelForAST(ast.typeParameters[1])
+      return key === undefined || value === undefined ? undefined : `ReadonlyMap<${key}, ${value}>`
+    }
+    if (typeConstructor?._tag === 'ReadonlySet' && ast.typeParameters[0] !== undefined) {
+      const value = getElementLabelForAST(ast.typeParameters[0])
+      return value === undefined ? undefined : `ReadonlySet<${value}>`
     }
   }
-
   return undefined
 }
 
-/**
- * Narrow a `Schema.Union(...)` of tagged structs to the member matching the
- * runtime value's `_tag`. Returns the original AST when the union isn't
- * discriminated by `_tag` or no member matches.
- *
- * Each member of the union is itself unwrapped (Refinement/Transformation/
- * Suspend) before we look for a `_tag` PropertySignature whose type is a
- * `Literal`. The returned AST is the matching member's *raw* AST so callers
- * keep its annotations (description, identifier, ...).
- *
- * @see https://github.com/overengineeringstudio/effect-utils/issues/686
- */
 export const narrowUnionByTag = (rawAst: SchemaAST.AST, value: unknown): SchemaAST.AST => {
-  if (
-    value === null ||
-    typeof value !== 'object' ||
-    !('_tag' in value) ||
-    typeof (value as { _tag: unknown })._tag !== 'string'
-  ) {
-    return rawAst
-  }
-
+  if (value === null || typeof value !== 'object' || !('_tag' in value)) return rawAst
   const ast = unwrapAstForDisplay(rawAst)
   if (ast._tag !== 'Union') return rawAst
-
-  const tagValue = (value as { _tag: string })._tag
-  const unionAst = ast as SchemaAST.Union
-
-  for (const member of unionAst.types) {
-    const memberDisplay = unwrapAstForDisplay(member)
-    if (memberDisplay._tag !== 'TypeLiteral') continue
-    const tagProp = (memberDisplay as SchemaAST.TypeLiteral).propertySignatures.find(
-      (sig) => sig.name === '_tag',
-    )
-    if (tagProp === undefined) continue
-    const tagPropType = unwrapAstForDisplay(tagProp.type)
-    if (tagPropType._tag !== 'Literal') continue
-    if ((tagPropType as SchemaAST.Literal).literal === tagValue) {
+  for (const member of ast.types) {
+    const candidate = unwrapAstForDisplay(member)
+    if (candidate._tag !== 'Objects') continue
+    const tag = candidate.propertySignatures.find((property) => property.name === '_tag')?.type
+    if (tag?._tag === 'Literal' && tag.literal === (value as { readonly _tag: unknown })._tag) {
       return member
     }
   }
-
   return rawAst
 }
 
-/**
- * Get the value schema for a `Schema.Map` / `Schema.ReadonlyMap` (key/value)
- * declaration. Returns `undefined` when the schema isn't a Map declaration or
- * when the type parameters can't be extracted.
- *
- * @see https://github.com/overengineeringstudio/effect-utils/issues/686
- */
 export const getMapKeyValueSchema = (
-  schema: S.Schema.AnyNoContext,
-): { key: S.Schema.AnyNoContext; value: S.Schema.AnyNoContext } | undefined => {
+  schema: SchemaView,
+): { key: SchemaView; value: SchemaView } | undefined => {
   const ast = unwrapAstForDisplay(schema.ast)
   if (ast._tag !== 'Declaration') return undefined
-  const declAst = ast as SchemaAST.Declaration
-  const typeCtor = declAst.annotations[TypeConstructorAnnotationId] as
-    | { _tag?: unknown }
-    | undefined
-  if (typeCtor?._tag !== 'ReadonlyMap') return undefined
-  if (declAst.typeParameters.length < 2) return undefined
-  const [keyAst, valueAst] = declAst.typeParameters
-  if (keyAst === undefined || valueAst === undefined) return undefined
-  return {
-    key: { ast: keyAst } as S.Schema.AnyNoContext,
-    value: { ast: valueAst } as S.Schema.AnyNoContext,
-  }
+  const typeConstructor = asRecord(ast.annotations?.typeConstructor)
+  if (typeConstructor?._tag !== 'ReadonlyMap') return undefined
+  const [key, value] = ast.typeParameters
+  return key === undefined || value === undefined
+    ? undefined
+    : { key: view(key), value: view(value) }
 }
 
-/**
- * Get the element schema for a `Schema.Set` / `Schema.ReadonlySet`
- * declaration. Returns `undefined` when the schema isn't a Set declaration.
- *
- * @see https://github.com/overengineeringstudio/effect-utils/issues/686
- */
-export const getSetElementSchema = (
-  schema: S.Schema.AnyNoContext,
-): S.Schema.AnyNoContext | undefined => {
+export const getSetElementSchema = (schema: SchemaView): SchemaView | undefined => {
   const ast = unwrapAstForDisplay(schema.ast)
   if (ast._tag !== 'Declaration') return undefined
-  const declAst = ast as SchemaAST.Declaration
-  const typeCtor = declAst.annotations[TypeConstructorAnnotationId] as
-    | { _tag?: unknown }
-    | undefined
-  if (typeCtor?._tag !== 'ReadonlySet') return undefined
-  if (declAst.typeParameters.length < 1) return undefined
-  const [valueAst] = declAst.typeParameters
-  if (valueAst === undefined) return undefined
-  return { ast: valueAst } as S.Schema.AnyNoContext
+  const typeConstructor = asRecord(ast.annotations?.typeConstructor)
+  const value = ast.typeParameters[0]
+  return typeConstructor?._tag === 'ReadonlySet' && value !== undefined ? view(value) : undefined
 }
 
-/**
- * Best-effort short label for an element/value/key AST inside a container
- * label. Prefers the user-set `title`/`identifier`, falls back to the type
- * kind (`string`, `number`, ...). Returns `undefined` for things we can't
- * name simply (anonymous structs, anonymous unions).
- */
-const getElementLabelForAST = (rawAst: SchemaAST.AST): string | undefined => {
-  const ast = unwrapAstForDisplay(rawAst)
-  const annotations = getAnnotationsFromAST(rawAst)
-  const display = getDisplayName(annotations)
-  if (display !== undefined) return display
-
-  switch (ast._tag) {
-    case 'StringKeyword':
-      return 'string'
-    case 'NumberKeyword':
-      return 'number'
-    case 'BooleanKeyword':
-      return 'boolean'
-    case 'BigIntKeyword':
-      return 'bigint'
-    case 'SymbolKeyword':
-      return 'symbol'
-    case 'UnknownKeyword':
-      return 'unknown'
-    case 'AnyKeyword':
-      return 'any'
-    case 'Literal':
-      return stringifyShort((ast as SchemaAST.Literal).literal)
-    default:
-      return undefined
-  }
-}
-
-/**
- * Build the display-ready info bundle for a schema.
- *
- * Returns even when the schema has no annotations — callers should check
- * `hasContent` to decide whether the tooltip is worth rendering.
- */
-export const getSchemaInfo = (schema: S.Schema.AnyNoContext): SchemaInfo => {
+export const getSchemaInfo = (schema: SchemaView): SchemaInfo => {
   const rawAst = schema.ast
   const displayAst = unwrapAstForDisplay(rawAst)
-
-  // Read annotations from both the raw and unwrapped AST so things like
-  // `description` set on a refinement wrapper are still surfaced.
-  const rawAnnotations = getAnnotationsFromAST(rawAst)
-  const displayAnnotations = getAnnotationsFromAST(displayAst)
-  const annotations: SchemaAnnotations = { ...displayAnnotations, ...rawAnnotations }
-
+  const annotations = {
+    ...getAnnotationsFromAST(displayAst),
+    ...getAnnotationsFromAST(rawAst),
+  }
   const displayName = getDisplayName(annotations)
-  const typeKind = getTypeKind(rawAst)
-
-  const examples =
-    annotations.examples !== undefined && annotations.examples.length > 0
-      ? annotations.examples.map((v) => formatValueForDisplay(v, annotations))
-      : undefined
-
+  const examples = annotations.examples?.map(
+    (value) => formatWithPretty(value, annotations) ?? stringifyShort(value),
+  )
   const defaultValue =
-    annotations.default !== undefined
-      ? formatValueForDisplay(annotations.default, annotations)
-      : undefined
-
+    annotations.default === undefined
+      ? undefined
+      : (formatWithPretty(annotations.default, annotations) ?? stringifyShort(annotations.default))
   const constraints = getConstraintsFromJSONSchema(rawAst)
   const possible = getPossibleValuesFromAST(rawAst)
   const containerLabel = getContainerLabelForAST(rawAst)
-
-  /*
-   * Lineage and its companion annotations are read off the raw schema (not the
-   * unwrapped AST) — same reason as other annotation reads: a user may attach
-   * lineage to the refinement wrapper, and unwrapping would lose it. The
-   * helpers themselves try raw-then-unwrapped so either layer wins.
-   */
   const lineageValue = Lineage.getLineage(schema)
+  const authority = Lineage.getAuthority(schema)
+  const freshness = Lineage.getFreshness(schema)
+  const reference = Lineage.getReference(schema)
   const lineage: LineageBundle | undefined =
-    lineageValue !== undefined
-      ? (() => {
-          const authority = Lineage.getAuthority(schema)
-          const freshness = Lineage.getFreshness(schema)
-          const reference = Lineage.getReference(schema)
-          return {
-            display: Lineage.getLineageDisplay(lineageValue),
-            ...(authority !== undefined ? { authority } : {}),
-            ...(freshness !== undefined ? { freshness } : {}),
-            ...(reference !== undefined ? { reference } : {}),
-          }
-        })()
-      : (() => {
-          /* No primary Lineage but companion annotations may still exist. */
-          const authority = Lineage.getAuthority(schema)
-          const freshness = Lineage.getFreshness(schema)
-          const reference = Lineage.getReference(schema)
-          if (authority === undefined && freshness === undefined && reference === undefined) {
-            return undefined
-          }
-          return {
-            /* Synthesize a minimal display for companion-only annotations. */
-            display: {
-              badge: '',
-              badgeTitle: '',
-              kindLabel: '',
-              summary: '',
-            },
-            ...(authority !== undefined ? { authority } : {}),
-            ...(freshness !== undefined ? { freshness } : {}),
-            ...(reference !== undefined ? { reference } : {}),
-          }
-        })()
-
-  const meaningfulDescription =
-    isTrivialDescription(annotations.description) === true ? undefined : annotations.description
-
+    lineageValue === undefined &&
+    authority === undefined &&
+    freshness === undefined &&
+    reference === undefined
+      ? undefined
+      : {
+          display:
+            lineageValue === undefined
+              ? { badge: '', badgeTitle: '', kindLabel: '', summary: '' }
+              : Lineage.getLineageDisplay(lineageValue),
+          ...(authority === undefined ? {} : { authority }),
+          ...(freshness === undefined ? {} : { freshness }),
+          ...(reference === undefined ? {} : { reference }),
+        }
+  const description =
+    annotations.description !== undefined && TRIVIAL_DESCRIPTIONS.has(annotations.description)
+      ? undefined
+      : annotations.description
   const hasContent =
-    meaningfulDescription !== undefined ||
+    description !== undefined ||
     annotations.documentation !== undefined ||
     examples !== undefined ||
     defaultValue !== undefined ||
     constraints.length > 0 ||
     possible !== undefined ||
     lineage !== undefined
-
   return {
-    ...(displayName !== undefined ? { displayName } : {}),
-    ...(typeKind !== undefined ? { typeKind } : {}),
-    ...(meaningfulDescription !== undefined ? { description: meaningfulDescription } : {}),
-    ...(annotations.documentation !== undefined
-      ? { documentation: annotations.documentation }
-      : {}),
-    ...(examples !== undefined ? { examples } : {}),
-    ...(defaultValue !== undefined ? { defaultValue } : {}),
-    ...(constraints.length > 0 ? { constraints } : {}),
-    ...(possible !== undefined
-      ? { possibleValues: possible.values, possibleValuesTruncated: possible.truncated }
-      : {}),
-    ...(containerLabel !== undefined ? { containerLabel } : {}),
-    ...(lineage !== undefined ? { lineage } : {}),
+    ...(displayName === undefined ? {} : { displayName }),
+    ...(getTypeKind(rawAst) === undefined ? {} : { typeKind: getTypeKind(rawAst) }),
+    ...(description === undefined ? {} : { description }),
+    ...(annotations.documentation === undefined
+      ? {}
+      : { documentation: annotations.documentation }),
+    ...(examples === undefined ? {} : { examples }),
+    ...(defaultValue === undefined ? {} : { defaultValue }),
+    ...(constraints.length === 0 ? {} : { constraints }),
+    ...(possible === undefined
+      ? {}
+      : { possibleValues: possible.values, possibleValuesTruncated: possible.truncated }),
+    ...(containerLabel === undefined ? {} : { containerLabel }),
+    ...(lineage === undefined ? {} : { lineage }),
     hasContent,
   }
 }
 
-export type SchemaRegistry = Map<string, S.Schema.AnyNoContext>
+export type SchemaRegistry = Map<string, SchemaView>
 
-/** Create a schema registry for matching schemas to constructor names */
 export const createSchemaRegistry = (): SchemaRegistry => new Map()
 
-/** Register a schema with its identifier/title for lookup */
 export const registerSchema = (
   registry: SchemaRegistry,
-  schema: S.Schema.AnyNoContext,
+  schema: SchemaView,
   name?: string,
 ): void => {
   const annotations = getAnnotations(schema)
   const key = name ?? annotations.identifier ?? annotations.title
-  if (key !== undefined) {
-    registry.set(key, schema)
-  }
+  if (key !== undefined) registry.set(key, schema)
 }
 
-/** Look up a schema by constructor name or other identifier */
-export const lookupSchema = (
-  registry: SchemaRegistry,
-  name: string,
-): S.Schema.AnyNoContext | undefined => {
-  return registry.get(name)
-}
+export const lookupSchema = (registry: SchemaRegistry, name: string): SchemaView | undefined =>
+  registry.get(name)

--- a/packages/@overeng/react-inspector/src/schema/lineage.ts
+++ b/packages/@overeng/react-inspector/src/schema/lineage.ts
@@ -86,9 +86,9 @@ const LineageSchema = Schema.Union([
   }),
   Schema.TaggedStruct('Projection', {
     of: LineageRefSchema,
-    stalenessMs: Schema.optional(Schema.Number),
+    stalenessMs: Schema.optional(Schema.Finite),
   }),
-  Schema.TaggedStruct('Cache', { of: LineageRefSchema, ttlMs: Schema.optional(Schema.Number) }),
+  Schema.TaggedStruct('Cache', { of: LineageRefSchema, ttlMs: Schema.optional(Schema.Finite) }),
   Schema.TaggedStruct('Mirror', { of: LineageRefSchema, system: Schema.optional(Schema.String) }),
   Schema.TaggedStruct('External', { system: Schema.String, ref: Schema.optional(Schema.String) }),
   Schema.TaggedStruct('Computed', {
@@ -103,7 +103,7 @@ const AuthoritySchema = Schema.Struct({
 })
 const FreshnessSchema = Schema.Struct({
   capturedAt: Schema.optional(Schema.Literals(['now', 'event-time', 'snapshot'])),
-  maxAgeMs: Schema.optional(Schema.Number),
+  maxAgeMs: Schema.optional(Schema.Finite),
 })
 const ReferenceSchema = Schema.TaggedStruct('ForeignKey', {
   targetSchema: Schema.String,

--- a/packages/@overeng/react-inspector/src/schema/lineage.ts
+++ b/packages/@overeng/react-inspector/src/schema/lineage.ts
@@ -1,0 +1,311 @@
+import { Schema, type SchemaAST } from 'effect'
+
+export type LineageRef =
+  | { readonly _tag: 'Field'; readonly path: string }
+  | { readonly _tag: 'Schema'; readonly identifier: string }
+  | { readonly _tag: 'External'; readonly system: string; readonly ref: string }
+
+export type DerivationKind =
+  | { readonly _tag: 'Pure' }
+  | {
+      readonly _tag: 'Aggregation'
+      readonly op: 'sum' | 'count' | 'min' | 'max' | 'avg' | 'custom'
+    }
+  | { readonly _tag: 'Reduction'; readonly description: string }
+  | { readonly _tag: 'External'; readonly service: string }
+
+export type Lineage =
+  | { readonly _tag: 'SourceOfTruth'; readonly owner?: string; readonly system?: string }
+  | {
+      readonly _tag: 'Derived'
+      readonly from: ReadonlyArray<LineageRef>
+      readonly how: DerivationKind
+      readonly pure?: boolean
+    }
+  | { readonly _tag: 'Projection'; readonly of: LineageRef; readonly stalenessMs?: number }
+  | { readonly _tag: 'Cache'; readonly of: LineageRef; readonly ttlMs?: number }
+  | { readonly _tag: 'Mirror'; readonly of: LineageRef; readonly system?: string }
+  | { readonly _tag: 'External'; readonly system: string; readonly ref?: string }
+  | { readonly _tag: 'Computed'; readonly fn?: string; readonly description?: string }
+
+export interface Authority {
+  readonly writers: ReadonlyArray<string>
+  readonly readers?: ReadonlyArray<string>
+}
+
+export interface Freshness {
+  readonly capturedAt?: 'now' | 'event-time' | 'snapshot'
+  readonly maxAgeMs?: number
+}
+
+export interface Reference {
+  readonly _tag: 'ForeignKey'
+  readonly targetSchema: string
+  readonly targetField?: string
+}
+
+export interface LineageDisplay {
+  readonly badge: string
+  readonly badgeTitle: string
+  readonly kindLabel: string
+  readonly summary: string
+  readonly details?: ReadonlyArray<{ readonly label: string; readonly value: string }>
+}
+
+const annotationKeys = {
+  lineage: '@overeng/lineage',
+  authority: '@overeng/authority',
+  freshness: '@overeng/freshness',
+  reference: '@overeng/reference',
+} as const
+
+const LineageRefSchema = Schema.Union([
+  Schema.TaggedStruct('Field', { path: Schema.String }),
+  Schema.TaggedStruct('Schema', { identifier: Schema.String }),
+  Schema.TaggedStruct('External', { system: Schema.String, ref: Schema.String }),
+])
+
+const DerivationKindSchema = Schema.Union([
+  Schema.TaggedStruct('Pure', {}),
+  Schema.TaggedStruct('Aggregation', {
+    op: Schema.Literals(['sum', 'count', 'min', 'max', 'avg', 'custom']),
+  }),
+  Schema.TaggedStruct('Reduction', { description: Schema.String }),
+  Schema.TaggedStruct('External', { service: Schema.String }),
+])
+
+const LineageSchema = Schema.Union([
+  Schema.TaggedStruct('SourceOfTruth', {
+    owner: Schema.optional(Schema.String),
+    system: Schema.optional(Schema.String),
+  }),
+  Schema.TaggedStruct('Derived', {
+    from: Schema.Array(LineageRefSchema),
+    how: DerivationKindSchema,
+    pure: Schema.optional(Schema.Boolean),
+  }),
+  Schema.TaggedStruct('Projection', {
+    of: LineageRefSchema,
+    stalenessMs: Schema.optional(Schema.Number),
+  }),
+  Schema.TaggedStruct('Cache', { of: LineageRefSchema, ttlMs: Schema.optional(Schema.Number) }),
+  Schema.TaggedStruct('Mirror', { of: LineageRefSchema, system: Schema.optional(Schema.String) }),
+  Schema.TaggedStruct('External', { system: Schema.String, ref: Schema.optional(Schema.String) }),
+  Schema.TaggedStruct('Computed', {
+    fn: Schema.optional(Schema.String),
+    description: Schema.optional(Schema.String),
+  }),
+])
+
+const AuthoritySchema = Schema.Struct({
+  writers: Schema.Array(Schema.String),
+  readers: Schema.optional(Schema.Array(Schema.String)),
+})
+const FreshnessSchema = Schema.Struct({
+  capturedAt: Schema.optional(Schema.Literals(['now', 'event-time', 'snapshot'])),
+  maxAgeMs: Schema.optional(Schema.Number),
+})
+const ReferenceSchema = Schema.TaggedStruct('ForeignKey', {
+  targetSchema: Schema.String,
+  targetField: Schema.optional(Schema.String),
+})
+
+type SchemaView = { readonly ast: SchemaAST.AST }
+
+const annotation = (schema: SchemaView, key: string): unknown => {
+  let value = schema.ast.context?.annotations?.[key] ?? schema.ast.annotations?.[key]
+  for (const check of schema.ast.checks ?? []) {
+    if (key in (check.annotations ?? {})) value = check.annotations?.[key]
+  }
+  return value
+}
+
+const decode = <S extends Schema.ConstraintDecoder<unknown>>(
+  decoder: S,
+  value: unknown,
+): S['Type'] | undefined =>
+  Schema.decodeUnknownOption(decoder)(value).pipe((option) =>
+    option._tag === 'Some' ? option.value : undefined,
+  )
+
+export const getLineage = (schema: SchemaView): Lineage | undefined =>
+  decode(LineageSchema, annotation(schema, annotationKeys.lineage))
+
+export const getAuthority = (schema: SchemaView): Authority | undefined =>
+  decode(AuthoritySchema, annotation(schema, annotationKeys.authority))
+
+export const getFreshness = (schema: SchemaView): Freshness | undefined =>
+  decode(FreshnessSchema, annotation(schema, annotationKeys.freshness))
+
+export const getReference = (schema: SchemaView): Reference | undefined =>
+  decode(ReferenceSchema, annotation(schema, annotationKeys.reference))
+
+const annotate =
+  <V>(key: string, value: V) =>
+  <S extends Schema.Top>(schema: S): S['Rebuild'] =>
+    schema.annotate({ [key]: value })
+
+const fieldRef = (path: string): LineageRef => ({
+  _tag: 'Field',
+  path: path.startsWith('$') === true ? path : `$.${path}`,
+})
+const coerceRef = (ref: string | LineageRef): LineageRef =>
+  typeof ref === 'string' ? fieldRef(ref) : ref
+
+const coerceDerivationKind = (
+  how: DerivationKind | DerivationKind['_tag'] | undefined,
+): DerivationKind => {
+  if (how === undefined) return { _tag: 'Pure' }
+  if (typeof how !== 'string') return how
+
+  switch (how) {
+    case 'Pure':
+      return { _tag: 'Pure' }
+    case 'Aggregation':
+      return { _tag: 'Aggregation', op: 'custom' }
+    case 'Reduction':
+      return { _tag: 'Reduction', description: '' }
+    case 'External':
+      return { _tag: 'External', service: '' }
+  }
+}
+
+export const sourceOfTruth = (opts: { owner?: string; system?: string } = {}) =>
+  annotate(annotationKeys.lineage, { _tag: 'SourceOfTruth', ...opts } satisfies Lineage)
+
+export const derivedFrom = (args: {
+  from: ReadonlyArray<string | LineageRef>
+  how?: DerivationKind | DerivationKind['_tag']
+  pure?: boolean
+}) =>
+  annotate(annotationKeys.lineage, {
+    _tag: 'Derived',
+    from: args.from.map(coerceRef),
+    how: coerceDerivationKind(args.how),
+    ...(args.pure === undefined ? {} : { pure: args.pure }),
+  } satisfies Lineage)
+
+export const projection = (args: { of: string | LineageRef; stalenessMs?: number }) =>
+  annotate(annotationKeys.lineage, {
+    _tag: 'Projection',
+    of: coerceRef(args.of),
+    ...(args.stalenessMs === undefined ? {} : { stalenessMs: args.stalenessMs }),
+  } satisfies Lineage)
+
+export const cache = (args: { of: string | LineageRef; ttlMs?: number }) =>
+  annotate(annotationKeys.lineage, {
+    _tag: 'Cache',
+    of: coerceRef(args.of),
+    ...(args.ttlMs === undefined ? {} : { ttlMs: args.ttlMs }),
+  } satisfies Lineage)
+
+export const mirror = (args: { of: string | LineageRef; system?: string }) =>
+  annotate(annotationKeys.lineage, {
+    _tag: 'Mirror',
+    of: coerceRef(args.of),
+    ...(args.system === undefined ? {} : { system: args.system }),
+  } satisfies Lineage)
+
+export const external = (args: { system: string; ref?: string }) =>
+  annotate(annotationKeys.lineage, {
+    _tag: 'External',
+    system: args.system,
+    ...(args.ref === undefined ? {} : { ref: args.ref }),
+  } satisfies Lineage)
+
+export const computed = (opts: { fn?: string; description?: string } = {}) =>
+  annotate(annotationKeys.lineage, { _tag: 'Computed', ...opts } satisfies Lineage)
+
+export const authority = (value: Authority) => annotate(annotationKeys.authority, value)
+export const freshness = (value: Freshness) => annotate(annotationKeys.freshness, value)
+export const foreignKey = (args: { targetSchema: string; targetField?: string }) =>
+  annotate(annotationKeys.reference, {
+    _tag: 'ForeignKey',
+    targetSchema: args.targetSchema,
+    ...(args.targetField === undefined ? {} : { targetField: args.targetField }),
+  } satisfies Reference)
+
+const refToString = (ref: LineageRef): string => {
+  switch (ref._tag) {
+    case 'Field':
+      return ref.path
+    case 'Schema':
+      return ref.identifier
+    case 'External':
+      return `${ref.system}:${ref.ref}`
+  }
+}
+
+const withDetails = (
+  base: Omit<LineageDisplay, 'details'>,
+  details: ReadonlyArray<{ readonly label: string; readonly value: string }>,
+): LineageDisplay => (details.length === 0 ? base : { ...base, details })
+
+export const getLineageDisplay = (lineage: Lineage): LineageDisplay => {
+  switch (lineage._tag) {
+    case 'SourceOfTruth':
+      return withDetails(
+        {
+          badge: '⇆',
+          badgeTitle: 'Source of truth',
+          kindLabel: 'Source of truth',
+          summary:
+            lineage.system === undefined ? 'Authoritative value' : `Owned by ${lineage.system}`,
+        },
+        [
+          ...(lineage.owner === undefined ? [] : [{ label: 'owner', value: lineage.owner }]),
+          ...(lineage.system === undefined ? [] : [{ label: 'system', value: lineage.system }]),
+        ],
+      )
+    case 'Derived': {
+      const sources = lineage.from.map(refToString).join(', ')
+      return {
+        badge: 'ƒ',
+        badgeTitle: `Derived from ${sources}`,
+        kindLabel: 'Derived',
+        summary: `Derived from ${sources}`,
+      }
+    }
+    case 'Projection': {
+      const source = refToString(lineage.of)
+      return {
+        badge: '≈',
+        badgeTitle: `Projection of ${source}`,
+        kindLabel: 'Projection',
+        summary: `Projection of ${source}`,
+      }
+    }
+    case 'Cache': {
+      const source = refToString(lineage.of)
+      return {
+        badge: '☷',
+        badgeTitle: `Cache of ${source}`,
+        kindLabel: 'Cache',
+        summary: `Cached value of ${source}`,
+      }
+    }
+    case 'Mirror': {
+      const source = refToString(lineage.of)
+      return {
+        badge: '↻',
+        badgeTitle: `Mirror of ${source}`,
+        kindLabel: 'Mirror',
+        summary: `Mirror of ${source}`,
+      }
+    }
+    case 'External':
+      return {
+        badge: '↗',
+        badgeTitle: `External: ${lineage.system}`,
+        kindLabel: 'External',
+        summary: lineage.ref === undefined ? lineage.system : `${lineage.system}:${lineage.ref}`,
+      }
+    case 'Computed':
+      return {
+        badge: '⊙',
+        badgeTitle: 'Computed',
+        kindLabel: 'Computed',
+        summary: lineage.description ?? lineage.fn ?? 'Computed at read time',
+      }
+  }
+}

--- a/packages/@overeng/react-inspector/src/schema/mod.tsx
+++ b/packages/@overeng/react-inspector/src/schema/mod.tsx
@@ -1,3 +1,5 @@
+/* oxlint-disable oxc/no-barrel-file -- This module is the package's intentional public schema API. */
+
 export {
   type LineageBundle,
   type SchemaAnnotations,

--- a/packages/@overeng/react-inspector/src/schema/mod.tsx
+++ b/packages/@overeng/react-inspector/src/schema/mod.tsx
@@ -37,4 +37,4 @@ export { SchemaAwareObjectValue } from './SchemaAwareObjectValue.tsx'
 export { SchemaAwareObjectPreview } from './SchemaAwareObjectPreview.tsx'
 export { SchemaTooltip, type SchemaTooltipProps } from './SchemaTooltip.tsx'
 
-export { Lineage } from '@overeng/utils'
+export * as Lineage from './lineage.ts'

--- a/packages/@overeng/react-inspector/stories/effect-schema.stories.tsx
+++ b/packages/@overeng/react-inspector/stories/effect-schema.stories.tsx
@@ -34,8 +34,8 @@ const UserSchema = Schema.Struct({
   id: Schema.Number,
   name: Schema.String,
   email: Schema.String,
-  createdAt: Schema.DateFromSelf,
-}).annotations({
+  createdAt: Schema.Date,
+}).annotate({
   identifier: 'User',
   title: 'User',
 })
@@ -55,7 +55,7 @@ export const BasicSchemaWithTitle = {
 }
 
 /** Product schema with pretty print annotation */
-const PriceSchema = Schema.Number.annotations({
+const PriceSchema = Schema.Number.annotate({
   identifier: 'Price',
   pretty: (value) => `$${(value as number).toFixed(2)}`,
 })
@@ -65,7 +65,7 @@ const ProductSchema = Schema.Struct({
   name: Schema.String,
   price: PriceSchema,
   quantity: Schema.Number,
-}).annotations({
+}).annotate({
   identifier: 'Product',
   title: 'Product',
 })
@@ -92,7 +92,7 @@ const AddressSchema = Schema.Struct({
   city: Schema.String,
   country: Schema.String,
   zip: Schema.String,
-}).annotations({
+}).annotate({
   identifier: 'Address',
   title: 'Address',
 })
@@ -102,7 +102,7 @@ const PersonSchema = Schema.Struct({
   id: Schema.Number,
   name: Schema.String,
   address: AddressSchema,
-}).annotations({
+}).annotate({
   identifier: 'Person',
   title: 'Person',
 })
@@ -126,7 +126,7 @@ export const NestedSchemaWithAnnotations = {
 }
 
 /** Temperature schema with pretty print for formatting */
-const TemperatureSchema = Schema.Number.annotations({
+const TemperatureSchema = Schema.Number.annotate({
   identifier: 'Temperature',
   pretty: (value) => `${value}°C`,
 })
@@ -135,11 +135,11 @@ const TemperatureSchema = Schema.Number.annotations({
 const WeatherReportSchema = Schema.Struct({
   location: Schema.String,
   temperature: TemperatureSchema,
-  humidity: Schema.Number.annotations({
+  humidity: Schema.Number.annotate({
     pretty: (value) => `${value}%`,
   }),
   conditions: Schema.String,
-}).annotations({
+}).annotate({
   identifier: 'WeatherReport',
   title: 'Weather Report',
 })
@@ -161,7 +161,7 @@ export const PrettyPrintForMultipleFields = {
 }
 
 /** Array of users example */
-const UsersArraySchema = Schema.Array(UserSchema).annotations({
+const UsersArraySchema = Schema.Array(UserSchema).annotate({
   identifier: 'Users',
   title: 'Users',
 })
@@ -200,7 +200,7 @@ export const WithoutSchema = {
 }
 
 /** Order schema with complex formatting */
-const MoneySchema = Schema.Number.annotations({
+const MoneySchema = Schema.Number.annotate({
   identifier: 'Money',
   pretty: (value) => {
     const num = value as number
@@ -216,7 +216,7 @@ const OrderItemSchema = Schema.Struct({
   name: Schema.String,
   price: MoneySchema,
   quantity: Schema.Number,
-}).annotations({
+}).annotate({
   identifier: 'OrderItem',
   title: 'Order Item',
 })
@@ -229,7 +229,7 @@ const OrderSchema = Schema.Struct({
   tax: MoneySchema,
   total: MoneySchema,
   status: Schema.String,
-}).annotations({
+}).annotate({
   identifier: 'Order',
   title: 'Order',
 })
@@ -255,12 +255,12 @@ export const ComplexOrderExample = {
 }
 
 /** Enum-like union type example */
-const StatusSchema = Schema.Union(
+const StatusSchema = Schema.Union([
   Schema.Literal('pending'),
   Schema.Literal('processing'),
   Schema.Literal('completed'),
   Schema.Literal('cancelled'),
-).annotations({
+]).annotate({
   identifier: 'OrderStatus',
   title: 'Order Status',
 })
@@ -269,7 +269,7 @@ const TaskSchema = Schema.Struct({
   id: Schema.Number,
   title: Schema.String,
   status: StatusSchema,
-  priority: Schema.Number.annotations({
+  priority: Schema.Number.annotate({
     pretty: (value) => {
       const num = value as number
       if (num >= 8) return 'High'
@@ -277,7 +277,7 @@ const TaskSchema = Schema.Struct({
       return 'Low'
     },
   }),
-}).annotations({
+}).annotate({
   identifier: 'Task',
   title: 'Task',
 })
@@ -300,7 +300,7 @@ export const TaskWithPriorityFormatting = {
 const PointSchema = Schema.Struct({
   x: Schema.Number,
   y: Schema.Number,
-}).annotations({
+}).annotate({
   identifier: 'Point',
   title: 'Point',
   pretty: (value) => {
@@ -345,38 +345,38 @@ export const UsingSchemaProviderDirectly = {
 
 /** Schema with description annotations - hover over fields to see tooltips */
 const DocumentedUserSchema = Schema.Struct({
-  id: Schema.Number.annotations({
+  id: Schema.Number.annotate({
     description: 'Unique identifier for the user in the database',
   }),
-  name: Schema.String.annotations({
+  name: Schema.String.annotate({
     description: 'Full legal name of the user',
   }),
-  email: Schema.String.annotations({
+  email: Schema.String.annotate({
     description: 'Primary email address used for authentication and notifications',
   }),
-  role: Schema.Union(
+  role: Schema.Union([
     Schema.Literal('admin'),
     Schema.Literal('moderator'),
     Schema.Literal('user'),
-  ).annotations({
+  ]).annotate({
     description: 'Access level determining permissions in the system',
   }),
   preferences: Schema.Struct({
-    theme: Schema.Union(Schema.Literal('light'), Schema.Literal('dark')).annotations({
+    theme: Schema.Union([Schema.Literal('light'), Schema.Literal('dark')]).annotate({
       description: 'UI color scheme preference',
     }),
-    notifications: Schema.Boolean.annotations({
+    notifications: Schema.Boolean.annotate({
       description: 'Whether to receive email notifications',
     }),
-    language: Schema.String.annotations({
+    language: Schema.String.annotate({
       description: 'Preferred language code (e.g., en-US, de-DE)',
     }),
-  }).annotations({
+  }).annotate({
     identifier: 'UserPreferences',
     title: 'User Preferences',
     description: 'User-configurable settings for the application',
   }),
-}).annotations({
+}).annotate({
   identifier: 'DocumentedUser',
   title: 'User',
   description: 'A registered user in the system with authentication credentials and preferences',
@@ -415,7 +415,7 @@ export const SchemaWithDescriptionTooltips = {
 
 /** API Response schema with detailed field descriptions */
 const ApiResponseSchema = Schema.Struct({
-  status: Schema.Number.annotations({
+  status: Schema.Number.annotate({
     description: 'HTTP status code of the response (e.g., 200, 404, 500)',
     pretty: (value) => {
       const code = value as number
@@ -427,44 +427,44 @@ const ApiResponseSchema = Schema.Struct({
   data: Schema.Struct({
     items: Schema.Array(
       Schema.Struct({
-        id: Schema.String.annotations({
+        id: Schema.String.annotate({
           description: 'UUID v4 identifier',
         }),
-        value: Schema.Number.annotations({
+        value: Schema.Number.annotate({
           description: 'Numeric value in base units',
           pretty: (v) => `${v} units`,
         }),
-      }).annotations({
+      }).annotate({
         identifier: 'DataItem',
         title: 'Data Item',
         description: 'Individual data record from the API',
       }),
-    ).annotations({
+    ).annotate({
       description: 'Array of data items returned by the query',
     }),
-    total: Schema.Number.annotations({
+    total: Schema.Number.annotate({
       description:
         'Total count of items matching the query (may exceed items.length due to pagination)',
     }),
-  }).annotations({
+  }).annotate({
     identifier: 'ResponseData',
     title: 'Response Data',
     description: 'Payload containing the requested data',
   }),
   meta: Schema.Struct({
-    requestId: Schema.String.annotations({
+    requestId: Schema.String.annotate({
       description: 'Unique identifier for tracing this request through logs',
     }),
-    duration: Schema.Number.annotations({
+    duration: Schema.Number.annotate({
       description: 'Server-side processing time in milliseconds',
       pretty: (v) => `${v}ms`,
     }),
-  }).annotations({
+  }).annotate({
     identifier: 'ResponseMeta',
     title: 'Metadata',
     description: 'Request metadata for debugging and monitoring',
   }),
-}).annotations({
+}).annotate({
   identifier: 'ApiResponse',
   title: 'API Response',
   description: 'Standard response envelope for all API endpoints',
@@ -541,17 +541,20 @@ const Hint: React.FC<{ children: React.ReactNode }> = ({ children }) => (
 
 /** Refinement-driven constraints (NonEmpty + max length, Int + Between). */
 const UserHandleSchema = Schema.String.pipe(
-  Schema.nonEmptyString({ message: () => 'handle must not be empty' }),
-  Schema.maxLength(20),
-  Schema.pattern(/^[a-z0-9_]+$/i),
-).annotations({
+  Schema.check(Schema.isMinLength(1, { message: 'handle must not be empty' })),
+  Schema.check(Schema.isMaxLength(20)),
+  Schema.check(Schema.isPattern(/^[a-z0-9_]+$/i)),
+).annotate({
   identifier: 'UserHandle',
   title: 'Handle',
   description: 'Unique short alias used in URLs and @mentions',
   examples: ['alice', 'bob_42'],
 })
 
-const AgeSchema = Schema.Number.pipe(Schema.int(), Schema.between(0, 150)).annotations({
+const AgeSchema = Schema.Number.pipe(
+  Schema.check(Schema.isInt()),
+  Schema.check(Schema.isBetween({ minimum: 0, maximum: 150 })),
+).annotate({
   identifier: 'Age',
   title: 'Age',
   description: 'Age in whole years',
@@ -559,37 +562,39 @@ const AgeSchema = Schema.Number.pipe(Schema.int(), Schema.between(0, 150)).annot
   default: 0,
 })
 
-const RoleSchema = Schema.Union(
+const RoleSchema = Schema.Union([
   Schema.Literal('owner'),
   Schema.Literal('admin'),
   Schema.Literal('member'),
   Schema.Literal('guest'),
-).annotations({
+]).annotate({
   identifier: 'Role',
   title: 'Role',
   description: 'Access tier within the workspace',
   default: 'member',
 })
 
-const PrioritySchema = Schema.Enums({
+const PrioritySchema = Schema.Enum({
   Low: 0,
   Medium: 1,
   High: 2,
   Critical: 3,
-} as const).annotations({
+} as const).annotate({
   identifier: 'Priority',
   title: 'Priority',
   description: 'Numeric priority bucket',
 })
 
-const EmailSchema = Schema.String.pipe(Schema.pattern(/^[^@\s]+@[^@\s]+\.[^@\s]+$/)).annotations({
+const EmailSchema = Schema.String.pipe(
+  Schema.check(Schema.isPattern(/^[^@\s]+@[^@\s]+\.[^@\s]+$/)),
+).annotate({
   identifier: 'Email',
   title: 'Email',
   description: 'Primary contact email; verified at signup',
   examples: ['alice@example.com'],
 })
 
-const MoneyV2Schema = Schema.Number.annotations({
+const MoneyV2Schema = Schema.Number.annotate({
   identifier: 'Money',
   title: 'Money (USD)',
   description: 'Currency amount in US dollars',
@@ -606,10 +611,10 @@ const ShowcaseUserSchema = Schema.Struct({
   role: RoleSchema,
   priority: PrioritySchema,
   balance: MoneyV2Schema,
-  bio: Schema.String.pipe(Schema.maxLength(280)).annotations({
+  bio: Schema.String.pipe(Schema.check(Schema.isMaxLength(280))).annotate({
     description: 'Free-form profile bio. Limited to a single tweet.',
   }),
-}).annotations({
+}).annotate({
   identifier: 'ShowcaseUser',
   title: 'Showcase User',
   description: 'A user record that exercises every schema annotation kind the tooltip understands.',
@@ -690,8 +695,8 @@ export const SchemaTooltipKeyboardA11y = {
  * want a wall of values in the tooltip.
  */
 const ManyStatusesSchema = Schema.Union(
-  ...Array.from({ length: 20 }, (_, i) => Schema.Literal(`status_${i}` as const)),
-).annotations({
+  Array.from({ length: 20 }, (_, i) => Schema.Literal(`status_${i}` as const)),
+).annotate({
   identifier: 'ManyStatuses',
   title: 'Status',
   description: 'One of many possible statuses (truncated in tooltip).',
@@ -699,7 +704,7 @@ const ManyStatusesSchema = Schema.Union(
 
 const TruncationDemoSchema = Schema.Struct({
   status: ManyStatusesSchema,
-}).annotations({
+}).annotate({
   identifier: 'TruncationDemo',
   title: 'Truncation Demo',
 })
@@ -728,7 +733,7 @@ export const SchemaTooltipTruncatedPossibleValues = {
  */
 const PlainSchema = Schema.Struct({
   plainField: Schema.String,
-  withDescription: Schema.String.annotations({ description: 'Only this one has a tooltip.' }),
+  withDescription: Schema.String.annotate({ description: 'Only this one has a tooltip.' }),
 })
 
 export const SchemaTooltipMixedAnnotated = {
@@ -754,7 +759,7 @@ export const SchemaTooltipMixedAnnotated = {
 const ItemSchema = Schema.Struct({
   sku: Schema.String,
   qty: Schema.Number,
-}).annotations({
+}).annotate({
   identifier: 'Item',
   title: 'Item',
 })
@@ -763,16 +768,16 @@ const InventorySchema = Schema.Struct({
   /* Anonymous `Schema.Array(Item)` — label becomes `Array<Item>`. */
   defaultItems: Schema.Array(ItemSchema),
   /* Named array — its own identifier wins over the constructed label. */
-  pinnedItems: Schema.Array(ItemSchema).annotations({
+  pinnedItems: Schema.Array(ItemSchema).annotate({
     identifier: 'PinnedItems',
     title: 'Pinned Items',
     description: 'Items pinned to the top of the inventory view.',
   }),
   /* Record with a named value schema → `Record<string, Money>`. */
-  priceOverrides: Schema.Record({ key: Schema.String, value: MoneyV2Schema }),
+  priceOverrides: Schema.Record(Schema.String, MoneyV2Schema),
   /* Fixed tuple of primitives → `[number, number, number]`. */
-  rgb: Schema.Tuple(Schema.Number, Schema.Number, Schema.Number),
-}).annotations({
+  rgb: Schema.Tuple([Schema.Number, Schema.Number, Schema.Number]),
+}).annotate({
   identifier: 'Inventory',
   title: 'Inventory',
 })
@@ -820,12 +825,12 @@ export const ContainerLabels = {
 
 const StockMapSchema = Schema.Struct({
   /* `Map<string, Money>` — runtime is a real Map instance. */
-  pricesByLocation: Schema.MapFromSelf({ key: Schema.String, value: MoneyV2Schema }),
+  pricesByLocation: Schema.ReadonlyMap(Schema.String, MoneyV2Schema),
   /* `Set<Item>` — runtime is a real Set instance. */
-  uniqueItems: Schema.SetFromSelf(ItemSchema),
+  uniqueItems: Schema.ReadonlySet(ItemSchema),
   /* `ReadonlyMap<string, number>` — distinct prefix. */
-  readonlyCounts: Schema.ReadonlyMapFromSelf({ key: Schema.String, value: Schema.Number }),
-}).annotations({
+  readonlyCounts: Schema.ReadonlyMap(Schema.String, Schema.Number),
+}).annotate({
   identifier: 'StockMap',
   title: 'Stock Map',
 })
@@ -845,9 +850,8 @@ const sampleStockMap = {
 /**
  * Map/Set container labels — addresses #686.
  *
- * `Schema.MapFromSelf({ key, value })` renders as `Map<string, Money>(N)` and
- * `Schema.SetFromSelf(Item)` as `Set<Item>(N)`. `Schema.ReadonlyMapFromSelf`
- * keeps the `ReadonlyMap<...>` prefix.
+ * `Schema.ReadonlyMap(key, value)` renders as `ReadonlyMap<string, Money>(N)` and
+ * `Schema.ReadonlySet(Item)` as `ReadonlySet<Item>(N)`.
  */
 export const MapAndSetContainerLabels = {
   render: () => (
@@ -873,7 +877,7 @@ const EventCreatedSchema = Schema.Struct({
   _tag: Schema.Literal('Created'),
   id: Schema.String,
   createdAt: Schema.String,
-}).annotations({
+}).annotate({
   identifier: 'EventCreated',
   title: 'Created Event',
   description: 'A resource was created.',
@@ -883,7 +887,7 @@ const EventUpdatedSchema = Schema.Struct({
   _tag: Schema.Literal('Updated'),
   id: Schema.String,
   changedFields: Schema.Array(Schema.String),
-}).annotations({
+}).annotate({
   identifier: 'EventUpdated',
   title: 'Updated Event',
   description: 'An existing resource was modified.',
@@ -892,18 +896,18 @@ const EventUpdatedSchema = Schema.Struct({
 const EventDeletedSchema = Schema.Struct({
   _tag: Schema.Literal('Deleted'),
   id: Schema.String,
-}).annotations({
+}).annotate({
   identifier: 'EventDeleted',
   title: 'Deleted Event',
   description: 'A resource was removed.',
 })
 
-const EventSchema = Schema.Union(EventCreatedSchema, EventUpdatedSchema, EventDeletedSchema)
+const EventSchema = Schema.Union([EventCreatedSchema, EventUpdatedSchema, EventDeletedSchema])
 
 const AuditEntrySchema = Schema.Struct({
   actor: Schema.String,
   event: EventSchema,
-}).annotations({
+}).annotate({
   identifier: 'AuditEntry',
   title: 'Audit Entry',
 })
@@ -929,7 +933,7 @@ const sampleUpdated = {
 /**
  * Runtime tagged-union narrowing — addresses #686.
  *
- * The `event` field is a `Schema.Union(Created, Updated, Deleted)`. When the
+ * The `event` field is a `Schema.Union([Created, Updated, Deleted])`. When the
  * runtime value carries `_tag: 'Created'`, tooltips, badge, and field
  * annotations narrow to `EventCreated`; same for `'Updated'`.
  */
@@ -977,7 +981,7 @@ const OrderTotalsSchema = Schema.Struct({
     Lineage.freshness({ capturedAt: 'event-time', maxAgeMs: 5_000 }),
     Lineage.foreignKey({ targetSchema: 'Customer', targetField: 'id' }),
   ),
-}).annotations({
+}).annotate({
   identifier: 'OrderTotals',
   title: 'Order Totals',
   description: 'Money breakdown for an order; exercises every lineage kind.',

--- a/packages/@overeng/react-inspector/tsconfig.json
+++ b/packages/@overeng/react-inspector/tsconfig.json
@@ -49,9 +49,5 @@
     "strictNullChecks": false
   },
   "include": ["src/**/*"],
-  "references": [
-    {
-      "path": "../utils"
-    }
-  ]
+  "references": []
 }

--- a/packages/@overeng/react-inspector/tsconfig.json.genie.ts
+++ b/packages/@overeng/react-inspector/tsconfig.json.genie.ts
@@ -21,5 +21,5 @@ export default tsconfigJson({
     noImplicitReturns: false,
   },
   include: ['src/**/*'],
-  references: [{ path: '../utils' }],
+  references: [],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/tui-stories/nix/build.nix
+++ b/packages/@overeng/tui-stories/nix/build.nix
@@ -21,7 +21,7 @@ let
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
       "." = {
-        hash = "sha256-WWN13PiC46GMSZACKIj8xw8lK9xOL3niiz81T9+Pqiw=";
+        hash = "sha256-Tc4Uihleic5jhbj6GHzWs/XXtug6fuUxAfDgGc2TlpE=";
       };
     };
     nativeNodePackages = opentuiCoreNative.packages;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,7 +73,7 @@ importers:
         version: 0.107.0(@effect/cluster@0.59.0(861aab2b2f519122eff8723f7fac38c9))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@effect/vitest':
         specifier: 0.29.0
-        version: 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@overeng/utils-dev':
         specifier: workspace:^
         version: link:../utils-dev
@@ -88,7 +88,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/@overeng/ci-tools:
     dependencies:
@@ -131,7 +131,7 @@ importers:
         version: 0.107.0(@effect/cluster@0.59.0(861aab2b2f519122eff8723f7fac38c9))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@effect/vitest':
         specifier: 0.29.0
-        version: 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@overeng/utils-dev':
         specifier: workspace:^
         version: link:../utils-dev
@@ -146,7 +146,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/@overeng/content-address:
     dependencies:
@@ -159,7 +159,7 @@ importers:
     devDependencies:
       '@effect/vitest':
         specifier: 0.29.0
-        version: 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@overeng/utils-dev':
         specifier: workspace:^
         version: link:../utils-dev
@@ -171,7 +171,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/@overeng/effect-ai-claude-cli:
     devDependencies:
@@ -183,7 +183,7 @@ importers:
         version: 0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4)
       '@effect/vitest':
         specifier: 0.29.0
-        version: 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@overeng/utils-dev':
         specifier: workspace:^
         version: link:../utils-dev
@@ -195,10 +195,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: 8.0.16
-        version: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/@overeng/effect-path:
     devDependencies:
@@ -210,7 +210,7 @@ importers:
         version: 0.107.0(@effect/cluster@0.59.0(861aab2b2f519122eff8723f7fac38c9))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@effect/vitest':
         specifier: 0.29.0
-        version: 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@overeng/utils-dev':
         specifier: workspace:^
         version: link:../utils-dev
@@ -225,7 +225,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/@overeng/effect-react:
     dependencies:
@@ -238,10 +238,10 @@ importers:
         version: link:../utils
       '@storybook/react':
         specifier: 10.4.6
-        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(typescript@6.0.3)
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(typescript@6.0.3)
       '@storybook/react-vite':
         specifier: 10.4.6
-        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@types/react':
         specifier: 19.2.17
         version: 19.2.17
@@ -250,7 +250,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: 6.0.2
-        version: 6.0.2(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 6.0.2(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       effect:
         specifier: 3.21.4
         version: 3.21.4
@@ -265,16 +265,16 @@ importers:
         version: 19.2.7(react@19.2.7)
       storybook:
         specifier: 10.4.6
-        version: 10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       typescript:
         specifier: 6.0.3
         version: 6.0.3
       vite:
         specifier: 8.0.16
-        version: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/@overeng/effect-rpc-tanstack:
     devDependencies:
@@ -301,7 +301,7 @@ importers:
         version: 1.170.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/react-start':
         specifier: 1.168.26
-        version: 1.168.26(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 1.168.26(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@types/react':
         specifier: 19.2.17
         version: 19.2.17
@@ -319,10 +319,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: 8.0.16
-        version: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/@overeng/effect-rpc-tanstack/examples/basic:
     dependencies:
@@ -337,7 +337,7 @@ importers:
         version: 1.170.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/react-start':
         specifier: 1.168.26
-        version: 1.168.26(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 1.168.26(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       effect:
         specifier: 3.21.4
         version: 3.21.4
@@ -356,7 +356,7 @@ importers:
         version: 1.61.0
       '@tanstack/router-plugin':
         specifier: 1.168.18
-        version: 1.168.18(@tanstack/react-router@1.170.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 1.168.18(@tanstack/react-router@1.170.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@types/node':
         specifier: 26.0.0
         version: 26.0.0
@@ -368,13 +368,13 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: 6.0.2
-        version: 6.0.2(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 6.0.2(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       typescript:
         specifier: 6.0.3
         version: 6.0.3
       vite:
         specifier: 8.0.16
-        version: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/@overeng/effect-schema-form:
     devDependencies:
@@ -392,7 +392,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/@overeng/effect-schema-form-aria:
     dependencies:
@@ -405,19 +405,19 @@ importers:
         version: link:../utils
       '@storybook/react':
         specifier: 10.4.6
-        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(typescript@6.0.3)
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(typescript@6.0.3)
       '@storybook/react-vite':
         specifier: 10.4.6
-        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@tailwindcss/vite':
         specifier: 4.3.1
-        version: 4.3.1(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.3.1(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@types/react':
         specifier: 19.2.17
         version: 19.2.17
       '@vitejs/plugin-react':
         specifier: 6.0.2
-        version: 6.0.2(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 6.0.2(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       effect:
         specifier: 3.21.4
         version: 3.21.4
@@ -432,7 +432,7 @@ importers:
         version: 19.2.7(react@19.2.7)
       storybook:
         specifier: 10.4.6
-        version: 10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       tailwindcss:
         specifier: 4.3.1
         version: 4.3.1
@@ -441,10 +441,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: 8.0.16
-        version: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/@overeng/genie:
     dependencies:
@@ -477,7 +477,7 @@ importers:
         version: 0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)
       '@effect/vitest':
         specifier: 0.29.0
-        version: 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@effect/workflow':
         specifier: 0.18.2
         version: 0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
@@ -495,7 +495,7 @@ importers:
         version: 1.61.0
       '@storybook/react':
         specifier: 10.4.6
-        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(typescript@6.0.3)
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(typescript@6.0.3)
       '@types/react':
         specifier: 19.2.17
         version: 19.2.17
@@ -519,7 +519,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
     dependenciesMeta:
       '@overeng/tui-react':
         injected: true
@@ -544,7 +544,7 @@ importers:
         version: link:../utils-dev
       '@storybook/react-vite':
         specifier: 10.4.6
-        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@types/bun':
         specifier: 1.3.14
         version: 1.3.14
@@ -556,13 +556,13 @@ importers:
         version: 3.8.4
       storybook:
         specifier: 10.4.6
-        version: 10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/@overeng/kdl:
     devDependencies:
       '@effect/vitest':
         specifier: 0.29.0
-        version: 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@overeng/utils-dev':
         specifier: workspace:^
         version: link:../utils-dev
@@ -577,7 +577,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/@overeng/kdl-effect:
     dependencies:
@@ -587,7 +587,7 @@ importers:
     devDependencies:
       '@effect/vitest':
         specifier: 0.29.0
-        version: 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@overeng/utils-dev':
         specifier: workspace:^
         version: link:../utils-dev
@@ -602,7 +602,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/@overeng/megarepo:
     dependencies:
@@ -635,7 +635,7 @@ importers:
         version: 0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)
       '@effect/vitest':
         specifier: 0.29.0
-        version: 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@effect/workflow':
         specifier: 0.18.2
         version: 0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
@@ -668,7 +668,7 @@ importers:
         version: 1.61.0
       '@storybook/react':
         specifier: 10.4.6
-        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(typescript@6.0.3)
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(typescript@6.0.3)
       '@types/react':
         specifier: 19.2.17
         version: 19.2.17
@@ -689,7 +689,7 @@ importers:
         version: 0.33.0(react@19.2.7)
       vitest:
         specifier: 4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
     dependenciesMeta:
       '@overeng/tui-react':
         injected: true
@@ -708,7 +708,7 @@ importers:
         version: link:../utils-dev
       '@storybook/react-vite':
         specifier: 10.4.6
-        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@types/bun':
         specifier: 1.3.14
         version: 1.3.14
@@ -717,7 +717,7 @@ importers:
         version: 26.0.0
       '@vitejs/plugin-react':
         specifier: 6.0.2
-        version: 6.0.2(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 6.0.2(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@xterm/addon-fit':
         specifier: 0.11.0
         version: 0.11.0
@@ -726,13 +726,13 @@ importers:
         version: 6.0.0
       storybook:
         specifier: 10.4.6
-        version: 10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       typescript:
         specifier: 6.0.3
         version: 6.0.3
       vite:
         specifier: 8.0.16
-        version: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/@overeng/notion-cli:
     dependencies:
@@ -765,7 +765,7 @@ importers:
         version: 0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)
       '@effect/vitest':
         specifier: 0.29.0
-        version: 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@effect/workflow':
         specifier: 0.18.2
         version: 0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
@@ -780,7 +780,7 @@ importers:
         version: link:../effect-path
       '@overeng/notion-datasource-sync':
         specifier: workspace:^
-        version: file:packages/@overeng/notion-datasource-sync(8961a53a2c1167db99940b01d437ceb7)
+        version: file:packages/@overeng/notion-datasource-sync(4c1b32bf4d87d139b029c3f731dae8b5)
       '@overeng/notion-effect-client':
         specifier: workspace:^
         version: link:../notion-effect-client
@@ -807,7 +807,7 @@ importers:
         version: 1.61.0
       '@storybook/react':
         specifier: 10.4.6
-        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(typescript@6.0.3)
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(typescript@6.0.3)
       '@types/react':
         specifier: 19.2.17
         version: 19.2.17
@@ -828,7 +828,7 @@ importers:
         version: 0.33.0(react@19.2.7)
       vitest:
         specifier: 4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
     dependenciesMeta:
       '@overeng/tui-react':
         injected: true
@@ -844,28 +844,28 @@ importers:
         version: link:../utils-dev
       '@storybook/react-vite':
         specifier: 10.4.6
-        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@types/node':
         specifier: 26.0.0
         version: 26.0.0
       '@vitejs/plugin-react':
         specifier: 6.0.2
-        version: 6.0.2(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 6.0.2(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       storybook:
         specifier: 10.4.6
-        version: 10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       typescript:
         specifier: 6.0.3
         version: 6.0.3
       vite:
         specifier: 8.0.16
-        version: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/@overeng/notion-core:
     devDependencies:
       '@overeng/utils-dev':
         specifier: workspace:^
-        version: link:../utils-dev
+        version: file:packages/@overeng/utils-dev(3ef323b47afd0fd52f21f3adfcfeecab)
       '@types/node':
         specifier: 26.0.0
         version: 26.0.0
@@ -874,7 +874,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/@overeng/notion-datasource-sync:
     dependencies:
@@ -901,7 +901,7 @@ importers:
         version: link:../otel-contract
       '@overeng/tui-react':
         specifier: workspace:^
-        version: file:packages/@overeng/tui-react(42e014f16d8ff36142805d1f94ce3058)
+        version: file:packages/@overeng/tui-react(6798979a39838481330f93862b5e7b0a)
       '@overeng/utils':
         specifier: workspace:^
         version: link:../utils
@@ -941,7 +941,7 @@ importers:
         version: 0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)
       '@effect/vitest':
         specifier: 0.29.0
-        version: 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@effect/workflow':
         specifier: 0.18.2
         version: 0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
@@ -956,7 +956,7 @@ importers:
         version: 1.61.0
       '@storybook/react':
         specifier: 10.4.6
-        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(typescript@6.0.3)
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(typescript@6.0.3)
       '@types/node':
         specifier: 26.0.0
         version: 26.0.0
@@ -980,7 +980,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/@overeng/notion-effect-client:
     dependencies:
@@ -1004,7 +1004,7 @@ importers:
         version: 0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)
       '@effect/vitest':
         specifier: 0.29.0
-        version: 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@effect/workflow':
         specifier: 0.18.2
         version: 0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
@@ -1061,7 +1061,7 @@ importers:
         version: 5.1.0
       vitest:
         specifier: 4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
     devDependencies:
       '@overeng/utils-dev':
         specifier: workspace:^
@@ -1081,7 +1081,7 @@ importers:
     devDependencies:
       '@effect/vitest':
         specifier: 0.29.0
-        version: 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@overeng/utils-dev':
         specifier: workspace:^
         version: link:../utils-dev
@@ -1096,7 +1096,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/@overeng/notion-md:
     dependencies:
@@ -1148,7 +1148,7 @@ importers:
         version: 0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)
       '@effect/vitest':
         specifier: 0.29.0
-        version: 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@effect/workflow':
         specifier: 0.18.2
         version: 0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
@@ -1163,10 +1163,10 @@ importers:
         version: 1.61.0
       '@storybook/react':
         specifier: 10.4.6
-        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(typescript@6.0.3)
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(typescript@6.0.3)
       '@storybook/react-vite':
         specifier: 10.4.6
-        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@types/node':
         specifier: 26.0.0
         version: 26.0.0
@@ -1178,7 +1178,7 @@ importers:
         version: 0.33.0(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: 6.0.2
-        version: 6.0.2(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 6.0.2(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       effect:
         specifier: 3.21.4
         version: 3.21.4
@@ -1193,16 +1193,16 @@ importers:
         version: 0.33.0(react@19.2.7)
       storybook:
         specifier: 10.4.6
-        version: 10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       typescript:
         specifier: 6.0.3
         version: 6.0.3
       vite:
         specifier: 8.0.16
-        version: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/@overeng/notion-property-write:
     dependencies:
@@ -1212,7 +1212,7 @@ importers:
     devDependencies:
       '@effect/vitest':
         specifier: 0.29.0
-        version: 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@overeng/utils-dev':
         specifier: workspace:^
         version: link:../utils-dev
@@ -1227,7 +1227,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/@overeng/notion-react:
     dependencies:
@@ -1251,7 +1251,7 @@ importers:
         version: 0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)
       '@effect/vitest':
         specifier: 0.29.0
-        version: 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@effect/workflow':
         specifier: 0.18.2
         version: 0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
@@ -1272,7 +1272,7 @@ importers:
         version: 3.21.4
       vitest:
         specifier: 4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
     devDependencies:
       '@opentelemetry/api':
         specifier: 1.9.1
@@ -1285,10 +1285,10 @@ importers:
         version: link:../utils-dev
       '@storybook/react':
         specifier: 10.4.6
-        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(typescript@6.0.3)
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(typescript@6.0.3)
       '@storybook/react-vite':
         specifier: 10.4.6
-        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@types/katex':
         specifier: 0.16.8
         version: 0.16.8
@@ -1321,13 +1321,13 @@ importers:
         version: 4.2.0
       storybook:
         specifier: 10.4.6
-        version: 10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       typescript:
         specifier: 6.0.3
         version: 6.0.3
       vite:
         specifier: 8.0.16
-        version: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/@overeng/otel-contract:
     dependencies:
@@ -1349,7 +1349,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/@overeng/oxc-config:
     devDependencies:
@@ -1376,7 +1376,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/@overeng/pty-effect:
     dependencies:
@@ -1389,7 +1389,7 @@ importers:
     devDependencies:
       '@effect/vitest':
         specifier: 0.29.0
-        version: 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@overeng/utils-dev':
         specifier: workspace:^
         version: link:../utils-dev
@@ -1404,50 +1404,23 @@ importers:
         version: 6.0.3
       vite:
         specifier: 8.0.16
-        version: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/@overeng/react-inspector:
     dependencies:
-      '@effect/cluster':
-        specifier: ^0.59.0
-        version: 0.59.0(861aab2b2f519122eff8723f7fac38c9)
-      '@effect/experimental':
-        specifier: ^0.60.0
-        version: 0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)(ioredis@5.11.1)
-      '@effect/opentelemetry':
-        specifier: ^0.63.0
-        version: 0.63.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)(effect@3.21.4)
-      '@effect/platform':
-        specifier: ^0.96.2
-        version: 0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4)
-      '@effect/platform-node':
-        specifier: ^0.107.0
-        version: 0.107.0(@effect/cluster@0.59.0(861aab2b2f519122eff8723f7fac38c9))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
-      '@effect/rpc':
-        specifier: ^0.75.1
-        version: 0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)
-      '@effect/workflow':
-        specifier: ^0.18.2
-        version: 0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
-      '@playwright/test':
-        specifier: ^1.61.0
-        version: 1.61.0
       is-dom:
         specifier: 1.1.0
         version: 1.1.0
     devDependencies:
-      '@overeng/utils':
-        specifier: workspace:^
-        version: link:../utils
       '@storybook/react':
         specifier: 10.4.6
-        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(typescript@6.0.3)
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(typescript@6.0.3)
       '@storybook/react-vite':
         specifier: 10.4.6
-        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@testing-library/react':
         specifier: 16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -1462,10 +1435,10 @@ importers:
         version: 19.2.17
       '@vitejs/plugin-react':
         specifier: 6.0.2
-        version: 6.0.2(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 6.0.2(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       effect:
-        specifier: 3.21.4
-        version: 3.21.4
+        specifier: 4.0.0-beta.98
+        version: 4.0.0-beta.98
       happy-dom:
         specifier: 20.10.6
         version: 20.10.6
@@ -1477,16 +1450,16 @@ importers:
         version: 19.2.7(react@19.2.7)
       storybook:
         specifier: 10.4.6
-        version: 10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       typescript:
         specifier: 6.0.3
         version: 6.0.3
       vite:
         specifier: 8.0.16
-        version: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/@overeng/restate-effect:
     dependencies:
@@ -1526,7 +1499,7 @@ importers:
         version: 0.63.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)(effect@3.21.4)
       '@effect/vitest':
         specifier: 0.29.0
-        version: 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@opentelemetry/api':
         specifier: 1.9.1
         version: 1.9.1
@@ -1571,7 +1544,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/@overeng/tui-core:
     devDependencies:
@@ -1583,7 +1556,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/@overeng/tui-react:
     dependencies:
@@ -1607,7 +1580,7 @@ importers:
         version: 0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)
       '@effect/vitest':
         specifier: 0.29.0
-        version: 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@effect/workflow':
         specifier: 0.18.2
         version: 0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
@@ -1643,7 +1616,7 @@ importers:
         version: 8.2.1
       vitest:
         specifier: 4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       yoga-layout:
         specifier: 3.2.1
         version: 3.2.1
@@ -1668,10 +1641,10 @@ importers:
         version: link:../utils-dev
       '@storybook/react':
         specifier: 10.4.6
-        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(typescript@6.0.3)
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(typescript@6.0.3)
       '@storybook/react-vite':
         specifier: 10.4.6
-        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@types/node':
         specifier: 26.0.0
         version: 26.0.0
@@ -1683,7 +1656,7 @@ importers:
         version: 0.33.0(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: 6.0.2
-        version: 6.0.2(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 6.0.2(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       react:
         specifier: 19.2.7
         version: 19.2.7
@@ -1695,13 +1668,13 @@ importers:
         version: 0.33.0(react@19.2.7)
       storybook:
         specifier: 10.4.6
-        version: 10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       typescript:
         specifier: 6.0.3
         version: 6.0.3
       vite:
         specifier: 8.0.16
-        version: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/@overeng/tui-stories:
     dependencies:
@@ -1740,7 +1713,7 @@ importers:
         version: 0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)
       '@effect/vitest':
         specifier: 0.29.0
-        version: 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@effect/workflow':
         specifier: 0.18.2
         version: 0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
@@ -1764,7 +1737,7 @@ importers:
         version: 1.61.0
       '@storybook/react':
         specifier: 10.4.6
-        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(typescript@6.0.3)
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(typescript@6.0.3)
       '@types/react':
         specifier: 19.2.17
         version: 19.2.17
@@ -1785,7 +1758,7 @@ importers:
         version: 0.33.0(react@19.2.7)
       vitest:
         specifier: 4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
     dependenciesMeta:
       '@overeng/tui-react':
         injected: true
@@ -1798,13 +1771,13 @@ importers:
         version: link:../utils-dev
       '@storybook/react-vite':
         specifier: 10.4.6
-        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@types/node':
         specifier: 26.0.0
         version: 26.0.0
       storybook:
         specifier: 10.4.6
-        version: 10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -1822,7 +1795,7 @@ importers:
         version: 0.107.0(@effect/cluster@0.59.0(861aab2b2f519122eff8723f7fac38c9))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@effect/vitest':
         specifier: 0.29.0
-        version: 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@noble/hashes':
         specifier: 2.2.0
         version: 2.2.0
@@ -1843,7 +1816,7 @@ importers:
         version: 5.11.1
       vitest:
         specifier: 4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
     devDependencies:
       '@effect/cluster':
         specifier: 0.59.0
@@ -1886,19 +1859,19 @@ importers:
         version: 1.61.0
       '@storybook/react-vite':
         specifier: 10.4.6
-        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@types/node':
         specifier: 26.0.0
         version: 26.0.0
       storybook:
         specifier: 10.4.6
-        version: 10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       typescript:
         specifier: 6.0.3
         version: 6.0.3
       vite:
         specifier: 8.0.16
-        version: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/@overeng/utils-dev:
     devDependencies:
@@ -1913,7 +1886,7 @@ importers:
         version: 0.107.0(@effect/cluster@0.59.0(861aab2b2f519122eff8723f7fac38c9))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@effect/vitest':
         specifier: 0.29.0
-        version: 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 26.0.0
         version: 26.0.0
@@ -1925,7 +1898,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
 packages:
 
@@ -2412,8 +2385,18 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
+    resolution: {integrity: sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
     resolution: {integrity: sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4':
+    resolution: {integrity: sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==}
     cpu: [x64]
     os: [darwin]
 
@@ -2422,8 +2405,18 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4':
+    resolution: {integrity: sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==}
+    cpu: [arm64]
+    os: [linux]
+
   '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
     resolution: {integrity: sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4':
+    resolution: {integrity: sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==}
     cpu: [arm]
     os: [linux]
 
@@ -2432,8 +2425,18 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4':
+    resolution: {integrity: sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==}
+    cpu: [x64]
+    os: [linux]
+
   '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
     resolution: {integrity: sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4':
+    resolution: {integrity: sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==}
     cpu: [x64]
     os: [win32]
 
@@ -2652,6 +2655,16 @@ packages:
       react: ^19.2.7
       react-dom: ^19.2.7
       react-reconciler: ^0.33.0
+
+  '@overeng/utils-dev@file:packages/@overeng/utils-dev':
+    resolution: {directory: packages/@overeng/utils-dev, type: directory}
+    peerDependencies:
+      '@effect/opentelemetry': ^0.63.0
+      '@effect/platform': ^0.96.2
+      '@effect/platform-node': ^0.107.0
+      '@effect/vitest': ^0.29.0
+      effect: ^3.21.4
+      vitest: ^4.1.9
 
   '@overeng/utils@file:packages/@overeng/utils':
     resolution: {directory: packages/@overeng/utils, type: directory}
@@ -4111,6 +4124,9 @@ packages:
   effect@3.21.4:
     resolution: {integrity: sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ==}
 
+  effect@4.0.0-beta.98:
+    resolution: {integrity: sha512-oz+bsG5h+6RNrw4t5GMfQrk/xBS8ROoqkYsuvRhBr5O7mCOrpvH/hbw+QrDzvKIpX4HJClwm86F94c87W0sJxg==}
+
   electron-to-chromium@1.5.344:
     resolution: {integrity: sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==}
 
@@ -4212,6 +4228,10 @@ packages:
   fast-check@3.23.2:
     resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
     engines: {node: '>=8.0.0'}
+
+  fast-check@4.9.0:
+    resolution: {integrity: sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==}
+    engines: {node: '>=12.17.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -4329,6 +4349,10 @@ packages:
   ini@4.1.3:
     resolution: {integrity: sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  ini@7.0.0:
+    resolution: {integrity: sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
   ioredis@5.11.1:
     resolution: {integrity: sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==}
@@ -4650,11 +4674,21 @@ packages:
   msgpackr-extract@3.0.3:
     resolution: {integrity: sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==}
 
+  msgpackr-extract@3.0.4:
+    resolution: {integrity: sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==}
+    hasBin: true
+
   msgpackr@1.11.10:
     resolution: {integrity: sha512-iCZNq+HszvF+fC3anCm4nBmWEnbeIAfpDs6IStAEKhQ2YSgkjzVG2FF9XJqwwQh5bH3N9OUTUt4QwVN6MLMLtA==}
 
+  msgpackr@2.0.4:
+    resolution: {integrity: sha512-o1C5KRmuRt+apqMr1HuGSqWStZoRBUpEsCsl15uM9VdAF1qHLtvMOU2En747EnTyEl6c4pzPewRMFF31s1CNbA==}
+
   multipasta@0.2.7:
     resolution: {integrity: sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==}
+
+  multipasta@0.2.8:
+    resolution: {integrity: sha512-ZPWuMKyv0cSO29f7hozp+k6+crZbQijV8ipMvxNxRf2SwtYGTX1ZX89Kd20VV4H9Znonx+EQn+iy1wGQsJ+b+Q==}
 
   nanoid@3.3.13:
     resolution: {integrity: sha512-sPdqC6ByMVVGvF1ynvvMo0/o+oD1VX7DaHhijt1bFgjvBkHBib4t49GoNDhf2NDta4oeUNlaGbSt5K7qjZ955Q==}
@@ -4743,12 +4777,10 @@ packages:
   playwright-core@1.61.0:
     resolution: {integrity: sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==}
     engines: {node: '>=18'}
-    hasBin: true
 
   playwright@1.61.0:
     resolution: {integrity: sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==}
     engines: {node: '>=18'}
-    hasBin: true
 
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
@@ -4775,6 +4807,9 @@ packages:
 
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+
+  pure-rand@8.4.2:
+    resolution: {integrity: sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==}
 
   react-aria-components@1.19.0:
     resolution: {integrity: sha512-2smSS5nqJ8cGYMQezuUXveZm7eMyHCqTN6mDpylQBYLYbdF5dxCCuW1DHn1VKLe1DybSfPvX/cZtJlDmvFfn8A==}
@@ -5041,6 +5076,10 @@ packages:
   toml@3.0.0:
     resolution: {integrity: sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==}
 
+  toml@4.3.0:
+    resolution: {integrity: sha512-lVb8X9BsPVuH0M4BKeS91tXAmJvCjQ5UIyAbQFaxkKGyUFK2RPkhwaFSQH8vbpl1d23eu/IBH+dwVMHWaq9A5A==}
+    engines: {node: '>=20'}
+
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
@@ -5076,7 +5115,6 @@ packages:
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
-    hasBin: true
 
   ufo@1.6.3:
     resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
@@ -5129,6 +5167,9 @@ packages:
 
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+
+  uuid@14.0.1:
+    resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
     hasBin: true
 
   vfile-message@4.0.3:
@@ -5190,7 +5231,6 @@ packages:
   vitest@4.1.9:
     resolution: {integrity: sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
-    hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
@@ -5292,6 +5332,10 @@ packages:
 
   yaml@2.8.3:
     resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
 
@@ -5465,10 +5509,27 @@ snapshots:
       effect: 3.21.4
       kubernetes-types: 1.30.0
 
+  '@effect/cluster@0.59.0(a861707c884fd639fa58e997bd8ab378)':
+    dependencies:
+      '@effect/platform': 0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98)
+      '@effect/rpc': 0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98))(effect@4.0.0-beta.98)
+      '@effect/sql': 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98))(effect@4.0.0-beta.98)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98))(effect@4.0.0-beta.98)
+      '@effect/workflow': 0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98))(effect@4.0.0-beta.98)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98))(@effect/rpc@0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98))(effect@4.0.0-beta.98))(effect@4.0.0-beta.98)
+      effect: 4.0.0-beta.98
+      kubernetes-types: 1.30.0
+
   '@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)(ioredis@5.11.1)':
     dependencies:
       '@effect/platform': 0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4)
       effect: 3.21.4
+      uuid: 11.1.0
+    optionalDependencies:
+      ioredis: 5.11.1
+
+  '@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98))(effect@4.0.0-beta.98)(ioredis@5.11.1)':
+    dependencies:
+      '@effect/platform': 0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98)
+      effect: 4.0.0-beta.98
       uuid: 11.1.0
     optionalDependencies:
       ioredis: 5.11.1
@@ -5486,6 +5547,19 @@ snapshots:
       '@opentelemetry/semantic-conventions': 1.41.1
       effect: 3.21.4
 
+  '@effect/opentelemetry@0.63.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98))(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)(effect@4.0.0-beta.98)':
+    dependencies:
+      '@effect/platform': 0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.219.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-node': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-web': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+      effect: 4.0.0-beta.98
+
   '@effect/platform-node-shared@0.60.0(@effect/cluster@0.59.0(861aab2b2f519122eff8723f7fac38c9))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)':
     dependencies:
       '@effect/cluster': 0.59.0(861aab2b2f519122eff8723f7fac38c9)
@@ -5494,6 +5568,20 @@ snapshots:
       '@effect/sql': 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)
       '@parcel/watcher': 2.5.6
       effect: 3.21.4
+      multipasta: 0.2.7
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@effect/platform-node-shared@0.60.0(@effect/cluster@0.59.0(a861707c884fd639fa58e997bd8ab378))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98))(@effect/rpc@0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98))(effect@4.0.0-beta.98))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98))(effect@4.0.0-beta.98)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98))(effect@4.0.0-beta.98))(effect@4.0.0-beta.98)':
+    dependencies:
+      '@effect/cluster': 0.59.0(a861707c884fd639fa58e997bd8ab378)
+      '@effect/platform': 0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98)
+      '@effect/rpc': 0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98))(effect@4.0.0-beta.98)
+      '@effect/sql': 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98))(effect@4.0.0-beta.98)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98))(effect@4.0.0-beta.98)
+      '@parcel/watcher': 2.5.6
+      effect: 4.0.0-beta.98
       multipasta: 0.2.7
       ws: 8.21.0
     transitivePeerDependencies:
@@ -5515,9 +5603,31 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  '@effect/platform-node@0.107.0(@effect/cluster@0.59.0(a861707c884fd639fa58e997bd8ab378))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98))(@effect/rpc@0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98))(effect@4.0.0-beta.98))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98))(effect@4.0.0-beta.98)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98))(effect@4.0.0-beta.98))(effect@4.0.0-beta.98)':
+    dependencies:
+      '@effect/cluster': 0.59.0(a861707c884fd639fa58e997bd8ab378)
+      '@effect/platform': 0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98)
+      '@effect/platform-node-shared': 0.60.0(@effect/cluster@0.59.0(a861707c884fd639fa58e997bd8ab378))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98))(@effect/rpc@0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98))(effect@4.0.0-beta.98))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98))(effect@4.0.0-beta.98)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98))(effect@4.0.0-beta.98))(effect@4.0.0-beta.98)
+      '@effect/rpc': 0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98))(effect@4.0.0-beta.98)
+      '@effect/sql': 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98))(effect@4.0.0-beta.98)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98))(effect@4.0.0-beta.98)
+      effect: 4.0.0-beta.98
+      mime: 3.0.0
+      undici: 7.25.0
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4)':
     dependencies:
       effect: 3.21.4
+      find-my-way-ts: 0.1.6
+      msgpackr: 1.11.10
+      multipasta: 0.2.7
+
+  '@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98)':
+    dependencies:
+      effect: 4.0.0-beta.98
       find-my-way-ts: 0.1.6
       msgpackr: 1.11.10
       multipasta: 0.2.7
@@ -5539,6 +5649,12 @@ snapshots:
       effect: 3.21.4
       msgpackr: 1.11.10
 
+  '@effect/rpc@0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98))(effect@4.0.0-beta.98)':
+    dependencies:
+      '@effect/platform': 0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98)
+      effect: 4.0.0-beta.98
+      msgpackr: 1.11.10
+
   '@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)':
     dependencies:
       '@effect/experimental': 0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)(ioredis@5.11.1)
@@ -5546,14 +5662,26 @@ snapshots:
       effect: 3.21.4
       uuid: 11.1.0
 
+  '@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98))(effect@4.0.0-beta.98)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98))(effect@4.0.0-beta.98)':
+    dependencies:
+      '@effect/experimental': 0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98))(effect@4.0.0-beta.98)(ioredis@5.11.1)
+      '@effect/platform': 0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98)
+      effect: 4.0.0-beta.98
+      uuid: 11.1.0
+
   '@effect/typeclass@0.40.0(effect@3.21.4)':
     dependencies:
       effect: 3.21.4
 
-  '@effect/vitest@0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))':
+  '@effect/vitest@0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))':
     dependencies:
       effect: 3.21.4
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+
+  '@effect/vitest@0.29.0(effect@4.0.0-beta.98)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))':
+    dependencies:
+      effect: 4.0.0-beta.98
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   '@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)':
     dependencies:
@@ -5561,6 +5689,13 @@ snapshots:
       '@effect/platform': 0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4)
       '@effect/rpc': 0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)
       effect: 3.21.4
+
+  '@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98))(effect@4.0.0-beta.98)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98))(@effect/rpc@0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98))(effect@4.0.0-beta.98))(effect@4.0.0-beta.98)':
+    dependencies:
+      '@effect/experimental': 0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98))(effect@4.0.0-beta.98)(ioredis@5.11.1)
+      '@effect/platform': 0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98)
+      '@effect/rpc': 0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98))(effect@4.0.0-beta.98)
+      effect: 4.0.0-beta.98
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -5743,11 +5878,11 @@ snapshots:
 
   '@ioredis/commands@1.10.0': {}
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       glob: 13.0.6
       react-docgen-typescript: 2.4.0(typescript@6.0.3)
-      vite: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
     optionalDependencies:
       typescript: 6.0.3
 
@@ -5773,19 +5908,37 @@ snapshots:
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     optional: true
 
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
+    optional: true
+
   '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4':
     optional: true
 
   '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
     optional: true
 
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4':
+    optional: true
+
   '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4':
     optional: true
 
   '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
     optional: true
 
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4':
+    optional: true
+
   '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4':
     optional: true
 
   '@myobie/pty@0.10.0(patch_hash=e6d9b2f6990efbb98235e6e4018e3e9bb5ac94bc54ea6764364857206b6b95a5)':
@@ -5955,7 +6108,7 @@ snapshots:
 
   '@overeng/notion-core@file:packages/@overeng/notion-core': {}
 
-  '@overeng/notion-datasource-sync@file:packages/@overeng/notion-datasource-sync(8961a53a2c1167db99940b01d437ceb7)':
+  '@overeng/notion-datasource-sync@file:packages/@overeng/notion-datasource-sync(4c1b32bf4d87d139b029c3f731dae8b5)':
     dependencies:
       '@effect/cli': 0.75.2(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@effect/cluster': 0.59.0(861aab2b2f519122eff8723f7fac38c9)
@@ -5967,13 +6120,13 @@ snapshots:
       '@effect/workflow': 0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@overeng/content-address': file:packages/@overeng/content-address
       '@overeng/notion-core': file:packages/@overeng/notion-core
-      '@overeng/notion-effect-client': file:packages/@overeng/notion-effect-client(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)(@types/node@26.0.0)(happy-dom@20.10.6)(ioredis@5.11.1)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@overeng/notion-effect-client': file:packages/@overeng/notion-effect-client(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)(@types/node@26.0.0)(happy-dom@20.10.6)(ioredis@5.11.1)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@overeng/notion-effect-schema': file:packages/@overeng/notion-effect-schema(effect@3.21.4)
-      '@overeng/notion-md': file:packages/@overeng/notion-md(156d7d85520f823baaad6771d85132e3)
+      '@overeng/notion-md': file:packages/@overeng/notion-md(e050c1a9919203d858ee780abec2aa8c)
       '@overeng/notion-property-write': file:packages/@overeng/notion-property-write(effect@3.21.4)
       '@overeng/otel-contract': file:packages/@overeng/otel-contract(effect@3.21.4)
-      '@overeng/tui-react': file:packages/@overeng/tui-react(963b4abc7688066e8a39338d8dd489ad)
-      '@overeng/utils': file:packages/@overeng/utils(d3fbded9548a79913cb43ce3b598dbe4)
+      '@overeng/tui-react': file:packages/@overeng/tui-react(f46a82eee0022b02039fb6985530b658)
+      '@overeng/utils': file:packages/@overeng/utils(164a3c7e6db43b522d428b3c2aa22201)
       '@playwright/test': 1.61.0
       effect: 3.21.4
       react: 19.2.7
@@ -6015,7 +6168,7 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@overeng/notion-effect-client@file:packages/@overeng/notion-effect-client(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)(@types/node@26.0.0)(happy-dom@20.10.6)(ioredis@5.11.1)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@overeng/notion-effect-client@file:packages/@overeng/notion-effect-client(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)(@types/node@26.0.0)(happy-dom@20.10.6)(ioredis@5.11.1)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@effect/cluster': 0.59.0(861aab2b2f519122eff8723f7fac38c9)
       '@effect/experimental': 0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)(ioredis@5.11.1)
@@ -6023,13 +6176,13 @@ snapshots:
       '@effect/platform': 0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4)
       '@effect/platform-node': 0.107.0(@effect/cluster@0.59.0(861aab2b2f519122eff8723f7fac38c9))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@effect/rpc': 0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)
-      '@effect/vitest': 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))
+      '@effect/vitest': 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@effect/workflow': 0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@overeng/content-address': file:packages/@overeng/content-address
       '@overeng/notion-core': file:packages/@overeng/notion-core
       '@overeng/notion-effect-schema': file:packages/@overeng/notion-effect-schema(effect@3.21.4)
       '@overeng/otel-contract': file:packages/@overeng/otel-contract(effect@3.21.4)
-      '@overeng/utils': file:packages/@overeng/utils(d3fbded9548a79913cb43ce3b598dbe4)
+      '@overeng/utils': file:packages/@overeng/utils(164a3c7e6db43b522d428b3c2aa22201)
       '@playwright/test': 1.61.0
       effect: 3.21.4
       mdast-util-gfm-strikethrough: 2.0.0
@@ -6042,7 +6195,7 @@ snapshots:
       remark-stringify: 11.0.0
       unified: 11.0.5
       unist-util-visit: 5.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@effect/sql'
@@ -6077,7 +6230,7 @@ snapshots:
       '@overeng/notion-core': file:packages/@overeng/notion-core
       effect: 3.21.4
 
-  '@overeng/notion-md@file:packages/@overeng/notion-md(156d7d85520f823baaad6771d85132e3)':
+  '@overeng/notion-md@file:packages/@overeng/notion-md(e050c1a9919203d858ee780abec2aa8c)':
     dependencies:
       '@effect/cli': 0.75.2(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@effect/cluster': 0.59.0(861aab2b2f519122eff8723f7fac38c9)
@@ -6089,11 +6242,11 @@ snapshots:
       '@effect/workflow': 0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@overeng/content-address': file:packages/@overeng/content-address
       '@overeng/notion-core': file:packages/@overeng/notion-core
-      '@overeng/notion-effect-client': file:packages/@overeng/notion-effect-client(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)(@types/node@26.0.0)(happy-dom@20.10.6)(ioredis@5.11.1)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@overeng/notion-effect-client': file:packages/@overeng/notion-effect-client(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)(@types/node@26.0.0)(happy-dom@20.10.6)(ioredis@5.11.1)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@overeng/notion-effect-schema': file:packages/@overeng/notion-effect-schema(effect@3.21.4)
       '@overeng/notion-property-write': file:packages/@overeng/notion-property-write(effect@3.21.4)
       '@overeng/otel-contract': file:packages/@overeng/otel-contract(effect@3.21.4)
-      '@overeng/utils': file:packages/@overeng/utils(d3fbded9548a79913cb43ce3b598dbe4)
+      '@overeng/utils': file:packages/@overeng/utils(164a3c7e6db43b522d428b3c2aa22201)
       '@playwright/test': 1.61.0
       effect: 3.21.4
     transitivePeerDependencies:
@@ -6137,7 +6290,7 @@ snapshots:
 
   '@overeng/tui-core@file:packages/@overeng/tui-core': {}
 
-  '@overeng/tui-react@file:packages/@overeng/tui-react(42e014f16d8ff36142805d1f94ce3058)':
+  '@overeng/tui-react@file:packages/@overeng/tui-react(6798979a39838481330f93862b5e7b0a)':
     dependencies:
       '@effect-atom/atom': 0.5.3(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@effect-atom/atom-react': 0.5.0(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)(react@19.2.7)(scheduler@0.27.0)
@@ -6148,14 +6301,14 @@ snapshots:
       '@effect/platform': 0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4)
       '@effect/platform-node': 0.107.0(@effect/cluster@0.59.0(861aab2b2f519122eff8723f7fac38c9))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@effect/rpc': 0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)
-      '@effect/vitest': 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))
+      '@effect/vitest': 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@effect/workflow': 0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@opentui/core': 0.4.1(typescript@6.0.3)(web-tree-sitter@0.25.10)
       '@opentui/react': 0.4.1(react-devtools-core@7.0.1)(react@19.2.7)(typescript@6.0.3)(web-tree-sitter@0.25.10)(ws@8.21.0)
       '@overeng/tui-core': file:packages/@overeng/tui-core
-      '@overeng/utils': file:packages/@overeng/utils(d3fbded9548a79913cb43ce3b598dbe4)
+      '@overeng/utils': file:packages/@overeng/utils(164a3c7e6db43b522d428b3c2aa22201)
       '@playwright/test': 1.61.0
-      '@storybook/react': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(typescript@6.0.3)
+      '@storybook/react': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(typescript@6.0.3)
       '@types/react': 19.2.17
       '@types/react-reconciler': 0.33.0(@types/react@19.2.17)
       '@xterm/addon-fit': 0.11.0
@@ -6168,7 +6321,7 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
       react-reconciler: 0.33.0(react@19.2.7)
       string-width: 8.2.1
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       yoga-layout: 3.2.1
     transitivePeerDependencies:
       - '@edge-runtime/vm'
@@ -6197,7 +6350,7 @@ snapshots:
       - typescript
       - vite
 
-  '@overeng/tui-react@file:packages/@overeng/tui-react(963b4abc7688066e8a39338d8dd489ad)':
+  '@overeng/tui-react@file:packages/@overeng/tui-react(f46a82eee0022b02039fb6985530b658)':
     dependencies:
       '@effect-atom/atom': 0.5.3(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@effect-atom/atom-react': 0.5.0(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)(react@19.2.7)(scheduler@0.27.0)
@@ -6208,14 +6361,14 @@ snapshots:
       '@effect/platform': 0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4)
       '@effect/platform-node': 0.107.0(@effect/cluster@0.59.0(861aab2b2f519122eff8723f7fac38c9))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@effect/rpc': 0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)
-      '@effect/vitest': 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))
+      '@effect/vitest': 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@effect/workflow': 0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@opentui/core': 0.4.1(typescript@6.0.3)(web-tree-sitter@0.25.10)
       '@opentui/react': 0.4.1(react-devtools-core@7.0.1)(react@19.2.7)(typescript@6.0.3)(web-tree-sitter@0.25.10)(ws@8.21.0)
       '@overeng/tui-core': file:packages/@overeng/tui-core
-      '@overeng/utils': file:packages/@overeng/utils(d3fbded9548a79913cb43ce3b598dbe4)
+      '@overeng/utils': file:packages/@overeng/utils(164a3c7e6db43b522d428b3c2aa22201)
       '@playwright/test': 1.61.0
-      '@storybook/react': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(typescript@6.0.3)
+      '@storybook/react': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(typescript@6.0.3)
       '@types/react': 19.2.17
       '@types/react-reconciler': 0.33.0(@types/react@19.2.17)
       '@xterm/addon-fit': 0.11.0
@@ -6228,7 +6381,7 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
       react-reconciler: 0.33.0(react@19.2.7)
       string-width: 8.2.1
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       yoga-layout: 3.2.1
     transitivePeerDependencies:
       - '@edge-runtime/vm'
@@ -6257,7 +6410,16 @@ snapshots:
       - typescript
       - vite
 
-  '@overeng/utils@file:packages/@overeng/utils(d3fbded9548a79913cb43ce3b598dbe4)':
+  '@overeng/utils-dev@file:packages/@overeng/utils-dev(3ef323b47afd0fd52f21f3adfcfeecab)':
+    dependencies:
+      '@effect/opentelemetry': 0.63.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98))(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)(effect@4.0.0-beta.98)
+      '@effect/platform': 0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98)
+      '@effect/platform-node': 0.107.0(@effect/cluster@0.59.0(a861707c884fd639fa58e997bd8ab378))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98))(@effect/rpc@0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98))(effect@4.0.0-beta.98))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98))(effect@4.0.0-beta.98)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@4.0.0-beta.98))(effect@4.0.0-beta.98))(effect@4.0.0-beta.98)
+      '@effect/vitest': 0.29.0(effect@4.0.0-beta.98)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      effect: 4.0.0-beta.98
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+
+  '@overeng/utils@file:packages/@overeng/utils(164a3c7e6db43b522d428b3c2aa22201)':
     dependencies:
       '@effect/cluster': 0.59.0(861aab2b2f519122eff8723f7fac38c9)
       '@effect/experimental': 0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)(ioredis@5.11.1)
@@ -6265,7 +6427,7 @@ snapshots:
       '@effect/platform': 0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4)
       '@effect/platform-node': 0.107.0(@effect/cluster@0.59.0(861aab2b2f519122eff8723f7fac38c9))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@effect/rpc': 0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)
-      '@effect/vitest': 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))
+      '@effect/vitest': 0.29.0(effect@3.21.4)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       '@effect/workflow': 0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4)(ioredis@5.11.1))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@noble/hashes': 2.2.0
       '@opentelemetry/api': 1.9.1
@@ -6274,7 +6436,7 @@ snapshots:
       effect: 3.21.4
       effect-distributed-lock: 0.0.11(patch_hash=a365d5c8857e3a421ea3b83b6be483433a5a75b344072aa68c4c984b14ec5a0b)(effect@3.21.4)(ioredis@5.11.1)(typescript@6.0.3)
       ioredis: 5.11.1
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@types/node'
@@ -6700,44 +6862,44 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@storybook/builder-vite@10.4.6(esbuild@0.27.7)(rollup@4.60.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@storybook/builder-vite@10.4.6(esbuild@0.27.7)(rollup@4.60.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
-      '@storybook/csf-plugin': 10.4.6(esbuild@0.27.7)(rollup@4.60.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
-      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.27.7)(rollup@4.60.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       ts-dedent: 2.2.0
-      vite: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - esbuild
       - rollup
       - webpack
 
-  '@storybook/builder-vite@10.4.6(esbuild@0.27.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@storybook/builder-vite@10.4.6(esbuild@0.27.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
-      '@storybook/csf-plugin': 10.4.6(esbuild@0.27.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
-      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.27.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       ts-dedent: 2.2.0
-      vite: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - esbuild
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.4.6(esbuild@0.27.7)(rollup@4.60.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@storybook/csf-plugin@10.4.6(esbuild@0.27.7)(rollup@4.60.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
-      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.27.7
       rollup: 4.60.2
-      vite: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
-  '@storybook/csf-plugin@10.4.6(esbuild@0.27.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@storybook/csf-plugin@10.4.6(esbuild@0.27.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
-      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.27.7
-      vite: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@storybook/global@5.0.0': {}
 
@@ -6746,39 +6908,39 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  '@storybook/react-dom-shim@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))':
+  '@storybook/react-dom-shim@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))':
     dependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  '@storybook/react-dom-shim@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))':
+  '@storybook/react-dom-shim@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))':
     dependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  '@storybook/react-vite@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@storybook/react-vite@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@rollup/pluginutils': 5.3.0(rollup@4.60.2)
-      '@storybook/builder-vite': 10.4.6(esbuild@0.27.7)(rollup@4.60.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
-      '@storybook/react': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(typescript@6.0.3)
+      '@storybook/builder-vite': 10.4.6(esbuild@0.27.7)(rollup@4.60.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@storybook/react': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(typescript@6.0.3)
       empathic: 2.0.0
       magic-string: 0.30.21
       react: 19.2.7
       react-docgen: 8.0.3
       react-dom: 19.2.7(react@19.2.7)
       resolve: 1.22.12
-      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       tsconfig-paths: 4.2.0
-      vite: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
@@ -6788,21 +6950,21 @@ snapshots:
       - typescript
       - webpack
 
-  '@storybook/react-vite@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@storybook/react-vite@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@rollup/pluginutils': 5.3.0(rollup@4.60.2)
-      '@storybook/builder-vite': 10.4.6(esbuild@0.27.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
-      '@storybook/react': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(typescript@6.0.3)
+      '@storybook/builder-vite': 10.4.6(esbuild@0.27.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@storybook/react': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(typescript@6.0.3)
       empathic: 2.0.0
       magic-string: 0.30.21
       react: 19.2.7
       react-docgen: 8.0.3
       react-dom: 19.2.7(react@19.2.7)
       resolve: 1.22.12
-      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       tsconfig-paths: 4.2.0
-      vite: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
@@ -6812,15 +6974,15 @@ snapshots:
       - typescript
       - webpack
 
-  '@storybook/react@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(typescript@6.0.3)':
+  '@storybook/react@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(typescript@6.0.3)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))
+      '@storybook/react-dom-shim': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       react: 19.2.7
       react-docgen: 8.0.3
       react-docgen-typescript: 2.4.0(typescript@6.0.3)
       react-dom: 19.2.7(react@19.2.7)
-      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
@@ -6828,15 +6990,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@storybook/react@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(typescript@6.0.3)':
+  '@storybook/react@10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(typescript@6.0.3)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))
+      '@storybook/react-dom-shim': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
       react: 19.2.7
       react-docgen: 8.0.3
       react-docgen-typescript: 2.4.0(typescript@6.0.3)
       react-dom: 19.2.7(react@19.2.7)
-      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
@@ -6909,12 +7071,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.1
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.1
 
-  '@tailwindcss/vite@4.3.1(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@tailwindcss/vite@4.3.1(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@tailwindcss/node': 4.3.1
       '@tailwindcss/oxide': 4.3.1
       tailwindcss: 4.3.1
-      vite: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@tanstack/history@1.162.0': {}
 
@@ -6935,14 +7097,14 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  '@tanstack/react-start-rsc@0.1.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@tanstack/react-start-rsc@0.1.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@tanstack/react-router': 1.170.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/router-core': 1.171.13
       '@tanstack/router-utils': 1.162.2
       '@tanstack/start-client-core': 1.170.12
       '@tanstack/start-fn-stubs': 1.162.0
-      '@tanstack/start-plugin-core': 1.171.18(@tanstack/react-router@1.170.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@tanstack/start-plugin-core': 1.171.18(@tanstack/react-router@1.170.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@tanstack/start-server-core': 1.169.15
       '@tanstack/start-storage-context': 1.167.15
       pathe: 2.0.3
@@ -6966,21 +7128,21 @@ snapshots:
     transitivePeerDependencies:
       - crossws
 
-  '@tanstack/react-start@1.168.26(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@tanstack/react-start@1.168.26(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@tanstack/react-router': 1.170.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/react-start-client': 1.168.14(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@tanstack/react-start-rsc': 0.1.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@tanstack/react-start-rsc': 0.1.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@tanstack/react-start-server': 1.167.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/router-utils': 1.162.2
       '@tanstack/start-client-core': 1.170.12
-      '@tanstack/start-plugin-core': 1.171.18(@tanstack/react-router@1.170.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@tanstack/start-plugin-core': 1.171.18(@tanstack/react-router@1.170.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@tanstack/start-server-core': 1.169.15
       pathe: 2.0.3
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      vite: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - crossws
@@ -7016,7 +7178,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.168.18(@tanstack/react-router@1.170.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@tanstack/router-plugin@1.168.18(@tanstack/react-router@1.170.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/template': 7.28.6
@@ -7029,7 +7191,7 @@ snapshots:
       zod: 4.4.3
     optionalDependencies:
       '@tanstack/react-router': 1.170.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      vite: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -7055,14 +7217,14 @@ snapshots:
 
   '@tanstack/start-fn-stubs@1.162.0': {}
 
-  '@tanstack/start-plugin-core@1.171.18(@tanstack/react-router@1.170.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@tanstack/start-plugin-core@1.171.18(@tanstack/react-router@1.170.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/core': 7.29.0
       '@babel/types': 7.29.0
       '@tanstack/router-core': 1.171.13
       '@tanstack/router-generator': 1.167.17
-      '@tanstack/router-plugin': 1.168.18(@tanstack/react-router@1.170.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@tanstack/router-plugin': 1.168.18(@tanstack/react-router@1.170.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@tanstack/router-utils': 1.162.2
       '@tanstack/start-server-core': 1.169.15
       exsolve: 1.0.8
@@ -7074,11 +7236,11 @@ snapshots:
       srvx: 0.11.16
       tinyglobby: 0.2.17
       ufo: 1.6.3
-      vitefu: 1.1.3(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitefu: 1.1.3(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       xmlbuilder2: 4.0.3
       zod: 4.4.3
     optionalDependencies:
-      vite: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@tanstack/react-router'
       - crossws
@@ -7315,10 +7477,10 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -7337,13 +7499,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.9(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.9(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -7589,6 +7751,19 @@ snapshots:
       '@standard-schema/spec': 1.1.0
       fast-check: 3.23.2
 
+  effect@4.0.0-beta.98:
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      fast-check: 4.9.0
+      find-my-way-ts: 0.1.6
+      ini: 7.0.0
+      kubernetes-types: 1.30.0
+      msgpackr: 2.0.4
+      multipasta: 0.2.8
+      toml: 4.3.0
+      uuid: 14.0.1
+      yaml: 2.9.0
+
   electron-to-chromium@1.5.344: {}
 
   emoji-regex@10.6.0: {}
@@ -7723,6 +7898,10 @@ snapshots:
     dependencies:
       pure-rand: 6.1.0
 
+  fast-check@4.9.0:
+    dependencies:
+      pure-rand: 8.4.2
+
   fast-deep-equal@3.1.3: {}
 
   fast-json-stable-stringify@2.1.0: {}
@@ -7831,6 +8010,8 @@ snapshots:
   indent-string@4.0.0: {}
 
   ini@4.1.3: {}
+
+  ini@7.0.0: {}
 
   ioredis@5.11.1:
     dependencies:
@@ -8252,11 +8433,29 @@ snapshots:
       '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.3
     optional: true
 
+  msgpackr-extract@3.0.4:
+    dependencies:
+      node-gyp-build-optional-packages: 5.2.2
+    optionalDependencies:
+      '@msgpackr-extract/msgpackr-extract-darwin-arm64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-darwin-x64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-linux-arm': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-linux-arm64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-linux-x64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.4
+    optional: true
+
   msgpackr@1.11.10:
     optionalDependencies:
       msgpackr-extract: 3.0.3
 
+  msgpackr@2.0.4:
+    optionalDependencies:
+      msgpackr-extract: 3.0.4
+
   multipasta@0.2.7: {}
+
+  multipasta@0.2.8: {}
 
   nanoid@3.3.13: {}
 
@@ -8413,6 +8612,8 @@ snapshots:
   punycode@2.3.1: {}
 
   pure-rand@6.1.0: {}
+
+  pure-rand@8.4.2: {}
 
   react-aria-components@1.19.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
@@ -8661,11 +8862,11 @@ snapshots:
 
   std-env@4.1.0: {}
 
-  storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)):
+  storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@storybook/react-vite': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@storybook/react-vite': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@testing-library/jest-dom': 6.9.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
       '@vitest/expect': 3.2.4
@@ -8695,11 +8896,11 @@ snapshots:
       - vite
       - webpack
 
-  storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)):
+  storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@storybook/react-vite': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@storybook/react-vite': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@testing-library/jest-dom': 6.9.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
       '@vitest/expect': 3.2.4
@@ -8785,6 +8986,8 @@ snapshots:
   tinyspy@4.0.4: {}
 
   toml@3.0.0: {}
+
+  toml@4.3.0: {}
 
   trim-lines@3.0.1: {}
 
@@ -8886,6 +9089,8 @@ snapshots:
 
   uuid@11.1.0: {}
 
+  uuid@14.0.1: {}
+
   vfile-message@4.0.3:
     dependencies:
       '@types/unist': 3.0.3
@@ -8896,7 +9101,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3):
+  vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -8909,16 +9114,16 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.7.0
       tsx: 4.21.0
-      yaml: 2.8.3
+      yaml: 2.9.0
 
-  vitefu@1.1.3(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)):
+  vitefu@1.1.3(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)):
     optionalDependencies:
-      vite: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
-  vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.9
-      '@vitest/mocker': 4.1.9(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.9(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.9
       '@vitest/runner': 4.1.9
       '@vitest/snapshot': 4.1.9
@@ -8935,7 +9140,7 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -8979,6 +9184,8 @@ snapshots:
   yallist@3.1.1: {}
 
   yaml@2.8.3: {}
+
+  yaml@2.9.0: {}
 
   yocto-queue@0.1.0: {}
 

--- a/pnpm-workspace.yaml.genie.ts
+++ b/pnpm-workspace.yaml.genie.ts
@@ -9,6 +9,15 @@ export default pnpmWorkspaceYaml.root({
   catalogVersions: catalog,
   catalogDuplicateExceptions: [
     {
+      package: 'effect',
+      // The inspector directly consumes Effect 4 schemas from LiveStore. Keep
+      // an exact Effect 4 development install for its tests while the published
+      // package uses the consumer's peer instance; never cast across majors.
+      reason:
+        '@overeng/react-inspector tests against Effect 4 while the repository catalog remains on Effect 3; published consumers provide Effect through its peer contract',
+      issue: '#925',
+    },
+    {
       package: 'string-width',
       // @opentui/core@0.4.1 (latest) pins string-width@7.2.0 exactly, so pnpm
       // dedupe cannot collapse it onto the catalog 8.x. We deliberately do NOT


### PR DESCRIPTION
## Problem

`@overeng/react-inspector` interpreted Effect 4 schemas with Effect 3 AST APIs inherited through `@overeng/utils`. LiveStore Devtools passes consumer-created Effect 4 schemas into the inspector, which could crash while reading missing Effect 3 annotation structures.

## Goal

Inspect and render consumer-created Effect 4 schemas without cross-major casts or a private Effect runtime, while preserving schema annotations, checks, containers, tagged-union narrowing, and Lineage metadata.

## Decisions

- Publish `effect` as `^4.0.0-beta.97` peer dependency. The exact `4.0.0-beta.98` dependency is development-only; this accepts both the current Devtools beta.97 cohort and contrib beta.98 cohort.
- Replace the Effect 3 `@overeng/utils` Lineage dependency with a package-local Effect 4 implementation. Importing the shared utility would retain the cross-major runtime boundary.
- Model inspection inputs as an AST-only `SchemaView`, rather than manufacturing full schema values or casting between Effect majors.
- Resolve Effect 4 annotations from AST nodes and check nodes, including custom pretty formatters and `check.annotations.meta` constraint metadata.
- Inline the small Storybook config so the package's development render path no longer loads Effect 3 through `@overeng/utils`.

## Verification

- `devenv tasks run ts:check:strict --show-output`: passed repository-wide.
- `devenv tasks run lint:check --show-output`: passed repository-wide with 0 diagnostics.
- `vitest run --config vitest.config.ts`: 6 files, 34 tests passed.
- Targeted Storybook TypeScript check over `stories/effect-schema.stories.tsx`: passed.
- `storybook build`: 268 modules transformed; production Storybook build completed successfully with no undefined Effect imports.
- `oxfmt --check`: 15 files passed.
- `git diff --check`: passed.
- Packed-consumer proof with `effect@4.0.0-beta.97`: rendered `Consumer.Schema` and `Ada`; `pnpm list effect --depth 2` showed one beta.97 consumer instance satisfying the inspector peer.
- The same rebuilt tarball with `effect@4.0.0-beta.98`: rendered the same schema; dependency proof showed one beta.98 consumer instance satisfying the peer.
- Cold and independent `--rebuild` Nix proofs passed for the affected pnpm fixed-output closures; the consuming `.#notion-md` package also compiled and passed its CLI smoke test.

## Complexity

The package-local Lineage module is deliberate duplication at the major-version boundary. Reusing the current shared module would reintroduce Effect 3; issue #925 tracks removal of this temporary repository-wide split.

## Concerns

Effect 4 remains prerelease. The peer starts at the oldest directly proven cohort (beta.97), and the package development suite pins beta.98 so API drift is visible.

## Friction & bottlenecks

The lockfile change invalidated several pnpm fixed-output hashes across repository CLI closures. Those hashes are now refreshed and independently rebuilt; full configured lint, strict TypeScript, FOD, Storybook, bundle, and integration checks pass locally or in CI.

## Follow-ups

- #925 tracks repository-wide Effect 4 migration and removal of the temporary dual-major development exception.

## References

Refs #925

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | ☁️ co3-billow |
| `agent_session_id` | 7f3b9666-034f-4e9e-890b-491957f7f75b |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.144.1 |
| `agent_runtime` | Codex CLI 0.144.1 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/1n76sy6i9y3ki3k4w04jksqvygw67sj0-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/jn6r0r7r59x3a525jch4pwzwykszqp60-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils-react-inspector-effect4/schickling/2026-07-17-react-inspector-effect4 |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@4eac376 |
</details>
<!-- agent-footer:end -->