### PR TITLE
Add megarepo member resolver enforcing lock/checkout lockstep

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -273,6 +273,13 @@
       # CLI guard helpers: .mkCliGuard for single guards, .fromTasks/.stripGuards for task-driven guards
       lib.cliGuard = { pkgs }: import ./nix/devenv-modules/tasks/lib/cli-guard.nix { inherit pkgs; };
 
+      # Resolve a megarepo member for Nix evaluation while enforcing that a
+      # commit-pinned checkout matches megarepo.lock (see nix/megarepo-member.nix).
+      # Consumers MUST load this from the pinned flake input rather than from the
+      # materialized checkout, otherwise resolving the member would require the
+      # member to already be resolved.
+      lib.megarepoMember = { lib }: import ./nix/megarepo-member.nix { inherit lib; };
+
       # Builder function for external repos to create their own Bun CLIs
       lib.mkBunCli = { pkgs }: import ./nix/workspace-tools/lib/mk-bun-cli.nix { inherit pkgs; };
 

--- a/nix/megarepo-member.nix
+++ b/nix/megarepo-member.nix
@@ -1,0 +1,106 @@
+# Resolve a megarepo member for Nix evaluation, guaranteeing that the
+# materialized checkout matches `megarepo.lock`.
+#
+# WHY THIS EXISTS
+#
+# Repos whose `devenv.nix` imports Nix helpers from a megarepo member (rather
+# than only from the pinned flake input) need the member's *Nix* outputs and the
+# member's *TypeScript generator sources* to come from the same revision — the
+# `genie` CLI built by Nix evaluates `.genie.ts` sources read from the same
+# checkout. Reading `./repos/<member>` directly achieves that lockstep, but it
+# feeds an untracked, unversioned directory into Nix evaluation: if the checkout
+# drifts from `megarepo.lock` (e.g. the lock moved but `mr apply` was never
+# re-run), evaluation fails with an opaque error such as
+# `error: attribute 'gh-labels' missing` before the shell can even be entered —
+# and the diagnostic that would explain it (`mr:lock-sync-check`) lives *inside*
+# that shell. See livestorejs/livestore#1467.
+#
+# This helper keeps the lockstep property but makes drift an explicit, actionable
+# error instead of an opaque one.
+#
+# WORKTREE MODES
+#
+# `mr` materializes members in one of two modes, distinguishable from the
+# worktree name recorded in the member's `.git` file
+# (`gitdir: …/.bare/worktrees/<name>`):
+#
+#   * commit mode   — `<name>` is a 40-char sha; the member is pinned to exactly
+#                     that revision, so it MUST match `megarepo.lock`.
+#   * tracking mode — `<name>` is a branch; the member is deliberately editable
+#                     (`mr config pin <member> --checkout <ref>`) for
+#                     co-development, so its revision is EXPECTED to differ and
+#                     is left alone.
+#
+# Anything we cannot positively identify as drifted is allowed through: we only
+# fail when we are certain the checkout disagrees with the lock.
+{ lib }:
+{
+  /*
+    Resolve a member to a flake, preferring the materialized checkout.
+
+    - not materialized      -> `pinned` (the flake input)
+    - tracking worktree     -> local checkout (deliberate co-development)
+    - commit worktree, match-> local checkout (lockstep holds)
+    - commit worktree, drift-> throw with the exact remediation
+  */
+  resolve =
+    {
+      # Member name as it appears in `megarepo.lock`, e.g. "effect-utils".
+      name,
+      # Path to the materialized member, e.g. `./repos/effect-utils`.
+      memberPath,
+      # Path to the repo's `megarepo.lock`.
+      lockFile,
+      # Flake input to fall back to when the member is not materialized.
+      pinned,
+    }:
+    let
+      gitPath = memberPath + "/.git";
+
+      # A materialized member is a git *worktree*, so `.git` is a regular file
+      # containing `gitdir: <path>`; a plain clone has a `.git/` directory (and
+      # therefore a `.git/HEAD`). Probing for `.git/HEAD` distinguishes the two
+      # using only `pathExists` — `readFileType` refuses to inspect a path
+      # reached through the member symlink.
+      isWorktree = builtins.pathExists gitPath && !builtins.pathExists (memberPath + "/.git/HEAD");
+
+      worktreeName =
+        if !isWorktree then
+          null
+        else
+          lib.last (lib.splitString "/" (lib.removeSuffix "\n" (builtins.readFile gitPath)));
+
+      # 40 hex chars => the worktree is pinned to a concrete commit.
+      isCommitMode = worktreeName != null && builtins.match "[0-9a-f]{40}" worktreeName != null;
+
+      lockedCommit = (builtins.fromJSON (builtins.readFile lockFile)).members.${name}.commit;
+
+      localFlake = builtins.getFlake (builtins.toString memberPath);
+    in
+    if !builtins.pathExists (memberPath + "/flake.nix") then
+      pinned
+    else if !isCommitMode then
+      # Tracking worktree (or an unidentifiable checkout): deliberate override.
+      localFlake
+    else if worktreeName == lockedCommit then
+      localFlake
+    else
+      throw ''
+        megarepo member '${name}' is out of sync with megarepo.lock.
+
+          materialized: ${worktreeName}
+          expected:     ${lockedCommit}
+
+        Nix helpers and generator sources are both read from this checkout, so a
+        mismatch would silently pair the '${name}' Nix build with generator
+        sources from a different revision.
+
+        Fix it by re-materializing the member (runnable outside the dev shell):
+
+          mr apply
+
+        To co-develop '${name}' instead, switch it to a tracking worktree:
+
+          mr config pin ${name} --checkout <ref>
+      '';
+}


