### PR TITLE
fix(ci): root devenv resolution across Nix GC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -505,55 +505,7 @@ jobs:
             exit 1
           fi
 
-          DEVENV_GC_ROOT_DIR="${RUNNER_TEMP:-/tmp}/genie-nix-gc-roots"
-          DEVENV_GC_ROOT_ID=$(printf '%s' "${GITHUB_RUN_ID:-local-$$}-${GITHUB_RUN_ATTEMPT:-0}-${GITHUB_JOB:-job}" | tr -c 'A-Za-z0-9._-' '_')
-          DEVENV_GC_ROOT="$DEVENV_GC_ROOT_DIR/devenv-$DEVENV_GC_ROOT_ID"
-
-          resolve_devenv_once() {
-            mkdir -p "$DEVENV_GC_ROOT_DIR"
-            nix build \
-              --accept-flake-config \
-              --option extra-substituters https://devenv.cachix.org \
-              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --out-link "$DEVENV_GC_ROOT" \
-              --print-out-paths \
-              "github:cachix/devenv/$DEVENV_REV#devenv"
-          }
-
-          resolve_devenv() {
-            local invalid_path
-            local log
-            local rc
-
-            log=$(mktemp)
-            if resolve_devenv_once 2>"$log"; then
-              cat "$log" >&2
-              rm -f "$log"
-              return 0
-            else
-              rc=$?
-            fi
-            cat "$log" >&2
-            invalid_path=$(grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" "$log" |
-              head -1 | grep -o "/nix/store/[^']*" || true)
-            rm -f "$log"
-            [ -n "$invalid_path" ] || return "$rc"
-
-            echo "::warning::devenv resolution hit an invalid Nix store path; clearing the client eval cache and retrying once: $invalid_path" >&2
-            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/nix/eval-cache-"* ~/.cache/nix/eval-cache-*
-            nix-store --repair-path "$invalid_path" >/dev/null 2>&1 ||
-              nix-store --realise "$invalid_path" >/dev/null 2>&1 || true
-            if resolve_devenv_once; then
-              if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
-                echo '### Recovered Nix store lifecycle incident' >> "$GITHUB_STEP_SUMMARY"
-                echo "- Invalid path: $invalid_path" >> "$GITHUB_STEP_SUMMARY"
-                echo '- Attempts: 2/2' >> "$GITHUB_STEP_SUMMARY"
-              fi
-              return 0
-            else
-              return $?
-            fi
-          }
+          . '${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -830,55 +782,7 @@ jobs:
             exit 1
           fi
 
-          DEVENV_GC_ROOT_DIR="${RUNNER_TEMP:-/tmp}/genie-nix-gc-roots"
-          DEVENV_GC_ROOT_ID=$(printf '%s' "${GITHUB_RUN_ID:-local-$$}-${GITHUB_RUN_ATTEMPT:-0}-${GITHUB_JOB:-job}" | tr -c 'A-Za-z0-9._-' '_')
-          DEVENV_GC_ROOT="$DEVENV_GC_ROOT_DIR/devenv-$DEVENV_GC_ROOT_ID"
-
-          resolve_devenv_once() {
-            mkdir -p "$DEVENV_GC_ROOT_DIR"
-            nix build \
-              --accept-flake-config \
-              --option extra-substituters https://devenv.cachix.org \
-              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --out-link "$DEVENV_GC_ROOT" \
-              --print-out-paths \
-              "github:cachix/devenv/$DEVENV_REV#devenv"
-          }
-
-          resolve_devenv() {
-            local invalid_path
-            local log
-            local rc
-
-            log=$(mktemp)
-            if resolve_devenv_once 2>"$log"; then
-              cat "$log" >&2
-              rm -f "$log"
-              return 0
-            else
-              rc=$?
-            fi
-            cat "$log" >&2
-            invalid_path=$(grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" "$log" |
-              head -1 | grep -o "/nix/store/[^']*" || true)
-            rm -f "$log"
-            [ -n "$invalid_path" ] || return "$rc"
-
-            echo "::warning::devenv resolution hit an invalid Nix store path; clearing the client eval cache and retrying once: $invalid_path" >&2
-            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/nix/eval-cache-"* ~/.cache/nix/eval-cache-*
-            nix-store --repair-path "$invalid_path" >/dev/null 2>&1 ||
-              nix-store --realise "$invalid_path" >/dev/null 2>&1 || true
-            if resolve_devenv_once; then
-              if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
-                echo '### Recovered Nix store lifecycle incident' >> "$GITHUB_STEP_SUMMARY"
-                echo "- Invalid path: $invalid_path" >> "$GITHUB_STEP_SUMMARY"
-                echo '- Attempts: 2/2' >> "$GITHUB_STEP_SUMMARY"
-              fi
-              return 0
-            else
-              return $?
-            fi
-          }
+          . '${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -1142,55 +1046,7 @@ jobs:
             exit 1
           fi
 
-          DEVENV_GC_ROOT_DIR="${RUNNER_TEMP:-/tmp}/genie-nix-gc-roots"
-          DEVENV_GC_ROOT_ID=$(printf '%s' "${GITHUB_RUN_ID:-local-$$}-${GITHUB_RUN_ATTEMPT:-0}-${GITHUB_JOB:-job}" | tr -c 'A-Za-z0-9._-' '_')
-          DEVENV_GC_ROOT="$DEVENV_GC_ROOT_DIR/devenv-$DEVENV_GC_ROOT_ID"
-
-          resolve_devenv_once() {
-            mkdir -p "$DEVENV_GC_ROOT_DIR"
-            nix build \
-              --accept-flake-config \
-              --option extra-substituters https://devenv.cachix.org \
-              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --out-link "$DEVENV_GC_ROOT" \
-              --print-out-paths \
-              "github:cachix/devenv/$DEVENV_REV#devenv"
-          }
-
-          resolve_devenv() {
-            local invalid_path
-            local log
-            local rc
-
-            log=$(mktemp)
-            if resolve_devenv_once 2>"$log"; then
-              cat "$log" >&2
-              rm -f "$log"
-              return 0
-            else
-              rc=$?
-            fi
-            cat "$log" >&2
-            invalid_path=$(grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" "$log" |
-              head -1 | grep -o "/nix/store/[^']*" || true)
-            rm -f "$log"
-            [ -n "$invalid_path" ] || return "$rc"
-
-            echo "::warning::devenv resolution hit an invalid Nix store path; clearing the client eval cache and retrying once: $invalid_path" >&2
-            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/nix/eval-cache-"* ~/.cache/nix/eval-cache-*
-            nix-store --repair-path "$invalid_path" >/dev/null 2>&1 ||
-              nix-store --realise "$invalid_path" >/dev/null 2>&1 || true
-            if resolve_devenv_once; then
-              if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
-                echo '### Recovered Nix store lifecycle incident' >> "$GITHUB_STEP_SUMMARY"
-                echo "- Invalid path: $invalid_path" >> "$GITHUB_STEP_SUMMARY"
-                echo '- Attempts: 2/2' >> "$GITHUB_STEP_SUMMARY"
-              fi
-              return 0
-            else
-              return $?
-            fi
-          }
+          . '${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -1451,55 +1307,7 @@ jobs:
             exit 1
           fi
 
-          DEVENV_GC_ROOT_DIR="${RUNNER_TEMP:-/tmp}/genie-nix-gc-roots"
-          DEVENV_GC_ROOT_ID=$(printf '%s' "${GITHUB_RUN_ID:-local-$$}-${GITHUB_RUN_ATTEMPT:-0}-${GITHUB_JOB:-job}" | tr -c 'A-Za-z0-9._-' '_')
-          DEVENV_GC_ROOT="$DEVENV_GC_ROOT_DIR/devenv-$DEVENV_GC_ROOT_ID"
-
-          resolve_devenv_once() {
-            mkdir -p "$DEVENV_GC_ROOT_DIR"
-            nix build \
-              --accept-flake-config \
-              --option extra-substituters https://devenv.cachix.org \
-              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --out-link "$DEVENV_GC_ROOT" \
-              --print-out-paths \
-              "github:cachix/devenv/$DEVENV_REV#devenv"
-          }
-
-          resolve_devenv() {
-            local invalid_path
-            local log
-            local rc
-
-            log=$(mktemp)
-            if resolve_devenv_once 2>"$log"; then
-              cat "$log" >&2
-              rm -f "$log"
-              return 0
-            else
-              rc=$?
-            fi
-            cat "$log" >&2
-            invalid_path=$(grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" "$log" |
-              head -1 | grep -o "/nix/store/[^']*" || true)
-            rm -f "$log"
-            [ -n "$invalid_path" ] || return "$rc"
-
-            echo "::warning::devenv resolution hit an invalid Nix store path; clearing the client eval cache and retrying once: $invalid_path" >&2
-            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/nix/eval-cache-"* ~/.cache/nix/eval-cache-*
-            nix-store --repair-path "$invalid_path" >/dev/null 2>&1 ||
-              nix-store --realise "$invalid_path" >/dev/null 2>&1 || true
-            if resolve_devenv_once; then
-              if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
-                echo '### Recovered Nix store lifecycle incident' >> "$GITHUB_STEP_SUMMARY"
-                echo "- Invalid path: $invalid_path" >> "$GITHUB_STEP_SUMMARY"
-                echo '- Attempts: 2/2' >> "$GITHUB_STEP_SUMMARY"
-              fi
-              return 0
-            else
-              return $?
-            fi
-          }
+          . '${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -1763,55 +1571,7 @@ jobs:
             exit 1
           fi
 
-          DEVENV_GC_ROOT_DIR="${RUNNER_TEMP:-/tmp}/genie-nix-gc-roots"
-          DEVENV_GC_ROOT_ID=$(printf '%s' "${GITHUB_RUN_ID:-local-$$}-${GITHUB_RUN_ATTEMPT:-0}-${GITHUB_JOB:-job}" | tr -c 'A-Za-z0-9._-' '_')
-          DEVENV_GC_ROOT="$DEVENV_GC_ROOT_DIR/devenv-$DEVENV_GC_ROOT_ID"
-
-          resolve_devenv_once() {
-            mkdir -p "$DEVENV_GC_ROOT_DIR"
-            nix build \
-              --accept-flake-config \
-              --option extra-substituters https://devenv.cachix.org \
-              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --out-link "$DEVENV_GC_ROOT" \
-              --print-out-paths \
-              "github:cachix/devenv/$DEVENV_REV#devenv"
-          }
-
-          resolve_devenv() {
-            local invalid_path
-            local log
-            local rc
-
-            log=$(mktemp)
-            if resolve_devenv_once 2>"$log"; then
-              cat "$log" >&2
-              rm -f "$log"
-              return 0
-            else
-              rc=$?
-            fi
-            cat "$log" >&2
-            invalid_path=$(grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" "$log" |
-              head -1 | grep -o "/nix/store/[^']*" || true)
-            rm -f "$log"
-            [ -n "$invalid_path" ] || return "$rc"
-
-            echo "::warning::devenv resolution hit an invalid Nix store path; clearing the client eval cache and retrying once: $invalid_path" >&2
-            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/nix/eval-cache-"* ~/.cache/nix/eval-cache-*
-            nix-store --repair-path "$invalid_path" >/dev/null 2>&1 ||
-              nix-store --realise "$invalid_path" >/dev/null 2>&1 || true
-            if resolve_devenv_once; then
-              if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
-                echo '### Recovered Nix store lifecycle incident' >> "$GITHUB_STEP_SUMMARY"
-                echo "- Invalid path: $invalid_path" >> "$GITHUB_STEP_SUMMARY"
-                echo '- Attempts: 2/2' >> "$GITHUB_STEP_SUMMARY"
-              fi
-              return 0
-            else
-              return $?
-            fi
-          }
+          . '${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -2051,55 +1811,7 @@ jobs:
             exit 1
           fi
 
-          DEVENV_GC_ROOT_DIR="${RUNNER_TEMP:-/tmp}/genie-nix-gc-roots"
-          DEVENV_GC_ROOT_ID=$(printf '%s' "${GITHUB_RUN_ID:-local-$$}-${GITHUB_RUN_ATTEMPT:-0}-${GITHUB_JOB:-job}" | tr -c 'A-Za-z0-9._-' '_')
-          DEVENV_GC_ROOT="$DEVENV_GC_ROOT_DIR/devenv-$DEVENV_GC_ROOT_ID"
-
-          resolve_devenv_once() {
-            mkdir -p "$DEVENV_GC_ROOT_DIR"
-            nix build \
-              --accept-flake-config \
-              --option extra-substituters https://devenv.cachix.org \
-              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --out-link "$DEVENV_GC_ROOT" \
-              --print-out-paths \
-              "github:cachix/devenv/$DEVENV_REV#devenv"
-          }
-
-          resolve_devenv() {
-            local invalid_path
-            local log
-            local rc
-
-            log=$(mktemp)
-            if resolve_devenv_once 2>"$log"; then
-              cat "$log" >&2
-              rm -f "$log"
-              return 0
-            else
-              rc=$?
-            fi
-            cat "$log" >&2
-            invalid_path=$(grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" "$log" |
-              head -1 | grep -o "/nix/store/[^']*" || true)
-            rm -f "$log"
-            [ -n "$invalid_path" ] || return "$rc"
-
-            echo "::warning::devenv resolution hit an invalid Nix store path; clearing the client eval cache and retrying once: $invalid_path" >&2
-            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/nix/eval-cache-"* ~/.cache/nix/eval-cache-*
-            nix-store --repair-path "$invalid_path" >/dev/null 2>&1 ||
-              nix-store --realise "$invalid_path" >/dev/null 2>&1 || true
-            if resolve_devenv_once; then
-              if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
-                echo '### Recovered Nix store lifecycle incident' >> "$GITHUB_STEP_SUMMARY"
-                echo "- Invalid path: $invalid_path" >> "$GITHUB_STEP_SUMMARY"
-                echo '- Attempts: 2/2' >> "$GITHUB_STEP_SUMMARY"
-              fi
-              return 0
-            else
-              return $?
-            fi
-          }
+          . '${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -2302,55 +2014,7 @@ jobs:
             exit 1
           fi
 
-          DEVENV_GC_ROOT_DIR="${RUNNER_TEMP:-/tmp}/genie-nix-gc-roots"
-          DEVENV_GC_ROOT_ID=$(printf '%s' "${GITHUB_RUN_ID:-local-$$}-${GITHUB_RUN_ATTEMPT:-0}-${GITHUB_JOB:-job}" | tr -c 'A-Za-z0-9._-' '_')
-          DEVENV_GC_ROOT="$DEVENV_GC_ROOT_DIR/devenv-$DEVENV_GC_ROOT_ID"
-
-          resolve_devenv_once() {
-            mkdir -p "$DEVENV_GC_ROOT_DIR"
-            nix build \
-              --accept-flake-config \
-              --option extra-substituters https://devenv.cachix.org \
-              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --out-link "$DEVENV_GC_ROOT" \
-              --print-out-paths \
-              "github:cachix/devenv/$DEVENV_REV#devenv"
-          }
-
-          resolve_devenv() {
-            local invalid_path
-            local log
-            local rc
-
-            log=$(mktemp)
-            if resolve_devenv_once 2>"$log"; then
-              cat "$log" >&2
-              rm -f "$log"
-              return 0
-            else
-              rc=$?
-            fi
-            cat "$log" >&2
-            invalid_path=$(grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" "$log" |
-              head -1 | grep -o "/nix/store/[^']*" || true)
-            rm -f "$log"
-            [ -n "$invalid_path" ] || return "$rc"
-
-            echo "::warning::devenv resolution hit an invalid Nix store path; clearing the client eval cache and retrying once: $invalid_path" >&2
-            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/nix/eval-cache-"* ~/.cache/nix/eval-cache-*
-            nix-store --repair-path "$invalid_path" >/dev/null 2>&1 ||
-              nix-store --realise "$invalid_path" >/dev/null 2>&1 || true
-            if resolve_devenv_once; then
-              if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
-                echo '### Recovered Nix store lifecycle incident' >> "$GITHUB_STEP_SUMMARY"
-                echo "- Invalid path: $invalid_path" >> "$GITHUB_STEP_SUMMARY"
-                echo '- Attempts: 2/2' >> "$GITHUB_STEP_SUMMARY"
-              fi
-              return 0
-            else
-              return $?
-            fi
-          }
+          . '${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -2662,55 +2326,7 @@ jobs:
             exit 1
           fi
 
-          DEVENV_GC_ROOT_DIR="${RUNNER_TEMP:-/tmp}/genie-nix-gc-roots"
-          DEVENV_GC_ROOT_ID=$(printf '%s' "${GITHUB_RUN_ID:-local-$$}-${GITHUB_RUN_ATTEMPT:-0}-${GITHUB_JOB:-job}" | tr -c 'A-Za-z0-9._-' '_')
-          DEVENV_GC_ROOT="$DEVENV_GC_ROOT_DIR/devenv-$DEVENV_GC_ROOT_ID"
-
-          resolve_devenv_once() {
-            mkdir -p "$DEVENV_GC_ROOT_DIR"
-            nix build \
-              --accept-flake-config \
-              --option extra-substituters https://devenv.cachix.org \
-              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --out-link "$DEVENV_GC_ROOT" \
-              --print-out-paths \
-              "github:cachix/devenv/$DEVENV_REV#devenv"
-          }
-
-          resolve_devenv() {
-            local invalid_path
-            local log
-            local rc
-
-            log=$(mktemp)
-            if resolve_devenv_once 2>"$log"; then
-              cat "$log" >&2
-              rm -f "$log"
-              return 0
-            else
-              rc=$?
-            fi
-            cat "$log" >&2
-            invalid_path=$(grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" "$log" |
-              head -1 | grep -o "/nix/store/[^']*" || true)
-            rm -f "$log"
-            [ -n "$invalid_path" ] || return "$rc"
-
-            echo "::warning::devenv resolution hit an invalid Nix store path; clearing the client eval cache and retrying once: $invalid_path" >&2
-            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/nix/eval-cache-"* ~/.cache/nix/eval-cache-*
-            nix-store --repair-path "$invalid_path" >/dev/null 2>&1 ||
-              nix-store --realise "$invalid_path" >/dev/null 2>&1 || true
-            if resolve_devenv_once; then
-              if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
-                echo '### Recovered Nix store lifecycle incident' >> "$GITHUB_STEP_SUMMARY"
-                echo "- Invalid path: $invalid_path" >> "$GITHUB_STEP_SUMMARY"
-                echo '- Attempts: 2/2' >> "$GITHUB_STEP_SUMMARY"
-              fi
-              return 0
-            else
-              return $?
-            fi
-          }
+          . '${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -2973,55 +2589,7 @@ jobs:
             exit 1
           fi
 
