### PR TITLE
fix(react-inspector): preserve exact optional metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **react-inspector / Effect 4**: preserve exact-optional public metadata types
+  across Effect 4 schema decoding, and compile the migrated schema surface as a
+  strict downstream consumer in the workspace typecheck graph.
 - **react-inspector / Effect 4**: align the package's development and build
   runtime with its `^4.0.0-beta.97` peer contract so declarations and tests use
   the same Effect version as LiveStore DevTools.

--- a/packages/@overeng/react-inspector/src/schema/effect4.unit.test.tsx
+++ b/packages/@overeng/react-inspector/src/schema/effect4.unit.test.tsx
@@ -106,4 +106,29 @@ describe('Effect 4 consumer schema compatibility', () => {
       pure: true,
     })
   })
+
+  it('decodes absent lineage metadata as omitted exact-optional properties', () => {
+    const schema = Schema.String.pipe(
+      Lineage.sourceOfTruth(),
+      Lineage.authority({ writers: [] }),
+      Lineage.freshness({}),
+      Lineage.foreignKey({ targetSchema: 'Consumer.Record' }),
+    )
+
+    const lineage = Lineage.getLineage(schema)
+    const authority = Lineage.getAuthority(schema)
+    const freshness = Lineage.getFreshness(schema)
+    const reference = Lineage.getReference(schema)
+
+    expect(lineage).toEqual({ _tag: 'SourceOfTruth' })
+    expect(Object.hasOwn(lineage ?? {}, 'owner')).toBe(false)
+    expect(Object.hasOwn(lineage ?? {}, 'system')).toBe(false)
+    expect(authority).toEqual({ writers: [] })
+    expect(Object.hasOwn(authority ?? {}, 'readers')).toBe(false)
+    expect(freshness).toEqual({})
+    expect(Object.hasOwn(freshness ?? {}, 'capturedAt')).toBe(false)
+    expect(Object.hasOwn(freshness ?? {}, 'maxAgeMs')).toBe(false)
+    expect(reference).toEqual({ _tag: 'ForeignKey', targetSchema: 'Consumer.Record' })
+    expect(Object.hasOwn(reference ?? {}, 'targetField')).toBe(false)
+  })
 })

