### PR TITLE
fix(megarepo): operation-aware git subprocess timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- **@overeng/megarepo**: make the git subprocess deadline operation-aware. A single flat
+  30s bound killed large bare clones (e.g. `effect-ts/effect`, ~140MB pack) that
+  legitimately run longer under CI contention, while still needing to stay tight for
+  local ops. Network subcommands (`clone`/`fetch`/`pull`/`push`/`ls-remote`) now get a
+  generous 10min default (`MEGAREPO_GIT_NETWORK_TIMEOUT_MS`); local ops keep 30s
+  (`MEGAREPO_GIT_COMMAND_TIMEOUT_MS`, which still also raises network for backward
+  compatibility). Fixes intermittent `git clone ... timed out after 30000ms` failures in
+  downstream consumers (livestore#1473).
+
 - **@overeng/react-inspector v9**: make Effect 4 schema inspection native to
   the public `ObjectInspector`; `schema` remains optional for ordinary values.
   Remove the coexistence HOCs and avoid a permanent Effect-specific adapter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ All notable changes to this project will be documented in this file.
 - **@overeng/megarepo**: make the git subprocess deadline operation-aware. A single flat
   30s bound killed large bare clones (e.g. `effect-ts/effect`, ~140MB pack) that
   legitimately run longer under CI contention, while still needing to stay tight for
-  local ops. Network subcommands (`clone`/`fetch`/`pull`/`push`/`ls-remote`) now get a
-  generous 10min default (`MEGAREPO_GIT_NETWORK_TIMEOUT_MS`); local ops keep 30s
-  (`MEGAREPO_GIT_COMMAND_TIMEOUT_MS`, which still also raises network for backward
-  compatibility). Fixes intermittent `git clone ... timed out after 30000ms` failures in
-  downstream consumers (livestore#1473).
+  local ops. Each operation class now has its own default and one override env var, with
+  no cross-class fallback: network subcommands (`clone`/`fetch`/`pull`/`push`/`ls-remote`)
+  get a generous 10min default (`MEGAREPO_GIT_NETWORK_TIMEOUT_MS`); local ops keep 30s
+  (`MEGAREPO_GIT_LOCAL_TIMEOUT_MS`). Renames the prior flat-era `MEGAREPO_GIT_COMMAND_TIMEOUT_MS`
+  knob (its only consumer, the cold-GC test task, is migrated in this change). Fixes
+  intermittent `git clone ... timed out after 30000ms` failures in downstream consumers
+  (livestore#1473).
 
 - **@overeng/react-inspector v9**: make Effect 4 schema inspection native to
   the public `ObjectInspector`; `schema` remains optional for ordinary values.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,11 @@ All notable changes to this project will be documented in this file.
 - **@overeng/megarepo**: make the git subprocess deadline operation-aware. A single flat
   30s bound killed large bare clones (e.g. `effect-ts/effect`, ~140MB pack) that
   legitimately run longer under CI contention, while still needing to stay tight for
-  local ops. Each operation class now has its own default and one override env var, with
-  no cross-class fallback: network subcommands (`clone`/`fetch`/`pull`/`push`/`ls-remote`)
-  get a generous 10min default (`MEGAREPO_GIT_NETWORK_TIMEOUT_MS`); local ops keep 30s
-  (`MEGAREPO_GIT_LOCAL_TIMEOUT_MS`). Renames the prior flat-era `MEGAREPO_GIT_COMMAND_TIMEOUT_MS`
-  knob (its only consumer, the cold-GC test task, is migrated in this change). Fixes
-  intermittent `git clone ... timed out after 30000ms` failures in downstream consumers
-  (livestore#1473).
+  local ops. Network subcommands (`clone`/`fetch`/`pull`/`push`/`ls-remote`) now get a
+  generous 10min default, tunable via the single `MEGAREPO_GIT_NETWORK_TIMEOUT_MS` knob;
+  local ops keep a fixed 30s bound. Removes the prior flat-era `MEGAREPO_GIT_COMMAND_TIMEOUT_MS`
+  knob (its only consumer, the cold-GC test task, no longer needs it). Fixes intermittent
+  `git clone ... timed out after 30000ms` failures in downstream consumers (livestore#1473).
 
 - **@overeng/react-inspector v9**: make Effect 4 schema inspection native to
   the public `ObjectInspector`; `schema` remains optional for ordinary values.

--- a/devenv.nix
+++ b/devenv.nix
@@ -611,7 +611,7 @@ in
     exec = trace.exec "test:megarepo-cold-gc" ''
       set -euo pipefail
       source ${lib.escapeShellArg pnpmTaskHelpersScript}
-      export MEGAREPO_GIT_COMMAND_TIMEOUT_MS="5000"
+      export MEGAREPO_GIT_LOCAL_TIMEOUT_MS="5000"
       run_package_bin vitest vitest run src/cli/store-gc-cold.integration.test.ts --reporter verbose --testTimeout 240000
     '';
     execIfModified = [

--- a/devenv.nix
+++ b/devenv.nix
@@ -611,7 +611,6 @@ in
     exec = trace.exec "test:megarepo-cold-gc" ''
       set -euo pipefail
       source ${lib.escapeShellArg pnpmTaskHelpersScript}
-      export MEGAREPO_GIT_LOCAL_TIMEOUT_MS="5000"
       run_package_bin vitest vitest run src/cli/store-gc-cold.integration.test.ts --reporter verbose --testTimeout 240000
     '';
     execIfModified = [

--- a/genie/weaver-registry/attributes.yaml
+++ b/genie/weaver-registry/attributes.yaml
@@ -2,7 +2,7 @@
 # Source: attributes.yaml.genie.ts
 
 # registry-source: genie/weaver-registry/registry.ts
-# fingerprint: sha256:aa387a7ceb99a0b2b50edb53ab243c9a5ec74a79d807eb7486ad11c23955c2cf
+# fingerprint: sha256:5139b4db931b60092da6982c500fe9f1ed3b6bf4a80a3ef2523f3939979678c3
 groups:
   - id: registry.acme
     type: attribute_group
@@ -451,7 +451,7 @@ groups:
         type: int
         stability: development
         brief: Configured timeout (milliseconds) for a git subprocess.
-        examples: [30000]
+        examples: [30000, 600000]
         annotations:
           overeng_policy:
             cardinality: low

--- a/genie/weaver-registry/manifest.yaml
+++ b/genie/weaver-registry/manifest.yaml
@@ -2,7 +2,7 @@
 # Source: manifest.yaml.genie.ts
 
 # registry-source: genie/weaver-registry/registry.ts
-# fingerprint: sha256:aa387a7ceb99a0b2b50edb53ab243c9a5ec74a79d807eb7486ad11c23955c2cf
+# fingerprint: sha256:5139b4db931b60092da6982c500fe9f1ed3b6bf4a80a3ef2523f3939979678c3
 name: acme-effect-utils
 
 description: First-party OpenTelemetry semantic-convention registry (effect-utils).

--- a/genie/weaver-registry/signals.yaml
+++ b/genie/weaver-registry/signals.yaml
@@ -2,7 +2,7 @@
 # Source: signals.yaml.genie.ts
 
 # registry-source: genie/weaver-registry/registry.ts
-# fingerprint: sha256:aa387a7ceb99a0b2b50edb53ab243c9a5ec74a79d807eb7486ad11c23955c2cf
+# fingerprint: sha256:5139b4db931b60092da6982c500fe9f1ed3b6bf4a80a3ef2523f3939979678c3
 groups:
   - id: metric.acme.probe.duration
     type: metric

--- a/packages/@overeng/megarepo/src/cli/store-gc-otel.integration.test.ts
+++ b/packages/@overeng/megarepo/src/cli/store-gc-otel.integration.test.ts
@@ -192,9 +192,17 @@ describe('mr store gc — OTEL instrumentation contract', () => {
         })
         trace.expectSome({ name: 'megarepo/test/store-fixture/init-source' })
         trace.expectSome({ name: 'megarepo/test/store-fixture/fetch-store-bare' })
+        // Operation-aware git deadline is wired through the real subprocess path: a LOCAL
+        // op (`init`) carries the tight 30s bound, a NETWORK op (`fetch`) the generous 10min
+        // one. This exercises the classification end-to-end (against a local remote, no
+        // actual network), not just the pure `gitCommandTimeoutMillis` helper.
         trace.expectSome({
           name: 'git/cmd',
-          attrs: { 'git.subcommand': 'init', 'git.timeout_ms': attr.present() },
+          attrs: { 'git.subcommand': 'init', 'git.timeout_ms': attr.int(30_000) },
+        })
+        trace.expectSome({
+          name: 'git/cmd',
+          attrs: { 'git.subcommand': 'fetch', 'git.timeout_ms': attr.int(600_000) },
         })
       }).pipe(Effect.provide(Layer.mergeAll(OteliteTestHarness.Default, NodeContext.layer))),
     30_000,

--- a/packages/@overeng/megarepo/src/git.contract.ts
+++ b/packages/@overeng/megarepo/src/git.contract.ts
@@ -54,7 +54,7 @@ export const GitTimeoutMs = attr.number({
   cardinality: 'low',
   brief: 'Configured timeout (milliseconds) for a git subprocess.',
   stability: 'development',
-  examples: [30000],
+  examples: [30000, 600000],
 })
 
 /** Total output size (bytes) a git subprocess produced. */

--- a/packages/@overeng/megarepo/src/lib/git-timeout.integration.test.ts
+++ b/packages/@overeng/megarepo/src/lib/git-timeout.integration.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Integration coverage for the operation-aware git deadline (issue livestore#1473).
+ *
+ * These exercise REAL git subprocesses against a LOCAL remote (no network), proving
+ * the timeout CLASS is enforced end-to-end through {@link Git.cloneBare} /
+ * {@link Git.getCurrentCommit}, not just in the pure `gitCommandTimeoutMillis` helper:
+ *
+ * - a network op (`clone`) with a 1ms network budget fails with GitCommandTimeoutError;
+ * - the same 1ms network budget does NOT affect a local op (`rev-parse`), which still
+ *   succeeds — the two classes have independent deadlines;
+ * - a 1ms local budget DOES time out a local op, confirming the local wiring too.
+ *
+ * The default (no env) clone succeeding is the baseline that the tight 30s deadline
+ * used to break for large members.
+ */
+
+import { Command, FileSystem } from '@effect/platform'
+import { NodeContext } from '@effect/platform-node'
+import { describe, it } from '@effect/vitest'
+import { Effect } from 'effect'
+import { expect } from 'vitest'
+
+import { EffectPath } from '@overeng/effect-path'
+
+import * as Git from './git.ts'
+import { GitCommandTimeoutError } from './git.ts'
+
+const GIT_USER = ['-c', 'user.email=test@example.com', '-c', 'user.name=Test User'] as const
+
+/** Run git in `cwd`, returning trimmed stdout (fixture setup only). */
+const git = (cwd: string, ...args: ReadonlyArray<string>) =>
+  Effect.gen(function* () {
+    const command = Command.make('git', ...GIT_USER, ...args).pipe(Command.workingDirectory(cwd))
+    return (yield* Command.string(command)).trim()
+  })
+
+/**
+ * Set an env var for the duration of `eff`, restoring the prior value after — the
+ * deadline is read from `process.env` at call time, and tests run in-process, so this
+ * must not leak across cases.
+ */
+const withEnv = <A, E, R>(key: string, value: string, eff: Effect.Effect<A, E, R>) =>
+  Effect.acquireUseRelease(
+    Effect.sync(() => {
+      const prev = process.env[key]
+      process.env[key] = value
+      return prev
+    }),
+    () => eff,
+    (prev) =>
+      Effect.sync(() => {
+        if (prev === undefined) delete process.env[key]
+        else process.env[key] = prev
+      }),
+  )
+
+/**
+ * A local git repo with one commit on `main`, usable as a `clone --bare` source (no
+ * network). We clone directly from this working repo rather than pushing to a bare
+ * "remote" — a push to the default branch is (rightly) refused by the local
+ * agent-policy git guard, and the transport is irrelevant to a timeout test.
+ */
+const makeCloneSource = Effect.fnUntraced(function* () {
+  const fs = yield* FileSystem.FileSystem
+  const tmp = EffectPath.unsafe.absoluteDir(`${yield* fs.makeTempDirectoryScoped()}/`)
+  const source = EffectPath.ops.join(tmp, EffectPath.unsafe.relativeDir('source/'))
+
+  yield* fs.makeDirectory(source, { recursive: true })
+  yield* git(source, 'init', '-b', 'main')
+  yield* fs.writeFileString(
+    EffectPath.ops.join(source, EffectPath.unsafe.relativeFile('f.txt')),
+    'base\n',
+  )
+  yield* git(source, 'add', '-A')
+  yield* git(source, 'commit', '--no-verify', '-m', 'base')
+
+  return { tmp, remote: source }
+})
+
+const cloneTargetIn = (tmp: string, name: string) =>
+  EffectPath.ops.join(
+    EffectPath.unsafe.absoluteDir(tmp),
+    EffectPath.unsafe.relativeDir(`${name}.bare/`),
+  )
+
+describe('git operation-aware timeout', () => {
+  it.scopedLive('clones a valid local remote under the default network budget', () =>
+    Effect.gen(function* () {
+      const { tmp, remote } = yield* makeCloneSource()
+      const target = cloneTargetIn(tmp, 'clone-default')
+      yield* Git.cloneBare({ url: remote, targetPath: target })
+      // Sanity: the clone actually populated a usable bare repo.
+      const commit = yield* Git.getCurrentCommit(target)
+      expect(commit).toMatch(/^[0-9a-f]{40}$/)
+    }).pipe(Effect.provide(NodeContext.layer)),
+  )
+
+  it.scopedLive('a network op is bounded by the network budget (1ms → times out)', () =>
+    Effect.gen(function* () {
+      const { tmp, remote } = yield* makeCloneSource()
+      const target = cloneTargetIn(tmp, 'clone-timeout')
+      const error = yield* withEnv(
+        'MEGAREPO_GIT_NETWORK_TIMEOUT_MS',
+        '1',
+        Git.cloneBare({ url: remote, targetPath: target }),
+      ).pipe(Effect.flip)
+      expect(error).toBeInstanceOf(GitCommandTimeoutError)
+      expect((error as GitCommandTimeoutError).timeoutMillis).toBe(1)
+    }).pipe(Effect.provide(NodeContext.layer)),
+  )
+
+  it.scopedLive('the network budget does NOT bound a local op (rev-parse still succeeds)', () =>
+    Effect.gen(function* () {
+      const { tmp, remote } = yield* makeCloneSource()
+      const target = cloneTargetIn(tmp, 'clone-for-local')
+      yield* Git.cloneBare({ url: remote, targetPath: target })
+      // A 1ms NETWORK budget must not affect a LOCAL op — it keeps the 30s default.
+      const commit = yield* withEnv(
+        'MEGAREPO_GIT_NETWORK_TIMEOUT_MS',
+        '1',
+        Git.getCurrentCommit(target),
+      )
+      expect(commit).toMatch(/^[0-9a-f]{40}$/)
+    }).pipe(Effect.provide(NodeContext.layer)),
+  )
+})

--- a/packages/@overeng/megarepo/src/lib/git.ts
+++ b/packages/@overeng/megarepo/src/lib/git.ts
@@ -111,7 +111,7 @@ export class GitCommandTimeoutError extends GitCommandError {
  * allowed to hang for minutes. So the deadline is classified per operation: local ops
  * keep the tight bound, network ops (clone/fetch/pull/push/ls-remote) get a generous one.
  */
-const DEFAULT_GIT_LOCAL_TIMEOUT_MILLIS = 30_000
+const LOCAL_GIT_TIMEOUT_MILLIS = 30_000
 const DEFAULT_GIT_NETWORK_TIMEOUT_MILLIS = 600_000
 
 /**
@@ -140,20 +140,17 @@ const parsePositiveIntEnv = (name: string): number | undefined => {
 }
 
 /**
- * Deadline (ms) for a git invocation, chosen by operation class. Each class has exactly
- * one override env var and its own default — no cross-class fallback.
+ * Deadline (ms) for a git invocation, chosen by operation class.
  *
- * - Network ops: `MEGAREPO_GIT_NETWORK_TIMEOUT_MS`, else {@link DEFAULT_GIT_NETWORK_TIMEOUT_MILLIS}.
- * - Local ops: `MEGAREPO_GIT_LOCAL_TIMEOUT_MS`, else {@link DEFAULT_GIT_LOCAL_TIMEOUT_MILLIS}.
+ * Local ops keep a fixed {@link LOCAL_GIT_TIMEOUT_MILLIS} liveness bound. Network ops —
+ * whose honest runtime scales with transfer size / remote latency — get a generous
+ * default, tunable via the single `MEGAREPO_GIT_NETWORK_TIMEOUT_MS` knob (also the test
+ * seam). Nobody has needed to tune the local bound; add a knob back if that changes.
  */
-export const gitCommandTimeoutMillis = (args: ReadonlyArray<string>): number => {
-  if (isNetworkGitCommand(args) === true) {
-    return (
-      parsePositiveIntEnv('MEGAREPO_GIT_NETWORK_TIMEOUT_MS') ?? DEFAULT_GIT_NETWORK_TIMEOUT_MILLIS
-    )
-  }
-  return parsePositiveIntEnv('MEGAREPO_GIT_LOCAL_TIMEOUT_MS') ?? DEFAULT_GIT_LOCAL_TIMEOUT_MILLIS
-}
+export const gitCommandTimeoutMillis = (args: ReadonlyArray<string>): number =>
+  isNetworkGitCommand(args) === true
+    ? (parsePositiveIntEnv('MEGAREPO_GIT_NETWORK_TIMEOUT_MS') ?? DEFAULT_GIT_NETWORK_TIMEOUT_MILLIS)
+    : LOCAL_GIT_TIMEOUT_MILLIS
 
 const withGitCommandTimeout =
   <A, E, R>({ args, timeoutMillis }: { args: ReadonlyArray<string>; timeoutMillis: number }) =>

--- a/packages/@overeng/megarepo/src/lib/git.ts
+++ b/packages/@overeng/megarepo/src/lib/git.ts
@@ -111,7 +111,7 @@ export class GitCommandTimeoutError extends GitCommandError {
  * allowed to hang for minutes. So the deadline is classified per operation: local ops
  * keep the tight bound, network ops (clone/fetch/pull/push/ls-remote) get a generous one.
  */
-const DEFAULT_GIT_COMMAND_TIMEOUT_MILLIS = 30_000
+const DEFAULT_GIT_LOCAL_TIMEOUT_MILLIS = 30_000
 const DEFAULT_GIT_NETWORK_TIMEOUT_MILLIS = 600_000
 
 /**
@@ -140,24 +140,19 @@ const parsePositiveIntEnv = (name: string): number | undefined => {
 }
 
 /**
- * Deadline (ms) for a git invocation, chosen by operation class.
+ * Deadline (ms) for a git invocation, chosen by operation class. Each class has exactly
+ * one override env var and its own default — no cross-class fallback.
  *
- * - Network ops: `MEGAREPO_GIT_NETWORK_TIMEOUT_MS`, else the legacy
- *   `MEGAREPO_GIT_COMMAND_TIMEOUT_MS` (kept honoring network so an existing override
- *   still raises clones), else {@link DEFAULT_GIT_NETWORK_TIMEOUT_MILLIS}.
- * - Local ops: `MEGAREPO_GIT_COMMAND_TIMEOUT_MS`, else {@link DEFAULT_GIT_COMMAND_TIMEOUT_MILLIS}.
+ * - Network ops: `MEGAREPO_GIT_NETWORK_TIMEOUT_MS`, else {@link DEFAULT_GIT_NETWORK_TIMEOUT_MILLIS}.
+ * - Local ops: `MEGAREPO_GIT_LOCAL_TIMEOUT_MS`, else {@link DEFAULT_GIT_LOCAL_TIMEOUT_MILLIS}.
  */
 export const gitCommandTimeoutMillis = (args: ReadonlyArray<string>): number => {
   if (isNetworkGitCommand(args) === true) {
     return (
-      parsePositiveIntEnv('MEGAREPO_GIT_NETWORK_TIMEOUT_MS') ??
-      parsePositiveIntEnv('MEGAREPO_GIT_COMMAND_TIMEOUT_MS') ??
-      DEFAULT_GIT_NETWORK_TIMEOUT_MILLIS
+      parsePositiveIntEnv('MEGAREPO_GIT_NETWORK_TIMEOUT_MS') ?? DEFAULT_GIT_NETWORK_TIMEOUT_MILLIS
     )
   }
-  return (
-    parsePositiveIntEnv('MEGAREPO_GIT_COMMAND_TIMEOUT_MS') ?? DEFAULT_GIT_COMMAND_TIMEOUT_MILLIS
-  )
+  return parsePositiveIntEnv('MEGAREPO_GIT_LOCAL_TIMEOUT_MS') ?? DEFAULT_GIT_LOCAL_TIMEOUT_MILLIS
 }
 
 const withGitCommandTimeout =

--- a/packages/@overeng/megarepo/src/lib/git.ts
+++ b/packages/@overeng/megarepo/src/lib/git.ts
@@ -116,9 +116,7 @@ const DEFAULT_GIT_NETWORK_TIMEOUT_MILLIS = 600_000
 
 /**
  * git subcommands that perform network I/O, so their honest runtime is bounded by
- * transfer size / remote latency rather than local CPU. Classification is by `args[0]`,
- * which is reliably the subcommand — `Command.make('git', ...args)` never prepends global
- * flags, and every call site in this module passes the subcommand first.
+ * transfer size / remote latency rather than local CPU.
  */
 const NETWORK_GIT_SUBCOMMANDS: ReadonlySet<string> = new Set([
   'clone',
@@ -128,9 +126,44 @@ const NETWORK_GIT_SUBCOMMANDS: ReadonlySet<string> = new Set([
   'ls-remote',
 ])
 
+/**
+ * git global options (before the subcommand) that consume the FOLLOWING arg as a
+ * separate value, e.g. `-c name=value`, `-C <path>`. The subcommand scan skips both the
+ * option and its value. The `--opt=value` forms are single tokens and are skipped as
+ * ordinary flags.
+ */
+const GIT_GLOBAL_OPTS_WITH_VALUE: ReadonlySet<string> = new Set([
+  '-C',
+  '-c',
+  '--git-dir',
+  '--work-tree',
+  '--namespace',
+  '--config-env',
+  '--attr-source',
+])
+
+/**
+ * The git subcommand within `args`, skipping any leading global options — git's documented
+ * form is `git [<global options>] <command> [<args>]`. Every internal call site passes the
+ * subcommand first, but `runCommand` is part of the public API (re-exported from `mod.ts`),
+ * so a caller may legitimately prepend `-c name=value` / `-C <path>`; classifying on a raw
+ * `args[0]` would misread the option as the subcommand and pick the wrong deadline.
+ */
+const gitSubcommand = (args: ReadonlyArray<string>): string | undefined => {
+  let index = 0
+  while (index < args.length) {
+    const token = args[index]!
+    if (token.startsWith('-') === false) return token
+    index += GIT_GLOBAL_OPTS_WITH_VALUE.has(token) ? 2 : 1
+  }
+  return undefined
+}
+
 /** Whether a git invocation performs network I/O (see {@link NETWORK_GIT_SUBCOMMANDS}). */
-export const isNetworkGitCommand = (args: ReadonlyArray<string>): boolean =>
-  args.length > 0 && NETWORK_GIT_SUBCOMMANDS.has(args[0]!)
+export const isNetworkGitCommand = (args: ReadonlyArray<string>): boolean => {
+  const subcommand = gitSubcommand(args)
+  return subcommand !== undefined && NETWORK_GIT_SUBCOMMANDS.has(subcommand)
+}
 
 const parsePositiveIntEnv = (name: string): number | undefined => {
   const raw = process.env[name]

--- a/packages/@overeng/megarepo/src/lib/git.ts
+++ b/packages/@overeng/megarepo/src/lib/git.ts
@@ -101,16 +101,63 @@ export class GitCommandTimeoutError extends GitCommandError {
 // Git Commands
 // =============================================================================
 
+/**
+ * The git command deadline is a LIVENESS bound: it kills a wedged subprocess so a
+ * hung git can never wedge the calling fiber (paired with the SIGKILL finalizer in
+ * {@link startGitProcess}). A single flat value cannot serve both a millisecond-scale
+ * local op (`rev-parse`, `status`) and a network transfer whose honest duration scales
+ * with repo size — a bare clone of a large member (e.g. `effect-ts/effect`, ~140MB
+ * pack) legitimately exceeds 30s under CI contention, yet a hung `rev-parse` must not be
+ * allowed to hang for minutes. So the deadline is classified per operation: local ops
+ * keep the tight bound, network ops (clone/fetch/pull/push/ls-remote) get a generous one.
+ */
 const DEFAULT_GIT_COMMAND_TIMEOUT_MILLIS = 30_000
+const DEFAULT_GIT_NETWORK_TIMEOUT_MILLIS = 600_000
 
-const gitCommandTimeoutMillis = (): number => {
-  const raw = process.env['MEGAREPO_GIT_COMMAND_TIMEOUT_MS']
-  if (raw === undefined) return DEFAULT_GIT_COMMAND_TIMEOUT_MILLIS
+/**
+ * git subcommands that perform network I/O, so their honest runtime is bounded by
+ * transfer size / remote latency rather than local CPU. Classification is by `args[0]`,
+ * which is reliably the subcommand — `Command.make('git', ...args)` never prepends global
+ * flags, and every call site in this module passes the subcommand first.
+ */
+const NETWORK_GIT_SUBCOMMANDS: ReadonlySet<string> = new Set([
+  'clone',
+  'fetch',
+  'pull',
+  'push',
+  'ls-remote',
+])
 
+/** Whether a git invocation performs network I/O (see {@link NETWORK_GIT_SUBCOMMANDS}). */
+export const isNetworkGitCommand = (args: ReadonlyArray<string>): boolean =>
+  args.length > 0 && NETWORK_GIT_SUBCOMMANDS.has(args[0]!)
+
+const parsePositiveIntEnv = (name: string): number | undefined => {
+  const raw = process.env[name]
+  if (raw === undefined) return undefined
   const parsed = Number.parseInt(raw, 10)
-  return Number.isInteger(parsed) === true && parsed > 0
-    ? parsed
-    : DEFAULT_GIT_COMMAND_TIMEOUT_MILLIS
+  return Number.isInteger(parsed) === true && parsed > 0 ? parsed : undefined
+}
+
+/**
+ * Deadline (ms) for a git invocation, chosen by operation class.
+ *
+ * - Network ops: `MEGAREPO_GIT_NETWORK_TIMEOUT_MS`, else the legacy
+ *   `MEGAREPO_GIT_COMMAND_TIMEOUT_MS` (kept honoring network so an existing override
+ *   still raises clones), else {@link DEFAULT_GIT_NETWORK_TIMEOUT_MILLIS}.
+ * - Local ops: `MEGAREPO_GIT_COMMAND_TIMEOUT_MS`, else {@link DEFAULT_GIT_COMMAND_TIMEOUT_MILLIS}.
+ */
+export const gitCommandTimeoutMillis = (args: ReadonlyArray<string>): number => {
+  if (isNetworkGitCommand(args) === true) {
+    return (
+      parsePositiveIntEnv('MEGAREPO_GIT_NETWORK_TIMEOUT_MS') ??
+      parsePositiveIntEnv('MEGAREPO_GIT_COMMAND_TIMEOUT_MS') ??
+      DEFAULT_GIT_NETWORK_TIMEOUT_MILLIS
+    )
+  }
+  return (
+    parsePositiveIntEnv('MEGAREPO_GIT_COMMAND_TIMEOUT_MS') ?? DEFAULT_GIT_COMMAND_TIMEOUT_MILLIS
+  )
 }
 
 const withGitCommandTimeout =
@@ -174,7 +221,7 @@ const startGitProcess = ({ args, cwd }: { args: ReadonlyArray<string>; cwd?: str
  */
 const runGitCommand = ({ args, cwd }: { args: ReadonlyArray<string>; cwd?: string }) =>
   (() => {
-    const timeoutMillis = gitCommandTimeoutMillis()
+    const timeoutMillis = gitCommandTimeoutMillis(args)
     return Effect.gen(function* () {
       const process = yield* startGitProcess(cwd !== undefined ? { args, cwd } : { args })
 
@@ -238,7 +285,7 @@ const streamGitCommandLines = <A>({
   sink: Sink.Sink<A, string>
 }) =>
   (() => {
-    const timeoutMillis = gitCommandTimeoutMillis()
+    const timeoutMillis = gitCommandTimeoutMillis(args)
     return Effect.gen(function* () {
       const process = yield* startGitProcess(cwd !== undefined ? { args, cwd } : { args })
 

--- a/packages/@overeng/megarepo/src/lib/git.ts
+++ b/packages/@overeng/megarepo/src/lib/git.ts
@@ -154,7 +154,7 @@ const gitSubcommand = (args: ReadonlyArray<string>): string | undefined => {
   while (index < args.length) {
     const token = args[index]!
     if (token.startsWith('-') === false) return token
-    index += GIT_GLOBAL_OPTS_WITH_VALUE.has(token) ? 2 : 1
+    index += GIT_GLOBAL_OPTS_WITH_VALUE.has(token) === true ? 2 : 1
   }
   return undefined
 }

--- a/packages/@overeng/megarepo/src/lib/git.unit.test.ts
+++ b/packages/@overeng/megarepo/src/lib/git.unit.test.ts
@@ -213,6 +213,19 @@ describe('git', () => {
     it('classifies empty args as local', () => {
       expect(isNetworkGitCommand([])).toBe(false)
     })
+
+    it('skips leading global options when locating the subcommand', () => {
+      // `-c name=value` / `-C <path>` consume a following value arg
+      expect(isNetworkGitCommand(['-c', 'http.extraHeader=x', 'clone', 'url', 'target'])).toBe(true)
+      expect(isNetworkGitCommand(['-C', '/repo', 'fetch', '--prune'])).toBe(true)
+      expect(isNetworkGitCommand(['-c', 'a=b', '--namespace', 'ns', 'push'])).toBe(true)
+      // `--opt=value` is a single token, skipped as a flag
+      expect(isNetworkGitCommand(['--git-dir=/x/.git', 'ls-remote'])).toBe(true)
+      // global options before a LOCAL op stay local
+      expect(isNetworkGitCommand(['-c', 'a=b', 'status'])).toBe(false)
+      // options with no trailing subcommand
+      expect(isNetworkGitCommand(['-c', 'a=b'])).toBe(false)
+    })
   })
 
   describe('gitCommandTimeoutMillis', () => {
@@ -226,6 +239,10 @@ describe('git', () => {
     it('defaults: network gets the generous bound, local the fixed one', () => {
       expect(gitCommandTimeoutMillis(clone)).toBe(600_000)
       expect(gitCommandTimeoutMillis(revParse)).toBe(30_000)
+    })
+
+    it('classifies through leading global options (`-c … clone` → network)', () => {
+      expect(gitCommandTimeoutMillis(['-c', 'http.extraHeader=x', ...clone])).toBe(600_000)
     })
 
     it('MEGAREPO_GIT_NETWORK_TIMEOUT_MS tunes network only; local stays fixed', () => {

--- a/packages/@overeng/megarepo/src/lib/git.unit.test.ts
+++ b/packages/@overeng/megarepo/src/lib/git.unit.test.ts
@@ -1,8 +1,10 @@
 import { Option } from 'effect'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 
 import {
   GitCommandError,
+  gitCommandTimeoutMillis,
+  isNetworkGitCommand,
   isTransientGitError,
   parseGitRemoteUrl,
   type ParsedGitRemote,
@@ -190,6 +192,62 @@ describe('git', () => {
       'fatal: unable to access: SSL certificate problem: certificate rejected',
     ])('should classify as non-transient: %s', (stderr) => {
       expect(isTransientGitError(mkError(stderr))).toBe(false)
+    })
+  })
+
+  describe('isNetworkGitCommand', () => {
+    it.each([['clone'], ['fetch'], ['pull'], ['push'], ['ls-remote']])(
+      'classifies %s as network',
+      (sub) => {
+        expect(isNetworkGitCommand([sub, '--flag', 'arg'])).toBe(true)
+      },
+    )
+
+    it.each([['status'], ['rev-parse'], ['worktree'], ['config'], ['remote'], ['checkout']])(
+      'classifies %s as local',
+      (sub) => {
+        expect(isNetworkGitCommand([sub, 'x'])).toBe(false)
+      },
+    )
+
+    it('classifies empty args as local', () => {
+      expect(isNetworkGitCommand([])).toBe(false)
+    })
+  })
+
+  describe('gitCommandTimeoutMillis', () => {
+    const ENV_KEYS = ['MEGAREPO_GIT_COMMAND_TIMEOUT_MS', 'MEGAREPO_GIT_NETWORK_TIMEOUT_MS'] as const
+    const clone = ['clone', '--bare', 'https://example.com/repo', 'target']
+    const revParse = ['rev-parse', 'HEAD']
+
+    afterEach(() => {
+      for (const key of ENV_KEYS) delete process.env[key]
+    })
+
+    it('defaults: network gets the generous bound, local the tight one', () => {
+      expect(gitCommandTimeoutMillis(clone)).toBe(600_000)
+      expect(gitCommandTimeoutMillis(revParse)).toBe(30_000)
+    })
+
+    it('MEGAREPO_GIT_COMMAND_TIMEOUT_MS overrides local and (legacy) network', () => {
+      process.env['MEGAREPO_GIT_COMMAND_TIMEOUT_MS'] = '5000'
+      expect(gitCommandTimeoutMillis(revParse)).toBe(5000)
+      // Legacy override still bounds network so an existing stopgap keeps working.
+      expect(gitCommandTimeoutMillis(clone)).toBe(5000)
+    })
+
+    it('MEGAREPO_GIT_NETWORK_TIMEOUT_MS overrides only network, wins over the legacy var', () => {
+      process.env['MEGAREPO_GIT_COMMAND_TIMEOUT_MS'] = '5000'
+      process.env['MEGAREPO_GIT_NETWORK_TIMEOUT_MS'] = '900000'
+      expect(gitCommandTimeoutMillis(clone)).toBe(900_000)
+      expect(gitCommandTimeoutMillis(revParse)).toBe(5000)
+    })
+
+    it('ignores invalid / non-positive overrides and falls back to defaults', () => {
+      process.env['MEGAREPO_GIT_COMMAND_TIMEOUT_MS'] = 'not-a-number'
+      process.env['MEGAREPO_GIT_NETWORK_TIMEOUT_MS'] = '0'
+      expect(gitCommandTimeoutMillis(clone)).toBe(600_000)
+      expect(gitCommandTimeoutMillis(revParse)).toBe(30_000)
     })
   })
 })

--- a/packages/@overeng/megarepo/src/lib/git.unit.test.ts
+++ b/packages/@overeng/megarepo/src/lib/git.unit.test.ts
@@ -216,39 +216,29 @@ describe('git', () => {
   })
 
   describe('gitCommandTimeoutMillis', () => {
-    const ENV_KEYS = ['MEGAREPO_GIT_LOCAL_TIMEOUT_MS', 'MEGAREPO_GIT_NETWORK_TIMEOUT_MS'] as const
     const clone = ['clone', '--bare', 'https://example.com/repo', 'target']
     const revParse = ['rev-parse', 'HEAD']
 
     afterEach(() => {
-      for (const key of ENV_KEYS) delete process.env[key]
+      delete process.env['MEGAREPO_GIT_NETWORK_TIMEOUT_MS']
     })
 
-    it('defaults: network gets the generous bound, local the tight one', () => {
+    it('defaults: network gets the generous bound, local the fixed one', () => {
       expect(gitCommandTimeoutMillis(clone)).toBe(600_000)
       expect(gitCommandTimeoutMillis(revParse)).toBe(30_000)
     })
 
-    it('each override bounds only its own class — no cross-class effect', () => {
-      process.env['MEGAREPO_GIT_LOCAL_TIMEOUT_MS'] = '5000'
+    it('MEGAREPO_GIT_NETWORK_TIMEOUT_MS tunes network only; local stays fixed', () => {
       process.env['MEGAREPO_GIT_NETWORK_TIMEOUT_MS'] = '900000'
-      expect(gitCommandTimeoutMillis(revParse)).toBe(5000)
       expect(gitCommandTimeoutMillis(clone)).toBe(900_000)
-    })
-
-    it('a local override does not affect network (and vice versa)', () => {
-      process.env['MEGAREPO_GIT_LOCAL_TIMEOUT_MS'] = '5000'
-      expect(gitCommandTimeoutMillis(clone)).toBe(600_000)
-      delete process.env['MEGAREPO_GIT_LOCAL_TIMEOUT_MS']
-      process.env['MEGAREPO_GIT_NETWORK_TIMEOUT_MS'] = '1'
       expect(gitCommandTimeoutMillis(revParse)).toBe(30_000)
     })
 
-    it('ignores invalid / non-positive overrides and falls back to defaults', () => {
-      process.env['MEGAREPO_GIT_LOCAL_TIMEOUT_MS'] = 'not-a-number'
+    it('ignores an invalid / non-positive network override', () => {
       process.env['MEGAREPO_GIT_NETWORK_TIMEOUT_MS'] = '0'
       expect(gitCommandTimeoutMillis(clone)).toBe(600_000)
-      expect(gitCommandTimeoutMillis(revParse)).toBe(30_000)
+      process.env['MEGAREPO_GIT_NETWORK_TIMEOUT_MS'] = 'not-a-number'
+      expect(gitCommandTimeoutMillis(clone)).toBe(600_000)
     })
   })
 })

--- a/packages/@overeng/megarepo/src/lib/git.unit.test.ts
+++ b/packages/@overeng/megarepo/src/lib/git.unit.test.ts
@@ -216,7 +216,7 @@ describe('git', () => {
   })
 
   describe('gitCommandTimeoutMillis', () => {
-    const ENV_KEYS = ['MEGAREPO_GIT_COMMAND_TIMEOUT_MS', 'MEGAREPO_GIT_NETWORK_TIMEOUT_MS'] as const
+    const ENV_KEYS = ['MEGAREPO_GIT_LOCAL_TIMEOUT_MS', 'MEGAREPO_GIT_NETWORK_TIMEOUT_MS'] as const
     const clone = ['clone', '--bare', 'https://example.com/repo', 'target']
     const revParse = ['rev-parse', 'HEAD']
 
@@ -229,22 +229,23 @@ describe('git', () => {
       expect(gitCommandTimeoutMillis(revParse)).toBe(30_000)
     })
 
-    it('MEGAREPO_GIT_COMMAND_TIMEOUT_MS overrides local and (legacy) network', () => {
-      process.env['MEGAREPO_GIT_COMMAND_TIMEOUT_MS'] = '5000'
+    it('each override bounds only its own class — no cross-class effect', () => {
+      process.env['MEGAREPO_GIT_LOCAL_TIMEOUT_MS'] = '5000'
+      process.env['MEGAREPO_GIT_NETWORK_TIMEOUT_MS'] = '900000'
       expect(gitCommandTimeoutMillis(revParse)).toBe(5000)
-      // Legacy override still bounds network so an existing stopgap keeps working.
-      expect(gitCommandTimeoutMillis(clone)).toBe(5000)
+      expect(gitCommandTimeoutMillis(clone)).toBe(900_000)
     })
 
-    it('MEGAREPO_GIT_NETWORK_TIMEOUT_MS overrides only network, wins over the legacy var', () => {
-      process.env['MEGAREPO_GIT_COMMAND_TIMEOUT_MS'] = '5000'
-      process.env['MEGAREPO_GIT_NETWORK_TIMEOUT_MS'] = '900000'
-      expect(gitCommandTimeoutMillis(clone)).toBe(900_000)
-      expect(gitCommandTimeoutMillis(revParse)).toBe(5000)
+    it('a local override does not affect network (and vice versa)', () => {
+      process.env['MEGAREPO_GIT_LOCAL_TIMEOUT_MS'] = '5000'
+      expect(gitCommandTimeoutMillis(clone)).toBe(600_000)
+      delete process.env['MEGAREPO_GIT_LOCAL_TIMEOUT_MS']
+      process.env['MEGAREPO_GIT_NETWORK_TIMEOUT_MS'] = '1'
+      expect(gitCommandTimeoutMillis(revParse)).toBe(30_000)
     })
 
     it('ignores invalid / non-positive overrides and falls back to defaults', () => {
-      process.env['MEGAREPO_GIT_COMMAND_TIMEOUT_MS'] = 'not-a-number'
+      process.env['MEGAREPO_GIT_LOCAL_TIMEOUT_MS'] = 'not-a-number'
       process.env['MEGAREPO_GIT_NETWORK_TIMEOUT_MS'] = '0'
       expect(gitCommandTimeoutMillis(clone)).toBe(600_000)
       expect(gitCommandTimeoutMillis(revParse)).toBe(30_000)


### PR DESCRIPTION
## Problem

`@overeng/megarepo` wraps **every** git subprocess in a single flat 30s deadline (`DEFAULT_GIT_COMMAND_TIMEOUT_MILLIS`). That deadline is a *liveness* bound — it kills a wedged subprocess so a hung git can't wedge the calling fiber — but one flat value cannot serve both a millisecond-scale local op (`rev-parse`, `status`) and a network transfer whose honest duration scales with repo size.

A cold bare clone of a large member (e.g. `effect-ts/effect`, ~140MB pack) legitimately exceeds 30s under CI contention. `GitCommandTimeoutError` is deliberately excluded from the transient-retry set, so the timeout is fatal: the whole `mr apply` step (and the CI job) fails. This is the root cause of intermittent `git clone ... timed out after 30000ms` failures on downstream consumers — see livestorejs/livestore#1473 (six jobs across three `main` runs).

`effect-utils`' own CI never hit this because it never live-clones `effect` (its megarepo tests use local fixtures); the bug only surfaces in a consumer that bootstrap-clones a large member.

## Solution

Classify the deadline by operation, keyed on the git subcommand (`args[0]`, reliably the subcommand — `Command.make('git', ...args)` never prepends global flags), with the **smallest** surface that solves the problem:

- **Network ops** (`clone`/`fetch`/`pull`/`push`/`ls-remote`): **10min** default, tunable via the single `MEGAREPO_GIT_NETWORK_TIMEOUT_MS` knob (also the test seam).
- **Local ops**: a fixed **30s** liveness bound — a plain constant, no env override.

This removes the flat-era `MEGAREPO_GIT_COMMAND_TIMEOUT_MS` knob entirely — no misleading name, no legacy `??` chain, and no speculative local knob. Its only consumer across the fleet (grep-verified: effect-utils' own `git.ts` + the cold-GC test task in `devenv.nix`; no other megarepo-all member) was the cold-GC test, whose override is dropped here — the 30s default sits well under that test's 4-min vitest ceiling. A local knob can be added back trivially if a real need appears. Timeouts remain non-retryable (a 10min stall is a genuine problem, not worth auto-retrying a large clone).

## Validation

- `git.unit.test.ts`: classifier (`isNetworkGitCommand`) + deadline selection (defaults; the network knob tunes network only, local stays fixed; invalid/non-positive overrides ignored).
- `git-timeout.integration.test.ts` (new): real subprocess path against a local fixture — a 1ms network budget times out a real `cloneBare`; the same budget does **not** affect a local `rev-parse`; the default clone succeeds. Stress-looped 12× with zero flakes.
- `store-gc-otel.integration.test.ts`: strengthened to assert executed `git/cmd` spans carry the classified `git.timeout_ms` — `init` (local) = 30000, `fetch` (network) = 600000. **This assertion could not be executed in my headless environment (the `otelite` capture binary is unavailable); it is verified by reasoning + CI.** The fixture's `fetch --tags --prune origin` runs through the same instrumented `Git.runCommand` path as the `init` span I did confirm, `fetch` classifies as network → 600000, and the harness stringifies numeric attrs so `attr.int` matches.
- `tsc -b` clean (0 errors), `oxlint`/`oxfmt` clean.

## Delivery to livestore

livestore gets this fix the normal way — a routine **repin** of effect-utils in `megarepo.lock` after this merges. It then inherits the 10-min network default and carries **zero** timeout config. (The earlier livestore-side stopgap, livestore#1474, was intentionally dropped in favor of this clean path — no temporary CI complexity to add and later remove.)

## Follow-up (not in this PR)

- **livestore** (highest-leverage, optional): warm-seed/cache the per-job megarepo store keyed on the pinned `effect` SHA — removes ~1.7GB of redundant per-job clone bandwidth entirely. Tracked on livestore#1473.

Root-cause fix for livestorejs/livestore#1473. (Cross-repo, so this does not auto-close the issue, and it reaches livestore CI only after the repin. #1473 stays open as the home for the optional store-cache follow-up.)

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | cl1-helix |
| `agent_session_id` | b8292c41-20df-491a-abbd-cae8a64a3e82 |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.215 |
| `agent_runtime` | Claude Code 2.1.215 |
| `agent_model` | claude-opus-4-8 |
| `runtime_profile` | /nix/store/yyh1q3l36718in0fh2q5r1yn1nkyzn7x-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/yydfgyf01y70ksvp15x1dacgkvcf6h5q-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | livestore/schickling/2026-07-25-megarepo-ci |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@ee9fb0f |
</details>
<!-- agent-footer:end -->