### PR TITLE
fix(megarepo): fail apply when it leaves a member drifted from the lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,23 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- **@overeng/megarepo**: `mr apply` now fails when it leaves a pinned member drifted from
+  `megarepo.lock`. Previously every path returning `skipped` exited 0, so apply could report
+  success over a workspace that disagreed with the lock that produced it — invisible because
+  `repos/` is gitignored and `mr:lock-sync-check` compares lock against lock, never workspace
+  against lock. Commit and tag worktrees are pinned materializations and now report an error
+  naming both revisions; branch worktrees stay a skip, since co-development deliberately moves
+  `HEAD` ahead of the lock. The dirty-worktree protection is unchanged — apply still refuses to
+  clobber uncommitted work, it just no longer claims success while doing so. Fixes #962; this is
+  the root cause behind livestorejs/livestore#1467 and #1168.
+
 - **genie/ci-workflow**: add opt-in megarepo store caching — `applyMegarepoLockStep({ cacheableStore: true })`
   pins `MEGAREPO_STORE` to a stable `cacheableMegarepoStore` path, and reusable
   `restoreMegarepoStoreStep({ skip })` / `saveMegarepoStoreStep({ skip })` (actions/cache keyed on the
   consumer's `megarepo.lock`, partitioned by the `skip` set so a partial store never poisons a full
   job) go around it so CI jobs stop cold-cloning large members (e.g. `effect-ts/effect`)
   every run. The default `jobLocalMegarepoStore` (run-scoped) is unchanged; caching requires the stable
-  path because GitHub derives an actions/cache *version* from the path, so a run-scoped path never
+  path because GitHub derives an actions/cache _version_ from the path, so a run-scoped path never
   restores. Validated end-to-end in a consumer (restore hits, one deduped cache). Default behavior for
   existing consumers is untouched.
 