-          DEVENV_GC_ROOT_DIR="${RUNNER_TEMP:-/tmp}/genie-nix-gc-roots"
-          DEVENV_GC_ROOT_ID=$(printf '%s' "${GITHUB_RUN_ID:-local-$$}-${GITHUB_RUN_ATTEMPT:-0}-${GITHUB_JOB:-job}" | tr -c 'A-Za-z0-9._-' '_')
-          DEVENV_GC_ROOT="$DEVENV_GC_ROOT_DIR/devenv-$DEVENV_GC_ROOT_ID"
-
-          resolve_devenv_once() {
-            mkdir -p "$DEVENV_GC_ROOT_DIR"
-            nix build \
-              --accept-flake-config \
-              --option extra-substituters https://devenv.cachix.org \
-              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --out-link "$DEVENV_GC_ROOT" \
-              --print-out-paths \
-              "github:cachix/devenv/$DEVENV_REV#devenv"
-          }
-
-          resolve_devenv() {
-            local invalid_path
-            local log
-            local rc
-
-            log=$(mktemp)
-            if resolve_devenv_once 2>"$log"; then
-              cat "$log" >&2
-              rm -f "$log"
-              return 0
-            else
-              rc=$?
-            fi
-            cat "$log" >&2
-            invalid_path=$(grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" "$log" |
-              head -1 | grep -o "/nix/store/[^']*" || true)
-            rm -f "$log"
-            [ -n "$invalid_path" ] || return "$rc"
-
-            echo "::warning::devenv resolution hit an invalid Nix store path; clearing the client eval cache and retrying once: $invalid_path" >&2
-            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/nix/eval-cache-"* ~/.cache/nix/eval-cache-*
-            nix-store --repair-path "$invalid_path" >/dev/null 2>&1 ||
-              nix-store --realise "$invalid_path" >/dev/null 2>&1 || true
-            if resolve_devenv_once; then
-              if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
-                echo '### Recovered Nix store lifecycle incident' >> "$GITHUB_STEP_SUMMARY"
-                echo "- Invalid path: $invalid_path" >> "$GITHUB_STEP_SUMMARY"
-                echo '- Attempts: 2/2' >> "$GITHUB_STEP_SUMMARY"
-              fi
-              return 0
-            else
-              return $?
-            fi
-          }
+          . '${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -3282,55 +2850,7 @@ jobs:
             exit 1
           fi
 
-          DEVENV_GC_ROOT_DIR="${RUNNER_TEMP:-/tmp}/genie-nix-gc-roots"
-          DEVENV_GC_ROOT_ID=$(printf '%s' "${GITHUB_RUN_ID:-local-$$}-${GITHUB_RUN_ATTEMPT:-0}-${GITHUB_JOB:-job}" | tr -c 'A-Za-z0-9._-' '_')
-          DEVENV_GC_ROOT="$DEVENV_GC_ROOT_DIR/devenv-$DEVENV_GC_ROOT_ID"
-
-          resolve_devenv_once() {
-            mkdir -p "$DEVENV_GC_ROOT_DIR"
-            nix build \
-              --accept-flake-config \
-              --option extra-substituters https://devenv.cachix.org \
-              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --out-link "$DEVENV_GC_ROOT" \
-              --print-out-paths \
-              "github:cachix/devenv/$DEVENV_REV#devenv"
-          }
-
-          resolve_devenv() {
-            local invalid_path
-            local log
-            local rc
-
-            log=$(mktemp)
-            if resolve_devenv_once 2>"$log"; then
-              cat "$log" >&2
-              rm -f "$log"
-              return 0
-            else
-              rc=$?
-            fi
-            cat "$log" >&2
-            invalid_path=$(grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" "$log" |
-              head -1 | grep -o "/nix/store/[^']*" || true)
-            rm -f "$log"
-            [ -n "$invalid_path" ] || return "$rc"
-
-            echo "::warning::devenv resolution hit an invalid Nix store path; clearing the client eval cache and retrying once: $invalid_path" >&2
-            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/nix/eval-cache-"* ~/.cache/nix/eval-cache-*
-            nix-store --repair-path "$invalid_path" >/dev/null 2>&1 ||
-              nix-store --realise "$invalid_path" >/dev/null 2>&1 || true
-            if resolve_devenv_once; then
-              if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
-                echo '### Recovered Nix store lifecycle incident' >> "$GITHUB_STEP_SUMMARY"
-                echo "- Invalid path: $invalid_path" >> "$GITHUB_STEP_SUMMARY"
-                echo '- Attempts: 2/2' >> "$GITHUB_STEP_SUMMARY"
-              fi
-              return 0
-            else
-              return $?
-            fi
-          }
+          . '${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -3591,55 +3111,7 @@ jobs:
             exit 1
           fi
 
-          DEVENV_GC_ROOT_DIR="${RUNNER_TEMP:-/tmp}/genie-nix-gc-roots"
-          DEVENV_GC_ROOT_ID=$(printf '%s' "${GITHUB_RUN_ID:-local-$$}-${GITHUB_RUN_ATTEMPT:-0}-${GITHUB_JOB:-job}" | tr -c 'A-Za-z0-9._-' '_')
-          DEVENV_GC_ROOT="$DEVENV_GC_ROOT_DIR/devenv-$DEVENV_GC_ROOT_ID"
-
-          resolve_devenv_once() {
-            mkdir -p "$DEVENV_GC_ROOT_DIR"
-            nix build \
-              --accept-flake-config \
-              --option extra-substituters https://devenv.cachix.org \
-              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --out-link "$DEVENV_GC_ROOT" \
-              --print-out-paths \
-              "github:cachix/devenv/$DEVENV_REV#devenv"
-          }
-
-          resolve_devenv() {
-            local invalid_path
-            local log
-            local rc
-
-            log=$(mktemp)
-            if resolve_devenv_once 2>"$log"; then
-              cat "$log" >&2
-              rm -f "$log"
-              return 0
-            else
-              rc=$?
-            fi
-            cat "$log" >&2
-            invalid_path=$(grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" "$log" |
-              head -1 | grep -o "/nix/store/[^']*" || true)
-            rm -f "$log"
-            [ -n "$invalid_path" ] || return "$rc"
-
-            echo "::warning::devenv resolution hit an invalid Nix store path; clearing the client eval cache and retrying once: $invalid_path" >&2
-            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/nix/eval-cache-"* ~/.cache/nix/eval-cache-*
-            nix-store --repair-path "$invalid_path" >/dev/null 2>&1 ||
-              nix-store --realise "$invalid_path" >/dev/null 2>&1 || true
-            if resolve_devenv_once; then
-              if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
-                echo '### Recovered Nix store lifecycle incident' >> "$GITHUB_STEP_SUMMARY"
-                echo "- Invalid path: $invalid_path" >> "$GITHUB_STEP_SUMMARY"
-                echo '- Attempts: 2/2' >> "$GITHUB_STEP_SUMMARY"
-              fi
-              return 0
-            else
-              return $?
-            fi
-          }
+          . '${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -3907,55 +3379,7 @@ jobs:
             exit 1
           fi
 
-          DEVENV_GC_ROOT_DIR="${RUNNER_TEMP:-/tmp}/genie-nix-gc-roots"
-          DEVENV_GC_ROOT_ID=$(printf '%s' "${GITHUB_RUN_ID:-local-$$}-${GITHUB_RUN_ATTEMPT:-0}-${GITHUB_JOB:-job}" | tr -c 'A-Za-z0-9._-' '_')
-          DEVENV_GC_ROOT="$DEVENV_GC_ROOT_DIR/devenv-$DEVENV_GC_ROOT_ID"
-
-          resolve_devenv_once() {
-            mkdir -p "$DEVENV_GC_ROOT_DIR"
-            nix build \
-              --accept-flake-config \
-              --option extra-substituters https://devenv.cachix.org \
-              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --out-link "$DEVENV_GC_ROOT" \
-              --print-out-paths \
-              "github:cachix/devenv/$DEVENV_REV#devenv"
-          }
-
-          resolve_devenv() {
-            local invalid_path
-            local log
-            local rc
-
-            log=$(mktemp)
-            if resolve_devenv_once 2>"$log"; then
-              cat "$log" >&2
-              rm -f "$log"
-              return 0
-            else
-              rc=$?
-            fi
-            cat "$log" >&2
-            invalid_path=$(grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" "$log" |
-              head -1 | grep -o "/nix/store/[^']*" || true)
-            rm -f "$log"
-            [ -n "$invalid_path" ] || return "$rc"
-
-            echo "::warning::devenv resolution hit an invalid Nix store path; clearing the client eval cache and retrying once: $invalid_path" >&2
-            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/nix/eval-cache-"* ~/.cache/nix/eval-cache-*
-            nix-store --repair-path "$invalid_path" >/dev/null 2>&1 ||
-              nix-store --realise "$invalid_path" >/dev/null 2>&1 || true
-            if resolve_devenv_once; then
-              if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
-                echo '### Recovered Nix store lifecycle incident' >> "$GITHUB_STEP_SUMMARY"
-                echo "- Invalid path: $invalid_path" >> "$GITHUB_STEP_SUMMARY"
-                echo '- Attempts: 2/2' >> "$GITHUB_STEP_SUMMARY"
-              fi
-              return 0
-            else
-              return $?
-            fi
-          }
+          . '${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -4226,55 +3650,7 @@ jobs:
             exit 1
           fi
 
-          DEVENV_GC_ROOT_DIR="${RUNNER_TEMP:-/tmp}/genie-nix-gc-roots"
-          DEVENV_GC_ROOT_ID=$(printf '%s' "${GITHUB_RUN_ID:-local-$$}-${GITHUB_RUN_ATTEMPT:-0}-${GITHUB_JOB:-job}" | tr -c 'A-Za-z0-9._-' '_')
-          DEVENV_GC_ROOT="$DEVENV_GC_ROOT_DIR/devenv-$DEVENV_GC_ROOT_ID"
-
-          resolve_devenv_once() {
-            mkdir -p "$DEVENV_GC_ROOT_DIR"
-            nix build \
-              --accept-flake-config \
-              --option extra-substituters https://devenv.cachix.org \
-              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --out-link "$DEVENV_GC_ROOT" \
-              --print-out-paths \
-              "github:cachix/devenv/$DEVENV_REV#devenv"
-          }
-
-          resolve_devenv() {
-            local invalid_path
-            local log
-            local rc
-
-            log=$(mktemp)
-            if resolve_devenv_once 2>"$log"; then
-              cat "$log" >&2
-              rm -f "$log"
-              return 0
-            else
-              rc=$?
-            fi
-            cat "$log" >&2
-            invalid_path=$(grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" "$log" |
-              head -1 | grep -o "/nix/store/[^']*" || true)
-            rm -f "$log"
-            [ -n "$invalid_path" ] || return "$rc"
-
-            echo "::warning::devenv resolution hit an invalid Nix store path; clearing the client eval cache and retrying once: $invalid_path" >&2
-            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/nix/eval-cache-"* ~/.cache/nix/eval-cache-*
-            nix-store --repair-path "$invalid_path" >/dev/null 2>&1 ||
-              nix-store --realise "$invalid_path" >/dev/null 2>&1 || true
-            if resolve_devenv_once; then
-              if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
-                echo '### Recovered Nix store lifecycle incident' >> "$GITHUB_STEP_SUMMARY"
-                echo "- Invalid path: $invalid_path" >> "$GITHUB_STEP_SUMMARY"
-                echo '- Attempts: 2/2' >> "$GITHUB_STEP_SUMMARY"
-              fi
-              return 0
-            else
-              return $?
-            fi
-          }
+          . '${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -5127,55 +4503,7 @@ jobs:
             exit 1
           fi
 
-          DEVENV_GC_ROOT_DIR="${RUNNER_TEMP:-/tmp}/genie-nix-gc-roots"
-          DEVENV_GC_ROOT_ID=$(printf '%s' "${GITHUB_RUN_ID:-local-$$}-${GITHUB_RUN_ATTEMPT:-0}-${GITHUB_JOB:-job}" | tr -c 'A-Za-z0-9._-' '_')
-          DEVENV_GC_ROOT="$DEVENV_GC_ROOT_DIR/devenv-$DEVENV_GC_ROOT_ID"
-
-          resolve_devenv_once() {
-            mkdir -p "$DEVENV_GC_ROOT_DIR"
-            nix build \
-              --accept-flake-config \
-              --option extra-substituters https://devenv.cachix.org \
-              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --out-link "$DEVENV_GC_ROOT" \
-              --print-out-paths \
-              "github:cachix/devenv/$DEVENV_REV#devenv"
-          }
-
-          resolve_devenv() {
-            local invalid_path
-            local log
-            local rc
-
-            log=$(mktemp)
-            if resolve_devenv_once 2>"$log"; then
-              cat "$log" >&2
-              rm -f "$log"
-              return 0
-            else
-              rc=$?
-            fi
-            cat "$log" >&2
-            invalid_path=$(grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" "$log" |
-              head -1 | grep -o "/nix/store/[^']*" || true)
-            rm -f "$log"
-            [ -n "$invalid_path" ] || return "$rc"
-
-            echo "::warning::devenv resolution hit an invalid Nix store path; clearing the client eval cache and retrying once: $invalid_path" >&2
-            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/nix/eval-cache-"* ~/.cache/nix/eval-cache-*
-            nix-store --repair-path "$invalid_path" >/dev/null 2>&1 ||
-              nix-store --realise "$invalid_path" >/dev/null 2>&1 || true
-            if resolve_devenv_once; then
-              if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
-                echo '### Recovered Nix store lifecycle incident' >> "$GITHUB_STEP_SUMMARY"
-                echo "- Invalid path: $invalid_path" >> "$GITHUB_STEP_SUMMARY"
-                echo '- Attempts: 2/2' >> "$GITHUB_STEP_SUMMARY"
-              fi
-              return 0
-            else
-              return $?
-            fi
-          }
+          . '${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -8685,55 +8013,7 @@ jobs:
             exit 1
           fi
 
-          DEVENV_GC_ROOT_DIR="${RUNNER_TEMP:-/tmp}/genie-nix-gc-roots"
-          DEVENV_GC_ROOT_ID=$(printf '%s' "${GITHUB_RUN_ID:-local-$$}-${GITHUB_RUN_ATTEMPT:-0}-${GITHUB_JOB:-job}" | tr -c 'A-Za-z0-9._-' '_')
-          DEVENV_GC_ROOT="$DEVENV_GC_ROOT_DIR/devenv-$DEVENV_GC_ROOT_ID"
-
-          resolve_devenv_once() {
-            mkdir -p "$DEVENV_GC_ROOT_DIR"
-            nix build \
-              --accept-flake-config \
-              --option extra-substituters https://devenv.cachix.org \
-              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --out-link "$DEVENV_GC_ROOT" \
-              --print-out-paths \
-              "github:cachix/devenv/$DEVENV_REV#devenv"
-          }
-
-          resolve_devenv() {
-            local invalid_path
-            local log
-            local rc
-
-            log=$(mktemp)
-            if resolve_devenv_once 2>"$log"; then
-              cat "$log" >&2
-              rm -f "$log"
-              return 0
-            else
-              rc=$?
-            fi
-            cat "$log" >&2
-            invalid_path=$(grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" "$log" |
-              head -1 | grep -o "/nix/store/[^']*" || true)
-            rm -f "$log"
-            [ -n "$invalid_path" ] || return "$rc"
-
-            echo "::warning::devenv resolution hit an invalid Nix store path; clearing the client eval cache and retrying once: $invalid_path" >&2
-            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/nix/eval-cache-"* ~/.cache/nix/eval-cache-*
-            nix-store --repair-path "$invalid_path" >/dev/null 2>&1 ||
-              nix-store --realise "$invalid_path" >/dev/null 2>&1 || true
-            if resolve_devenv_once; then
-              if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
-                echo '### Recovered Nix store lifecycle incident' >> "$GITHUB_STEP_SUMMARY"
-                echo "- Invalid path: $invalid_path" >> "$GITHUB_STEP_SUMMARY"
-                echo '- Attempts: 2/2' >> "$GITHUB_STEP_SUMMARY"
-              fi
-              return 0
-            else
-              return $?
-            fi
-          }
+          . '${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -8997,55 +8277,7 @@ jobs:
             exit 1
           fi
 
-          DEVENV_GC_ROOT_DIR="${RUNNER_TEMP:-/tmp}/genie-nix-gc-roots"
-          DEVENV_GC_ROOT_ID=$(printf '%s' "${GITHUB_RUN_ID:-local-$$}-${GITHUB_RUN_ATTEMPT:-0}-${GITHUB_JOB:-job}" | tr -c 'A-Za-z0-9._-' '_')
-          DEVENV_GC_ROOT="$DEVENV_GC_ROOT_DIR/devenv-$DEVENV_GC_ROOT_ID"
-
-          resolve_devenv_once() {
-            mkdir -p "$DEVENV_GC_ROOT_DIR"
-            nix build \
-              --accept-flake-config \
-              --option extra-substituters https://devenv.cachix.org \
-              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --out-link "$DEVENV_GC_ROOT" \
-              --print-out-paths \
-              "github:cachix/devenv/$DEVENV_REV#devenv"
-          }
-
-          resolve_devenv() {
-            local invalid_path
-            local log
-            local rc
-
-            log=$(mktemp)
-            if resolve_devenv_once 2>"$log"; then
-              cat "$log" >&2
-              rm -f "$log"
-              return 0
-            else
-              rc=$?
-            fi
-            cat "$log" >&2
-            invalid_path=$(grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" "$log" |
-              head -1 | grep -o "/nix/store/[^']*" || true)
-            rm -f "$log"
-            [ -n "$invalid_path" ] || return "$rc"
-
-            echo "::warning::devenv resolution hit an invalid Nix store path; clearing the client eval cache and retrying once: $invalid_path" >&2
-            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/nix/eval-cache-"* ~/.cache/nix/eval-cache-*
-            nix-store --repair-path "$invalid_path" >/dev/null 2>&1 ||
-              nix-store --realise "$invalid_path" >/dev/null 2>&1 || true
-            if resolve_devenv_once; then
-              if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
-                echo '### Recovered Nix store lifecycle incident' >> "$GITHUB_STEP_SUMMARY"
-                echo "- Invalid path: $invalid_path" >> "$GITHUB_STEP_SUMMARY"
-                echo '- Attempts: 2/2' >> "$GITHUB_STEP_SUMMARY"
-              fi
-              return 0
-            else
-              return $?
-            fi
-          }
+          . '${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -9342,55 +8574,7 @@ jobs:
             exit 1
           fi
 
