### PR TITLE
feat(otel-contract+genie): per-entry owner/source/constName metadata through registry composition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- **@overeng/otel-contract**: add additive, optional per-entry `owner` / `source` /
+  `constName` metadata to the `./registry` authoring surface (`AttrDef`, `SignalDef`,
+  `WeaverAttrMeta`, every `attr.*` / `span` / `metric` / `operation` builder, plus
+  `toAttrDef` and the `fragment` projection). `defineOtelContract` accepts contract-level
+  `defaultOwner` / `defaultSource` defaults applied to every projected entry that does not
+  override them. Fully backward compatible — the projected registry is byte-identical for
+  contracts that set none of the new fields.
+
 - **react-inspector / Effect 4**: align the development dependency and peer
   floor to Effect `4.0.0-beta.99`, anchor injected test helpers to the separate
   Effect 3 catalog, and fail generation if either cohort's exact identity drifts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,11 @@ All notable changes to this project will be documented in this file.
   `WeaverAttrMeta`, every `attr.*` / `span` / `metric` / `operation` builder, plus
   `toAttrDef` and the `fragment` projection). `defineOtelContract` accepts contract-level
   `defaultOwner` / `defaultSource` defaults applied to every projected entry that does not
-  override them. Fully backward compatible — the projected registry is byte-identical for
-  contracts that set none of the new fields.
+  override them. `@overeng/genie`'s Layer-1 `AttrDef` / `SignalDef` carry the same additive
+  optional fields so the metadata stays typed through `registryFromMembers` composition into
+  the registry downstream consumers read; the fields are non-normative to weaver (renderers
+  ignore them) so generated YAML/TS/Rust output is unchanged. Fully backward compatible — the
+  projected registry is byte-identical for contracts that set none of the new fields.
 
 - **react-inspector / Effect 4**: align the development dependency and peer
   floor to Effect `4.0.0-beta.99`, anchor injected test helpers to the separate

--- a/packages/@overeng/genie/src/runtime/composition/weaver-composition.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/composition/weaver-composition.unit.test.ts
@@ -88,6 +88,57 @@ describe('registryFromMembers (SC-R08/R09)', () => {
     expect(issues.some((i) => i.rule === 'weaver/dangling-ref')).toBe(true)
   })
 
