### PR TITLE
fix(megarepo): disambiguate duplicate repository locks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Fix megarepo Nix lock validation for current and legacy members that share one repository while preserving fail-closed ambiguity checks.
+
 ### Fixed
 
 - **react-inspector / Effect 4**: preserve exact-optional public metadata types

--- a/nix/devenv-modules/tasks/shared/megarepo-lock-sync.jq
+++ b/nix/devenv-modules/tasks/shared/megarepo-lock-sync.jq
@@ -1,0 +1,64 @@
+def repo_key($node):
+  if $node.locked?.type == "github" then
+    "\($node.locked.owner)/\($node.locked.repo)"
+  elif $node.locked?.type == "git" then
+    ($node.locked.url // $node.original.url // "") as $url |
+    if $url == "" then
+      empty
+    else
+      $url
+      | sub("^git\\+ssh://git@github.com/"; "")
+      | sub("^ssh://git@github.com/"; "")
+      | sub("^git@github.com:"; "")
+      | sub("^https://github.com/"; "")
+      | sub("\\.git$"; "")
+    end
+  else
+    empty
+  end;
+
+[$lf[0].nodes | to_entries[] |
+  (repo_key(.value)) as $key |
+  select($key != null and $key != "") |
+  { key: $key, rev: .value.locked.rev, name: .key }
+] as $lock_inputs |
+[$ml[0].members | to_entries[] |
+  {
+    key: (.value.url | split("/") | .[-2:] | join("/")),
+    rev: .value.commit,
+    name: .key
+  }
+] as $members |
+[$lock_inputs[] as $input |
+  [$members[] | select(.key == $input.key)] as $candidates |
+  select($candidates | length > 0) |
+  [$candidates[] | select(.name == $input.name)] as $named |
+  if $named | length == 1 then
+    select($input.rev != $named[0].rev) |
+    {
+      member: $named[0].name,
+      input: $input.name,
+      expected: $named[0].rev,
+      actual: $input.rev,
+      reason: "named-member-mismatch"
+    }
+  elif $named | length > 1 then
+    {
+      member: $input.name,
+      input: $input.name,
+      expected: ($named | map(.rev) | unique | join(",")),
+      actual: $input.rev,
+      reason: "ambiguous-named-member"
+    }
+  else
+    [$candidates[] | select(.rev == $input.rev)] as $matches |
+    select($matches | length != 1) |
+    {
+      member: ($candidates | map(.name) | join(",")),
+      input: $input.name,
+      expected: ($candidates | map(.rev) | unique | join(",")),
+      actual: $input.rev,
+      reason: (if $matches | length == 0 then "no-declared-revision" else "ambiguous-revision" end)
+    }
+  end
+]

--- a/nix/devenv-modules/tasks/shared/megarepo.nix
+++ b/nix/devenv-modules/tasks/shared/megarepo.nix
@@ -75,45 +75,12 @@ let
 
     mismatches=$(${jq} -n \
       --slurpfile ml "$ml" \
-      --slurpfile lf "$lf" '
-      def repo_key($node):
-        if $node.locked?.type == "github" then
-          "\($node.locked.owner)/\($node.locked.repo)"
-        elif $node.locked?.type == "git" then
-          ($node.locked.url // $node.original.url // "") as $url |
-          if $url == "" then
-            empty
-          else
-            $url
-            | sub("^git\\+ssh://git@github.com/"; "")
-            | sub("^ssh://git@github.com/"; "")
-            | sub("^git@github.com:"; "")
-            | sub("^https://github.com/"; "")
-            | sub("\\.git$"; "")
-          end
-        else
-          empty
-        end;
-
-      [$lf[0].nodes | to_entries[] |
-        (repo_key(.value)) as $key |
-        select($key != null and $key != "") |
-        { key: $key, rev: .value.locked.rev, name: .key }
-      ] as $lock_inputs |
-      [$ml[0].members | to_entries[] |
-        (.value.url | split("/") | .[-2:] | join("/")) as $mkey |
-        .value.commit as $expected |
-        .key as $member |
-        $lock_inputs[] |
-        select(.key == $mkey) |
-        select(.rev != $expected) |
-        { member: $member, input: .name, expected: $expected, actual: .rev }
-      ] | unique_by(.input)
-    ')
+      --slurpfile lf "$lf" \
+      -f ${./megarepo-lock-sync.jq})
 
     count=$(echo "$mismatches" | ${jq} -r 'length')
     if [ "$count" -gt 0 ]; then
-      echo "$mismatches" | ${jq} -r '.[] | "  \(.member) (\(.input)): expected \(.expected[0:12])… got \(.actual[0:12])…"'
+      echo "$mismatches" | ${jq} -r '.[] | "  \(.member) (\(.input)): expected \(.expected[0:12])… got \(.actual[0:12])… [\(.reason)]"'
       return 1
     fi
     return 0

--- a/nix/devenv-modules/tasks/shared/tests/megarepo-lock-sync.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/megarepo-lock-sync.test.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+policy="$(cd "$(dirname "$0")/.." && pwd)/megarepo-lock-sync.jq"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+write_members() {
+  local current="$1"
+  local legacy="$2"
+  jq -n --arg current "$current" --arg legacy "$legacy" '{
+    members: {
+      "effect-utils": {url: "https://github.com/example/effect-utils", commit: $current},
+      "effect-utils-legacy": {url: "https://github.com/example/effect-utils", commit: $legacy}
+    }
+  }' > "$tmpdir/megarepo.lock"
+}
+
+write_inputs() {
+  jq -n --arg current "$1" --arg legacy "$2" --arg auxiliary "$3" '{
+    nodes: {
+      "effect-utils": {locked: {type: "github", owner: "example", repo: "effect-utils", rev: $current}},
+      "effect-utils-legacy": {locked: {type: "github", owner: "example", repo: "effect-utils", rev: $legacy}},
+      playwright: {locked: {type: "github", owner: "example", repo: "effect-utils", rev: $auxiliary}}
+    }
+  }' > "$tmpdir/devenv.lock"
+}
+
+check_count() {
+  jq -n \
+    --slurpfile ml "$tmpdir/megarepo.lock" \
+    --slurpfile lf "$tmpdir/devenv.lock" \
+    -f "$policy" \
+    | jq -e --argjson expected "$1" 'length == $expected' >/dev/null
+}
+
+current="1111111111111111111111111111111111111111"
+legacy="2222222222222222222222222222222222222222"
+unknown="3333333333333333333333333333333333333333"
+
+echo "Test 1: named current and legacy inputs select their exact same-repo members"
+write_members "$current" "$legacy"
+write_inputs "$current" "$legacy" "$current"
+check_count 0
+
+echo "Test 2: a named input cannot silently resolve to the other same-repo member"
+write_inputs "$legacy" "$legacy" "$current"
+check_count 1
+
+echo "Test 3: an auxiliary input may match exactly one declared same-repo member"
+write_inputs "$current" "$legacy" "$legacy"
+check_count 0
+
+echo "Test 4: an auxiliary input with no declared revision fails closed"
+write_inputs "$current" "$legacy" "$unknown"
+check_count 1
+
+echo "Test 5: an auxiliary input matching multiple declared members fails closed"
+write_members "$current" "$current"
+write_inputs "$current" "$current" "$current"
+check_count 1
+
+echo "All megarepo lock sync tests passed."