-          DEVENV_GC_ROOT_DIR="${RUNNER_TEMP:-/tmp}/genie-nix-gc-roots"
-          DEVENV_GC_ROOT_ID=$(printf '%s' "${GITHUB_RUN_ID:-local-$$}-${GITHUB_RUN_ATTEMPT:-0}-${GITHUB_JOB:-job}" | tr -c 'A-Za-z0-9._-' '_')
-          DEVENV_GC_ROOT="$DEVENV_GC_ROOT_DIR/devenv-$DEVENV_GC_ROOT_ID"
-
-          resolve_devenv_once() {
-            mkdir -p "$DEVENV_GC_ROOT_DIR"
-            nix build \
-              --accept-flake-config \
-              --option extra-substituters https://devenv.cachix.org \
-              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --out-link "$DEVENV_GC_ROOT" \
-              --print-out-paths \
-              "github:cachix/devenv/$DEVENV_REV#devenv"
-          }
-
-          resolve_devenv() {
-            local invalid_path
-            local log
-            local rc
-
-            log=$(mktemp)
-            if resolve_devenv_once 2>"$log"; then
-              cat "$log" >&2
-              rm -f "$log"
-              return 0
-            else
-              rc=$?
-            fi
-            cat "$log" >&2
-            invalid_path=$(grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" "$log" |
-              head -1 | grep -o "/nix/store/[^']*" || true)
-            rm -f "$log"
-            [ -n "$invalid_path" ] || return "$rc"
-
-            echo "::warning::devenv resolution hit an invalid Nix store path; clearing the client eval cache and retrying once: $invalid_path" >&2
-            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/nix/eval-cache-"* ~/.cache/nix/eval-cache-*
-            nix-store --repair-path "$invalid_path" >/dev/null 2>&1 ||
-              nix-store --realise "$invalid_path" >/dev/null 2>&1 || true
-            if resolve_devenv_once; then
-              if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
-                echo '### Recovered Nix store lifecycle incident' >> "$GITHUB_STEP_SUMMARY"
-                echo "- Invalid path: $invalid_path" >> "$GITHUB_STEP_SUMMARY"
-                echo '- Attempts: 2/2' >> "$GITHUB_STEP_SUMMARY"
-              fi
-              return 0
-            else
-              return $?
-            fi
-          }
+          . '${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -9678,55 +8862,7 @@ jobs:
             exit 1
           fi
 
-          DEVENV_GC_ROOT_DIR="${RUNNER_TEMP:-/tmp}/genie-nix-gc-roots"
-          DEVENV_GC_ROOT_ID=$(printf '%s' "${GITHUB_RUN_ID:-local-$$}-${GITHUB_RUN_ATTEMPT:-0}-${GITHUB_JOB:-job}" | tr -c 'A-Za-z0-9._-' '_')
-          DEVENV_GC_ROOT="$DEVENV_GC_ROOT_DIR/devenv-$DEVENV_GC_ROOT_ID"
-
-          resolve_devenv_once() {
-            mkdir -p "$DEVENV_GC_ROOT_DIR"
-            nix build \
-              --accept-flake-config \
-              --option extra-substituters https://devenv.cachix.org \
-              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --out-link "$DEVENV_GC_ROOT" \
-              --print-out-paths \
-              "github:cachix/devenv/$DEVENV_REV#devenv"
-          }
-
-          resolve_devenv() {
-            local invalid_path
-            local log
-            local rc
-
-            log=$(mktemp)
-            if resolve_devenv_once 2>"$log"; then
-              cat "$log" >&2
-              rm -f "$log"
-              return 0
-            else
-              rc=$?
-            fi
-            cat "$log" >&2
-            invalid_path=$(grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" "$log" |
-              head -1 | grep -o "/nix/store/[^']*" || true)
-            rm -f "$log"
-            [ -n "$invalid_path" ] || return "$rc"
-
-            echo "::warning::devenv resolution hit an invalid Nix store path; clearing the client eval cache and retrying once: $invalid_path" >&2
-            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/nix/eval-cache-"* ~/.cache/nix/eval-cache-*
-            nix-store --repair-path "$invalid_path" >/dev/null 2>&1 ||
-              nix-store --realise "$invalid_path" >/dev/null 2>&1 || true
-            if resolve_devenv_once; then
-              if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
-                echo '### Recovered Nix store lifecycle incident' >> "$GITHUB_STEP_SUMMARY"
-                echo "- Invalid path: $invalid_path" >> "$GITHUB_STEP_SUMMARY"
-                echo '- Attempts: 2/2' >> "$GITHUB_STEP_SUMMARY"
-              fi
-              return 0
-            else
-              return $?
-            fi
-          }
+          . '${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -505,14 +505,54 @@ jobs:
             exit 1
           fi
 
-          resolve_devenv() {
+          DEVENV_GC_ROOT_DIR="${RUNNER_TEMP:-/tmp}/genie-nix-gc-roots"
+          DEVENV_GC_ROOT_ID=$(printf '%s' "${GITHUB_RUN_ID:-local-$$}-${GITHUB_RUN_ATTEMPT:-0}-${GITHUB_JOB:-job}" | tr -c 'A-Za-z0-9._-' '_')
+          DEVENV_GC_ROOT="$DEVENV_GC_ROOT_DIR/devenv-$DEVENV_GC_ROOT_ID"
+
+          resolve_devenv_once() {
+            mkdir -p "$DEVENV_GC_ROOT_DIR"
             nix build \
               --accept-flake-config \
               --option extra-substituters https://devenv.cachix.org \
               --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --no-link \
+              --out-link "$DEVENV_GC_ROOT" \
               --print-out-paths \
               "github:cachix/devenv/$DEVENV_REV#devenv"
+          }
+
+          resolve_devenv() {
+            local invalid_path
+            local log
+            local rc
+
+            log=$(mktemp)
+            if resolve_devenv_once 2>"$log"; then
+              cat "$log" >&2
+              rm -f "$log"
+              return 0
+            else
+              rc=$?
+            fi
+            cat "$log" >&2
+            invalid_path=$(grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" "$log" |
+              head -1 | grep -o "/nix/store/[^']*" || true)
+            rm -f "$log"
+            [ -n "$invalid_path" ] || return "$rc"
+
+            echo "::warning::devenv resolution hit an invalid Nix store path; clearing the client eval cache and retrying once: $invalid_path" >&2
+            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/nix/eval-cache-"* ~/.cache/nix/eval-cache-*
+            nix-store --repair-path "$invalid_path" >/dev/null 2>&1 ||
+              nix-store --realise "$invalid_path" >/dev/null 2>&1 || true
+            if resolve_devenv_once; then
+              if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+                echo '### Recovered Nix store lifecycle incident' >> "$GITHUB_STEP_SUMMARY"
+                echo "- Invalid path: $invalid_path" >> "$GITHUB_STEP_SUMMARY"
+                echo '- Attempts: 2/2' >> "$GITHUB_STEP_SUMMARY"
+              fi
+              return 0
+            else
+              return $?
+            fi
           }
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
@@ -550,6 +590,15 @@ jobs:
             fi
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
           fi
+
+          # resolve_devenv_once uses this out-link directly, so Nix registers the GC
+          # root before a successful build returns. RUNNER_TEMP cleanup removes it after
+          # the job; the run/attempt/job namespace prevents cross-job replacement.
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ "$(readlink -e "$DEVENV_GC_ROOT")" != "$DEVENV_OUT" ]; then
+            echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
+            exit 1
+          fi
+          echo "DEVENV_GC_ROOT=$DEVENV_GC_ROOT" >> "$GITHUB_ENV"
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"
@@ -781,14 +830,54 @@ jobs:
             exit 1
           fi
 
-          resolve_devenv() {
+          DEVENV_GC_ROOT_DIR="${RUNNER_TEMP:-/tmp}/genie-nix-gc-roots"
+          DEVENV_GC_ROOT_ID=$(printf '%s' "${GITHUB_RUN_ID:-local-$$}-${GITHUB_RUN_ATTEMPT:-0}-${GITHUB_JOB:-job}" | tr -c 'A-Za-z0-9._-' '_')
+          DEVENV_GC_ROOT="$DEVENV_GC_ROOT_DIR/devenv-$DEVENV_GC_ROOT_ID"
+
+          resolve_devenv_once() {
+            mkdir -p "$DEVENV_GC_ROOT_DIR"
             nix build \
               --accept-flake-config \
               --option extra-substituters https://devenv.cachix.org \
               --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --no-link \
+              --out-link "$DEVENV_GC_ROOT" \
               --print-out-paths \
               "github:cachix/devenv/$DEVENV_REV#devenv"
+          }
+
+          resolve_devenv() {
+            local invalid_path
+            local log
+            local rc
+
+            log=$(mktemp)
+            if resolve_devenv_once 2>"$log"; then
+              cat "$log" >&2
+              rm -f "$log"
+              return 0
+            else
+              rc=$?
+            fi
+            cat "$log" >&2
+            invalid_path=$(grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" "$log" |
+              head -1 | grep -o "/nix/store/[^']*" || true)
+            rm -f "$log"
+            [ -n "$invalid_path" ] || return "$rc"
+
+            echo "::warning::devenv resolution hit an invalid Nix store path; clearing the client eval cache and retrying once: $invalid_path" >&2
+            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/nix/eval-cache-"* ~/.cache/nix/eval-cache-*
+            nix-store --repair-path "$invalid_path" >/dev/null 2>&1 ||
+              nix-store --realise "$invalid_path" >/dev/null 2>&1 || true
+            if resolve_devenv_once; then
+              if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+                echo '### Recovered Nix store lifecycle incident' >> "$GITHUB_STEP_SUMMARY"
+                echo "- Invalid path: $invalid_path" >> "$GITHUB_STEP_SUMMARY"
+                echo '- Attempts: 2/2' >> "$GITHUB_STEP_SUMMARY"
+              fi
+              return 0
+            else
+              return $?
+            fi
           }
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
@@ -826,6 +915,15 @@ jobs:
             fi
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
           fi
+
+          # resolve_devenv_once uses this out-link directly, so Nix registers the GC
+          # root before a successful build returns. RUNNER_TEMP cleanup removes it after
+          # the job; the run/attempt/job namespace prevents cross-job replacement.
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ "$(readlink -e "$DEVENV_GC_ROOT")" != "$DEVENV_OUT" ]; then
+            echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
+            exit 1
+          fi
+          echo "DEVENV_GC_ROOT=$DEVENV_GC_ROOT" >> "$GITHUB_ENV"
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"
@@ -1044,14 +1142,54 @@ jobs:
             exit 1
           fi
 
-          resolve_devenv() {
+          DEVENV_GC_ROOT_DIR="${RUNNER_TEMP:-/tmp}/genie-nix-gc-roots"
+          DEVENV_GC_ROOT_ID=$(printf '%s' "${GITHUB_RUN_ID:-local-$$}-${GITHUB_RUN_ATTEMPT:-0}-${GITHUB_JOB:-job}" | tr -c 'A-Za-z0-9._-' '_')
+          DEVENV_GC_ROOT="$DEVENV_GC_ROOT_DIR/devenv-$DEVENV_GC_ROOT_ID"
+
+          resolve_devenv_once() {
+            mkdir -p "$DEVENV_GC_ROOT_DIR"
             nix build \
               --accept-flake-config \
               --option extra-substituters https://devenv.cachix.org \
               --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --no-link \
+              --out-link "$DEVENV_GC_ROOT" \
               --print-out-paths \
               "github:cachix/devenv/$DEVENV_REV#devenv"
+          }
+
+          resolve_devenv() {
+            local invalid_path
+            local log
+            local rc
+
+            log=$(mktemp)
+            if resolve_devenv_once 2>"$log"; then
+              cat "$log" >&2
+              rm -f "$log"
+              return 0
+            else
+              rc=$?
+            fi
+            cat "$log" >&2
+            invalid_path=$(grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" "$log" |
+              head -1 | grep -o "/nix/store/[^']*" || true)
+            rm -f "$log"
+            [ -n "$invalid_path" ] || return "$rc"
+
+            echo "::warning::devenv resolution hit an invalid Nix store path; clearing the client eval cache and retrying once: $invalid_path" >&2
+            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/nix/eval-cache-"* ~/.cache/nix/eval-cache-*
+            nix-store --repair-path "$invalid_path" >/dev/null 2>&1 ||
+              nix-store --realise "$invalid_path" >/dev/null 2>&1 || true
+            if resolve_devenv_once; then
+              if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+                echo '### Recovered Nix store lifecycle incident' >> "$GITHUB_STEP_SUMMARY"
+                echo "- Invalid path: $invalid_path" >> "$GITHUB_STEP_SUMMARY"
+                echo '- Attempts: 2/2' >> "$GITHUB_STEP_SUMMARY"
+              fi
+              return 0
+            else
+              return $?
+            fi
           }
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
@@ -1089,6 +1227,15 @@ jobs:
             fi
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
           fi
+
+          # resolve_devenv_once uses this out-link directly, so Nix registers the GC
+          # root before a successful build returns. RUNNER_TEMP cleanup removes it after
+          # the job; the run/attempt/job namespace prevents cross-job replacement.
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ "$(readlink -e "$DEVENV_GC_ROOT")" != "$DEVENV_OUT" ]; then
+            echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
+            exit 1
+          fi
+          echo "DEVENV_GC_ROOT=$DEVENV_GC_ROOT" >> "$GITHUB_ENV"
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"
@@ -1304,14 +1451,54 @@ jobs:
             exit 1
           fi
 
-          resolve_devenv() {
+          DEVENV_GC_ROOT_DIR="${RUNNER_TEMP:-/tmp}/genie-nix-gc-roots"
+          DEVENV_GC_ROOT_ID=$(printf '%s' "${GITHUB_RUN_ID:-local-$$}-${GITHUB_RUN_ATTEMPT:-0}-${GITHUB_JOB:-job}" | tr -c 'A-Za-z0-9._-' '_')
+          DEVENV_GC_ROOT="$DEVENV_GC_ROOT_DIR/devenv-$DEVENV_GC_ROOT_ID"
+
+          resolve_devenv_once() {
+            mkdir -p "$DEVENV_GC_ROOT_DIR"
             nix build \
               --accept-flake-config \
               --option extra-substituters https://devenv.cachix.org \
               --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --no-link \
+              --out-link "$DEVENV_GC_ROOT" \
               --print-out-paths \
               "github:cachix/devenv/$DEVENV_REV#devenv"
+          }
+
+          resolve_devenv() {
+            local invalid_path
+            local log
+            local rc
+
+            log=$(mktemp)
+            if resolve_devenv_once 2>"$log"; then
+              cat "$log" >&2
+              rm -f "$log"
+              return 0
+            else
+              rc=$?
+            fi
+            cat "$log" >&2
+            invalid_path=$(grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" "$log" |
+              head -1 | grep -o "/nix/store/[^']*" || true)
+            rm -f "$log"
+            [ -n "$invalid_path" ] || return "$rc"
+
+            echo "::warning::devenv resolution hit an invalid Nix store path; clearing the client eval cache and retrying once: $invalid_path" >&2
+            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/nix/eval-cache-"* ~/.cache/nix/eval-cache-*
+            nix-store --repair-path "$invalid_path" >/dev/null 2>&1 ||
+              nix-store --realise "$invalid_path" >/dev/null 2>&1 || true
+            if resolve_devenv_once; then
+              if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+                echo '### Recovered Nix store lifecycle incident' >> "$GITHUB_STEP_SUMMARY"
+                echo "- Invalid path: $invalid_path" >> "$GITHUB_STEP_SUMMARY"
+                echo '- Attempts: 2/2' >> "$GITHUB_STEP_SUMMARY"
+              fi
+              return 0
+            else
+              return $?
+            fi
           }
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
@@ -1349,6 +1536,15 @@ jobs:
             fi
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
           fi
+
+          # resolve_devenv_once uses this out-link directly, so Nix registers the GC
+          # root before a successful build returns. RUNNER_TEMP cleanup removes it after
+          # the job; the run/attempt/job namespace prevents cross-job replacement.
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ "$(readlink -e "$DEVENV_GC_ROOT")" != "$DEVENV_OUT" ]; then
+            echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
+            exit 1
+          fi
+          echo "DEVENV_GC_ROOT=$DEVENV_GC_ROOT" >> "$GITHUB_ENV"
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"
@@ -1567,14 +1763,54 @@ jobs:
             exit 1
           fi
 
