### PR TITLE
Centralize devenv profiling and verification with otelite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- **devenv observability**: add a lightweight `devenvModules.observability`
+  adapter that captures native devenv OTLP/gRPC and effect-utils OTLP/HTTP task
+  spans in one isolated otelite trace. Consumers get consistent
+  `otel:profile:<name>` / `otel:verify:<name>` tasks and project attribution
+  without copying shell/Nix orchestration or importing the full local
+  Collector/Tempo/Grafana stack.
+
 - **devenv-modules**: GitHub workflow commands emitted by tasks now go to stderr. devenv does not
   forward a task's stdout, so `echo "::warning::…"` there never reached the runner — it produced no
   annotation and no log group. That silently affected the two `::notice::` emits in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to this project will be documented in this file.
   `otel:profile:<name>` / `otel:verify:<name>` tasks and project attribution
   without copying shell/Nix orchestration or importing the full local
   Collector/Tempo/Grafana stack.
+  The shared setup module also gains `skipNonInteractive`, removing the need
+  for consumers to replace `setup:gate` (and accidentally drop its tracing)
+  just to keep non-interactive shell entry cheap.
 
 - **devenv-modules**: GitHub workflow commands emitted by tasks now go to stderr. devenv does not
   forward a task's stdout, so `echo "::warning::…"` there never reached the runner — it produced no

--- a/context/otelite/spec.md
+++ b/context/otelite/spec.md
@@ -267,6 +267,28 @@ exercise the real receiver and the real binary (per house rules).
   transports) is shared across Rust integration tests and the Effect wrapper
   tests, so both layers test against the same known input.
 
+### Devenv adapter
+
+`devenvModules.observability` is the reusable adapter between native devenv
+task tracing and otelite. A consumer supplies a stable project name and,
+optionally, a task profile. The module:
+
+- adds the bootstrap-safe `otel-span` and Nix-built `otelite` binaries;
+- sends native devenv spans over OTLP/gRPC and effect-utils task spans over
+  OTLP/HTTP to one invocation-scoped otelite capture;
+- emits low-cardinality `devenv.project.name` on effect-utils task spans;
+- provides `otel:profile:<name>` for retained diagnostic captures and
+  `otel:verify:<name>` for a hermetic, automatically cleaned shape check; and
+- optionally composes the existing Collector/Tempo/Grafana module through
+  `backend = "auto" | "local" | "system"`.
+
+The default `ambient` backend does not add the production-like local stack, so
+repositories can adopt the common capture contract without pulling
+Collector/Tempo/Grafana into their development closure. The adapter owns
+transport and lifecycle mechanics only; repository-specific performance and
+correctness assertions continue to consume `spans.ndjson` with `jq` or the
+typed Effect wrapper.
+
 ## Trace-derived metrics (spanmetrics)
 
 `inspect --signal traces --derive-metrics` projects captured spans into RED

--- a/context/workarounds/devenv-issues.md
+++ b/context/workarounds/devenv-issues.md
@@ -2,75 +2,41 @@
 
 ## Active Workarounds
 
-### DEVENV-02: Task tracing lacks OTLP export and observability features
+### DEVENV-02: Detailed OTLP task phases require global CLI verbosity
 
-**Issue:** https://github.com/cachix/devenv/issues/2415 (OTEL support feature request)
+**Issue:** https://github.com/cachix/devenv/issues/3037
 
-**Related:**
+**Resolved foundation:**
 
-- https://github.com/cachix/devenv/issues/2456 (docs: clarify `--trace-output` requirement)
-- https://github.com/cachix/devenv/issues/1457 (Task Server Protocol - proposes JSON-RPC with timestamps)
+- https://github.com/cachix/devenv/issues/2415
+- https://github.com/cachix/devenv/pull/2740
 
-**Affected repos:** All repos using devenv tasks that need CI observability
+**Affected repos:** Repositories using shared effect-utils setup profiling
 
-**Symptoms:**
+Devenv 2.1 natively exports root, evaluation, build, task, and process spans to
+OTLP. It also propagates `TRACEPARENT` and `TRACESTATE` to subprocesses, so
+instrumented tools can join the native trace. Native orchestration tracing is
+therefore no longer a workaround owned by effect-utils.
 
