### PR TITLE
feat(genie/ci-workflow): opt-in megarepo store caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- **genie/ci-workflow**: add opt-in megarepo store caching — `applyMegarepoLockStep({ cacheableStore: true })`
+  pins `MEGAREPO_STORE` to a stable `cacheableMegarepoStore` path, and reusable
+  `restoreMegarepoStoreStep` / `saveMegarepoStoreStep` (actions/cache keyed on the consumer's
+  `megarepo.lock`) go around it so CI jobs stop cold-cloning large members (e.g. `effect-ts/effect`)
+  every run. The default `jobLocalMegarepoStore` (run-scoped) is unchanged; caching requires the stable
+  path because GitHub derives an actions/cache *version* from the path, so a run-scoped path never
+  restores. Validated end-to-end in a consumer (restore hits, one deduped cache). Default behavior for
+  existing consumers is untouched.
+
 - **@overeng/megarepo**: make the git subprocess deadline operation-aware. A single flat
   30s bound killed large bare clones (e.g. `effect-ts/effect`, ~140MB pack) that
   legitimately run longer under CI contention, while still needing to stay tight for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ All notable changes to this project will be documented in this file.
 
 - **genie/ci-workflow**: add opt-in megarepo store caching — `applyMegarepoLockStep({ cacheableStore: true })`
   pins `MEGAREPO_STORE` to a stable `cacheableMegarepoStore` path, and reusable
-  `restoreMegarepoStoreStep` / `saveMegarepoStoreStep` (actions/cache keyed on the consumer's
-  `megarepo.lock`) go around it so CI jobs stop cold-cloning large members (e.g. `effect-ts/effect`)
+  `restoreMegarepoStoreStep({ skip })` / `saveMegarepoStoreStep({ skip })` (actions/cache keyed on the
+  consumer's `megarepo.lock`, partitioned by the `skip` set so a partial store never poisons a full
+  job) go around it so CI jobs stop cold-cloning large members (e.g. `effect-ts/effect`)
   every run. The default `jobLocalMegarepoStore` (run-scoped) is unchanged; caching requires the stable
   path because GitHub derives an actions/cache *version* from the path, so a run-scoped path never
   restores. Validated end-to-end in a consumer (restore hits, one deduped cache). Default behavior for