--- a/packages/@overeng/react-inspector/src/schema/effectSchema.tsx
+++ b/packages/@overeng/react-inspector/src/schema/effectSchema.tsx
@@ -409,6 +409,7 @@ export const getSchemaInfo = (schema: SchemaView): SchemaInfo => {
   const constraints = getConstraintsFromJSONSchema(rawAst)
   const possible = getPossibleValuesFromAST(rawAst)
   const containerLabel = getContainerLabelForAST(rawAst)
+  const typeKind = getTypeKind(rawAst)
   const lineageValue = Lineage.getLineage(schema)
   const authority = Lineage.getAuthority(schema)
   const freshness = Lineage.getFreshness(schema)
@@ -443,7 +444,7 @@ export const getSchemaInfo = (schema: SchemaView): SchemaInfo => {
     lineage !== undefined
   return {
     ...(displayName === undefined ? {} : { displayName }),
-    ...(getTypeKind(rawAst) === undefined ? {} : { typeKind: getTypeKind(rawAst) }),
+    ...(typeKind === undefined ? {} : { typeKind }),
     ...(description === undefined ? {} : { description }),
     ...(annotations.documentation === undefined
       ? {}

--- a/packages/@overeng/react-inspector/src/schema/lineage.ts
+++ b/packages/@overeng/react-inspector/src/schema/lineage.ts
@@ -76,38 +76,47 @@ const DerivationKindSchema = Schema.Union([
 
 const LineageSchema = Schema.Union([
   Schema.TaggedStruct('SourceOfTruth', {
-    owner: Schema.optional(Schema.String),
-    system: Schema.optional(Schema.String),
+    owner: Schema.optionalKey(Schema.String),
+    system: Schema.optionalKey(Schema.String),
   }),
   Schema.TaggedStruct('Derived', {
     from: Schema.Array(LineageRefSchema),
     how: DerivationKindSchema,
-    pure: Schema.optional(Schema.Boolean),
+    pure: Schema.optionalKey(Schema.Boolean),
   }),
   Schema.TaggedStruct('Projection', {
     of: LineageRefSchema,
-    stalenessMs: Schema.optional(Schema.Finite),
+    stalenessMs: Schema.optionalKey(Schema.Finite),
   }),
-  Schema.TaggedStruct('Cache', { of: LineageRefSchema, ttlMs: Schema.optional(Schema.Finite) }),
-  Schema.TaggedStruct('Mirror', { of: LineageRefSchema, system: Schema.optional(Schema.String) }),
-  Schema.TaggedStruct('External', { system: Schema.String, ref: Schema.optional(Schema.String) }),
+  Schema.TaggedStruct('Cache', {
+    of: LineageRefSchema,
+    ttlMs: Schema.optionalKey(Schema.Finite),
+  }),
+  Schema.TaggedStruct('Mirror', {
+    of: LineageRefSchema,
+    system: Schema.optionalKey(Schema.String),
+  }),
+  Schema.TaggedStruct('External', {
+    system: Schema.String,
+    ref: Schema.optionalKey(Schema.String),
+  }),
   Schema.TaggedStruct('Computed', {
-    fn: Schema.optional(Schema.String),
-    description: Schema.optional(Schema.String),
+    fn: Schema.optionalKey(Schema.String),
+    description: Schema.optionalKey(Schema.String),
   }),
 ])
 
 const AuthoritySchema = Schema.Struct({
   writers: Schema.Array(Schema.String),
-  readers: Schema.optional(Schema.Array(Schema.String)),
+  readers: Schema.optionalKey(Schema.Array(Schema.String)),
 })
 const FreshnessSchema = Schema.Struct({
-  capturedAt: Schema.optional(Schema.Literals(['now', 'event-time', 'snapshot'])),
-  maxAgeMs: Schema.optional(Schema.Finite),
+  capturedAt: Schema.optionalKey(Schema.Literals(['now', 'event-time', 'snapshot'])),
+  maxAgeMs: Schema.optionalKey(Schema.Finite),
 })
 const ReferenceSchema = Schema.TaggedStruct('ForeignKey', {
   targetSchema: Schema.String,
-  targetField: Schema.optional(Schema.String),
+  targetField: Schema.optionalKey(Schema.String),
 })
 
 type SchemaView = { readonly ast: SchemaAST.AST }

--- a/packages/@overeng/react-inspector/test-d/exact-optional-consumer.ts
+++ b/packages/@overeng/react-inspector/test-d/exact-optional-consumer.ts
@@ -1,0 +1,19 @@
+import { Schema } from 'effect'
+
+import { type SchemaInfo, getSchemaInfo } from '../src/schema/effectSchema.tsx'
+import * as Lineage from '../src/schema/lineage.ts'
+
+const schema = Schema.String.pipe(
+  Lineage.sourceOfTruth(),
+  Lineage.authority({ writers: [] }),
+  Lineage.freshness({}),
+  Lineage.foreignKey({ targetSchema: 'Consumer.Record' }),
+)
+
+const schemaInfo: SchemaInfo = getSchemaInfo(schema)
+const lineage: Lineage.Lineage | undefined = Lineage.getLineage(schema)
+const authority: Lineage.Authority | undefined = Lineage.getAuthority(schema)
+const freshness: Lineage.Freshness | undefined = Lineage.getFreshness(schema)
+const reference: Lineage.Reference | undefined = Lineage.getReference(schema)
+
+void [schemaInfo, lineage, authority, freshness, reference]

--- a/packages/@overeng/react-inspector/tsconfig.strict-consumer.json
+++ b/packages/@overeng/react-inspector/tsconfig.strict-consumer.json
@@ -1,0 +1,51 @@
+// Generated file - DO NOT EDIT
+// Source: tsconfig.strict-consumer.json.genie.ts
+{
+  "compilerOptions": {
+    "target": "ES2024",
+    "lib": ["ES2023", "DOM"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "allowJs": false,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "plugins": [
+      {
+        "name": "@effect/language-service",
+        "ignoreEffectWarningsInTscExitCode": false,
+        "ignoreEffectSuggestionsInTscExitCode": false,
+        "ignoreEffectErrorsInTscExitCode": false,
+        "includeSuggestionsInTsc": true,
+        "pipeableMinArgCount": 2,
+        "diagnosticSeverity": {
+          "missedPipeableOpportunity": "warning",
+          "schemaUnionOfLiterals": "warning",
+          "anyUnknownInErrorContext": "warning",
+          "preferSchemaOverJson": "warning"
+        }
+      }
+    ],
+    "rootDir": ".",
+    "jsx": "react-jsx",
+    "composite": true,
+    "noEmit": true
+  },
+  "include": ["src/schema/effectSchema.tsx", "src/schema/lineage.ts", "test-d/**/*"],
+  "references": []
+}

--- a/packages/@overeng/react-inspector/tsconfig.strict-consumer.json.genie.ts
+++ b/packages/@overeng/react-inspector/tsconfig.strict-consumer.json.genie.ts
@@ -1,0 +1,15 @@
+import { baseTsconfigCompilerOptions, reactJsx } from '../../../genie/internal.ts'
+import { tsconfigJson, type TSConfigArgs } from '../genie/src/runtime/mod.ts'
+
+export default tsconfigJson({
+  compilerOptions: {
+    ...baseTsconfigCompilerOptions,
+    lib: ['ES2023', 'DOM'],
+    rootDir: '.',
+    ...reactJsx,
+    composite: true,
+    noEmit: true,
+  },
+  include: ['src/schema/effectSchema.tsx', 'src/schema/lineage.ts', 'test-d/**/*'],
+  references: [],
+} satisfies TSConfigArgs)

--- a/tsconfig.all.json
+++ b/tsconfig.all.json
@@ -88,6 +88,9 @@
       "path": "./packages/@overeng/react-inspector"
     },
     {
+      "path": "./packages/@overeng/react-inspector/tsconfig.strict-consumer.json"
+    },
+    {
       "path": "./packages/@overeng/restate-effect"
     },
     {

--- a/tsconfig.all.json.genie.ts
+++ b/tsconfig.all.json.genie.ts
@@ -8,4 +8,5 @@ export default tsconfigJsonFromPackages({
   packages: rootWorkspacePackages,
   repoName: 'effect-utils',
   files: [],
+  extraReferences: ['packages/@overeng/react-inspector/tsconfig.strict-consumer.json'],
 } satisfies TSConfigArgs)


### PR DESCRIPTION
## Summary

- decode React Inspector lineage metadata with Effect 4's exact-optional `Schema.optionalKey`
- cache schema `typeKind` before conditionally adding it to the exact-optional public result
- add a strict downstream-consumer project to the normal workspace typecheck graph
- verify absent decoded metadata remains an omitted key at runtime

## Why

LiveStore DevTools compiles `@overeng/react-inspector` under `strict` and
`exactOptionalPropertyTypes`. The package's intentionally relaxed legacy
tsconfig did not catch five Effect 4 migration errors: four decoder results
included explicit `undefined`, and one repeated getter call defeated narrowing.

`Schema.optionalKey` is the exact-optional API available at the package's
declared `effect@^4.0.0-beta.97` peer floor, so this preserves the public types
without widening them or raising the Effect peer requirement.

## Verification

- `devenv tasks run ts:check:strict`
- React Inspector Vitest: 6 files, 35 tests passed
- `devenv tasks run check:quick`
- `devenv tasks run lint:check`
- `devenv tasks run genie:check`
- `git diff --check`

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | ☁️ co3-billow |
| `agent_session_id` | 7f3b9666-034f-4e9e-890b-491957f7f75b |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.144.1 |
| `agent_runtime` | Codex CLI 0.144.1 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/1n76sy6i9y3ki3k4w04jksqvygw67sj0-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/jn6r0r7r59x3a525jch4pwzwykszqp60-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-17-react-inspector-exact-optionals |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@4eac376 |
</details>
<!-- agent-footer:end -->