### PR TITLE
fix(devenv): handle ts:emit edge references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **devenv / ts:emit**: resolve project references with filesystem directory
+  checks so dotted directory names map to `tsconfig.json`, and treat an
+  all-`noEmit` reference graph as successful no-work instead of invoking the
+  compiler with an empty build root.
 - **@overeng/utils**: restore the downstream `@effect/platform` patch
   projection in the generated package manifest after vendoring
   `effect-distributed-lock`.

--- a/nix/devenv-modules/tasks/shared/tests/ts-task-smoke.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/ts-task-smoke.test.sh
@@ -87,6 +87,7 @@ mkdir -p \
   "$workspace/node_modules/typescript" \
   "$workspace/packages/no-emit" \
   "$workspace/packages/emit" \
+  "$workspace/packages/dotted.name" \
   "$tmpdir/bin"
 
 cat > "$workspace/tsconfig.all.json" <<'EOF'
@@ -96,7 +97,8 @@ cat > "$workspace/tsconfig.all.json" <<'EOF'
   "references": [
     { "path": "packages/no-emit/tsconfig.json" }, // explicit file path
     // This mid-file comment used to break the old JSON.parse path.
-    { "path": "packages/emit" }
+    { "path": "packages/emit" },
+    { "path": "packages/dotted.name" }
   ]
 }
 EOF
@@ -116,6 +118,15 @@ cat > "$workspace/packages/emit/tsconfig.json" <<'EOF'
   "compilerOptions": {
     "composite": true,
     // Keep this project in the emit graph.
+    "declaration": true
+  }
+}
+EOF
+
+cat > "$workspace/packages/dotted.name/tsconfig.json" <<'EOF'
+{
+  "compilerOptions": {
+    "composite": true,
     "declaration": true
   }
 }
@@ -223,6 +234,9 @@ if (paths.includes('packages/no-emit/tsconfig.json')) {
 if (!paths.includes('packages/emit')) {
   throw new Error('emit project should remain in generated emit tsconfig')
 }
+if (!paths.includes('packages/dotted.name')) {
+  throw new Error('dotted directory reference should remain in generated emit tsconfig')
+}
 
 fs.copyFileSync(configPath, process.env.TEST_CAPTURED_TSCONFIG)
 NODE
@@ -259,6 +273,31 @@ echo "Test 2: ts:emit status uses the same filtered graph"
 )
 test -f "$TEST_CAPTURED_TSCONFIG"
 grep -q -- '--dry --noCheck --verbose --pretty false' "$TEST_TSC_LOG"
+
+echo "Test 3: ts:emit succeeds without invoking tsc when every referenced project is noEmit"
+cat > "$workspace/tsconfig.all.json" <<'EOF'
+{
+  "files": [],
+  "references": [
+    { "path": "packages/no-emit" }
+  ]
+}
+EOF
+(
+  cd "$workspace"
+  : > "$TEST_TSC_LOG"
+  rm -f "$TEST_CAPTURED_TSCONFIG"
+  bash "$tmpdir/ts-emit.exec.sh" > "$tmpdir/no-work.out"
+  grep -qF "ts:emit: no emit-capable referenced projects" "$tmpdir/no-work.out"
+  assert_eq "" "$(cat "$TEST_TSC_LOG")" "ts:emit exec should not invoke tsc for all-noEmit graph"
+
+  set +e
+  bash "$tmpdir/ts-emit.status.sh"
+  exit_code=$?
+  set -e
+  assert_exit_code 0 "$exit_code" "ts:emit status should succeed for all-noEmit graph"
+  assert_eq "" "$(cat "$TEST_TSC_LOG")" "ts:emit status should not invoke tsc for all-noEmit graph"
+)
 
 echo ""
 echo "ts task smoke test passed"

--- a/nix/devenv-modules/tasks/shared/ts.nix
+++ b/nix/devenv-modules/tasks/shared/ts.nix
@@ -118,7 +118,15 @@ let
 
     const resolveReferenceTsconfig = (referencePath) => {
       const resolvedPath = path.resolve(baseDir, referencePath)
-      return path.extname(resolvedPath) ? resolvedPath : path.join(resolvedPath, 'tsconfig.json')
+      try {
+        return fs.statSync(resolvedPath).isDirectory()
+          ? path.join(resolvedPath, 'tsconfig.json')
+          : resolvedPath
+      } catch {
+        return path.basename(resolvedPath).endsWith('.json')
+          ? resolvedPath
+          : path.join(resolvedPath, 'tsconfig.json')
+      }
     }
 
     const rootConfig = readTsconfig(sourceTsconfig)