-- No native OTLP export to observability systems (Datadog, Honeycomb, etc.)
-- No summary statistics (total wall time, parallelism efficiency, cache hit rates)
-- No historical metrics tracking across CI runs
+The remaining gap is narrower. Devenv creates `check status` and
+`execute command` child activities, but marks them as Debug. Normal OTLP
+captures expose only aggregate task duration. `--verbose` exposes both phases
+but also changes console/TUI verbosity and exports unrelated debug activity.
 
-**Current capabilities (devenv 2.0.0):**
+**Current workaround:** The shared observability module joins native devenv
+OTLP/gRPC spans with Effect task-phase OTLP/HTTP spans in one isolated otelite
+capture. This preserves status-versus-execution timing until devenv can select
+OTLP detail independently from human-facing verbosity.
 
-JSON traces are available but require `--trace-output` (traces are disabled by default):
+**Deletion criterion:** After #3037 ships in a tagged devenv release and the
+native task → status/exec → instrumented-child hierarchy passes the shared
+otelite proof, remove only the `otel-span` task-phase producer, HTTP bridge, and
+Effect-parent assertion.
 
-```bash
-# Enable JSON traces to a file
-devenv tasks run <task> --no-tui --trace-output file:/tmp/trace.json --trace-format json
-
-# Or output to stdout/stderr
-devenv tasks run <task> --no-tui --trace-output stdout --trace-format json
-```
-
-JSON trace output includes:
-
-- Per-task start/complete events with timestamps
-- Span context with parent/child relationships (span_id, parent_id)
-- Activity kinds: task, command, evaluate, operation
-- Outcomes: success, cached, failure
-- Command paths executed
-
-Example trace event:
-
-```json
-{
-  "fields": {
-    "event": {
-      "activity_kind": "task",
-      "event": "complete",
-      "id": 9223372036854775817,
-      "name": "ts:check",
-      "outcome": "success",
-      "timestamp": "2026-02-03T14:08:00.556348000Z"
-    }
-  },
-  "span_context": { "span_id": 274877906946, "parent_id": 274877906945 }
-}
-```
-
-**R10 requirements gap analysis:**
-
-| Requirement                       | Status       | Notes                                             |
-| --------------------------------- | ------------ | ------------------------------------------------- |
-| (a) Per-task timing               | ✅ Available | Via `--trace-output` JSON with timestamps         |
-| (b) Dependency visualization      | ✅ Available | Via span parent/child relationships in JSON       |
-| (c) Stdout/stderr capture         | ⚠️ Partial   | Available with `--show-output`, not in trace JSON |
-| (d) Structured export (JSON/OTLP) | ⚠️ Partial   | JSON available, OTLP not yet implemented          |
-| (e) Summary statistics            | ❌ Missing   | Must be computed from raw trace events            |
-| (f) Metrics over time             | ❌ Missing   | No built-in cross-run tracking                    |
-
-**Workaround:** Use `--trace-output file:<path> --trace-format json` to get structured traces, then post-process for observability platforms.
-
-**Potential upstream contribution:** Issue #2415 proposes adding native OTLP export using `tracing-opentelemetry` crate.
+The rest of `nix/devenv-modules/observability.nix` is durable shared tooling:
+otelite lifecycle, hermetic capture, inspection assertions, profile/verify task
+generation, project conventions, backend selection, and check wiring remain
+effect-utils responsibilities.
 
 ---
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -354,6 +354,12 @@ in
     (taskModules.worktree-guard { })
     # OpenTelemetry observability stack (Collector + Tempo + Grafana)
     (import ./nix/devenv-modules/otel.nix { })
+    # Hermetic native-devenv + effect-utils task-tree capture. Ambient mode
+    # composes with the full stack above without importing it a second time.
+    (import ./nix/devenv-modules/observability.nix {
+      project = "effect-utils";
+      wireInto = [ "check:all" ];
+    })
     # gh:apply-labels / gh:check-labels — reconcile .github/labels.json with live labels
     (import ./nix/devenv-modules/gh-labels.nix { repo = "overengineeringstudio/effect-utils"; })
     # Playwright browser drivers and environment setup