### PR DESCRIPTION
Foundation for fixing livestorejs/livestore#1467 (`devenv shell` failing with `error: attribute 'gh-labels' missing` from a clean checkout). Consumer adoption follows in a downstream PR.

## Problem

A repo whose `devenv.nix` imports Nix helpers from a **materialized megarepo member** — rather than only from the pinned flake input — depends on two things agreeing:

- the member's **Nix outputs** (which build the `genie` CLI), and
- the member's **TypeScript generator sources** (the `.genie.ts` files that CLI evaluates)

Reading `./repos/<member>` directly is what guarantees they're the same revision. But it also feeds an **untracked, unversioned directory into Nix evaluation**. If that checkout drifts from `megarepo.lock` — the lock moved, `mr apply` was never re-run — evaluation dies with an opaque error *before the shell can be entered*. The check that would have explained it (`mr:lock-sync-check`) only runs **inside** that shell, so the diagnostic is unreachable exactly when it's needed.

Note that `repos/` is gitignored, so a `git status`-clean checkout says nothing about whether members match the lock.

## Approach

`lib.megarepoMember.resolve` keeps the lockstep property and makes drift explicit:

| state | result |
|---|---|
| member not materialized | pinned flake input |
| tracking worktree | local checkout (deliberate co-development) |
| commit worktree, matches lock | local checkout (lockstep holds) |
| commit worktree, drifted | throw naming both revisions + the remedy |

Modes are distinguished from the worktree name recorded in the member's `.git` file (`gitdir: …/worktrees/<name>`): a 40-char sha means the member is pinned to a commit and **must** match the lock; a branch name means it's deliberately editable, so its revision is expected to differ and is left alone. That keeps `mr config pin <member> --checkout <ref>` co-development working untouched.

Implementation stays pure — only `pathExists` and `readFile`. `readFileType` refuses to inspect paths reached through the member symlink, and Nix has no `readlink`, so the worktree/clone distinction is made by probing for `.git/HEAD`.

Consumers must load the helper from the **pinned flake input**, never the materialized checkout — otherwise resolving a member would require that member to already be resolved.

## Validation

Evaluated against a real materialized member in all three states:

- **matching** (`b5e983b0` == lock) → resolves to the local flake, `devenvModules` present — no behaviour change
- **drifted** (`b5e983b0` vs lock `f007561eb`, i.e. the reported failure) → throws, naming both revisions and pointing at `mr apply`
- **tracking** (worktree name `main`) → correctly classified as non-commit mode, left alone

`check:quick` passes.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🌄 cl2-vale |
| `agent_session_id` | d1dbf622-1045-4840-aa99-085f5211d5cf |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.215 |
| `agent_runtime` | Claude Code 2.1.215 |
| `agent_model` | claude-opus-4-8 |
| `runtime_profile` | /nix/store/r0yyx5vd9frm4d8klx3i3c1930d9k2ix-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/1rg1cdw91rx4gris2kh0sdwyd4d39nxf-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-21-megarepo-member-lockstep |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->