@@ -133,6 +141,13 @@ let
       const refConfig = readTsconfig(refTsconfig)
       return refConfig.compilerOptions?.noEmit !== true
     })
+
+    if (
+      rootConfig.references.length === 0 &&
+      (!Array.isArray(rootConfig.files) || rootConfig.files.length === 0)
+    ) {
+      rootConfig.__effectUtilsTsEmitNoWork = true
+    }
 
     fs.writeFileSync(targetTsconfig, JSON.stringify(rootConfig))
     NODE
@@ -407,6 +422,10 @@ let
         _emit_tsconfig="$(mktemp "$_emit_tmpdir/.ts-emit-XXXXXX.json")"
         trap 'rm -f "$_emit_tsconfig"' EXIT
         generate_emit_tsconfig "${tsconfigFile}" "$_emit_tsconfig"
+        if ${pkgs.nodejs}/bin/node -e 'const fs = require("node:fs"); process.exit(JSON.parse(fs.readFileSync(process.argv[1], "utf8")).__effectUtilsTsEmitNoWork === true ? 0 : 1)' "$_emit_tsconfig"; then
+          echo "ts:emit: no emit-capable referenced projects"
+          exit 0
+        fi
         ${tscWithDiagnostics "ts:emit" tscBin "--build \"$_emit_tsconfig\"" "--noCheck"}
       '';
       # trace-audit-allow: raw status - argument to trace.withStatus "ts:emit" above.
@@ -420,6 +439,9 @@ let
         _emit_tsconfig="$(mktemp "$_emit_tmpdir/.ts-emit-XXXXXX.json")"
         trap 'rm -f "$_emit_tsconfig"' EXIT
         generate_emit_tsconfig "${tsconfigFile}" "$_emit_tsconfig"
+        if ${pkgs.nodejs}/bin/node -e 'const fs = require("node:fs"); process.exit(JSON.parse(fs.readFileSync(process.argv[1], "utf8")).__effectUtilsTsEmitNoWork === true ? 0 : 1)' "$_emit_tsconfig"; then
+          exit 0
+        fi
         _out="$(${tscBin} --build "$_emit_tsconfig" --dry --noCheck --verbose --pretty false 2>&1)" || exit 1
         # tsc --build --dry reports pending work as:
         # - "A non-dry build would build project ..."


### PR DESCRIPTION
**Problem**
`ts:emit` had two edge-case failures in its filtered build-root generation:

- dotted directory references were classified as files because the resolver used `path.extname`, producing directory-read failures instead of appending `tsconfig.json` (#939);
- when every referenced project was `noEmit: true`, filtering produced an empty build root, so the compiler could fail with TS18002 instead of treating the emit task as no work (#940).

**Goal**
Make `ts:emit` resolve referenced tsconfigs the same way for normal and dotted directories, and make an all-`noEmit` graph a successful no-work path for both `exec` and `status`.

**Decisions**
The resolver now asks the filesystem whether an existing reference is a directory. For missing references, it only treats paths ending in `.json` as explicit config files; everything else is resolved as a directory containing `tsconfig.json`.

The filtered temp config carries a private no-work marker when it has no `files` and no remaining `references`. The task scripts read that marker and exit before invoking the compiler.

**Verification**
- `CI=1 bash nix/devenv-modules/tasks/shared/tests/ts-task-smoke.test.sh` passed, including dotted directory and all-`noEmit` repros.
- `CI=1 devenv tasks run check:quick --no-tui` exited 0.
- `git diff --check` passed.

**Complexity**
No new abstraction or dependency. This is a small extension of the existing temp-config helper.

**Concerns**
The no-work marker is intentionally private to the generated temporary config and is never written to checked-in tsconfig files.

**Friction & Bottlenecks**
None introduced. Coordination found #921's core pnpm issue was already fixed by #936, and projection-health defense-in-depth remains with #922.

**Follow-ups**
None for this PR.

**References**
Closes #939.
Closes #940.
Refs #921.
Refs #922.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🔊 co1-sound |
| `agent_session_id` | 20219167-6152-4a96-a347-231544e032ed |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.144.1 |
| `agent_runtime` | Codex CLI 0.144.1 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/1n76sy6i9y3ki3k4w04jksqvygw67sj0-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/jn6r0r7r59x3a525jch4pwzwykszqp60-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-19-2026-07-19-hubfix-921-939-940 |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@4eac376 |
</details>
<!-- agent-footer:end -->