### PR TITLE
fix(pnpm): honor exports over stale main targets

### DIFF
--- a/nix/devenv-modules/tasks/shared/check-node-modules-projection-health.cjs
+++ b/nix/devenv-modules/tasks/shared/check-node-modules-projection-health.cjs
@@ -140,7 +140,10 @@ const verifyPackageContent = ({ pkg, packageDir, entryPath, failures }) => {
     : []
   if (includedFiles.length === 0) return
 
-  if (typeof pkg.main === 'string') {
+  // Node gives `exports` precedence over the legacy `main` entry point. Some
+  // packages retain a stale `main` after moving their supported entry points
+  // behind `exports`, so only validate `main` when it is authoritative.
+  if (pkg.exports === undefined && typeof pkg.main === 'string') {
     if (
       packageTargetIsShipped({ includedFiles, target: pkg.main }) &&
       !targetExistsWithNodeResolution(packageDir, pkg.main)

--- a/nix/devenv-modules/tasks/shared/tests/pnpm.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/pnpm.test.sh
@@ -100,6 +100,20 @@ EOF
   ln -s ../store/v11/links/pkg/1.0.0/hash/node_modules/pkg "$root/node_modules/pkg"
 }
 
+make_exports_override_stale_main_fixture() {
+  local root="$1"
+  local package_root="$root/store/v11/links/pkg/1.0.0/hash/node_modules/pkg"
+
+  mkdir -p "$package_root/dist"
+  mkdir -p "$root/node_modules"
+  cat > "$package_root/package.json" <<'EOF'
+{"name":"pkg","files":["dist"],"main":"./dist/missing-legacy.cjs","exports":{".":{"import":"./dist/index.js","require":"./dist/index.cjs"}}}
+EOF
+  touch "$package_root/dist/index.js"
+  touch "$package_root/dist/index.cjs"
+  ln -s ../store/v11/links/pkg/1.0.0/hash/node_modules/pkg "$root/node_modules/pkg"
+}
+
 make_unshipped_conditional_export_fixture() {
   local root="$1"
   local package_root="$root/store/v11/links/pkg/1.0.0/hash/node_modules/pkg"
@@ -738,7 +752,20 @@ exit_code=$?
 set -e
 assert_exit_code 0 "$exit_code" "projection health ignores optional subpath exports"
 
-echo "Test 32: dependency materialization profile is stable for identical contracts"
+echo "Test 32: Projection health gives exports precedence over a stale legacy main target"
+exports_override_main_dir="$test_dir/exports-override-main"
+make_exports_override_stale_main_fixture "$exports_override_main_dir"
+set +e
+check_node_modules_links_healthy node "$PROJECTION_SCRIPT" "$exports_override_main_dir/node_modules" >/dev/null 2>&1
+exit_code=$?
+set -e
+assert_exit_code 0 "$exit_code" "projection health accepts valid exports despite a stale legacy main"
+assert_eq \
+  "index.cjs" \
+  "$(cd "$exports_override_main_dir" && node -e 'const path = require("node:path"); process.stdout.write(path.basename(require.resolve("pkg")))')" \
+  "Node resolves the exported require target instead of legacy main"
+
+echo "Test 33: dependency materialization profile is stable for identical contracts"
 profile_contract="$test_dir/profile-contract.json"
 cat > "$profile_contract" <<'EOF'
 {
@@ -809,7 +836,7 @@ assert_json_field \
   "(value) => value.authorities.gc" \
   "dependency profile records gc authority"
 
-echo "Test 33: source-only files are not dependency profile identity inputs"
+echo "Test 34: source-only files are not dependency profile identity inputs"
 mkdir -p "$test_dir/profile-source/packages/app/src"
 cp "$profile_contract" "$test_dir/profile-source/pnpm-install-contract.json"
 echo "export const value = 1" > "$test_dir/profile-source/packages/app/src/index.ts"
@@ -825,7 +852,7 @@ echo "export const value = 1" > "$test_dir/profile-source/packages/app/src/index
     "source-only mutations do not affect dependency profile identity"
 )
 
-echo "Test 34: manifest contract changes dependency profile identity"
+echo "Test 35: manifest contract changes dependency profile identity"
 manifest_contract="$test_dir/profile-contract-manifest-change.json"
 node - "$profile_contract" "$manifest_contract" <<'EOF'
 const fs = require('node:fs')
@@ -841,14 +868,14 @@ if [ "$(node -e "const fs = require('node:fs'); process.stdout.write(JSON.parse(
   exit 1
 fi
 
-echo "Test 35: unknown dependency materialization trait fails closed"
+echo "Test 36: unknown dependency materialization trait fails closed"
 set +e
 emit_dependency_materialization_profile node "$profile_contract" unknownTrait >/dev/null 2>&1
 exit_code=$?
 set -e
 assert_exit_code 1 "$exit_code" "unknown store trait should fail"
 
-echo "Test 36: store doctor refuses raw prune of a shared files pool"
+echo "Test 37: store doctor refuses raw prune of a shared files pool"
 doctor_registry="$test_dir/doctor-registry.json"
 shared_files="$test_dir/shared-files/v11"
 shared_root="$test_dir/profile-a/store/v11"
@@ -878,7 +905,7 @@ assert_json_field \
   "(value) => value.siblings.join(',')" \
   "shared pool doctor reports sibling profiles"
 
-echo "Test 37: store doctor allows isolated profile-local pool prune"
+echo "Test 38: store doctor allows isolated profile-local pool prune"
 isolated_files="$test_dir/isolated/store/v11/files"
 mkdir -p "$isolated_files"
 isolated_registry="$test_dir/isolated-registry.json"
@@ -900,7 +927,7 @@ assert_json_field \
   "(value) => value.decision" \
   "isolated local pool prune is allowed"
 
-echo "Test 38: repair plan targets every root sharing a files pool"
+echo "Test 39: repair plan targets every root sharing a files pool"
 repair_plan="$test_dir/repair-plan.json"
 dependency_materialization_repair_plan node "$doctor_registry" pool-shared > "$repair_plan"
 assert_json_field \


### PR DESCRIPTION
## Problem

The node_modules projection health checker treats `main` and `exports` as independent active package entry points. Packages such as `@terrastruct/d2` can retain a stale legacy `main` while providing valid `exports.import` and `exports.require` targets, causing healthy pnpm projections to be purged and then rejected again.

## Goal

Match Node package entry precedence without weakening detection of missing active runtime content.

## Decisions

- Validate `main` only when `exports` is undefined, because Node gives `exports` precedence for package entry resolution.
- Keep root runtime `exports` validation unchanged. Missing shipped export targets still fail closed.
- Keep this change narrow against current `main`. PR #922 rewrites projection ownership and overlaps these files, but does not currently implement this entry-point precedence; it must retain this semantic rule when rebased.

## Verification

- `bash nix/devenv-modules/tasks/shared/tests/pnpm.test.sh`: 39/39 cases passed.
- New GVS-shaped regression fixture has a missing legacy `main`, valid `exports.import` and `exports.require`, and passes projection health.
- The fixture also proves Node resolves `require("pkg")` to the exported `index.cjs` target.
- Existing missing-export regression still exits 1, proving missing active package content remains rejected.
- `devenv tasks run check:quick --no-tui`: passed.
- `devenv tasks run check:all --no-tui`: passed in 378s, including strict TypeScript, lint, all package tests, Nix flake evaluation, pnpm install, and Weaver registry checks.

## Complexity

No new complexity. This is one precedence guard plus a focused regression fixture.

## Concerns

PR #922 overlaps the checker as part of a broader topology rewrite and will need to preserve this condition during rebase.

## Friction & bottlenecks

An initial concurrent `check:quick` evaluation raced lint's temporary `.oxlint-with-plugins.*.json` cleanup while Nix snapshotted the worktree. A quiescent rerun passed; no product or checker change was needed.

## Follow-ups

- Preserve this precedence rule in PR #922's rewritten checker and projection digest.

## References

- overengineeringstudio/overeng#200
- #922

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | ☁️ co3-billow |
| `agent_session_id` | 7f3b9666-034f-4e9e-890b-491957f7f75b |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.144.1 |
| `agent_runtime` | Codex CLI 0.144.1 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/1n76sy6i9y3ki3k4w04jksqvygw67sj0-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/jn6r0r7r59x3a525jch4pwzwykszqp60-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-17-projection-exports |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@4eac376 |
</details>
<!-- agent-footer:end -->