--- a/genie/ci-workflow.ts
+++ b/genie/ci-workflow.ts
@@ -195,8 +195,11 @@ export {
 export {
   applyMegarepoLockStep,
   defaultRefPolicyCheckStep,
+  cacheableMegarepoStore,
   installMegarepoStep,
   jobLocalMegarepoStore,
+  restoreMegarepoStoreStep,
+  saveMegarepoStoreStep,
   syncMegarepoWorkspaceStep,
   type DefaultRefPolicyCheckStepOptions,
 } from './ci-workflow/megarepo.ts'

--- a/genie/ci-workflow/megarepo.ts
+++ b/genie/ci-workflow/megarepo.ts
@@ -4,6 +4,43 @@ import { shellSingleQuote } from './shared.ts'
 export const jobLocalMegarepoStore =
   '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
 
+/**
+ * Stable megarepo store path for consumers that cache the store (see {@link restoreMegarepoStoreStep}).
+ *
+ * GitHub derives an `actions/cache` *version* from the cache `path`, so a run-scoped path
+ * (like {@link jobLocalMegarepoStore}) yields a new version every run and restores **never hit**;
+ * each job also writes a duplicate. A stable path — mirroring the pnpm-state cache's
+ * `${{ github.workspace }}` path — keeps the version stable across runs, so restores hit and
+ * GitHub's reserve dedups the concurrent saves. Safe: GitHub runs one job per (ephemeral) runner,
+ * so `runner.temp` is already per-job; a persistent runner's sequential jobs just reuse the warm
+ * store. Opt in via `applyMegarepoLockStep({ cacheableStore: true })`.
+ */
+export const cacheableMegarepoStore = '${{ runner.temp }}/megarepo-store'
+
+/** `actions/cache` key for the megarepo store, keyed on the consumer's root `megarepo.lock`. */
+const megarepoStoreCacheKey = "megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+
+/**
+ * Restore the {@link cacheableMegarepoStore} BEFORE the sync step (use with
+ * `applyMegarepoLockStep({ cacheableStore: true })`). On a hit `mr apply` finds the pinned member
+ * commits already present and no-ops instead of cold-cloning large members from GitHub. Pairs with
+ * {@link saveMegarepoStoreStep}. A restored store re-applies cleanly (git/mr reuse the bares).
+ */
+export const restoreMegarepoStoreStep = {
+  name: 'Restore megarepo store',
+  id: 'restore-megarepo-store',
+  uses: 'actions/cache/restore@v4',
+  with: { path: cacheableMegarepoStore, key: megarepoStoreCacheKey },
+} as const
+
+/** Save the {@link cacheableMegarepoStore} AFTER the sync step, guarded on a cold restore. */
+export const saveMegarepoStoreStep = {
+  name: 'Save megarepo store',
+  if: "${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}",
+  uses: 'actions/cache/save@v4',
+  with: { path: cacheableMegarepoStore, key: megarepoStoreCacheKey },
+} as const
+
 const appendGitHubPathLine = (valueExpression: string) =>
   `printf '%s\\n' ${valueExpression} >> "$GITHUB_PATH"`
 
@@ -70,7 +107,9 @@ ${args.join(' ')}`,
  * Resolves the CLI inline with `nix run` to avoid `nix profile install`
  * conflicts on self-hosted runners.
  */
-export const applyMegarepoLockStep = (opts?: { skip?: string[] }) => {
+export const applyMegarepoLockStep = (opts?: { skip?: string[]; cacheableStore?: boolean }) => {
+  const megarepoStore =
+    opts?.cacheableStore === true ? cacheableMegarepoStore : jobLocalMegarepoStore
   const skipCsv = opts?.skip?.join(',') ?? ''
   const skipArgs = skipCsv === '' ? '' : `--skip ${shellSingleQuote(skipCsv)}`
   const quotedSkipCsv = shellSingleQuote(skipCsv)
@@ -82,7 +121,7 @@ export const applyMegarepoLockStep = (opts?: { skip?: string[] }) => {
 fi`
   return {
     name: 'Sync megarepo dependencies',
-    env: { MEGAREPO_STORE: jobLocalMegarepoStore },
+    env: { MEGAREPO_STORE: megarepoStore },
     run: `EU_REV=$(jq -r '.members["effect-utils"].commit' megarepo.lock)
 if [ -z "$EU_REV" ] || [ "$EU_REV" = "null" ]; then
   echo '::error::megarepo.lock missing members["effect-utils"].commit'

--- a/genie/ci-workflow/megarepo.ts
+++ b/genie/ci-workflow/megarepo.ts
@@ -17,29 +17,50 @@ export const jobLocalMegarepoStore =
  */
 export const cacheableMegarepoStore = '${{ runner.temp }}/megarepo-store'
 
-/** `actions/cache` key for the megarepo store, keyed on the consumer's root `megarepo.lock`. */
-const megarepoStoreCacheKey = "megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+/**
+ * `actions/cache` key for the megarepo store, keyed on the consumer's root `megarepo.lock` and
+ * **partitioned by the skip set**. Jobs that skip different members produce different store
+ * contents; without partitioning they collide on one key, so a partial store (from a skipping
+ * job) would be restored by a full job that then re-clones the omitted member — and, because the
+ * exact restore reports `cache-hit=true`, never republishes the enriched store, re-cloning every
+ * run. Pass the SAME `skip` here as to {@link applyMegarepoLockStep}.
+ */
+const megarepoStoreCacheKey = (skip?: readonly string[]): string => {
+  const scope =
+    skip === undefined || skip.length === 0
+      ? 'full'
+      : `skip-${[...skip]
+          .sort()
+          .join('.')
+          .replace(/[^a-zA-Z0-9._-]/g, '_')}`
+  // Concatenate (not a template literal) so the GitHub `${{ … }}` expressions stay literal.
+  return 'megarepo-store-v1-${{ runner.os }}-' + scope + "-${{ hashFiles('megarepo.lock') }}"
+}
 
 /**
  * Restore the {@link cacheableMegarepoStore} BEFORE the sync step (use with
  * `applyMegarepoLockStep({ cacheableStore: true })`). On a hit `mr apply` finds the pinned member
- * commits already present and no-ops instead of cold-cloning large members from GitHub. Pairs with
+ * commits already present and no-ops instead of cold-cloning large members from GitHub. Pass the
+ * same `skip` as the sync step so the cache identity matches the store contents. Pairs with
  * {@link saveMegarepoStoreStep}. A restored store re-applies cleanly (git/mr reuse the bares).
  */
-export const restoreMegarepoStoreStep = {
+export const restoreMegarepoStoreStep = (opts?: { skip?: readonly string[] }) => ({
   name: 'Restore megarepo store',
   id: 'restore-megarepo-store',
   uses: 'actions/cache/restore@v4',
-  with: { path: cacheableMegarepoStore, key: megarepoStoreCacheKey },
-} as const
+  with: { path: cacheableMegarepoStore, key: megarepoStoreCacheKey(opts?.skip) },
+})
 
-/** Save the {@link cacheableMegarepoStore} AFTER the sync step, guarded on a cold restore. */
-export const saveMegarepoStoreStep = {
+/**
+ * Save the {@link cacheableMegarepoStore} AFTER the sync step, guarded on a cold restore. Pass the
+ * same `skip` as {@link restoreMegarepoStoreStep} / {@link applyMegarepoLockStep}.
+ */
+export const saveMegarepoStoreStep = (opts?: { skip?: readonly string[] }) => ({
   name: 'Save megarepo store',
   if: "${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}",
   uses: 'actions/cache/save@v4',
-  with: { path: cacheableMegarepoStore, key: megarepoStoreCacheKey },
-} as const
+  with: { path: cacheableMegarepoStore, key: megarepoStoreCacheKey(opts?.skip) },
+})
 
 const appendGitHubPathLine = (valueExpression: string) =>
   `printf '%s\\n' ${valueExpression} >> "$GITHUB_PATH"`

--- a/genie/external.ts
+++ b/genie/external.ts
@@ -223,7 +223,11 @@ export {
   mqLabels,
 } from './labels.ts'
 
-export { deriveSystemLabels, systemLabelColor, type DeriveSystemLabelsArgs } from './system-labels.ts'
+export {
+  deriveSystemLabels,
+  systemLabelColor,
+  type DeriveSystemLabelsArgs,
+} from './system-labels.ts'
 
 /**
  * Catalog versions - single source of truth for dependency versions
@@ -880,6 +884,9 @@ export {
   standardCIEnv,
   syncMegarepoWorkspaceStep,
   applyMegarepoLockStep,
+  cacheableMegarepoStore,
+  restoreMegarepoStoreStep,
+  saveMegarepoStoreStep,
   RUNNER_PROFILES,
   type CiMeasurementDescriptor,
   type DevenvPerfJobOptions,

--- a/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
@@ -145,7 +145,7 @@ const validateNixStoreStepSource = extractSourceBlock(
 
 const applyMegarepoLockStepSource = extractSourceBlock(
   ciWorkflowSource,
-  'export const applyMegarepoLockStep = (opts?: { skip?: string[] }) => {',
+  'export const applyMegarepoLockStep = (opts?: { skip?: string[]; cacheableStore?: boolean }) => {',
   'export type DefaultRefPolicyCheckStepOptions = {',
 )
 const defaultRefPolicyCheckStepSource = extractSourceBlock(


### PR DESCRIPTION
## What

Add **opt-in** megarepo store caching so consumers stop cold-cloning large members (e.g. `effect-ts/effect`) from GitHub on every CI run — the redundant-clone follow-up to the timeout fix (livestorejs/livestore#1473, #1480):

- `applyMegarepoLockStep({ cacheableStore: true })` pins `MEGAREPO_STORE` to a stable `cacheableMegarepoStore` path.
- Reusable `restoreMegarepoStoreStep` / `saveMegarepoStoreStep` (actions/cache keyed on the consumer's `megarepo.lock`) go around the sync step.

On a cache hit `mr apply` finds the pinned commits present and no-ops → zero network clone.

## Why a stable path (the crux)

GitHub derives an `actions/cache` **version** from the cache `path`. The default `jobLocalMegarepoStore` embeds `run_id`/`run_attempt`/`job`, so it gets a **new version every run** → restores **never hit**, and each of ~13 jobs writes a **duplicate** (≈13 GB, over the repo limit). A stable path — mirroring the pnpm-state cache's `${{ github.workspace }}` path — keeps the version stable, so restores hit and GitHub's reserve dedups the concurrent saves.

## Opt-in / safe

The default `jobLocalMegarepoStore` (run-scoped) is **unchanged** — existing consumers are unaffected. Caching is opt-in via the flag. Safe because GitHub runs one job per (ephemeral) runner, so `runner.temp` is already per-job; a persistent runner's sequential jobs simply reuse the warm store.

## Validated end-to-end in a consumer

Proven in livestorejs/livestore#1487 (livestore CI, this exact generated wiring):
- Cold run → **one** 359 MB cache (not 12 duplicates).
- Fresh run → **restore hits** (5 s download; Save step skipped on `cache-hit=true`); sync drops from a full `effect` clone (~56 s) to a no-op (the residual is the fixed `nix run mr` cost). Whole run green.

effect-utils' own CI doesn't cold-clone, so these steps don't appear in its workflows (no genie drift); `oxlint`/`oxfmt` clean. livestore will repin and switch from its local override to `{ cacheableStore: true }` (identical YAML).

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | cl1-helix |
| `agent_session_id` | b8292c41-20df-491a-abbd-cae8a64a3e82 |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.215 |
| `agent_runtime` | Claude Code 2.1.215 |
| `agent_model` | claude-opus-4-8 |
| `runtime_profile` | /nix/store/yyh1q3l36718in0fh2q5r1yn1nkyzn7x-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/yydfgyf01y70ksvp15x1dacgkvcf6h5q-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-25-megarepo-store-cache-v2 |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@ee9fb0f |
</details>
<!-- agent-footer:end -->