### PR TITLE
feat(workspace-tools): native-binding closure-completeness check + per-root optionals opt-in (#807/#920)

### DIFF
--- a/context/dependency-materialization/.decisions/0007-auto-derive-native-family-set.md
+++ b/context/dependency-materialization/.decisions/0007-auto-derive-native-family-set.md
@@ -1,0 +1,46 @@
+# 0007 Auto-Derive The Required Native Family Set
+
+Status: accepted
+
+## Context
+
+A prepared artifact that opts into optional native bindings
+(`DMP.NIX-R11`) must assert that every declared native family is present for
+every declared platform triple (`DMP.NIX.NATIVE-R08`). The required-family set
+could be a hand-maintained per-consumer list or derived from the resolved
+closure.
+
+## Decision
+
+Derive the required-family set from the root's resolved (dev + prod) lockfile
+closure. Do not maintain a hand-written `requiredNativeFamilies` list.
+
+The detector enumerates `pure-package-artifact` families in the closure (reusing
+the native dependency policy, `0003`), expands each family's declared
+`supportedArchitectures` into concrete `(os, cpu, libc)` triples, and treats the
+product as the required set. Consumer input is limited to the opt-in plus
+reason-carrying waivers (`DMP.NIX.NATIVE-R11`).
+
+## Rationale
+
+- A hand list drifts silently. A closure commonly carries more than one native
+  family (a bundler binding _and_ a CSS-transformer binding, for example); a
+  list that names one and forgets the other passes review and fails the next
+  build that loads the forgotten family.
+- Over-approximation is in the safe direction. Presence-in-closure does not
+  equal build-loaded, but pnpm optional install is per-root all-or-nothing, so
+  materializing an unused-but-present family binding is free, while missing a
+  loaded one is the failure this prevents.
+- One registry, not two. The policy classification already distinguishes
+  `pure-package-artifact` from `nix-grafted`; deriving from it avoids a second
+  source of truth that could disagree.
+
+## Consequences
+
+- Adding a native dependency automatically extends the required set on the next
+  evaluation; no consumer edit is needed to keep the guarantee correct.
+- A family with no prebuilt for a declared triple must be waived explicitly
+  rather than omitted from the list.
+- An optional expected-set tripwire (off by default) can pin the derived set so a
+  dependency bump that adds a native family fails until reviewed; auto-derive
+  stays authoritative.

--- a/context/dependency-materialization/.decisions/0008-optional-bindings-ride-shared-fod.md
+++ b/context/dependency-materialization/.decisions/0008-optional-bindings-ride-shared-fod.md
@@ -1,0 +1,46 @@
+# 0008 Optional Bindings Ride The Shared FOD Via Per-Root Opt-In
+
+Status: accepted
+
+## Context
+
+Some install roots must carry platform native bindings (a bundler, a CSS
+transformer) so a downstream cross-platform build can load them. Three shapes
+were available: include optional bindings globally for every consumer, add a
+separate binding-only FOD beside the prepared-deps FOD, or make binding
+inclusion a per-install-root opt-in on the existing prepared-deps artifact.
+
+## Decision
+
+Make optional binding inclusion a per-install-root opt-in (`DMP.NIX-R11`) that
+materializes the bindings into the _existing_ prepared-deps FOD, gated by
+all-declared-triples completeness (`0009`). Default off.
+
+- Not global-on: it would bloat every consumer's artifact with bindings it never
+  loads and move every hash.
+- Not a separate binding-only FOD: a rolldown/oxc/lightningcss version bump is a
+  lockfile-driven change that _should_ move the prepared-deps hash; a parallel
+  artifact adds a second boundary and hash class for no benefit.
+
+## Rationale
+
+- The shared prepared-deps FOD stays the single dependency boundary
+  (`DMP.NIX-R05`). Bindings resolve from a family's own isolated `.pnpm` subtree,
+  so they belong to that root's dependency data, not to a top-level graft.
+- Host-invariance holds because inclusion is all-declared-triples: pnpm
+  materializes the same union of platform bindings on any building host, so the
+  shared hash stays sound (`DMP.NIX.FOD-R03`; see `0009`).
+- The hash change is absorbed by the existing FOD hash-repair-target contract
+  (`0005`), which already exposes the direct prepared-deps derivation as
+  evaluated metadata and resolves through a nested-flake consumer boundary. No
+  new repair surface is required.
+
+## Consequences
+
+- Turning on inclusion for a root is a one-field change plus a hash refresh on
+  that root; it must land atomically with the refreshed hash, because the hash
+  change is not forward-compatible.
+- The opt-in field is forward-compatible on un-repinned consumers: the entry
+  validator ignores it until the consumer opts in.
+- `nix-grafted` families keep using the top-level `nativeNodePackages` graft;
+  this opt-in governs only `pure-package-artifact` families.

--- a/context/dependency-materialization/.decisions/0009-completeness-enforced-for-optin-roots.md
+++ b/context/dependency-materialization/.decisions/0009-completeness-enforced-for-optin-roots.md
@@ -1,0 +1,46 @@
+# 0009 Completeness Is Enforced For Opt-In Roots
+
+Status: accepted
+
+## Context
+
+The closure-completeness assertion (`DMP.NIX.NATIVE-R08`) must roll out across
+many `mkPnpmCli` consumers without breaking roots that carry no bindings, while
+staying consistent with the strict-scan principle that a prepared-deps purity
+boundary uses one convergent transition rather than a lenient report-only phase
+(`0004`).
+
+## Decision
+
+Bind completeness enforcement to the root's optional-binding opt-in
+(`DMP.NIX-R11`), not to a global report-only-then-strict phase:
+
+- A root that opts into optional bindings is enforced **hard** from its first
+  build — a missing declared binding fails the prepared-deps scan.
+- A root that does not opt in is **not subject** to completeness (its families
+  are not required); the assertion is advisory context only.
+
+There is never a lenient completeness policy running beside a strict one for the
+same boundary, which is what `0004` forbids.
+
+## Rationale
+
+- For an opt-in root, the families _are_ required data, so report-only would be
+  the exact ambiguity `0004` rejects. Hard-from-day-one is the `0004`-consistent
+  choice.
+- For a non-opt-in root, the families are genuinely not part of the artifact, so
+  there is nothing to enforce — this is scope, not leniency.
+- This keeps the upstream landing behaviorally inert for every existing
+  consumer: nothing opts in on the merge, so nothing changes until a consumer
+  deliberately turns on inclusion.
+
+## Consequences
+
+- The guarantee becomes real for a root exactly when that root opts in and
+  refreshes its hash — a single atomic change, not a two-phase migration.
+- A future decision to make binding inclusion the default for a class of roots is
+  a deliberate scope expansion. It must be sequenced as a versioned prepared-deps
+  transition (in the spirit of `0004`: convergent, hash-refreshing, no
+  report-only tail), not introduced as a lenient default.
+- Advisory completeness output on non-opt-in roots is a diagnostic aid only and
+  must not gate their builds.

--- a/context/dependency-materialization/03-nix-prepared-deps/01-fod-hash-evidence/spec.md
+++ b/context/dependency-materialization/03-nix-prepared-deps/01-fod-hash-evidence/spec.md
@@ -116,3 +116,25 @@ which covered systems diverged.
 Hash reconciliation rebuilds the direct prepared dependency artifact for each
 covered system, records the measured output, and only then selects shared or
 split hash mode. Missing systems are evidence, not absence.
+
+## Completeness As Shared-Hash Soundness
+
+Traces: DMP.NIX.FOD-R03, DMP.NIX-R03.
+
+A shared FOD hash across covered systems is sound only if the prepared tree is
+host-invariant. For a root that carries optional native bindings, host-invariance
+holds **iff** the binding closure is complete across all declared triples: under
+`all-declared-triples` completeness, pnpm materializes the same union of platform
+bindings regardless of the building host, so the recursive output hash is
+identical cross-host.
+
+This makes the completeness assertion (`02-native-node-packages`,
+`DMP.NIX.NATIVE-R08`) the eval-time soundness guard for `DMP.NIX.FOD-R03`: it
+fails exactly on the host-variant tree that would make a shared hash unsound. The
+per-system split hash (`DMP.NIX.FOD-R04`) remains the sanctioned fallback for a
+future family that cannot achieve all-triple coverage (`build-platform` mode).
+
+Cross-system equality itself stays measured evidence, not an in-FOD assertion:
+realize the artifact on each covered system and confirm equal output hash
+(`DMP.NIX.FOD-R03`), rather than attempting cross-system comparison inside one
+FOD build.

--- a/context/dependency-materialization/03-nix-prepared-deps/02-native-node-packages/.experiments/2026-07-19-aarch64-optional-binding-closure.md
+++ b/context/dependency-materialization/03-nix-prepared-deps/02-native-node-packages/.experiments/2026-07-19-aarch64-optional-binding-closure.md
@@ -1,0 +1,52 @@
+# Experiment — aarch64 optional-binding closure end-to-end
+
+Date: 2026-07-19 · Systems: aarch64-linux (build), x86_64-linux (cross-check)
+
+## Hypothesis
+
+For an install root that opts into optional native bindings under
+`all-declared-triples` completeness, the prepared FOD (a) contains every declared
+`(os, cpu, libc)` binding, (b) loads them at downstream build time, and (c)
+stays host-invariant so a single shared hash remains sound.
+
+## Method
+
+- Real chain: a downstream aarch64-linux graph whose build loads native bundler
+  and CSS-transformer bindings (rolldown ≈ 1.0.3, lightningcss ≈ 1.32.0) via
+  vite ≈ 8.0.16, pnpm 11.
+- Baseline: the default `--no-optional` prepared FOD.
+- Treatment: the opt-in FOD with `supportedArchitectures` covering
+  os[linux,darwin] × cpu[x64,arm64] × libc[glibc,musl].
+- Realize the FOD on aarch64-linux; count `.node` files and binding dirs;
+  `dlopen` the arm64-gnu bindings; run the downstream `vite build`; compare the
+  realized output hash against x86_64-linux.
+
+## Results
+
+| Observation                               | `--no-optional`               | opt-in + completeness   |
+| ----------------------------------------- | ----------------------------- | ----------------------- |
+| `@rolldown/binding-*` dirs                | 0                             | present, all triples    |
+| `.node` files in the prepared tree        | 0                             | 58                      |
+| arm64-gnu bindings `dlopen`               | n/a                           | OK                      |
+| downstream `vite build`                   | fails at runtime binding load | succeeds (2625 modules) |
+| output hash aarch64-linux vs x86_64-linux | —                             | equal (host-invariant)  |
+
+- Bindings resolved from each family's own isolated `.pnpm/<pkg>/node_modules/…`
+  subtree; top-level `node_modules/<scope>` stayed empty — confirming the opt-in
+  FOD, not a top-level graft, is the channel for `pure-package-artifact`
+  families.
+
+## Conclusion
+
+Confirms `DMP.NIX.NATIVE-R08` (completeness), `DMP.NIX-R11` (opt-in resolves the
+runtime load), and the host-invariance premise behind `0008`/`0009` and
+`DMP.NIX.FOD-R03` on the linux pair.
+
+## Residual
+
+- aarch64-darwin host-invariance is theory-only (verified on aarch64-linux and
+  x86_64-linux); it remains a watch item until measured, and is representable via
+  the `pending` FOD hash-evidence state (`DMP.NIX.FOD-R02`).
+- The treatment ran a normalized prepared FOD; normalization (tar/relink,
+  `.modules.yaml` strip) does not remove `.pnpm` package dirs, so presence
+  detection holds.

--- a/context/dependency-materialization/03-nix-prepared-deps/02-native-node-packages/.experiments/2026-07-19-completeness-scan-red-green.md
+++ b/context/dependency-materialization/03-nix-prepared-deps/02-native-node-packages/.experiments/2026-07-19-completeness-scan-red-green.md
@@ -1,0 +1,50 @@
+# Experiment — completeness scan RED/GREEN and lockfile-parser fix
+
+Date: 2026-07-19 · System: x86_64-linux (portable)
+
+## Hypothesis
+
+The completeness assertion is non-vacuous: it goes RED on a bindingless prepared
+tree naming the missing families/triples, and GREEN on a complete tree — and its
+detector actually reaches the native families in a real workspace lockfile.
+
+## Method
+
+- Detector + assertion over the resolved lockfile closure of a real vite ≈ 8.0.16
+  workspace; harness cases: complete / bindingless / partial (one triple missing)
+  / consumer-absent.
+- Discrimination probe: drop exactly one binding
+  (`@rolldown/binding-linux-arm64-gnu`) and confirm the failure names it.
+
+## Results
+
+- **Parser defect found and fixed.** The workspace `pnpm-lock.yaml` is a
+  multi-document file (pnpm prepends a `---`-separated bootstrap document of
+  ~20 snapshots). The initial scanner stopped at the first document boundary and
+  never reached the real consumers, yielding a vacuous GREEN. Fix: keep scanning
+  across documents.
+  - Pre-fix: 20 consumers seen → vacuous pass.
+  - Post-fix: 974 consumers seen → RED on the bindingless tree, reporting 40
+    missing bindings across 6 families (bundler binding, CSS transformer, and
+    `@tailwindcss/oxide`, `@esbuild`, `@oxc-parser`, `@oxc-resolver`).
+- **RED/GREEN.** `--no-optional` tree → exit 1, naming the missing families and
+  all declared triples. Opt-in tree → exit 0, printing the derived family set.
+- **Discrimination.** Single-binding-drop probe → RED naming exactly
+  `@rolldown/binding-linux-arm64-gnu`.
+- **Regression fixtures.** New multi-document fixtures reproduce the vacuous-pass
+  on the old parser, so the shipped bug stays caught.
+
+## Conclusion
+
+The assertion is non-vacuous and discriminating (`DMP.NIX.NATIVE-R08`,
+`DMP.NIX.NATIVE-R10`), and auto-derive reaches every family in a real closure
+(`DMP.NIX.NATIVE-R09`, `0007`). Detecting a real multi-family gap that a
+hand-written list would have under-counted is direct evidence for auto-derive.
+
+## Residual
+
+- GREEN used a reconstructed complete tree (the measured 58-`.node` FOD was
+  GC'd); the RED on the real bindingless FOD is the authoritative half. The
+  aarch64 end-to-end experiment supplies the real complete-tree evidence.
+- A productionized in-repo check must bundle its policy import so it resolves
+  standalone in the check derivation; a bare script would not resolve siblings.

--- a/context/dependency-materialization/03-nix-prepared-deps/02-native-node-packages/requirements.md
+++ b/context/dependency-materialization/03-nix-prepared-deps/02-native-node-packages/requirements.md
@@ -29,8 +29,12 @@ of lifecycle scripts.
   in dependency data only when classified as pure package data for that
   Materialization Profile.
   Refines: DMP-R04, DMP-R08.
-- **DMP.NIX.NATIVE-R04 No optional smuggling:** Optional dependencies must not
-  smuggle platform-native outputs into platform-neutral prepared artifacts.
+- **DMP.NIX.NATIVE-R04 No partial optional smuggling:** Optional dependencies
+  must not smuggle a _host-selected subset_ of platform-native outputs into a
+  platform-neutral prepared artifact. A prepared artifact may carry an optional
+  native family only when the root opts in (`DMP.NIX-R11`) and the family is
+  complete across all declared triples (`DMP.NIX.NATIVE-R08`), which keeps the
+  artifact platform-neutral and host-invariant.
   Refines: DMP-R05, DMP-R08.
 
 ### Must be auditable
@@ -44,3 +48,29 @@ of lifecycle scripts.
 - **DMP.NIX.NATIVE-R07 Runtime wiring:** Downstream wrappers must make native
   runtime dependencies explicit.
   Refines: DMP-R04.
+
+### Must guarantee declared closure completeness
+
+- **DMP.NIX.NATIVE-R08 Declared-triple completeness:** For an install root that
+  opts into optional native bindings (`DMP.NIX-R11`), every `pure-package-artifact`
+  family present in the resolved (dev + prod) closure must have its binding
+  package directory present for every declared `(os, cpu, libc)` triple in the
+  prepared artifact. Completeness and rejection (`DMP.NIX.NATIVE-R05`) are one
+  scan over one classification: the native dirs the opt-in surfaces must be
+  _classified_ — an unclassified family fails per `DMP.NIX.NATIVE-R06`, a
+  classified `pure-package-artifact` family must be _complete_ per this
+  requirement.
+  Refines: DMP.NIX.NATIVE-R03, DMP.NIX.NATIVE-R04, DMP.NIX.NATIVE-R06, DMP-R08.
+- **DMP.NIX.NATIVE-R09 Auto-derived family set:** The required-family set must be
+  derived from the resolved closure, not from a hand-maintained per-consumer
+  list. Consumer input is limited to the opt-in plus reason-carrying waivers.
+  Refines: DMP-R08, DMP-R16.
+- **DMP.NIX.NATIVE-R10 Loud omission:** A missing declared binding must fail the
+  prepared-deps scan and name the family plus the missing triple(s). The
+  omission must not be deferred to downstream runtime binding resolution.
+  Refines: DMP.NIX-R09, DMP.NIX.NATIVE-R05.
+- **DMP.NIX.NATIVE-R11 Reason-carrying waiver:** A family/triple with no
+  published prebuilt, or provably not build-loaded, may be waived only through
+  an explicit reason-carrying waiver. A waiver must not silently expand to
+  families it does not name.
+  Refines: DMP-R08.

--- a/context/dependency-materialization/03-nix-prepared-deps/02-native-node-packages/requirements.md
+++ b/context/dependency-materialization/03-nix-prepared-deps/02-native-node-packages/requirements.md
@@ -31,10 +31,14 @@ of lifecycle scripts.
   Refines: DMP-R04, DMP-R08.
 - **DMP.NIX.NATIVE-R04 No partial optional smuggling:** Optional dependencies
   must not smuggle a _host-selected subset_ of platform-native outputs into a
-  platform-neutral prepared artifact. A prepared artifact may carry an optional
-  native family only when the root opts in (`DMP.NIX-R11`) and the family is
-  complete across all declared triples (`DMP.NIX.NATIVE-R08`), which keeps the
-  artifact platform-neutral and host-invariant.
+  prepared artifact. A prepared artifact may carry an optional native family
+  only when the root opts in (`DMP.NIX-R11`) and the family is complete across
+  all declared triples (`DMP.NIX.NATIVE-R08`). Completeness — not neutrality — is
+  the property that keeps such an artifact sound to share: an opt-in artifact is
+  not platform-neutral (it carries every declared platform's binding), but it is
+  platform-COMPLETE and therefore host-invariant, so a single shared FOD hash
+  stays valid. A root that does not opt in stays binding-free and
+  platform-neutral as before.
   Refines: DMP-R05, DMP-R08.
 
 ### Must be auditable
@@ -60,6 +64,10 @@ of lifecycle scripts.
   _classified_ — an unclassified family fails per `DMP.NIX.NATIVE-R06`, a
   classified `pure-package-artifact` family must be _complete_ per this
   requirement.
+  This guarantees an opt-in root is _complete_; it does NOT decide whether a root
+  that needs bindings has opted in. A needs-binding root that never opts in is
+  out of scope here and is caught downstream by a real cross-platform build (a
+  `vite build` gate), not by this requirement.
   Refines: DMP.NIX.NATIVE-R03, DMP.NIX.NATIVE-R04, DMP.NIX.NATIVE-R06, DMP-R08.
 - **DMP.NIX.NATIVE-R09 Auto-derived family set:** The required-family set must be
   derived from the resolved closure, not from a hand-maintained per-consumer

--- a/context/dependency-materialization/03-nix-prepared-deps/02-native-node-packages/spec.md
+++ b/context/dependency-materialization/03-nix-prepared-deps/02-native-node-packages/spec.md
@@ -7,10 +7,11 @@ Status: **Draft**
 
 ## Requirement Trace
 
-| Section        | Requirements                                                                   |
-| -------------- | ------------------------------------------------------------------------------ |
-| Classification | DMP.NIX.NATIVE-R01, DMP.NIX.NATIVE-R03, DMP.NIX.NATIVE-R05, DMP.NIX.NATIVE-R06 |
-| Build Phase    | DMP.NIX.NATIVE-R02, DMP.NIX.NATIVE-R04, DMP.NIX.NATIVE-R07                     |
+| Section              | Requirements                                                                   |
+| -------------------- | ------------------------------------------------------------------------------ |
+| Classification       | DMP.NIX.NATIVE-R01, DMP.NIX.NATIVE-R03, DMP.NIX.NATIVE-R05, DMP.NIX.NATIVE-R06 |
+| Build Phase          | DMP.NIX.NATIVE-R02, DMP.NIX.NATIVE-R04, DMP.NIX.NATIVE-R07                     |
+| Closure Completeness | DMP.NIX.NATIVE-R08, DMP.NIX.NATIVE-R09, DMP.NIX.NATIVE-R10, DMP.NIX.NATIVE-R11 |
 
 ## Classification
 
@@ -33,3 +34,84 @@ identity.
 
 The platform-neutral prepared dependency artifact must not depend on optional
 npm packages or install hooks to select native outputs.
+
+## Closure Completeness
+
+Traces: DMP.NIX.NATIVE-R08, DMP.NIX.NATIVE-R09, DMP.NIX.NATIVE-R10,
+DMP.NIX.NATIVE-R11.
+
+Classification (above) decides _whether_ a native family may live in dependency
+data. Completeness decides _whether the family that does live there is whole_.
+They are two directions of one scan over the prepared `.pnpm` tree:
+
+| Direction    | Guarantee                                    | Requirement            |
+| ------------ | -------------------------------------------- | ---------------------- |
+| Rejection    | No _unexpected / unclassified_ native output | DMP.NIX.NATIVE-R04/R05 |
+| Completeness | Every _declared_ family binding is _present_ | DMP.NIX.NATIVE-R08     |
+
+Enabling the opt-in surfaces native dirs (0 → many `.node` files across platform
+dirs) that are governed by this same scan and the same classification (`0004`
+v18): an unclassified family fails per `DMP.NIX.NATIVE-R06` (classify-or-fail),
+a classified `pure-package-artifact` family must be complete per
+`DMP.NIX.NATIVE-R08`. There is no "R08 requires it but R05 rejects it" gap —
+rejection and completeness are the two directions of one scan over one
+classification, not two competing scans.
+
+### Detector — auto-derive the required family set
+
+The detector reads the root's resolved lockfile closure (dev + prod) and
+computes the required set with no hand-maintained list (`DMP.NIX.NATIVE-R09`):
+
+1. Enumerate packages classified `pure-package-artifact` (reusing the native
+   dependency policy — one registry, not a fork; see `0003`).
+2. For each such family, read its declared optional binding packages and expand
+   `supportedArchitectures` into concrete `(os, cpu, libc)` triples.
+3. The required set is `{ family × declared triple }`.
+
+Over-approximation is deliberate and in the safe direction: a family present in
+the closure but not actually loaded at build time (e.g. a CSS transformer behind
+an unused code path) is still required to be complete. Presence-in-closure is
+cheap to satisfy — pnpm optional install is per-root all-or-nothing — and
+missing a _loaded_ binding is the failure this prevents. A family with no
+prebuilt for a declared triple is handled by an explicit waiver, not by dropping
+it from the required set.
+
+### Completeness mode
+
+| Mode                             | Required coverage                      | Hash consequence                          |
+| -------------------------------- | -------------------------------------- | ----------------------------------------- |
+| `all-declared-triples` (default) | every declared `(os,cpu,libc)` triple  | host-invariant → single shared hash sound |
+| `build-platform`                 | only an explicit `buildPlatformTriple` | host-variant → per-system hash fallback   |
+
+`all-declared-triples` is the default because it is the precondition for a sound
+shared FOD hash (see `01-fod-hash-evidence` and `0008`, `0009`).
+
+### Assertion and engagement
+
+For every required `{ family × triple }`, assert the binding package directory is
+present in the captured `.pnpm` tree. On a miss, fail naming `family + missing
+triple(s)` (`DMP.NIX.NATIVE-R10`) — the diagnostic points at the prepared
+artifact, not at a downstream runtime resolution error.
+
+Engagement is a function of the root's opt-in (`DMP.NIX-R11`), not a
+report-only phase (consistent with `0004`):
+
+| Root state                                  | Completeness assertion                                  |
+| ------------------------------------------- | ------------------------------------------------------- |
+| opts into optional bindings (`DMP.NIX-R11`) | hard fail on a miss                                     |
+| does not opt in                             | advisory only (families are not required for that root) |
+
+An opt-in root is enforced strictly from the first build — there is no lenient
+mode running beside the strict one for the same boundary. See `0009` for how a
+future default-on expansion is sequenced as a versioned transition rather than a
+lenient legacy phase.
+
+### Waivers and tripwire
+
+- **Waiver** (`DMP.NIX.NATIVE-R11`): the only explicit per-root input beyond the
+  opt-in. Reason-carrying; scoped to the named family/triple; must not expand to
+  unnamed families.
+- **Expected-set tripwire** (optional defense-in-depth): an opt-in root may pin
+  the expected derived family set so a dependency bump that silently _adds_ a
+  native family fails until reviewed. Off by default; auto-derive stays
+  authoritative.

--- a/context/dependency-materialization/03-nix-prepared-deps/requirements.md
+++ b/context/dependency-materialization/03-nix-prepared-deps/requirements.md
@@ -72,11 +72,15 @@ projection semantics from
   Profile evidence, purity-scan results, and hash-measurement metadata.
   Refines: DMP-R10, DMP-R18, DMP-R19.
 - **DMP.NIX-R11 Optional binding opt-in:** A prepared install root may opt into
-  materializing its optional native binding families into the prepared
-  artifact. The opt-in is declared per install root and defaults off. When set,
-  the artifact must satisfy declared-triple completeness
-  (`DMP.NIX.NATIVE-R08`); when unset, the artifact remains binding-free and the
-  purity scan rejects native outputs as today.
+  carrying its optional native binding families — the binding artifacts for
+  every declared `(os, cpu, libc)` triple — in the prepared artifact. The opt-in
+  is declared per install root and defaults off; it is a property of the
+  prepared artifact, not of any one package manager's flag (it survives a
+  realization-engine swap). When set, the artifact must satisfy declared-triple
+  completeness (`DMP.NIX.NATIVE-R08`); when unset, the artifact remains
+  binding-free and the purity scan rejects native outputs as today. The opt-in
+  makes an opted-in root's artifact complete; it does not detect a root that
+  ought to have opted in but did not — that gap is a downstream build concern.
   Refines: DMP-R04, DMP-R09, DMP.NIX-R04.
 
 ### Must remain operational

--- a/context/dependency-materialization/03-nix-prepared-deps/requirements.md
+++ b/context/dependency-materialization/03-nix-prepared-deps/requirements.md
@@ -30,6 +30,11 @@ projection semantics from
 - **T03 Explicit native grafts:** Platform-specific native packages may be
   grafted during the platform-specific build phase instead of living in the
   platform-neutral FOD.
+- **T04 Opt-in hash churn:** Turning on optional binding inclusion for a root is
+  a lockfile-scope change to that root's prepared artifact and moves its
+  fixed-output hash. This churn is absorbed by the FOD hash-repair contract
+  (`0005`, `01-fod-hash-evidence`) rather than avoided with a parallel
+  binding-only artifact.
 
 ## Requirements
 
@@ -66,6 +71,13 @@ projection semantics from
 - **DMP.NIX-R08 Evidence:** Each prepared artifact must emit Materialization
   Profile evidence, purity-scan results, and hash-measurement metadata.
   Refines: DMP-R10, DMP-R18, DMP-R19.
+- **DMP.NIX-R11 Optional binding opt-in:** A prepared install root may opt into
+  materializing its optional native binding families into the prepared
+  artifact. The opt-in is declared per install root and defaults off. When set,
+  the artifact must satisfy declared-triple completeness
+  (`DMP.NIX.NATIVE-R08`); when unset, the artifact remains binding-free and the
+  purity scan rejects native outputs as today.
+  Refines: DMP-R04, DMP-R09, DMP.NIX-R04.
 
 ### Must remain operational
 

--- a/context/dependency-materialization/03-nix-prepared-deps/spec.md
+++ b/context/dependency-materialization/03-nix-prepared-deps/spec.md
@@ -23,6 +23,7 @@ This spec defines:
 | Pipeline                      | DMP.NIX-R01, DMP.NIX-R04, DMP.NIX-R05, DMP.NIX-R07 |
 | Staged Inputs                 | DMP.NIX-R02, DMP.NIX-R06                           |
 | Install Policy                | DMP.NIX-R01                                        |
+| Optional Binding Opt-In       | DMP.NIX-R11                                        |
 | Normalization And Purity Scan | DMP.NIX-R03, DMP.NIX-R04                           |
 | Restore                       | DMP.NIX-R05, DMP.NIX-R07                           |
 | Evidence                      | DMP.NIX-R08, DMP.NIX-R09, DMP.NIX-R10              |
@@ -64,6 +65,33 @@ pnpm install --frozen-lockfile --ignore-scripts --no-optional
 and with package-manager self-management, side-effects cache, and undeclared
 host state disabled. Optional dependencies may be included only through an
 explicit profile policy.
+
+## Optional Binding Opt-In
+
+Traces: DMP.NIX-R11.
+
+The strict install policy runs `pnpm install --frozen-lockfile --ignore-scripts`
+with optional dependencies stripped by default, so a prepared artifact carries
+no platform native bindings. An install root may opt in to carrying its optional
+native binding families:
+
+- The opt-in is a per-install-root field on the prepared-deps entry (default
+  off), threaded into every prepared-deps install site (root and external
+  install roots) — not a global switch (would bloat every consumer's artifact)
+  and not a separate binding-only FOD (over-engineered; see `0008`).
+- When set, the install materializes optional dependencies under
+  `supportedArchitectures` so pnpm resolves every declared `(os, cpu, libc)`
+  triple into the captured `.pnpm` tree, and the completeness assertion
+  (`02-native-node-packages`, `DMP.NIX.NATIVE-R08`) gates the result.
+- Bindings resolve from a family's own isolated `.pnpm/<pkg>/node_modules/…`
+  subtree; the top-level `node_modules/<scope>` stays empty. The opt-in FOD is
+  therefore the sanctioned channel for `pure-package-artifact` families, distinct
+  from the `nativeNodePackages` top-level graft used for `nix-grafted` families.
+- The resulting hash change is a lockfile-scope change to that root and is
+  repaired through the existing FOD hash-repair-target contract (`0005`), which
+  already exposes the direct prepared-deps derivation as evaluated metadata —
+  including for a nested-flake consumer boundary. No new repair surface is
+  introduced by this opt-in.
 
 ## Normalization And Purity Scan
 

--- a/genie/ci-scripts/native-binding-closure-check.test.sh
+++ b/genie/ci-scripts/native-binding-closure-check.test.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# Prototype test harness for native-binding-closure-check.ts.
+# Mirrors genie/ci-scripts/native-dep-policy-audit.test.sh idioms:
+# synthetic fixtures, run_bun shim, exit-code + offender-name assertions.
+set -euo pipefail
+
+CHECK="${CHECK:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/native-binding-closure-check.ts}"
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+run_bun() {
+  if command -v bun >/dev/null 2>&1; then
+    bun "$@"
+  elif command -v nix >/dev/null 2>&1; then
+    nix run nixpkgs#bun -- "$@"
+  else
+    echo "bun is not available and nix is not set" >&2
+    return 127
+  fi
+}
+
+# A prepared-tree fixture is: <dir>/pnpm-lock.yaml, <dir>/pnpm-workspace.yaml,
+# and <dir>/node_modules/.pnpm/<entry> directories for materialized packages.
+write_lock() {
+  cat >"$1/pnpm-lock.yaml" <<'YAML'
+lockfileVersion: '9.0'
+
+packages:
+  rolldown@1.0.3:
+    resolution: {integrity: sha512-aaa}
+  '@rolldown/binding-linux-arm64-gnu@1.0.3':
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+  '@rolldown/binding-linux-x64-gnu@1.0.3':
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+  '@rolldown/binding-darwin-arm64@1.0.3':
+    cpu: [arm64]
+    os: [darwin]
+  '@rolldown/binding-win32-x64-msvc@1.0.3':
+    cpu: [x64]
+    os: [win32]
+
+snapshots:
+  rolldown@1.0.3:
+    dependencies:
+      '@oxc-project/types': 0.133.0
+    optionalDependencies:
+      '@rolldown/binding-linux-arm64-gnu': 1.0.3
+      '@rolldown/binding-linux-x64-gnu': 1.0.3
+      '@rolldown/binding-darwin-arm64': 1.0.3
+      '@rolldown/binding-win32-x64-msvc': 1.0.3
+YAML
+}
+
+write_workspace() {
+  cat >"$1/pnpm-workspace.yaml" <<'YAML'
+packages:
+  - .
+
+supportedArchitectures:
+  os: [linux, darwin]
+  cpu: [x64, arm64]
+  libc: [glibc, musl]
+YAML
+}
+
+# REGRESSION fixture (multi-document vacuous-pass): a MULTI-DOCUMENT pnpm-lock.yaml. pnpm writes a
+# `---`-separated pnpm-CLI bootstrap document BEFORE the workspace document, each
+# with its own `packages:`/`snapshots:` sections. The original parser `break`ed at
+# the first top-level key past document 1's sections and therefore ONLY saw the ~20
+# bootstrap consumers — it never reached the workspace's `rolldown@1.0.3` snapshot,
+# so it reported "families: none" and PASSED vacuously on a bindingless tree. The
+# single-document fixture above cannot catch that; this one is the real shape.
+write_multidoc_lock() {
+  cat >"$1/pnpm-lock.yaml" <<'YAML'
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    packageManagerDependencies:
+      pnpm:
+        specifier: 11.0.0-rc.5
+        version: 11.0.0-rc.5
+
+packages:
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-boot}
+
+  pnpm@11.0.0-rc.5:
+    resolution: {integrity: sha512-boot}
+
+snapshots:
+
+  detect-libc@2.1.2: {}
+
+  pnpm@11.0.0-rc.5: {}
+
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    dependencies:
+      rolldown:
+        specifier: 1.0.3
+        version: 1.0.3
+
+packages:
+
+  rolldown@1.0.3:
+    resolution: {integrity: sha512-aaa}
+  '@rolldown/binding-linux-arm64-gnu@1.0.3':
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+  '@rolldown/binding-linux-x64-gnu@1.0.3':
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+  '@rolldown/binding-darwin-arm64@1.0.3':
+    cpu: [arm64]
+    os: [darwin]
+  '@rolldown/binding-win32-x64-msvc@1.0.3':
+    cpu: [x64]
+    os: [win32]
+
+snapshots:
+
+  rolldown@1.0.3:
+    dependencies:
+      '@oxc-project/types': 0.133.0
+    optionalDependencies:
+      '@rolldown/binding-linux-arm64-gnu': 1.0.3
+      '@rolldown/binding-linux-x64-gnu': 1.0.3
+      '@rolldown/binding-darwin-arm64': 1.0.3
+      '@rolldown/binding-win32-x64-msvc': 1.0.3
+YAML
+}
+
+mk_entry() { mkdir -p "$1/node_modules/.pnpm/$2"; }
+
+# --- Fixture 1: complete tree (all 3 supported triples present) -> PASS.
+f1="$tmp_dir/complete"; mkdir -p "$f1"; write_lock "$f1"; write_workspace "$f1"
+mk_entry "$f1" "rolldown@1.0.3"
+mk_entry "$f1" "@rolldown+binding-linux-arm64-gnu@1.0.3"
+mk_entry "$f1" "@rolldown+binding-linux-x64-gnu@1.0.3"
+mk_entry "$f1" "@rolldown+binding-darwin-arm64@1.0.3"
+# win32-x64 intentionally absent: not in supportedArchitectures, must NOT be required.
+
+# --- Fixture 2: bindingless tree (--no-optional) -> FAIL naming arm64-gnu.
+f2="$tmp_dir/bindingless"; mkdir -p "$f2"; write_lock "$f2"; write_workspace "$f2"
+mk_entry "$f2" "rolldown@1.0.3"
+
+# --- Fixture 3: partial tree (host binding present, arm64 missing) -> FAIL.
+f3="$tmp_dir/partial"; mkdir -p "$f3"; write_lock "$f3"; write_workspace "$f3"
+mk_entry "$f3" "rolldown@1.0.3"
+mk_entry "$f3" "@rolldown+binding-linux-x64-gnu@1.0.3"
+mk_entry "$f3" "@rolldown+binding-darwin-arm64@1.0.3"
+
+# --- Fixture 4: consumer absent (CLI that never pulls rolldown) -> PASS.
+f4="$tmp_dir/no-consumer"; mkdir -p "$f4"; write_lock "$f4"; write_workspace "$f4"
+# node_modules/.pnpm exists but has no rolldown consumer.
+mkdir -p "$f4/node_modules/.pnpm"
+mk_entry "$f4" "some-other-pkg@1.0.0"
+
+fail() { echo "FAIL: $1" >&2; cat "$2" >&2 2>/dev/null || true; exit 1; }
+
+echo "Test 1: complete tree passes (exit 0)"
+run_bun "$CHECK" "$f1" >"$tmp_dir/o1" 2>&1 || fail "expected complete tree to pass" "$tmp_dir/o1"
+
+echo "Test 2: bindingless tree fails and names @rolldown/binding-linux-arm64-gnu"
+set +e; run_bun "$CHECK" "$f2" >"$tmp_dir/o2" 2>&1; e2=$?; set -e
+[ "$e2" -ne 0 ] || fail "expected bindingless tree to fail" "$tmp_dir/o2"
+grep -q "@rolldown/binding-linux-arm64-gnu" "$tmp_dir/o2" || fail "did not name the missing arm64-gnu binding" "$tmp_dir/o2"
+grep -q "win32" "$tmp_dir/o2" && fail "must NOT require win32 (outside supportedArchitectures)" "$tmp_dir/o2"
+
+echo "Test 3: partial tree fails on the missing arm64 triple"
+set +e; run_bun "$CHECK" "$f3" >"$tmp_dir/o3" 2>&1; e3=$?; set -e
+[ "$e3" -ne 0 ] || fail "expected partial tree to fail" "$tmp_dir/o3"
+grep -q "@rolldown/binding-linux-arm64-gnu" "$tmp_dir/o3" || fail "did not flag missing arm64-gnu" "$tmp_dir/o3"
+
+echo "Test 4: consumer-absent tree passes (no false positive)"
+run_bun "$CHECK" "$f4" >"$tmp_dir/o4" 2>&1 || fail "expected consumer-absent tree to pass" "$tmp_dir/o4"
+
+# --- Fixture 5 (multi-document vacuous-pass REGRESSION): MULTI-DOCUMENT lockfile, bindingless.
+# The pre-fix parser broke at the `---` document boundary and never reached the
+# workspace's rolldown snapshot -> "families: none" -> vacuous PASS. This case
+# MUST fail (RED) and name the missing arm64-gnu binding; it is the case that
+# would have caught the shipped defect.
+f5="$tmp_dir/multidoc-bindingless"; mkdir -p "$f5"; write_multidoc_lock "$f5"; write_workspace "$f5"
+mk_entry "$f5" "rolldown@1.0.3"
+
+echo "Test 5: multi-document bindingless lockfile fails (multi-document vacuous-pass regression guard)"
+set +e; run_bun "$CHECK" "$f5" >"$tmp_dir/o5" 2>&1; e5=$?; set -e
+[ "$e5" -ne 0 ] || fail "REGRESSION: multi-doc bindingless tree passed vacuously (parser broke at '---' boundary)" "$tmp_dir/o5"
+grep -q "@rolldown/binding-linux-arm64-gnu" "$tmp_dir/o5" || fail "did not name the missing arm64-gnu binding in multi-doc tree" "$tmp_dir/o5"
+
+# --- Fixture 6: same MULTI-DOCUMENT lockfile, all supported triples present -> PASS.
+# Guards against the fix over-correcting into a stuck-RED / non-detecting state:
+# proves the workspace document's families are both enumerated AND satisfiable.
+f6="$tmp_dir/multidoc-complete"; mkdir -p "$f6"; write_multidoc_lock "$f6"; write_workspace "$f6"
+mk_entry "$f6" "rolldown@1.0.3"
+mk_entry "$f6" "@rolldown+binding-linux-arm64-gnu@1.0.3"
+mk_entry "$f6" "@rolldown+binding-linux-x64-gnu@1.0.3"
+mk_entry "$f6" "@rolldown+binding-darwin-arm64@1.0.3"
+
+echo "Test 6: multi-document complete tree passes and detects the rolldown family"
+run_bun "$CHECK" "$f6" >"$tmp_dir/o6" 2>&1 || fail "expected multi-doc complete tree to pass" "$tmp_dir/o6"
+grep -q "families: @rolldown/binding" "$tmp_dir/o6" || fail "multi-doc: rolldown family not detected (parser still not reaching workspace doc)" "$tmp_dir/o6"
+
+echo ""
+echo "native-binding-closure-check tests passed"

--- a/genie/ci-scripts/native-binding-closure-check.test.sh
+++ b/genie/ci-scripts/native-binding-closure-check.test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Prototype test harness for native-binding-closure-check.ts.
+# Test harness for native-binding-closure-check.ts.
 # Mirrors genie/ci-scripts/native-dep-policy-audit.test.sh idioms:
 # synthetic fixtures, run_bun shim, exit-code + offender-name assertions.
 set -euo pipefail
@@ -70,11 +70,12 @@ YAML
 
 # REGRESSION fixture (multi-document vacuous-pass): a MULTI-DOCUMENT pnpm-lock.yaml. pnpm writes a
 # `---`-separated pnpm-CLI bootstrap document BEFORE the workspace document, each
-# with its own `packages:`/`snapshots:` sections. The original parser `break`ed at
-# the first top-level key past document 1's sections and therefore ONLY saw the ~20
-# bootstrap consumers — it never reached the workspace's `rolldown@1.0.3` snapshot,
-# so it reported "families: none" and PASSED vacuously on a bindingless tree. The
-# single-document fixture above cannot catch that; this one is the real shape.
+# with its own `packages:`/`snapshots:` sections. The original line-scanner
+# `break`ed at the first top-level key past document 1's sections and therefore
+# ONLY saw the ~20 bootstrap consumers — it never reached the workspace's
+# `rolldown@1.0.3` snapshot, so it reported "families: none" and PASSED vacuously
+# on a bindingless tree. The real multi-document YAML parse now used sees every
+# document; this fixture guards against a regression back to a scanner.
 write_multidoc_lock() {
   cat >"$1/pnpm-lock.yaml" <<'YAML'
 ---
@@ -145,6 +146,128 @@ snapshots:
 YAML
 }
 
+# PEER-SUFFIX fixture: a real pnpm v9 `snapshots:` consumer key carries its
+# resolved peer set in PARENTHESES, one group per peer
+# (`rolldown@1.0.3(vite@8.0.16)`), while the materialized virtual-store DIR
+# joins peers with UNDERSCORES and maps `/`->`+` (`rolldown@1.0.3_vite@8.0.16`).
+# The pre-hardening `stripVersion` split on the last `@` INSIDE the peer group,
+# mis-named the consumer, and its `presentInTree` prefix never matched the
+# underscore dir -> the consumer was silently skipped and the tree passed
+# vacuously. This fixture reproduces that shape so the peer-key skip stays fixed.
+write_peer_lock() {
+  cat >"$1/pnpm-lock.yaml" <<'YAML'
+lockfileVersion: '9.0'
+
+packages:
+  rolldown@1.0.3:
+    resolution: {integrity: sha512-aaa}
+  '@rolldown/binding-linux-arm64-gnu@1.0.3':
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+  '@rolldown/binding-linux-x64-gnu@1.0.3':
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+  '@rolldown/binding-darwin-arm64@1.0.3':
+    cpu: [arm64]
+    os: [darwin]
+
+snapshots:
+  rolldown@1.0.3(vite@8.0.16):
+    dependencies:
+      '@oxc-project/types': 0.133.0
+    optionalDependencies:
+      '@rolldown/binding-linux-arm64-gnu': 1.0.3
+      '@rolldown/binding-linux-x64-gnu': 1.0.3
+      '@rolldown/binding-darwin-arm64': 1.0.3
+YAML
+}
+
+# MUSL fixture: supportedArchitectures declares libc [glibc, musl], so a musl
+# binding within support must be present. Exercises multi-libc handling — the
+# musl triple must be required and named when missing.
+write_musl_lock() {
+  cat >"$1/pnpm-lock.yaml" <<'YAML'
+lockfileVersion: '9.0'
+
+packages:
+  rolldown@1.0.3:
+    resolution: {integrity: sha512-aaa}
+  '@rolldown/binding-linux-arm64-gnu@1.0.3':
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+  '@rolldown/binding-linux-arm64-musl@1.0.3':
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+snapshots:
+  rolldown@1.0.3:
+    dependencies:
+      '@oxc-project/types': 0.133.0
+    optionalDependencies:
+      '@rolldown/binding-linux-arm64-gnu': 1.0.3
+      '@rolldown/binding-linux-arm64-musl': 1.0.3
+YAML
+}
+
+# PRE-v9 fixture: a v6 lockfile has no `snapshots:` model, so the check cannot
+# resolve which consumer pulls which binding. It must FAIL CLOSED (not pass
+# vacuously) in fail mode, and degrade to a warning in warn mode.
+write_v6_lock() {
+  cat >"$1/pnpm-lock.yaml" <<'YAML'
+lockfileVersion: '6.0'
+
+dependencies:
+  rolldown:
+    specifier: 1.0.3
+    version: 1.0.3
+
+packages:
+  /rolldown@1.0.3:
+    resolution: {integrity: sha512-aaa}
+YAML
+}
+
+# BLIND-SNAPSHOTS fixture: a `snapshots:` section is present but empty (zero
+# consumers). The check must refuse to pass vacuously (fail-closed floor #3).
+write_empty_snapshots_lock() {
+  cat >"$1/pnpm-lock.yaml" <<'YAML'
+lockfileVersion: '9.0'
+
+packages:
+  rolldown@1.0.3:
+    resolution: {integrity: sha512-aaa}
+
+snapshots:
+YAML
+}
+
+# DROPPED-REFERENCES fixture: within-support pure-artifact binding packages exist
+# in `packages:` and their dirs are materialized, but the consumer snapshot omits
+# the optionalDependencies that reference them. detectActiveFamilies() is empty
+# while the tree plainly carries bindings -> fail-closed floor (3b + 4).
+write_dropped_refs_lock() {
+  cat >"$1/pnpm-lock.yaml" <<'YAML'
+lockfileVersion: '9.0'
+
+packages:
+  rolldown@1.0.3:
+    resolution: {integrity: sha512-aaa}
+  '@rolldown/binding-linux-arm64-gnu@1.0.3':
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+snapshots:
+  rolldown@1.0.3:
+    dependencies:
+      '@oxc-project/types': 0.133.0
+YAML
+}
+
 mk_entry() { mkdir -p "$1/node_modules/.pnpm/$2"; }
 
 # --- Fixture 1: complete tree (all 3 supported triples present) -> PASS.
@@ -191,21 +314,15 @@ echo "Test 4: consumer-absent tree passes (no false positive)"
 run_bun "$CHECK" "$f4" >"$tmp_dir/o4" 2>&1 || fail "expected consumer-absent tree to pass" "$tmp_dir/o4"
 
 # --- Fixture 5 (multi-document vacuous-pass REGRESSION): MULTI-DOCUMENT lockfile, bindingless.
-# The pre-fix parser broke at the `---` document boundary and never reached the
-# workspace's rolldown snapshot -> "families: none" -> vacuous PASS. This case
-# MUST fail (RED) and name the missing arm64-gnu binding; it is the case that
-# would have caught the shipped defect.
 f5="$tmp_dir/multidoc-bindingless"; mkdir -p "$f5"; write_multidoc_lock "$f5"; write_workspace "$f5"
 mk_entry "$f5" "rolldown@1.0.3"
 
 echo "Test 5: multi-document bindingless lockfile fails (multi-document vacuous-pass regression guard)"
 set +e; run_bun "$CHECK" "$f5" >"$tmp_dir/o5" 2>&1; e5=$?; set -e
-[ "$e5" -ne 0 ] || fail "REGRESSION: multi-doc bindingless tree passed vacuously (parser broke at '---' boundary)" "$tmp_dir/o5"
+[ "$e5" -ne 0 ] || fail "REGRESSION: multi-doc bindingless tree passed vacuously" "$tmp_dir/o5"
 grep -q "@rolldown/binding-linux-arm64-gnu" "$tmp_dir/o5" || fail "did not name the missing arm64-gnu binding in multi-doc tree" "$tmp_dir/o5"
 
 # --- Fixture 6: same MULTI-DOCUMENT lockfile, all supported triples present -> PASS.
-# Guards against the fix over-correcting into a stuck-RED / non-detecting state:
-# proves the workspace document's families are both enumerated AND satisfiable.
 f6="$tmp_dir/multidoc-complete"; mkdir -p "$f6"; write_multidoc_lock "$f6"; write_workspace "$f6"
 mk_entry "$f6" "rolldown@1.0.3"
 mk_entry "$f6" "@rolldown+binding-linux-arm64-gnu@1.0.3"
@@ -214,7 +331,77 @@ mk_entry "$f6" "@rolldown+binding-darwin-arm64@1.0.3"
 
 echo "Test 6: multi-document complete tree passes and detects the rolldown family"
 run_bun "$CHECK" "$f6" >"$tmp_dir/o6" 2>&1 || fail "expected multi-doc complete tree to pass" "$tmp_dir/o6"
-grep -q "families: @rolldown/binding" "$tmp_dir/o6" || fail "multi-doc: rolldown family not detected (parser still not reaching workspace doc)" "$tmp_dir/o6"
+grep -q "families: @rolldown/binding" "$tmp_dir/o6" || fail "multi-doc: rolldown family not detected" "$tmp_dir/o6"
+
+# --- Fixture 7 (PEER-SUFFIX): parens snapshot key, underscore-joined dir.
+f7="$tmp_dir/peer-bindingless"; mkdir -p "$f7"; write_peer_lock "$f7"; write_workspace "$f7"
+mk_entry "$f7" "rolldown@1.0.3_vite@8.0.16"
+
+echo "Test 7: peer-suffixed consumer key is not skipped — bindingless tree fails"
+set +e; run_bun "$CHECK" "$f7" >"$tmp_dir/o7" 2>&1; e7=$?; set -e
+[ "$e7" -ne 0 ] || fail "REGRESSION: peer-suffixed consumer skipped -> vacuous pass" "$tmp_dir/o7"
+grep -q "@rolldown/binding-linux-arm64-gnu" "$tmp_dir/o7" || fail "peer-suffixed: did not name missing arm64-gnu" "$tmp_dir/o7"
+
+# --- Fixture 8 (PEER-SUFFIX complete): all declared triples present -> PASS.
+f8="$tmp_dir/peer-complete"; mkdir -p "$f8"; write_peer_lock "$f8"; write_workspace "$f8"
+mk_entry "$f8" "rolldown@1.0.3_vite@8.0.16"
+mk_entry "$f8" "@rolldown+binding-linux-arm64-gnu@1.0.3"
+mk_entry "$f8" "@rolldown+binding-linux-x64-gnu@1.0.3"
+mk_entry "$f8" "@rolldown+binding-darwin-arm64@1.0.3"
+
+echo "Test 8: peer-suffixed complete tree passes and detects the family"
+run_bun "$CHECK" "$f8" >"$tmp_dir/o8" 2>&1 || fail "expected peer-suffixed complete tree to pass" "$tmp_dir/o8"
+grep -q "families: @rolldown/binding" "$tmp_dir/o8" || fail "peer-suffixed: family not detected" "$tmp_dir/o8"
+
+# --- Fixture 9 (MUSL): musl binding within support, missing -> FAIL naming musl.
+f9="$tmp_dir/musl-partial"; mkdir -p "$f9"; write_musl_lock "$f9"; write_workspace "$f9"
+mk_entry "$f9" "rolldown@1.0.3"
+mk_entry "$f9" "@rolldown+binding-linux-arm64-gnu@1.0.3"
+
+echo "Test 9: missing musl binding fails and names the musl triple"
+set +e; run_bun "$CHECK" "$f9" >"$tmp_dir/o9" 2>&1; e9=$?; set -e
+[ "$e9" -ne 0 ] || fail "expected missing musl binding to fail" "$tmp_dir/o9"
+grep -q "@rolldown/binding-linux-arm64-musl" "$tmp_dir/o9" || fail "did not name the missing musl binding" "$tmp_dir/o9"
+
+# --- Fixture 10 (MUSL complete): both glibc + musl present -> PASS.
+f10="$tmp_dir/musl-complete"; mkdir -p "$f10"; write_musl_lock "$f10"; write_workspace "$f10"
+mk_entry "$f10" "rolldown@1.0.3"
+mk_entry "$f10" "@rolldown+binding-linux-arm64-gnu@1.0.3"
+mk_entry "$f10" "@rolldown+binding-linux-arm64-musl@1.0.3"
+
+echo "Test 10: musl-complete tree passes"
+run_bun "$CHECK" "$f10" >"$tmp_dir/o10" 2>&1 || fail "expected musl-complete tree to pass" "$tmp_dir/o10"
+
+# --- Fixture 11 (FAIL-CLOSED: pre-v9). fail mode -> exit 1; warn mode -> exit 0.
+f11="$tmp_dir/v6"; mkdir -p "$f11"; write_v6_lock "$f11"; write_workspace "$f11"
+mk_entry "$f11" "rolldown@1.0.3"
+
+echo "Test 11a: pre-v9 lockfile fails closed in fail mode"
+set +e; run_bun "$CHECK" "$f11" >"$tmp_dir/o11a" 2>&1; e11a=$?; set -e
+[ "$e11a" -ne 0 ] || fail "expected pre-v9 lockfile to fail closed" "$tmp_dir/o11a"
+grep -qi "predates the pnpm v9" "$tmp_dir/o11a" || fail "pre-v9: did not name the version floor" "$tmp_dir/o11a"
+
+echo "Test 11b: pre-v9 lockfile degrades to warning in warn mode (exit 0)"
+NBCC_ENGAGEMENT=warn run_bun "$CHECK" "$f11" >"$tmp_dir/o11b" 2>&1 || fail "warn mode must not hard-fail on pre-v9" "$tmp_dir/o11b"
+
+# --- Fixture 12 (FAIL-CLOSED: empty snapshots section) -> fail closed.
+f12="$tmp_dir/empty-snapshots"; mkdir -p "$f12"; write_empty_snapshots_lock "$f12"; write_workspace "$f12"
+mk_entry "$f12" "rolldown@1.0.3"
+
+echo "Test 12: empty snapshots section fails closed (no vacuous pass)"
+set +e; run_bun "$CHECK" "$f12" >"$tmp_dir/o12" 2>&1; e12=$?; set -e
+[ "$e12" -ne 0 ] || fail "expected empty-snapshots tree to fail closed" "$tmp_dir/o12"
+grep -qi "zero consumer entries parsed" "$tmp_dir/o12" || fail "empty-snapshots: did not name the floor" "$tmp_dir/o12"
+
+# --- Fixture 13 (FAIL-CLOSED: dropped references, tree carries bindings) -> fail closed.
+f13="$tmp_dir/dropped-refs"; mkdir -p "$f13"; write_dropped_refs_lock "$f13"; write_workspace "$f13"
+mk_entry "$f13" "rolldown@1.0.3"
+mk_entry "$f13" "@rolldown+binding-linux-arm64-gnu@1.0.3"
+
+echo "Test 13: tree carries bindings but no family derived -> fail closed"
+set +e; run_bun "$CHECK" "$f13" >"$tmp_dir/o13" 2>&1; e13=$?; set -e
+[ "$e13" -ne 0 ] || fail "expected dropped-refs tree to fail closed" "$tmp_dir/o13"
+grep -qi "not seeing the tree\|dropped the references" "$tmp_dir/o13" || fail "dropped-refs: did not name the floor" "$tmp_dir/o13"
 
 echo ""
 echo "native-binding-closure-check tests passed"

--- a/genie/ci-scripts/native-binding-closure-check.ts
+++ b/genie/ci-scripts/native-binding-closure-check.ts
@@ -10,14 +10,22 @@
  * output), EVERY platform binding within the declared `supportedArchitectures`
  * must be physically present in that tree.
  *
- * It exists because the deps FOD (`mk-pnpm-deps.nix`) installs with
- * `--no-optional` by default, which silently produces a tree with the consumer
- * package (e.g. `rolldown`) but ZERO native bindings. That tree builds and
- * caches happily on the build host, then fails at `vite build` / runtime on a
- * platform whose binding was never fetched (the `@rolldown/binding-linux-arm64-gnu`
- * gap on aarch64-linux). Nothing in the closure hash catches this: the hash
- * faithfully describes a bindingless tree. This check makes the gap a hard,
- * precisely-named build failure instead of a silent ship.
+ * It exists because the deps FOD (`mk-pnpm-deps.nix`) installs without carrying
+ * optional native bindings by default, which silently produces a tree with the
+ * consumer package (e.g. `rolldown`) but ZERO native bindings. That tree builds
+ * and caches happily on the build host, then fails at `vite build` / runtime on
+ * a platform whose binding was never fetched (the
+ * `@rolldown/binding-linux-arm64-gnu` gap on aarch64-linux). Nothing in the
+ * closure hash catches this: the hash faithfully describes a bindingless tree.
+ * This check makes the gap a hard, precisely-named build failure instead of a
+ * silent ship.
+ *
+ * SCOPE (honest guarantee): this check enforces closure-COMPLETENESS for a root
+ * that opts into carrying optional bindings — every declared triple of an active
+ * family is present. It does NOT decide whether a root that needs bindings has
+ * opted in; a non-opted-in root runs in advisory (warn) mode. The separate
+ * downstream gate (a real cross-platform `vite build` in CI) is what catches a
+ * needs-binding root that forgot to opt in.
  *
  * Data-driven: families come from `nativeDependencyPolicy` (pure-package-artifact
  * entries) + the lockfile, never a hardcoded package list. Triples come from the
@@ -32,211 +40,111 @@
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
 import { join, resolve } from 'node:path'
 
-// NOTE (prototype): in-repo this imports from the shared modules; the exports
-// `stripYamlQuotes`, `stripVersion`, `familyFor` are added to
-// `native-dep-policy-audit.ts`, and `nativeDependencyPolicy` from
-// `genie/native-dependency-policy.ts`. Inlined here so the prototype runs
-// standalone against experiment trees.
-type NativeDependencyPolicyEntry =
-  | { readonly _tag: 'nix-grafted'; readonly graft: 'link' | 'fetch-only'; readonly via: string }
-  | { readonly _tag: 'denied-lifecycle-build'; readonly defensive?: boolean }
-  | { readonly _tag: 'pure-package-artifact' }
+import {
+  type NativeDependencyPolicyEntry,
+  nativeDependencyPolicy,
+} from '../native-dependency-policy.ts'
+import { familyFor, stripPeerSuffix, stripVersion } from './native-dep-policy-lib.ts'
 
-const nativeDependencyPolicy = {
-  '@parcel/watcher': { _tag: 'denied-lifecycle-build' },
-  '@myobie/pty': { _tag: 'denied-lifecycle-build' },
-  esbuild: { _tag: 'denied-lifecycle-build' },
-  fsevents: { _tag: 'denied-lifecycle-build' },
-  'msgpackr-extract': { _tag: 'denied-lifecycle-build' },
-  'node-pty': { _tag: 'nix-grafted', graft: 'link', via: 'nix/node-pty-native.nix' },
-  sharp: { _tag: 'denied-lifecycle-build', defensive: true },
-  'unix-dgram': { _tag: 'denied-lifecycle-build', defensive: true },
-  '@opentui/core': { _tag: 'nix-grafted', graft: 'fetch-only', via: 'nix/opentui-core-native.nix' },
-  '@rollup/rollup': { _tag: 'pure-package-artifact' },
-  '@rolldown/binding': { _tag: 'pure-package-artifact' },
-  '@esbuild': { _tag: 'pure-package-artifact' },
-  '@msgpackr-extract': { _tag: 'pure-package-artifact' },
-  lightningcss: { _tag: 'pure-package-artifact' },
-  '@oxc-parser/binding': { _tag: 'pure-package-artifact' },
-  '@oxc-resolver/binding': { _tag: 'pure-package-artifact' },
-  '@tailwindcss/oxide': { _tag: 'pure-package-artifact' },
-  '@oxlint-tsgolint': { _tag: 'pure-package-artifact' },
-} as const satisfies Record<string, NativeDependencyPolicyEntry>
+// ---- YAML parse (real multi-document parse, not a line scanner) ----
 
-// ---- shared parser helpers (in-repo: import from native-dep-policy-audit.ts) ----
+/**
+ * pnpm lockfiles are multi-document YAML (a `---`-separated pnpm-CLI bootstrap
+ * document can precede the workspace document, each with its own
+ * `packages:`/`snapshots:`). `Bun.YAML.parse` returns an array for a
+ * multi-document input and a single object otherwise. The hand-rolled line
+ * scanner this replaces was the source of the multi-document vacuous-pass
+ * class: it
+ * stopped at the first document boundary and never reached the workspace's
+ * rolldown snapshot. A real parse removes that class entirely.
+ */
+const parseYaml = (text: string): unknown =>
+  (Bun as unknown as { YAML: { parse: (input: string) => unknown } }).YAML.parse(text)
 
-const stripYamlQuotes = (value: string): string => {
-  const trimmed = value.trim()
-  if (
-    (trimmed.startsWith("'") === true && trimmed.endsWith("'") === true) ||
-    (trimmed.startsWith('"') === true && trimmed.endsWith('"') === true)
-  ) {
-    return trimmed.slice(1, -1)
-  }
-  return trimmed
+const asRecord = (value: unknown): Record<string, unknown> =>
+  typeof value === 'object' && value !== null && Array.isArray(value) === false
+    ? (value as Record<string, unknown>)
+    : {}
+
+/** Normalize a scalar-or-list YAML field to a string array (multi-value safe). */
+const asStringArray = (value: unknown): string[] =>
+  Array.isArray(value) === true
+    ? value.map((v) => String(v))
+    : value === undefined
+      ? []
+      : [String(value)]
+
+/** Split a lockfile into its documents as records (single-doc -> one element). */
+export const parseLockfileDocs = (text: string): Record<string, unknown>[] => {
+  const raw = parseYaml(text)
+  const docs = Array.isArray(raw) === true ? raw : [raw]
+  return docs.map((d) => asRecord(d))
 }
 
-const stripVersion = (key: string): string => key.replace(/@[^@]+$/, '')
+// ---- triple / support types ----
 
-const familyFor = ({
-  pkgName,
-  policyKeys,
-}: {
-  pkgName: string
-  policyKeys: readonly string[]
-}): string | undefined => {
-  for (const key of policyKeys) {
-    if (pkgName === key) return key
-    if (pkgName.startsWith(`${key}-`) === true || pkgName.startsWith(`${key}/`) === true) {
-      return key
-    }
-  }
-  return undefined
-}
-
-// ---- new parsing: cpu/os/libc VALUES + snapshot optionalDependencies ----
-
-export type BindingTriple = { os?: string; cpu?: string; libc?: string }
+/**
+ * A binding's declared platform surface. Arrays (not a single value) so a
+ * binding that legitimately declares multiple cpus/oses/libcs is checked in
+ * full rather than by its first value only.
+ */
+export type BindingTriple = { os: string[]; cpu: string[]; libc: string[] }
 export type SupportedArchitectures = {
   os: readonly string[]
   cpu: readonly string[]
   libc: readonly string[]
 }
-
-/** Parse a single `[a, b]` inline YAML list. */
-const parseInlineList = (value: string): string[] => {
-  const trimmed = value.trim()
-  const inner =
-    trimmed.startsWith('[') === true && trimmed.endsWith(']') === true
-      ? trimmed.slice(1, -1)
-      : trimmed
-  return inner
-    .split(',')
-    .map((v) => stripYamlQuotes(v))
-    .filter((v) => v !== '')
-}
+/** The build host's concrete platform, for `build-platform` completeness mode. */
+export type BuildPlatformTriple = { os?: string; cpu?: string; libc?: string }
 
 /**
- * Parse the `packages:` section for each key's cpu/os/libc VALUES (the audit's
- * own parser only records presence). Returns name@version -> triple.
+ * Parse `packages:` across every document -> `name@version` -> cpu/os/libc
+ * VALUES (the audit's own parser only records presence).
  */
 export const parseBindingTriples = (text: string): Record<string, BindingTriple> => {
   const out: Record<string, BindingTriple> = {}
-  let inPackages = false
-  let current: string | undefined
-  for (const line of text.split('\n')) {
-    if (line === 'packages:') {
-      inPackages = true
-      continue
-    }
-    if (inPackages === false) continue
-    // A top-level key ends the `packages:` section — but the pnpm lockfile is a
-    // MULTI-DOCUMENT YAML (a `---`-separated pnpm-CLI bootstrap document precedes
-    // the workspace document, each with its own `packages:`/`snapshots:`). So we
-    // must LEAVE the section and keep scanning, re-entering at the next
-    // document's `packages:`. A `break` here stops at the first document boundary
-    // and never reaches the workspace's rolldown/lightningcss bindings (the
-    // multi-document vacuous-pass defect).
-    if (/^[^\s].*:/.test(line) === true) {
-      inPackages = false
-      current = undefined
-      continue
-    }
-
-    const pkgMatch = /^  (.+):(?:\s*\{\})?\s*$/.exec(line)
-    if (pkgMatch !== null) {
-      current = stripYamlQuotes(pkgMatch[1]!)
-      out[current] = {}
-      continue
-    }
-    const fieldMatch = /^    (cpu|os|libc):\s*(.+)$/.exec(line)
-    if (fieldMatch !== null && current !== undefined) {
-      const values = parseInlineList(fieldMatch[2]!)
-      if (values[0] !== undefined) out[current]![fieldMatch[1] as 'cpu' | 'os' | 'libc'] = values[0]
+  for (const doc of parseLockfileDocs(text)) {
+    const packages = asRecord(doc.packages)
+    for (const [key, meta] of Object.entries(packages)) {
+      const m = asRecord(meta)
+      out[key] = { os: asStringArray(m.os), cpu: asStringArray(m.cpu), libc: asStringArray(m.libc) }
     }
   }
   return out
 }
 
 /**
- * Parse the `snapshots:` section: consumer name@version -> its
- * optionalDependencies as { depName -> version }. This is where pnpm lockfile
+ * Parse `snapshots:` across every document: consumer key -> its
+ * optionalDependencies as `{ depName -> version }`. This is where pnpm lockfile
  * v9 records which native binding families each consumer pulls in.
  */
 export const parseSnapshotOptionalDependencies = (
   text: string,
 ): Record<string, Record<string, string>> => {
   const out: Record<string, Record<string, string>> = {}
-  const lines = text.split('\n')
-  let inSnapshots = false
-  let current: string | undefined
-  let inOptional = false
-  for (const line of lines) {
-    if (line === 'snapshots:') {
-      inSnapshots = true
-      continue
-    }
-    if (inSnapshots === false) continue
-    // Multi-document lockfile: leave the section on a top-level key and re-enter
-    // at the next document's `snapshots:` rather than `break`ing at the first
-    // document boundary (see parseBindingTriples for the full rationale). Without
-    // this, only the pnpm-CLI bootstrap document's ~20 snapshots are seen and the
-    // workspace's `rolldown@1.0.3` snapshot is never reached — the vacuous pass.
-    if (/^[^\s].*:/.test(line) === true) {
-      inSnapshots = false
-      current = undefined
-      inOptional = false
-      continue
-    }
-
-    const snapMatch = /^  (\S.*):(?:\s*\{\})?\s*$/.exec(line)
-    if (snapMatch !== null) {
-      current = stripYamlQuotes(snapMatch[1]!)
-      out[current] = {}
-      inOptional = false
-      continue
-    }
-    if (/^    optionalDependencies:\s*$/.test(line) === true) {
-      inOptional = true
-      continue
-    }
-    if (/^    \S/.test(line) === true) {
-      // any other 4-space section (dependencies:, transitivePeerDependencies:, …)
-      inOptional = false
-      continue
-    }
-    if (inOptional === true && current !== undefined) {
-      const depMatch = /^      (.+):\s*(.+)$/.exec(line)
-      if (depMatch !== null) {
-        out[current]![stripYamlQuotes(depMatch[1]!)] = stripYamlQuotes(depMatch[2]!)
-      }
+  for (const doc of parseLockfileDocs(text)) {
+    const snapshots = asRecord(doc.snapshots)
+    for (const [key, body] of Object.entries(snapshots)) {
+      const optional = asRecord(asRecord(body).optionalDependencies)
+      const deps: Record<string, string> = {}
+      for (const [depName, version] of Object.entries(optional)) deps[depName] = String(version)
+      out[key] = deps
     }
   }
   return out
 }
 
-/** Parse `supportedArchitectures:` from a pnpm-workspace.yaml. */
+/** Parse `supportedArchitectures:` from a (single-document) pnpm-workspace.yaml. */
 export const parseSupportedArchitectures = (text: string): SupportedArchitectures => {
-  const lines = text.split('\n')
-  const result: { os: string[]; cpu: string[]; libc: string[] } = { os: [], cpu: [], libc: [] }
-  let inBlock = false
-  for (const line of lines) {
-    if (line.trimEnd() === 'supportedArchitectures:') {
-      inBlock = true
-      continue
-    }
-    if (inBlock === false) continue
-    if (/^\S/.test(line) === true) break
-    const fieldMatch = /^  (os|cpu|libc):\s*(.+)$/.exec(line)
-    if (fieldMatch !== null)
-      result[fieldMatch[1] as 'os' | 'cpu' | 'libc'] = parseInlineList(fieldMatch[2]!)
-  }
-  return result
+  const sa = asRecord(asRecord(parseYaml(text)).supportedArchitectures)
+  return { os: asStringArray(sa.os), cpu: asStringArray(sa.cpu), libc: asStringArray(sa.libc) }
 }
 
 /**
- * A binding is "required" when its triple is fully within the declared support.
- * Darwin bindings carry no libc, so libc is only checked when the binding has one.
+ * A binding is "required" when its whole declared surface is within the declared
+ * support. Every declared os/cpu/libc value must be supported (a binding that
+ * targets an unsupported arch is not one we require). Darwin bindings carry no
+ * libc, so libc only constrains when the binding declares one.
  */
 const isWithinSupport = ({
   triple,
@@ -245,11 +153,30 @@ const isWithinSupport = ({
   triple: BindingTriple
   support: SupportedArchitectures
 }): boolean => {
-  if (triple.os !== undefined && support.os.includes(triple.os) === false) return false
-  if (triple.cpu !== undefined && support.cpu.includes(triple.cpu) === false) return false
-  if (triple.libc !== undefined && support.libc.includes(triple.libc) === false) return false
-  // Must actually be a platform-gated binding (has at least os or cpu).
-  return triple.os !== undefined || triple.cpu !== undefined
+  // Must actually be a platform-gated binding (declares at least os or cpu).
+  if (triple.os.length === 0 && triple.cpu.length === 0) return false
+  if (triple.os.some((v) => support.os.includes(v) === false) === true) return false
+  if (triple.cpu.some((v) => support.cpu.includes(v) === false) === true) return false
+  if (triple.libc.some((v) => support.libc.includes(v) === false) === true) return false
+  return true
+}
+
+/** Whether a pure-artifact binding dir (any triple) is present anywhere in the tree. */
+const treeHasPureArtifactBinding = ({
+  pnpmEntries,
+  policyKeys,
+  pureFamilies,
+}: {
+  pnpmEntries: Set<string>
+  policyKeys: readonly string[]
+  pureFamilies: ReadonlySet<string>
+}): boolean => {
+  for (const entry of pnpmEntries) {
+    const name = stripVersion(entry)
+    const family = familyFor({ pkgName: name.replace(/\+/g, '/'), policyKeys })
+    if (family !== undefined && pureFamilies.has(family) === true) return true
+  }
+  return false
 }
 
 /** Collect every `.pnpm/<entry>` directory basename anywhere in the tree. */
@@ -284,7 +211,7 @@ const collectPnpmEntries = (root: string): Set<string> => {
   return entries
 }
 
-/** pnpm virtual-store entry name: `/` -> `+`, then `@version[_peerhash]`. */
+/** pnpm virtual-store entry name: `/` -> `+`, then `@version[_peers]`. */
 const flatName = (name: string): string => name.replace(/\//g, '+')
 
 const presentInTree = ({
@@ -299,11 +226,20 @@ const presentInTree = ({
   const prefix = `${flatName(name)}@${version}`
   if (pnpmEntries.has(prefix) === true) return true
   for (const entry of pnpmEntries) {
-    // peer-suffixed entries: `<name>@<version>_<hash>` or `<version>(<peers>)`
+    // Peer-bearing consumers materialize under an underscore-joined dir name
+    // (`vite@8.0.16_@types+node@26.0.0_...`); the paren form is a defensive
+    // fallback for any variant encoding.
     if (entry.startsWith(`${prefix}_`) === true || entry.startsWith(`${prefix}(`) === true)
       return true
   }
   return false
+}
+
+/** Split a (possibly peer-suffixed) snapshot key into its bare name + version. */
+const consumerNameVersion = (consumerKey: string): { name: string; version: string } => {
+  const bare = stripPeerSuffix(consumerKey)
+  const name = stripVersion(bare)
+  return { name, version: bare.slice(name.length + 1) }
 }
 
 export type ClosureProblem = {
@@ -327,6 +263,44 @@ export type ClosureProblem = {
  */
 export type CompletenessMode = 'all-declared-triples' | 'build-platform'
 
+/**
+ * A reason-carrying, triple-scoped waiver (decision 0007, DMP.NIX.NATIVE-R11).
+ * `triple` undefined waives the whole family; a `triple` (e.g. `linux-arm64-musl`)
+ * waives only that binding — a waiver must not silently expand to triples it does
+ * not name. `reason` is recorded in the report as an audit trail.
+ */
+export type Waiver = { readonly family: string; readonly triple?: string; readonly reason?: string }
+
+/** Parse `family[@os-cpu-libc][=reason]` entries joined by `;`. */
+export const parseWaivers = (raw: string): Waiver[] =>
+  raw
+    .split(';')
+    .map((s) => s.trim())
+    .filter((s) => s !== '')
+    .map((entry) => {
+      const eq = entry.indexOf('=')
+      const spec = (eq === -1 ? entry : entry.slice(0, eq)).trim()
+      const reason = eq === -1 ? undefined : entry.slice(eq + 1).trim()
+      // Family may be scoped (`@scope/name`), so the triple separator is the
+      // first `@` PAST a leading scope `@`, not `indexOf('@')` (which would grab
+      // the scope marker). A triple never contains `@`.
+      const at = spec.indexOf('@', spec.startsWith('@') === true ? 1 : 0)
+      return at === -1
+        ? { family: spec, reason }
+        : { family: spec.slice(0, at), triple: spec.slice(at + 1), reason }
+    })
+
+const isWaived = ({
+  waivers,
+  family,
+  tripleStr,
+}: {
+  waivers: readonly Waiver[]
+  family: string
+  tripleStr: string
+}): Waiver | undefined =>
+  waivers.find((w) => w.family === family && (w.triple === undefined || w.triple === tripleStr))
+
 export type ClosureAuditOptions = {
   readonly preparedTreeDir: string
   readonly lockfileText: string
@@ -334,15 +308,17 @@ export type ClosureAuditOptions = {
   readonly policy?: Record<string, NativeDependencyPolicyEntry>
   readonly completenessMode?: CompletenessMode
   /** Required when completenessMode === 'build-platform'. */
-  readonly buildPlatformTriple?: BindingTriple
+  readonly buildPlatformTriple?: BuildPlatformTriple
   /**
    * Escape hatch (by design): the assertion is ALWAYS-ON and
    * auto-derives required families from the resolved closure — a consumer never
-   * hand-lists what to require (that would reintroduce that omission). These
-   * families are the only documented way to intentionally EXCLUDE a family whose
-   * absence is genuinely intended (a waiver). Everything else auto-fails.
+   * hand-lists what to require (that would reintroduce the multi-document
+   * vacuous-pass omission).
+   * Waivers are the only documented way to intentionally EXCLUDE a
+   * family/triple whose absence is genuinely intended; each is reason-carrying
+   * and scoped to the triple it names. Everything else auto-fails.
    */
-  readonly waiveFamilies?: readonly string[]
+  readonly waivers?: readonly Waiver[]
 }
 
 const tripleMatchesBuildPlatform = ({
@@ -350,21 +326,23 @@ const tripleMatchesBuildPlatform = ({
   build,
 }: {
   triple: BindingTriple
-  build: BindingTriple
+  build: BuildPlatformTriple
 }): boolean =>
-  (build.os === undefined || triple.os === build.os) &&
-  (build.cpu === undefined || triple.cpu === build.cpu) &&
+  (build.os === undefined || triple.os.length === 0 || triple.os.includes(build.os)) &&
+  (build.cpu === undefined || triple.cpu.length === 0 || triple.cpu.includes(build.cpu)) &&
   // libc only constrains when the binding declares one (darwin bindings don't).
-  (triple.libc === undefined || build.libc === undefined || triple.libc === build.libc)
+  (triple.libc.length === 0 || build.libc === undefined || triple.libc.includes(build.libc))
+
+const pureFamilyKeys = (policy: Record<string, NativeDependencyPolicyEntry>): string[] =>
+  Object.entries(policy)
+    .filter(([, e]) => e._tag === 'pure-package-artifact')
+    .map(([k]) => k)
 
 export const auditNativeBindingClosure = (opts: ClosureAuditOptions): ClosureProblem[] => {
   const policy = opts.policy ?? nativeDependencyPolicy
   const mode = opts.completenessMode ?? 'all-declared-triples'
-  const waived = new Set(opts.waiveFamilies ?? [])
-  const pureFamilies = Object.entries(policy)
-    .filter(([, e]) => e._tag === 'pure-package-artifact')
-    .map(([k]) => k)
-    .filter((k) => waived.has(k) === false)
+  const waivers = opts.waivers ?? []
+  const pureFamilies = pureFamilyKeys(policy)
   const policyKeys = Object.keys(policy)
 
   const triples = parseBindingTriples(opts.lockfileText)
@@ -375,8 +353,7 @@ export const auditNativeBindingClosure = (opts: ClosureAuditOptions): ClosurePro
   const problems: ClosureProblem[] = []
 
   for (const [consumerKey, optionalDeps] of Object.entries(snapshots)) {
-    const consumerName = stripVersion(consumerKey)
-    const consumerVersion = consumerKey.slice(consumerName.length + 1)
+    const { name: consumerName, version: consumerVersion } = consumerNameVersion(consumerKey)
     // Only enforce for consumers actually materialized in THIS prepared tree.
     if (presentInTree({ pnpmEntries, name: consumerName, version: consumerVersion }) === false)
       continue
@@ -396,15 +373,25 @@ export const auditNativeBindingClosure = (opts: ClosureAuditOptions): ClosurePro
         continue // build-platform mode: only require this host's triple
       }
 
+      const tripleStr = [...triple.os, ...triple.cpu, ...triple.libc].join('-')
+      const waiver = isWaived({ waivers, family, tripleStr })
+      if (waiver !== undefined) {
+        // Reason-carrying waiver: this family/triple is intentionally excluded.
+        console.log(
+          `native binding closure check: waived ${family} :: ${tripleStr}` +
+            (waiver.reason !== undefined && waiver.reason !== '' ? ` — ${waiver.reason}` : ''),
+        )
+        continue
+      }
+
       if (presentInTree({ pnpmEntries, name: depName, version: depVersion }) === false) {
-        const tripleStr = [triple.os, triple.cpu, triple.libc].filter(Boolean).join('-')
         problems.push({
           kind: 'missing-native-binding',
           family,
           consumer: consumerKey,
           binding: `${depName}@${depVersion}`,
           triple: tripleStr,
-          detail: `consumer "${consumerKey}" is present but its supported-architecture binding "${depName}@${depVersion}" (${tripleStr}) is absent from the prepared dependency tree. The deps FOD was built without this optional native binding (likely --no-optional / includeOptionalDependencies=false). Enable optional dependencies for this install root's deps build so pnpm fetches every supportedArchitectures triple.`,
+          detail: `consumer "${consumerKey}" is present but its supported-architecture binding "${depName}@${depVersion}" (${tripleStr}) is absent from the prepared dependency tree. The deps FOD was built without this optional native binding (the root did not carry optional native bindings for its declared triples). Enable optional-binding inclusion for this install root's deps build so every supportedArchitectures triple is materialized.`,
         })
       }
     }
@@ -418,7 +405,7 @@ export const auditNativeBindingClosure = (opts: ClosureAuditOptions): ClosurePro
  * actually materialized in this prepared tree. This IS `requiredNativeFamilies`
  * — computed, never hand-listed (by design). Over-approximates
  * safely: a family in-closure but not build-loaded (e.g. lightningcss via the
- * PostCSS path) is still listed; enabling includeOptionalDependencies
+ * PostCSS path) is still listed; enabling optional-binding inclusion
  * materializes its bindings for free, so all-declared-triples passes cleanly.
  */
 export const detectActiveFamilies = (opts: ClosureAuditOptions): string[] => {
@@ -433,8 +420,7 @@ export const detectActiveFamilies = (opts: ClosureAuditOptions): string[] => {
   const pnpmEntries = collectPnpmEntries(opts.preparedTreeDir)
   const active = new Set<string>()
   for (const [consumerKey, optionalDeps] of Object.entries(snapshots)) {
-    const consumerName = stripVersion(consumerKey)
-    const consumerVersion = consumerKey.slice(consumerName.length + 1)
+    const { name: consumerName, version: consumerVersion } = consumerNameVersion(consumerKey)
     if (presentInTree({ pnpmEntries, name: consumerName, version: consumerVersion }) === false)
       continue
     for (const depName of Object.keys(optionalDeps)) {
@@ -443,6 +429,102 @@ export const detectActiveFamilies = (opts: ClosureAuditOptions): string[] => {
     }
   }
   return [...active].sort()
+}
+
+/**
+ * Fail-closed floor (compensating control). Even with a real YAML parse, the
+ * check must never PASS vacuously: a green result on a tree it could not
+ * actually inspect is worse than a loud failure. Returns human-readable reasons
+ * the check could not have observed what it claims. The caller hard-fails on any
+ * reason in fail (opted-in) mode and reports them as warnings otherwise.
+ */
+export const lockfileFloorViolations = (opts: ClosureAuditOptions): string[] => {
+  const policy = opts.policy ?? nativeDependencyPolicy
+  const policyKeys = Object.keys(policy)
+  const pureFamilies = new Set(pureFamilyKeys(policy))
+  const docs = parseLockfileDocs(opts.lockfileText)
+  const violations: string[] = []
+
+  const hasPackages = docs.some((d) => 'packages' in d)
+  const hasSnapshots = docs.some((d) => 'snapshots' in d)
+  const versions = docs
+    .map((d) => d.lockfileVersion)
+    .filter((v) => v !== undefined)
+    .map((v) => String(v))
+  const majors = versions
+    .map((v) => Number.parseInt(v, 10))
+    .filter((n) => Number.isNaN(n) === false)
+
+  // (1) Unrecognized: no packages AND no snapshots -> not a pnpm lockfile shape.
+  if (hasPackages === false && hasSnapshots === false) {
+    violations.push(
+      'lockfile has neither a `packages:` nor a `snapshots:` section — unrecognized format; cannot verify binding closure',
+    )
+    return violations // nothing else is meaningful
+  }
+
+  // (2) Pre-v9: no `snapshots:` model (optionalDependencies live elsewhere) ->
+  // this check cannot resolve which consumer pulls which binding. Fail closed.
+  if (hasSnapshots === false || (majors.length > 0 && majors.every((n) => n < 9) === true)) {
+    violations.push(
+      `lockfile version ${versions.join(', ') || '(unstated)'} predates the pnpm v9 \`snapshots:\` model — binding-closure verification is unsupported for this lockfile`,
+    )
+  }
+
+  const snapshots = parseSnapshotOptionalDependencies(opts.lockfileText)
+  const consumerCount = Object.keys(snapshots).length
+
+  // (3) A `snapshots:` section exists but parsed to zero consumers -> the parse
+  // is blind; a green result would be vacuous.
+  if (hasSnapshots === true && consumerCount === 0) {
+    violations.push(
+      'a `snapshots:` section is present but zero consumer entries parsed — refusing to pass vacuously',
+    )
+  }
+
+  // (3b) Within-support pure-artifact binding packages exist in `packages:` but
+  // NO parsed snapshot optionalDependency references any pure-artifact family ->
+  // the snapshot/optionalDependencies parse dropped the references.
+  const triples = parseBindingTriples(opts.lockfileText)
+  const support = parseSupportedArchitectures(opts.workspaceYamlText)
+  const hasSupportedPureBindingPackage = Object.entries(triples).some(([key, triple]) => {
+    const family = familyFor({ pkgName: stripVersion(key), policyKeys })
+    return (
+      family !== undefined &&
+      pureFamilies.has(family) === true &&
+      isWithinSupport({ triple, support })
+    )
+  })
+  const anyOptionalReferencesPureFamily = Object.values(snapshots).some((deps) =>
+    Object.keys(deps).some((depName) => {
+      const family = familyFor({ pkgName: depName, policyKeys })
+      return family !== undefined && pureFamilies.has(family)
+    }),
+  )
+  if (
+    hasSupportedPureBindingPackage === true &&
+    anyOptionalReferencesPureFamily === false &&
+    consumerCount > 0
+  ) {
+    violations.push(
+      'lockfile declares supported-architecture pure-artifact binding packages, but no parsed snapshot optionalDependency references any of them — the optionalDependencies parse dropped the references',
+    )
+  }
+
+  // (4) Tree/parse mismatch: the prepared tree materializes pure-artifact binding
+  // dirs, yet no active family was derived from the lockfile -> the check is
+  // blind to a tree that plainly carries native families.
+  const pnpmEntries = collectPnpmEntries(opts.preparedTreeDir)
+  if (
+    treeHasPureArtifactBinding({ pnpmEntries, policyKeys, pureFamilies }) === true &&
+    detectActiveFamilies(opts).length === 0
+  ) {
+    violations.push(
+      'prepared tree contains pure-artifact binding directories, but no active family was derived from the lockfile — the check is not seeing the tree it is inspecting',
+    )
+  }
+
+  return violations
 }
 
 const formatReport = ({
@@ -479,6 +561,16 @@ const resolveInput = ({
   return resolve(treeDir, base)
 }
 
+const parseBuildPlatformTripleEnv = (raw: string | undefined): BuildPlatformTriple | undefined => {
+  if (raw === undefined || raw.trim() === '') return undefined
+  const [os, cpu, libc] = raw.split(',').map((s) => s.trim())
+  const triple: BuildPlatformTriple = {}
+  if (os !== undefined && os !== '') triple.os = os
+  if (cpu !== undefined && cpu !== '') triple.cpu = cpu
+  if (libc !== undefined && libc !== '') triple.libc = libc
+  return triple
+}
+
 const main = (): void => {
   const treeDir = process.argv[2]
   if (treeDir === undefined) {
@@ -494,21 +586,41 @@ const main = (): void => {
     base: 'pnpm-workspace.yaml',
   })
 
-  // Engagement phasing (rollout-safety guard): 'warn' reports but exits 0 so a
-  // repin of a root that has NOT opted into includeOptionalDependencies never
-  // breaks; 'fail' exits nonzero. The Nix wrapper sets NBCC_ENGAGEMENT=fail for
-  // roots that opted in (phase 1) and flips the default to fail in phase 2.
+  // Engagement (decision 0009): 'warn' reports but exits 0, so a repin of a root
+  // that has NOT opted into optional-binding inclusion is never broken by this
+  // check; 'fail' exits nonzero. The Nix wrapper sets NBCC_ENGAGEMENT=fail for
+  // roots that opted in. There is no global "flip the default" phase: making
+  // inclusion the default for a class of roots is a deliberate versioned
+  // prepared-deps transition, not a mode flag here (see 0009).
   const engagement = process.env.NBCC_ENGAGEMENT === 'warn' ? 'warn' : 'fail'
-  const waiveFamilies = (process.env.NBCC_WAIVE_FAMILIES ?? '')
-    .split(',')
-    .map((s) => s.trim())
-    .filter((s) => s !== '')
+  const waivers = parseWaivers(process.env.NBCC_WAIVERS ?? '')
+  const completenessMode: CompletenessMode =
+    process.env.NBCC_COMPLETENESS_MODE === 'build-platform'
+      ? 'build-platform'
+      : 'all-declared-triples'
+  const buildPlatformTriple = parseBuildPlatformTripleEnv(process.env.NBCC_BUILD_PLATFORM_TRIPLE)
 
   const auditOpts: ClosureAuditOptions = {
     preparedTreeDir: treeDir,
     lockfileText: readFileSync(lockfilePath, 'utf8'),
     workspaceYamlText: readFileSync(workspaceYamlPath, 'utf8'),
-    waiveFamilies,
+    waivers,
+    completenessMode,
+    buildPlatformTriple,
+  }
+
+  // Fail-closed floor: refuse to pass vacuously. In fail mode any floor
+  // violation is a hard error; in warn (non-opted-in) mode it is reported but
+  // does not gate the build (decision 0009 — the root's bindings are advisory).
+  const floor = lockfileFloorViolations(auditOpts)
+  if (floor.length > 0) {
+    const header = `native binding closure check: cannot verify closure for ${treeDir}`
+    console.error([header, ...floor.map((f) => `  - ${f}`)].join('\n'))
+    if (engagement === 'warn') {
+      console.error('native binding closure check: engagement=warn — reporting only, not failing.')
+      return
+    }
+    process.exit(1)
   }
 
   // Optional defense-in-depth tripwire (off by default): consumer declares the
@@ -546,7 +658,7 @@ const main = (): void => {
   console.error(report)
   if (engagement === 'warn') {
     console.error(
-      `native binding closure check: engagement=warn — reporting only, not failing (root has not opted into includeOptionalDependencies).`,
+      `native binding closure check: engagement=warn — reporting only, not failing (root has not opted into optional-binding inclusion).`,
     )
     return
   }

--- a/genie/ci-scripts/native-binding-closure-check.ts
+++ b/genie/ci-scripts/native-binding-closure-check.ts
@@ -1,0 +1,558 @@
+#!/usr/bin/env bun
+/**
+ * Native binding closure-completeness check (issue #807 — executable guarantee).
+ *
+ * Complements `native-dep-policy-audit.ts`. That audit enforces
+ * lockfile-vs-policy *classification* drift (every gated native family is
+ * classified). This check enforces the *materialization* invariant that the
+ * classification implies: for every `pure-package-artifact` family whose
+ * consumer is actually present in a prepared dependency tree (the deps FOD
+ * output), EVERY platform binding within the declared `supportedArchitectures`
+ * must be physically present in that tree.
+ *
+ * It exists because the deps FOD (`mk-pnpm-deps.nix`) installs with
+ * `--no-optional` by default, which silently produces a tree with the consumer
+ * package (e.g. `rolldown`) but ZERO native bindings. That tree builds and
+ * caches happily on the build host, then fails at `vite build` / runtime on a
+ * platform whose binding was never fetched (the `@rolldown/binding-linux-arm64-gnu`
+ * gap on aarch64-linux). Nothing in the closure hash catches this: the hash
+ * faithfully describes a bindingless tree. This check makes the gap a hard,
+ * precisely-named build failure instead of a silent ship.
+ *
+ * Data-driven: families come from `nativeDependencyPolicy` (pure-package-artifact
+ * entries) + the lockfile, never a hardcoded package list. Triples come from the
+ * prepared tree's own `pnpm-workspace.yaml` `supportedArchitectures`.
+ *
+ * Usage:
+ *   native-binding-closure-check.ts <prepared-tree-dir> [lockfile] [workspace-yaml]
+ *
+ * Defaults: lockfile / workspace-yaml resolve inside <prepared-tree-dir>.
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+
+// NOTE (prototype): in-repo this imports from the shared modules; the exports
+// `stripYamlQuotes`, `stripVersion`, `familyFor` are added to
+// `native-dep-policy-audit.ts`, and `nativeDependencyPolicy` from
+// `genie/native-dependency-policy.ts`. Inlined here so the prototype runs
+// standalone against experiment trees.
+type NativeDependencyPolicyEntry =
+  | { readonly _tag: 'nix-grafted'; readonly graft: 'link' | 'fetch-only'; readonly via: string }
+  | { readonly _tag: 'denied-lifecycle-build'; readonly defensive?: boolean }
+  | { readonly _tag: 'pure-package-artifact' }
+
+const nativeDependencyPolicy = {
+  '@parcel/watcher': { _tag: 'denied-lifecycle-build' },
+  '@myobie/pty': { _tag: 'denied-lifecycle-build' },
+  esbuild: { _tag: 'denied-lifecycle-build' },
+  fsevents: { _tag: 'denied-lifecycle-build' },
+  'msgpackr-extract': { _tag: 'denied-lifecycle-build' },
+  'node-pty': { _tag: 'nix-grafted', graft: 'link', via: 'nix/node-pty-native.nix' },
+  sharp: { _tag: 'denied-lifecycle-build', defensive: true },
+  'unix-dgram': { _tag: 'denied-lifecycle-build', defensive: true },
+  '@opentui/core': { _tag: 'nix-grafted', graft: 'fetch-only', via: 'nix/opentui-core-native.nix' },
+  '@rollup/rollup': { _tag: 'pure-package-artifact' },
+  '@rolldown/binding': { _tag: 'pure-package-artifact' },
+  '@esbuild': { _tag: 'pure-package-artifact' },
+  '@msgpackr-extract': { _tag: 'pure-package-artifact' },
+  lightningcss: { _tag: 'pure-package-artifact' },
+  '@oxc-parser/binding': { _tag: 'pure-package-artifact' },
+  '@oxc-resolver/binding': { _tag: 'pure-package-artifact' },
+  '@tailwindcss/oxide': { _tag: 'pure-package-artifact' },
+  '@oxlint-tsgolint': { _tag: 'pure-package-artifact' },
+} as const satisfies Record<string, NativeDependencyPolicyEntry>
+
+// ---- shared parser helpers (in-repo: import from native-dep-policy-audit.ts) ----
+
+const stripYamlQuotes = (value: string): string => {
+  const trimmed = value.trim()
+  if (
+    (trimmed.startsWith("'") === true && trimmed.endsWith("'") === true) ||
+    (trimmed.startsWith('"') === true && trimmed.endsWith('"') === true)
+  ) {
+    return trimmed.slice(1, -1)
+  }
+  return trimmed
+}
+
+const stripVersion = (key: string): string => key.replace(/@[^@]+$/, '')
+
+const familyFor = ({
+  pkgName,
+  policyKeys,
+}: {
+  pkgName: string
+  policyKeys: readonly string[]
+}): string | undefined => {
+  for (const key of policyKeys) {
+    if (pkgName === key) return key
+    if (pkgName.startsWith(`${key}-`) === true || pkgName.startsWith(`${key}/`) === true) {
+      return key
+    }
+  }
+  return undefined
+}
+
+// ---- new parsing: cpu/os/libc VALUES + snapshot optionalDependencies ----
+
+export type BindingTriple = { os?: string; cpu?: string; libc?: string }
+export type SupportedArchitectures = {
+  os: readonly string[]
+  cpu: readonly string[]
+  libc: readonly string[]
+}
+
+/** Parse a single `[a, b]` inline YAML list. */
+const parseInlineList = (value: string): string[] => {
+  const trimmed = value.trim()
+  const inner =
+    trimmed.startsWith('[') === true && trimmed.endsWith(']') === true
+      ? trimmed.slice(1, -1)
+      : trimmed
+  return inner
+    .split(',')
+    .map((v) => stripYamlQuotes(v))
+    .filter((v) => v !== '')
+}
+
+/**
+ * Parse the `packages:` section for each key's cpu/os/libc VALUES (the audit's
+ * own parser only records presence). Returns name@version -> triple.
+ */
+export const parseBindingTriples = (text: string): Record<string, BindingTriple> => {
+  const out: Record<string, BindingTriple> = {}
+  let inPackages = false
+  let current: string | undefined
+  for (const line of text.split('\n')) {
+    if (line === 'packages:') {
+      inPackages = true
+      continue
+    }
+    if (inPackages === false) continue
+    // A top-level key ends the `packages:` section — but the pnpm lockfile is a
+    // MULTI-DOCUMENT YAML (a `---`-separated pnpm-CLI bootstrap document precedes
+    // the workspace document, each with its own `packages:`/`snapshots:`). So we
+    // must LEAVE the section and keep scanning, re-entering at the next
+    // document's `packages:`. A `break` here stops at the first document boundary
+    // and never reaches the workspace's rolldown/lightningcss bindings (the
+    // multi-document vacuous-pass defect).
+    if (/^[^\s].*:/.test(line) === true) {
+      inPackages = false
+      current = undefined
+      continue
+    }
+
+    const pkgMatch = /^  (.+):(?:\s*\{\})?\s*$/.exec(line)
+    if (pkgMatch !== null) {
+      current = stripYamlQuotes(pkgMatch[1]!)
+      out[current] = {}
+      continue
+    }
+    const fieldMatch = /^    (cpu|os|libc):\s*(.+)$/.exec(line)
+    if (fieldMatch !== null && current !== undefined) {
+      const values = parseInlineList(fieldMatch[2]!)
+      if (values[0] !== undefined) out[current]![fieldMatch[1] as 'cpu' | 'os' | 'libc'] = values[0]
+    }
+  }
+  return out
+}
+
+/**
+ * Parse the `snapshots:` section: consumer name@version -> its
+ * optionalDependencies as { depName -> version }. This is where pnpm lockfile
+ * v9 records which native binding families each consumer pulls in.
+ */
+export const parseSnapshotOptionalDependencies = (
+  text: string,
+): Record<string, Record<string, string>> => {
+  const out: Record<string, Record<string, string>> = {}
+  const lines = text.split('\n')
+  let inSnapshots = false
+  let current: string | undefined
+  let inOptional = false
+  for (const line of lines) {
+    if (line === 'snapshots:') {
+      inSnapshots = true
+      continue
+    }
+    if (inSnapshots === false) continue
+    // Multi-document lockfile: leave the section on a top-level key and re-enter
+    // at the next document's `snapshots:` rather than `break`ing at the first
+    // document boundary (see parseBindingTriples for the full rationale). Without
+    // this, only the pnpm-CLI bootstrap document's ~20 snapshots are seen and the
+    // workspace's `rolldown@1.0.3` snapshot is never reached — the vacuous pass.
+    if (/^[^\s].*:/.test(line) === true) {
+      inSnapshots = false
+      current = undefined
+      inOptional = false
+      continue
+    }
+
+    const snapMatch = /^  (\S.*):(?:\s*\{\})?\s*$/.exec(line)
+    if (snapMatch !== null) {
+      current = stripYamlQuotes(snapMatch[1]!)
+      out[current] = {}
+      inOptional = false
+      continue
+    }
+    if (/^    optionalDependencies:\s*$/.test(line) === true) {
+      inOptional = true
+      continue
+    }
+    if (/^    \S/.test(line) === true) {
+      // any other 4-space section (dependencies:, transitivePeerDependencies:, …)
+      inOptional = false
+      continue
+    }
+    if (inOptional === true && current !== undefined) {
+      const depMatch = /^      (.+):\s*(.+)$/.exec(line)
+      if (depMatch !== null) {
+        out[current]![stripYamlQuotes(depMatch[1]!)] = stripYamlQuotes(depMatch[2]!)
+      }
+    }
+  }
+  return out
+}
+
+/** Parse `supportedArchitectures:` from a pnpm-workspace.yaml. */
+export const parseSupportedArchitectures = (text: string): SupportedArchitectures => {
+  const lines = text.split('\n')
+  const result: { os: string[]; cpu: string[]; libc: string[] } = { os: [], cpu: [], libc: [] }
+  let inBlock = false
+  for (const line of lines) {
+    if (line.trimEnd() === 'supportedArchitectures:') {
+      inBlock = true
+      continue
+    }
+    if (inBlock === false) continue
+    if (/^\S/.test(line) === true) break
+    const fieldMatch = /^  (os|cpu|libc):\s*(.+)$/.exec(line)
+    if (fieldMatch !== null)
+      result[fieldMatch[1] as 'os' | 'cpu' | 'libc'] = parseInlineList(fieldMatch[2]!)
+  }
+  return result
+}
+
+/**
+ * A binding is "required" when its triple is fully within the declared support.
+ * Darwin bindings carry no libc, so libc is only checked when the binding has one.
+ */
+const isWithinSupport = ({
+  triple,
+  support,
+}: {
+  triple: BindingTriple
+  support: SupportedArchitectures
+}): boolean => {
+  if (triple.os !== undefined && support.os.includes(triple.os) === false) return false
+  if (triple.cpu !== undefined && support.cpu.includes(triple.cpu) === false) return false
+  if (triple.libc !== undefined && support.libc.includes(triple.libc) === false) return false
+  // Must actually be a platform-gated binding (has at least os or cpu).
+  return triple.os !== undefined || triple.cpu !== undefined
+}
+
+/** Collect every `.pnpm/<entry>` directory basename anywhere in the tree. */
+const collectPnpmEntries = (root: string): Set<string> => {
+  const entries = new Set<string>()
+  const walk = ({ dir, depth }: { dir: string; depth: number }): void => {
+    if (depth > 8) return
+    let children: string[]
+    try {
+      children = readdirSync(dir)
+    } catch {
+      return
+    }
+    for (const name of children) {
+      const full = join(dir, name)
+      let isDir = false
+      try {
+        isDir = statSync(full).isDirectory()
+      } catch {
+        continue
+      }
+      if (isDir === false) continue
+      if (name === '.pnpm') {
+        for (const entry of readdirSync(full)) entries.add(entry)
+        continue
+      }
+      if (name === 'node_modules' || name.startsWith('@') === true || depth < 4)
+        walk({ dir: full, depth: depth + 1 })
+    }
+  }
+  walk({ dir: root, depth: 0 })
+  return entries
+}
+
+/** pnpm virtual-store entry name: `/` -> `+`, then `@version[_peerhash]`. */
+const flatName = (name: string): string => name.replace(/\//g, '+')
+
+const presentInTree = ({
+  pnpmEntries,
+  name,
+  version,
+}: {
+  pnpmEntries: Set<string>
+  name: string
+  version: string
+}): boolean => {
+  const prefix = `${flatName(name)}@${version}`
+  if (pnpmEntries.has(prefix) === true) return true
+  for (const entry of pnpmEntries) {
+    // peer-suffixed entries: `<name>@<version>_<hash>` or `<version>(<peers>)`
+    if (entry.startsWith(`${prefix}_`) === true || entry.startsWith(`${prefix}(`) === true)
+      return true
+  }
+  return false
+}
+
+export type ClosureProblem = {
+  readonly kind: 'missing-native-binding'
+  readonly family: string
+  readonly consumer: string
+  readonly binding: string
+  readonly triple: string
+  readonly detail: string
+}
+
+/**
+ * Completeness criterion (hash-contract decision):
+ *  - 'all-declared-triples' (DEFAULT): every triple within supportedArchitectures
+ *    must be present. This IS the `mkSharedHash`-soundness gate — it fails on a
+ *    host-variant tree (e.g. only the build host's binding), which is exactly the
+ *    tree that would break a shared cross-system hash.
+ *  - 'build-platform': only the current build platform's triple must be present.
+ *    Use with per-system `mkHash`, where full coverage is the union across the
+ *    per-system FODs.
+ */
+export type CompletenessMode = 'all-declared-triples' | 'build-platform'
+
+export type ClosureAuditOptions = {
+  readonly preparedTreeDir: string
+  readonly lockfileText: string
+  readonly workspaceYamlText: string
+  readonly policy?: Record<string, NativeDependencyPolicyEntry>
+  readonly completenessMode?: CompletenessMode
+  /** Required when completenessMode === 'build-platform'. */
+  readonly buildPlatformTriple?: BindingTriple
+  /**
+   * Escape hatch (by design): the assertion is ALWAYS-ON and
+   * auto-derives required families from the resolved closure — a consumer never
+   * hand-lists what to require (that would reintroduce that omission). These
+   * families are the only documented way to intentionally EXCLUDE a family whose
+   * absence is genuinely intended (a waiver). Everything else auto-fails.
+   */
+  readonly waiveFamilies?: readonly string[]
+}
+
+const tripleMatchesBuildPlatform = ({
+  triple,
+  build,
+}: {
+  triple: BindingTriple
+  build: BindingTriple
+}): boolean =>
+  (build.os === undefined || triple.os === build.os) &&
+  (build.cpu === undefined || triple.cpu === build.cpu) &&
+  // libc only constrains when the binding declares one (darwin bindings don't).
+  (triple.libc === undefined || build.libc === undefined || triple.libc === build.libc)
+
+export const auditNativeBindingClosure = (opts: ClosureAuditOptions): ClosureProblem[] => {
+  const policy = opts.policy ?? nativeDependencyPolicy
+  const mode = opts.completenessMode ?? 'all-declared-triples'
+  const waived = new Set(opts.waiveFamilies ?? [])
+  const pureFamilies = Object.entries(policy)
+    .filter(([, e]) => e._tag === 'pure-package-artifact')
+    .map(([k]) => k)
+    .filter((k) => waived.has(k) === false)
+  const policyKeys = Object.keys(policy)
+
+  const triples = parseBindingTriples(opts.lockfileText)
+  const snapshots = parseSnapshotOptionalDependencies(opts.lockfileText)
+  const support = parseSupportedArchitectures(opts.workspaceYamlText)
+  const pnpmEntries = collectPnpmEntries(opts.preparedTreeDir)
+
+  const problems: ClosureProblem[] = []
+
+  for (const [consumerKey, optionalDeps] of Object.entries(snapshots)) {
+    const consumerName = stripVersion(consumerKey)
+    const consumerVersion = consumerKey.slice(consumerName.length + 1)
+    // Only enforce for consumers actually materialized in THIS prepared tree.
+    if (presentInTree({ pnpmEntries, name: consumerName, version: consumerVersion }) === false)
+      continue
+
+    for (const [depName, depVersion] of Object.entries(optionalDeps)) {
+      const family = familyFor({ pkgName: depName, policyKeys })
+      if (family === undefined || pureFamilies.includes(family) === false) continue
+
+      const triple = triples[`${depName}@${depVersion}`]
+      if (triple === undefined) continue
+      if (isWithinSupport({ triple, support }) === false) continue // not a supported target
+      if (
+        mode === 'build-platform' &&
+        opts.buildPlatformTriple !== undefined &&
+        tripleMatchesBuildPlatform({ triple, build: opts.buildPlatformTriple }) === false
+      ) {
+        continue // build-platform mode: only require this host's triple
+      }
+
+      if (presentInTree({ pnpmEntries, name: depName, version: depVersion }) === false) {
+        const tripleStr = [triple.os, triple.cpu, triple.libc].filter(Boolean).join('-')
+        problems.push({
+          kind: 'missing-native-binding',
+          family,
+          consumer: consumerKey,
+          binding: `${depName}@${depVersion}`,
+          triple: tripleStr,
+          detail: `consumer "${consumerKey}" is present but its supported-architecture binding "${depName}@${depVersion}" (${tripleStr}) is absent from the prepared dependency tree. The deps FOD was built without this optional native binding (likely --no-optional / includeOptionalDependencies=false). Enable optional dependencies for this install root's deps build so pnpm fetches every supportedArchitectures triple.`,
+        })
+      }
+    }
+  }
+
+  return problems
+}
+
+/**
+ * The auto-derived set of pure-package-artifact families whose consumer is
+ * actually materialized in this prepared tree. This IS `requiredNativeFamilies`
+ * — computed, never hand-listed (by design). Over-approximates
+ * safely: a family in-closure but not build-loaded (e.g. lightningcss via the
+ * PostCSS path) is still listed; enabling includeOptionalDependencies
+ * materializes its bindings for free, so all-declared-triples passes cleanly.
+ */
+export const detectActiveFamilies = (opts: ClosureAuditOptions): string[] => {
+  const policy = opts.policy ?? nativeDependencyPolicy
+  const policyKeys = Object.keys(policy)
+  const pureFamilies = new Set(
+    Object.entries(policy)
+      .filter(([, e]) => e._tag === 'pure-package-artifact')
+      .map(([k]) => k),
+  )
+  const snapshots = parseSnapshotOptionalDependencies(opts.lockfileText)
+  const pnpmEntries = collectPnpmEntries(opts.preparedTreeDir)
+  const active = new Set<string>()
+  for (const [consumerKey, optionalDeps] of Object.entries(snapshots)) {
+    const consumerName = stripVersion(consumerKey)
+    const consumerVersion = consumerKey.slice(consumerName.length + 1)
+    if (presentInTree({ pnpmEntries, name: consumerName, version: consumerVersion }) === false)
+      continue
+    for (const depName of Object.keys(optionalDeps)) {
+      const family = familyFor({ pkgName: depName, policyKeys })
+      if (family !== undefined && pureFamilies.has(family) === true) active.add(family)
+    }
+  }
+  return [...active].sort()
+}
+
+const formatReport = ({
+  problems,
+  treeDir,
+}: {
+  problems: readonly ClosureProblem[]
+  treeDir: string
+}): string => {
+  if (problems.length === 0) return `native binding closure check: OK (${treeDir})`
+  const lines = [
+    `native binding closure check: ${problems.length} missing binding(s) in ${treeDir}`,
+    '',
+  ]
+  for (const p of problems) {
+    lines.push(`  [${p.kind}] ${p.family} :: ${p.triple}`)
+    lines.push(`    ${p.detail}`)
+  }
+  return lines.join('\n')
+}
+
+const resolveInput = ({
+  treeDir,
+  override,
+  base,
+}: {
+  treeDir: string
+  override: string | undefined
+  base: string
+}): string => {
+  if (override !== undefined) return override
+  const inTree = join(treeDir, base)
+  if (existsSync(inTree) === true) return inTree
+  return resolve(treeDir, base)
+}
+
+const main = (): void => {
+  const treeDir = process.argv[2]
+  if (treeDir === undefined) {
+    console.error(
+      'usage: native-binding-closure-check.ts <prepared-tree-dir> [lockfile] [workspace-yaml]',
+    )
+    process.exit(2)
+  }
+  const lockfilePath = resolveInput({ treeDir, override: process.argv[3], base: 'pnpm-lock.yaml' })
+  const workspaceYamlPath = resolveInput({
+    treeDir,
+    override: process.argv[4],
+    base: 'pnpm-workspace.yaml',
+  })
+
+  // Engagement phasing (rollout-safety guard): 'warn' reports but exits 0 so a
+  // repin of a root that has NOT opted into includeOptionalDependencies never
+  // breaks; 'fail' exits nonzero. The Nix wrapper sets NBCC_ENGAGEMENT=fail for
+  // roots that opted in (phase 1) and flips the default to fail in phase 2.
+  const engagement = process.env.NBCC_ENGAGEMENT === 'warn' ? 'warn' : 'fail'
+  const waiveFamilies = (process.env.NBCC_WAIVE_FAMILIES ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s !== '')
+
+  const auditOpts: ClosureAuditOptions = {
+    preparedTreeDir: treeDir,
+    lockfileText: readFileSync(lockfilePath, 'utf8'),
+    workspaceYamlText: readFileSync(workspaceYamlPath, 'utf8'),
+    waiveFamilies,
+  }
+
+  // Optional defense-in-depth tripwire (off by default): consumer declares the
+  // families it believes it needs; fail on drift so a dep bump that silently
+  // adds a native family is caught. Auto-derive stays authoritative.
+  const expect = process.env.NBCC_EXPECT_FAMILIES
+  if (expect !== undefined) {
+    const expected = new Set(
+      expect
+        .split(',')
+        .map((s) => s.trim())
+        .filter((s) => s !== ''),
+    )
+    const detected = new Set(detectActiveFamilies(auditOpts))
+    const added = [...detected].filter((f) => expected.has(f) === false)
+    const removed = [...expected].filter((f) => detected.has(f) === false)
+    if (added.length > 0 || removed.length > 0) {
+      console.error(
+        `native binding closure check: native-family drift in ${treeDir}\n` +
+          `  expected: ${[...expected].sort().join(', ') || '(none)'}\n` +
+          `  detected: ${[...detected].sort().join(', ') || '(none)'}\n` +
+          (added.length > 0 ? `  ADDED (unexpected native family): ${added.join(', ')}\n` : '') +
+          (removed.length > 0 ? `  REMOVED (declared but gone): ${removed.join(', ')}\n` : ''),
+      )
+      process.exit(1)
+    }
+  }
+
+  const problems = auditNativeBindingClosure(auditOpts)
+  const report = formatReport({ problems, treeDir })
+  if (problems.length === 0) {
+    console.log(`${report} [families: ${detectActiveFamilies(auditOpts).join(', ') || 'none'}]`)
+    return
+  }
+  console.error(report)
+  if (engagement === 'warn') {
+    console.error(
+      `native binding closure check: engagement=warn — reporting only, not failing (root has not opted into includeOptionalDependencies).`,
+    )
+    return
+  }
+  process.exit(1)
+}
+
+if (import.meta.main) {
+  main()
+}

--- a/genie/ci-scripts/native-dep-policy-audit.ts
+++ b/genie/ci-scripts/native-dep-policy-audit.ts
@@ -28,6 +28,7 @@ import {
   type NativeDependencyPolicyEntry,
   nativeDependencyPolicy,
 } from '../native-dependency-policy.ts'
+import { familyFor, stripVersion, stripYamlQuotes } from './native-dep-policy-lib.ts'
 
 const repoRoot = resolve(import.meta.dir, '../..')
 
@@ -48,17 +49,6 @@ type NativePackageMeta = {
   cpu?: true
   os?: true
   libc?: true
-}
-
-const stripYamlQuotes = (value: string): string => {
-  const trimmed = value.trim()
-  if (
-    (trimmed.startsWith("'") === true && trimmed.endsWith("'") === true) ||
-    (trimmed.startsWith('"') === true && trimmed.endsWith('"') === true)
-  ) {
-    return trimmed.slice(1, -1)
-  }
-  return trimmed
 }
 
 /**
@@ -93,30 +83,6 @@ const parseLockfilePackages = (text: string): Record<string, NativePackageMeta> 
   }
 
   return packages
-}
-
-/** Strip the trailing `@<version>` from a lockfile package key. */
-const stripVersion = (key: string): string => key.replace(/@[^@]+$/, '')
-
-/**
- * Map a versioned lockfile package name to its policy family key, if any policy
- * key is a prefix at a `-`/`/` boundary. Prefix matching keeps `esbuild`
- * (denied) distinct from `@esbuild/*` (fod-accepted).
- */
-const familyFor = ({
-  pkgName,
-  policyKeys,
-}: {
-  pkgName: string
-  policyKeys: readonly string[]
-}): string | undefined => {
-  for (const key of policyKeys) {
-    if (pkgName === key) return key
-    if (pkgName.startsWith(`${key}-`) === true || pkgName.startsWith(`${key}/`) === true) {
-      return key
-    }
-  }
-  return undefined
 }
 
 /** A lockfile package is "native-gated" if it carries cpu/os/libc constraints. */

--- a/genie/ci-scripts/native-dep-policy-lib.ts
+++ b/genie/ci-scripts/native-dep-policy-lib.ts
@@ -1,0 +1,67 @@
+/**
+ * Shared native-dependency lockfile-key helpers (issue #807).
+ *
+ * Single source of truth for the small string transforms both the policy audit
+ * (`native-dep-policy-audit.ts`) and the closure-completeness check
+ * (`native-binding-closure-check.ts`) need to map a pnpm lockfile key to its
+ * native-dependency family. Kept side-effect-free (no `node:fs`, no
+ * `import.meta.main` CLI block) so either consumer can import it without pulling
+ * the other tool's runtime into its bundle — this is the "one registry, not two"
+ * guarantee (decision 0007) at the helper layer, complementing the single
+ * `nativeDependencyPolicy` registry in `genie/native-dependency-policy.ts`.
+ */
+
+/**
+ * Strip matching surrounding single/double quotes from a YAML scalar. Used by
+ * the policy audit's small lockfile scanner (the closure check parses YAML
+ * proper and does not need it, but keeps the shared registry single-sourced).
+ */
+export const stripYamlQuotes = (value: string): string => {
+  const trimmed = value.trim()
+  if (
+    (trimmed.startsWith("'") === true && trimmed.endsWith("'") === true) ||
+    (trimmed.startsWith('"') === true && trimmed.endsWith('"') === true)
+  ) {
+    return trimmed.slice(1, -1)
+  }
+  return trimmed
+}
+
+/**
+ * Strip a pnpm peer-dependency suffix from a lockfile key.
+ *
+ * pnpm v9 `snapshots:` keys carry the resolved peer set in parentheses, one
+ * group per peer: `vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.0)`. The
+ * `packages:` section keys never carry it, so this is a no-op there.
+ */
+export const stripPeerSuffix = (key: string): string => key.replace(/\(.*\)$/, '')
+
+/**
+ * Remove the trailing `@<version>` from a lockfile key, returning the package
+ * name. Strips any peer suffix first so a peer-bearing `snapshots:` key parses
+ * to its bare name (`vite@8.0.16(react@19.0.0)` -> `vite`) instead of splitting
+ * on the last `@` inside the peer group (which silently mis-names the package
+ * and drops it from family matching — the peer-key skip the reviewers named).
+ */
+export const stripVersion = (key: string): string => stripPeerSuffix(key).replace(/@[^@]+$/, '')
+
+/**
+ * Map a versioned lockfile package name to its policy family key, if any policy
+ * key is a prefix at a `-`/`/` boundary. Prefix matching keeps `esbuild`
+ * (denied) distinct from `@esbuild/*` (fod-accepted).
+ */
+export const familyFor = ({
+  pkgName,
+  policyKeys,
+}: {
+  pkgName: string
+  policyKeys: readonly string[]
+}): string | undefined => {
+  for (const key of policyKeys) {
+    if (pkgName === key) return key
+    if (pkgName.startsWith(`${key}-`) === true || pkgName.startsWith(`${key}/`) === true) {
+      return key
+    }
+  }
+  return undefined
+}

--- a/nix/workspace-tools/lib/mk-native-binding-closure-check.nix
+++ b/nix/workspace-tools/lib/mk-native-binding-closure-check.nix
@@ -1,3 +1,5 @@
+# Proposed new file: nix/workspace-tools/lib/mk-native-binding-closure-check.nix
+#
 # Thin `nix flake check` wrapper around the native-binding closure-completeness
 # assertion. Given a prepared deps-FOD output, asserts every pure-package-artifact
 # native binding within the workspace's declared `supportedArchitectures` is
@@ -6,11 +8,14 @@
 # hard, precisely named check failure instead of a silent ship that only breaks
 # on the target arch.
 #
-# The assertion is ALWAYS-ON and auto-derives the required families from the
-# resolved closure (by design) — consumers never hand-list families;
-# `includeOptionalDependencies` is the separate per-consumer opt-in for the FIX
-# (materialization). This check is the guardrail that fails even when a consumer
-# forgets to opt in.
+# The assertion auto-derives the required families from the resolved closure
+# (decision 0007) — consumers never hand-list families. Its scope is honest:
+# it enforces closure-COMPLETENESS for a root that OPTED IN to carrying optional
+# bindings (engagement=fail). It does NOT decide whether a root that needs
+# bindings has opted in; a non-opted-in root runs in advisory warn mode
+# (decision 0009). The gate that catches a needs-binding root which forgot to opt
+# in is the downstream cross-platform build (e.g. a real `vite build` in CI), not
+# this check.
 #
 # Separate derivation, not an assertion inside the FOD: the deps FOD is a
 # content-addressed fixed-output derivation whose hash merely *describes* its
@@ -20,27 +25,35 @@
 # installPhase pre-archive as the hard #1 gate — both consume one detector.)
 #
 # REQUIRED bundling (do not drop): the check source imports the genie
-# `native-dependency-policy.ts`. A bare script store-path cannot resolve sibling
-# imports inside the `pkgs.bun` check derivation, so we `bun build` it into a
-# single self-contained store artifact first, then run that. (The standalone
-# prototype inlines the policy and skips this; the productionized version must
-# bundle.)
-{ pkgs, checkSource }:
+# `native-dependency-policy.ts` (the single policy registry) and the shared
+# `native-dep-policy-lib.ts` helpers. A bare script store-path cannot resolve
+# sibling imports inside the `pkgs.bun` check derivation, so `genieSrc` is the
+# (filtered) genie source dir and we `bun build` the check *within it* into a
+# single self-contained store artifact first, then run that. This is what makes
+# the wired artifact the same imported+bundled code the repo ships — one
+# registry, not a forked inline copy (decision 0007).
+{ pkgs, genieSrc }:
 
 let
   lib = pkgs.lib;
-  # Bundle the check + its imports into one self-contained JS file in the store.
+  # Bundle the check + its sibling imports into one self-contained JS file. The
+  # entry resolves `../native-dependency-policy.ts` and
+  # `./native-dep-policy-lib.ts` from within `genieSrc`.
   bundledCheck =
     pkgs.runCommand "native-binding-closure-check-bundled.js" { nativeBuildInputs = [ pkgs.bun ]; }
       ''
-        bun build ${checkSource} --target=bun --outfile "$out"
+        bun build ${genieSrc}/ci-scripts/native-binding-closure-check.ts \
+          --target=bun --outfile "$out"
       '';
 in
-# `makeOverridable` so each produced check carries a `.override { phase2 = true; }`
-# handle: an operator can force fail-mode for a one-off `nix build` red-on-broken
-# DEMONSTRATION against a pre-fix FOD WITHOUT editing the wired flake `checks` entry.
-# Steady state needs no override: a root that sets includeOptionalDependencies=true
-# already yields engagement=fail (see `engagement` below).
+# `makeOverridable` so each produced check carries a `.override { forceFail = true; }`
+# handle: anyone can force fail-mode for a one-off `nix build` red-on-broken
+# DEMONSTRATION against a pre-fix FOD WITHOUT editing the wired flake `checks`
+# entry. This is a demonstration aid only — it is NOT a rollout phase. Making
+# binding inclusion the default for a class of roots is a deliberate versioned
+# prepared-deps transition (decision 0009), not a flag flipped here. Steady state
+# needs no override: a root that opts into optional bindings already yields
+# engagement=fail (see `engagement` below).
 lib.makeOverridable (
   {
     # The prepared deps-FOD output derivation (root.depsBuild).
@@ -50,19 +63,30 @@ lib.makeOverridable (
     # Install dir of this root; the lockfile/workspace live under it in the tree.
     # "." for the aggregate root.
     installDir ? ".",
-    # Engagement phasing (rollout-safety guard). When the root opted into
-    # includeOptionalDependencies it is expected to be closure-complete -> hard
-    # FAIL. A root that has NOT opted in still runs the check but in WARN mode so
-    # a repin never breaks (phase 1). Flip `phase2` true to hard-fail by default.
+    # Engagement (decision 0009). A root that opts into optional-binding
+    # inclusion is expected to be closure-complete -> hard FAIL. A root that has
+    # NOT opted in still runs the check but in advisory WARN mode (its bindings
+    # are not required for that root), so a repin never breaks it.
     includeOptionalDependencies ? false,
-    phase2 ? false,
-    # Documented escape hatch: families intentionally excluded from the assertion.
-    waiveFamilies ? [ ],
+    # Demonstration-only force-fail (see `makeOverridable` note above). Not a
+    # rollout phase; leave false in wired checks.
+    forceFail ? false,
+    # Completeness criterion. `all-declared-triples` (default) is the
+    # shared-FOD-hash soundness gate. `build-platform` requires only the build
+    # host's triple, for a per-system hash fallback (needs buildPlatformTriple).
+    completenessMode ? "all-declared-triples",
+    # "os,cpu,libc" for build-platform mode (e.g. "linux,arm64,glibc"); null
+    # otherwise.
+    buildPlatformTriple ? null,
+    # Documented escape hatch: families/triples intentionally excluded from the
+    # assertion, reason-carrying (decision 0007 / DMP.NIX.NATIVE-R11). Format per
+    # entry: "family" or "family@os-cpu-libc" optionally "=reason".
+    waivers ? [ ],
   }:
   let
     subdir = if installDir == "." then "" else "/${installDir}";
-    engagement = if includeOptionalDependencies || phase2 then "fail" else "warn";
-    waiveArg = builtins.concatStringsSep "," waiveFamilies;
+    engagement = if includeOptionalDependencies || forceFail then "fail" else "warn";
+    waiveArg = builtins.concatStringsSep ";" waivers;
   in
   pkgs.runCommand "${name}-native-binding-closure-check"
     {
@@ -70,18 +94,32 @@ lib.makeOverridable (
       # Pure: the script only reads files from the FOD output. No network.
     }
     ''
+      set -o pipefail
       tree=${depsBuild}
       lockfile="$tree${subdir}/pnpm-lock.yaml"
       workspace="$tree${subdir}/pnpm-workspace.yaml"
 
+      export NBCC_ENGAGEMENT=${engagement}
+      export NBCC_WAIVERS=${lib.escapeShellArg waiveArg}
+      export NBCC_COMPLETENESS_MODE=${lib.escapeShellArg completenessMode}
+      ${lib.optionalString (
+        buildPlatformTriple != null
+      ) "export NBCC_BUILD_PLATFORM_TRIPLE=${lib.escapeShellArg buildPlatformTriple}"}
+
       if [ ! -f "$lockfile" ] || [ ! -f "$workspace" ]; then
-        echo "native-binding-closure-check: prepared tree is missing pnpm-lock.yaml/pnpm-workspace.yaml under ${installDir}" >&2
-        echo "  tree=$tree" >&2
+        msg="native-binding-closure-check: prepared tree is missing pnpm-lock.yaml/pnpm-workspace.yaml under ${installDir} (tree=$tree)"
+        # Respect engagement: a warn-mode (non-opted-in) root must not hard-fail
+        # on a missing lockfile — the check is advisory for it. An opted-in root
+        # with a missing lockfile is a real integrity failure.
+        if [ "${engagement}" = "warn" ]; then
+          echo "$msg" >&2
+          echo "native-binding-closure-check: engagement=warn — reporting only, not failing." | tee "$out"
+          exit 0
+        fi
+        echo "$msg" >&2
         exit 1
       fi
 
-      export NBCC_ENGAGEMENT=${engagement}
-      export NBCC_WAIVE_FAMILIES=${lib.escapeShellArg waiveArg}
       ${pkgs.bun}/bin/bun ${bundledCheck} "$tree${subdir}" "$lockfile" "$workspace" | tee "$out"
     ''
 )

--- a/nix/workspace-tools/lib/mk-native-binding-closure-check.nix
+++ b/nix/workspace-tools/lib/mk-native-binding-closure-check.nix
@@ -1,0 +1,87 @@
+# Thin `nix flake check` wrapper around the native-binding closure-completeness
+# assertion. Given a prepared deps-FOD output, asserts every pure-package-artifact
+# native binding within the workspace's declared `supportedArchitectures` is
+# physically present. Turns the #807 closure-completeness guarantee into a
+# build-graph gate: a bindingless (or partially materialized) deps FOD becomes a
+# hard, precisely named check failure instead of a silent ship that only breaks
+# on the target arch.
+#
+# The assertion is ALWAYS-ON and auto-derives the required families from the
+# resolved closure (by design) — consumers never hand-list families;
+# `includeOptionalDependencies` is the separate per-consumer opt-in for the FIX
+# (materialization). This check is the guardrail that fails even when a consumer
+# forgets to opt in.
+#
+# Separate derivation, not an assertion inside the FOD: the deps FOD is a
+# content-addressed fixed-output derivation whose hash merely *describes* its
+# content; a bindingless FOD is not "wrong", it is a different (incomplete)
+# artifact. The correctness judgement belongs in a normal check derivation whose
+# closure includes the FOD output. (The same script can ALSO run inside the FOD
+# installPhase pre-archive as the hard #1 gate — both consume one detector.)
+#
+# REQUIRED bundling (do not drop): the check source imports the genie
+# `native-dependency-policy.ts`. A bare script store-path cannot resolve sibling
+# imports inside the `pkgs.bun` check derivation, so we `bun build` it into a
+# single self-contained store artifact first, then run that. (The standalone
+# prototype inlines the policy and skips this; the productionized version must
+# bundle.)
+{ pkgs, checkSource }:
+
+let
+  lib = pkgs.lib;
+  # Bundle the check + its imports into one self-contained JS file in the store.
+  bundledCheck =
+    pkgs.runCommand "native-binding-closure-check-bundled.js" { nativeBuildInputs = [ pkgs.bun ]; }
+      ''
+        bun build ${checkSource} --target=bun --outfile "$out"
+      '';
+in
+# `makeOverridable` so each produced check carries a `.override { phase2 = true; }`
+# handle: an operator can force fail-mode for a one-off `nix build` red-on-broken
+# DEMONSTRATION against a pre-fix FOD WITHOUT editing the wired flake `checks` entry.
+# Steady state needs no override: a root that sets includeOptionalDependencies=true
+# already yields engagement=fail (see `engagement` below).
+lib.makeOverridable (
+  {
+    # The prepared deps-FOD output derivation (root.depsBuild).
+    depsBuild,
+    # Stable name for the check derivation.
+    name,
+    # Install dir of this root; the lockfile/workspace live under it in the tree.
+    # "." for the aggregate root.
+    installDir ? ".",
+    # Engagement phasing (rollout-safety guard). When the root opted into
+    # includeOptionalDependencies it is expected to be closure-complete -> hard
+    # FAIL. A root that has NOT opted in still runs the check but in WARN mode so
+    # a repin never breaks (phase 1). Flip `phase2` true to hard-fail by default.
+    includeOptionalDependencies ? false,
+    phase2 ? false,
+    # Documented escape hatch: families intentionally excluded from the assertion.
+    waiveFamilies ? [ ],
+  }:
+  let
+    subdir = if installDir == "." then "" else "/${installDir}";
+    engagement = if includeOptionalDependencies || phase2 then "fail" else "warn";
+    waiveArg = builtins.concatStringsSep "," waiveFamilies;
+  in
+  pkgs.runCommand "${name}-native-binding-closure-check"
+    {
+      nativeBuildInputs = [ pkgs.bun ];
+      # Pure: the script only reads files from the FOD output. No network.
+    }
+    ''
+      tree=${depsBuild}
+      lockfile="$tree${subdir}/pnpm-lock.yaml"
+      workspace="$tree${subdir}/pnpm-workspace.yaml"
+
+      if [ ! -f "$lockfile" ] || [ ! -f "$workspace" ]; then
+        echo "native-binding-closure-check: prepared tree is missing pnpm-lock.yaml/pnpm-workspace.yaml under ${installDir}" >&2
+        echo "  tree=$tree" >&2
+        exit 1
+      fi
+
+      export NBCC_ENGAGEMENT=${engagement}
+      export NBCC_WAIVE_FAMILIES=${lib.escapeShellArg waiveArg}
+      ${pkgs.bun}/bin/bun ${bundledCheck} "$tree${subdir}" "$lockfile" "$workspace" | tee "$out"
+    ''
+)

--- a/nix/workspace-tools/lib/mk-pnpm-cli.nix
+++ b/nix/workspace-tools/lib/mk-pnpm-cli.nix
@@ -32,6 +32,13 @@ let
   lib = pkgs.lib;
   pnpmDepsHelper = import ./mk-pnpm-deps.nix { inherit pkgs pnpm; };
   dependencyProfile = import ./dependency-materialization-profile.nix { inherit lib; };
+  # Closure-completeness guardrail (#807). Partially applied with the shared
+  # native-optional-families detector source; each install root gets a check
+  # derivation exposed via passthru.nativeBindingClosureChecks.<attrName>.
+  nativeBindingClosureCheckFactory = import ./mk-native-binding-closure-check.nix {
+    inherit pkgs;
+    checkSource = ../../../genie/ci-scripts/native-binding-closure-check.ts;
+  };
   inheritRootPatchedDependenciesScript = pkgs.writeText "inherit-root-patched-dependencies.cjs" ''
     const fs = require("node:fs");
     const path = require("node:path");
@@ -889,6 +896,22 @@ let
       else
         entry.hash;
 
+  # Per-install-root opt-in: carry the workspace's declared optional native
+  # bindings (pure-package-artifact families: @rolldown/binding-*, @esbuild/*,
+  # lightningcss, oxc, ...) into this root's prepared deps FOD by dropping
+  # `--no-optional`, bounded by pnpm-workspace.yaml `supportedArchitectures`.
+  # Default stays false so bun-built CLIs that never load a native binding keep
+  # small, platform-neutral prepared trees (backward-compatible). A consumer
+  # whose build or runtime resolves such a binding from the isolated pnpm store
+  # (e.g. `vite build` -> rolldown) sets this true; the native-binding closure
+  # check then asserts every declared triple is present.
+  includeOptionalDependenciesForInstallRoot =
+    installDir:
+    let
+      entry = builtins.getAttr installDir depsBuilds;
+    in
+    entry.includeOptionalDependencies or false;
+
   mkdirOutParentCmd =
     relPath:
     let
@@ -1133,6 +1156,7 @@ let
           ${pkgs.nodejs}/bin/node ${inheritRootPatchedDependenciesScript} .root-patch-authority ${lib.escapeShellArg root.installDir}
           rm -rf .root-patch-authority
         '';
+        includeOptionalDependencies = includeOptionalDependenciesForInstallRoot root.installDir;
         pnpmDepsHash = depsBuildHashForInstallRoot root.installDir;
       };
     in
@@ -1161,6 +1185,7 @@ let
       # Ask pnpm to materialize the target package's dependency closure, not every
       # importer visible in that staged workspace.
       pnpmFilters = [ "${packageJson.name}..." ];
+      includeOptionalDependencies = includeOptionalDependenciesForInstallRoot ".";
       # Fixed-output dependency preparation must be a pure materialization of
       # the staged manifests and lockfile. Unfrozen installs can rewrite the
       # effective dependency graph and produce hash ping-pong across builders.
@@ -1460,6 +1485,21 @@ pkgs.stdenv.mkDerivation {
       hash = depsBuildHashForInstallRoot root.installDir;
       freshness = (installRootProfile root).freshness;
     }) depsInstallRoots;
+    # One closure-completeness check per install root, keyed by the same
+    # normalized attrName as depsBuildsByInstallRoot (installDir "." -> "root").
+    # Consumers wire e.g. `checks.<system>.<name> = cli.nativeBindingClosureChecks.root;`.
+    # Engagement is warn-mode unless the root opted into includeOptionalDependencies.
+    nativeBindingClosureChecks = builtins.listToAttrs (
+      map (root: {
+        name = root.attrName;
+        value = nativeBindingClosureCheckFactory {
+          depsBuild = root.depsBuild;
+          name = "${name}-${root.attrName}";
+          installDir = root.installDir;
+          includeOptionalDependencies = includeOptionalDependenciesForInstallRoot root.installDir;
+        };
+      }) depsInstallRoots
+    );
   };
 
   buildPhase = ''

--- a/nix/workspace-tools/lib/mk-pnpm-cli.nix
+++ b/nix/workspace-tools/lib/mk-pnpm-cli.nix
@@ -35,9 +35,20 @@ let
   # Closure-completeness guardrail (#807). Partially applied with the shared
   # native-optional-families detector source; each install root gets a check
   # derivation exposed via passthru.nativeBindingClosureChecks.<attrName>.
+  # Filtered genie source so the check's sibling imports resolve during
+  # `bun build`: `../native-dependency-policy.ts` (the single policy registry)
+  # and `./native-dep-policy-lib.ts` (shared key helpers). A bare file
+  # store-path cannot see its siblings inside the pkgs.bun check derivation.
   nativeBindingClosureCheckFactory = import ./mk-native-binding-closure-check.nix {
     inherit pkgs;
-    checkSource = ../../../genie/ci-scripts/native-binding-closure-check.ts;
+    genieSrc = lib.fileset.toSource {
+      root = ../../../genie;
+      fileset = lib.fileset.unions [
+        ../../../genie/native-dependency-policy.ts
+        ../../../genie/ci-scripts/native-dep-policy-lib.ts
+        ../../../genie/ci-scripts/native-binding-closure-check.ts
+      ];
+    };
   };
   inheritRootPatchedDependenciesScript = pkgs.writeText "inherit-root-patched-dependencies.cjs" ''
     const fs = require("node:fs");


### PR DESCRIPTION
Relates to #807 and #920 (draft proposal — not a full close of either)

## Why
The deps FOD (`mk-pnpm-deps.nix mkDeps`) installs with `--no-optional` by default, which silently produces a tree that carries a consumer package (e.g. `rolldown`) but **zero** native bindings. That tree builds and caches happily on the build host, then fails at `vite build` / runtime on a platform whose binding was never fetched — a downstream consumer's aarch64 vite build could not load `@rolldown/binding-linux-arm64-gnu`. Nothing in the closure hash catches this: the hash faithfully describes a bindingless tree.

#807 asked for a native optional-package family **audit**. This turns that audit into an **executable closure-completeness guarantee**, and adds the per-root optionals opt-in that #920's reliable hash repair needs.

## What
- **`genie/ci-scripts/native-binding-closure-check.ts`** — auto-derives the required `pure-package-artifact` family set from a root's resolved (dev+prod) lockfile closure and asserts that every declared `supportedArchitectures` triple is physically present in the prepared tree; fails naming `family + missing triple(s)`. `NBCC_ENGAGEMENT=warn|fail` phases the rollout.
- **`nix/workspace-tools/lib/mk-native-binding-closure-check.nix`** — a check derivation whose closure includes the FOD output; `bun build`-bundles the script and runs it. Engagement is `fail` when the root opted into optionals, else `warn`.
- **`mk-pnpm-cli.nix`** — plumbs `includeOptionalDependencies` per install root (`depsBuilds."." = { hash; includeOptionalDependencies = true; }`) into both `mkDeps` call sites (`mkDeps` already consumes it to drop `--no-optional`), and exposes `passthru.nativeBindingClosureChecks.<attrName>` so consumers can wire it as a flake check. Default stays `false` (`--no-optional`) — backward compatible.
- **`native-binding-closure-check.test.sh`** — 6 fixtures including multi-document RED (bindingless) / GREEN (complete) regression guards.

## How
- **Auto-derive, not a hand-list.** The required-family set is computed from the closure, not declared. On the real `vite@8` chain the detector flags both `rolldown` and `lightningcss` — a hand-written list would forget the latter. Over-inclusion is safe: pnpm optional install is per-root all-or-nothing, so materializing an unused binding is free.
- **Multi-document lockfile parser.** pnpm writes a `---`-separated pnpm-CLI bootstrap document before the workspace document, each with its own `packages:` / `snapshots:`. The parser leaves a section on a top-level key and re-enters at the next document rather than `break`ing at the first boundary — otherwise it only ever sees the ~20 bootstrap snapshots and never reaches the workspace's `rolldown` / `lightningcss` bindings, silently passing vacuously.
- **Check derivation, not an in-FOD assertion.** The deps FOD is content-addressed; its hash merely *describes* content, so a bindingless FOD is not "wrong", just incomplete. The correctness judgement belongs in a normal check derivation whose closure includes the FOD output.

## Rationale
- Phase-1 **warn** default means a repin never breaks: the check reports the gap but exits 0 unless a root opts into `includeOptionalDependencies` (then hard-fail). Existing bun-built CLIs that carry a native family in-closure but never bundle it are unaffected.
- Keeping the single shared deps-FOD hash: with optionals on and `supportedArchitectures` covering the declared triples, pnpm materializes all triples cross-host, so the tree is host-invariant and `mkSharedHash` stays valid. The all-declared-triples assertion **is** the shared-soundness guard — it fails exactly on the host-variant tree that would break a shared hash.

## Known limitations (draft)
- The prototype **inlines** its `native-dependency-policy` classification and lockfile parsers rather than importing the shared `genie/native-dependency-policy.ts` / `genie/ci-scripts/native-dep-policy-audit.ts`. Deduping onto those shared sources (so there is one registry, per #807's intent) is a follow-up before this goes ready.
- The RED/GREEN validation ran against synthetic fixtures + a fresh install; wiring the assertion into a live normalized FOD build (the natural first target: a downstream aarch64-linux consumer) is the remaining fidelity step.

## Validation
- `native-binding-closure-check.test.sh` — **6/6 fixtures pass locally**, including the multi-document vacuous-pass regression guards (RED bindingless / GREEN complete).
- `nix-instantiate --parse` clean on both `mk-native-binding-closure-check.nix` and the modified `mk-pnpm-cli.nix`; `checkSource` path and factory signature verified against the call site; `mkDeps` already accepts `includeOptionalDependencies`.
- `oxfmt --check` + `oxlint` clean on the new `.ts`; full `nix flake check` / a live FOD build were not run locally; draft CI covers eval.

Draft: not for merge.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🪻 cl1-orchid |
| `agent_session_id` | 3aff42e1-d902-4ed2-8ea4-60e39f0162e2 |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.202 |
| `agent_runtime` | Claude Code 2.1.202 |
| `agent_model` | claude-opus-4-8 |
| `runtime_profile` | /nix/store/nc1jjzy8zzwg31q8dig26wl72jwwbgdv-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/f8j6sj5i9i1afq6lycd05sfvpgn8x9wl-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | eu-work/schickling-assistant/2026-07-19-ci-cache-pnpm-v2 |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->