--- a/packages/@overeng/megarepo/docs/decisions/0009-apply-drift-postcondition.md
+++ b/packages/@overeng/megarepo/docs/decisions/0009-apply-drift-postcondition.md
@@ -1,0 +1,50 @@
+# Fail apply when a pinned worktree stays drifted from the lock
+
+## Status
+
+accepted
+
+## Context
+
+`mr apply` promises Lock → Workspace, but every path that returned `skipped`
+exited 0. When a skip left a member materialized at a revision other than the one
+`megarepo.lock` records, apply reported success over a workspace that disagreed
+with the lock that produced it.
+
+Nothing else caught it. `repos/` is gitignored, so `git status` stays clean.
+`mr:lock-sync-check` compares `devenv.lock` against `megarepo.lock` — lock against
+lock, never workspace against lock. `mr status` does compute the drift, but nothing
+gates on it.
+
+That combination put a contributor's checkout at one revision while the lock said
+another (livestorejs/livestore#1467, and the same failure a second time in
+livestorejs/livestore#1168). They had not skipped a step; apply told them it had
+succeeded.
+
+## Decision
+
+A commit worktree (`refs/commits/<sha>/`) is a _pinned materialization_: apply put
+it there to satisfy an exact lock entry, and nothing else legitimately moves it. If
+its sha no longer matches the lock, apply failed its contract regardless of why it
+could not switch — so it reports an error naming both revisions and exits non-zero,
+instead of a silent skip.
+
+Branch worktrees are excluded. Co-development deliberately moves `HEAD` ahead of the
+lock, and failing there would break the normal local loop.
+
+The dirty-worktree protection itself is unchanged: apply still refuses to clobber
+uncommitted work. It just no longer claims success while doing so.
+
+## Alternatives considered
+
+- **Fail on any drifted worktree, branch or commit.** Simpler rule, but it breaks
+  co-development: a branch worktree ahead of the lock is the intended state during
+  local development, not an error.
+- **Force-switch the worktree to the locked revision.** Restores the postcondition
+  without a new error path, but silently discards uncommitted work. `--force`
+  already exists for callers who want that.
+- **Detect the drift in each downstream consumer.** A consumer-side guard (for
+  example, validating the checkout inside a `devenv.nix`) was proposed in
+  livestorejs/livestore#1468. It special-cases one consumer, leaves every other one
+  exposed, and #1467 recurring after #1168 is evidence that the defect has to be
+  fixed where the workspace is written.

--- a/packages/@overeng/megarepo/docs/spec.md
+++ b/packages/@overeng/megarepo/docs/spec.md
@@ -482,7 +482,8 @@ uncommitted work and `--force` was not given — it reports an **error** naming 
 revisions, not a skip, and exits non-zero.
 
 Branch worktrees are exempt. Co-development deliberately moves `HEAD` ahead of the
-lock, so a branch worktree that disagrees stays a skip.
+lock, so a branch worktree that disagrees stays a skip. See
+[decision 0009](./decisions/0009-apply-drift-postcondition.md).
 
 This postcondition matters because the drift is otherwise invisible: `repos/` is
 gitignored, so `git status` stays clean, and `mr:lock-sync-check` compares

--- a/packages/@overeng/megarepo/docs/spec.md
+++ b/packages/@overeng/megarepo/docs/spec.md
@@ -473,6 +473,29 @@ Strict mode that guarantees exact reproducibility from the lock file:
 - **Clones and fetches if needed** - lock apply will clone bare repos and fetch updates to materialize the locked state; it only prevents _updating_ the lock file
 - **Never modifies lock file** - the lock is read-only, all state comes from the committed lock
 
+**Postcondition — Lock → Workspace:** when apply exits successfully, every member
+it handled is materialized at the revision `megarepo.lock` records. A commit
+worktree (`refs/commits/<sha>/`) is a pinned materialization: apply put it there
+to satisfy an exact lock entry, and nothing else legitimately moves it. If apply
+cannot bring such a worktree to the locked revision — for example because it holds
+uncommitted work and `--force` was not given — it reports an **error** naming both
+revisions, not a skip, and exits non-zero.
+
+Branch worktrees are exempt. Co-development deliberately moves `HEAD` ahead of the
+lock, so a branch worktree that disagrees stays a skip.
+
+This postcondition matters because the drift is otherwise invisible: `repos/` is
+gitignored, so `git status` stays clean, and `mr:lock-sync-check` compares
+`devenv.lock` against `megarepo.lock` — lock against lock, never workspace against
+lock.
+
+```
+lib  ref changed but old worktree has 1 uncommitted changes (use --force to override)
+       workspace is at b2a37b45 but megarepo.lock records 35f9c042
+       hint: commit or discard the changes in the worktree, then re-run 'mr apply'
+             (or use --force to discard them)
+```
+
 **Worktree modes** (`--worktree-mode`):
 
 | Mode       | Worktree path          | Behavior                                                                                                      |

--- a/packages/@overeng/megarepo/src/cli/sync.integration.test.ts
+++ b/packages/@overeng/megarepo/src/cli/sync.integration.test.ts
@@ -2011,6 +2011,148 @@ describe('mr lock', () => {
       ),
     )
 
+    /**
+     * A commit worktree is a pinned materialization: apply put it there to satisfy an exact
+     * lock entry. Leaving one at the wrong sha means apply did not deliver Lock → Workspace,
+     * so reporting `skipped` would exit 0 and hide a workspace that disagrees with the lock
+     * that produced it (#962).
+     */
+    it.effect(
+      'should fail when a dirty commit worktree leaves the member drifted from the lock',
+      Effect.fnUntraced(
+        function* () {
+          const fs = yield* FileSystem.FileSystem
+          const store = yield* createStoreFixture([
+            { host: 'example.com', owner: 'acme', repo: 'lib', branches: ['main'] },
+          ])
+          const mainWorktree = store.worktreePaths['example.com/acme/lib#main']
+          if (mainWorktree === undefined) throw new Error('Missing main worktree')
+          const lockedCommit = (yield* runGitCommand(mainWorktree, 'rev-parse', 'HEAD')).trim()
+
+          const { workspacePath } = yield* createWorkspaceWithLock({
+            members: { lib: 'https://example.com/acme/lib#main' },
+            lockEntries: {
+              lib: { url: 'https://example.com/acme/lib', ref: 'main', commit: lockedCommit },
+            },
+          })
+          const env = { MEGAREPO_STORE: store.storePath.slice(0, -1) }
+
+          // Materialize the pinned commit worktree the lock currently names.
+          yield* runApplyCommand({ cwd: workspacePath, args: ['--worktree-mode', 'commit'], env })
+
+          const symlinkPath = EffectPath.ops.join(
+            workspacePath,
+            EffectPath.unsafe.relativeFile('repos/lib'),
+          )
+          const pinnedLink = yield* fs.readLink(symlinkPath)
+          expect(pinnedLink).toContain(`/refs/commits/${lockedCommit}`)
+
+          // Move the lock on to a second real commit, then dirty the pinned worktree so apply
+          // cannot switch away from it.
+          yield* fs.writeFileString(
+            EffectPath.ops.join(mainWorktree, EffectPath.unsafe.relativeFile('next.txt')),
+            'next\n',
+          )
+          yield* addCommit({ repoPath: mainWorktree, message: 'Advance main' })
+          const newCommit = (yield* runGitCommand(mainWorktree, 'rev-parse', 'HEAD')).trim()
+
+          yield* writeLockFile({
+            lockPath: EffectPath.ops.join(
+              workspacePath,
+              EffectPath.unsafe.relativeFile(LOCK_FILE_NAME),
+            ),
+            lockFile: updateLockedMember({
+              lockFile: createEmptyLockFile(),
+              memberName: 'lib',
+              member: createLockedMember({
+                url: 'https://example.com/acme/lib',
+                ref: 'main',
+                commit: newCommit,
+              }),
+            }),
+          })
+
+          yield* fs.writeFileString(
+            EffectPath.unsafe.absoluteFile(`${pinnedLink.replace(/\/$/, '')}/dirty.txt`),
+            'uncommitted work\n',
+          )
+
+          const result = yield* runApplyCommand({
+            cwd: workspacePath,
+            args: ['--worktree-mode', 'commit', '--output', 'json'],
+            env,
+          })
+          const json = decodeSyncJsonOutput(result.stdout.trim())
+
+          expect(json.results[0]?.status).toBe('error')
+          expect(json.results[0]?.message).toContain(lockedCommit.slice(0, 8))
+          expect(json.results[0]?.message).toContain(newCommit.slice(0, 8))
+          expect(result.exitCode).toBe(1)
+
+          // The uncommitted work is still protected — apply reports, it does not clobber.
+          expect(yield* fs.readLink(symlinkPath)).toBe(pinnedLink)
+        },
+        Effect.provide(NodeContext.layer),
+        Effect.scoped,
+      ),
+      { timeout: 15_000 },
+    )
+
+    /**
+     * Branch worktrees are the co-development surface: local commits deliberately move HEAD
+     * ahead of the lock. Failing on that would break the normal local loop, so a dirty branch
+     * worktree stays a skip even when its commit disagrees with the lock.
+     */
+    it.effect(
+      'should still skip, not fail, when a dirty branch worktree disagrees with the lock',
+      Effect.fnUntraced(
+        function* () {
+          const fs = yield* FileSystem.FileSystem
+          const store = yield* createStoreFixture([
+            { host: 'example.com', owner: 'acme', repo: 'lib', branches: ['main'] },
+          ])
+          const mainWorktree = store.worktreePaths['example.com/acme/lib#main']
+          if (mainWorktree === undefined) throw new Error('Missing main worktree')
+
+          // Advance the branch past the commit the lock will record, so the branch worktree is
+          // legitimately ahead — exactly the co-development shape.
+          const staleCommit = (yield* runGitCommand(mainWorktree, 'rev-parse', 'HEAD')).trim()
+          yield* fs.writeFileString(
+            EffectPath.ops.join(mainWorktree, EffectPath.unsafe.relativeFile('wip.txt')),
+            'wip\n',
+          )
+          yield* addCommit({ repoPath: mainWorktree, message: 'Local work' })
+
+          const { workspacePath } = yield* createWorkspaceWithLock({
+            members: { lib: 'https://example.com/acme/lib#main' },
+            lockEntries: {
+              lib: { url: 'https://example.com/acme/lib', ref: 'main', commit: staleCommit },
+            },
+          })
+          const env = { MEGAREPO_STORE: store.storePath.slice(0, -1) }
+
+          yield* runApplyCommand({ cwd: workspacePath, args: ['--worktree-mode', 'tracking'], env })
+          yield* fs.writeFileString(
+            EffectPath.ops.join(mainWorktree, EffectPath.unsafe.relativeFile('dirty.txt')),
+            'uncommitted work\n',
+          )
+
+          const result = yield* runApplyCommand({
+            cwd: workspacePath,
+            args: ['--worktree-mode', 'tracking', '--output', 'json'],
+            env,
+          })
+          const json = decodeSyncJsonOutput(result.stdout.trim())
+
+          expect(json.results[0]?.status).not.toBe('error')
+          expect(result.exitCode).toBe(0)
+        },
+        Effect.provide(NodeContext.layer),
+        Effect.scoped,
+      ),
+      { timeout: 15_000 },
+    )
+
     it.effect(
       'should allow ref change with --force even if old worktree is dirty',
       Effect.fnUntraced(

--- a/packages/@overeng/megarepo/src/cli/sync.integration.test.ts
+++ b/packages/@overeng/megarepo/src/cli/sync.integration.test.ts
@@ -125,19 +125,41 @@ const runMrCommand = ({
         }),
     )
 
+    /**
+     * A member-level failure is a reported result, not an Effect failure, so the command still
+     * succeeds. The non-zero exit comes from the TUI app's `exitCode` mapper, which assigns
+     * `process.exitCode` on unmount — so that is what has to be observed here.
+     *
+     * `process.exitCode` is global: it is cleared before the run and restored afterwards, or a
+     * command that legitimately exits non-zero would also fail the vitest process itself.
+     */
+    const processExitCode = yield* Effect.acquireRelease(
+      Effect.sync(() => {
+        const previous = process.exitCode
+        process.exitCode = undefined
+        return { previous }
+      }),
+      ({ previous }) =>
+        Effect.sync(() => {
+          process.exitCode = previous
+        }),
+    )
+
     const argv = ['node', 'mr', ...command, ...args]
     const effect = Cli.Command.run(mrCommand, { name: 'mr', version: 'test' })(argv).pipe(
       Effect.provideService(Cwd, cwd),
       Effect.provide(consoleLayer),
     )
     const exit = yield* Effect.exit(effect)
+    const reportedExitCode = process.exitCode
     void envCapture
+    void processExitCode
 
     return {
       exit,
       stdout: (yield* getStdoutLines).join('\n'),
       stderr: [stderrCapture.stderrChunks.join(''), ...(yield* getStderrLines)].join('\n'),
-      exitCode: Exit.isSuccess(exit) === true ? 0 : 1,
+      exitCode: Exit.isSuccess(exit) === false ? 1 : Number(reportedExitCode ?? 0),
     }
   }).pipe(Effect.scoped)
 