### PR DESCRIPTION
## Problem

The megarepo Nix lock validator cross-joined every lock input with every member that shared its GitHub repository. A workspace carrying current and legacy members from one repository could therefore never pass: a lock at either declared revision was reported as mismatching the other member.

## Goal

Support explicit current/legacy same-repository members without weakening lock authority or accepting ambiguous auxiliary inputs.

## Decisions

- Prefer an exact lock-input/member name match and require that exact member revision.
- For auxiliary inputs that share a repository but have no same-named member, require the locked revision to match exactly one declared member.
- Reject auxiliary inputs with zero or multiple declared matches.
- Extract the jq policy into a directly executable file so positive and negative cases use the production comparison logic.

## Verification

- `bash nix/devenv-modules/tasks/shared/tests/megarepo-lock-sync.test.sh` - 5 cases passed.
- `devenv tasks run devenv-modules:test` - passed all shared module shell tests.
- `devenv tasks run lint:check` - passed.
- `devenv tasks run check:all` - affected gates passed, including lock sync, source policy, module tests, strict TypeScript, lint, Nix flake, Cargo, and Weaver. One unrelated Restate scheduling timing assertion failed while waiting for a rotated wake ID.
- `devenv tasks run test:restate-effect` - passed on isolated rerun in 213 seconds, classifying the full-run failure as transient.
- `git diff --check` - passed.

## Complexity

The policy remains a single jq pass. The additional branching only disambiguates duplicate repository ownership and reports the reason for each rejection.

## Concerns

An auxiliary input intentionally fails when multiple declared members share its exact revision. This is fail-closed: callers must provide an unambiguous member revision instead of relying on member ordering.

## Friction & bottlenecks

The repository-wide gate rebuilt the uncached Weaver closure and exposed an unrelated timing-sensitive Restate test. The isolated package rerun passed without code changes.

## Follow-ups

None.

## References

- Downstream discovery: https://github.com/overengineeringstudio/overeng/pull/200

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | ☁️ co3-billow |
| `agent_session_id` | 7f3b9666-034f-4e9e-890b-491957f7f75b |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.144.1 |
| `agent_runtime` | Codex CLI 0.144.1 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/1n76sy6i9y3ki3k4w04jksqvygw67sj0-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/jn6r0r7r59x3a525jch4pwzwykszqp60-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling/2026-07-18-megarepo-lock-duplicates |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@4eac376 |
</details>
<!-- agent-footer:end -->