+  it('carries per-entry owner/source/constName through composition into the registry (typed)', () => {
+    // Mirror-elimination flow-through: the additive per-entry metadata must survive from a member
+    // fragment into the COMPOSED registry that downstream consumers read — TYPED, not cast.
+    const owned: RegistryFragment = {
+      namespace: 'owned',
+      memberPath: 'packages/owned',
+      displayName: 'Owned',
+      attributes: [
+        {
+          id: 'owned.k',
+          type: 'string',
+          brief: 'k',
+          stability: 'development',
+          examples: ['x'],
+          owner: 'team-a',
+          source: 'owned/k.ts',
+          constName: 'OWNED_K',
+        },
+      ],
+      foreignRefs: [],
+      signals: [
+        {
+          kind: 'metric',
+          id: 'metric.owned.m',
+          metric_name: 'owned.m',
+          instrument: 'counter',
+          unit: '1',
+          brief: 'm',
+          stability: 'development',
+          owner: 'team-b',
+          constName: 'OWNED_M',
+          attributes: [{ ref: 'owned.k', requirement_level: 'required' }],
+        },
+      ],
+    }
+    const { registry } = registryFromMembers({
+      members: [member(owned)],
+      name: 'r',
+      description: 'd',
+      schemaUrl: 's',
+    })
+    const attribute = registry.groups[0]!.attributes[0]!
+    expect(attribute.owner).toBe('team-a')
+    expect(attribute.source).toBe('owned/k.ts')
+    expect(attribute.constName).toBe('OWNED_K')
+    const signal = registry.signals[0]!
+    expect(signal.owner).toBe('team-b')
+    expect(signal.constName).toBe('OWNED_M')
+    expect('source' in signal).toBe(false)
+  })
+
   it('defers upstream-namespaced refs to weaver (no dangling issue)', () => {
     const withUpstream: RegistryFragment = {
       ...acme,

--- a/packages/@overeng/genie/src/runtime/weaver/mod.ts
+++ b/packages/@overeng/genie/src/runtime/weaver/mod.ts
@@ -92,6 +92,16 @@ export type AttrDef = {
   /** machine-readable policy annotations (non-normative to upstream weaver). */
   readonly policy?: { readonly cardinality?: Cardinality; readonly encode?: Encode }
   readonly bridge?: Bridge
+  /**
+   * Per-entry catalog metadata carried through composition for downstream consumers (telemetry
+   * mirror elimination). All additive/optional and NON-NORMATIVE to weaver — the renderers pick
+   * emitted fields explicitly, so these never enter the generated YAML/TS/Rust. `owner`
+   * (accountable team/person), `source` (originating file/system), `constName` (override for the
+   * derived generated const name). Mirrored by `@overeng/otel-contract` `./registry` Layer 2.
+   */
+  readonly owner?: string
+  readonly source?: string
+  readonly constName?: string
 }
 
 /** A signal's REFERENCE to an attribute defined elsewhere, refining its requirement level. */
@@ -107,9 +117,20 @@ export type SpanKind = 'internal' | 'client' | 'server' | 'producer' | 'consumer
 /** OTel metric instrument for a `metric` signal (weaver `instrument`). */
 export type Instrument = 'counter' | 'updowncounter' | 'gauge' | 'histogram'
 
+/**
+ * Per-entry signal metadata carried through composition for downstream consumers (telemetry mirror
+ * elimination). All additive/optional and NON-NORMATIVE to weaver (renderers ignore them, so they
+ * never enter generated output). Mirrored by `@overeng/otel-contract` `./registry` Layer 2.
+ */
+type SignalMeta = {
+  readonly owner?: string
+  readonly source?: string
+  readonly constName?: string
+}
+
 /** A `span` or `metric` signal definition (a weaver group carrying attribute references). */
 export type SignalDef =
-  | {
+  | ({
       readonly kind: 'span'
       readonly id: string
       /**
@@ -123,8 +144,8 @@ export type SignalDef =
       readonly stability: Stability
       readonly deprecated?: Deprecated
       readonly attributes: ReadonlyArray<AttrRef>
-    }
-  | {
+    } & SignalMeta)
+  | ({
       readonly kind: 'metric'
       readonly id: string
       readonly metric_name: string
@@ -134,7 +155,7 @@ export type SignalDef =
       readonly stability: Stability
       readonly deprecated?: Deprecated
       readonly attributes: ReadonlyArray<AttrRef>
-    }
+    } & SignalMeta)
 
 /** A namespaced cluster of attribute definitions (weaver `attribute_group`). */
 export type AttributeGroup = {

--- a/packages/@overeng/otel-contract/src/registry.ts
+++ b/packages/@overeng/otel-contract/src/registry.ts
@@ -106,6 +106,15 @@ export type AttrDef = {
   readonly deprecated?: Deprecated
   readonly policy?: { readonly cardinality?: Cardinality; readonly encode?: Encode }
   readonly bridge?: Bridge
+  /**
+   * Per-entry catalog metadata carried for downstream consumers (mirror-elimination). All
+   * additive/optional: `owner` (team/person accountable), `source` (originating file/system),
+   * `constName` (override for the derived generated const name — genie otherwise derives
+   * `pascal(id)`; supply only to override that default).
+   */
+  readonly owner?: string
+  readonly source?: string
+  readonly constName?: string
 }
 
 /** A signal reference to a catalog attribute + its requirement level. */
@@ -121,9 +130,21 @@ export type SpanKind = 'internal' | 'client' | 'server' | 'producer' | 'consumer
 /** OpenTelemetry metric instrument kind. */
 export type Instrument = 'counter' | 'updowncounter' | 'gauge' | 'histogram'
 
+/**
+ * Per-entry signal metadata carried for downstream consumers (mirror-elimination). All
+ * additive/optional: `owner` (team/person accountable), `source` (originating file/system),
+ * `constName` (override for the derived generated const name — genie otherwise derives
+ * `SPAN_${namePascal(name)}` / `METRIC_${namePascal(name)}`; supply only to override).
+ */
+type SignalMeta = {
+  readonly owner?: string
+  readonly source?: string
+  readonly constName?: string
+}
+
 /** A span or metric signal group (references the catalog). */
 export type SignalDef =
-  | {
+  | ({
       readonly kind: 'span'
       readonly id: string
       /**
@@ -137,8 +158,8 @@ export type SignalDef =
       readonly stability: Stability
       readonly deprecated?: Deprecated
       readonly attributes: ReadonlyArray<AttrRef>
-    }
-  | {
+    } & SignalMeta)
+  | ({
       readonly kind: 'metric'
       readonly id: string
       readonly metric_name: string
@@ -148,7 +169,7 @@ export type SignalDef =
       readonly stability: Stability
       readonly deprecated?: Deprecated
       readonly attributes: ReadonlyArray<AttrRef>
-    }
+    } & SignalMeta)
 
 /** One member’s registry slice (mirrors genie Layer-1 `RegistryFragment`). */
 export type RegistryFragment = {
@@ -217,6 +238,10 @@ export type WeaverAttrMeta = {
   readonly note?: string
   readonly deprecated?: Deprecated
   readonly bridge?: Bridge
+  /** Per-entry catalog metadata (see {@link AttrDef}); additive/optional. */
+  readonly owner?: string
+  readonly source?: string
+  readonly constName?: string
 }
 
 /**
@@ -232,6 +257,9 @@ type WeaverAttrMetaInput = {
   readonly note?: string | undefined
   readonly deprecated?: Deprecated | undefined
   readonly bridge?: Bridge | undefined
+  readonly owner?: string | undefined
+  readonly source?: string | undefined
+  readonly constName?: string | undefined
 }
 
 /** deep annotation read (mirrors otel-contract's own walk through Refinement/Transformation/Union). */
@@ -271,17 +299,43 @@ const keyOf = (schema: Attribute): string => {
 // attr.* — attribute builders. Return REAL annotated Effect Schemas.
 // ---------------------------------------------------------------------------
 
+/**
+ * Per-entry metadata accepted by every `attr.*` / signal builder. All optional/additive:
+ * `owner`/`source`/`constName` (see {@link AttrDef}). Contract-level `owner`/`source` defaults
+ * (via `defineOtelContract`) fill entries that omit them.
+ */
+export type EntryMetaInput = {
+  readonly owner?: string
+  readonly source?: string
+  readonly constName?: string
+}
+
+/**
+ * Thread the optional per-entry metadata onto a weaver meta record. The return allows explicit
+ * `| undefined` (mirroring {@link WeaverAttrMetaInput}) so it composes under
+ * `exactOptionalPropertyTypes`; `toAttrDef` strips the undefineds when projecting.
+ */
+const entryMeta = (
+  o: EntryMetaInput,
+): {
+  readonly owner?: string | undefined
+  readonly source?: string | undefined
+  readonly constName?: string | undefined
+} => ({ owner: o.owner, source: o.source, constName: o.constName })
+
 /** Attribute builders. Each returns a REAL annotated Effect Schema (otel + weaver metadata). */
 export const attr = {
-  string: (o: {
-    key: string
-    cardinality: Cardinality
-    brief: string
-    stability: Stability
-    examples: ReadonlyArray<string>
-    note?: string
-    deprecated?: Deprecated
-  }) =>
+  string: (
+    o: {
+      key: string
+      cardinality: Cardinality
+      brief: string
+      stability: Stability
+      examples: ReadonlyArray<string>
+      note?: string
+      deprecated?: Deprecated
+    } & EntryMetaInput,
+  ) =>
     annotateWeaver({
       schema: OtelAttr.string({ key: o.key, metadata: { cardinality: o.cardinality } }),
       meta: {
@@ -291,18 +345,21 @@ export const attr = {
         examples: o.examples,
         note: o.note,
         deprecated: o.deprecated,
+        ...entryMeta(o),
       },
     }),
 
-  number: (o: {
-    key: string
-    weaverType?: 'int' | 'double'
-    cardinality?: Cardinality
-    brief: string
-    stability: Stability
-    examples?: ReadonlyArray<number>
-    note?: string
-  }) =>
+  number: (
+    o: {
+      key: string
+      weaverType?: 'int' | 'double'
+      cardinality?: Cardinality
+      brief: string
+      stability: Stability
+      examples?: ReadonlyArray<number>
+      note?: string
+    } & EntryMetaInput,
+  ) =>
     annotateWeaver({
       schema: OtelAttr.number({
         key: o.key,
@@ -314,24 +371,35 @@ export const attr = {
         weaverType: o.weaverType ?? 'double',
         examples: o.examples,
         note: o.note,
+        ...entryMeta(o),
       },
     }),
 
-  boolean: (o: { key: string; brief: string; stability: Stability; note?: string }) =>
+  boolean: (
+    o: { key: string; brief: string; stability: Stability; note?: string } & EntryMetaInput,
+  ) =>
     annotateWeaver({
       schema: OtelAttr.boolean({ key: o.key }),
-      meta: { brief: o.brief, stability: o.stability, weaverType: 'boolean', note: o.note },
+      meta: {
+        brief: o.brief,
+        stability: o.stability,
+        weaverType: 'boolean',
+        note: o.note,
+        ...entryMeta(o),
+      },
     }),
 
-  enum: <const V extends readonly [string, ...string[]]>(o: {
-    key: string
-    values: V
-    briefs: Record<V[number], string>
-    brief: string
-    stability: Stability
-    note?: string
-    deprecated?: Deprecated
-  }) =>
+  enum: <const V extends readonly [string, ...string[]]>(
+    o: {
+      key: string
+      values: V
+      briefs: Record<V[number], string>
+      brief: string
+      stability: Stability
+      note?: string
+      deprecated?: Deprecated
+    } & EntryMetaInput,
+  ) =>
     annotateWeaver({
       schema: OtelAttr.literal(o.key, ...o.values) as unknown as Schema.Schema<V[number]>,
       meta: {
@@ -348,6 +416,7 @@ export const attr = {
         },
         note: o.note,
         deprecated: o.deprecated,
+        ...entryMeta(o),
       },
     }),
 
@@ -356,15 +425,17 @@ export const attr = {
    * schema underneath is a plain string; the weaver type is carried explicitly because it cannot
    * be reconstructed from the AST.
    */
-  template: (o: {
-    key: string
-    templateType: 'string' | 'string[]' | 'int' | 'boolean'
-    cardinality: Cardinality
-    brief: string
-    stability: Stability
-    examples?: ReadonlyArray<string>
-    note?: string
-  }) =>
+  template: (
+    o: {
+      key: string
+      templateType: 'string' | 'string[]' | 'int' | 'boolean'
+      cardinality: Cardinality
+      brief: string
+      stability: Stability
+      examples?: ReadonlyArray<string>
+      note?: string
+    } & EntryMetaInput,
+  ) =>
     annotateWeaver({
       schema: OtelAttr.string({ key: o.key, metadata: { cardinality: o.cardinality } }),
       meta: {
@@ -373,6 +444,7 @@ export const attr = {
         weaverType: `template[${o.templateType}]` as WeaverType,
         examples: o.examples,
         note: o.note,
+        ...entryMeta(o),
       },
     }),
 } as const
@@ -477,6 +549,13 @@ const structOf = (fields: Record<string, Schema.Struct.Field>): Schema.Schema.An
 // span / metric / operation — compose refs, derive the runtime encoder + weaver signal.
 // ---------------------------------------------------------------------------
 
+/** Conditional-spread the per-entry metadata onto a `SignalDef` (keeps `undefined` keys off). */
+const signalMetaSpread = (o: EntryMetaInput): SignalMeta => ({
+  ...(o.owner !== undefined ? { owner: o.owner } : {}),
+  ...(o.source !== undefined ? { source: o.source } : {}),
+  ...(o.constName !== undefined ? { constName: o.constName } : {}),
+})
+
 /** A span contract: derived encoder + weaver signal projection. */
 export type SpanContract = {
   readonly kind: 'span'
@@ -492,14 +571,16 @@ export type SpanContract = {
  * `OtelAttrs.defineSync` (the same field plan `OtelSpan.define` would compile) and `span.label`
  * stays runtime-only, filtered from the registry projection.
  */
-export const span = (o: {
-  id: string
-  kind: SpanKind
-  brief: string
-  stability: Stability
-  deprecated?: Deprecated
-  attributes: Record<string, FieldSpec>
-}): SpanContract => {
+export const span = (
+  o: {
+    id: string
+    kind: SpanKind
+    brief: string
+    stability: Stability
+    deprecated?: Deprecated
+    attributes: Record<string, FieldSpec>
+  } & EntryMetaInput,
+): SpanContract => {
   const { fields, refList, refs } = buildFields(o.attributes)
   const encoder = OtelAttrs.defineSync(structOf(fields))
   return {
@@ -514,6 +595,7 @@ export const span = (o: {
       brief: o.brief,
       stability: o.stability,
       ...(o.deprecated !== undefined ? { deprecated: o.deprecated } : {}),
+      ...signalMetaSpread(o),
       attributes: refList,
     }),
   }
@@ -534,17 +616,19 @@ export type MetricContract = {
  * same-concept-same-key, namespaced). The metric label `restate.service` IS the catalog entry
  * `restate.service` — no short-key metric namespace.
  */
-export const metric = (o: {
-  id: string
-  name: string
-  instrument: Instrument
-  unit: string
-  brief: string
-  stability: Stability
-  deprecated?: Deprecated
-  boundaries?: ReadonlyArray<number>
-  labels: Record<string, FieldSpec>
-}): MetricContract => {
+export const metric = (
+  o: {
+    id: string
+    name: string
+    instrument: Instrument
+    unit: string
+    brief: string
+    stability: Stability
+    deprecated?: Deprecated
+    boundaries?: ReadonlyArray<number>
+    labels: Record<string, FieldSpec>
+  } & EntryMetaInput,
+): MetricContract => {
   const { fields, refList, refs } = buildFields(o.labels)
   const labelStruct = structOf(fields)
   // `OtelMetric` has no `updowncounter` constructor. Reject at author time rather than silently
@@ -589,6 +673,7 @@ export const metric = (o: {
       brief: o.brief,
       stability: o.stability,
       ...(o.deprecated !== undefined ? { deprecated: o.deprecated } : {}),
+      ...signalMetaSpread(o),
       attributes: refList,
     }),
   }
@@ -611,16 +696,18 @@ export type OperationContract = {
 export const operation = <
   F extends Record<string, FieldSpec>,
   L extends Record<string, Schema.Schema.AnyNoContext>,
->(o: {
-  id: string
-  name: string
-  brief: string
-  stability: Stability
-  span_kind?: SpanKind
-  attributes: F
-  labelFields?: L
-  label: (value: never) => string
-}): OperationContract => {
+>(
+  o: {
+    id: string
+    name: string
+    brief: string
+    stability: Stability
+    span_kind?: SpanKind
+    attributes: F
+    labelFields?: L
+    label: (value: never) => string
+  } & EntryMetaInput,
+): OperationContract => {
   const { fields, refList, refs } = buildFields(o.attributes)
   // runtime-only label-source fields — NOT catalog refs, absent from the registry.
   for (const [field, schema] of Object.entries(o.labelFields ?? {})) {
@@ -643,6 +730,7 @@ export const operation = <
       span_kind: o.span_kind ?? 'internal',
       brief: o.brief,
       stability: o.stability,
+      ...signalMetaSpread(o),
       attributes: refList,
     }),
   }
@@ -662,6 +750,13 @@ export type OtelContract = {
   readonly displayName: string
   readonly signals: ReadonlyArray<Signal>
   readonly docOnlyAttributes: ReadonlyArray<Attribute>
+  /**
+   * Contract-level metadata defaults (mirror-elimination). `owner` is naturally contract-uniform
+   * and `source` is often per-file; both are applied to every projected entry that does NOT carry
+   * its own value (per-entry always wins). Additive/optional.
+   */
+  readonly defaultOwner?: string
+  readonly defaultSource?: string
 }
 
 /** Project one annotated attribute Schema → Layer 1 `AttrDef` (reads AST annotations). */
@@ -687,6 +782,9 @@ export const toAttrDef = (schema: Attribute): AttrDef => {
     ...(weaver.note !== undefined ? { note: weaver.note } : {}),
     ...(weaver.deprecated !== undefined ? { deprecated: weaver.deprecated } : {}),
     ...(weaver.bridge !== undefined ? { bridge: weaver.bridge } : {}),
+    ...(weaver.owner !== undefined ? { owner: weaver.owner } : {}),
+    ...(weaver.source !== undefined ? { source: weaver.source } : {}),
+    ...(weaver.constName !== undefined ? { constName: weaver.constName } : {}),
     policy,
   }
 }
@@ -725,6 +823,9 @@ export const defineOtelContract = (o: {
   displayName: string
   signals: ReadonlyArray<Signal>
   docOnlyAttributes?: ReadonlyArray<Attribute>
+  /** Contract-level metadata defaults; see {@link OtelContract}. Applied in {@link fragment}. */
+  defaultOwner?: string
+  defaultSource?: string
 }): OtelContract => {
   const doc = o.docOnlyAttributes ?? []
   const ownKeys = new Set<string>()
@@ -739,12 +840,36 @@ export const defineOtelContract = (o: {
     displayName: o.displayName,
     signals: o.signals,
     docOnlyAttributes: doc,
+    ...(o.defaultOwner !== undefined ? { defaultOwner: o.defaultOwner } : {}),
+    ...(o.defaultSource !== undefined ? { defaultSource: o.defaultSource } : {}),
   }
 }
 
 // ---------------------------------------------------------------------------
 // The projector (design-time): OtelContract → RegistryFragment.
 // ---------------------------------------------------------------------------
+
+/**
+ * Fill contract-level `owner`/`source` defaults onto a projected entry that omits its own value
+ * (per-entry always wins). Preserves the conditional-spread idiom so no `undefined` key leaks in.
+ */
+const applyMetaDefaults = <T extends { readonly owner?: string; readonly source?: string }>({
+  entry,
+  defaultOwner,
+  defaultSource,
+}: {
+  entry: T
+  defaultOwner: string | undefined
+  defaultSource: string | undefined
+}): T => {
+  const owner = entry.owner ?? defaultOwner
+  const source = entry.source ?? defaultSource
+  return {
+    ...entry,
+    ...(owner !== undefined ? { owner } : {}),
+    ...(source !== undefined ? { source } : {}),
+  }
+}
 
 /** Project a contract to a Layer-1 registry fragment (reads annotations; derives catalog). */
 export const fragment = (contract: OtelContract): RegistryFragment => {
@@ -759,8 +884,10 @@ export const fragment = (contract: OtelContract): RegistryFragment => {
   }
   for (const a of contract.docOnlyAttributes) ownByKey.set(keyOf(a), a)
 
+  const defaults = { defaultOwner: contract.defaultOwner, defaultSource: contract.defaultSource }
   const ownCatalog = [...ownByKey.values()]
     .map(toAttrDef)
+    .map((entry) => applyMetaDefaults({ entry, ...defaults }))
     .toSorted((a, b) => a.id.localeCompare(b.id))
   return {
     namespace: contract.namespace,
@@ -768,6 +895,6 @@ export const fragment = (contract: OtelContract): RegistryFragment => {
     displayName: contract.displayName,
     attributes: ownCatalog,
     foreignRefs: [...foreignRefs].toSorted((a, b) => a.localeCompare(b)),
-    signals: contract.signals.map((s) => s.signal()),
+    signals: contract.signals.map((s) => applyMetaDefaults({ entry: s.signal(), ...defaults })),
   }
 }

--- a/packages/@overeng/otel-contract/src/registry.unit.test.ts
+++ b/packages/@overeng/otel-contract/src/registry.unit.test.ts
@@ -539,6 +539,154 @@ describe('metric derivation + label invariants (SC-R14)', () => {
   })
 })
 
+// ---------------------------------------------------------------------------
+// Per-entry owner/source/constName metadata (eu#1316 Track 2 — mirror elimination).
+// All additive/optional: they must round-trip authoring → fragment projection, honour
+// contract-level defaults with per-entry override, and leave existing entries byte-identical.
+// ---------------------------------------------------------------------------
+
+describe('per-entry owner/source/constName metadata (additive)', () => {
+  const ownedAttr = attr.string({
+    key: 'acme.owned',
+    cardinality: 'low',
+    brief: 'owned attr',
+    stability: 'development',
+    examples: ['x'],
+    owner: 'team-attr',
+    source: 'acme/owned.ts',
+    constName: 'OWNED',
+  })
+  const plainAttr = attr.string({
+    key: 'acme.plain',
+    cardinality: 'low',
+    brief: 'plain attr',
+    stability: 'development',
+    examples: ['x'],
+  })
+
+  it('round-trips owner/source/constName through toAttrDef', () => {
+    const def = toAttrDef(ownedAttr)
+    expect(def.owner).toBe('team-attr')
+    expect(def.source).toBe('acme/owned.ts')
+    expect(def.constName).toBe('OWNED')
+  })
+
+  it('omits the metadata keys entirely when absent (no undefined pollution / byte-identical)', () => {
+    const def = toAttrDef(plainAttr)
+    expect('owner' in def).toBe(false)
+    expect('source' in def).toBe(false)
+    expect('constName' in def).toBe(false)
+    // full-shape equality: an unadorned attr projects exactly as before this feature.
+    expect(def).toEqual({
+      id: 'acme.plain',
+      type: 'string',
+      brief: 'plain attr',
+      stability: 'development',
+      examples: ['x'],
+      policy: { cardinality: 'low' },
+    })
+  })
+
+  it('projects per-entry metadata onto span and metric SignalDefs', () => {
+    const contract = defineOtelContract({
+      memberPath: 'packages/acme',
+      displayName: 'Acme',
+      signals: [
+        span({
+          id: 'span.acme.owned',
+          kind: 'internal',
+          brief: 'owned span',
+          stability: 'development',
+          owner: 'team-span',
+          source: 'acme/span.ts',
+          constName: 'PROBE',
+          attributes: { owned: required(ownedAttr) },
+        }),
+        metric({
+          id: 'metric.acme.owned',
+          name: 'acme.owned',
+          instrument: 'counter',
+          unit: '1',
+          brief: 'owned metric',
+          stability: 'development',
+          owner: 'team-metric',
+          labels: { owned: required(ownedAttr) },
+        }),
+      ],
+    })
+    const byId = new Map(fragment(contract).signals.map((s) => [s.id, s]))
+    const spanSig = byId.get('span.acme.owned')!
+    expect(spanSig.owner).toBe('team-span')
+    expect(spanSig.source).toBe('acme/span.ts')
+    expect(spanSig.constName).toBe('PROBE')
+    const metricSig = byId.get('metric.acme.owned')!
+    expect(metricSig.owner).toBe('team-metric')
+    expect('source' in metricSig).toBe(false) // per-entry omitted → key absent
+    expect('constName' in metricSig).toBe(false)
+  })
+
+  it('applies contract-level defaultOwner/defaultSource, with per-entry override winning', () => {
+    const contract = defineOtelContract({
+      memberPath: 'packages/acme',
+      displayName: 'Acme',
+      defaultOwner: 'team-default',
+      defaultSource: 'acme/default.ts',
+      signals: [
+        span({
+          id: 'span.acme.override',
+          kind: 'internal',
+          brief: 'span overriding owner',
+          stability: 'development',
+          owner: 'team-override', // wins over defaultOwner; source falls back to default
+          attributes: { owned: required(ownedAttr), plain: required(plainAttr) },
+        }),
+      ],
+      docOnlyAttributes: [
+        attr.string({
+          key: 'acme.doc',
+          cardinality: 'low',
+          brief: 'doc-only attr',
+          stability: 'development',
+          examples: ['x'],
+        }),
+      ],
+    })
+    const frag = fragment(contract)
+    const attrById = new Map(frag.attributes.map((a) => [a.id, a]))
+
+    // per-entry attr metadata WINS over the contract default:
+    expect(attrById.get('acme.owned')!.owner).toBe('team-attr')
+    expect(attrById.get('acme.owned')!.source).toBe('acme/owned.ts')
+    // an attr with no own metadata inherits BOTH contract defaults:
+    expect(attrById.get('acme.plain')!.owner).toBe('team-default')
+    expect(attrById.get('acme.plain')!.source).toBe('acme/default.ts')
+    // constName is NEVER contract-defaulted (per-entry override only):
+    expect('constName' in attrById.get('acme.plain')!).toBe(false)
+    // doc-only attrs receive the defaults too:
+    expect(attrById.get('acme.doc')!.owner).toBe('team-default')
+    expect(attrById.get('acme.doc')!.source).toBe('acme/default.ts')
+
+    // signal: per-entry owner override wins; source falls back to the contract default.
+    const sig = frag.signals.find((s) => s.id === 'span.acme.override')!
+    expect(sig.owner).toBe('team-override')
+    expect(sig.source).toBe('acme/default.ts')
+  })
+
+  it('leaves the demo contract projection free of metadata keys (backward compatible)', () => {
+    const frag = fragment(demoContract)
+    for (const a of frag.attributes) {
+      expect('owner' in a).toBe(false)
+      expect('source' in a).toBe(false)
+      expect('constName' in a).toBe(false)
+    }
+    for (const s of frag.signals) {
+      expect('owner' in s).toBe(false)
+      expect('source' in s).toBe(false)
+      expect('constName' in s).toBe(false)
+    }
+  })
+})
+
 describe('operation label extractor: trim + non-finite rejection (SC-R14 mechanism parity)', () => {
   const op = operation({
     id: 'span.acme.op2',


### PR DESCRIPTION
## What

The **effect-utils half** of dotfiles epic `schickling/dotfiles#1316` Track 2 (telemetry **mirror elimination**). dotfiles maintains 18 `*.registry.ts` mirror files (~4,235 LOC) that hand-copy per-entry telemetry metadata Genie can't otherwise reach. This PR removes the *data* half of that blocker: `@overeng/otel-contract` now carries the per-entry metadata, and `@overeng/genie` carries it through composition into the registry downstream consumers read.

**Purely additive & backward compatible** — every new field is optional, no wire-name changes, generated output is byte-identical, no behavior change for existing consumers.

### 1. otel-contract — per-entry metadata (all optional)
Added `owner?` / `source?` / `constName?` to the `./registry` authoring surface:
- Types: `AttrDef`, `SignalDef` (span + metric), `WeaverAttrMeta`.
- Builders: every `attr.*`, plus `span` / `metric` / `operation`.
- Projection: `toAttrDef` reads them back from the schema annotation; `fragment` carries them onto the projected `RegistryFragment`.

`constName` is an **optional override** for the derived generated const name (genie already derives `pascal(id)` / `SPAN_…` / `METRIC_…`; dotfiles just drops the prefix), not required data.

`defineOtelContract` accepts contract-level `defaultOwner` / `defaultSource`, applied in `fragment` to every projected entry that does not override them (per-entry always wins). `owner` is naturally contract-uniform; `source` is often per-file. `constName` is per-entry only (never defaulted).

### 2. genie — carry the metadata through composition (typed)
Added the same additive/optional `owner` / `source` / `constName` to genie's Layer-1 `AttrDef` / `SignalDef`, so the metadata stays **typed** as it flows through `registryFromMembers` into the composed `Registry`. The fields are **non-normative to weaver**: the YAML/TS/Rust renderers pick emitted fields explicitly and never spread the whole def, so generated output is byte-identical (`genie:check` clean). This is *not* a staging/generation change — it is type-level flow-through required by the epic.

## M1 verdict — composition export is directly consumable (unblocked)

`registryFromMembers` (+ `RegistryFromMembersArgs` / `RegistryComposition` / `RegistryMember` / `UpstreamDependency` / `orphanSeamPaths`) are plain-TS exports in `packages/@overeng/genie/src/runtime/composition/mod.ts`, exposed via the package.json `"./composition"` subpath — **normal source / validation path, no compiled-binary genie-staging wall**. An external consumer can import `@overeng/genie/composition` directly; **no genie-staging PR is needed**. (dotfiles currently keeps a verbatim shim copy `registry-composition.ts` — that is pre-migration legacy to be replaced by the upstream import as part of the epic, not evidence of un-importability.)

## Why B (carry through genie), not otel-contract-only

Verified against the actual consumer: `dotfiles flakes/grafana-dashboards/src/telemetry/composed-registry.ts` reads the **composed** `Registry` (`dotfilesTelemetryRegistry.registry.signals` / `.groups[].attributes`), not per-member `fragment()` output — and `constName` today lives on the mirror entries (`telemetry-registry.ts` reads `entry.constName`). For mirror elimination, that metadata must become readable off the composed registry's `AttrDef` / `SignalDef` (genie's Layer-1 types) — so those must carry the fields typed. This is exactly brief item 1 ("flow into whatever registry projection genie consumes, so a downstream composed registry can read them").

## Tests / checks
- `registry.unit.test.ts` (otel-contract): `owner`/`source`/`constName` round-trip through `defineOtelContract` → builder → `fragment`; contract-level defaults with per-entry override; backward-compat assertion that unadorned entries project **byte-identically** (no `undefined` key pollution). 48 tests pass.
- `weaver-composition.unit.test.ts` (genie): compile-time **drift guard** still compiles (both mirrors carry the same optional fields); a new test asserts the metadata survives **typed** into `registry.groups[].attributes[]` and `registry.signals[]`. 7 tests pass.
- `tsgo --build` clean; `genie:check` clean (generated YAML/TS/Rust unchanged); `lint:check` clean.

Refs: `schickling/dotfiles#1316`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 💦 cl1-thaw |
| `agent_session_id` | d961cede-afd0-46b7-8b6a-127d2582841e |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.202 |
| `agent_runtime` | Claude Code 2.1.202 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/nc1jjzy8zzwg31q8dig26wl72jwwbgdv-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/f8j6sj5i9i1afq6lycd05sfvpgn8x9wl-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-19-weaver-otel-contract-meta |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->