--- a/packages/@overeng/megarepo/src/lib/sync/member.ts
+++ b/packages/@overeng/megarepo/src/lib/sync/member.ts
@@ -114,6 +114,31 @@ const createSymlink = ({ target, link }: { target: string; link: string }) =>
     yield* fs.symlink(target.replace(/\/$/, ''), link.replace(/\/$/, ''))
   })
 
+/** A pinned materialization that disagrees with the lock entry that produced it. */
+type PinnedDrift = { materialized: string; locked: string }
+
+/**
+ * Apply promises Lock → Workspace. When it cannot deliver that for a member, reporting
+ * `skipped` exits 0 and leaves the workspace silently disagreeing with the lock — the
+ * failure mode behind #962. Report the drift instead so the exit code is honest.
+ */
+const applyDriftError = ({
+  name,
+  reason,
+  drift,
+}: {
+  name: string
+  reason: string
+  drift: PinnedDrift
+}): MemberSyncResult => ({
+  name,
+  status: 'error',
+  message:
+    `${reason}\n` +
+    `  workspace is at ${drift.materialized.slice(0, 8)} but megarepo.lock records ${drift.locked.slice(0, 8)}\n` +
+    `  hint: commit or discard the changes in the worktree, then re-run 'mr apply' (or use --force to discard them)`,
+})
+
 /**
  * Sync a single member: use bare repo + worktree pattern
  *
@@ -317,6 +342,22 @@ export const syncMember = <R = never>({
       .pipe(Effect.orElseSucceed(() => null))
     const memberExists = currentLink !== null
 
+    // A commit worktree (`refs/commits/<sha>`) is a pinned materialization: apply put it there
+    // to satisfy an exact lock entry, and nothing else legitimately moves it. So if its sha
+    // disagrees with the lock, the workspace is wrong no matter why apply could not fix it.
+    //
+    // Branch worktrees are deliberately excluded. Co-development moves HEAD ahead of the lock
+    // on purpose, so failing on that would break the normal local loop.
+    const currentSymlinkRef =
+      currentLink !== null ? extractRefFromSymlinkPath(currentLink.replace(/\/$/, '')) : undefined
+    const pinnedDrift: PinnedDrift | undefined =
+      isApplyMode === true &&
+      currentSymlinkRef?.type === 'commit' &&
+      lockedMember !== undefined &&
+      currentSymlinkRef.ref !== lockedMember.commit
+        ? { materialized: currentSymlinkRef.ref, locked: lockedMember.commit }
+        : undefined
+
     // In lock and apply modes, if member exists, check if symlink points to correct ref
     if (memberExists === true && (isLockMode === true || isApplyMode === true)) {
       const currentLinkNormalized = currentLink?.replace(/\/$/, '')
@@ -391,14 +432,13 @@ export const syncMember = <R = never>({
           })),
         )
         if (worktreeStatus.isDirty === true || worktreeStatus.hasUnpushed === true) {
-          return {
-            name,
-            status: 'skipped',
-            message:
-              worktreeStatus.isDirty === true
-                ? `ref changed but old worktree has ${worktreeStatus.changesCount} uncommitted changes (use --force to override)`
-                : 'ref changed but old worktree has unpushed commits (use --force to override)',
-          } satisfies MemberSyncResult
+          const reason =
+            worktreeStatus.isDirty === true
+              ? `ref changed but old worktree has ${worktreeStatus.changesCount} uncommitted changes (use --force to override)`
+              : 'ref changed but old worktree has unpushed commits (use --force to override)'
+          return pinnedDrift !== undefined
+            ? applyDriftError({ name, reason, drift: pinnedDrift })
+            : ({ name, status: 'skipped', message: reason } satisfies MemberSyncResult)
         }
       }
       // Fall through to content-aware worktree selection
@@ -417,14 +457,13 @@ export const syncMember = <R = never>({
         (worktreeStatus.isDirty === true || worktreeStatus.hasUnpushed === true) &&
         force === false
       ) {
-        return {
-          name,
-          status: 'skipped',
-          message:
-            worktreeStatus.isDirty === true
-              ? `${worktreeStatus.changesCount} uncommitted changes (use --force to override)`
-              : 'has unpushed commits (use --force to override)',
-        } satisfies MemberSyncResult
+        const reason =
+          worktreeStatus.isDirty === true
+            ? `${worktreeStatus.changesCount} uncommitted changes (use --force to override)`
+            : 'has unpushed commits (use --force to override)'
+        return pinnedDrift !== undefined
+          ? applyDriftError({ name, reason, drift: pinnedDrift })
+          : ({ name, status: 'skipped', message: reason } satisfies MemberSyncResult)
       }
     }
 

--- a/packages/@overeng/megarepo/src/lib/sync/member.ts
+++ b/packages/@overeng/megarepo/src/lib/sync/member.ts
@@ -114,8 +114,47 @@ const createSymlink = ({ target, link }: { target: string; link: string }) =>
     yield* fs.symlink(target.replace(/\/$/, ''), link.replace(/\/$/, ''))
   })
 
-/** A pinned materialization that disagrees with the lock entry that produced it. */
+/**
+ * A pinned materialization that disagrees with the lock entry that produced it.
+ *
+ * Both sides are already display-formatted: commit worktrees are identified by sha and are
+ * abbreviated, tag worktrees by tag name and are shown whole.
+ */
 type PinnedDrift = { materialized: string; locked: string }