-          resolve_devenv() {
+          DEVENV_GC_ROOT_DIR="${RUNNER_TEMP:-/tmp}/genie-nix-gc-roots"
+          DEVENV_GC_ROOT_ID=$(printf '%s' "${GITHUB_RUN_ID:-local-$$}-${GITHUB_RUN_ATTEMPT:-0}-${GITHUB_JOB:-job}" | tr -c 'A-Za-z0-9._-' '_')
+          DEVENV_GC_ROOT="$DEVENV_GC_ROOT_DIR/devenv-$DEVENV_GC_ROOT_ID"
+
+          resolve_devenv_once() {
+            mkdir -p "$DEVENV_GC_ROOT_DIR"
             nix build \
               --accept-flake-config \
               --option extra-substituters https://devenv.cachix.org \
               --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --no-link \
+              --out-link "$DEVENV_GC_ROOT" \
               --print-out-paths \
               "github:cachix/devenv/$DEVENV_REV#devenv"
+          }
+
+          resolve_devenv() {
+            local invalid_path
+            local log
+            local rc
+
+            log=$(mktemp)
+            if resolve_devenv_once 2>"$log"; then
+              cat "$log" >&2
+              rm -f "$log"
+              return 0
+            else
+              rc=$?
+            fi
+            cat "$log" >&2
+            invalid_path=$(grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" "$log" |
+              head -1 | grep -o "/nix/store/[^']*" || true)
+            rm -f "$log"
+            [ -n "$invalid_path" ] || return "$rc"
+
+            echo "::warning::devenv resolution hit an invalid Nix store path; clearing the client eval cache and retrying once: $invalid_path" >&2
+            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/nix/eval-cache-"* ~/.cache/nix/eval-cache-*
+            nix-store --repair-path "$invalid_path" >/dev/null 2>&1 ||
+              nix-store --realise "$invalid_path" >/dev/null 2>&1 || true
+            if resolve_devenv_once; then
+              if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+                echo '### Recovered Nix store lifecycle incident' >> "$GITHUB_STEP_SUMMARY"
+                echo "- Invalid path: $invalid_path" >> "$GITHUB_STEP_SUMMARY"
+                echo '- Attempts: 2/2' >> "$GITHUB_STEP_SUMMARY"
+              fi
+              return 0
+            else
+              return $?
+            fi
           }
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
@@ -1612,6 +1848,15 @@ jobs:
             fi
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
           fi
+
+          # resolve_devenv_once uses this out-link directly, so Nix registers the GC
+          # root before a successful build returns. RUNNER_TEMP cleanup removes it after
+          # the job; the run/attempt/job namespace prevents cross-job replacement.
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ "$(readlink -e "$DEVENV_GC_ROOT")" != "$DEVENV_OUT" ]; then
+            echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
+            exit 1
+          fi
+          echo "DEVENV_GC_ROOT=$DEVENV_GC_ROOT" >> "$GITHUB_ENV"
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"
@@ -1806,14 +2051,54 @@ jobs:
             exit 1
           fi
 
-          resolve_devenv() {
+          DEVENV_GC_ROOT_DIR="${RUNNER_TEMP:-/tmp}/genie-nix-gc-roots"
+          DEVENV_GC_ROOT_ID=$(printf '%s' "${GITHUB_RUN_ID:-local-$$}-${GITHUB_RUN_ATTEMPT:-0}-${GITHUB_JOB:-job}" | tr -c 'A-Za-z0-9._-' '_')
+          DEVENV_GC_ROOT="$DEVENV_GC_ROOT_DIR/devenv-$DEVENV_GC_ROOT_ID"
+
+          resolve_devenv_once() {
+            mkdir -p "$DEVENV_GC_ROOT_DIR"
             nix build \
               --accept-flake-config \
               --option extra-substituters https://devenv.cachix.org \
               --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --no-link \
+              --out-link "$DEVENV_GC_ROOT" \
               --print-out-paths \
               "github:cachix/devenv/$DEVENV_REV#devenv"
+          }
+
+          resolve_devenv() {
+            local invalid_path
+            local log
+            local rc
+
+            log=$(mktemp)
+            if resolve_devenv_once 2>"$log"; then
+              cat "$log" >&2
+              rm -f "$log"
+              return 0
+            else
+              rc=$?
+            fi
+            cat "$log" >&2
+            invalid_path=$(grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" "$log" |
+              head -1 | grep -o "/nix/store/[^']*" || true)
+            rm -f "$log"
+            [ -n "$invalid_path" ] || return "$rc"
+
+            echo "::warning::devenv resolution hit an invalid Nix store path; clearing the client eval cache and retrying once: $invalid_path" >&2
+            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/nix/eval-cache-"* ~/.cache/nix/eval-cache-*
+            nix-store --repair-path "$invalid_path" >/dev/null 2>&1 ||
+              nix-store --realise "$invalid_path" >/dev/null 2>&1 || true
+            if resolve_devenv_once; then
+              if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+                echo '### Recovered Nix store lifecycle incident' >> "$GITHUB_STEP_SUMMARY"
+                echo "- Invalid path: $invalid_path" >> "$GITHUB_STEP_SUMMARY"
+                echo '- Attempts: 2/2' >> "$GITHUB_STEP_SUMMARY"
+              fi
+              return 0
+            else
+              return $?
+            fi
           }
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
@@ -1851,6 +2136,15 @@ jobs:
             fi
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
           fi
+
+          # resolve_devenv_once uses this out-link directly, so Nix registers the GC
+          # root before a successful build returns. RUNNER_TEMP cleanup removes it after
+          # the job; the run/attempt/job namespace prevents cross-job replacement.
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ "$(readlink -e "$DEVENV_GC_ROOT")" != "$DEVENV_OUT" ]; then
+            echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
+            exit 1
+          fi
+          echo "DEVENV_GC_ROOT=$DEVENV_GC_ROOT" >> "$GITHUB_ENV"
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"
@@ -2008,14 +2302,54 @@ jobs:
             exit 1
           fi
 
-          resolve_devenv() {
+          DEVENV_GC_ROOT_DIR="${RUNNER_TEMP:-/tmp}/genie-nix-gc-roots"
+          DEVENV_GC_ROOT_ID=$(printf '%s' "${GITHUB_RUN_ID:-local-$$}-${GITHUB_RUN_ATTEMPT:-0}-${GITHUB_JOB:-job}" | tr -c 'A-Za-z0-9._-' '_')
+          DEVENV_GC_ROOT="$DEVENV_GC_ROOT_DIR/devenv-$DEVENV_GC_ROOT_ID"
+
+          resolve_devenv_once() {
+            mkdir -p "$DEVENV_GC_ROOT_DIR"
             nix build \
               --accept-flake-config \
               --option extra-substituters https://devenv.cachix.org \
               --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --no-link \
+              --out-link "$DEVENV_GC_ROOT" \
               --print-out-paths \
               "github:cachix/devenv/$DEVENV_REV#devenv"
+          }
+
+          resolve_devenv() {
+            local invalid_path
+            local log
+            local rc
+
+            log=$(mktemp)
+            if resolve_devenv_once 2>"$log"; then
+              cat "$log" >&2
+              rm -f "$log"
+              return 0
+            else
+              rc=$?
+            fi
+            cat "$log" >&2
+            invalid_path=$(grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" "$log" |
+              head -1 | grep -o "/nix/store/[^']*" || true)
+            rm -f "$log"
+            [ -n "$invalid_path" ] || return "$rc"
+
+            echo "::warning::devenv resolution hit an invalid Nix store path; clearing the client eval cache and retrying once: $invalid_path" >&2
+            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/nix/eval-cache-"* ~/.cache/nix/eval-cache-*
+            nix-store --repair-path "$invalid_path" >/dev/null 2>&1 ||
+              nix-store --realise "$invalid_path" >/dev/null 2>&1 || true
+            if resolve_devenv_once; then
+              if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+                echo '### Recovered Nix store lifecycle incident' >> "$GITHUB_STEP_SUMMARY"
+                echo "- Invalid path: $invalid_path" >> "$GITHUB_STEP_SUMMARY"
+                echo '- Attempts: 2/2' >> "$GITHUB_STEP_SUMMARY"
+              fi
+              return 0
+            else
+              return $?
+            fi
           }
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
@@ -2053,6 +2387,15 @@ jobs:
             fi
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
           fi
+
+          # resolve_devenv_once uses this out-link directly, so Nix registers the GC
+          # root before a successful build returns. RUNNER_TEMP cleanup removes it after
+          # the job; the run/attempt/job namespace prevents cross-job replacement.
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ "$(readlink -e "$DEVENV_GC_ROOT")" != "$DEVENV_OUT" ]; then
+            echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
+            exit 1
+          fi
+          echo "DEVENV_GC_ROOT=$DEVENV_GC_ROOT" >> "$GITHUB_ENV"
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"
@@ -2319,14 +2662,54 @@ jobs:
             exit 1
           fi
 
-          resolve_devenv() {
+          DEVENV_GC_ROOT_DIR="${RUNNER_TEMP:-/tmp}/genie-nix-gc-roots"
+          DEVENV_GC_ROOT_ID=$(printf '%s' "${GITHUB_RUN_ID:-local-$$}-${GITHUB_RUN_ATTEMPT:-0}-${GITHUB_JOB:-job}" | tr -c 'A-Za-z0-9._-' '_')
+          DEVENV_GC_ROOT="$DEVENV_GC_ROOT_DIR/devenv-$DEVENV_GC_ROOT_ID"
+
+          resolve_devenv_once() {
+            mkdir -p "$DEVENV_GC_ROOT_DIR"
             nix build \
               --accept-flake-config \
               --option extra-substituters https://devenv.cachix.org \
               --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --no-link \
+              --out-link "$DEVENV_GC_ROOT" \
               --print-out-paths \
               "github:cachix/devenv/$DEVENV_REV#devenv"
+          }
+
+          resolve_devenv() {
+            local invalid_path
+            local log
+            local rc
+
+            log=$(mktemp)
+            if resolve_devenv_once 2>"$log"; then
+              cat "$log" >&2
+              rm -f "$log"
+              return 0
+            else
+              rc=$?
+            fi
+            cat "$log" >&2
+            invalid_path=$(grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" "$log" |
+              head -1 | grep -o "/nix/store/[^']*" || true)
+            rm -f "$log"
+            [ -n "$invalid_path" ] || return "$rc"
+
+            echo "::warning::devenv resolution hit an invalid Nix store path; clearing the client eval cache and retrying once: $invalid_path" >&2
+            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/nix/eval-cache-"* ~/.cache/nix/eval-cache-*
+            nix-store --repair-path "$invalid_path" >/dev/null 2>&1 ||
+              nix-store --realise "$invalid_path" >/dev/null 2>&1 || true
+            if resolve_devenv_once; then
+              if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+                echo '### Recovered Nix store lifecycle incident' >> "$GITHUB_STEP_SUMMARY"
+                echo "- Invalid path: $invalid_path" >> "$GITHUB_STEP_SUMMARY"
+                echo '- Attempts: 2/2' >> "$GITHUB_STEP_SUMMARY"
+              fi
+              return 0
+            else
+              return $?
+            fi
           }
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
@@ -2364,6 +2747,15 @@ jobs:
             fi
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
           fi
+
+          # resolve_devenv_once uses this out-link directly, so Nix registers the GC
+          # root before a successful build returns. RUNNER_TEMP cleanup removes it after
+          # the job; the run/attempt/job namespace prevents cross-job replacement.
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ "$(readlink -e "$DEVENV_GC_ROOT")" != "$DEVENV_OUT" ]; then
+            echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
+            exit 1
+          fi
+          echo "DEVENV_GC_ROOT=$DEVENV_GC_ROOT" >> "$GITHUB_ENV"
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"
@@ -2581,14 +2973,54 @@ jobs:
             exit 1
           fi
 
-          resolve_devenv() {
+          DEVENV_GC_ROOT_DIR="${RUNNER_TEMP:-/tmp}/genie-nix-gc-roots"
+          DEVENV_GC_ROOT_ID=$(printf '%s' "${GITHUB_RUN_ID:-local-$$}-${GITHUB_RUN_ATTEMPT:-0}-${GITHUB_JOB:-job}" | tr -c 'A-Za-z0-9._-' '_')
+          DEVENV_GC_ROOT="$DEVENV_GC_ROOT_DIR/devenv-$DEVENV_GC_ROOT_ID"
+
+          resolve_devenv_once() {
+            mkdir -p "$DEVENV_GC_ROOT_DIR"
             nix build \
               --accept-flake-config \
               --option extra-substituters https://devenv.cachix.org \
               --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --no-link \
+              --out-link "$DEVENV_GC_ROOT" \
               --print-out-paths \
               "github:cachix/devenv/$DEVENV_REV#devenv"
+          }
+
+          resolve_devenv() {
+            local invalid_path
+            local log
+            local rc
+
+            log=$(mktemp)
+            if resolve_devenv_once 2>"$log"; then
+              cat "$log" >&2
+              rm -f "$log"
+              return 0
+            else
+              rc=$?
+            fi
+            cat "$log" >&2
+            invalid_path=$(grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" "$log" |
+              head -1 | grep -o "/nix/store/[^']*" || true)
+            rm -f "$log"
+            [ -n "$invalid_path" ] || return "$rc"
+
+            echo "::warning::devenv resolution hit an invalid Nix store path; clearing the client eval cache and retrying once: $invalid_path" >&2
+            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/nix/eval-cache-"* ~/.cache/nix/eval-cache-*
+            nix-store --repair-path "$invalid_path" >/dev/null 2>&1 ||
+              nix-store --realise "$invalid_path" >/dev/null 2>&1 || true
+            if resolve_devenv_once; then
+              if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+                echo '### Recovered Nix store lifecycle incident' >> "$GITHUB_STEP_SUMMARY"
+                echo "- Invalid path: $invalid_path" >> "$GITHUB_STEP_SUMMARY"
+                echo '- Attempts: 2/2' >> "$GITHUB_STEP_SUMMARY"
+              fi
+              return 0
+            else
+              return $?
+            fi
           }
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
@@ -2626,6 +3058,15 @@ jobs:
             fi
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
           fi
+
+          # resolve_devenv_once uses this out-link directly, so Nix registers the GC
+          # root before a successful build returns. RUNNER_TEMP cleanup removes it after
+          # the job; the run/attempt/job namespace prevents cross-job replacement.
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ "$(readlink -e "$DEVENV_GC_ROOT")" != "$DEVENV_OUT" ]; then
+            echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
+            exit 1
+          fi
+          echo "DEVENV_GC_ROOT=$DEVENV_GC_ROOT" >> "$GITHUB_ENV"
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"
@@ -2841,14 +3282,54 @@ jobs:
             exit 1
           fi
 
-          resolve_devenv() {
+          DEVENV_GC_ROOT_DIR="${RUNNER_TEMP:-/tmp}/genie-nix-gc-roots"
+          DEVENV_GC_ROOT_ID=$(printf '%s' "${GITHUB_RUN_ID:-local-$$}-${GITHUB_RUN_ATTEMPT:-0}-${GITHUB_JOB:-job}" | tr -c 'A-Za-z0-9._-' '_')
+          DEVENV_GC_ROOT="$DEVENV_GC_ROOT_DIR/devenv-$DEVENV_GC_ROOT_ID"
+
+          resolve_devenv_once() {
+            mkdir -p "$DEVENV_GC_ROOT_DIR"
             nix build \
               --accept-flake-config \
               --option extra-substituters https://devenv.cachix.org \
               --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --no-link \
+              --out-link "$DEVENV_GC_ROOT" \
               --print-out-paths \
               "github:cachix/devenv/$DEVENV_REV#devenv"
+          }
+
+          resolve_devenv() {
+            local invalid_path
+            local log
+            local rc
+
+            log=$(mktemp)
+            if resolve_devenv_once 2>"$log"; then
+              cat "$log" >&2
+              rm -f "$log"
+              return 0
+            else
+              rc=$?
+            fi
+            cat "$log" >&2
+            invalid_path=$(grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" "$log" |
+              head -1 | grep -o "/nix/store/[^']*" || true)
+            rm -f "$log"
+            [ -n "$invalid_path" ] || return "$rc"
+
+            echo "::warning::devenv resolution hit an invalid Nix store path; clearing the client eval cache and retrying once: $invalid_path" >&2
+            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/nix/eval-cache-"* ~/.cache/nix/eval-cache-*
+            nix-store --repair-path "$invalid_path" >/dev/null 2>&1 ||
+              nix-store --realise "$invalid_path" >/dev/null 2>&1 || true
+            if resolve_devenv_once; then
+              if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+                echo '### Recovered Nix store lifecycle incident' >> "$GITHUB_STEP_SUMMARY"
+                echo "- Invalid path: $invalid_path" >> "$GITHUB_STEP_SUMMARY"
+                echo '- Attempts: 2/2' >> "$GITHUB_STEP_SUMMARY"
+              fi
+              return 0
+            else
+              return $?
+            fi
           }
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
@@ -2886,6 +3367,15 @@ jobs:
             fi
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
           fi
+
+          # resolve_devenv_once uses this out-link directly, so Nix registers the GC
+          # root before a successful build returns. RUNNER_TEMP cleanup removes it after
+          # the job; the run/attempt/job namespace prevents cross-job replacement.
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ "$(readlink -e "$DEVENV_GC_ROOT")" != "$DEVENV_OUT" ]; then
+            echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
+            exit 1
+          fi
+          echo "DEVENV_GC_ROOT=$DEVENV_GC_ROOT" >> "$GITHUB_ENV"
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"
@@ -3101,14 +3591,54 @@ jobs:
             exit 1
           fi
 
-          resolve_devenv() {
+          DEVENV_GC_ROOT_DIR="${RUNNER_TEMP:-/tmp}/genie-nix-gc-roots"
+          DEVENV_GC_ROOT_ID=$(printf '%s' "${GITHUB_RUN_ID:-local-$$}-${GITHUB_RUN_ATTEMPT:-0}-${GITHUB_JOB:-job}" | tr -c 'A-Za-z0-9._-' '_')
+          DEVENV_GC_ROOT="$DEVENV_GC_ROOT_DIR/devenv-$DEVENV_GC_ROOT_ID"
+
+          resolve_devenv_once() {
+            mkdir -p "$DEVENV_GC_ROOT_DIR"
             nix build \
               --accept-flake-config \
               --option extra-substituters https://devenv.cachix.org \
               --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --no-link \
+              --out-link "$DEVENV_GC_ROOT" \
               --print-out-paths \
               "github:cachix/devenv/$DEVENV_REV#devenv"
+          }
+
+          resolve_devenv() {
+            local invalid_path
+            local log
+            local rc
+
+            log=$(mktemp)
+            if resolve_devenv_once 2>"$log"; then
+              cat "$log" >&2
+              rm -f "$log"
+              return 0
+            else
+              rc=$?
+            fi
+            cat "$log" >&2
+            invalid_path=$(grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" "$log" |
+              head -1 | grep -o "/nix/store/[^']*" || true)
+            rm -f "$log"
+            [ -n "$invalid_path" ] || return "$rc"
+
+            echo "::warning::devenv resolution hit an invalid Nix store path; clearing the client eval cache and retrying once: $invalid_path" >&2
+            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/nix/eval-cache-"* ~/.cache/nix/eval-cache-*
+            nix-store --repair-path "$invalid_path" >/dev/null 2>&1 ||
+              nix-store --realise "$invalid_path" >/dev/null 2>&1 || true
+            if resolve_devenv_once; then
+              if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+                echo '### Recovered Nix store lifecycle incident' >> "$GITHUB_STEP_SUMMARY"
+                echo "- Invalid path: $invalid_path" >> "$GITHUB_STEP_SUMMARY"
+                echo '- Attempts: 2/2' >> "$GITHUB_STEP_SUMMARY"
+              fi
+              return 0
+            else
+              return $?
+            fi
           }
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
@@ -3146,6 +3676,15 @@ jobs:
             fi
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
           fi
+
+          # resolve_devenv_once uses this out-link directly, so Nix registers the GC
+          # root before a successful build returns. RUNNER_TEMP cleanup removes it after
+          # the job; the run/attempt/job namespace prevents cross-job replacement.
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ "$(readlink -e "$DEVENV_GC_ROOT")" != "$DEVENV_OUT" ]; then
+            echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
+            exit 1
+          fi
+          echo "DEVENV_GC_ROOT=$DEVENV_GC_ROOT" >> "$GITHUB_ENV"
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"
@@ -3368,14 +3907,54 @@ jobs:
             exit 1
           fi
 