--- a/flake.nix
+++ b/flake.nix
@@ -231,6 +231,9 @@
     // {
       # Devenv modules for importing into other repos
       devenvModules = {
+        # Lightweight native-devenv + effect-utils capture, optionally composed
+        # with the full Collector/Tempo/Grafana stack.
+        observability = import ./nix/devenv-modules/observability.nix;
         # OpenTelemetry observability stack (Collector + Tempo + Grafana)
         otel = import ./nix/devenv-modules/otel.nix;
         # Shared task modules (parameterized) - meant for reuse in other repos

--- a/nix/devenv-modules/observability.nix
+++ b/nix/devenv-modules/observability.nix
@@ -1,0 +1,190 @@
+# Lightweight, repository-agnostic devenv observability.
+#
+# This module deliberately keeps capture orchestration in effect-utils while
+# leaving domain assertions in the owning repository. It joins native devenv
+# OTLP/gRPC spans and effect-utils OTLP/HTTP task spans in one otelite capture.
+{
+  project,
+  backend ? "ambient",
+  profile ? {
+    name = "setup";
+    task = "setup:strict";
+    mode = "before";
+    smokeTask = "setup:gate";
+    smokeMode = "single";
+    bridgeTask = "setup:gate";
+  },
+  wireInto ? [ ],
+}:
+{
+  pkgs,
+  lib,
+  ...
+}:
+let
+  validBackends = [
+    "ambient"
+    "auto"
+    "local"
+    "system"
+  ];
+  _backend =
+    if builtins.elem backend validBackends then
+      backend
+    else
+      throw "effect-utils observability: backend must be one of ${builtins.concatStringsSep ", " validBackends}";
+
+  otelSpan = import ./otel/otel-span.nix { inherit pkgs; };
+  otelite = import (../../packages + "/@overeng/otelite/nix/build.nix") { inherit pkgs; };
+
+  capture =
+    if profile == null then
+      null
+    else
+      pkgs.writeShellApplication {
+        name = "devenv-otel-capture-${profile.name}";
+        runtimeInputs = [
+          pkgs.coreutils
+          pkgs.jq
+        ];
+        text = ''
+          target_task="$1"
+          task_mode="$2"
+          capture_dir="$3"
+          bridge_task="$4"
+
+          mkdir -p "$capture_dir"
+          summary_file="$capture_dir/summary.json"
+          spans_file="$capture_dir/spans.ndjson"
+
+          # Native devenv uses OTLP/gRPC while effect-utils shell spans use
+          # OTLP/HTTP. Otelite owns both isolated receivers for this invocation.
+          # shellcheck disable=SC2016
+          env \
+            -u DEVENV_TRACE_TO \
+            -u OTEL_TASK_TRACEPARENT \
+            -u TRACEPARENT \
+            -u OTEL_SHELL_ENTRY_NS \
+            ${otelite}/bin/otelite run \
+              --out "$capture_dir/capture" \
+              --protocol grpc \
+              -- \
+              bash -ceu '
+                export OTEL_EXPORTER_OTLP_ENDPOINT="$OTELITE_HTTP_ENDPOINT"
+                export DEVENV_TUI=false
+                exec devenv tasks run "$1" \
+                  --mode "$2" \
+                  --no-tui \
+                  --trace-to "otlp-grpc:''${OTELITE_GRPC_ENDPOINT}"
+              ' bash "$target_task" "$task_mode" \
+              | tee "$summary_file"
+
+          ${otelite}/bin/otelite inspect "$capture_dir/capture" \
+            --signal traces > "$spans_file"
+
+          jq -e '
+            .schema == "otelite.summary/v1"
+            and .child.exit_code == 0
+            and .counts.rejected == 0
+            and .counts.spans > 0
+          ' "$summary_file" >/dev/null
+
+          jq -s -e --arg task "$target_task" '
+            ([.[].trace_id] | unique | length) == 1
+            and any(.[];
+              .service == "devenv"
+              and .name == "devenv"
+              and .parent_span_id == null
+            )
+            and any(.[];
+              .service == "devenv"
+              and .name == $task
+              and .attrs["devenv.activity.kind"] == "task"
+            )
+          ' "$spans_file" >/dev/null
+
+          jq -s -e \
+            --arg bridge "$bridge_task" \
+            --arg project ${lib.escapeShellArg project} '
+            ([.[] | select(
+              .service == "devenv"
+              and .name == $bridge
+              and .attrs["devenv.activity.kind"] == "task"
+            )][0].span_id) as $native
+            | $native != null
+              and any(.[];
+                .service == "effect-utils-devenv"
+                and .name == "devenv.task.exec"
+                and .attrs["task.name"] == $bridge
+                and .attrs["devenv.project.name"] == $project
+                and .parent_span_id == $native
+              )
+          ' "$spans_file" >/dev/null
+
+          ${otelite}/bin/otelite inspect "$capture_dir/capture" \
+            --signal traces --summary --pretty >&2
+          printf 'Trace capture: %s\n' "$capture_dir" >&2
+        '';
+      };
+
+  profileTaskName = if profile == null then null else "otel:profile:${profile.name}";
+  verifyTaskName = if profile == null then null else "otel:verify:${profile.name}";
+  profileTasks =
+    if profile == null then
+      { }
+    else
+      {
+        "${profileTaskName}" = {
+          description = "Capture ${profile.task} with native devenv and effect-utils spans";
+          exec = ''
+            capture_dir="''${DEVENV_OTEL_CAPTURE_DIR:-$DEVENV_ROOT/tmp/devenv-traces/${profile.name}-$(date -u +%Y%m%dT%H%M%SZ)-$$}"
+            exec ${capture}/bin/devenv-otel-capture-${profile.name} \
+              ${lib.escapeShellArg profile.task} \
+              ${lib.escapeShellArg profile.mode} \
+              "$capture_dir" \
+              ${lib.escapeShellArg profile.bridgeTask}
+          '';
+        };
+
+        "${verifyTaskName}" = {
+          description = "Verify native devenv and effect-utils ${profile.name} spans form one trace";
+          exec = ''
+            test_dir="$(mktemp -d)"
+            trap 'rm -rf "$test_dir"' EXIT
+            ${capture}/bin/devenv-otel-capture-${profile.name} \
+              ${lib.escapeShellArg profile.smokeTask} \
+              ${lib.escapeShellArg profile.smokeMode} \
+              "$test_dir/trace" \
+              ${lib.escapeShellArg profile.bridgeTask}
+          '';
+        };
+      };
+  wiredTasks = lib.genAttrs wireInto (_: {
+    after = [ verifyTaskName ];
+  });
+in
+{
+  assertions = [
+    {
+      assertion = project != "";
+      message = "effect-utils observability: project must not be empty";
+    }
+    {
+      assertion = profile != null || wireInto == [ ];
+      message = "effect-utils observability: wireInto requires a profile";
+    }
+  ];
+
+  imports = lib.optional (_backend != "ambient") (
+    import ./otel.nix {
+      mode = _backend;
+    }
+  );
+
+  env.OTEL_DEVENV_PROJECT = project;
+  packages = [
+    otelSpan
+    otelite
+  ];
+  tasks = profileTasks // wiredTasks;
+}

--- a/nix/devenv-modules/observability.nix
+++ b/nix/devenv-modules/observability.nix
@@ -1,8 +1,11 @@
 # Lightweight, repository-agnostic devenv observability.
 #
-# This module deliberately keeps capture orchestration in effect-utils while
-# leaving domain assertions in the owning repository. It joins native devenv
-# OTLP/gRPC spans and effect-utils OTLP/HTTP task spans in one otelite capture.
+# This module deliberately keeps hermetic capture, verification, and backend
+# composition in effect-utils while leaving domain assertions in the owning
+# repository. Native devenv owns orchestration tracing; the Effect task bridge
+# temporarily preserves status-versus-exec phase detail until devenv can export
+# Debug task activities without coupling them to global CLI verbosity:
+# https://github.com/cachix/devenv/issues/3037
 {
   project,
   backend ? "ambient",
@@ -34,6 +37,8 @@ let
     else
       throw "effect-utils observability: backend must be one of ${builtins.concatStringsSep ", " validBackends}";
 
+  # Temporary compatibility producer for task-phase detail. Keep otelite and
+  # the profile/verify surface after this producer can be retired.
   otelSpan = import ./otel/otel-span.nix { inherit pkgs; };
   otelite = import (../../packages + "/@overeng/otelite/nix/build.nix") { inherit pkgs; };
 
@@ -57,8 +62,8 @@ let
           summary_file="$capture_dir/summary.json"
           spans_file="$capture_dir/spans.ndjson"
 
-          # Native devenv uses OTLP/gRPC while effect-utils shell spans use
-          # OTLP/HTTP. Otelite owns both isolated receivers for this invocation.
+          # Native devenv uses OTLP/gRPC while the temporary task-phase
+          # producer uses OTLP/HTTP. Otelite owns the isolated capture.
           # shellcheck disable=SC2016
           env \
             -u DEVENV_TRACE_TO \

--- a/nix/devenv-modules/tasks/README.md
+++ b/nix/devenv-modules/tasks/README.md
@@ -76,6 +76,8 @@ are needed.
     retained package records are rejected transactionally if they lose
     `hasBin` metadata.
 - `setup.nix` - Setup tasks
+  - `skipNonInteractive = true` keeps automatic shell entry cheap for
+    non-interactive callers; `DEVENV_FORCE_SETUP=1` explicitly overrides it.
 - `test.nix` - Test tasks
 - `test-playwright.nix` - Playwright e2e tasks
 - `ts.nix` - TypeScript tasks (`ts:check`, `ts:check:strict`, build/watch/clean helpers)

--- a/nix/devenv-modules/tasks/README.md
+++ b/nix/devenv-modules/tasks/README.md
@@ -19,6 +19,29 @@ imports = [
 ];
 ```
 
+## Observability
+
+Import the sibling observability module once to capture native devenv spans
+and effect-utils task spans as one otelite trace:
+
+```nix
+imports = [
+  (inputs.effect-utils.devenvModules.observability {
+    project = "my-repo";
+    # Optional: compose the full Collector/Tempo/Grafana stack.
+    backend = "auto";
+    # Optional: gate an existing aggregate task on the hermetic shape check.
+    wireInto = [ "check:all" ];
+  })
+];
+```
+
+The default `backend = "ambient"` adds only `otel-span`, otelite, and the
+`otel:profile:setup` / `otel:verify:setup` tasks. It intentionally avoids the
+full local observability stack. Override `profile` to capture a different task
+graph, or set `profile = null` when only the packages and project attribution
+are needed.
+
 ### Characteristics:
 
 - **Configurable** via function parameters

--- a/nix/devenv-modules/tasks/lib/trace.nix
+++ b/nix/devenv-modules/tasks/lib/trace.nix
@@ -167,7 +167,12 @@ let
   # adapter records where the structured-source contract is met).
   traceExec = taskName: execBody: ''
     if ${otelCanEmitShell}; then
+      _otel_project_attr=()
+      if [ -n "''${OTEL_DEVENV_PROJECT:-}" ]; then
+        _otel_project_attr=(--attr "devenv.project.name=$OTEL_DEVENV_PROJECT")
+      fi
       otel-span run "effect-utils-devenv" "devenv.task.exec" \
+        "''${_otel_project_attr[@]}" \
         --attr "tool.name=devenv" \
         --attr "task.name=${taskName}" \
         --attr "task.phase=exec" \
@@ -187,7 +192,12 @@ let
   traceStatus = taskName: method: statusBody: ''
     if ${otelCanEmitShell}; then
       _status_exit=0
+      _otel_project_attr=()
+      if [ -n "''${OTEL_DEVENV_PROJECT:-}" ]; then
+        _otel_project_attr=(--attr "devenv.project.name=$OTEL_DEVENV_PROJECT")
+      fi
       otel-span run "effect-utils-devenv" "devenv.task.status" \
+        "''${_otel_project_attr[@]}" \
         --attr "tool.name=devenv" \
         --attr "task.name=${taskName}" \
         --attr "task.phase=status" \

--- a/nix/devenv-modules/tasks/shared/setup.nix
+++ b/nix/devenv-modules/tasks/shared/setup.nix
@@ -31,6 +31,7 @@
   optionalTasks ? [ ],
   completionsCliNames ? [ ],
   skipDuringRebase ? true,
+  skipNonInteractive ? false,
 }:
 {
   lib,
@@ -322,6 +323,14 @@ in
         ];
         exec = trace.exec "setup:gate" ''
           set -euo pipefail
+
+          if ${lib.boolToString skipNonInteractive} \
+            && [ "''${DEVENV_FORCE_SETUP:-}" != "1" ] \
+            && { [ ! -t 0 ] || [ ! -t 1 ]; }; then
+            echo "Skipping shell-entry setup for non-interactive devenv invocation"
+            exit 0
+          fi
+
           ${setupFingerprintEnv}
 
           _git_dir=$(${git} rev-parse --git-dir 2>/dev/null)


### PR DESCRIPTION
## Problem

Repositories that want to profile devenv task graphs need a repeatable local capture
and verification surface. Copying shell/Nix orchestration into each repository
creates drift, while importing the full Collector/Tempo/Grafana stack is excessive
for hermetic CI or setup benchmarks.

Native devenv 2.1 already owns root, evaluation, build, task, and process tracing
and propagates W3C trace context. The remaining upstream gap is narrower:
status-check and execution child activities are Debug-only, so ordinary OTLP
captures cannot distinguish those phases without globally noisy `--verbose`.

## Solution

- Export a lightweight `devenvModules.observability` adapter.
- Use otelite for isolated capture, inspection, topology assertions, and reusable
  `otel:profile:<name>` / `otel:verify:<name>` tasks.
- Keep the full local stack optional through
  `backend = "auto" | "local" | "system"`.
- Attribute temporary effect-utils task-phase spans with
  `devenv.project.name`.
- Join native devenv OTLP/gRPC and the temporary Effect OTLP/HTTP phase producer
  in one trace.
- Let consumers express a non-interactive setup skip through
  `taskModules.setup.skipNonInteractive` without replacing the shared traced
  `setup:gate`.
- Self-host the adapter in effect-utils and wire its hermetic shape check into
  `check:all`.

The ownership boundary is explicit: native devenv owns orchestration telemetry;
effect-utils durably owns otelite lifecycle, verification, profiles, backend
composition, and repository policy. Only the duplicate Effect status/exec producer
is transitional, tracked by [cachix/devenv#3037](https://github.com/cachix/devenv/issues/3037).

## Validation

- `devenv tasks run otel:verify:setup --mode single --no-tui`
  - 16 spans in one trace
  - native `devenv` root
  - native `setup:gate` task
  - project-attributed `effect-utils-devenv/devenv.task.exec` child
- `devenv tasks run lint:nix --mode before --no-tui`
- `devenv tasks run lint:check:format --mode single --no-tui`
- Native-only/combined benchmark, N=8:
  - native-only: 422.25 ms average, 15 spans
  - combined: 470.25 ms average, 16 spans
  - temporary phase bridge tax: +48.00 ms / +11.4%
- Native `--verbose` experiment proved existing phase activities:
  `setup:record-cache` 311.66 ms = status 48.64 ms + execution 262.74 ms.

Representative downstream E2E captures also pass in LiveStore, diffstream,
dotfiles, and another consumer.

## Consumer stack

- livestorejs/livestore#1503
- overengineeringstudio/diffstream#71
- overengineeringstudio/overeng#204
- schickling/schickling.dev#131
- schickling/schickling-stiftung#238
- schickling/dotfiles#1331
- aggregate alignment: schickling/megarepo-all#113

## Trade-offs and follow-up

- The default backend is deliberately `ambient`; consumers that want the
  production-like local stack opt in.
- The current dual-producer trace pays a small measured tax to preserve
  status-versus-execution timing. After devenv#3037 ships and passes the shared
  topology proof, remove `otel-span`, the Effect OTLP/HTTP bridge, duplicate
  task children, and Effect-parent assertion. Keep the rest of the module.
- Distributed devenv 2.1.2 supports gRPC by default while HTTP exporters are
  opt-in Cargo features. This is not a blocker for the selected topology.
- This complements the typed Vitest otelite wrapper in #885 and raw CLI
  assertion surface; it does not replace either.
- It supersedes only the duplicated repo-local devenv capture-orchestration
  portion of the broader #886 work. It does not supersede that PR's typed
  telemetry/VRS scope or #778's endpoint semantics.
- Downstream migrations remain separate PRs so this shared contract can land
  first.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | co3-nova |
| `agent_session_id` | fabbecde-5efe-4752-b82d-3bde982ab17f |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.145.0 |
| `agent_runtime` | Codex CLI 0.145.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/g65ryv9zcr8acxxjlpgcrynh8d7s7qwn-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/hiw5ggfjp9mr78vbrq30i77ypfyixv32-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-27-2026-07-27-devenv-otel |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->