### PR TITLE
Emit workflow commands on stderr so they survive devenv task capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- **devenv-modules**: GitHub workflow commands emitted by tasks now go to stderr. devenv does not
+  forward a task's stdout, so `echo "::warning::…"` there never reached the runner — it produced no
+  annotation and no log group. That silently affected the two `::notice::` emits in
+  `workflow-report` and the `::group::`/`::endgroup::` pairs in `context` and `pnpm`, so CI log
+  grouping from inside a task had never worked. Adds `lint:nix:workflow-commands` (wired into
+  `lint:nix`) to fail on any unredirected emit under `nix/devenv-modules`, and documents the
+  channel in `nix/devenv-modules/tasks/README.md`. Consumers writing their own tasks should apply
+  the same rule. Fixes #968.
+
 - **@overeng/megarepo**: `mr apply` now fails when it leaves a pinned member drifted from
   `megarepo.lock`. Previously every path returning `skipped` exited 0, so apply could report
   success over a workspace that disagreed with the lock that produced it — invisible because

--- a/nix/devenv-modules/tasks/README.md
+++ b/nix/devenv-modules/tasks/README.md
@@ -100,6 +100,28 @@ Helper functions used by task modules:
 - `cli-guard.nix` - Guarded task-owned CLI wrappers
 - `trace.nix` - Task tracing wrappers
 
+## Task Output
+
+devenv does not forward a task's **stdout** to the caller — on success or on
+failure, and regardless of `--show-output` or `DEVENV_TASK_PASSTHROUGH`. Its
+**stderr** is forwarded in every case.
+
+So anything a task emits for the operator, and every GitHub workflow command,
+must go to stderr:
+
+```nix
+echo "::warning::pnpm store was rebuilt from scratch" >&2
+```
+
+On stdout the same line is silently discarded: it never reaches the job log, and
+GitHub never turns it into an annotation or a log group. `lint:nix:workflow-commands`
+fails the build on any `echo "::…"` here that is missing `>&2`.
+
+Stdout is not a reliable channel in either direction: a direct `devenv tasks run`
+of a failing task discarded its stdout too, while a failing *dependency* task's
+stdout does appear in devenv's error summary in CI. Rather than depend on which
+case applies, put anything you need to read on stderr.
+
 ## Adding New Tasks
 
 ### For Shared Tasks:

--- a/nix/devenv-modules/tasks/shared/context.nix
+++ b/nix/devenv-modules/tasks/shared/context.nix
@@ -21,7 +21,7 @@ in
           local server_script="$2"
           shift 2
           
-          echo "::group::$label"
+          echo "::group::$label" >&2
           
           # Start server in background
           bun "$SOCKET_DIR/$server_script" &
@@ -38,7 +38,7 @@ in
           kill $SERVER_PID 2>/dev/null || true
           trap - EXIT
           
-          echo "::endgroup::"
+          echo "::endgroup::" >&2
         }
 
         # WS echo

--- a/nix/devenv-modules/tasks/shared/lint-nix.nix
+++ b/nix/devenv-modules/tasks/shared/lint-nix.nix
@@ -102,7 +102,7 @@ let
       description = "Check GitHub workflow commands in task definitions go to stderr";
       exec = trace.exec "lint:nix:workflow-commands" ''
         offenders=$(${git} ls-files 'nix/devenv-modules/*.nix' 'nix/devenv-modules/*.sh' \
-          | xargs grep -nE 'echo +"::' \
+          | xargs grep -nE "(echo|printf)( +-[A-Za-z]+)* +['\"]::" \
           | grep -v '>&2' || true)
 
         if [ -n "$offenders" ]; then