-          resolve_devenv() {
+          DEVENV_GC_ROOT_DIR="${RUNNER_TEMP:-/tmp}/genie-nix-gc-roots"
+          DEVENV_GC_ROOT_ID=$(printf '%s' "${GITHUB_RUN_ID:-local-$$}-${GITHUB_RUN_ATTEMPT:-0}-${GITHUB_JOB:-job}" | tr -c 'A-Za-z0-9._-' '_')
+          DEVENV_GC_ROOT="$DEVENV_GC_ROOT_DIR/devenv-$DEVENV_GC_ROOT_ID"
+
+          resolve_devenv_once() {
+            mkdir -p "$DEVENV_GC_ROOT_DIR"
             nix build \
               --accept-flake-config \
               --option extra-substituters https://devenv.cachix.org \
               --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --no-link \
+              --out-link "$DEVENV_GC_ROOT" \
               --print-out-paths \
               "github:cachix/devenv/$DEVENV_REV#devenv"
+          }
+
+          resolve_devenv() {
+            local invalid_path
+            local log
+            local rc
+
+            log=$(mktemp)
+            if resolve_devenv_once 2>"$log"; then
+              cat "$log" >&2
+              rm -f "$log"
+              return 0
+            else
+              rc=$?
+            fi
+            cat "$log" >&2
+            invalid_path=$(grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" "$log" |
+              head -1 | grep -o "/nix/store/[^']*" || true)
+            rm -f "$log"
+            [ -n "$invalid_path" ] || return "$rc"
+
+            echo "::warning::devenv resolution hit an invalid Nix store path; clearing the client eval cache and retrying once: $invalid_path" >&2
+            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/nix/eval-cache-"* ~/.cache/nix/eval-cache-*
+            nix-store --repair-path "$invalid_path" >/dev/null 2>&1 ||
+              nix-store --realise "$invalid_path" >/dev/null 2>&1 || true
+            if resolve_devenv_once; then
+              if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+                echo '### Recovered Nix store lifecycle incident' >> "$GITHUB_STEP_SUMMARY"
+                echo "- Invalid path: $invalid_path" >> "$GITHUB_STEP_SUMMARY"
+                echo '- Attempts: 2/2' >> "$GITHUB_STEP_SUMMARY"
+              fi
+              return 0
+            else
+              return $?
+            fi
           }
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
@@ -3413,6 +3992,15 @@ jobs:
             fi
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
           fi
+
+          # resolve_devenv_once uses this out-link directly, so Nix registers the GC
+          # root before a successful build returns. RUNNER_TEMP cleanup removes it after
+          # the job; the run/attempt/job namespace prevents cross-job replacement.
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ "$(readlink -e "$DEVENV_GC_ROOT")" != "$DEVENV_OUT" ]; then
+            echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
+            exit 1
+          fi
+          echo "DEVENV_GC_ROOT=$DEVENV_GC_ROOT" >> "$GITHUB_ENV"
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"
@@ -3638,14 +4226,54 @@ jobs:
             exit 1
           fi
 
-          resolve_devenv() {
+          DEVENV_GC_ROOT_DIR="${RUNNER_TEMP:-/tmp}/genie-nix-gc-roots"
+          DEVENV_GC_ROOT_ID=$(printf '%s' "${GITHUB_RUN_ID:-local-$$}-${GITHUB_RUN_ATTEMPT:-0}-${GITHUB_JOB:-job}" | tr -c 'A-Za-z0-9._-' '_')
+          DEVENV_GC_ROOT="$DEVENV_GC_ROOT_DIR/devenv-$DEVENV_GC_ROOT_ID"
+
+          resolve_devenv_once() {
+            mkdir -p "$DEVENV_GC_ROOT_DIR"
             nix build \
               --accept-flake-config \
               --option extra-substituters https://devenv.cachix.org \
               --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --no-link \
+              --out-link "$DEVENV_GC_ROOT" \
               --print-out-paths \
               "github:cachix/devenv/$DEVENV_REV#devenv"
+          }
+
+          resolve_devenv() {
+            local invalid_path
+            local log
+            local rc
+
+            log=$(mktemp)
+            if resolve_devenv_once 2>"$log"; then
+              cat "$log" >&2
+              rm -f "$log"
+              return 0
+            else
+              rc=$?
+            fi
+            cat "$log" >&2
+            invalid_path=$(grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" "$log" |
+              head -1 | grep -o "/nix/store/[^']*" || true)
+            rm -f "$log"
+            [ -n "$invalid_path" ] || return "$rc"
+
+            echo "::warning::devenv resolution hit an invalid Nix store path; clearing the client eval cache and retrying once: $invalid_path" >&2
+            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/nix/eval-cache-"* ~/.cache/nix/eval-cache-*
+            nix-store --repair-path "$invalid_path" >/dev/null 2>&1 ||
+              nix-store --realise "$invalid_path" >/dev/null 2>&1 || true
+            if resolve_devenv_once; then
+              if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+                echo '### Recovered Nix store lifecycle incident' >> "$GITHUB_STEP_SUMMARY"
+                echo "- Invalid path: $invalid_path" >> "$GITHUB_STEP_SUMMARY"
+                echo '- Attempts: 2/2' >> "$GITHUB_STEP_SUMMARY"
+              fi
+              return 0
+            else
+              return $?
+            fi
           }
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
@@ -3683,6 +4311,15 @@ jobs:
             fi
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
           fi
+
+          # resolve_devenv_once uses this out-link directly, so Nix registers the GC
+          # root before a successful build returns. RUNNER_TEMP cleanup removes it after
+          # the job; the run/attempt/job namespace prevents cross-job replacement.
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ "$(readlink -e "$DEVENV_GC_ROOT")" != "$DEVENV_OUT" ]; then
+            echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
+            exit 1
+          fi
+          echo "DEVENV_GC_ROOT=$DEVENV_GC_ROOT" >> "$GITHUB_ENV"
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"
@@ -4490,14 +5127,54 @@ jobs:
             exit 1
           fi
 
-          resolve_devenv() {
+          DEVENV_GC_ROOT_DIR="${RUNNER_TEMP:-/tmp}/genie-nix-gc-roots"
+          DEVENV_GC_ROOT_ID=$(printf '%s' "${GITHUB_RUN_ID:-local-$$}-${GITHUB_RUN_ATTEMPT:-0}-${GITHUB_JOB:-job}" | tr -c 'A-Za-z0-9._-' '_')
+          DEVENV_GC_ROOT="$DEVENV_GC_ROOT_DIR/devenv-$DEVENV_GC_ROOT_ID"
+
+          resolve_devenv_once() {
+            mkdir -p "$DEVENV_GC_ROOT_DIR"
             nix build \
               --accept-flake-config \
               --option extra-substituters https://devenv.cachix.org \
               --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --no-link \
+              --out-link "$DEVENV_GC_ROOT" \
               --print-out-paths \
               "github:cachix/devenv/$DEVENV_REV#devenv"
+          }
+
+          resolve_devenv() {
+            local invalid_path
+            local log
+            local rc
+
+            log=$(mktemp)
+            if resolve_devenv_once 2>"$log"; then
+              cat "$log" >&2
+              rm -f "$log"
+              return 0
+            else
+              rc=$?
+            fi
+            cat "$log" >&2
+            invalid_path=$(grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" "$log" |
+              head -1 | grep -o "/nix/store/[^']*" || true)
+            rm -f "$log"
+            [ -n "$invalid_path" ] || return "$rc"
+
+            echo "::warning::devenv resolution hit an invalid Nix store path; clearing the client eval cache and retrying once: $invalid_path" >&2
+            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/nix/eval-cache-"* ~/.cache/nix/eval-cache-*
+            nix-store --repair-path "$invalid_path" >/dev/null 2>&1 ||
+              nix-store --realise "$invalid_path" >/dev/null 2>&1 || true
+            if resolve_devenv_once; then
+              if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+                echo '### Recovered Nix store lifecycle incident' >> "$GITHUB_STEP_SUMMARY"
+                echo "- Invalid path: $invalid_path" >> "$GITHUB_STEP_SUMMARY"
+                echo '- Attempts: 2/2' >> "$GITHUB_STEP_SUMMARY"
+              fi
+              return 0
+            else
+              return $?
+            fi
           }
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
@@ -4535,6 +5212,15 @@ jobs:
             fi
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
           fi
+
+          # resolve_devenv_once uses this out-link directly, so Nix registers the GC
+          # root before a successful build returns. RUNNER_TEMP cleanup removes it after
+          # the job; the run/attempt/job namespace prevents cross-job replacement.
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ "$(readlink -e "$DEVENV_GC_ROOT")" != "$DEVENV_OUT" ]; then
+            echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
+            exit 1
+          fi
+          echo "DEVENV_GC_ROOT=$DEVENV_GC_ROOT" >> "$GITHUB_ENV"
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"
@@ -7999,14 +8685,54 @@ jobs:
             exit 1
           fi
 
-          resolve_devenv() {
+          DEVENV_GC_ROOT_DIR="${RUNNER_TEMP:-/tmp}/genie-nix-gc-roots"
+          DEVENV_GC_ROOT_ID=$(printf '%s' "${GITHUB_RUN_ID:-local-$$}-${GITHUB_RUN_ATTEMPT:-0}-${GITHUB_JOB:-job}" | tr -c 'A-Za-z0-9._-' '_')
+          DEVENV_GC_ROOT="$DEVENV_GC_ROOT_DIR/devenv-$DEVENV_GC_ROOT_ID"
+
+          resolve_devenv_once() {
+            mkdir -p "$DEVENV_GC_ROOT_DIR"
             nix build \
               --accept-flake-config \
               --option extra-substituters https://devenv.cachix.org \
               --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --no-link \
+              --out-link "$DEVENV_GC_ROOT" \
               --print-out-paths \
               "github:cachix/devenv/$DEVENV_REV#devenv"
+          }
+
+          resolve_devenv() {
+            local invalid_path
+            local log
+            local rc
+
+            log=$(mktemp)
+            if resolve_devenv_once 2>"$log"; then
+              cat "$log" >&2
+              rm -f "$log"
+              return 0
+            else
+              rc=$?
+            fi
+            cat "$log" >&2
+            invalid_path=$(grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" "$log" |
+              head -1 | grep -o "/nix/store/[^']*" || true)
+            rm -f "$log"
+            [ -n "$invalid_path" ] || return "$rc"
+
+            echo "::warning::devenv resolution hit an invalid Nix store path; clearing the client eval cache and retrying once: $invalid_path" >&2
+            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/nix/eval-cache-"* ~/.cache/nix/eval-cache-*
+            nix-store --repair-path "$invalid_path" >/dev/null 2>&1 ||
+              nix-store --realise "$invalid_path" >/dev/null 2>&1 || true
+            if resolve_devenv_once; then
+              if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+                echo '### Recovered Nix store lifecycle incident' >> "$GITHUB_STEP_SUMMARY"
+                echo "- Invalid path: $invalid_path" >> "$GITHUB_STEP_SUMMARY"
+                echo '- Attempts: 2/2' >> "$GITHUB_STEP_SUMMARY"
+              fi
+              return 0
+            else
+              return $?
+            fi
           }
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
@@ -8044,6 +8770,15 @@ jobs:
             fi
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
           fi
+
+          # resolve_devenv_once uses this out-link directly, so Nix registers the GC
+          # root before a successful build returns. RUNNER_TEMP cleanup removes it after
+          # the job; the run/attempt/job namespace prevents cross-job replacement.
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ "$(readlink -e "$DEVENV_GC_ROOT")" != "$DEVENV_OUT" ]; then
+            echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
+            exit 1
+          fi
+          echo "DEVENV_GC_ROOT=$DEVENV_GC_ROOT" >> "$GITHUB_ENV"
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"
@@ -8262,14 +8997,54 @@ jobs:
             exit 1
           fi
 
-          resolve_devenv() {
+          DEVENV_GC_ROOT_DIR="${RUNNER_TEMP:-/tmp}/genie-nix-gc-roots"
+          DEVENV_GC_ROOT_ID=$(printf '%s' "${GITHUB_RUN_ID:-local-$$}-${GITHUB_RUN_ATTEMPT:-0}-${GITHUB_JOB:-job}" | tr -c 'A-Za-z0-9._-' '_')
+          DEVENV_GC_ROOT="$DEVENV_GC_ROOT_DIR/devenv-$DEVENV_GC_ROOT_ID"
+
+          resolve_devenv_once() {
+            mkdir -p "$DEVENV_GC_ROOT_DIR"
             nix build \
               --accept-flake-config \
               --option extra-substituters https://devenv.cachix.org \
               --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --no-link \
+              --out-link "$DEVENV_GC_ROOT" \
               --print-out-paths \
               "github:cachix/devenv/$DEVENV_REV#devenv"
+          }
+
+          resolve_devenv() {
+            local invalid_path
+            local log
+            local rc
+
+            log=$(mktemp)
+            if resolve_devenv_once 2>"$log"; then
+              cat "$log" >&2
+              rm -f "$log"
+              return 0
+            else
+              rc=$?
+            fi
+            cat "$log" >&2
+            invalid_path=$(grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" "$log" |
+              head -1 | grep -o "/nix/store/[^']*" || true)
+            rm -f "$log"
+            [ -n "$invalid_path" ] || return "$rc"
+
+            echo "::warning::devenv resolution hit an invalid Nix store path; clearing the client eval cache and retrying once: $invalid_path" >&2
+            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/nix/eval-cache-"* ~/.cache/nix/eval-cache-*
+            nix-store --repair-path "$invalid_path" >/dev/null 2>&1 ||
+              nix-store --realise "$invalid_path" >/dev/null 2>&1 || true
+            if resolve_devenv_once; then
+              if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+                echo '### Recovered Nix store lifecycle incident' >> "$GITHUB_STEP_SUMMARY"
+                echo "- Invalid path: $invalid_path" >> "$GITHUB_STEP_SUMMARY"
+                echo '- Attempts: 2/2' >> "$GITHUB_STEP_SUMMARY"
+              fi
+              return 0
+            else
+              return $?
+            fi
           }
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
@@ -8307,6 +9082,15 @@ jobs:
             fi
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
           fi
+
+          # resolve_devenv_once uses this out-link directly, so Nix registers the GC
+          # root before a successful build returns. RUNNER_TEMP cleanup removes it after
+          # the job; the run/attempt/job namespace prevents cross-job replacement.
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ "$(readlink -e "$DEVENV_GC_ROOT")" != "$DEVENV_OUT" ]; then
+            echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
+            exit 1
+          fi
+          echo "DEVENV_GC_ROOT=$DEVENV_GC_ROOT" >> "$GITHUB_ENV"
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"
@@ -8558,14 +9342,54 @@ jobs:
             exit 1
           fi
 
-          resolve_devenv() {
+          DEVENV_GC_ROOT_DIR="${RUNNER_TEMP:-/tmp}/genie-nix-gc-roots"
+          DEVENV_GC_ROOT_ID=$(printf '%s' "${GITHUB_RUN_ID:-local-$$}-${GITHUB_RUN_ATTEMPT:-0}-${GITHUB_JOB:-job}" | tr -c 'A-Za-z0-9._-' '_')
+          DEVENV_GC_ROOT="$DEVENV_GC_ROOT_DIR/devenv-$DEVENV_GC_ROOT_ID"
+
+          resolve_devenv_once() {
+            mkdir -p "$DEVENV_GC_ROOT_DIR"
             nix build \
               --accept-flake-config \
               --option extra-substituters https://devenv.cachix.org \
               --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --no-link \
+              --out-link "$DEVENV_GC_ROOT" \
               --print-out-paths \
               "github:cachix/devenv/$DEVENV_REV#devenv"
+          }
+
+          resolve_devenv() {
+            local invalid_path
+            local log
+            local rc
+
+            log=$(mktemp)
+            if resolve_devenv_once 2>"$log"; then
+              cat "$log" >&2
+              rm -f "$log"
+              return 0
+            else
+              rc=$?
+            fi
+            cat "$log" >&2
+            invalid_path=$(grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" "$log" |
+              head -1 | grep -o "/nix/store/[^']*" || true)
+            rm -f "$log"
+            [ -n "$invalid_path" ] || return "$rc"
+
+            echo "::warning::devenv resolution hit an invalid Nix store path; clearing the client eval cache and retrying once: $invalid_path" >&2
+            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/nix/eval-cache-"* ~/.cache/nix/eval-cache-*
+            nix-store --repair-path "$invalid_path" >/dev/null 2>&1 ||
+              nix-store --realise "$invalid_path" >/dev/null 2>&1 || true
+            if resolve_devenv_once; then
+              if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+                echo '### Recovered Nix store lifecycle incident' >> "$GITHUB_STEP_SUMMARY"
+                echo "- Invalid path: $invalid_path" >> "$GITHUB_STEP_SUMMARY"
+                echo '- Attempts: 2/2' >> "$GITHUB_STEP_SUMMARY"
+              fi
+              return 0
+            else
+              return $?
+            fi
           }
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
@@ -8603,6 +9427,15 @@ jobs:
             fi
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
           fi
+
+          # resolve_devenv_once uses this out-link directly, so Nix registers the GC
+          # root before a successful build returns. RUNNER_TEMP cleanup removes it after
+          # the job; the run/attempt/job namespace prevents cross-job replacement.
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ "$(readlink -e "$DEVENV_GC_ROOT")" != "$DEVENV_OUT" ]; then
+            echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
+            exit 1
+          fi
+          echo "DEVENV_GC_ROOT=$DEVENV_GC_ROOT" >> "$GITHUB_ENV"
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"
@@ -8845,14 +9678,54 @@ jobs:
             exit 1
           fi
 
