### PR TITLE
Streamline shared label catalog + export gh-labels module

### DIFF
--- a/.github/labels.json
+++ b/.github/labels.json
@@ -106,81 +106,6 @@
       "description": "Temporary PR validates CI measurement/reporting behavior · Set: manual"
     },
     {
-      "name": "mq:agent-active",
-      "color": "0969da",
-      "description": "Hypermerge has dispatched an agent · Set: Hypermerge daemon"
-    },
-    {
-      "name": "mq:blocked",
-      "color": "b60205",
-      "description": "Hypermerge is not currently advancing this PR · Set: Hypermerge daemon"
-    },
-    {
-      "name": "mq:ci-admitted",
-      "color": "1f883d",
-      "description": "Hypermerge admitted this PR to scarce-runner CI · Set: Hypermerge daemon"
-    },
-    {
-      "name": "mq:enrolled",
-      "color": "5319e7",
-      "description": "PR is enrolled in Hypermerge · Set: manual (mirrors GH auto-merge)"
-    },
-    {
-      "name": "mq:merge-held",
-      "color": "bfd4f2",
-      "description": "Hypermerge may prove this PR green but must not merge it · Set: manual"
-    },
-    {
-      "name": "mq:needs-agent",
-      "color": "d93f0b",
-      "description": "Hypermerge needs agentic intervention · Set: Hypermerge daemon"
-    },
-    {
-      "name": "mq:needs-human",
-      "color": "8250df",
-      "description": "Hypermerge needs human review · Set: Hypermerge daemon"
-    },
-    {
-      "name": "mq:priority-0",
-      "color": "0e8a16",
-      "description": "Hypermerge priority mirror · Set: manual (via mq-cli)"
-    },
-    {
-      "name": "mq:priority-1",
-      "color": "0e8a16",
-      "description": "Hypermerge priority mirror · Set: manual (via mq-cli)"
-    },
-    {
-      "name": "mq:priority-10",
-      "color": "0e8a16",
-      "description": "Hypermerge priority mirror · Set: manual (via mq-cli)"
-    },
-    {
-      "name": "mq:priority-100",
-      "color": "0e8a16",
-      "description": "Hypermerge priority mirror · Set: manual (via mq-cli)"
-    },
-    {
-      "name": "mq:priority-20",
-      "color": "0e8a16",
-      "description": "Hypermerge priority mirror · Set: manual (via mq-cli)"
-    },
-    {
-      "name": "mq:priority-30",
-      "color": "0e8a16",
-      "description": "Hypermerge priority mirror · Set: manual (via mq-cli)"
-    },
-    {
-      "name": "mq:queue-head",
-      "color": "fbca04",
-      "description": "Current Hypermerge head for this repository · Set: Hypermerge daemon"
-    },
-    {
-      "name": "mq:status",
-      "color": "5319e7",
-      "description": "Pinned Hypermerge status issue · Set: Hypermerge daemon"
-    },
-    {
       "name": "origin:agent",
       "color": "6f42c1",
       "description": "Filed or primarily produced by an AI agent · Set: AI agent or manual"
@@ -194,6 +119,16 @@
       "name": "state:blocked",
       "color": "6e7781",
       "description": "Blocked on an external dependency or decision · Set: manual"
+    },
+    {
+      "name": "state:declined",
+      "color": "6e7781",
+      "description": "Reviewed and declined; will not be acted on · Set: manual"
+    },
+    {
+      "name": "state:duplicate",
+      "color": "6e7781",
+      "description": "Duplicate of an existing item; tracked elsewhere · Set: manual"
     },
     {
       "name": "state:needs-research",
@@ -388,7 +323,7 @@
     {
       "name": "type:chore",
       "color": "bfd4e2",
-      "description": "Maintenance, cleanup, dependencies, CI, or refactoring · Set: manual"
+      "description": "Maintenance, cleanup, dependencies, or CI · Set: manual"
     },
     {
       "name": "type:docs",
@@ -397,7 +332,7 @@
     },
     {
       "name": "type:epic",
-      "color": "1d76db",
+      "color": "8250df",
       "description": "Large tracking issue with child tasks · Set: manual"
     },
     {
@@ -414,6 +349,16 @@
       "name": "type:rca",
       "color": "5319e7",
       "description": "Root-cause analysis or investigation record · Set: manual"
+    },
+    {
+      "name": "type:refactor",
+      "color": "c5def5",
+      "description": "Behavior-preserving code restructuring · Set: manual"
+    },
+    {
+      "name": "type:task",
+      "color": "bfd4e2",
+      "description": "Scoped implementation/follow-up work (not bug/feature/docs/incident/RCA/epic) · Set: manual"
     }
   ],
   "deprecated": [
@@ -423,6 +368,21 @@
     "duplicate",
     "enhancement",
     "invalid",
+    "mq:agent-active",
+    "mq:blocked",
+    "mq:ci-admitted",
+    "mq:enrolled",
+    "mq:merge-held",
+    "mq:needs-agent",
+    "mq:needs-human",
+    "mq:priority-0",
+    "mq:priority-1",
+    "mq:priority-10",
+    "mq:priority-100",
+    "mq:priority-20",
+    "mq:priority-30",
+    "mq:queue-head",
+    "mq:status",
     "nix-hash",
     "question",
     "wontfix"

--- a/.github/labels.json
+++ b/.github/labels.json
@@ -357,7 +357,7 @@
     },
     {
       "name": "type:task",
-      "color": "bfd4e2",
+      "color": "cdc5e2",
       "description": "Scoped implementation/follow-up work (not bug/feature/docs/incident/RCA/epic) · Set: manual"
     }
   ],

