### PR TITLE
feat(genie/ci-workflow): reusable megarepo store cache steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- **genie/ci-workflow**: add reusable `restoreMegarepoStoreStep` / `saveMegarepoStoreStep`
+  (GitHub Actions cache of the job-local megarepo store, keyed on the consumer's
+  `megarepo.lock`). Consumers place them around `applyMegarepoLockStep` so CI jobs stop
+  cold-cloning large members (e.g. `effect-ts/effect`) from GitHub on every run; on a hit
+  `mr apply` finds the pinned commits present and no-ops. Defined next to
+  `jobLocalMegarepoStore` so the cache path can't drift from the sync step's env. A
+  relocated store re-applies cleanly (git/mr repair moved worktrees, reuse bares), so the
+  run-scoped store path doesn't affect the lock-keyed cache.
+
 - **@overeng/megarepo**: make the git subprocess deadline operation-aware. A single flat
   30s bound killed large bare clones (e.g. `effect-ts/effect`, ~140MB pack) that
   legitimately run longer under CI contention, while still needing to stay tight for

--- a/genie/ci-workflow.ts
+++ b/genie/ci-workflow.ts
@@ -197,6 +197,8 @@ export {
   defaultRefPolicyCheckStep,
   installMegarepoStep,
   jobLocalMegarepoStore,
+  restoreMegarepoStoreStep,
+  saveMegarepoStoreStep,
   syncMegarepoWorkspaceStep,
   type DefaultRefPolicyCheckStepOptions,
 } from './ci-workflow/megarepo.ts'

--- a/genie/ci-workflow/megarepo.ts
+++ b/genie/ci-workflow/megarepo.ts
@@ -4,6 +4,44 @@ import { shellSingleQuote } from './shared.ts'
 export const jobLocalMegarepoStore =
   '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
 
+/**
+ * GitHub Actions cache key for the megarepo store, keyed on the consumer's root
+ * `megarepo.lock`. A hit means {@link applyMegarepoLockStep} finds every pinned member
+ * commit already present in the restored store and no-ops — no cold clone of large
+ * members (e.g. `effect-ts/effect`) from GitHub. The key changes only when a member
+ * commit moves. Caches are per-repository in GitHub Actions, so the shared prefix is safe.
+ */
+const megarepoStoreCacheKey = "megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+
+/**
+ * Restore the job-local megarepo store BEFORE the sync step so `mr apply` reuses cached
+ * bares instead of cloning. Pairs with {@link saveMegarepoStoreStep} and addresses each
+ * job cold-cloning every member on every run.
+ *
+ * {@link jobLocalMegarepoStore} embeds `run_id`, so the store lands at a new absolute path
+ * each run and git worktrees embed absolute paths — but a relocated store re-applies
+ * cleanly (git/mr repair the moved worktrees and reuse the bares with zero re-clones), so
+ * the run-scoped path is irrelevant to the lock-keyed cache content.
+ */
+export const restoreMegarepoStoreStep = {
+  name: 'Restore megarepo store',
+  id: 'restore-megarepo-store',
+  uses: 'actions/cache/restore@v4',
+  with: { path: jobLocalMegarepoStore, key: megarepoStoreCacheKey },
+} as const
+
+/**
+ * Save the megarepo store AFTER the sync step. Guarded on a cold restore, so on a shared
+ * key only the first job to finish writes it and the rest no-op (`cache-hit` was false but
+ * the key now exists). Place immediately after {@link applyMegarepoLockStep}.
+ */
+export const saveMegarepoStoreStep = {
+  name: 'Save megarepo store',
+  if: "${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}",
+  uses: 'actions/cache/save@v4',
+  with: { path: jobLocalMegarepoStore, key: megarepoStoreCacheKey },
+} as const
+
 const appendGitHubPathLine = (valueExpression: string) =>
   `printf '%s\\n' ${valueExpression} >> "$GITHUB_PATH"`
 

--- a/genie/external.ts
+++ b/genie/external.ts
@@ -223,7 +223,11 @@ export {
   mqLabels,
 } from './labels.ts'
 
-export { deriveSystemLabels, systemLabelColor, type DeriveSystemLabelsArgs } from './system-labels.ts'
+export {
+  deriveSystemLabels,
+  systemLabelColor,
+  type DeriveSystemLabelsArgs,
+} from './system-labels.ts'
 
 /**
  * Catalog versions - single source of truth for dependency versions
@@ -880,6 +884,8 @@ export {
   standardCIEnv,
   syncMegarepoWorkspaceStep,
   applyMegarepoLockStep,
+  restoreMegarepoStoreStep,
+  saveMegarepoStoreStep,
   RUNNER_PROFILES,
   type CiMeasurementDescriptor,
   type DevenvPerfJobOptions,


### PR DESCRIPTION
## What

Add reusable `restoreMegarepoStoreStep` / `saveMegarepoStoreStep` genie CI-workflow helpers — `actions/cache` of the job-local megarepo store, keyed on the consumer's `megarepo.lock`. Consumers place them around `applyMegarepoLockStep` so CI jobs stop **cold-cloning large members** (e.g. `effect-ts/effect`, ~140MB) from GitHub on every run.

This is the redundant-per-job-clone exposure behind the clone timeouts fixed in livestorejs/livestore#1473 — the follow-up bandwidth/throughput win (livestorejs/livestore#1480). On a cache **hit**, `mr apply` finds every pinned member commit already present and no-ops → zero network clone.

## Why here (not in each consumer)

1. **Reuse** — any megarepo consumer with large members wants it.
2. **Kills a fragility** — the cache steps run *before* the sync step sets `MEGAREPO_STORE`, so a consumer-local version must **duplicate the store-path literal** and silently miss if it ever drifts. Defining them next to `jobLocalMegarepoStore` removes the duplication.

## Correctness of a relocated store

`jobLocalMegarepoStore` embeds `run_id`, so the store lands at a new absolute path each run and git worktrees embed absolute paths. Verified locally: copying a populated store to a new path and re-running `mr apply --all` **reuses the bares with zero re-clones** and the worktrees resolve (git/mr repair the move). So the run-scoped path doesn't affect the lock-keyed cache content.

## Validation

- `oxlint` (JS plugins) + `oxfmt` clean; `genie --check` shows no drift (effect-utils' own CI doesn't cold-clone, so these steps don't appear in its workflows).
- The exact generated cache steps are validated **end-to-end in a real consumer** at livestorejs/livestore#1480's PR (livestore CI: cold miss → save, then a warm hit → `mr apply` no-ops). livestore then repins to this and swaps its local defs for these imports.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | cl1-helix |
| `agent_session_id` | b8292c41-20df-491a-abbd-cae8a64a3e82 |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.215 |
| `agent_runtime` | Claude Code 2.1.215 |
| `agent_model` | claude-opus-4-8 |
| `runtime_profile` | /nix/store/yyh1q3l36718in0fh2q5r1yn1nkyzn7x-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/yydfgyf01y70ksvp15x1dacgkvcf6h5q-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-25-megarepo-store-cache |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@ee9fb0f |
</details>
<!-- agent-footer:end -->