-          resolve_devenv() {
+          DEVENV_GC_ROOT_DIR="${RUNNER_TEMP:-/tmp}/genie-nix-gc-roots"
+          DEVENV_GC_ROOT_ID=$(printf '%s' "${GITHUB_RUN_ID:-local-$$}-${GITHUB_RUN_ATTEMPT:-0}-${GITHUB_JOB:-job}" | tr -c 'A-Za-z0-9._-' '_')
+          DEVENV_GC_ROOT="$DEVENV_GC_ROOT_DIR/devenv-$DEVENV_GC_ROOT_ID"
+
+          resolve_devenv_once() {
+            mkdir -p "$DEVENV_GC_ROOT_DIR"
             nix build \
               --accept-flake-config \
               --option extra-substituters https://devenv.cachix.org \
               --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --no-link \
+              --out-link "$DEVENV_GC_ROOT" \
               --print-out-paths \
               "github:cachix/devenv/$DEVENV_REV#devenv"
+          }
+
+          resolve_devenv() {
+            local invalid_path
+            local log
+            local rc
+
+            log=$(mktemp)
+            if resolve_devenv_once 2>"$log"; then
+              cat "$log" >&2
+              rm -f "$log"
+              return 0
+            else
+              rc=$?
+            fi
+            cat "$log" >&2
+            invalid_path=$(grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" "$log" |
+              head -1 | grep -o "/nix/store/[^']*" || true)
+            rm -f "$log"
+            [ -n "$invalid_path" ] || return "$rc"
+
+            echo "::warning::devenv resolution hit an invalid Nix store path; clearing the client eval cache and retrying once: $invalid_path" >&2
+            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/nix/eval-cache-"* ~/.cache/nix/eval-cache-*
+            nix-store --repair-path "$invalid_path" >/dev/null 2>&1 ||
+              nix-store --realise "$invalid_path" >/dev/null 2>&1 || true
+            if resolve_devenv_once; then
+              if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+                echo '### Recovered Nix store lifecycle incident' >> "$GITHUB_STEP_SUMMARY"
+                echo "- Invalid path: $invalid_path" >> "$GITHUB_STEP_SUMMARY"
+                echo '- Attempts: 2/2' >> "$GITHUB_STEP_SUMMARY"
+              fi
+              return 0
+            else
+              return $?
+            fi
           }
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
@@ -8890,6 +9763,15 @@ jobs:
             fi
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
           fi
+
+          # resolve_devenv_once uses this out-link directly, so Nix registers the GC
+          # root before a successful build returns. RUNNER_TEMP cleanup removes it after
+          # the job; the run/attempt/job namespace prevents cross-job replacement.
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ "$(readlink -e "$DEVENV_GC_ROOT")" != "$DEVENV_OUT" ]; then
+            echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
+            exit 1
+          fi
+          echo "DEVENV_GC_ROOT=$DEVENV_GC_ROOT" >> "$GITHUB_ENV"
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -594,7 +594,7 @@ jobs:
           # resolve_devenv_once uses this out-link directly, so Nix registers the GC
           # root before a successful build returns. RUNNER_TEMP cleanup removes it after
           # the job; the run/attempt/job namespace prevents cross-job replacement.
-          if [ ! -L "$DEVENV_GC_ROOT" ] || [ "$(readlink -e "$DEVENV_GC_ROOT")" != "$DEVENV_OUT" ]; then
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ ! "$DEVENV_GC_ROOT" -ef "$DEVENV_OUT" ]; then
             echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
             exit 1
           fi
@@ -919,7 +919,7 @@ jobs:
           # resolve_devenv_once uses this out-link directly, so Nix registers the GC
           # root before a successful build returns. RUNNER_TEMP cleanup removes it after
           # the job; the run/attempt/job namespace prevents cross-job replacement.
-          if [ ! -L "$DEVENV_GC_ROOT" ] || [ "$(readlink -e "$DEVENV_GC_ROOT")" != "$DEVENV_OUT" ]; then
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ ! "$DEVENV_GC_ROOT" -ef "$DEVENV_OUT" ]; then
             echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
             exit 1
           fi
@@ -1231,7 +1231,7 @@ jobs:
           # resolve_devenv_once uses this out-link directly, so Nix registers the GC
           # root before a successful build returns. RUNNER_TEMP cleanup removes it after
           # the job; the run/attempt/job namespace prevents cross-job replacement.
-          if [ ! -L "$DEVENV_GC_ROOT" ] || [ "$(readlink -e "$DEVENV_GC_ROOT")" != "$DEVENV_OUT" ]; then
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ ! "$DEVENV_GC_ROOT" -ef "$DEVENV_OUT" ]; then
             echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
             exit 1
           fi
@@ -1540,7 +1540,7 @@ jobs:
           # resolve_devenv_once uses this out-link directly, so Nix registers the GC
           # root before a successful build returns. RUNNER_TEMP cleanup removes it after
           # the job; the run/attempt/job namespace prevents cross-job replacement.
-          if [ ! -L "$DEVENV_GC_ROOT" ] || [ "$(readlink -e "$DEVENV_GC_ROOT")" != "$DEVENV_OUT" ]; then
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ ! "$DEVENV_GC_ROOT" -ef "$DEVENV_OUT" ]; then
             echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
             exit 1
           fi
@@ -1852,7 +1852,7 @@ jobs:
           # resolve_devenv_once uses this out-link directly, so Nix registers the GC
           # root before a successful build returns. RUNNER_TEMP cleanup removes it after
           # the job; the run/attempt/job namespace prevents cross-job replacement.
-          if [ ! -L "$DEVENV_GC_ROOT" ] || [ "$(readlink -e "$DEVENV_GC_ROOT")" != "$DEVENV_OUT" ]; then
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ ! "$DEVENV_GC_ROOT" -ef "$DEVENV_OUT" ]; then
             echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
             exit 1
           fi
@@ -2140,7 +2140,7 @@ jobs:
           # resolve_devenv_once uses this out-link directly, so Nix registers the GC
           # root before a successful build returns. RUNNER_TEMP cleanup removes it after
           # the job; the run/attempt/job namespace prevents cross-job replacement.
-          if [ ! -L "$DEVENV_GC_ROOT" ] || [ "$(readlink -e "$DEVENV_GC_ROOT")" != "$DEVENV_OUT" ]; then
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ ! "$DEVENV_GC_ROOT" -ef "$DEVENV_OUT" ]; then
             echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
             exit 1
           fi
@@ -2391,7 +2391,7 @@ jobs:
           # resolve_devenv_once uses this out-link directly, so Nix registers the GC
           # root before a successful build returns. RUNNER_TEMP cleanup removes it after
           # the job; the run/attempt/job namespace prevents cross-job replacement.
-          if [ ! -L "$DEVENV_GC_ROOT" ] || [ "$(readlink -e "$DEVENV_GC_ROOT")" != "$DEVENV_OUT" ]; then
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ ! "$DEVENV_GC_ROOT" -ef "$DEVENV_OUT" ]; then
             echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
             exit 1
           fi
@@ -2751,7 +2751,7 @@ jobs:
           # resolve_devenv_once uses this out-link directly, so Nix registers the GC
           # root before a successful build returns. RUNNER_TEMP cleanup removes it after
           # the job; the run/attempt/job namespace prevents cross-job replacement.
-          if [ ! -L "$DEVENV_GC_ROOT" ] || [ "$(readlink -e "$DEVENV_GC_ROOT")" != "$DEVENV_OUT" ]; then
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ ! "$DEVENV_GC_ROOT" -ef "$DEVENV_OUT" ]; then
             echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
             exit 1
           fi
@@ -3062,7 +3062,7 @@ jobs:
           # resolve_devenv_once uses this out-link directly, so Nix registers the GC
           # root before a successful build returns. RUNNER_TEMP cleanup removes it after
           # the job; the run/attempt/job namespace prevents cross-job replacement.
-          if [ ! -L "$DEVENV_GC_ROOT" ] || [ "$(readlink -e "$DEVENV_GC_ROOT")" != "$DEVENV_OUT" ]; then
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ ! "$DEVENV_GC_ROOT" -ef "$DEVENV_OUT" ]; then
             echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
             exit 1
           fi
@@ -3371,7 +3371,7 @@ jobs:
           # resolve_devenv_once uses this out-link directly, so Nix registers the GC
           # root before a successful build returns. RUNNER_TEMP cleanup removes it after
           # the job; the run/attempt/job namespace prevents cross-job replacement.
-          if [ ! -L "$DEVENV_GC_ROOT" ] || [ "$(readlink -e "$DEVENV_GC_ROOT")" != "$DEVENV_OUT" ]; then
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ ! "$DEVENV_GC_ROOT" -ef "$DEVENV_OUT" ]; then
             echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
             exit 1
           fi
@@ -3680,7 +3680,7 @@ jobs:
           # resolve_devenv_once uses this out-link directly, so Nix registers the GC
           # root before a successful build returns. RUNNER_TEMP cleanup removes it after
           # the job; the run/attempt/job namespace prevents cross-job replacement.
-          if [ ! -L "$DEVENV_GC_ROOT" ] || [ "$(readlink -e "$DEVENV_GC_ROOT")" != "$DEVENV_OUT" ]; then
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ ! "$DEVENV_GC_ROOT" -ef "$DEVENV_OUT" ]; then
             echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
             exit 1
           fi
@@ -3996,7 +3996,7 @@ jobs:
           # resolve_devenv_once uses this out-link directly, so Nix registers the GC
           # root before a successful build returns. RUNNER_TEMP cleanup removes it after
           # the job; the run/attempt/job namespace prevents cross-job replacement.
-          if [ ! -L "$DEVENV_GC_ROOT" ] || [ "$(readlink -e "$DEVENV_GC_ROOT")" != "$DEVENV_OUT" ]; then
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ ! "$DEVENV_GC_ROOT" -ef "$DEVENV_OUT" ]; then
             echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
             exit 1
           fi
@@ -4315,7 +4315,7 @@ jobs:
           # resolve_devenv_once uses this out-link directly, so Nix registers the GC
           # root before a successful build returns. RUNNER_TEMP cleanup removes it after
           # the job; the run/attempt/job namespace prevents cross-job replacement.
-          if [ ! -L "$DEVENV_GC_ROOT" ] || [ "$(readlink -e "$DEVENV_GC_ROOT")" != "$DEVENV_OUT" ]; then
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ ! "$DEVENV_GC_ROOT" -ef "$DEVENV_OUT" ]; then
             echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
             exit 1
           fi
@@ -5216,7 +5216,7 @@ jobs:
           # resolve_devenv_once uses this out-link directly, so Nix registers the GC
           # root before a successful build returns. RUNNER_TEMP cleanup removes it after
           # the job; the run/attempt/job namespace prevents cross-job replacement.
-          if [ ! -L "$DEVENV_GC_ROOT" ] || [ "$(readlink -e "$DEVENV_GC_ROOT")" != "$DEVENV_OUT" ]; then
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ ! "$DEVENV_GC_ROOT" -ef "$DEVENV_OUT" ]; then
             echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
             exit 1
           fi
@@ -8774,7 +8774,7 @@ jobs:
           # resolve_devenv_once uses this out-link directly, so Nix registers the GC
           # root before a successful build returns. RUNNER_TEMP cleanup removes it after
           # the job; the run/attempt/job namespace prevents cross-job replacement.
-          if [ ! -L "$DEVENV_GC_ROOT" ] || [ "$(readlink -e "$DEVENV_GC_ROOT")" != "$DEVENV_OUT" ]; then
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ ! "$DEVENV_GC_ROOT" -ef "$DEVENV_OUT" ]; then
             echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
             exit 1
           fi
@@ -9086,7 +9086,7 @@ jobs:
           # resolve_devenv_once uses this out-link directly, so Nix registers the GC
           # root before a successful build returns. RUNNER_TEMP cleanup removes it after
           # the job; the run/attempt/job namespace prevents cross-job replacement.
-          if [ ! -L "$DEVENV_GC_ROOT" ] || [ "$(readlink -e "$DEVENV_GC_ROOT")" != "$DEVENV_OUT" ]; then
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ ! "$DEVENV_GC_ROOT" -ef "$DEVENV_OUT" ]; then
             echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
             exit 1
           fi
@@ -9431,7 +9431,7 @@ jobs:
           # resolve_devenv_once uses this out-link directly, so Nix registers the GC
           # root before a successful build returns. RUNNER_TEMP cleanup removes it after
           # the job; the run/attempt/job namespace prevents cross-job replacement.
-          if [ ! -L "$DEVENV_GC_ROOT" ] || [ "$(readlink -e "$DEVENV_GC_ROOT")" != "$DEVENV_OUT" ]; then
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ ! "$DEVENV_GC_ROOT" -ef "$DEVENV_OUT" ]; then
             echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
             exit 1
           fi
@@ -9767,7 +9767,7 @@ jobs:
           # resolve_devenv_once uses this out-link directly, so Nix registers the GC
           # root before a successful build returns. RUNNER_TEMP cleanup removes it after
           # the job; the run/attempt/job namespace prevents cross-job replacement.
-          if [ ! -L "$DEVENV_GC_ROOT" ] || [ "$(readlink -e "$DEVENV_GC_ROOT")" != "$DEVENV_OUT" ]; then
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ ! "$DEVENV_GC_ROOT" -ef "$DEVENV_OUT" ]; then
             echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
             exit 1
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,10 @@ All notable changes to this project will be documented in this file.
   Effect 3 catalog, and fail generation if either cohort's exact identity drifts
   (#937).
 
+- Harden shared CI devenv resolution against host GC races: retry the proven
+  invalid-store-path signature once after client-local cache repair, root the
+  resolved closure for the job lifetime, and leave Nix daemon recovery to host
+  supervision instead of restarting the shared daemon from CI jobs.
 - Fix megarepo Nix lock validation for current and legacy members that share one repository while preserving fail-closed ambiguity checks.
 
 ### Fixed

--- a/genie/ci-scripts/nix-gc-race-retry.sh
+++ b/genie/ci-scripts/nix-gc-race-retry.sh
@@ -25,36 +25,6 @@ run_nix_gc_race_retry() {
     } >> "$GITHUB_STEP_SUMMARY"
   }
 
