### PR TITLE
fix(notion-effect-schema): hoist whitespace outside markdown emphasis delimiters

### DIFF
--- a/packages/@overeng/notion-effect-schema/src/rich-text-utils.ts
+++ b/packages/@overeng/notion-effect-schema/src/rich-text-utils.ts
@@ -76,8 +76,16 @@ const applyAnnotations = (opts: { text: string; steps: readonly AnnotationStep[]
 /** Apply markdown formatting based on annotations */
 const applyMarkdownAnnotations = (opts: { text: string; annotations: TextAnnotations }): string => {
   const { text, annotations } = opts
-  return applyAnnotations({
-    text,
+  // CommonMark emphasis/strong delimiters must directly hug non-whitespace (the
+  // "flanking" rule): `** bold **` is not parsed as emphasis and renders the
+  // literal asterisks. Notion bold/italic runs frequently include a trailing (or
+  // leading) space in `plain_text`, so hoist any surrounding whitespace outside
+  // the wrappers to keep the delimiters valid. An all-whitespace run gets no
+  // wrappers at all.
+  const [, leading = '', core = '', trailing = ''] = text.match(/^(\s*)([\s\S]*?)(\s*)$/) ?? []
+  if (core === '') return text
+  const wrapped = applyAnnotations({
+    text: core,
     steps: [
       { active: annotations.code, wrap: (s) => `\`${s}\`` },
       { active: annotations.strikethrough, wrap: (s) => `~~${s}~~` },
@@ -87,6 +95,7 @@ const applyMarkdownAnnotations = (opts: { text: string; annotations: TextAnnotat
       { active: annotations.underline, wrap: (s) => `<u>${s}</u>` },
     ],
   })
+  return `${leading}${wrapped}${trailing}`
 }
 
 /** Convert a single text rich text element to markdown */

--- a/packages/@overeng/notion-effect-schema/src/rich-text-utils.unit.test.ts
+++ b/packages/@overeng/notion-effect-schema/src/rich-text-utils.unit.test.ts
@@ -205,7 +205,9 @@ describe('toMarkdown', () => {
       makeText('„Romantik - was ist das?" ', { bold: true }),
       makeText('Musik - Dichtung - Gebet - Traum'),
     ]
-    expect(toMarkdown(richText)).toBe('**„Romantik - was ist das?"** Musik - Dichtung - Gebet - Traum')
+    expect(toMarkdown(richText)).toBe(
+      '**„Romantik - was ist das?"** Musik - Dichtung - Gebet - Traum',
+    )
   })
 
   it('drops delimiters for an all-whitespace formatted run', () => {

--- a/packages/@overeng/notion-effect-schema/src/rich-text-utils.unit.test.ts
+++ b/packages/@overeng/notion-effect-schema/src/rich-text-utils.unit.test.ts
@@ -182,6 +182,37 @@ describe('toMarkdown', () => {
     expect(toMarkdown(richText)).toBe('***Hello***')
   })
 
+  // Notion runs often carry a trailing/leading space inside the formatted run.
+  // `** bold **` violates CommonMark flanking rules and renders literal
+  // asterisks, so surrounding whitespace must sit outside the delimiters.
+  it('hoists a trailing space outside bold delimiters', () => {
+    const richText: RichTextArray = [makeText('18 Uhr ', { bold: true })]
+    expect(toMarkdown(richText)).toBe('**18 Uhr** ')
+  })
+
+  it('hoists a leading space outside bold delimiters', () => {
+    const richText: RichTextArray = [makeText(' Romantik', { bold: true })]
+    expect(toMarkdown(richText)).toBe(' **Romantik**')
+  })
+
+  it('hoists surrounding whitespace outside italic delimiters', () => {
+    const richText: RichTextArray = [makeText('  emphasis  ', { italic: true })]
+    expect(toMarkdown(richText)).toBe('  *emphasis*  ')
+  })
+
+  it('keeps a bold run and following text joinable without stray asterisks', () => {
+    const richText: RichTextArray = [
+      makeText('„Romantik - was ist das?" ', { bold: true }),
+      makeText('Musik - Dichtung - Gebet - Traum'),
+    ]
+    expect(toMarkdown(richText)).toBe('**„Romantik - was ist das?"** Musik - Dichtung - Gebet - Traum')
+  })
+
+  it('drops delimiters for an all-whitespace formatted run', () => {
+    const richText: RichTextArray = [makeText('   ', { bold: true })]
+    expect(toMarkdown(richText)).toBe('   ')
+  })
+
   it('converts links', () => {
     const richText: RichTextArray = [makeText('click here', { href: 'https://example.com' })]
     expect(toMarkdown(richText)).toBe('[click here](https://example.com)')


### PR DESCRIPTION
## Problem

`RichTextUtils.toMarkdown` wraps each Notion rich-text run's raw `plain_text` in emphasis delimiters (`**…**`, `*…*`). Notion runs very commonly carry a leading or trailing space inside the formatted run (e.g. a bold run `"18 Uhr "` or `"„Romantik…?" "`), producing `**18 Uhr **`.

Per CommonMark's flanking rules, a `**` immediately preceded by whitespace cannot *close* emphasis. So `**text **` is not parsed as strong and the delimiters render as **literal asterisks** in the final HTML. The failure is data-dependent: runs with a tight selection render fine, runs with a stray edge space leak `**`/`*` onto the page. A downstream site rendering event descriptions from Notion showed literal `**` scattered through the copy for exactly this reason.

## Goal

A formatted run with surrounding whitespace serializes to valid CommonMark that renders as `<strong>`/`<em>`, with the whitespace preserved in the right place.

## Decisions

- Fix in the markdown path (`applyMarkdownAnnotations`) rather than the shared `applyAnnotations` combinator: the flanking constraint is markdown-specific (the HTML target's `<strong> x </strong>` is perfectly valid), so the whitespace-hoisting logic belongs with the markdown wrappers, not in the shared ordering combinator.
- Hoist leading/trailing whitespace *outside* the wrappers (`**text** `) instead of trimming it, so intended spacing between runs is preserved.
- An all-whitespace run emits no delimiters at all (previously `**   **`, now `   `).

## Verification

New unit tests in `rich-text-utils.unit.test.ts` cover trailing/leading/both-side whitespace for bold and italic, a bold-run-then-plain-run join, and the all-whitespace case. Existing bold/italic/code assertions are unchanged (no regression for tight runs).

Cross-checked the emitted markdown through `micromark` (the same CommonMark engine remark/MDX use):

| input run (bold)            | before          | after (this PR) | renders |
| --------------------------- | --------------- | --------------- | ------- |
| `18 Uhr ` (trailing space)  | `**18 Uhr **`   | `**18 Uhr** `   | `<strong>18 Uhr</strong>` |
| ` Romantik` (leading space) | `** Romantik**` | ` **Romantik**` | `<strong>Romantik</strong>` |
| `18 Uhr` (no space)         | `**18 Uhr**`    | `**18 Uhr**`    | `<strong>18 Uhr</strong>` (unchanged) |

Before, the first two rendered as literal `**…**` paragraphs.

## Complexity

No new complexity — one regex split plus an early return in an existing function.

## Concerns

None functional. The `<u>` underline fallback also gets whitespace hoisted; harmless (HTML doesn't care where the space sits relative to the tag).

## Follow-ups

None.

## References

Found via a downstream consumer rendering Notion event content to a static site.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🛤️ cl1-trail |
| `agent_session_id` | 1fbe585b-e551-4aec-8528-f0bda39384e3 |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.202 |
| `agent_runtime` | Claude Code 2.1.202 |
| `agent_model` | claude-opus-4-8 |
| `runtime_profile` | /nix/store/7zk2q0ys9q4a56njyzrhjb80la5x3zig-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/syf5wix8dv0qpkfhi5x7xz1ykpbwqww2-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-19-fix-notion-md-bold-whitespace |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->