+
+/**
+ * Whether a materialized worktree contradicts the lock entry that produced it.
+ *
+ * Commit (`refs/commits/<sha>`) and tag (`refs/tags/<tag>`) worktrees are pinned: apply put
+ * them there to satisfy an exact lock entry, and nothing else legitimately moves them. Branch
+ * worktrees are excluded — co-development moves `HEAD` ahead of the lock on purpose.
+ *
+ * The two pinned kinds compare on different fields, because a commit worktree is named by sha
+ * and a tag worktree by tag name. Comparing a tag against `lockedMember.commit` would report
+ * drift for every correctly-materialized tag.
+ */
+export const computePinnedDrift = ({
+  symlinkRef,
+  lockedMember,
+}: {
+  symlinkRef: { ref: string; type: 'branch' | 'tag' | 'commit' } | undefined
+  lockedMember: { ref: string; commit: string } | undefined
+}): PinnedDrift | undefined => {
+  if (symlinkRef === undefined || lockedMember === undefined) return undefined
+
+  switch (symlinkRef.type) {
+    case 'commit':
+      return symlinkRef.ref !== lockedMember.commit
+        ? { materialized: symlinkRef.ref.slice(0, 8), locked: lockedMember.commit.slice(0, 8) }
+        : undefined
+    case 'tag':
+      return symlinkRef.ref !== lockedMember.ref
+        ? { materialized: symlinkRef.ref, locked: lockedMember.ref }
+        : undefined
+    case 'branch':
+      return undefined
+  }
+}
 
 /**
  * Apply promises Lock → Workspace. When it cannot deliver that for a member, reporting
@@ -135,7 +174,7 @@ const applyDriftError = ({
   status: 'error',
   message:
     `${reason}\n` +
-    `  workspace is at ${drift.materialized.slice(0, 8)} but megarepo.lock records ${drift.locked.slice(0, 8)}\n` +
+    `  workspace is at ${drift.materialized} but megarepo.lock records ${drift.locked}\n` +
     `  hint: commit or discard the changes in the worktree, then re-run 'mr apply' (or use --force to discard them)`,
 })
 
@@ -342,20 +381,22 @@ export const syncMember = <R = never>({
       .pipe(Effect.orElseSucceed(() => null))
     const memberExists = currentLink !== null
 
-    // A commit worktree (`refs/commits/<sha>`) is a pinned materialization: apply put it there
-    // to satisfy an exact lock entry, and nothing else legitimately moves it. So if its sha
-    // disagrees with the lock, the workspace is wrong no matter why apply could not fix it.
+    // Commit (`refs/commits/<sha>`) and tag (`refs/tags/<tag>`) worktrees are pinned
+    // materializations: apply put them there to satisfy an exact lock entry, and nothing else
+    // legitimately moves them. So if one disagrees with the lock, the workspace is wrong no
+    // matter why apply could not fix it.
     //
     // Branch worktrees are deliberately excluded. Co-development moves HEAD ahead of the lock
     // on purpose, so failing on that would break the normal local loop.
+    //
+    // The two are compared on different fields: a commit worktree is named by sha, a tag
+    // worktree by tag name. Comparing a tag against `lockedMember.commit` would mismatch on
+    // every correctly-materialized tag.
     const currentSymlinkRef =
       currentLink !== null ? extractRefFromSymlinkPath(currentLink.replace(/\/$/, '')) : undefined
-    const pinnedDrift: PinnedDrift | undefined =
-      isApplyMode === true &&
-      currentSymlinkRef?.type === 'commit' &&
-      lockedMember !== undefined &&
-      currentSymlinkRef.ref !== lockedMember.commit
-        ? { materialized: currentSymlinkRef.ref, locked: lockedMember.commit }
+    const pinnedDrift =
+      isApplyMode === true
+        ? computePinnedDrift({ symlinkRef: currentSymlinkRef, lockedMember })
         : undefined
 
     // In lock and apply modes, if member exists, check if symlink points to correct ref

--- a/packages/@overeng/megarepo/src/lib/sync/member.unit.test.ts
+++ b/packages/@overeng/megarepo/src/lib/sync/member.unit.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+
+import { computePinnedDrift } from './member.ts'
+
+const sha = (n: string) => `${n}`.padEnd(40, '0')
+
+describe('computePinnedDrift', () => {
+  const locked = { ref: 'v2.0.0', commit: sha('bbbb') }
+
+  it('reports drift when a commit worktree names a different sha', () => {
+    const drift = computePinnedDrift({
+      symlinkRef: { ref: sha('aaaa'), type: 'commit' },
+      lockedMember: locked,
+    })
+
+    expect(drift).toEqual({ materialized: 'aaaa0000', locked: 'bbbb0000' })
+  })
+
+  it('reports no drift when a commit worktree matches the lock', () => {
+    expect(
+      computePinnedDrift({
+        symlinkRef: { ref: sha('bbbb'), type: 'commit' },
+        lockedMember: locked,
+      }),
+    ).toBeUndefined()
+  })
+
+  it('reports drift when a tag worktree names a different tag', () => {
+    const drift = computePinnedDrift({
+      symlinkRef: { ref: 'v1.0.0', type: 'tag' },
+      lockedMember: locked,
+    })
+
+    expect(drift).toEqual({ materialized: 'v1.0.0', locked: 'v2.0.0' })
+  })
+
+  it('reports no drift for a tag worktree matching the lock', () => {
+    // A tag worktree is named by tag, not sha. Comparing it against `commit` would report
+    // drift for every correctly-materialized tag.
+    expect(
+      computePinnedDrift({ symlinkRef: { ref: 'v2.0.0', type: 'tag' }, lockedMember: locked }),
+    ).toBeUndefined()
+  })
+
+  it('never reports drift for a branch worktree', () => {
+    // Co-development deliberately moves HEAD ahead of the lock.
+    expect(
+      computePinnedDrift({ symlinkRef: { ref: 'main', type: 'branch' }, lockedMember: locked }),
+    ).toBeUndefined()
+  })
+
+  it('reports no drift when the member is absent or unlocked', () => {
+    expect(computePinnedDrift({ symlinkRef: undefined, lockedMember: locked })).toBeUndefined()
+    expect(
+      computePinnedDrift({
+        symlinkRef: { ref: sha('aaaa'), type: 'commit' },
+        lockedMember: undefined,
+      }),
+    ).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Closes #962. (#962 has been rescoped to the `mr apply` half; the `mr fetch` stale-mirror
symptom originally filed alongside it is split out as #964 and is **not** addressed here.)

## Problem

`mr apply` promises **Lock → Workspace**, but every path that returns `skipped` exits 0
(`SyncOutput/app.ts` maps only `Error`/`PreflightFailed` to a non-zero code). So when a skip
left a member materialized at a revision other than the one `megarepo.lock` records, apply
reported success over a workspace that disagreed with the lock that produced it.

Nothing else caught it: `repos/` is gitignored, so `git status` stays clean, and
`mr:lock-sync-check` compares **lock ↔ lock** (`devenv.lock` vs `megarepo.lock`), never
**workspace ↔ lock**. `mr status` does compute the drift, but nothing gates on it.

This is what put a contributor's checkout at one revision while the lock said another
(livestorejs/livestore#1467) — they had not skipped a step; apply told them it had succeeded.

## Change

A commit worktree (`refs/commits/<sha>`) is a *pinned* materialization: apply put it there to
satisfy an exact lock entry, and nothing else legitimately moves it. If its sha no longer
matches the lock, apply failed its contract regardless of why it could not switch — so report
an error naming both revisions instead of a silent skip.

Branch worktrees are deliberately excluded. Co-development moves HEAD ahead of the lock on
purpose, and failing there would break the normal local loop.

The dirty-worktree protection itself is unchanged: apply still refuses to clobber uncommitted
work. It just no longer claims success while doing so.

```
lib  ref changed but old worktree has 1 uncommitted changes (use --force to override)
       workspace is at b2a37b45 but megarepo.lock records 35f9c042
       hint: commit or discard the changes in the worktree, then re-run 'mr apply'
             (or use --force to discard them)
```

### Why the dirty skip is the only path that needed this

I enumerated every `skipped` return in `syncMember` to check the fix is not covering one case
out of several. In apply mode the rest are already accounted for:

- **locked commit unreachable** — already returns `error` (`member.ts` `commitExists === false`,
  both sites), so a stale mirror fails loudly rather than drifting silently
- **local path members** — symlinked directly, no store materialization to pin
- **missing ref** — reachable only via an explicit `onMissingRef: 'skip'` opt-in
- the remaining skips are fetch-mode or lock-mode only

So the dirty/unpushed skip was the single path that could leave a pinned worktree disagreeing
with the lock at exit 0.

## Verification

End to end against a real store and the real CLI (`bin/mr.ts`), same workspace, before vs after:

| scenario | before | after |
|---|---|---|
| dirty **commit** worktree drifted from lock | `skipped`, **exit 0**, drift left in place | `error`, **exit 1**, both revisions named |
| same drift, worktree **clean** | `applied`, exit 0 | `applied`, exit 0 — symlink moves to the locked commit |
| dirty **branch** worktree ahead of lock (co-development) | `skipped`, exit 0 | `skipped`, exit 0 — unchanged |

In the failing case the symlink is left untouched, so the uncommitted work is still protected.

Two integration tests cover the first and third rows — the third exists specifically to pin the
co-development carve-out so a future tightening cannot silently break the local loop.

**One honest gap:** the second skip site this touches (the apply-mode dirty check that follows
the ref-change one) is not exercised by either the tests or the e2e — both hit the first site.
It appears unreachable in apply mode today, since the earlier check handles the same
force/dryRun/dirty condition first. I applied the same rule there anyway so the two cannot
diverge if that ordering ever changes; happy to drop it if you'd rather keep the diff minimal.

## Note on local test runs

I could not execute the new integration tests locally: `createStoreFixture` pushes `main` in a
throwaway temp repo, our agent-policy git wrapper refuses canonical branch names, the fixture
falls back to pushing `master`, and that is refused too (the surfaced error names `master`,
hiding the real cause). This blocks **all** `createStoreFixture` tests here, not just the new
ones — verified identical on a stock checkout. Filed separately as tooling friction; the tests
are written to the file's existing idiom and run normally in CI.

Other checks: `oxlint` clean on both files; `src/lib` suite identical with and without this
change (18 pre-existing failures from the same git-fixture constraint, 460 passing); typecheck
adds no new error class (the +2 are my two new `it.effect` blocks exhibiting the same
pre-existing pattern as the other 33 tests in that file, all from unbuilt project references).

## Follow-up (not in this PR)

`mr status` already computes workspace-vs-lock drift (`syncNeeded` / `syncReasons`) and nothing
consumes it. Gating that in shared checks would cover drift arising outside apply — including
#964, where a stale-but-consistent lock and workspace agree with each other and this guard
cannot see the problem.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🌄 cl2-vale |
| `agent_session_id` | d1dbf622-1045-4840-aa99-085f5211d5cf |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.215 |
| `agent_runtime` | Claude Code 2.1.215 |
| `agent_model` | claude-opus-4-8 |
| `runtime_profile` | /nix/store/r0yyx5vd9frm4d8klx3i3c1930d9k2ix-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/1rg1cdw91rx4gris2kh0sdwyd4d39nxf-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | livestore-contrib/schickling/2026-07-19-misc |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->