-  repair_nix_daemon() {
-    if [ "${NIX_GC_RACE_SKIP_DAEMON_REPAIR:-0}" = 1 ]; then
-      echo "::warning::Nix daemon repair skipped by NIX_GC_RACE_SKIP_DAEMON_REPAIR=1"
-      return 0
-    fi
-
-    echo "::warning::Nix daemon socket is unavailable; attempting daemon restart before retry"
-
-    if command -v launchctl >/dev/null 2>&1; then
-      sudo launchctl kickstart -k system/org.nixos.nix-daemon >/dev/null 2>&1 || true
-    fi
-
-    if command -v systemctl >/dev/null 2>&1; then
-      sudo systemctl restart nix-daemon.socket >/dev/null 2>&1 || true
-      sudo systemctl restart nix-daemon.service >/dev/null 2>&1 || true
-      sudo systemctl restart nix-daemon >/dev/null 2>&1 || true
-    fi
-
-    if [ ! -S /nix/var/nix/daemon-socket/socket ] && [ -x /nix/var/nix/profiles/default/bin/nix-daemon ]; then
-      sudo /nix/var/nix/profiles/default/bin/nix-daemon --daemon >/tmp/nix-daemon-restart.log 2>&1 || true
-    fi
-
-    for _ in 1 2 3 4 5; do
-      [ -S /nix/var/nix/daemon-socket/socket ] && return 0
-      sleep 1
-    done
-
-    return 0
-  }
-
   while [ "$attempt" -le "$max" ]; do
     echo "::notice::[ci] starting $task (attempt $attempt/$max)"
     (
@@ -130,8 +100,7 @@ run_nix_gc_race_retry() {
     fi
 
     if [ "$saw_daemon_socket_failure" = true ]; then
-      repair_nix_daemon
-      echo "::warning::Nix daemon socket failure detected for $task (attempt $attempt/$max); retrying after daemon repair"
+      echo "::warning::Nix daemon socket failure detected for $task (attempt $attempt/$max); retrying without mutating the host daemon (host supervision owns recovery)"
     elif [ "$saw_fetch_signature" = true ]; then
       echo "::warning::Nix source fetch corruption detected for $task (attempt $attempt/$max); retrying with a refreshed eval cache"
     elif [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then

--- a/genie/ci-scripts/nix-gc-race-retry.sh
+++ b/genie/ci-scripts/nix-gc-race-retry.sh
@@ -7,6 +7,7 @@ run_nix_gc_race_retry() {
   local task="$1"
   local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
   local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
+  local daemon_socket_retry_delay="${NIX_DAEMON_SOCKET_RETRY_DELAY_SECONDS:-2}"
   local attempt=1
   local log log_dir stdout_pipe stderr_pipe rc path start now elapsed hb_pid stdout_tee_pid stderr_tee_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature saw_daemon_socket_failure had_errexit
 
@@ -100,7 +101,7 @@ run_nix_gc_race_retry() {
     fi
 
     if [ "$saw_daemon_socket_failure" = true ]; then
-      echo "::warning::Nix daemon socket failure detected for $task (attempt $attempt/$max); retrying without mutating the host daemon (host supervision owns recovery)"
+      echo "::warning::Nix daemon socket failure detected for $task (attempt $attempt/$max); waiting $daemon_socket_retry_delay s for host supervision before retrying without mutating the host daemon"
     elif [ "$saw_fetch_signature" = true ]; then
       echo "::warning::Nix source fetch corruption detected for $task (attempt $attempt/$max); retrying with a refreshed eval cache"
     elif [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
@@ -113,6 +114,9 @@ run_nix_gc_race_retry() {
 
     [ -z "$path" ] || nix-store --realise "$path" 2>/dev/null || true
     rm -rf ~/.cache/nix/eval-cache-*
+    if [ "$saw_daemon_socket_failure" = true ] && [ "$attempt" -lt "$max" ]; then
+      sleep "$daemon_socket_retry_delay"
+    fi
     attempt=$((attempt + 1))
   done
 

--- a/genie/ci-scripts/nix-gc-race-retry.test.sh
+++ b/genie/ci-scripts/nix-gc-race-retry.test.sh
@@ -158,7 +158,7 @@ chmod +x "$fetch_fixture"
 CI_PROGRESS_HEARTBEAT_SECONDS=1 NIX_GC_RACE_MAX_RETRIES=2 run_nix_gc_race_retry "fetch-fixture" "$fetch_fixture" >/dev/null
 assert_eq "2" "$(cat "$test_dir/fetch-attempt")" "truncated tarball retry count"
 
-echo "Test 5: retries missing Nix daemon socket failures"
+echo "Test 5: retries missing Nix daemon socket failures without host mutation"
 daemon_fixture="$test_dir/daemon-fixture.sh"
 cat > "$daemon_fixture" <<EOF
 #!/usr/bin/env bash
@@ -176,10 +176,17 @@ fi
 echo "daemon recovered"
 EOF
 chmod +x "$daemon_fixture"
-CI_PROGRESS_HEARTBEAT_SECONDS=1 NIX_GC_RACE_MAX_RETRIES=2 NIX_GC_RACE_SKIP_DAEMON_REPAIR=1 run_nix_gc_race_retry "daemon-fixture" "$daemon_fixture" >/dev/null
+daemon_stdout="$test_dir/daemon-stdout"
+CI_PROGRESS_HEARTBEAT_SECONDS=1 NIX_GC_RACE_MAX_RETRIES=2 run_nix_gc_race_retry "daemon-fixture" "$daemon_fixture" >"$daemon_stdout"
 assert_eq "2" "$(cat "$test_dir/daemon-attempt")" "Nix daemon socket retry count"
+assert_contains "host supervision owns recovery" "$daemon_stdout" "daemon recovery ownership"
 
-echo "Test 6: does not retry when literal signature strings appear outside Nix error context"
+echo "Test 6: helper contains no host daemon mutation commands"
+assert_not_contains "sudo systemctl" "$SCRIPT" "systemd daemon mutation removed"
+assert_not_contains "sudo launchctl" "$SCRIPT" "launchd daemon mutation removed"
+assert_not_contains "nix-daemon --daemon" "$SCRIPT" "manual daemon mutation removed"
+
+echo "Test 7: does not retry when literal signature strings appear outside Nix error context"
 false_positive_fixture="$test_dir/false-positive-fixture.sh"
 cat > "$false_positive_fixture" <<'EOF'
 #!/usr/bin/env bash
@@ -196,7 +203,7 @@ exit_code=$?
 set -e
 assert_exit_code 9 "$exit_code" "non-error-context strings do not trigger retries"
 
-echo "Test 7: preserves the original exit code when no retry signature is present"
+echo "Test 8: preserves the original exit code when no retry signature is present"
 non_retry_fixture="$test_dir/non-retry-fixture.sh"
 cat > "$non_retry_fixture" <<'EOF'
 #!/usr/bin/env bash
@@ -211,7 +218,7 @@ exit_code=$?
 set -e
 assert_exit_code 7 "$exit_code" "non-signature failures keep their exit code"
 
-echo "Test 8: executes argv without shell eval"
+echo "Test 9: executes argv without shell eval"
 argv_fixture="$test_dir/argv-fixture.sh"
 argv_output="$test_dir/argv-output"
 cat > "$argv_fixture" <<'EOF'
@@ -223,7 +230,7 @@ chmod +x "$argv_fixture"
 CI_PROGRESS_HEARTBEAT_SECONDS=1 NIX_GC_RACE_MAX_RETRIES=1 run_nix_gc_race_retry "argv-fixture" "$argv_fixture" 'literal $HOME value' "$argv_output" >/dev/null
 assert_eq 'literal $HOME value' "$(cat "$argv_output")" "argv command arguments are not shell-expanded"
 
-echo "Test 9: preserves stdout and stderr while capturing retry signatures"
+echo "Test 10: preserves stdout and stderr while capturing retry signatures"
 stdio_fixture="$test_dir/stdio-fixture.sh"
 stdio_stdout="$test_dir/stdio-stdout"
 stdio_stderr="$test_dir/stdio-stderr"
@@ -244,7 +251,7 @@ assert_contains "stdout-marker" "$stdio_stdout" "stdout marker remains on stdout
 assert_contains "stderr-marker" "$stdio_stderr" "stderr marker remains on stderr"
 assert_not_contains "stderr-marker" "$stdio_stdout" "stderr marker does not move to stdout"
 
-echo "Test 10: wrapper script delegates shell commands to the retry helper"
+echo "Test 11: wrapper script delegates shell commands to the retry helper"
 wrapper_attempt_file="$test_dir/wrapper-attempt"
 wrapper_command=$(cat <<EOF
 attempt=1

--- a/genie/ci-scripts/nix-gc-race-retry.test.sh
+++ b/genie/ci-scripts/nix-gc-race-retry.test.sh
@@ -177,9 +177,16 @@ echo "daemon recovered"
 EOF
 chmod +x "$daemon_fixture"
 daemon_stdout="$test_dir/daemon-stdout"
-CI_PROGRESS_HEARTBEAT_SECONDS=1 NIX_GC_RACE_MAX_RETRIES=2 run_nix_gc_race_retry "daemon-fixture" "$daemon_fixture" >"$daemon_stdout"
+daemon_started_at="$(date +%s)"
+CI_PROGRESS_HEARTBEAT_SECONDS=60 NIX_DAEMON_SOCKET_RETRY_DELAY_SECONDS=1 NIX_GC_RACE_MAX_RETRIES=2 run_nix_gc_race_retry "daemon-fixture" "$daemon_fixture" >"$daemon_stdout"
+daemon_elapsed=$(( $(date +%s) - daemon_started_at ))
 assert_eq "2" "$(cat "$test_dir/daemon-attempt")" "Nix daemon socket retry count"
-assert_contains "host supervision owns recovery" "$daemon_stdout" "daemon recovery ownership"
+assert_contains "waiting 1 s for host supervision" "$daemon_stdout" "daemon recovery ownership"
+if [ "$daemon_elapsed" -lt 1 ]; then
+  echo "FAIL: daemon socket retry did not wait for host supervision"
+  echo "  elapsed: $daemon_elapsed s"
+  exit 1
+fi
 
 echo "Test 6: helper contains no host daemon mutation commands"
 assert_not_contains "sudo systemctl" "$SCRIPT" "systemd daemon mutation removed"

--- a/genie/ci-scripts/resolve-devenv.sh
+++ b/genie/ci-scripts/resolve-devenv.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Generated file - DO NOT EDIT
+# Source: resolve-devenv.sh.genie.ts
+
+
+DEVENV_GC_ROOT_DIR="${RUNNER_TEMP:-/tmp}/genie-nix-gc-roots"
+DEVENV_GC_ROOT_ID=$(printf '%s' "${GITHUB_RUN_ID:-local-$$}-${GITHUB_RUN_ATTEMPT:-0}-${GITHUB_JOB:-job}" | tr -c 'A-Za-z0-9._-' '_')
+DEVENV_GC_ROOT="$DEVENV_GC_ROOT_DIR/devenv-$DEVENV_GC_ROOT_ID"
+
+resolve_devenv_once() {
+  mkdir -p "$DEVENV_GC_ROOT_DIR"
+  nix build \
+    --accept-flake-config \
+    --option extra-substituters https://devenv.cachix.org \
+    --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
+    --out-link "$DEVENV_GC_ROOT" \
+    --print-out-paths \
+    "github:cachix/devenv/$DEVENV_REV#devenv"
+}
+
+resolve_devenv() {
+  local invalid_path
+  local log
+  local rc
+
+  log=$(mktemp)
+  if resolve_devenv_once 2>"$log"; then
+    cat "$log" >&2
+    rm -f "$log"
+    return 0
+  else
+    rc=$?
+  fi
+  cat "$log" >&2
+  invalid_path=$(grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" "$log" |
+    head -1 | grep -o "/nix/store/[^']*" || true)
+  rm -f "$log"
+  [ -n "$invalid_path" ] || return "$rc"
+
+  echo "::warning::devenv resolution hit an invalid Nix store path; clearing the client eval cache and retrying once: $invalid_path" >&2
+  rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/nix/eval-cache-"* ~/.cache/nix/eval-cache-*
+  nix-store --repair-path "$invalid_path" >/dev/null 2>&1 ||
+    nix-store --realise "$invalid_path" >/dev/null 2>&1 || true
+  if resolve_devenv_once; then
+    if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+      echo '### Recovered Nix store lifecycle incident' >> "$GITHUB_STEP_SUMMARY"
+      echo "- Invalid path: $invalid_path" >> "$GITHUB_STEP_SUMMARY"
+      echo '- Attempts: 2/2' >> "$GITHUB_STEP_SUMMARY"
+    fi
+    return 0
+  else
+    return $?
+  fi
+}

--- a/genie/ci-scripts/resolve-devenv.sh.genie.ts
+++ b/genie/ci-scripts/resolve-devenv.sh.genie.ts
@@ -1,0 +1,3 @@
+import { ciWorkflowSupportFiles } from '../ci-workflow/support-files.ts'
+
+export default ciWorkflowSupportFiles.resolveDevenv.output

--- a/genie/ci-workflow/setup.ts
+++ b/genie/ci-workflow/setup.ts
@@ -7,7 +7,6 @@ import {
   defaultCiRuntimeScriptsDir,
   jobLocalCiDiagnosticsDir,
   nixBinaryCachesExtraConf,
-  resolveDevenvFnScript,
   resolveDevenvRevScript,
   linuxX64Runner,
   runDevenvTasksBefore,
@@ -990,7 +989,7 @@ export const validateNixStoreStep = {
   name: 'Resolve devenv',
   run: `${resolveDevenvRevScript}
 
-${resolveDevenvFnScript}
+. ${shellSingleQuote(`${preparedCiRuntimeScriptsDir}/resolve-devenv.sh`)}
 
 # Temporary: capture diagnostics dir for #272 root-cause analysis.
 DIAG_ROOT="${'${RUNNER_TEMP:-/tmp}'}/nix-store-diagnostics-${'${GITHUB_JOB:-job}'}-${'${RUNNER_OS:-unknown}'}-${'${GITHUB_RUN_ATTEMPT:-0}'}"

--- a/genie/ci-workflow/setup.ts
+++ b/genie/ci-workflow/setup.ts
@@ -1028,6 +1028,15 @@ if ! nix-store --check-validity "$DEVENV_OUT" 2>/dev/null; then
   DEVENV_BIN="$DEVENV_OUT/bin/devenv"
 fi
 
+# resolve_devenv_once uses this out-link directly, so Nix registers the GC
+# root before a successful build returns. RUNNER_TEMP cleanup removes it after
+# the job; the run/attempt/job namespace prevents cross-job replacement.
+if [ ! -L "$DEVENV_GC_ROOT" ] || [ "$(readlink -e "$DEVENV_GC_ROOT")" != "$DEVENV_OUT" ]; then
+  echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
+  exit 1
+fi
+echo "DEVENV_GC_ROOT=$DEVENV_GC_ROOT" >> "$GITHUB_ENV"
+
 echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
 "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"`,
   shell: 'bash',

--- a/genie/ci-workflow/setup.ts
+++ b/genie/ci-workflow/setup.ts
@@ -1031,7 +1031,7 @@ fi
 # resolve_devenv_once uses this out-link directly, so Nix registers the GC
 # root before a successful build returns. RUNNER_TEMP cleanup removes it after
 # the job; the run/attempt/job namespace prevents cross-job replacement.
-if [ ! -L "$DEVENV_GC_ROOT" ] || [ "$(readlink -e "$DEVENV_GC_ROOT")" != "$DEVENV_OUT" ]; then
+if [ ! -L "$DEVENV_GC_ROOT" ] || [ ! "$DEVENV_GC_ROOT" -ef "$DEVENV_OUT" ]; then
   echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
   exit 1
 fi

--- a/genie/ci-workflow/shared.ts
+++ b/genie/ci-workflow/shared.ts
@@ -234,14 +234,54 @@ if [ -z "$DEVENV_REV" ] || [ "$DEVENV_REV" = "null" ]; then
   exit 1
 fi`
 
-export const resolveDevenvFnScript = `resolve_devenv() {
+export const resolveDevenvFnScript = `DEVENV_GC_ROOT_DIR="${'${RUNNER_TEMP:-/tmp}'}/genie-nix-gc-roots"
+DEVENV_GC_ROOT_ID=$(printf '%s' "${'${GITHUB_RUN_ID:-local-$$}'}-${'${GITHUB_RUN_ATTEMPT:-0}'}-${'${GITHUB_JOB:-job}'}" | tr -c 'A-Za-z0-9._-' '_')
+DEVENV_GC_ROOT="$DEVENV_GC_ROOT_DIR/devenv-$DEVENV_GC_ROOT_ID"
+
+resolve_devenv_once() {
+  mkdir -p "$DEVENV_GC_ROOT_DIR"
   nix build \\
     --accept-flake-config \\
     --option extra-substituters ${devenvBinaryCache.uri} \\
     --option extra-trusted-public-keys ${devenvBinaryCache.publicKey} \\
-    --no-link \\
+    --out-link "$DEVENV_GC_ROOT" \\
     --print-out-paths \\
     "github:cachix/devenv/$DEVENV_REV#devenv"
+}
+
+resolve_devenv() {
+  local invalid_path
+  local log
+  local rc
+
+  log=$(mktemp)
+  if resolve_devenv_once 2>"$log"; then
+    cat "$log" >&2
+    rm -f "$log"
+    return 0
+  else
+    rc=$?
+  fi
+  cat "$log" >&2
+  invalid_path=$(grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" "$log" |
+    head -1 | grep -o "/nix/store/[^']*" || true)
+  rm -f "$log"
+  [ -n "$invalid_path" ] || return "$rc"
+
+  echo "::warning::devenv resolution hit an invalid Nix store path; clearing the client eval cache and retrying once: $invalid_path" >&2
+  rm -rf "${'${XDG_CACHE_HOME:-$HOME/.cache}'}/nix/eval-cache-"* ~/.cache/nix/eval-cache-*
+  nix-store --repair-path "$invalid_path" >/dev/null 2>&1 ||
+    nix-store --realise "$invalid_path" >/dev/null 2>&1 || true
+  if resolve_devenv_once; then
+    if [ -n "${'${GITHUB_STEP_SUMMARY:-}'}" ]; then
+      echo '### Recovered Nix store lifecycle incident' >> "$GITHUB_STEP_SUMMARY"
+      echo "- Invalid path: $invalid_path" >> "$GITHUB_STEP_SUMMARY"
+      echo '- Attempts: 2/2' >> "$GITHUB_STEP_SUMMARY"
+    fi
+    return 0
+  else
+    return $?
+  fi
 }`
 
 export const shellSingleQuote = (value: string) => `'${value.replaceAll("'", `'"'"'`)}'`
@@ -348,14 +388,14 @@ export type GcRaceRetryOptions = {
  * those as the same root cause and retry after realizing the missing path and
  * clearing the eval cache.
  *
- * Some namespace runners also lose the multi-user Nix daemon socket after
- * setup; retry those after a best-effort daemon restart. This daemon-socket
- * sub-case is a distinct runner-side failure mode and is NOT covered by the
- * two upstream store-race refs below — it has no tracked upstream fix yet.
+ * Some runners also lose the multi-user Nix daemon socket after setup. Retry
+ * those passively so host supervision can restore service; CI jobs must not
+ * mutate the shared daemon. This daemon-socket sub-case is a distinct
+ * runner-side failure mode and is not covered by the upstream refs below.
  *
  * TODO: Remove the store-validity-race retry once NixOS/nix#15469 and
- * DeterminateSystems/nix-src#395 are released. The daemon-socket repair branch
- * must be reassessed separately (see `repair_nix_daemon`).
+ * DeterminateSystems/nix-src#395 are released. Reassess the daemon-socket retry
+ * separately when host supervision exposes a stronger availability contract.
  * @see https://github.com/NixOS/nix/pull/15469
  * @see https://github.com/DeterminateSystems/nix-src/issues/395
  */

--- a/genie/ci-workflow/support-files.ts
+++ b/genie/ci-workflow/support-files.ts
@@ -1,4 +1,5 @@
 import { createGenieOutput, type GenieOutput } from '../../packages/@overeng/genie/src/runtime/core.ts'
+import { resolveDevenvFnScript } from './shared.ts'
 
 const withTrailingNewline = (content: string) => (content.endsWith('\n') ? content : `${content}\n`)
 const dollar = '$'
@@ -14,6 +15,7 @@ export const ciWorkflowNixGcRaceRetryWrapperPath =
   'genie/ci-scripts/run-with-nix-gc-race-retry.sh'
 export const ciWorkflowJobLocalRustStateScriptPath =
   'genie/ci-scripts/prepare-job-local-rust-state.sh'
+export const ciWorkflowResolveDevenvScriptPath = 'genie/ci-scripts/resolve-devenv.sh'
 
 export const ciWorkflowNixGcRaceRetryScript = String.raw`#!/usr/bin/env bash
 
@@ -181,6 +183,10 @@ export const ciWorkflowSupportFiles = {
   jobLocalRustState: {
     path: ciWorkflowJobLocalRustStateScriptPath,
     output: textArtifact(ciWorkflowJobLocalRustStateScript),
+  },
+  resolveDevenv: {
+    path: ciWorkflowResolveDevenvScriptPath,
+    output: textArtifact(`#!/usr/bin/env bash\n\n${resolveDevenvFnScript}`),
   },
   nixGcRaceRetry: {
     path: ciWorkflowNixGcRaceRetryScriptPath,

--- a/genie/ci-workflow/support-files.ts
+++ b/genie/ci-workflow/support-files.ts
@@ -39,36 +39,6 @@ run_nix_gc_race_retry() {
     } >> "$GITHUB_STEP_SUMMARY"
   }
 
-  repair_nix_daemon() {
-    if [ "${dollar}{NIX_GC_RACE_SKIP_DAEMON_REPAIR:-0}" = 1 ]; then
-      echo "::warning::Nix daemon repair skipped by NIX_GC_RACE_SKIP_DAEMON_REPAIR=1"
-      return 0
-    fi
-
-    echo "::warning::Nix daemon socket is unavailable; attempting daemon restart before retry"
-
-    if command -v launchctl >/dev/null 2>&1; then
-      sudo launchctl kickstart -k system/org.nixos.nix-daemon >/dev/null 2>&1 || true
-    fi
-
-    if command -v systemctl >/dev/null 2>&1; then
-      sudo systemctl restart nix-daemon.socket >/dev/null 2>&1 || true
-      sudo systemctl restart nix-daemon.service >/dev/null 2>&1 || true
-      sudo systemctl restart nix-daemon >/dev/null 2>&1 || true
-    fi
-
-    if [ ! -S /nix/var/nix/daemon-socket/socket ] && [ -x /nix/var/nix/profiles/default/bin/nix-daemon ]; then
-      sudo /nix/var/nix/profiles/default/bin/nix-daemon --daemon >/tmp/nix-daemon-restart.log 2>&1 || true
-    fi
-
-    for _ in 1 2 3 4 5; do
-      [ -S /nix/var/nix/daemon-socket/socket ] && return 0
-      sleep 1
-    done
-
-    return 0
-  }
-
   while [ "$attempt" -le "$max" ]; do
     echo "::notice::[ci] starting $task (attempt $attempt/$max)"
     (
@@ -144,8 +114,7 @@ run_nix_gc_race_retry() {
     fi
 
     if [ "$saw_daemon_socket_failure" = true ]; then
-      repair_nix_daemon
-      echo "::warning::Nix daemon socket failure detected for $task (attempt $attempt/$max); retrying after daemon repair"
+      echo "::warning::Nix daemon socket failure detected for $task (attempt $attempt/$max); retrying without mutating the host daemon (host supervision owns recovery)"
     elif [ "$saw_fetch_signature" = true ]; then
       echo "::warning::Nix source fetch corruption detected for $task (attempt $attempt/$max); retrying with a refreshed eval cache"
     elif [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then

--- a/genie/ci-workflow/support-files.ts
+++ b/genie/ci-workflow/support-files.ts
@@ -21,6 +21,7 @@ run_nix_gc_race_retry() {
   local task="$1"
   local max="${dollar}{NIX_GC_RACE_MAX_RETRIES:-10}"
   local heartbeat="${dollar}{CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
+  local daemon_socket_retry_delay="${dollar}{NIX_DAEMON_SOCKET_RETRY_DELAY_SECONDS:-2}"
   local attempt=1
   local log log_dir stdout_pipe stderr_pipe rc path start now elapsed hb_pid stdout_tee_pid stderr_tee_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature saw_daemon_socket_failure had_errexit
 
@@ -114,7 +115,7 @@ run_nix_gc_race_retry() {
     fi
 
     if [ "$saw_daemon_socket_failure" = true ]; then
-      echo "::warning::Nix daemon socket failure detected for $task (attempt $attempt/$max); retrying without mutating the host daemon (host supervision owns recovery)"
+      echo "::warning::Nix daemon socket failure detected for $task (attempt $attempt/$max); waiting $daemon_socket_retry_delay s for host supervision before retrying without mutating the host daemon"
     elif [ "$saw_fetch_signature" = true ]; then
       echo "::warning::Nix source fetch corruption detected for $task (attempt $attempt/$max); retrying with a refreshed eval cache"
     elif [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
@@ -127,6 +128,9 @@ run_nix_gc_race_retry() {
 
     [ -z "$path" ] || nix-store --realise "$path" 2>/dev/null || true
     rm -rf ~/.cache/nix/eval-cache-*
+    if [ "$saw_daemon_socket_failure" = true ] && [ "$attempt" -lt "$max" ]; then
+      sleep "$daemon_socket_retry_delay"
+    fi
     attempt=$((attempt + 1))
   done
 

--- a/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
@@ -155,14 +155,10 @@ const validateNixStoreStepSource = extractSourceBlock(
   '/**\n * Upload diagnostics captured by `validateNixStoreStep` as a CI artifact.',
 )
 
-const resolveDevenvFnScript = extractSourceBlock(
-  generatedCiWorkflowYamlSource,
-  '          DEVENV_GC_ROOT_DIR="${RUNNER_TEMP:-/tmp}/genie-nix-gc-roots"',
-  '\n\n          # Temporary: capture diagnostics dir',
+const resolveDevenvFnScript = readFileSync(
+  new URL(['../../../../../../genie/ci-scripts', 'resolve-devenv.sh'].join('/'), import.meta.url),
+  'utf8',
 )
-  .split('\n')
-  .map((line) => line.replace(/^ {10}/, ''))
-  .join('\n')
 
 const applyMegarepoLockStepSource = extractSourceBlock(
   ciWorkflowSource,
@@ -515,6 +511,13 @@ printf '%s\\n' "$NIX_OUTPUT"
     )
     expect(validateNixStoreStepSource).toContain('[ ! "$DEVENV_GC_ROOT" -ef "$DEVENV_OUT" ]')
     expect(validateNixStoreStepSource).not.toContain('readlink -e')
+    expect(validateNixStoreStepSource).toContain(
+      '. ${shellSingleQuote(`${preparedCiRuntimeScriptsDir}/resolve-devenv.sh`)}',
+    )
+    expect(generatedCiWorkflowYamlSource).toContain(
+      ". '${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'",
+    )
+    expect(generatedCiWorkflowYamlSource).not.toContain('resolve_devenv_once()')
   })
 
   it('resolves the locked megarepo CLI through a git flake URL', () => {

--- a/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
@@ -1,4 +1,16 @@
-import { readFileSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
 import { describe, expect, it } from 'vitest'
 
@@ -143,6 +155,15 @@ const validateNixStoreStepSource = extractSourceBlock(
   '/**\n * Upload diagnostics captured by `validateNixStoreStep` as a CI artifact.',
 )
 
+const resolveDevenvFnScript = extractSourceBlock(
+  generatedCiWorkflowYamlSource,
+  '          DEVENV_GC_ROOT_DIR="${RUNNER_TEMP:-/tmp}/genie-nix-gc-roots"',
+  '\n\n          # Temporary: capture diagnostics dir',
+)
+  .split('\n')
+  .map((line) => line.replace(/^ {10}/, ''))
+  .join('\n')
+
 const applyMegarepoLockStepSource = extractSourceBlock(
   ciWorkflowSource,
   'export const applyMegarepoLockStep = (opts?: { skip?: string[]; cacheableStore?: boolean }) => {',
@@ -194,7 +215,9 @@ describe('ci workflow retry helpers', () => {
     expect(nixGcRaceRetryScriptSource).toContain('"$@" > "$stdout_pipe" 2> "$stderr_pipe"')
     expect(nixGcRaceRetryScriptSource).not.toContain('eval "$command"')
     expect(nixGcRaceRetryScriptSource).toContain("tr '\\r\\n' '  ' < \"$log\"")
-    expect(nixGcRaceRetryScriptSource).toContain('repair_nix_daemon')
+    expect(nixGcRaceRetryScriptSource).not.toContain('repair_nix_daemon')
+    expect(nixGcRaceRetryScriptSource).not.toContain('sudo systemctl')
+    expect(nixGcRaceRetryScriptSource).not.toContain('sudo launchctl')
     expect(nixGcRaceRetryScriptSource).not.toContain("awk 'BEGIN { ORS=")
   })
 
@@ -359,6 +382,138 @@ describe('ci workflow pnpm cache defaults', () => {
     expect(validateNixStoreStepSource).toContain(
       'rm -rf "${\'${XDG_CACHE_HOME:-$HOME/.cache}\'}"/nix/eval-cache-* ~/.cache/nix/eval-cache-*',
     )
+  })
+
+  it('retries initial devenv resolution once only for an extracted invalid store path', () => {
+    expect(resolveDevenvFnScript).toContain('[ -n "$invalid_path" ] || return "$rc"')
+    expect(resolveDevenvFnScript.match(/resolve_devenv_once/g)).toHaveLength(3)
+    expect(resolveDevenvFnScript).toContain('nix-store --repair-path "$invalid_path"')
+    expect(resolveDevenvFnScript).not.toContain('Failed to convert config.cachix to JSON')
+    expect(resolveDevenvFnScript).not.toContain('Truncated tar archive')
+  })
+
+  it('preserves a non-signature resolution failure status without retrying', () => {
+    const root = mkdtempSync(join(tmpdir(), 'genie-resolve-devenv-no-retry-'))
+    const bin = join(root, 'bin')
+    const attempts = join(root, 'attempts')
+    const existingOutput = join(root, 'existing-output')
+    const existingRootDir = join(root, 'genie-nix-gc-roots')
+    const existingRoot = join(existingRootDir, 'devenv-no-retry-1-unit')
+    mkdirSync(bin)
+    mkdirSync(existingOutput)
+    mkdirSync(existingRootDir)
+    symlinkSync(existingOutput, existingRoot)
+    writeFileSync(
+      join(bin, 'nix'),
+      `#!/usr/bin/env bash\nprintf 'attempt\\n' >> "$NIX_ATTEMPTS"\necho 'ordinary failure' >&2\nexit 23\n`,
+    )
+    chmodSync(join(bin, 'nix'), 0o755)
+    try {
+      const result = spawnSync(
+        'bash',
+        ['-c', `${resolveDevenvFnScript}\nDEVENV_REV=fixture\nresolve_devenv`],
+        {
+          encoding: 'utf8',
+          env: {
+            ...process.env,
+            GITHUB_JOB: 'unit',
+            GITHUB_RUN_ATTEMPT: '1',
+            GITHUB_RUN_ID: 'no-retry',
+            NIX_ATTEMPTS: attempts,
+            PATH: `${bin}:${process.env.PATH ?? ''}`,
+            RUNNER_TEMP: root,
+          },
+        },
+      )
+      expect(result.status).toBe(23)
+      expect(readFileSync(attempts, 'utf8')).toBe('attempt\n')
+      expect(readlinkSync(existingRoot)).toBe(existingOutput)
+    } finally {
+      rmSync(root, { force: true, recursive: true })
+    }
+  })
+
+  it('repairs an invalid path and atomically roots the successful retry', () => {
+    const root = mkdtempSync(join(tmpdir(), 'genie-resolve-devenv-retry-'))
+    const bin = join(root, 'bin')
+    const attempts = join(root, 'attempts')
+    const roots = join(root, 'roots')
+    const repairs = join(root, 'repairs')
+    const summary = join(root, 'summary')
+    const output = join(root, 'devenv-output')
+    mkdirSync(bin)
+    mkdirSync(output)
+    writeFileSync(
+      join(bin, 'nix'),
+      `#!/usr/bin/env bash
+set -euo pipefail
+attempt=1
+if [ -f "$NIX_ATTEMPTS" ]; then attempt=$(( $(wc -l < "$NIX_ATTEMPTS") + 1 )); fi
+printf 'attempt\\n' >> "$NIX_ATTEMPTS"
+out_link=''
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = '--out-link' ]; then out_link="$2"; shift 2; else shift; fi
+done
+printf '%s\\n' "$out_link" >> "$NIX_ROOTS"
+if [ "$attempt" -eq 1 ]; then
+  echo "error: path '/nix/store/missing-fixture.drv' is not valid" >&2
+  exit 17
+fi
+ln -s "$NIX_OUTPUT" "$out_link"
+printf '%s\\n' "$NIX_OUTPUT"
+`,
+    )
+    writeFileSync(
+      join(bin, 'nix-store'),
+      `#!/usr/bin/env bash\nprintf '%s\\n' "$*" >> "$NIX_REPAIRS"\nexit 0\n`,
+    )
+    chmodSync(join(bin, 'nix'), 0o755)
+    chmodSync(join(bin, 'nix-store'), 0o755)
+    try {
+      const result = spawnSync(
+        'bash',
+        ['-c', `${resolveDevenvFnScript}\nDEVENV_REV=fixture\nresolve_devenv`],
+        {
+          encoding: 'utf8',
+          env: {
+            ...process.env,
+            GITHUB_JOB: 'unit',
+            GITHUB_RUN_ATTEMPT: '1',
+            GITHUB_RUN_ID: 'retry',
+            GITHUB_STEP_SUMMARY: summary,
+            NIX_ATTEMPTS: attempts,
+            NIX_OUTPUT: output,
+            NIX_REPAIRS: repairs,
+            NIX_ROOTS: roots,
+            PATH: `${bin}:${process.env.PATH ?? ''}`,
+            RUNNER_TEMP: root,
+          },
+        },
+      )
+      expect(result.status, result.stderr).toBe(0)
+      expect(result.stdout).toBe(`${output}\n`)
+      expect(readFileSync(attempts, 'utf8')).toBe('attempt\nattempt\n')
+      const [firstRoot, secondRoot] = readFileSync(roots, 'utf8').trim().split('\n')
+      expect(firstRoot).toBe(secondRoot)
+      expect(readFileSync(repairs, 'utf8')).toContain(
+        '--repair-path /nix/store/missing-fixture.drv',
+      )
+      expect(readlinkSync(firstRoot!)).toBe(output)
+      expect(readFileSync(summary, 'utf8')).toContain('### Recovered Nix store lifecycle incident')
+      expect(readFileSync(summary, 'utf8')).toContain('- Attempts: 2/2')
+    } finally {
+      rmSync(root, { force: true, recursive: true })
+    }
+  })
+
+  it('roots the resolved devenv closure in runner job scratch space', () => {
+    expect(resolveDevenvFnScript).toContain('${RUNNER_TEMP:-/tmp}/genie-nix-gc-roots')
+    expect(resolveDevenvFnScript).toContain('--out-link "$DEVENV_GC_ROOT"')
+    expect(resolveDevenvFnScript).not.toContain('rm -f "$DEVENV_GC_ROOT"')
+    expect(resolveDevenvFnScript).toContain(
+      '${GITHUB_RUN_ID:-local-$$}-${GITHUB_RUN_ATTEMPT:-0}-${GITHUB_JOB:-job}',
+    )
+    expect(validateNixStoreStepSource).toContain('readlink -e "$DEVENV_GC_ROOT"')
   })
 
   it('resolves the locked megarepo CLI through a git flake URL', () => {

--- a/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
@@ -513,7 +513,8 @@ printf '%s\\n' "$NIX_OUTPUT"
     expect(resolveDevenvFnScript).toContain(
       '${GITHUB_RUN_ID:-local-$$}-${GITHUB_RUN_ATTEMPT:-0}-${GITHUB_JOB:-job}',
     )
-    expect(validateNixStoreStepSource).toContain('readlink -e "$DEVENV_GC_ROOT"')
+    expect(validateNixStoreStepSource).toContain('[ ! "$DEVENV_GC_ROOT" -ef "$DEVENV_OUT" ]')
+    expect(validateNixStoreStepSource).not.toContain('readlink -e')
   })
 
   it('resolves the locked megarepo CLI through a git flake URL', () => {


### PR DESCRIPTION
## Problem

Initial devenv resolution can fail when a shared runner GC invalidates a transitive Nix store path during evaluation. Existing recovery only handled invalid outputs after resolution and CI jobs could mutate the global Nix daemon.

## Goal

Make initial resolution resilient to the proven invalid-store signature while keeping host lifecycle ownership outside individual CI jobs.

## Decisions

- Build through a job-scoped GC root under runner scratch space.
- Retry exactly once only for the exact invalid Nix store path signature.
- Clear the client evaluation cache and best-effort repair or realise the extracted path before retrying.
- Preserve all non-signature failures and their exit status.
- Validate the root portably with Bash symlink and inode equality.
- Remove CI-owned Nix daemon restart and mutation; host supervision remains authoritative.
- Wait passively before daemon-socket retries so host supervision has time to recover; the delay defaults to two seconds and is configurable.
- Record recovered lifecycle incidents in the job summary.

## Verification

- `devenv tasks run test:genie --no-tui --refresh-task-cache`
- `devenv tasks run genie:check --no-tui --refresh-task-cache`
- `devenv tasks run check:quick --no-tui --refresh-task-cache`
- 11 shell retry-helper tests, including an elapsed-time assertion for passive daemon recovery
- Independent adversarial review: GO
- Generated workflow is 478,081 bytes; pull-request CI run 29658819227 completed successfully with 24 successful jobs and one intentional skip

## Complexity

The initial resolver is generated once as a checked-in helper and sourced by each job after checkout, avoiding per-job YAML duplication. The runtime policy remains deliberately narrow: one signature, one retry for initial resolution, plus bounded passive retries for existing classified transient failures.

## Concerns

This is defense in depth, not a replacement for host-owned drain-aware GC. The shared Nix store remains a shared failure domain until the runner host policy is deployed.

## Friction & bottlenecks

The local full aggregate gate advanced through flake evaluation, strict TypeScript, Genie, megarepo, devenv-module, Weaver, and multiple package-test batches before the shared host reached 100% disk and entered automatic GC. Scoped local gates are green, and the authoritative pull-request CI run completed successfully across all required Linux, macOS, Nix, integration, deployment, and reporting lanes.

## Follow-ups

- Adopt the helper in downstream repositories through normal effect-utils lock propagation after merge.
- Keep fetched-source retry PR #702 separate; it addresses a broader and different failure signature.

## References

- NixOS/nix#15469
- DeterminateSystems/nix-src#395

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🌰 co2-hazel |
| `agent_session_id` | 52c06194-ea95-44dd-aac8-e74da944ef27 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.144.1 |
| `agent_runtime` | Codex CLI 0.144.1 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/1n76sy6i9y3ki3k4w04jksqvygw67sj0-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/jn6r0r7r59x3a525jch4pwzwykszqp60-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-18-devenv-rooted-resolve |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@4eac376 |
</details>
<!-- agent-footer:end -->