### PR TITLE
refactor(utils): move distributed-lock behind @overeng/utils/lock subpath (encapsulate; #109)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ All notable changes to this project will be documented in this file.
   `tscBin` task-module argument and the JS TypeScript runtime parser from
   `ts.nix` while preserving noEmit project coverage in `ts:check` (#943).
 
+- **@overeng/utils**: move distributed-lock exports behind the
+  `@overeng/utils/lock` subpath so the general isomorphic barrel no longer
+  forces lock dependencies on unrelated consumers.
+
 - **react-inspector / Effect 4**: align the development dependency and peer
   floor to Effect `4.0.0-beta.99`, anchor injected test helpers to the separate
   Effect 3 catalog, and fail generation if either cohort's exact identity drifts

--- a/packages/@overeng/ci-tools/nix/build.nix
+++ b/packages/@overeng/ci-tools/nix/build.nix
@@ -19,7 +19,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-wgUckvN2hVyO2sNdt3v9Rq0KPeHwkN9IX+lsk6TFg3M=";
+      "." = mkSharedHash "sha256-XU8FgrXb/AWuxVYQQJtAmJiDGrKL65Q8or21tH1i0Ck=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/effect-distributed-lock/NOTICE
+++ b/packages/@overeng/effect-distributed-lock/NOTICE
@@ -1,5 +1,5 @@
-@overeng/effect-distributed-lock vendors the used non-Redis subset of
-effect-distributed-lock 0.0.11:
+@overeng/effect-distributed-lock is a maintained permanent first-party fork of
+the used non-Redis subset of effect-distributed-lock 0.0.11:
 
   https://github.com/ethanniser/effect-distributed-lock
 
@@ -9,3 +9,6 @@ Original copyright: Copyright (c) 2025 Ethan Niser
 This package keeps Backing, DistributedSemaphore, Errors, and the public index
 surface as first-party source in effect-utils. RedisBacking and its optional
 Redis client peer dependency are intentionally not vendored.
+
+Upstream PR #14 is a courtesy contribution; this package does not depend on
+upstream accepting or releasing it.

--- a/packages/@overeng/genie/nix/build.nix
+++ b/packages/@overeng/genie/nix/build.nix
@@ -26,7 +26,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-8rvIAWJYdWdaORvX634qGaZPNmG31Zc7tvtlTS9O5XI=";
+      "." = mkSharedHash "sha256-jREp3tZZuPrzTqQYxpV9SMS+B9dxQzTECkbe3QwmeOc=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/genie/src/core/generation.ts
+++ b/packages/@overeng/genie/src/core/generation.ts
@@ -14,7 +14,7 @@ import {
 } from '@effect/platform'
 import { Duration, Effect, Either, Option, Schema } from 'effect'
 
-import { DistributedSemaphore } from '@overeng/utils'
+import { DistributedSemaphore } from '@overeng/utils/lock'
 import { FileSystemBacking } from '@overeng/utils/node'
 
 import type { GenieOutput } from '../runtime/mod.ts'

--- a/packages/@overeng/megarepo/nix/build.nix
+++ b/packages/@overeng/megarepo/nix/build.nix
@@ -24,7 +24,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-MiQGQDimBg4ME5mH7kq9s+zwAyzdEzWDtYQn8dbkukM=";
+      "." = mkSharedHash "sha256-QJnKSzAiUHLSz/RMS+Jh2sH2/5D5JQeg1k+Cv5y5hRw=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     smokeTestArgs = [ "--help" ];

--- a/packages/@overeng/megarepo/src/lib/store-lock.ts
+++ b/packages/@overeng/megarepo/src/lib/store-lock.ts
@@ -20,7 +20,7 @@ import { createHash } from 'node:crypto'
 import { Context, Duration, Effect, Layer, SynchronizedRef } from 'effect'
 
 import type { AbsoluteDirPath } from '@overeng/effect-path'
-import { DistributedSemaphore, DistributedSemaphoreBacking } from '@overeng/utils'
+import { DistributedSemaphore, DistributedSemaphoreBacking } from '@overeng/utils/lock'
 import { FileSystemBacking } from '@overeng/utils/node'
 
 /** Default TTL for store locks (auto-expires if process crashes) */

--- a/packages/@overeng/megarepo/src/lib/store-lock.unit.test.ts
+++ b/packages/@overeng/megarepo/src/lib/store-lock.unit.test.ts
@@ -2,7 +2,7 @@ import { it } from '@effect/vitest'
 import { Effect, Ref } from 'effect'
 import { describe, expect } from 'vitest'
 
-import { InMemoryBacking } from '@overeng/utils'
+import { InMemoryBacking } from '@overeng/utils/lock'
 
 import { makeStoreLockLayerFromBacking, StoreLock } from './store-lock.ts'
 

--- a/packages/@overeng/notion-cli/nix/build.nix
+++ b/packages/@overeng/notion-cli/nix/build.nix
@@ -33,7 +33,7 @@ let
     installRuntimeWorkspace = true;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-qijNTviHT0LpS2NBEGsgo0QoWfPVNcPJcr34CfeVM0g=";
+      "." = mkSharedHash "sha256-idOBZZOKwFp5JdaNJjcJR9Loqbp4JRx4ATWKU//7z64=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/notion-md/nix/build.nix
+++ b/packages/@overeng/notion-md/nix/build.nix
@@ -20,7 +20,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-K1d0ehf+UsBAhz3s+ABS+rXDxNc+gPCGRKJnYJZRQIc=";
+      "." = mkSharedHash "sha256-CvBDmbF4IX4D2YYOLU4fgukKOVvJkhgknsU/x66FDz4=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/tui-stories/nix/build.nix
+++ b/packages/@overeng/tui-stories/nix/build.nix
@@ -21,7 +21,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-+nYeFYAEEOSdTxIlvuq9ihKaFRh3wYeS6LN2OAAKCz8=";
+      "." = mkSharedHash "sha256-ERIKTGAvrxUO705rfDy6k91Vgg1ao9/nnMucFPGtOcI=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/utils/README.md
+++ b/packages/@overeng/utils/README.md
@@ -15,11 +15,11 @@ bun add @overeng/utils
 - Workspace-aware command helpers (`cmd`, `cmdText`) with optional logging and retention
 - Effect-native access to current working directory via `CurrentWorkingDirectory`
 - Workspace root service backed by `WORKSPACE_ROOT` via `EffectUtilsWorkspace`
-- File system-backed distributed locks with TTL expiration and atomic operations
+- File system-backed distributed locks with TTL expiration and atomic operations via `@overeng/utils/lock`
 
 ### Distributed Lock / Semaphore
 
-This package re-exports the first-party `@overeng/effect-distributed-lock` core package and adds Node.js file-system backing implementations.
+The `@overeng/utils/lock` subpath re-exports the first-party `@overeng/effect-distributed-lock` core package. `@overeng/utils/node` adds Node.js file-system backing implementations.
 
 #### File System Backing
 
@@ -27,7 +27,7 @@ For single-machine scenarios where you need to coordinate locks across multiple 
 
 ```typescript
 import { FileSystemBacking } from '@overeng/utils/node'
-import { DistributedSemaphore } from '@overeng/utils'
+import { DistributedSemaphore } from '@overeng/utils/lock'
 import { Effect, Duration } from 'effect'
 import { NodeContext } from '@effect/platform-node'
 
@@ -101,7 +101,7 @@ After a force revoke, the victim holder's next TTL refresh will fail, triggering
 
 ## Exports
 
-### Isomorphic (`@overeng/utils`)
+### Lock (`@overeng/utils/lock`)
 
 Re-exports from `@overeng/effect-distributed-lock`:
 

--- a/packages/@overeng/utils/package.json
+++ b/packages/@overeng/utils/package.json
@@ -11,6 +11,7 @@
       "node": "./src/cuid/cuid.node.ts",
       "default": "./src/cuid/mod.ts"
     },
+    "./lock": "./src/lock/mod.ts",
     "./node": "./src/node/mod.ts",
     "./node/cli-help-rewrite": "./src/node/cli-help-rewrite.ts",
     "./node/cli-version": "./src/node/cli-version.ts",
@@ -34,6 +35,7 @@
       "./node/playwright/config": "./dist/node/playwright/config/mod.js",
       "./node/storybook": "./dist/node/storybook/mod.js",
       "./node/storybook/config": "./dist/node/storybook/config/mod.js",
+      "./lock": "./dist/lock/mod.js",
       "./browser": "./dist/browser/mod.js",
       "./cuid": {
         "browser": "./dist/cuid/cuid.browser.js",

--- a/packages/@overeng/utils/package.json.genie.ts
+++ b/packages/@overeng/utils/package.json.genie.ts
@@ -75,6 +75,7 @@ export default packageJson(
       './node/storybook/config': exportEntry('./src/node/storybook/config/mod.ts', {
         environment: 'node',
       }),
+      './lock': exportEntry('./src/lock/mod.ts', { environment: 'node' }),
       './browser': exportEntry('./src/browser/mod.ts', { environment: 'browser' }),
       './cuid': exportEntry(
         {
@@ -101,6 +102,7 @@ export default packageJson(
         './node/playwright/config': './dist/node/playwright/config/mod.js',
         './node/storybook': './dist/node/storybook/mod.js',
         './node/storybook/config': './dist/node/storybook/config/mod.js',
+        './lock': './dist/lock/mod.js',
         './browser': './dist/browser/mod.js',
         './cuid': {
           browser: './dist/cuid/cuid.browser.js',

--- a/packages/@overeng/utils/src/isomorphic/mod.ts
+++ b/packages/@overeng/utils/src/isomorphic/mod.ts
@@ -1,14 +1,3 @@
-export {
-  Backing,
-  DistributedSemaphore,
-  DistributedSemaphoreBacking,
-  LockLostError,
-  SemaphoreBackingError,
-} from '@overeng/effect-distributed-lock'
-
-/** In-memory backing for distributed semaphore (useful for tests) */
-export * as InMemoryBacking from './in-memory-backing.ts'
-
 /** Schema annotations for tracking data lineage (authority, freshness, references) */
 export * as Lineage from './lineage/mod.ts'
 

--- a/packages/@overeng/utils/src/lock/mod.ts
+++ b/packages/@overeng/utils/src/lock/mod.ts
@@ -1,0 +1,10 @@
+export {
+  Backing,
+  DistributedSemaphore,
+  DistributedSemaphoreBacking,
+  LockLostError,
+  SemaphoreBackingError,
+} from '@overeng/effect-distributed-lock'
+
+/** In-memory backing for distributed semaphore (useful for tests) */
+export * as InMemoryBacking from '../isomorphic/in-memory-backing.ts'

--- a/packages/@overeng/utils/src/node/file-system-backing.unit.test.ts
+++ b/packages/@overeng/utils/src/node/file-system-backing.unit.test.ts
@@ -8,8 +8,8 @@ import { Context, Deferred, Duration, Effect, Layer, Schema, Stream } from 'effe
 import { expect } from 'vitest'
 
 import { DistributedSemaphoreBacking } from '@overeng/effect-distributed-lock'
-import { DistributedSemaphore } from '@overeng/utils/lock'
 import { Vitest } from '@overeng/utils-dev/node-vitest'
+import { DistributedSemaphore } from '@overeng/utils/lock'
 import { FileSystemBacking as ReexportedFileSystemBacking } from '@overeng/utils/node'
 
 import * as FileSystemBacking from './file-system-backing.ts'

--- a/packages/@overeng/utils/src/node/file-system-backing.unit.test.ts
+++ b/packages/@overeng/utils/src/node/file-system-backing.unit.test.ts
@@ -8,7 +8,7 @@ import { Context, Deferred, Duration, Effect, Layer, Schema, Stream } from 'effe
 import { expect } from 'vitest'
 
 import { DistributedSemaphoreBacking } from '@overeng/effect-distributed-lock'
-import { DistributedSemaphore } from '@overeng/utils'
+import { DistributedSemaphore } from '@overeng/utils/lock'
 import { Vitest } from '@overeng/utils-dev/node-vitest'
 import { FileSystemBacking as ReexportedFileSystemBacking } from '@overeng/utils/node'
 


### PR DESCRIPTION
## Problem

`@overeng/utils` re-exported the distributed-lock API from its general isomorphic barrel, so consumers of the main `@overeng/utils` surface had to resolve `@overeng/effect-distributed-lock` even when they did not use locks.

## Goal

Move the distributed-lock API behind the dedicated `@overeng/utils/lock` subpath and keep the main barrel focused on general isomorphic utilities.

## Decisions

- Added `@overeng/utils/lock`, re-exporting `Backing`, `DistributedSemaphore`, `DistributedSemaphoreBacking`, `LockLostError`, `SemaphoreBackingError`, and the existing `InMemoryBacking` helper.
- Removed those lock exports from `@overeng/utils`.
- Kept `FileSystemBacking` in `@overeng/utils/node`; it is node-only and this avoids extra churn.
- Repointed in-repo lock consumers to `@overeng/utils/lock`.
- Documented `@overeng/effect-distributed-lock` as a maintained permanent first-party fork of dormant upstream `github.com/ethanniser/effect-distributed-lock`; upstream PR #14 remains courtesy-only.

## Verification

Local direct checks:

- `git diff --check HEAD~1..HEAD`
- `CI=1 packages/@overeng/utils/node_modules/.bin/tsc --build tsconfig.check.json --pretty false`
- `oxfmt --check` on changed source/config/docs files
- `oxlint --deny-warnings packages/@overeng/utils/package.json.genie.ts packages/@overeng/genie/src/core/generation.ts packages/@overeng/megarepo/src/lib/store-lock.ts packages/@overeng/megarepo/src/lib/store-lock.unit.test.ts packages/@overeng/utils/src/isomorphic/mod.ts packages/@overeng/utils/src/lock/mod.ts packages/@overeng/utils/src/node/file-system-backing.unit.test.ts`
- `CI=1 packages/@overeng/utils/node_modules/.bin/vitest run packages/@overeng/effect-distributed-lock/src/distributed-semaphore.test.ts packages/@overeng/utils/src/node/file-system-backing.unit.test.ts packages/@overeng/megarepo/src/lib/store-lock.unit.test.ts --testTimeout 30000 --hookTimeout 30000` (3 files, 32 tests)

CI run #4395 (`29694394367`) is green. Relevant gate jobs:

- `lint`: success
- `typecheck`: success
- `test (namespace-profile-linux-x86-64)`: success
- `test (namespace-profile-macos-arm64)`: success
- `test-megarepo-cold-gc`: success
- `nix-fod-check (namespace-profile-linux-x86-64)`: success
- `nix-fod-check (namespace-profile-macos-arm64)`: success

CI-reported FOD hashes applied:

- `ci-tools-unwrapped`: `sha256-XU8FgrXb/AWuxVYQQJtAmJiDGrKL65Q8or21tH1i0Ck=`
- `genie-unwrapped`: `sha256-jREp3tZZuPrzTqQYxpV9SMS+B9dxQzTECkbe3QwmeOc=`
- `megarepo`: `sha256-QJnKSzAiUHLSz/RMS+Jh2sH2/5D5JQeg1k+Cv5y5hRw=`
- `notion-cli-unwrapped`: `sha256-idOBZZOKwFp5JdaNJjcJR9Loqbp4JRx4ATWKU//7z64=`
- `notion-md-unwrapped`: `sha256-CvBDmbF4IX4D2YYOLU4fgukKOVvJkhgknsU/x66FDz4=`
- `tui-stories-unwrapped`: `sha256-ERIKTGAvrxUO705rfDy6k91Vgg1ao9/nnMucFPGtOcI=`

## Follow-ups

Downstream cleanup follows in the fleet repin cycle: drop vestigial external distributed-lock dependencies and repoint downstream consumers such as pimuseum.

Refs schickling/megarepo-all#109.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🐆 co1-puma |
| `agent_session_id` | 27bf35fa-7d26-4af6-8c91-7383cae82d69 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.142.5 |
| `agent_runtime` | Codex CLI 0.142.5 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/bppg27v2kwbrhl324p7k3g47v57spay8-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/darrgln714qdm9338kfwq2cl5wah86s6-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-19-eu931-encap |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@0e2a1cb |
</details>
<!-- agent-footer:end -->