### PR TITLE
fix(react-inspector): use current schema literal API

### DIFF
--- a/packages/@overeng/react-inspector/src/schema/lineage.ts
+++ b/packages/@overeng/react-inspector/src/schema/lineage.ts
@@ -68,7 +68,7 @@ const LineageRefSchema = Schema.Union([
 const DerivationKindSchema = Schema.Union([
   Schema.TaggedStruct('Pure', {}),
   Schema.TaggedStruct('Aggregation', {
-    op: Schema.Literals(['sum', 'count', 'min', 'max', 'avg', 'custom']),
+    op: Schema.Literal('sum', 'count', 'min', 'max', 'avg', 'custom'),
   }),
   Schema.TaggedStruct('Reduction', { description: Schema.String }),
   Schema.TaggedStruct('External', { service: Schema.String }),
@@ -111,7 +111,7 @@ const AuthoritySchema = Schema.Struct({
   readers: Schema.optionalKey(Schema.Array(Schema.String)),
 })
 const FreshnessSchema = Schema.Struct({
-  capturedAt: Schema.optionalKey(Schema.Literals(['now', 'event-time', 'snapshot'])),
+  capturedAt: Schema.optionalKey(Schema.Literal('now', 'event-time', 'snapshot')),
   maxAgeMs: Schema.optionalKey(Schema.Finite),
 })
 const ReferenceSchema = Schema.TaggedStruct('ForeignKey', {

--- a/packages/@overeng/react-inspector/src/schema/lineage.ts
+++ b/packages/@overeng/react-inspector/src/schema/lineage.ts
@@ -68,7 +68,14 @@ const LineageRefSchema = Schema.Union([
 const DerivationKindSchema = Schema.Union([
   Schema.TaggedStruct('Pure', {}),
   Schema.TaggedStruct('Aggregation', {
-    op: Schema.Literal('sum', 'count', 'min', 'max', 'avg', 'custom'),
+    op: Schema.Union([
+      Schema.Literal('sum'),
+      Schema.Literal('count'),
+      Schema.Literal('min'),
+      Schema.Literal('max'),
+      Schema.Literal('avg'),
+      Schema.Literal('custom'),
+    ]),
   }),
   Schema.TaggedStruct('Reduction', { description: Schema.String }),
   Schema.TaggedStruct('External', { service: Schema.String }),
@@ -111,7 +118,9 @@ const AuthoritySchema = Schema.Struct({
   readers: Schema.optionalKey(Schema.Array(Schema.String)),
 })
 const FreshnessSchema = Schema.Struct({
-  capturedAt: Schema.optionalKey(Schema.Literal('now', 'event-time', 'snapshot')),
+  capturedAt: Schema.optionalKey(
+    Schema.Union([Schema.Literal('now'), Schema.Literal('event-time'), Schema.Literal('snapshot')]),
+  ),
   maxAgeMs: Schema.optionalKey(Schema.Finite),
 })
 const ReferenceSchema = Schema.TaggedStruct('ForeignKey', {


### PR DESCRIPTION
Fixes the `@overeng/react-inspector` lineage schemas so they do not call the removed plural `Schema.Literals` helper.

The replacement uses unions of single-literal schemas, which typechecks in the current `effect-utils` package context and avoids the downstream runtime failure seen in dotfiles Forge imports.

Verification:
- `CI=1 devenv tasks run check:quick`
- `CI=1 DEVENV_TASK_PASSTHROUGH=1 devenv shell -- pnpm --filter @overeng/react-inspector exec vitest run --passWithNoTests`

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | ⬛ co1-void |
| `agent_session_id` | d13bdcee-a0f9-4454-94e0-8d0f256e26f3 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.144.1 |
| `agent_runtime` | Codex CLI 0.144.1 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/1n76sy6i9y3ki3k4w04jksqvygw67sj0-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/jn6r0r7r59x3a525jch4pwzwykszqp60-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-20-react-inspector-schema-literal |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@4eac376 |
</details>
<!-- agent-footer:end -->