### PR TITLE
test(store-lock): deterministic end-to-end regression proving eu#931 finalizer-order fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- **megarepo / StoreLock**: add a deterministic filesystem-backed regression
+  test for the distributed-lock finalizer ordering that prevents holder-file
+  resurrection between consecutive store lock acquisitions.
+
 - **react-inspector / Effect 4**: align the development dependency and peer
   floor to Effect `4.0.0-beta.99`, anchor injected test helpers to the separate
   Effect 3 catalog, and fail generation if either cohort's exact identity drifts

--- a/packages/@overeng/megarepo/src/lib/store-lock.unit.test.ts
+++ b/packages/@overeng/megarepo/src/lib/store-lock.unit.test.ts
@@ -1,14 +1,22 @@
+import { createHash } from 'node:crypto'
+
+import { FileSystem } from '@effect/platform'
+import { NodeContext } from '@effect/platform-node'
 import { it } from '@effect/vitest'
-import { Effect, Ref } from 'effect'
+import { Deferred, Duration, Effect, Ref, TestClock } from 'effect'
 import { describe, expect } from 'vitest'
 
+import { EffectPath } from '@overeng/effect-path'
 import { InMemoryBacking } from '@overeng/utils'
 
-import { makeStoreLockLayerFromBacking, StoreLock } from './store-lock.ts'
+import { makeStoreLockLayer, makeStoreLockLayerFromBacking, StoreLock } from './store-lock.ts'
 
 /** Provide StoreLock backed by an in-memory distributed semaphore */
 const withStoreLock = <A, E>(effect: Effect.Effect<A, E, StoreLock>): Effect.Effect<A, E, never> =>
   effect.pipe(Effect.provide(makeStoreLockLayerFromBacking(InMemoryBacking.layer)), Effect.scoped)
+
+const hashStoreLockKey = (key: string): string =>
+  createHash('sha256').update(key).digest('hex').slice(0, 32)
 
 describe('StoreLock', () => {
   it.effect(
@@ -110,5 +118,94 @@ describe('StoreLock', () => {
         }),
       ),
     { timeout: 30_000 },
+  )
+
+  it.effect(
+    'interrupts an in-flight file-system refresh before releasing a StoreLock holder',
+    () =>
+      Effect.gen(function* () {
+        const baseFs = yield* FileSystem.FileSystem
+        const tempDir = yield* baseFs.makeTempDirectoryScoped()
+        const storePath = EffectPath.unsafe.absoluteDir(`${tempDir}/store/`)
+        const lockKey = 'https://github.com/acme/widget.git'
+        const keyDir = `${storePath}.locks/${encodeURIComponent(
+          `repo/${hashStoreLockKey(lockKey)}`,
+        )}`
+        const refreshRenameReady = yield* Deferred.make<void>()
+        const allowRefreshRename = yield* Deferred.make<void>()
+        const refreshDone = yield* Deferred.make<'interrupted' | 'renamed'>()
+        let holderRenameCount = 0
+
+        const isHolderLockRename = (oldPath: string, newPath: string) =>
+          oldPath.endsWith('.tmp') === true &&
+          newPath.startsWith(`${keyDir}/`) === true &&
+          newPath.endsWith('.lock') === true
+
+        const isHolderLockRemove = (filePath: string) =>
+          filePath.startsWith(`${keyDir}/`) === true && filePath.endsWith('.lock') === true
+
+        const instrumentedFs = {
+          ...baseFs,
+          rename: (oldPath: string, newPath: string) => {
+            if (isHolderLockRename(oldPath, newPath) === false) {
+              return baseFs.rename(oldPath, newPath)
+            }
+
+            holderRenameCount += 1
+            if (holderRenameCount !== 2) {
+              return baseFs.rename(oldPath, newPath)
+            }
+
+            return Effect.gen(function* () {
+              yield* Deferred.succeed(refreshRenameReady, undefined)
+              yield* Deferred.await(allowRefreshRename)
+              yield* baseFs.rename(oldPath, newPath)
+              yield* Deferred.succeed(refreshDone, 'renamed')
+            }).pipe(
+              Effect.onInterrupt(() =>
+                Deferred.succeed(refreshDone, 'interrupted').pipe(Effect.asVoid),
+              ),
+            )
+          },
+          remove: (filePath: string) => {
+            if (isHolderLockRemove(filePath) === false) {
+              return baseFs.remove(filePath)
+            }
+
+            return Effect.gen(function* () {
+              yield* baseFs.remove(filePath)
+              yield* Deferred.succeed(allowRefreshRename, undefined)
+              yield* Deferred.await(refreshDone)
+            })
+          },
+        } as FileSystem.FileSystem
+
+        yield* Effect.gen(function* () {
+          const { withRepoLock } = yield* StoreLock
+
+          yield* withRepoLock(lockKey)(
+            Effect.gen(function* () {
+              yield* TestClock.adjust(Duration.seconds(101))
+              yield* Deferred.await(refreshRenameReady)
+            }),
+          )
+
+          const refreshResult = yield* Deferred.await(refreshDone)
+          const remainingHolderLocks = yield* baseFs
+            .readDirectory(keyDir)
+            .pipe(Effect.catchAll(() => Effect.succeed([] as Array<string>)))
+
+          expect(refreshResult).toBe('interrupted')
+          expect(remainingHolderLocks.filter((entry) => entry.endsWith('.lock'))).toEqual([])
+
+          const secondAcquireResult = yield* withRepoLock(lockKey)(Effect.succeed('acquired'))
+
+          expect(secondAcquireResult).toBe('acquired')
+        }).pipe(
+          Effect.provide(makeStoreLockLayer(storePath)),
+          Effect.provideService(FileSystem.FileSystem, instrumentedFs),
+        )
+      }).pipe(Effect.provide(NodeContext.layer), Effect.scoped),
+    { timeout: 20_000 },
   )
 })