--- a/nix/devenv-modules/tasks/shared/lint-nix.nix
+++ b/nix/devenv-modules/tasks/shared/lint-nix.nix
@@ -94,6 +94,25 @@ let
   };
 
   otherTasks = {
+    # devenv discards a task's stdout, so a GitHub workflow command echoed there
+    # never reaches the runner and never becomes an annotation or a log group.
+    # stderr is forwarded, so that is where these have to go. Without this guard
+    # the mistake is invisible: the emit looks correct and simply does nothing.
+    "lint:nix:workflow-commands" = {
+      description = "Check GitHub workflow commands in task definitions go to stderr";
+      exec = trace.exec "lint:nix:workflow-commands" ''
+        offenders=$(${git} ls-files 'nix/devenv-modules/*.nix' 'nix/devenv-modules/*.sh' \
+          | xargs grep -nE 'echo +"::' \
+          | grep -v '>&2' || true)
+
+        if [ -n "$offenders" ]; then
+          echo "Workflow commands must be written to stderr; devenv discards task stdout." >&2
+          echo "Append '>&2' to each line below:" >&2
+          echo "$offenders" >&2
+          exit 1
+        fi
+      '';
+    };
     "lint:nix:eval-warnings" = lib.mkIf hasEvalTargets {
       description = "Check for Nix evaluation warnings (deprecated APIs)";
       exec = trace.exec "lint:nix:eval-warnings" "${evalScript} ${evalTargetsArgs}";
@@ -103,6 +122,7 @@ let
       after = [
         "lint:nix:format"
         "lint:nix:deadcode"
+        "lint:nix:workflow-commands"
       ]
       ++ lib.optional hasEvalTargets "lint:nix:eval-warnings";
     };

--- a/nix/devenv-modules/tasks/shared/pnpm.nix
+++ b/nix/devenv-modules/tasks/shared/pnpm.nix
@@ -388,7 +388,7 @@ let
       fi
 
       if [ -n "''${GITHUB_ACTIONS:-}" ]; then
-        echo "::group::pnpm install failure diagnostics"
+        echo "::group::pnpm install failure diagnostics" >&2
       fi
 
       echo "[pnpm] Install failed: $classification" >&2
@@ -415,7 +415,7 @@ let
       fi
 
       if [ -n "''${GITHUB_ACTIONS:-}" ]; then
-        echo "::endgroup::"
+        echo "::endgroup::" >&2
       fi
 
       return "$rc"

--- a/nix/devenv-modules/tasks/shared/setup.nix
+++ b/nix/devenv-modules/tasks/shared/setup.nix
@@ -326,7 +326,6 @@ in
 
           # TEMPORARY PROBE for #968 — remove before merge.
           echo "::notice title=stderr-probe::PROBE-968 emitted from a succeeding devenv task via stderr" >&2
-          echo "::notice title=stdout-probe::PROBE-968-STDOUT should not appear"
 
           _git_dir=$(${git} rev-parse --git-dir 2>/dev/null)
           if [ -d "$_git_dir/rebase-merge" ] || [ -d "$_git_dir/rebase-apply" ]; then

--- a/nix/devenv-modules/tasks/shared/setup.nix
+++ b/nix/devenv-modules/tasks/shared/setup.nix
@@ -324,9 +324,6 @@ in
           set -euo pipefail
           ${setupFingerprintEnv}
 
-          # TEMPORARY PROBE for #968 — remove before merge.
-          echo "::notice title=stderr-probe::PROBE-968 emitted from a succeeding devenv task via stderr" >&2
-
           _git_dir=$(${git} rev-parse --git-dir 2>/dev/null)
           if [ -d "$_git_dir/rebase-merge" ] || [ -d "$_git_dir/rebase-apply" ]; then
             echo "Skipping setup during git rebase/cherry-pick"

--- a/nix/devenv-modules/tasks/shared/setup.nix
+++ b/nix/devenv-modules/tasks/shared/setup.nix
@@ -324,6 +324,10 @@ in
           set -euo pipefail
           ${setupFingerprintEnv}
 
+          # TEMPORARY PROBE for #968 — remove before merge.
+          echo "::notice title=stderr-probe::PROBE-968 emitted from a succeeding devenv task via stderr" >&2
+          echo "::notice title=stdout-probe::PROBE-968-STDOUT should not appear"
+
           _git_dir=$(${git} rev-parse --git-dir 2>/dev/null)
           if [ -d "$_git_dir/rebase-merge" ] || [ -d "$_git_dir/rebase-apply" ]; then
             echo "Skipping setup during git rebase/cherry-pick"

--- a/nix/devenv-modules/tasks/shared/workflow-report.nix
+++ b/nix/devenv-modules/tasks/shared/workflow-report.nix
@@ -113,12 +113,14 @@ in
         : "''${WORKFLOW_REPORT_PR_NUMBER:?WORKFLOW_REPORT_PR_NUMBER is required for workflow-report PR publishing}"
 
         if [ "''${WORKFLOW_REPORT_HEAD_REPO:-$GH_REPO}" != "$GH_REPO" ]; then
-          echo "::notice::workflow report PR comment skipped for fork pull request; summary remains available in the job summary"
+          # stderr, not stdout: devenv does not forward a task's stdout to the
+          # caller, so a workflow command echoed there never reaches the runner.
+          echo "::notice::workflow report PR comment skipped for fork pull request; summary remains available in the job summary" >&2
           exit 0
         fi
 
         if [ ! -s "$WORKFLOW_REPORT_COMMENT_BODY_PATH" ]; then
-          echo "::notice::workflow report comment body is empty; skipping PR comment"
+          echo "::notice::workflow report comment body is empty; skipping PR comment" >&2
           exit 0
         fi
 


### PR DESCRIPTION
Fixes #968.

## Problem

devenv does not forward a task's **stdout** to the caller, so a workflow command echoed there never reaches the runner and never becomes an annotation.

Both `::notice::` emits in `workflow-report.nix` were on stdout inside tasks that then `exit 0`. Neither has ever surfaced.

## Correction to the issue

#968 says devenv prints task stdout "only when the task fails". That is wrong — I verified it locally against devenv 2.1.2 with a minimal one-task project:

| | stdout | stderr |
| --- | --- | --- |
| task exits 0 | **discarded** | passes through |
| task exits 1 | **discarded** | passes through |

Neither `DEVENV_TASK_PASSTHROUGH=1` nor `--show-output` changes any cell — `--show-output` was my first guess and it makes no difference at all.

So the fix is smaller than any option the issue proposed: no pass-through filter, no per-task opt-in, no config. Operator-facing output goes to the channel devenv already forwards.

## Change

The two `::notice::` emits now write to stderr, with a comment stating why.

## Verification

Locally (devenv 2.1.2, minimal project, task echoing to both streams then `exit 0`):

```
stdout seen: 0   stderr seen: 1   file written: 1
```

This PR also carries a **temporary probe** in `setup:gate` emitting one `::notice::` on stderr and one on stdout, to prove the stderr→annotation link in real CI rather than assuming it. Expected: the stderr probe appears as an annotation, the stdout one does not. **The probe is removed before merge** — I will post the observed result here first.

## Concerns

- This fixes the emit sites and states the constraint, but nothing enforces it — a future `echo "::warning::…"` on stdout will be silently swallowed again. A lint or shared helper would enforce it; both add machinery, so I have left it as a comment at the point of use. Worth revisiting if it recurs.
- The underlying devenv behaviour is unchanged and still surprising: a task's stdout is discarded even when it fails. That is arguably worth an upstream report, separate from this.

## Downstream

livestorejs/livestore's quarantine reporter documents its `::warning::` as best-effort for this reason and relies on `$GITHUB_STEP_SUMMARY`. Once this lands, that annotation can be made reliable by switching it to stderr.

---

## Update: guard added, and the fix was incomplete

Fixing the two `::notice::` emits was not enough. `::group::` / `::endgroup::` in `context.nix` and `pnpm.nix` were on stdout as well, so **CI log grouping from inside a task has never worked either**. Those are redirected too.

That is exactly why a comment was not sufficient enforcement, so this now ships a guard: `lint:nix:workflow-commands`, wired into the existing `lint:nix` aggregate. It fails on any `echo "::…"` under `nix/devenv-modules` that is not redirected to stderr, printing the offending `file:line`.

**A lint, not a `checks.<system>` output.** This flake exposes no `checks`, and CI builds specific attrs rather than running `nix flake check` — so a check there would never execute. An unrun check is precisely the failure mode this change exists to fix.

Verified both directions:

```
clean tree                    -> no offenders
remove one '>&2' from pnpm.nix -> nix/devenv-modules/tasks/shared/pnpm.nix:418: echo "::endgroup::"
```

The guard's own grep pattern is written so it does not match itself.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | cl1-iris |
| `agent_session_id` | f0a25af9-c1ee-48a5-add1-5ea39125b283 |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.220 |
| `agent_runtime` | Claude Code 2.1.220 |
| `agent_model` | claude-opus-5 |
| `runtime_profile` | /nix/store/g65ryv9zcr8acxxjlpgcrynh8d7s7qwn-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/hiw5ggfjp9mr78vbrq30i77ypfyixv32-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | livestore/schickling/2026-07-25-1412 |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->