--- a/.github/labels.json.genie.ts
+++ b/.github/labels.json.genie.ts
@@ -1,4 +1,3 @@
-import { readdirSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 
 import {
@@ -6,14 +5,15 @@ import {
   commonLabels,
   deprecatedDefaults,
   legacyMigrations,
-  mqLabels,
+  mqDeprecated,
 } from '../genie/labels.ts'
+import { deriveSystemLabels } from '../genie/system-labels.ts'
 import { githubLabels, type LabelDef } from '../packages/@overeng/genie/src/runtime/mod.ts'
 
 /**
  * Repo-local `area:*` labels specific to effect-utils. Cross-repo concerns
  * (area:nix, area:typescript, area:ci, area:storybook, area:effect, area:devenv,
- * area:tooling) live in `genie/labels.ts` as `commonLabels`.
+ * area:tooling, area:megarepo) live in `genie/labels.ts` as `commonLabels`.
  */
 const effectUtilsAreaLabels: readonly LabelDef[] = [
   { name: 'area:rust', color: '1d76db', description: 'Rust code and tooling · Set: manual' },
@@ -43,33 +43,21 @@ const effectUtilsAreaLabels: readonly LabelDef[] = [
     color: '1d76db',
     description: 'genie config generator runtime + CLI · Set: manual',
   },
-  {
-    name: 'area:megarepo',
-    color: '1d76db',
-    description: 'megarepo CLI and conventions · Set: manual',
-  },
 ]
 
 /**
  * Repo-local `system:*` labels — one per concrete `@overeng/*` package. A
  * `system:*` value names a thing with its own identity that issues and feedback
  * are attributed *to*, distinct from the cross-cutting `area:*` concern axis.
- * Derived from the package directories (derive-don't-author) so the catalog
- * tracks the workspace automatically; the genie freshness gate regenerates and
- * diffs `labels.json`, so adding/removing a package is always reflected here.
+ * Derived from the package directories (derive-don't-author) via the shared
+ * `deriveSystemLabels` helper so the catalog tracks the workspace automatically;
+ * the genie freshness gate regenerates and diffs `labels.json`, so adding or
+ * removing a package is always reflected here.
  */
-const effectUtilsSystemLabels: readonly LabelDef[] = readdirSync(
-  fileURLToPath(new URL('../packages/@overeng', import.meta.url)),
-  { withFileTypes: true },
-)
-  .filter((entry) => entry.isDirectory())
-  .map((entry) => entry.name)
-  .sort()
-  .map((pkg) => ({
-    name: `system:${pkg}`,
-    color: 'a371f7',
-    description: `@overeng/${pkg} package · Set: manual`,
-  }))
+const effectUtilsSystemLabels: readonly LabelDef[] = deriveSystemLabels({
+  dir: fileURLToPath(new URL('../packages/@overeng', import.meta.url)),
+  describe: (pkg) => `@overeng/${pkg} package`,
+})
 
 /** Repo-local utility labels used by automation in this repo. */
 const effectUtilsAutomationLabels: readonly LabelDef[] = [
@@ -100,12 +88,12 @@ const repoLocalLegacyMigrations = [
 export default githubLabels({
   labels: [
     ...commonLabels,
-    ...mqLabels,
     ...andonLabels,
     ...effectUtilsAreaLabels,
     ...effectUtilsSystemLabels,
     ...effectUtilsAutomationLabels,
   ],
-  deprecated: [...deprecatedDefaults, ...repoLocalDeprecated],
+  // Retire the vestigial `mq:*` labels (no runtime acts on them) alongside the GitHub defaults.
+  deprecated: [...deprecatedDefaults, ...mqDeprecated, ...repoLocalDeprecated],
   legacyMigrations: [...legacyMigrations, ...repoLocalLegacyMigrations],
 })

--- a/flake.nix
+++ b/flake.nix
@@ -256,6 +256,9 @@
           bun = import ./nix/devenv-modules/tasks/shared/bun.nix;
           changesets = import ./nix/devenv-modules/tasks/shared/changesets.nix;
           github-ruleset = import ./nix/devenv-modules/tasks/shared/github-ruleset.nix;
+          # gh:apply-labels / gh:check-labels — reconcile .github/labels.json with live labels.
+          # Parameterized by `{ repo = "owner/name"; }`; consumed like the other task modules.
+          gh-labels = import ./nix/devenv-modules/gh-labels.nix;
           pnpm = import ./nix/devenv-modules/tasks/shared/pnpm.nix;
           nix-cli = import ./nix/devenv-modules/tasks/shared/nix-cli.nix;
           secretspec = import ./nix/devenv-modules/tasks/shared/secretspec.nix;

--- a/genie/external.ts
+++ b/genie/external.ts
@@ -219,6 +219,8 @@ export {
   deprecatedDefaults,
   legacyMigrations,
   mqDeprecated,
+  /** @deprecated kept for consumer backward-compat; empty — migrate to `mqDeprecated`. */
+  mqLabels,
 } from './labels.ts'
 
 export { deriveSystemLabels, systemLabelColor, type DeriveSystemLabelsArgs } from './system-labels.ts'

--- a/genie/external.ts
+++ b/genie/external.ts
@@ -218,8 +218,10 @@ export {
   commonLabels,
   deprecatedDefaults,
   legacyMigrations,
-  mqLabels,
+  mqDeprecated,
 } from './labels.ts'
+
+export { deriveSystemLabels, systemLabelColor, type DeriveSystemLabelsArgs } from './system-labels.ts'
 
 /**
  * Catalog versions - single source of truth for dependency versions

--- a/genie/labels.ts
+++ b/genie/labels.ts
@@ -43,8 +43,10 @@ const colors = {
   grey: 'bfd4e2',
   lightGrey: 'ededed',
   pale: 'bfd4f2',
-  /* Distinct light blue for `type:refactor` so it reads apart from the grey `type:chore`/`type:task` chips. */
+  /* Distinct light blue for `type:refactor` so it reads apart from the grey `type:chore` chip. */
   iceBlue: 'c5def5',
+  /* Pale lavender-grey for `type:task`, distinct from `type:chore` grey and `type:refactor` iceBlue. */
+  dust: 'cdc5e2',
   /* Neutral slate used as the single, axis-consistent color for all `state:*` labels. */
   slate: '6e7781',
 } as const
@@ -89,7 +91,7 @@ const typeLabels: readonly LabelDef[] = [
   },
   {
     name: 'type:task',
-    color: colors.grey,
+    color: colors.dust,
     description:
       'Scoped implementation/follow-up work (not bug/feature/docs/incident/RCA/epic) · Set: manual',
   },
@@ -243,6 +245,14 @@ export const mqDeprecated: readonly string[] = [
   'mq:status',
   ...mqPriorityLevels.map((n) => `mq:priority-${n}`),
 ]
+
+/**
+ * @deprecated The `mq:*` axis is retired — no labels are provisioned anymore. This is
+ * kept as an empty array purely so existing `...mqLabels` spreads / `mqLabels.map(...)`
+ * in consumer repos keep evaluating (non-breaking) until they migrate to `mqDeprecated`.
+ * Remove once no consumer references it.
+ */
+export const mqLabels: readonly LabelDef[] = []
 
 // ============================================================================
 // andon:* — cross-machine incident states (see /sk-andon)

--- a/genie/labels.ts
+++ b/genie/labels.ts
@@ -2,14 +2,13 @@
  * Shared GitHub label catalog reused across primary megarepo members.
  *
  * Composed by each repo's `.github/labels.json.genie.ts`. Consumers spread the
- * relevant axes (`commonLabels`, `mqLabels`, `andonLabels`) and add their own
- * repo-local `area:*` labels.
+ * relevant axes (`commonLabels`, `andonLabels`) and add their own repo-local
+ * `area:*`/`system:*` labels (see `deriveSystemLabels` in `./system-labels.ts`).
  *
- * Source of truth for `mq:*` colors/descriptions: kept loosely aligned with
- * `flakes/merge-queue/crates/mq-core/src/gh_client.rs` in dotfiles, which is
- * the runtime safety net for lazy label creation. The `devenv tasks run gh:apply-labels`
- * task is the canonical writer; `devenv tasks run gh:check-labels` reports drift without
- * applying.
+ * The merge-queue `mq:*` axis is retired (see `mqDeprecated` below); Hypermerge's
+ * `hy:*` labels live in dotfiles' hypermerge flake (only enrolled repo). The
+ * `devenv tasks run gh:apply-labels` task is the canonical writer;
+ * `devenv tasks run gh:check-labels` reports drift without applying.
  *
  * Every description includes a trailing `· Set: <who>` clause naming the
  * party responsible for applying the label (manual, Hypermerge daemon,
@@ -44,6 +43,8 @@ const colors = {
   grey: 'bfd4e2',
   lightGrey: 'ededed',
   pale: 'bfd4f2',
+  /* Distinct light blue for `type:refactor` so it reads apart from the grey `type:chore`/`type:task` chips. */
+  iceBlue: 'c5def5',
   /* Neutral slate used as the single, axis-consistent color for all `state:*` labels. */
   slate: '6e7781',
 } as const
@@ -54,8 +55,9 @@ const colors = {
 
 const typeLabels: readonly LabelDef[] = [
   {
+    // brightPurple (not brightBlue) so an epic chip is distinct from every `area:*` chip.
     name: 'type:epic',
-    color: colors.brightBlue,
+    color: colors.brightPurple,
     description: 'Large tracking issue with child tasks · Set: manual',
   },
   {
@@ -76,7 +78,20 @@ const typeLabels: readonly LabelDef[] = [
   {
     name: 'type:chore',
     color: colors.grey,
-    description: 'Maintenance, cleanup, dependencies, CI, or refactoring · Set: manual',
+    description: 'Maintenance, cleanup, dependencies, or CI · Set: manual',
+  },
+  {
+    // Behavior-preserving restructuring — a distinct kind of work from `type:chore`
+    // (deps/CI/tooling). Boundary: if runtime behavior is intentionally unchanged, it's refactor.
+    name: 'type:refactor',
+    color: colors.iceBlue,
+    description: 'Behavior-preserving code restructuring · Set: manual',
+  },
+  {
+    name: 'type:task',
+    color: colors.grey,
+    description:
+      'Scoped implementation/follow-up work (not bug/feature/docs/incident/RCA/epic) · Set: manual',
   },
   {
     name: 'type:agent-tooling',
@@ -114,6 +129,16 @@ const stateLabels: readonly LabelDef[] = [
     name: 'state:needs-research',
     color: colors.slate,
     description: 'Needs research / investigation before scope or approach is clear · Set: manual',
+  },
+  {
+    name: 'state:declined',
+    color: colors.slate,
+    description: 'Reviewed and declined; will not be acted on · Set: manual',
+  },
+  {
+    name: 'state:duplicate',
+    color: colors.slate,
+    description: 'Duplicate of an existing item; tracked elsewhere · Set: manual',
   },
 ]
 
@@ -174,6 +199,11 @@ const sharedAreaLabels: readonly LabelDef[] = [
     color: colors.brightBlue,
     description: 'Developer tooling, scripts, and utilities · Set: manual',
   },
+  {
+    name: 'area:megarepo',
+    color: colors.brightBlue,
+    description: 'megarepo CLI and conventions · Set: manual',
+  },
 ]
 
 // ============================================================================
@@ -189,71 +219,30 @@ const sharedAreaLabels: readonly LabelDef[] = [
 // ============================================================================
 
 // ============================================================================
-// mq:* — Hypermerge / merge-queue lifecycle labels
-//   Must stay loosely aligned with mq_label_color / mq_label_description in
-//   dotfiles/flakes/merge-queue/crates/mq-core/src/gh_client.rs.
+// mq:* — RETIRED merge-queue labels (cleanup only)
+//   The merge-queue runtime that owned these (`flakes/merge-queue/crates/mq-core`)
+//   is deleted; its successor Hypermerge uses `hy:req/*` + `hy:state/*` (defined in
+//   dotfiles' hypermerge flake) and deprecates every `mq:*`. No runtime acts on
+//   `mq:*` anymore, so the catalog no longer *provisions* them — it only exports
+//   their names as `mqDeprecated` so each repo can DELETE the vestigial live labels
+//   by composing them into its `deprecated` list. Do not re-add `mqLabels`.
 // ============================================================================
 
-const mqStaticLabels: readonly LabelDef[] = [
-  {
-    name: 'mq:enrolled',
-    color: colors.purple,
-    description: 'PR is enrolled in Hypermerge · Set: manual (mirrors GH auto-merge)',
-  },
-  {
-    name: 'mq:merge-held',
-    color: colors.pale,
-    description: 'Hypermerge may prove this PR green but must not merge it · Set: manual',
-  },
-  {
-    name: 'mq:blocked',
-    color: colors.red,
-    description: 'Hypermerge is not currently advancing this PR · Set: Hypermerge daemon',
-  },
-  {
-    name: 'mq:needs-agent',
-    color: colors.orange,
-    description: 'Hypermerge needs agentic intervention · Set: Hypermerge daemon',
-  },
-  {
-    name: 'mq:agent-active',
-    color: colors.blue,
-    description: 'Hypermerge has dispatched an agent · Set: Hypermerge daemon',
-  },
-  {
-    name: 'mq:needs-human',
-    color: colors.brightPurple,
-    description: 'Hypermerge needs human review · Set: Hypermerge daemon',
-  },
-  {
-    name: 'mq:ci-admitted',
-    color: colors.brightGreen,
-    description: 'Hypermerge admitted this PR to scarce-runner CI · Set: Hypermerge daemon',
-  },
-  {
-    name: 'mq:queue-head',
-    color: colors.yellow,
-    description: 'Current Hypermerge head for this repository · Set: Hypermerge daemon',
-  },
-  {
-    name: 'mq:status',
-    color: colors.purple,
-    description: 'Pinned Hypermerge status issue · Set: Hypermerge daemon',
-  },
-]
-
-/**
- * Canonical priority levels mirrored by Hypermerge. The runtime can create
- * additional `mq:priority-N` labels on demand (lazy `ensure_repo_label`); the
- * set below is what gets pre-created so triage UIs show consistent options.
- */
 const mqPriorityLevels = [0, 1, 10, 20, 30, 100] as const
 
-const mqPriorityLabels: readonly LabelDef[] = mqPriorityLevels.map((n) => ({
-  name: `mq:priority-${n}`,
-  color: colors.green,
-  description: 'Hypermerge priority mirror · Set: manual (via mq-cli)',
-}))
+/** Every `mq:*` label name, for repos cleaning up the retired merge-queue labels. */
+export const mqDeprecated: readonly string[] = [
+  'mq:enrolled',
+  'mq:merge-held',
+  'mq:blocked',
+  'mq:needs-agent',
+  'mq:agent-active',
+  'mq:needs-human',
+  'mq:ci-admitted',
+  'mq:queue-head',
+  'mq:status',
+  ...mqPriorityLevels.map((n) => `mq:priority-${n}`),
+]
 
 // ============================================================================
 // andon:* — cross-machine incident states (see /sk-andon)
@@ -299,9 +288,6 @@ export const commonLabels: readonly LabelDef[] = [
   ...originLabels,
   ...sharedAreaLabels,
 ]
-
-/** Hypermerge merge-queue labels including the canonical priority levels. */
-export const mqLabels: readonly LabelDef[] = [...mqStaticLabels, ...mqPriorityLabels]
 
 /** Andon cross-machine incident state labels. */
 export const andonLabels: readonly LabelDef[] = andonStateLabels

--- a/genie/system-labels.ts
+++ b/genie/system-labels.ts
@@ -1,0 +1,61 @@
+/**
+ * Shared `system:*` label derivation, reused across primary megarepo members.
+ *
+ * A `system:*` value names a thing with its own identity (a concrete package, a
+ * VRS-homed subsystem) that issues and feedback are attributed *to* — distinct
+ * from the cross-cutting `area:*` concern axis. The *values* are legitimately
+ * per-repo, but the derivation *logic* (read a directory, one `system:<name>`
+ * per subdirectory, violet `a371f7`, `· Set: manual`) was copy-pasted between
+ * effect-utils and dotfiles. This is that logic, once.
+ *
+ * Lives in `genie/` (consumed via the megarepo path / `#mr` alias by peer repos'
+ * `.github/labels.json.genie.ts`), not in the published `@overeng/genie` runtime
+ * package — it is genie-eval-time `readdirSync` glue, and the runtime should not
+ * carry it. Only the `LabelDef` *type* is imported from the runtime.
+ */
+
+import { readdirSync } from 'node:fs'
+
+import type { LabelDef } from '../packages/@overeng/genie/src/runtime/github-labels/mod.ts'
+
+/** Single, axis-consistent color for every `system:*` chip (violet, distinct from area blue). */
+export const systemLabelColor = 'a371f7'
+
+export interface DeriveSystemLabelsArgs {
+  /**
+   * Absolute directory whose immediate subdirectories each become one
+   * `system:<name>`. Callers resolve this from their own genie file, e.g.
+   * `fileURLToPath(new URL('../packages/@overeng', import.meta.url))`.
+   */
+  dir: string
+  /** Map a subdirectory name to the label description (the `· Set: manual` suffix is appended). */
+  describe: (name: string) => string
+  /** Subdirectory names to skip (e.g. already covered by an `area:*` label). */
+  exclude?: readonly string[]
+  /** Optional rename of the `system:` segment for a given subdirectory, e.g. `{ '19-feedback': 'feedback' }`. */
+  aliases?: Readonly<Record<string, string>>
+}
+
+/**
+ * Derive-don't-author `system:*` labels from a directory's subdirectories, sorted
+ * for byte-stable output so the genie freshness gate reflects package/subsystem
+ * adds and removes automatically.
+ */
+export const deriveSystemLabels = ({
+  dir,
+  describe,
+  exclude = [],
+  aliases = {},
+}: DeriveSystemLabelsArgs): readonly LabelDef[] => {
+  const excluded = new Set(exclude)
+  return readdirSync(dir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((name) => excluded.has(name) === false)
+    .sort()
+    .map((name) => ({
+      name: `system:${aliases[name] ?? name}`,
+      color: systemLabelColor,
+      description: `${describe(name)} · Set: manual`,
+    }))
+}

--- a/packages/@overeng/genie/src/runtime/github-labels/mod.ts
+++ b/packages/@overeng/genie/src/runtime/github-labels/mod.ts
@@ -69,18 +69,19 @@ export interface GithubLabelsArgs {
 /**
  * Creates a GitHub labels JSON configuration.
  *
- * Returns a `GenieOutput` whose `.data` is the desired-state record consumed
- * by `mq-cli repo labels`. Compose freely with shared catalog exports (e.g.
- * `commonLabels`, `mqLabels`, `andonLabels` from `effect-utils/genie/external.ts`).
+ * Returns a `GenieOutput` whose `.data` is the desired-state record reconciled
+ * to live GitHub by the `gh:apply-labels` task. Compose freely with shared
+ * catalog exports (e.g. `commonLabels`, `andonLabels` from
+ * `effect-utils/genie/external.ts`).
  *
  * @example
  * ```ts
- * import { githubLabels, commonLabels, mqLabels } from '<effect-utils>/genie/external.ts'
+ * import { githubLabels, commonLabels, andonLabels } from '<effect-utils>/genie/external.ts'
  *
  * export default githubLabels({
  *   labels: [
  *     ...commonLabels,
- *     ...mqLabels,
+ *     ...andonLabels,
  *     { name: 'area:my-thing', description: 'My subsystem', color: '1d76db' },
  *   ],
  *   deprecated: ['bug', 'enhancement', 'documentation'],


### PR DESCRIPTION
Keystone change for adopting composed GitHub label IaC across the consumer repos that build on this shared catalog. Upstream-first: downstream repin/adoption PRs follow once this lands.

## Problem
- The `gh-labels.nix` reconcile module (`gh:apply-labels`/`gh:check-labels`) was internal to this repo — not exported from the flake like its sibling `github-ruleset`, so consumer repos could not compose it.
- The `mq:*` merge-queue labels are vestigial: the runtime that owned them was removed, and its successor uses a different label prefix and deprecates `mq:*`. Several consumers still provision `mq:*` that no runtime acts on.
- `type:epic` shared `1d76db` with every `area:*` chip (visually indistinguishable).
- The `system:*` `readdirSync` derivation was copy-pasted between two consumers.
- No shared `type:refactor` despite a consumer hand-maintaining a bare `refactor` label — evidence that folding refactor into `type:chore` was insufficient.

## Changes (`genie/labels.ts`)
- **+`type:refactor`**; tighten `type:chore` to deps/CI/tooling.
- **Recolor `type:epic`** brightBlue → brightPurple (`8250df`); give `type:task` its own shade so it doesn't collide with grey `type:chore`.
- **Promote to baseline:** `area:megarepo`, `type:task`, `state:declined`, `state:duplicate`.
- **Retire the `mq:*` axis** → export `mqDeprecated` (names only) so consumers delete the vestigial live labels via their `deprecated` list. `mqLabels` is kept as an **empty `@deprecated` export** so existing `...mqLabels` spreads / `mqLabels.map(...)` in consumers keep evaluating — **this PR is non-breaking and safe to merge standalone**; downstream migrates to `mqDeprecated` at its own pace.
- **`genie/system-labels.ts`** (new): shared `deriveSystemLabels()`, re-exported via `genie/external.ts`; kept in `genie/` (not the runtime package) since it is genie-eval-time glue — only the `LabelDef` type crosses.
- **flake:** export `gh-labels` in `devenvModules.tasks`.

## Validation
`labels.json` regenerated; `genie:check` and `check:quick` pass locally. This repo self-applies (adopts the helper, drops the `mqLabels` spread, composes `mqDeprecated`).

## Follow-ups (downstream stack, not this PR)
Repin + adopt in the consumer repos: wire `gh-labels`, drop the `mqLabels` spread + compose `mqDeprecated`, and (for the repo gaining label IaC for the first time) add its `labels.json.genie.ts` plus the matching issue-template label updates.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🌬️ cl1-gust |
| `agent_session_id` | 9edd38a7-802d-42b6-a585-8811e148a65f |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.206 |
| `agent_runtime` | Claude Code 2.1.206 |
| `agent_model` | claude-opus-4-8 |
| `runtime_profile` | /nix/store/1n76sy6i9y3ki3k4w04jksqvygw67sj0-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/jn6r0r7r59x3a525jch4pwzwykszqp60-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | livestore-contrib/schickling/2026-07-19-misc |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@4eac376 |
</details>
<!-- agent-footer:end -->