### PR DESCRIPTION
**Problem**

The StoreLock finalizer-order fix for issue #931 had low-level coverage, but no deterministic end-to-end regression at the real StoreLock/FileSystemBacking boundary. The original flake was rare under statistical reruns, so a useful regression needs to force the losing interleave.

**Goal**

Prove that a StoreLock keepAlive refresh parked at the holder-file rename point is interrupted before holder release, so a consecutive acquisition of the same StoreLock cannot be blocked by a resurrected holder file.

**Decisions**

- Added the regression to the existing StoreLock test file instead of adding a new fixture file.
- The test uses the production `makeStoreLockLayer` and real `FileSystemBacking`; only the Effect `FileSystem` service is wrapped to pause the second holder-file `rename`, which is the resurrection point.
- The test drives the Effect `TestClock` forward 101s to hit StoreLock's 5m TTL / 3 refresh interval without real waiting.
- I did not add a full `mr store gc` two-run variant. The command path does not expose a clean deterministic hook at the holder-file rename boundary; forcing it there would require broader test-only plumbing. The StoreLock-level test still exercises the production lock layer and backing that `mr store gc` uses.

**Verification**

- Fixed code: `CI=1 run_package_bin vitest vitest run src/lib/store-lock.unit.test.ts --reporter verbose --testTimeout 20000 --hookTimeout 20000` passed: 1 file, 5 tests, including the new regression.
- Discrimination: temporarily swapped `DistributedSemaphore.tryTake` back to the buggy order (`forkScoped(keepAlive)` before `addFinalizer(release)`) and reran the same command. The new regression failed in 26ms with `expected 'renamed' to be 'interrupted'`, proving the forced refresh resurrected the holder under the old ordering.
- Restored the fixed order and reran the same single-file command: passed again, 1 file, 5 tests.
- `CI=1 pnpm --filter @overeng/megarepo exec tsc --build ../../../tsconfig.all.json --pretty false` passed with no diagnostics. This is the direct `tsc` build graph check; exact `ts:check` uses `tsgo`, which was not available outside the dev shell.
- `CI=1 GENIE_EXPORT_TYPE_PROOF_COMPILER=<local tsc> pnpm --filter @overeng/genie exec bun bin/genie.tsx --cwd ../../.. --check --output ci-plain` passed: 90 files unchanged.
- `CI=1 oxfmt --check packages/@overeng/megarepo/src/lib/store-lock.unit.test.ts CHANGELOG.md` passed.
- `git diff --check` passed.

**Complexity**

No production complexity. The test adds a small filesystem wrapper so the production FileSystemBacking can be interleaved deterministically at the exact holder-file rename boundary.

**Concerns**

- I could not run the exact `lint:check` outside devenv. The only `oxlint` on PATH was the plain profile binary, while this repo's config requires the devenv `oxlint-with-plugins` wrapper for `jsPlugins`; direct `oxlint --config .oxlintrc.json ...` exited 1 with no diagnostics.
- I avoided `devenv`/Nix/FOD work per the disk note. The fresh worktree needed a dependency projection; strict offline pnpm failed because the available stores missed tarballs, so I used `pnpm install --frozen-lockfile --ignore-scripts` against the shared user store. No scripts, Nix, or FOD builds were run.

**Friction & bottlenecks**

- Filed tooling feedback for the missing direct lint wrapper outside devenv.
- Root filesystem stayed above the 4G stop threshold during the work.

**Follow-ups**

None for this PR.

**References**

Refs #931.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🐧 co1-polar |
| `agent_session_id` | 63749266-eead-4445-a1aa-a485c6b374e6 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.144.1 |
| `agent_runtime` | Codex CLI 0.144.1 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/1n76sy6i9y3ki3k4w04jksqvygw67sj0-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/jn6r0r7r59x3a525jch4pwzwykszqp60-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-19-org-schickling-eu931-e2e |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@4eac376 |
</details>
<!-- agent-footer:end -->