### PR TITLE
Add @overeng/npm-release: pure decision layer for npm registry verification

### DIFF
--- a/.github/labels.json
+++ b/.github/labels.json
@@ -251,6 +251,11 @@
       "description": "@overeng/notion-react package · Set: manual"
     },
     {
+      "name": "system:npm-release",
+      "color": "a371f7",
+      "description": "@overeng/npm-release package · Set: manual"
+    },
+    {
       "name": "system:otel-contract",
       "color": "a371f7",
       "description": "@overeng/otel-contract package · Set: manual"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,18 @@ All notable changes to this project will be documented in this file.
   rejects an entry applied to a target it does not declare, then writes the job-summary line and
   emits the `::warning::` annotation on stdout, the channel GitHub documents for workflow
   commands.
-
+- **npm-release**: New `@overeng/npm-release` package — the decision layer for verifying that an
+  npm registry actually serves what a release published. `npm publish` exiting zero does not mean
+  the release is live: the version may not have propagated, the served tarball may not be the
+  artifact that was packed, or the dist-tag may still resolve to the previous version, so
+  `npm install` keeps serving the old release. `registryVerification` classifies those into `ok` /
+  `pending` / `mismatch`, separating retryable propagation from terminal disagreement (a published
+  npm version is immutable, so a wrong artifact can never become right). Zero dependencies and no
+  `effect` peer, following the `@overeng/kdl` / `@overeng/kdl-effect` split — the classification is
+  pure logic, testable offline and reusable from any publisher regardless of its runtime or Effect
+  major. VRS in `context/npm-release/`. Extracted from three separate hand-rolled implementations
+  across livestore and livestore-contrib, two of which were missing the dist-tag check entirely
+  (livestorejs/livestore#1504, livestorejs/livestore-contrib#27).
 - **devenv-modules**: GitHub workflow commands emitted by tasks now go to stderr. devenv does not
   forward a task's stdout, so `echo "::warning::…"` there never reached the runner — it produced no
   annotation and no log group. That silently affected the two `::notice::` emits in

--- a/context/README.md
+++ b/context/README.md
@@ -17,6 +17,8 @@ implementation details.
   content-addressed descriptors, stores, resolvers, and artifact URIs
 - [effect/](./effect/) - Effect socket examples and related package files
 - [opentui/](./opentui/) - OpenTUI integration example
+- [npm-release/](./npm-release/) - VRS for verifying that an npm registry
+  actually serves what a release published (version, tarball digest, dist-tag)
 - [otel.md](./otel.md) - OpenTelemetry notes
 - [otel-scrape/](./otel-scrape/) - VRS for wrapping build/dev tools into
   OTEL spans, events, metrics, and profile links

--- a/context/npm-release/.delta/DELTA-001-decision-layer-only.md
+++ b/context/npm-release/.delta/DELTA-001-decision-layer-only.md
@@ -1,0 +1,22 @@
+# DELTA-001: only the decision layer is implemented
+
+**Status:** Open
+
+## Divergence
+
+[spec.md](../spec.md) specifies a pipeline of rewrite → pack → publish → verify → repair. `@overeng/npm-release` currently implements only §Classification (the `verify` reduction) plus the provenance condition, as pure functions. It performs no IO and cannot publish or repair.
+
+Requirements not yet met: R01–R04 (convergence), R12–R13 (repair), R14–R17 (uniform publication across publishers).
+
+## Why it stands
+
+Two callers exist today and neither can consume an IO-bearing implementation yet:
+
+- `livestore` is on Effect `4.0.0-beta.99` while this repository is on `3.21.4`; the standing rule at that boundary is to isolate rather than cast across majors (see the `react-inspector` catalog exception, #937).
+- `livestore-contrib` publishes from a plain Node script and is mid-migration to Effect 4.
+
+Shipping the decision layer first closes the highest-value gap — the unchecked dist-tag, which was missing from two of the three existing implementations — without waiting on the migration, and is the substrate the full pipeline needs regardless.
+
+## Resolution
+
+Closes when the Effect 4 migration lands across effect-utils and its consumers, the pipeline stages are implemented here, and `livestore` and `livestore-contrib` are repointed at it (livestorejs/livestore-contrib#27).

--- a/context/npm-release/requirements.md
+++ b/context/npm-release/requirements.md
@@ -1,30 +1,58 @@
 # Requirements: npm-release
 
-> `vision.md` for this node is pending human authoring; a draft accompanies the
-> introducing PR.
+## Context
 
-## Verification Contract
+Constrained by [vision.md](./vision.md); implemented by [spec.md](./spec.md).
 
-- A published release must be verified against what the registry actually serves, not against the exit code of the publish command.
-- Verification must cover three independent properties: the version is visible, the served tarball matches the artifact that was packed, and the release's dist-tag resolves to exactly that version.
-- The dist-tag property must be checked for the tag the release published under, not a fixed assumption of `latest`.
-- Verification must be expressible per package, so a release group can report which member disagreed rather than only that the group failed.
+## Assumptions
 
-## Outcome Kinds
+- **A01 Caller-owned plan:** The caller supplies a resolved release plan — which packages, at which version, under which dist-tag. This system never derives one.
+- **A02 Credentials at the process edge:** Registry authentication is provided by the environment the caller runs in and is never stored, persisted, or brokered here.
+- **A03 npm semantics:** The registry model is npm's — immutable published versions, mutable dist-tags, and SRI tarball digests.
+- **A04 Eventual consistency:** A registry may not immediately reflect a successful publish, and propagation delay is not an error.
+- **A05 No rollback:** A published version is permanent in practice, so correction can only move forward.
 
-- Verification outcomes must distinguish _not yet converged_ from _disagrees_, because the two require opposite handling.
-- A disagreement that cannot become correct — the registry serving a different artifact under the same version — must be terminal, since a published npm version is immutable.
-- A registry state that can still converge — a version not yet visible, or a dist-tag that has not yet moved — must be retryable.
-- Every non-`ok` outcome must carry a reason naming the package and the observed versus expected values.
+## Acceptable Tradeoffs
 
-## Portability
+- **T01 Non-atomic groups:** Group publication is not atomic and will not be simulated as such. Partial state is expected and is addressed by convergence rather than prevented.
+- **T02 Digest scope:** Digest agreement can only be checked for packages this run packed. Packages already present on the registry are verified by version and dist-tag alone.
+- **T03 Repair limited to what npm permits:** Correction covers dist-tag moves and publishing missing members. It cannot cover replacing an already-published artifact.
 
-- The decision layer must not depend on a network client, filesystem, process runtime, or application framework.
-- The decision layer must be usable from consumers on different Effect major versions and from consumers using no Effect at all.
-- Runtime-flavoured wrappers may be layered on top, but must not become the only way to reach the decision layer.
+## Requirements
 
-## Boundaries
+### Must converge on the plan
 
-- This system must not perform the publish, hold registry credentials, or sign provenance.
-- This system must not choose release versions, dist-tag policy, or release membership.
-- Digest comparison must be skipped, not failed, when the caller has no locally packed artifact for a package — the case when a run repairs a partial release and skips packages already published.
+- **R01 Target state, not transaction:** Running against a plan must drive the registry toward that plan regardless of how far a previous attempt progressed.
+- **R02 Idempotent operations:** Every operation must be safe to repeat. Re-running a completed release must perform no writes.
+- **R03 No recovery mode:** Resuming an interrupted release must be an ordinary run, not a distinct mode or flag.
+- **R04 Existing version is not an error:** Encountering an already-published version must not fail the run by itself; it must be validated rather than rejected.
+
+### Must establish that the release is live
+
+- **R05 Registry-observed completion:** A release must be treated as complete only when the registry serves the intended version, the packed artifact, and a dist-tag resolving to that version.
+- **R06 Named dist-tag:** The dist-tag from the plan must be verified, never a fixed assumption of `latest`.
+- **R07 Per-package outcomes:** Outcomes must be attributable to individual packages, so a group failure identifies which member disagreed.
+- **R08 Actionable reasons:** Every non-success outcome must state the package and the observed versus intended values.
+
+### Must separate recoverable from terminal
+
+- **R09 Distinct outcome kinds:** Registry states that can still converge must be distinguished from states that never will.
+- **R10 Terminal digest disagreement:** A registry serving a different artifact under the intended version must fail immediately and must not be retried.
+- **R11 Bounded convergence:** Waiting for propagation must be bounded, and exhausting that bound must fail the release.
+
+### Must repair what it detects
+
+- **R12 Correct on detection:** Where npm permits correction, a detected divergence must be corrected within the same run rather than reported for manual action.
+- **R13 Repair is verified:** A correction must be followed by the same verification as an initial publish; applying it is not evidence it took effect.
+
+### Must hold uniformly across publishers
+
+- **R14 Single implementation:** Publication semantics — dependency rewriting, packing, publishing, provenance, verification, repair — must be implemented once and shared, not per repository.
+- **R15 Provenance by default:** Publishing must emit provenance wherever the execution environment can mint it.
+- **R16 Self-consistent artifacts:** Workspace-internal dependency ranges must be rewritten to exact published versions before packing, so a published artifact resolves without the workspace.
+- **R17 Onboarding cost:** Adding a publisher must require supplying a plan and credentials only.
+
+### Must be verifiable without a registry
+
+- **R18 Separable judgement:** The decision layer — classifying registry state against intent — must be usable and exhaustively testable without network access, a registry, or a process runtime.
+- **R19 Dependency-free core:** The decision layer must not depend on a network client, filesystem, or application framework, so it remains consumable from any runtime.

--- a/context/npm-release/requirements.md
+++ b/context/npm-release/requirements.md
@@ -1,0 +1,30 @@
+# Requirements: npm-release
+
+> `vision.md` for this node is pending human authoring; a draft accompanies the
+> introducing PR.
+
+## Verification Contract
+
+- A published release must be verified against what the registry actually serves, not against the exit code of the publish command.
+- Verification must cover three independent properties: the version is visible, the served tarball matches the artifact that was packed, and the release's dist-tag resolves to exactly that version.
+- The dist-tag property must be checked for the tag the release published under, not a fixed assumption of `latest`.
+- Verification must be expressible per package, so a release group can report which member disagreed rather than only that the group failed.
+
+## Outcome Kinds
+
+- Verification outcomes must distinguish _not yet converged_ from _disagrees_, because the two require opposite handling.
+- A disagreement that cannot become correct — the registry serving a different artifact under the same version — must be terminal, since a published npm version is immutable.
+- A registry state that can still converge — a version not yet visible, or a dist-tag that has not yet moved — must be retryable.
+- Every non-`ok` outcome must carry a reason naming the package and the observed versus expected values.
+
+## Portability
+
+- The decision layer must not depend on a network client, filesystem, process runtime, or application framework.
+- The decision layer must be usable from consumers on different Effect major versions and from consumers using no Effect at all.
+- Runtime-flavoured wrappers may be layered on top, but must not become the only way to reach the decision layer.
+
+## Boundaries
+
+- This system must not perform the publish, hold registry credentials, or sign provenance.
+- This system must not choose release versions, dist-tag policy, or release membership.
+- Digest comparison must be skipped, not failed, when the caller has no locally packed artifact for a package — the case when a run repairs a partial release and skips packages already published.

--- a/context/npm-release/spec.md
+++ b/context/npm-release/spec.md
@@ -84,7 +84,7 @@ Repair is followed by re-verification (R13); issuing the correction is not evide
 
 ## Provenance
 
-Publishing emits provenance wherever the environment can mint it (R15) — that is, on a CI provider with an OIDC identity, and never for a dry run, where it would be meaningless.
+Publishing emits provenance wherever the environment can mint it (R15) — on a CI provider with an OIDC identity, and never for a dry run, where it would be meaningless. That decision belongs to the publish stage, which is not implemented here yet; each publisher makes it locally until then (see [.delta/DELTA-001](./.delta/DELTA-001-decision-layer-only.md)).
 
 ## Design questions
 

--- a/context/npm-release/spec.md
+++ b/context/npm-release/spec.md
@@ -1,0 +1,47 @@
+# Spec: npm-release
+
+Implemented by `@overeng/npm-release`. Constrained by [requirements.md](./requirements.md).
+
+## Shape
+
+The package exports pure functions and types. It performs no IO: callers read registry state however they already can (an `npm view` invocation, a registry HTTP client) and hand plain data in.
+
+```
+RemoteRegistryState  what the registry currently serves for one package version
+RegistryVerification ok | pending | mismatch
+registryVerification (input) -> RegistryVerification
+```
+
+## Checks and precedence
+
+`registryVerification` evaluates in a fixed order, returning the first disagreement:
+
+| #   | Check                                             | Outcome when it disagrees                                  |
+| --- | ------------------------------------------------- | ---------------------------------------------------------- |
+| 1   | version visible on the registry                   | `pending` — not propagated, or the publish silently failed |
+| 2   | served version equals published version           | `mismatch`                                                 |
+| 3   | `dist.integrity` equals the locally packed digest | `mismatch`                                                 |
+| 4   | dist-tag exists                                   | `pending`                                                  |
+| 5   | dist-tag resolves to the published version        | `pending`                                                  |
+
+Order matters: an absent version makes every later check meaningless, so it is reported first rather than surfacing a confusing dist-tag complaint about a version that was never published.
+
+## Why the dist-tag checks are `pending`
+
+Checks 4 and 5 describe a mutable pointer that legitimately lags the immutable version during propagation. Reporting them as `mismatch` would fail releases on ordinary lag. Reporting them as `pending` lets the caller's retry budget decide: transient lag resolves, a tag that never moves exhausts the budget and fails. This is the failure mode where a publish succeeds but `npm install` keeps serving the previous release.
+
+## Why the digest check is `mismatch`
+
+A published npm version is immutable. If the registry serves a different tarball under the version we just published, no amount of waiting changes it — the release needs a human. Retrying here would convert a clear, immediate failure into a multi-minute silence.
+
+## Digest comparison is conditional
+
+The comparison runs only when both a local digest and a remote integrity are known. A caller repairing a partial release skips packages already on the registry and therefore has no local artifact for them; those packages are still version- and dist-tag-verified. Callers that need the stronger guarantee must pack every package.
+
+## Retry policy is the caller's
+
+The package classifies; it does not schedule. Retrying `pending`, bounding that retry, and turning an exhausted budget into a failure all belong to the caller, which owns the runtime and knows the release's time budget.
+
+## Provenance
+
+`shouldPublishWithProvenance` decides whether `npm publish --provenance` applies: only outside a dry run and only on a CI provider that can mint the OIDC identity provenance is derived from. It is a predicate, not a publisher — the caller assembles its own argv.

--- a/context/npm-release/spec.md
+++ b/context/npm-release/spec.md
@@ -1,47 +1,93 @@
 # Spec: npm-release
 
-Implemented by `@overeng/npm-release`. Constrained by [requirements.md](./requirements.md).
+This document specifies how npm publication converges on a release plan. It builds on [requirements.md](./requirements.md).
 
-## Shape
+## Status
 
-The package exports pure functions and types. It performs no IO: callers read registry state however they already can (an `npm view` invocation, a registry HTTP client) and hand plain data in.
+Draft. The decision layer (§Classification) is implemented in `@overeng/npm-release`; the surrounding pipeline is not yet — see [.delta/DELTA-001](./.delta/DELTA-001-decision-layer-only.md).
+
+## Scope
+
+**Defines:** the publication pipeline and its stage order, the classification of registry state against intent, convergence and idempotency semantics, repair operations, and provenance conditions.
+
+**Does not define:** release-plan derivation (versions, changelogs, tags, membership), credential acquisition, or registries other than npm. See [vision.md](./vision.md) §What This Is Not.
+
+## Pipeline
+
+One run takes a plan and converges the registry toward it. Stages are ordered; each is idempotent (R02).
+
+```mermaid
+flowchart LR
+  P[plan] --> RW[rewrite deps]
+  RW --> PK[pack]
+  PK --> PB[publish]
+  PB --> VF[verify]
+  VF -->|ok| D[done]
+  VF -->|pending| VF
+  VF -->|repairable| RP[repair]
+  RP --> VF
+  VF -->|mismatch| F[fail]
+```
+
+| Stage        | Does                                                            | Requirements |
+| ------------ | --------------------------------------------------------------- | ------------ |
+| rewrite deps | Replace workspace-internal ranges with exact published versions | R16          |
+| pack         | Produce the tarball and record its digest                       | T02          |
+| publish      | Publish if absent; validate if present                          | R04, R15     |
+| verify       | Compare registry state against intent                           | R05–R08      |
+| repair       | Correct divergence npm permits correcting                       | R12, R13     |
+
+A package already present on the registry skips `pack`/`publish` and enters `verify` directly, which is why digest agreement is conditional (T02).
+
+## Classification
+
+`verify` reduces registry state plus intent to one outcome. Checks evaluate in order, returning the first disagreement — an absent version makes later checks meaningless, so it is reported first rather than surfacing a confusing dist-tag complaint about a version that was never published.
+
+| #   | Check                                 | Outcome when it disagrees |
+| --- | ------------------------------------- | ------------------------- |
+| 1   | version visible                       | `pending`                 |
+| 2   | served version equals intended        | `mismatch`                |
+| 3   | `dist.integrity` equals packed digest | `mismatch`                |
+| 4   | dist-tag exists                       | `pending` (repairable)    |
+| 5   | dist-tag resolves to intended version | `pending` (repairable)    |
 
 ```
-RemoteRegistryState  what the registry currently serves for one package version
-RegistryVerification ok | pending | mismatch
-registryVerification (input) -> RegistryVerification
+ok        registry matches intent
+pending   may still converge — retry within the bound (R11)
+mismatch  never converges — fail now (R10)
 ```
 
-## Checks and precedence
+**Why 4 and 5 are `pending`, not `mismatch`:** a dist-tag is a mutable pointer that legitimately lags the immutable version during propagation. Treating lag as terminal would fail releases routinely. Treating it as `pending` lets the bound decide: transient lag resolves, a tag that never moves exhausts the bound and fails — or is repaired first (R12).
 
-`registryVerification` evaluates in a fixed order, returning the first disagreement:
+**Why 3 is terminal:** the registry serving different bytes under the intended version cannot be corrected, because npm versions are immutable (A05). Retrying converts a clear failure into a silent wait.
 
-| #   | Check                                             | Outcome when it disagrees                                  |
-| --- | ------------------------------------------------- | ---------------------------------------------------------- |
-| 1   | version visible on the registry                   | `pending` — not propagated, or the publish silently failed |
-| 2   | served version equals published version           | `mismatch`                                                 |
-| 3   | `dist.integrity` equals the locally packed digest | `mismatch`                                                 |
-| 4   | dist-tag exists                                   | `pending`                                                  |
-| 5   | dist-tag resolves to the published version        | `pending`                                                  |
+## Convergence
 
-Order matters: an absent version makes every later check meaningless, so it is reported first rather than surfacing a confusing dist-tag complaint about a version that was never published.
+There is no atomic group publish (T01), so correctness is defined by convergence rather than by transaction boundaries.
 
-## Why the dist-tag checks are `pending`
+- A run is a function of the plan and current registry state, not of what a previous run did (R01). No run-to-run state is persisted.
+- Re-running a completed release reaches `ok` on every package via the already-present path, performing no writes (R02).
+- Resuming an interrupted release is the same code path as a first run (R03); "repair" is not a mode.
+- `pending` is retried on a bounded schedule; exhausting it fails (R11). Scheduling policy belongs to the caller, which owns the runtime and the release's time budget.
 
-Checks 4 and 5 describe a mutable pointer that legitimately lags the immutable version during propagation. Reporting them as `mismatch` would fail releases on ordinary lag. Reporting them as `pending` lets the caller's retry budget decide: transient lag resolves, a tag that never moves exhausts the budget and fails. This is the failure mode where a publish succeeds but `npm install` keeps serving the previous release.
+## Repair
 
-## Why the digest check is `mismatch`
+Applies only where npm permits correction (T03).
 
-A published npm version is immutable. If the registry serves a different tarball under the version we just published, no amount of waiting changes it — the release needs a human. Retrying here would convert a clear, immediate failure into a multi-minute silence.
+| Divergence                            | Correction                                |
+| ------------------------------------- | ----------------------------------------- |
+| dist-tag absent or pointing elsewhere | move the dist-tag to the intended version |
+| package missing from the group        | publish it                                |
+| served artifact differs               | none — terminal (R10)                     |
 
-## Digest comparison is conditional
-
-The comparison runs only when both a local digest and a remote integrity are known. A caller repairing a partial release skips packages already on the registry and therefore has no local artifact for them; those packages are still version- and dist-tag-verified. Callers that need the stronger guarantee must pack every package.
-
-## Retry policy is the caller's
-
-The package classifies; it does not schedule. Retrying `pending`, bounding that retry, and turning an exhausted budget into a failure all belong to the caller, which owns the runtime and knows the release's time budget.
+Repair is followed by re-verification (R13); issuing the correction is not evidence it took effect.
 
 ## Provenance
 
-`shouldPublishWithProvenance` decides whether `npm publish --provenance` applies: only outside a dry run and only on a CI provider that can mint the OIDC identity provenance is derived from. It is a predicate, not a publisher — the caller assembles its own argv.
+Publishing emits provenance wherever the environment can mint it (R15) — that is, on a CI provider with an OIDC identity, and never for a dry run, where it would be meaningless.
+
+## Design questions
+
+- **DQ1 Credential surface.** How does the caller supply registry write authority for repair (R12) — ambient environment, or an explicit capability passed in? Resolved by the first consumer that repairs from a context where ambient auth is not already present.
+- **DQ2 Cross-runtime consumption.** How do consumers on a different Effect major reach the pipeline while the split persists — a subprocess boundary, or waiting for alignment? Resolved by the Effect 4 migration landing, which may dissolve the question entirely.
+- **DQ3 Package concurrency.** Are group members published concurrently, and does that risk a partially-visible group for longer? Resolved by measuring publish wall-clock against group size on a real release.

--- a/context/npm-release/vision.md
+++ b/context/npm-release/vision.md
@@ -1,0 +1,37 @@
+# Vision: npm-release
+
+## The Problem
+
+1. **Problem 1: Publishing reports success before the release is live.** `npm publish` exiting zero means the request was accepted, not that the registry serves the release. A version can be unpropagated, the served tarball can differ from the one that was packed, and the dist-tag can still resolve to the previous version — so installs keep getting the old release. None of these fail the publish command.
+2. **Problem 2: Every publisher re-implements publication, and the copies drift.** Dependency rewriting, packing, idempotent publishing, and post-publish checking are rebuilt per repository. Each copy covers a different subset of the correctness properties, so a property present in one is silently absent in another, and fixing one does not fix the rest.
+3. **Problem 3: A partial publication has no defined recovery.** Publishing a package group is not atomic. An interrupted run leaves some packages live and some not, with dist-tags possibly half-moved. Recovery is manual, differs per repository, and risks publishing a different artifact under a version that already exists.
+4. **Problem 4: Noticing a broken release does not repair it.** When drift is detected, the correction — moving a dist-tag, publishing a missing member — lives outside the tool that detected it, so an operator performs it by hand, under time pressure, against production.
+
+## The Vision
+
+- A release is a **target state, not a transaction**: the system converges the registry toward the plan it was given, so an interrupted run is resumed by running it again (Problem 3).
+- Publication is complete only when the registry **demonstrably serves the intended state** — the version, the artifact bytes that were packed, and a dist-tag resolving to them (Problem 1).
+- **One implementation of npm publication semantics serves every publisher**, so a correctness property is gained once rather than per repository (Problem 2).
+- Where npm permits it, the system **corrects what it detects** instead of handing the operator a diagnosis (Problem 4).
+- Disagreements the registry can still resolve are **distinguished from those it never will**, because the two demand opposite responses (Problems 1, 3).
+- **Every operation is safe to repeat**, so recovery needs no special mode and no operator judgement about what already happened (Problem 3).
+- The **judgement** about whether a release is correct is separable from performing it, so it can be verified exhaustively without a registry (Problem 2).
+
+## What This Is Not
+
+- **Not a decider of releases.** Versions, changelogs, git tags, GitHub Releases, and which packages belong to a release are the caller's; this system receives a plan and makes the registry match it.
+- **Not a registry abstraction.** The model is npm's specifically — immutable versions, mutable dist-tags, SRI digests. Another registry is a sibling system, not an extension of this one.
+- **Not a credential store.** Authentication is supplied at the process edge and never held, persisted, or brokered here.
+- **Not a rollback mechanism.** npm's unpublish policy makes a published version permanent in practice; correction means moving forward, never undoing.
+- **Not a monitoring system.** It answers at release time; it does not watch registries over time.
+- **Not a general-purpose npm client.**
+
+## Success Criteria
+
+1. Re-running a completed release against the same plan performs no writes and reports success.
+2. Re-running an interrupted release completes it, with no operator intervention and no distinct recovery mode.
+3. A release whose dist-tag did not move to the published version is detected and corrected within a single run.
+4. A registry serving a different artifact than the one packed fails the release immediately, without retry.
+5. Dependency rewriting, provenance, digest agreement, and dist-tag agreement hold identically for every publisher, verifiable from one test suite.
+6. The verdict logic is exercised exhaustively without network access or a registry.
+7. Adding a publisher requires supplying a plan and credentials — never re-implementing publication semantics.

--- a/devenv.nix
+++ b/devenv.nix
@@ -172,6 +172,7 @@ let
     "packages/@overeng/notion-md"
     "packages/@overeng/notion-property-write"
     "packages/@overeng/notion-react"
+    "packages/@overeng/npm-release"
     "packages/@overeng/otel-contract"
     "packages/@overeng/oxc-config"
     "packages/@overeng/pty-effect"

--- a/flake.nix
+++ b/flake.nix
@@ -133,6 +133,15 @@
               ;
             src = self;
           };
+          npm-release = import (rootPath + "/packages/@overeng/npm-release/nix/build.nix") {
+            inherit
+              pkgs
+              gitRev
+              commitTs
+              dirty
+              ;
+            src = self;
+          };
         };
         cliPackagesDirty = {
           genie = import (rootPath + "/packages/@overeng/genie/nix/build.nix") {
@@ -166,6 +175,11 @@
             src = self;
             dirty = true;
           };
+          npm-release = import (rootPath + "/packages/@overeng/npm-release/nix/build.nix") {
+            inherit pkgs gitRev commitTs;
+            src = self;
+            dirty = true;
+          };
         };
       in
       {
@@ -194,6 +208,9 @@
             notion-md = cliPackages.notion-md;
             notion-md-dirty = cliPackagesDirty.notion-md;
             "notion-md-pnpm-deps" = cliPackages.notion-md.passthru.depsBuildsByInstallRoot.root;
+            npm-release = cliPackages.npm-release;
+            npm-release-dirty = cliPackagesDirty.npm-release;
+            "npm-release-pnpm-deps" = cliPackages.npm-release.passthru.depsBuildsByInstallRoot.root;
             "oxc-config-plugin-pnpm-deps" = oxlintNpm.pluginBundle.passthru.pnpmDeps;
             # npm oxlint with NAPI bindings + pre-bundled @overeng/oxc-config plugin
             oxlint-npm = oxlintNpm;

--- a/genie/tsconfig-projects.ts
+++ b/genie/tsconfig-projects.ts
@@ -12,6 +12,7 @@ import effectRpcTanstackBasicTsconfig from '../packages/@overeng/effect-rpc-tans
 import effectRpcTanstackTsconfig from '../packages/@overeng/effect-rpc-tanstack/tsconfig.json.genie.ts'
 import effectSchemaFormAriaTsconfig from '../packages/@overeng/effect-schema-form-aria/tsconfig.json.genie.ts'
 import effectSchemaFormTsconfig from '../packages/@overeng/effect-schema-form/tsconfig.json.genie.ts'
+import type { GenieOutput, TSConfigArgs } from '../packages/@overeng/genie/src/runtime/mod.ts'
 import genieTsconfig from '../packages/@overeng/genie/tsconfig.json.genie.ts'
 import kdlEffectTsconfig from '../packages/@overeng/kdl-effect/tsconfig.json.genie.ts'
 import kdlTsconfig from '../packages/@overeng/kdl/tsconfig.json.genie.ts'
@@ -24,6 +25,7 @@ import notionEffectSchemaTsconfig from '../packages/@overeng/notion-effect-schem
 import notionMdTsconfig from '../packages/@overeng/notion-md/tsconfig.json.genie.ts'
 import notionPropertyWriteTsconfig from '../packages/@overeng/notion-property-write/tsconfig.json.genie.ts'
 import notionReactTsconfig from '../packages/@overeng/notion-react/tsconfig.json.genie.ts'
+import npmReleaseTsconfig from '../packages/@overeng/npm-release/tsconfig.json.genie.ts'
 import otelContractTsconfig from '../packages/@overeng/otel-contract/tsconfig.json.genie.ts'
 import oxcConfigTsconfig from '../packages/@overeng/oxc-config/tsconfig.json.genie.ts'
 import ptyEffectTsconfig from '../packages/@overeng/pty-effect/tsconfig.json.genie.ts'
@@ -35,7 +37,6 @@ import tuiReactTsconfig from '../packages/@overeng/tui-react/tsconfig.json.genie
 import tuiStoriesTsconfig from '../packages/@overeng/tui-stories/tsconfig.json.genie.ts'
 import utilsDevTsconfig from '../packages/@overeng/utils-dev/tsconfig.json.genie.ts'
 import utilsTsconfig from '../packages/@overeng/utils/tsconfig.json.genie.ts'
-import type { GenieOutput, TSConfigArgs } from '../packages/@overeng/genie/src/runtime/mod.ts'
 
 export type RootTsconfigProject = {
   path: string
@@ -61,6 +62,7 @@ const workspaceTsconfigsByPath = new Map<string, GenieOutput<TSConfigArgs>>([
   ['packages/@overeng/kdl-effect', kdlEffectTsconfig],
   ['packages/@overeng/megarepo', megarepoTsconfig],
   ['packages/@overeng/notion-cli', notionCliTsconfig],
+  ['packages/@overeng/npm-release', npmReleaseTsconfig],
   ['packages/@overeng/notion-core', notionCoreTsconfig],
   ['packages/@overeng/notion-datasource-sync', notionDatasourceSyncTsconfig],
   ['packages/@overeng/notion-effect-client', notionEffectClientTsconfig],
@@ -80,9 +82,7 @@ const workspaceTsconfigsByPath = new Map<string, GenieOutput<TSConfigArgs>>([
   ['packages/@overeng/utils-dev', utilsDevTsconfig],
 ])
 
-const rootWorkspacePackagePaths = rootWorkspacePackages.map(
-  (pkg) => pkg.meta.workspace.memberPath,
-)
+const rootWorkspacePackagePaths = rootWorkspacePackages.map((pkg) => pkg.meta.workspace.memberPath)
 
 const missingTsconfigPaths = rootWorkspacePackagePaths.filter(
   (path) => workspaceTsconfigsByPath.has(path) === false,

--- a/megarepo.lock
+++ b/megarepo.lock
@@ -4,9 +4,9 @@
     "effect": {
       "url": "https://github.com/effect-ts/effect",
       "ref": "main",
-      "commit": "3e59443be029e99d2b457bb43f682feb5ebcd2e0",
+      "commit": "e5998a45f69960b38eb2b8cb67cbb07b9e6962c7",
       "pinned": false,
-      "lockedAt": "2026-06-29T16:03:20.461Z"
+      "lockedAt": "2026-07-27T20:31:28.318Z"
     }
   }
 }

--- a/nix/oxc-config-plugin.nix
+++ b/nix/oxc-config-plugin.nix
@@ -29,7 +29,7 @@ let
     pnpm = pinnedPnpm;
   };
   packageDir = "packages/@overeng/oxc-config";
-  pnpmDepsHash = "sha256-GFdhKjd/6KLI8N1X7y3eq83Z/VDAsPsJZgc8zzOp7kE=";
+  pnpmDepsHash = "sha256-9niG+IdQv0A0mz/eDrBaptu82MxV9vfRmdVUwd76K3w=";
 
   srcPath =
     if builtins.isAttrs src && builtins.hasAttr "outPath" src then

--- a/nix/oxc-config-plugin.nix
+++ b/nix/oxc-config-plugin.nix
@@ -29,7 +29,7 @@ let
     pnpm = pinnedPnpm;
   };
   packageDir = "packages/@overeng/oxc-config";
-  pnpmDepsHash = "sha256-9niG+IdQv0A0mz/eDrBaptu82MxV9vfRmdVUwd76K3w=";
+  pnpmDepsHash = "sha256-q96MVwA5bTt96ucoYdLGOJvVdmlISZfQ4Ua3frB3CNU=";
 
   srcPath =
     if builtins.isAttrs src && builtins.hasAttr "outPath" src then

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "packages/@overeng/notion-md",
     "packages/@overeng/notion-property-write",
     "packages/@overeng/notion-react",
+    "packages/@overeng/npm-release",
     "packages/@overeng/otel-contract",
     "packages/@overeng/oxc-config",
     "packages/@overeng/pty-effect",

--- a/package.json.genie.ts
+++ b/package.json.genie.ts
@@ -25,6 +25,7 @@ import notionEffectSchemaPkg from './packages/@overeng/notion-effect-schema/pack
 import notionMdPkg from './packages/@overeng/notion-md/package.json.genie.ts'
 import notionPropertyWritePkg from './packages/@overeng/notion-property-write/package.json.genie.ts'
 import notionReactPkg from './packages/@overeng/notion-react/package.json.genie.ts'
+import npmReleasePkg from './packages/@overeng/npm-release/package.json.genie.ts'
 import otelContractPkg from './packages/@overeng/otel-contract/package.json.genie.ts'
 import oxcConfigPkg from './packages/@overeng/oxc-config/package.json.genie.ts'
 import ptyEffectPkg from './packages/@overeng/pty-effect/package.json.genie.ts'
@@ -54,6 +55,7 @@ export const rootWorkspacePackages = [
   kdlEffectPkg,
   megarepoPkg,
   notionCliPkg,
+  npmReleasePkg,
   notionCorePkg,
   notionDatasourceSyncPkg,
   notionEffectClientPkg,

--- a/packages/@overeng/ci-tools/nix/build.nix
+++ b/packages/@overeng/ci-tools/nix/build.nix
@@ -19,7 +19,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-XU8FgrXb/AWuxVYQQJtAmJiDGrKL65Q8or21tH1i0Ck=";
+      "." = mkSharedHash "sha256-hJlDxv9vR78LVB/0mTU5XnVRdYS9ZgbErNfdFNbviAE=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/ci-tools/nix/build.nix
+++ b/packages/@overeng/ci-tools/nix/build.nix
@@ -19,7 +19,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-hJlDxv9vR78LVB/0mTU5XnVRdYS9ZgbErNfdFNbviAE=";
+      "." = mkSharedHash "sha256-C9PMArMRavbdPppbAq3p5HV7VWU7sWeWGwuK1QS1a4w=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/genie/nix/build.nix
+++ b/packages/@overeng/genie/nix/build.nix
@@ -26,7 +26,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-jREp3tZZuPrzTqQYxpV9SMS+B9dxQzTECkbe3QwmeOc=";
+      "." = mkSharedHash "sha256-jO5lOzr8SeWADRRXXp/lK12pN7udHGxtNkzduuo9Jns=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/genie/nix/build.nix
+++ b/packages/@overeng/genie/nix/build.nix
@@ -26,7 +26,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-jO5lOzr8SeWADRRXXp/lK12pN7udHGxtNkzduuo9Jns=";
+      "." = mkSharedHash "sha256-n/uFcGEfTSILmy082La4Na3q8wrV0D1dLILnFRGwyKs=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/megarepo/nix/build.nix
+++ b/packages/@overeng/megarepo/nix/build.nix
@@ -24,7 +24,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-35ihEmCzuuScMb/ZLgEVpd2tONRnuUvYcD44r4O1Wk0=";
+      "." = mkSharedHash "sha256-TDZ/r/5c0amGWcpU/ePdVAB90NbSDR7mVgZqPYtxMyk=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     smokeTestArgs = [ "--help" ];

--- a/packages/@overeng/megarepo/nix/build.nix
+++ b/packages/@overeng/megarepo/nix/build.nix
@@ -24,7 +24,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-QJnKSzAiUHLSz/RMS+Jh2sH2/5D5JQeg1k+Cv5y5hRw=";
+      "." = mkSharedHash "sha256-35ihEmCzuuScMb/ZLgEVpd2tONRnuUvYcD44r4O1Wk0=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     smokeTestArgs = [ "--help" ];

--- a/packages/@overeng/notion-cli/nix/build.nix
+++ b/packages/@overeng/notion-cli/nix/build.nix
@@ -33,7 +33,7 @@ let
     installRuntimeWorkspace = true;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-idOBZZOKwFp5JdaNJjcJR9Loqbp4JRx4ATWKU//7z64=";
+      "." = mkSharedHash "sha256-m/+RedRXN6TtxuVOVWLep+KJYUAxLBBixpK7X1OBWhE=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/notion-cli/nix/build.nix
+++ b/packages/@overeng/notion-cli/nix/build.nix
@@ -33,7 +33,7 @@ let
     installRuntimeWorkspace = true;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-m/+RedRXN6TtxuVOVWLep+KJYUAxLBBixpK7X1OBWhE=";
+      "." = mkSharedHash "sha256-oSUwsCA2UB6gUu6HK+QBhjclg7x/tXOnmN6QeWU5b74=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/notion-md/nix/build.nix
+++ b/packages/@overeng/notion-md/nix/build.nix
@@ -20,7 +20,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-CvBDmbF4IX4D2YYOLU4fgukKOVvJkhgknsU/x66FDz4=";
+      "." = mkSharedHash "sha256-EcRhimHEywlIfG8WSG3IF+n53a9HkZhgHWrsHUAgC8o=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/npm-release/nix/build.nix
+++ b/packages/@overeng/npm-release/nix/build.nix
@@ -1,4 +1,4 @@
-# Nix derivation that builds notion-md CLI binary.
+# Nix derivation that builds the npm-release CLI binary.
 # Uses bun build --compile for native platform.
 {
   pkgs,
@@ -13,23 +13,23 @@ let
   pnpm = import ../../../../nix/pnpm.nix { inherit pkgs; };
   mkPnpmCli = import ../../../../nix/workspace-tools/lib/mk-pnpm-cli.nix { inherit pkgs pnpm; };
   unwrapped = mkPnpmCli {
-    name = "notion-md-unwrapped";
-    entry = "packages/@overeng/notion-md/src/cli.ts";
-    binaryName = "notion-md";
-    packageDir = "packages/@overeng/notion-md";
+    name = "npm-release-unwrapped";
+    entry = "packages/@overeng/npm-release/src/cli.ts";
+    binaryName = "npm-release";
+    packageDir = "packages/@overeng/npm-release";
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-fj+Jd7wOTIi/kJtMYzHgFaWsXr3Vjli9/PMv1mkdadI=";
+      "." = mkSharedHash "sha256-U3SzvoQUzLyM9EPQBdleezcDvIEpUZLQctXS0039NZw=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;
   };
 in
-pkgs.runCommand "notion-md"
+pkgs.runCommand "npm-release"
   {
     nativeBuildInputs = [ pkgs.makeWrapper ];
-    meta.mainProgram = "notion-md";
+    meta.mainProgram = "npm-release";
     passthru = {
       inherit (unwrapped.passthru)
         depsBuildEntries
@@ -41,5 +41,8 @@ pkgs.runCommand "notion-md"
   }
   ''
     mkdir -p $out/bin
-    makeWrapper ${unwrapped}/bin/notion-md $out/bin/notion-md
+    # The CLI shells out to `npm`, so the wrapper guarantees node/npm on PATH rather
+    # than inheriting whatever the calling repo happens to expose.
+    makeWrapper ${unwrapped}/bin/npm-release $out/bin/npm-release \
+      --prefix PATH : ${pkgs.lib.makeBinPath [ pkgs.nodejs ]}
   ''

--- a/packages/@overeng/npm-release/package.json
+++ b/packages/@overeng/npm-release/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@overeng/npm-release",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/mod.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": "./dist/mod.js"
+    }
+  },
+  "devDependencies": {
+    "@types/node": "26.0.0",
+    "typescript": "6.0.3",
+    "vitest": "4.1.9"
+  },
+  "$genie": {
+    "source": "package.json.genie.ts",
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/npm-release"
+    ]
+  }
+}

--- a/packages/@overeng/npm-release/package.json
+++ b/packages/@overeng/npm-release/package.json
@@ -4,18 +4,30 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./src/mod.ts"
+    ".": "./src/mod.ts",
+    "./cli": "./src/cli.ts"
   },
   "publishConfig": {
     "access": "public",
     "exports": {
-      ".": "./dist/mod.js"
+      ".": "./dist/mod.js",
+      "./cli": "./dist/cli.js"
     }
   },
   "devDependencies": {
+    "@effect/cli": "0.75.2",
+    "@effect/platform": "0.96.2",
+    "@effect/platform-node": "0.107.0",
     "@types/node": "26.0.0",
+    "effect": "3.21.4",
     "typescript": "6.0.3",
     "vitest": "4.1.9"
+  },
+  "peerDependencies": {
+    "@effect/cli": "^0.75.2",
+    "@effect/platform": "^0.96.2",
+    "@effect/platform-node": "^0.107.0",
+    "effect": "^3.21.4"
   },
   "$genie": {
     "source": "package.json.genie.ts",

--- a/packages/@overeng/npm-release/package.json.genie.ts
+++ b/packages/@overeng/npm-release/package.json.genie.ts
@@ -1,0 +1,40 @@
+// @genie-bootstrap
+import {
+  catalog,
+  exportEntry,
+  packageJson,
+  privatePackageDefaults,
+  type PackageJsonInputData,
+  workspaceMember,
+} from '../../../genie/internal.ts'
+
+/**
+ * No runtime dependencies and no `effect` peer: this package is the pure decision
+ * layer for npm registry verification, so it stays consumable from any runtime
+ * (including plain Node scripts and consumers on a different Effect major).
+ */
+const workspaceDeps = catalog.compose({
+  workspace: workspaceMember({ memberPath: 'packages/@overeng/npm-release' }),
+  devDependencies: {
+    external: {
+      ...catalog.pick('@types/node', 'typescript', 'vitest'),
+    },
+  },
+})
+
+export default packageJson(
+  {
+    name: '@overeng/npm-release',
+    ...privatePackageDefaults,
+    exports: {
+      '.': exportEntry('./src/mod.ts', { environment: 'isomorphic-es2024' }),
+    },
+    publishConfig: {
+      access: 'public',
+      exports: {
+        '.': './dist/mod.js',
+      },
+    },
+  } satisfies PackageJsonInputData,
+  workspaceDeps,
+)

--- a/packages/@overeng/npm-release/package.json.genie.ts
+++ b/packages/@overeng/npm-release/package.json.genie.ts
@@ -9,16 +9,21 @@ import {
 } from '../../../genie/internal.ts'
 
 /**
- * No runtime dependencies and no `effect` peer: this package is the pure decision
- * layer for npm registry verification, so it stays consumable from any runtime
- * (including plain Node scripts and consumers on a different Effect major).
+ * The `.` export is the decision layer and imports nothing at runtime, so consumers
+ * that only classify registry state pull in no dependencies. Effect appears here for
+ * the `./cli` entry, which is bundled into a standalone binary at build time.
  */
+const peerDepNames = ['@effect/cli', '@effect/platform', '@effect/platform-node', 'effect'] as const
+
 const workspaceDeps = catalog.compose({
   workspace: workspaceMember({ memberPath: 'packages/@overeng/npm-release' }),
   devDependencies: {
     external: {
-      ...catalog.pick('@types/node', 'typescript', 'vitest'),
+      ...catalog.pick(...peerDepNames, '@types/node', 'typescript', 'vitest'),
     },
+  },
+  peerDependencies: {
+    external: catalog.pick(...peerDepNames),
   },
 })
 
@@ -28,11 +33,13 @@ export default packageJson(
     ...privatePackageDefaults,
     exports: {
       '.': exportEntry('./src/mod.ts', { environment: 'isomorphic-es2024' }),
+      './cli': exportEntry('./src/cli.ts', { environment: 'bun' }),
     },
     publishConfig: {
       access: 'public',
       exports: {
         '.': './dist/mod.js',
+        './cli': './dist/cli.js',
       },
     },
   } satisfies PackageJsonInputData,

--- a/packages/@overeng/npm-release/src/cli.ts
+++ b/packages/@overeng/npm-release/src/cli.ts
@@ -1,0 +1,113 @@
+#!/usr/bin/env bun
+
+/**
+ * `npm-release` — verify that an npm registry serves what a release published.
+ *
+ * Shipped as a binary because its callers span runtimes: an Effect release command,
+ * a workflow shell step, and a plain Node script. A process boundary is the one
+ * interface all three can share, and is how this repository already ships `genie`
+ * and `megarepo`.
+ */
+
+import { Command as Cli, Options } from '@effect/cli'
+import { NodeContext, NodeRuntime } from '@effect/platform-node'
+import { Cause, Duration, Effect, Option, Schedule } from 'effect'
+
+import { readPlan, verifyPlan, type VerifyFailure } from './verify.ts'
+
+const planOption = Options.file('plan').pipe(
+  Options.withDescription(
+    'Path to a JSON verify plan: { schemaVersion, version, npmTag, packages }',
+  ),
+)
+
+const registryOption = Options.text('registry').pipe(
+  Options.withDefault('https://registry.npmjs.org'),
+  Options.withDescription('Registry to query'),
+)
+
+const attemptsOption = Options.integer('attempts').pipe(
+  Options.withDefault(60),
+  Options.withDescription('How many times to re-check a package that has not converged'),
+)
+
+const delaySecondsOption = Options.integer('delay-seconds').pipe(
+  Options.withDefault(5),
+  Options.withDescription('Seconds to wait between convergence checks'),
+)
+
+/**
+ * Problems first: an operator needs the failing package and why, not a success
+ * roll-call. Reasons are already package-qualified, so they are not re-prefixed.
+ */
+const renderFailures = (failures: ReadonlyArray<VerifyFailure>) =>
+  Effect.forEach(
+    failures,
+    (failure) =>
+      Effect.logError(`${failure.reason}${failure.terminal === true ? ' [terminal]' : ''}`),
+    { discard: true },
+  )
+
+const verifyCommand = Cli.make(
+  'verify',
+  {
+    plan: planOption,
+    registry: registryOption,
+    attempts: attemptsOption,
+    delaySeconds: delaySecondsOption,
+  },
+  Effect.fn('verify')(function* ({ plan: planPath, registry, attempts, delaySeconds }) {
+    const plan = yield* readPlan(planPath)
+    const schedule = Schedule.spaced(Duration.seconds(delaySeconds)).pipe(
+      Schedule.compose(Schedule.recurs(attempts)),
+    )
+
+    yield* Effect.logInfo(
+      `Verifying ${plan.packages.length} package(s) at ${plan.version} (dist-tag ${plan.npmTag})`,
+    )
+
+    yield* verifyPlan({ plan, registry, schedule }).pipe(
+      Effect.tapError((error) => renderFailures(error.failures)),
+    )
+
+    yield* Effect.logInfo(`All ${plan.packages.length} package(s) match the registry`)
+  }),
+).pipe(
+  Cli.withDescription(
+    'Verify that the registry serves the release described by a plan: version visibility, tarball digest, and dist-tag target.',
+  ),
+)
+
+const cli = Cli.run(Cli.make('npm-release').pipe(Cli.withSubcommands([verifyCommand])), {
+  name: 'npm-release',
+  version: '0.1.0',
+})
+
+/**
+ * Expected failures are already rendered as one line per package, so the default
+ * cause dump would bury that under a stack trace from inside a bundled binary —
+ * noise for the operator reading a failed release log.
+ */
+const reportUnexpected = (cause: Cause.Cause<unknown>) =>
+  Cause.isInterruptedOnly(cause) === true
+    ? Effect.void
+    : Option.match(Cause.failureOption(cause), {
+        onNone: () => Effect.logError(Cause.pretty(cause)),
+        onSome: (error) =>
+          isRendered(error) === true ? Effect.void : Effect.logError(String(error)),
+      })
+
+/** Failures already surfaced by `renderFailures`; re-logging them would duplicate. */
+const isRendered = (error: unknown) =>
+  typeof error === 'object' &&
+  error !== null &&
+  '_tag' in error &&
+  error._tag === 'VerificationFailed'
+
+if (import.meta.main) {
+  cli(process.argv).pipe(
+    Effect.tapErrorCause(reportUnexpected),
+    Effect.provide(NodeContext.layer),
+    NodeRuntime.runMain({ disableErrorReporting: true }),
+  )
+}

--- a/packages/@overeng/npm-release/src/mod.test.ts
+++ b/packages/@overeng/npm-release/src/mod.test.ts
@@ -1,11 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import {
-  integrityFromBase64Sha512,
-  type RemoteRegistryState,
-  registryVerification,
-  shouldPublishWithProvenance,
-} from './mod.ts'
+import { type RemoteRegistryState, registryVerification } from './mod.ts'
 
 describe('registryVerification', () => {
   const base = { pkg: '@scope/pkg', version: '1.2.0', npmTag: 'latest' }
@@ -115,25 +110,5 @@ describe('registryVerification', () => {
         remote,
       }),
     ).toEqual({ _tag: 'ok' })
-  })
-})
-
-describe('shouldPublishWithProvenance', () => {
-  it.each([
-    { dryRun: false, isGithubActions: true, expected: true },
-    { dryRun: true, isGithubActions: true, expected: false },
-    { dryRun: false, isGithubActions: false, expected: false },
-    { dryRun: true, isGithubActions: false, expected: false },
-  ])(
-    'dryRun=$dryRun isGithubActions=$isGithubActions -> $expected',
-    ({ dryRun, isGithubActions, expected }) => {
-      expect(shouldPublishWithProvenance({ dryRun, isGithubActions })).toBe(expected)
-    },
-  )
-})
-
-describe('integrityFromBase64Sha512', () => {
-  it('formats a digest the way npm reports dist.integrity', () => {
-    expect(integrityFromBase64Sha512('abc123==')).toBe('sha512-abc123==')
   })
 })

--- a/packages/@overeng/npm-release/src/mod.test.ts
+++ b/packages/@overeng/npm-release/src/mod.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  integrityFromBase64Sha512,
+  type RemoteRegistryState,
+  registryVerification,
+  shouldPublishWithProvenance,
+} from './mod.ts'
+
+describe('registryVerification', () => {
+  const base = { pkg: '@scope/pkg', version: '1.2.0', npmTag: 'latest' }
+  const localIntegrity = 'sha512-local'
+
+  it('accepts a release the registry serves under the expected version and dist-tag', () => {
+    expect(
+      registryVerification({
+        ...base,
+        localIntegrity,
+        remote: { version: '1.2.0', integrity: localIntegrity, distTag: '1.2.0' },
+      }),
+    ).toEqual({ _tag: 'ok' })
+  })
+
+  it('treats a not-yet-visible version as pending so propagation can be retried', () => {
+    expect(
+      registryVerification({
+        ...base,
+        localIntegrity,
+        remote: { version: undefined, integrity: undefined, distTag: '1.1.0' },
+      })._tag,
+    ).toBe('pending')
+  })
+
+  // The failure this package exists for: the version publishes fine, but the tag
+  // still resolves to the previous release, so installs stay on the old version.
+  it('flags a dist-tag still pointing at the previous release', () => {
+    expect(
+      registryVerification({
+        ...base,
+        localIntegrity,
+        remote: { version: '1.2.0', integrity: localIntegrity, distTag: '1.1.0' },
+      }),
+    ).toEqual({
+      _tag: 'pending',
+      reason: '@scope/pkg: dist-tag "latest" points at 1.1.0, expected 1.2.0',
+    })
+  })
+
+  it('flags an absent dist-tag, which leaves the published version unreachable', () => {
+    const result = registryVerification({
+      ...base,
+      localIntegrity,
+      remote: { version: '1.2.0', integrity: localIntegrity, distTag: undefined },
+    })
+
+    expect(result._tag).toBe('pending')
+    expect(result).toMatchObject({ reason: expect.stringContaining('is absent') })
+  })
+
+  // Immutable on npm, so retrying can never resolve it.
+  it('reports a differing tarball digest as an unrecoverable mismatch', () => {
+    expect(
+      registryVerification({
+        ...base,
+        localIntegrity,
+        remote: { version: '1.2.0', integrity: 'sha512-other', distTag: '1.2.0' },
+      })._tag,
+    ).toBe('mismatch')
+  })
+
+  it('reports an unexpected served version as a mismatch rather than pending', () => {
+    expect(
+      registryVerification({
+        ...base,
+        localIntegrity,
+        remote: { version: '9.9.9', integrity: localIntegrity, distTag: '1.2.0' },
+      })._tag,
+    ).toBe('mismatch')
+  })
+
+  // Repairing a partial release re-verifies packages it did not pack.
+  it('skips the digest comparison when there is no locally packed artifact', () => {
+    expect(
+      registryVerification({
+        ...base,
+        localIntegrity: undefined,
+        remote: { version: '1.2.0', integrity: 'sha512-whatever', distTag: '1.2.0' },
+      }),
+    ).toEqual({ _tag: 'ok' })
+  })
+
+  it('skips the digest comparison when the registry reports no integrity', () => {
+    expect(
+      registryVerification({
+        ...base,
+        localIntegrity,
+        remote: { version: '1.2.0', integrity: undefined, distTag: '1.2.0' },
+      }),
+    ).toEqual({ _tag: 'ok' })
+  })
+
+  it('verifies the dist-tag the release used rather than assuming latest', () => {
+    const remote: RemoteRegistryState = {
+      version: '2.0.0-beta.1',
+      integrity: localIntegrity,
+      distTag: '2.0.0-beta.1',
+    }
+
+    expect(
+      registryVerification({
+        pkg: '@scope/pkg',
+        version: '2.0.0-beta.1',
+        npmTag: 'next',
+        localIntegrity,
+        remote,
+      }),
+    ).toEqual({ _tag: 'ok' })
+  })
+})
+
+describe('shouldPublishWithProvenance', () => {
+  it.each([
+    { dryRun: false, isGithubActions: true, expected: true },
+    { dryRun: true, isGithubActions: true, expected: false },
+    { dryRun: false, isGithubActions: false, expected: false },
+    { dryRun: true, isGithubActions: false, expected: false },
+  ])(
+    'dryRun=$dryRun isGithubActions=$isGithubActions -> $expected',
+    ({ dryRun, isGithubActions, expected }) => {
+      expect(shouldPublishWithProvenance({ dryRun, isGithubActions })).toBe(expected)
+    },
+  )
+})
+
+describe('integrityFromBase64Sha512', () => {
+  it('formats a digest the way npm reports dist.integrity', () => {
+    expect(integrityFromBase64Sha512('abc123==')).toBe('sha512-abc123==')
+  })
+})

--- a/packages/@overeng/npm-release/src/mod.ts
+++ b/packages/@overeng/npm-release/src/mod.ts
@@ -1,0 +1,155 @@
+/**
+ * Verifying that an npm registry actually serves what a release intended to publish.
+ *
+ * `npm publish` exiting zero is not the same as the release being live. Three things
+ * can independently be wrong afterwards, and only the first is commonly checked:
+ *
+ * 1. the version is not visible (not propagated, or the publish silently failed),
+ * 2. the served tarball is not the artifact that was packed,
+ * 3. the dist-tag still resolves to the previous version, so `npm install <pkg>`
+ *    keeps serving the old release even though the new one published fine.
+ *
+ * This module is the decision layer for those checks: pure functions over plain
+ * data, with no dependency on Effect, a registry client, or a process runtime.
+ *
+ * ## Why the decision layer is dependency-free
+ *
+ * The interesting part of registry verification is the classification — which
+ * disagreements are worth retrying and which are terminal. That is pure logic, and
+ * keeping it free of IO means it can be exhaustively tested without a registry,
+ * a network, or a runtime, and reused from any caller: an Effect release command,
+ * a workflow step, or a plain Node script.
+ *
+ * This mirrors the `@overeng/kdl` / `@overeng/kdl-effect` split — pure core, with
+ * an Effect-flavoured wrapper layered on top rather than fused into it.
+ *
+ * A second, temporary reason reinforces it today: consumers sit on a different
+ * Effect major than this repository, and the standing rule at that boundary is to
+ * isolate rather than cast across majors. That constraint goes away once everything
+ * is on Effect 4; the layering reason above does not, which is why an
+ * `@overeng/npm-release-effect` wrapper belongs beside this module rather than
+ * replacing it.
+ */
+
+/** What a registry currently serves for one package version. */
+export type RemoteRegistryState = {
+  /** `undefined` when the exact version is not visible on the registry (yet). */
+  readonly version: string | undefined
+  /** Subresource integrity of the served tarball, e.g. `sha512-…`. */
+  readonly integrity: string | undefined
+  /** Version the mutable dist-tag resolves to; `undefined` when the tag does not exist. */
+  readonly distTag: string | undefined
+}
+
+/**
+ * Outcome of comparing a registry against what was published.
+ *
+ * `pending` and `mismatch` are distinct because they need opposite handling.
+ * Registry propagation is eventually consistent and worth retrying; a tarball
+ * digest that disagrees with what was packed can never become correct, because a
+ * published version is immutable on npm. Collapsing them into one "failed" state
+ * is what turns a fast, clear failure into a silent multi-minute retry loop.
+ */
+export type RegistryVerification =
+  | { readonly _tag: 'ok' }
+  /** Registry has not caught up yet; retrying may resolve this. */
+  | { readonly _tag: 'pending'; readonly reason: string }
+  /** Registry disagrees with what was published; retrying cannot fix it. */
+  | { readonly _tag: 'mismatch'; readonly reason: string }
+
+/** What a caller knows about a package it just published, plus what the registry reports. */
+export type RegistryVerificationInput = {
+  /** Package name, used only to build readable reasons. */
+  readonly pkg: string
+  /** Version that was published. */
+  readonly version: string
+  /** dist-tag the release published under, e.g. `latest`, `dev`, `snapshot`. */
+  readonly npmTag: string
+  /**
+   * Integrity of the locally packed tarball, when this run packed it.
+   *
+   * `undefined` disables the digest comparison — correct for packages skipped as
+   * already-published (repairing a partial release), where there is no local
+   * artifact to compare against.
+   */
+  readonly localIntegrity: string | undefined
+  readonly remote: RemoteRegistryState
+}
+
+/**
+ * Compare what a registry serves against what was published.
+ *
+ * A dist-tag pointing at a different version is reported as `pending`, not
+ * `mismatch`: during normal propagation the tag legitimately lags behind the
+ * version for a short window. It becomes a failure when the caller's retry budget
+ * is exhausted, which keeps genuine lag from failing a release while still
+ * catching a tag that never moves.
+ */
+export const registryVerification = ({
+  pkg,
+  version,
+  npmTag,
+  localIntegrity,
+  remote,
+}: RegistryVerificationInput): RegistryVerification => {
+  if (remote.version === undefined) {
+    return { _tag: 'pending', reason: `${pkg}@${version} is not visible on the registry yet` }
+  }
+
+  if (remote.version !== version) {
+    return {
+      _tag: 'mismatch',
+      reason: `${pkg}: registry serves version ${remote.version}, expected ${version}`,
+    }
+  }
+
+  if (
+    localIntegrity !== undefined &&
+    remote.integrity !== undefined &&
+    remote.integrity !== localIntegrity
+  ) {
+    return {
+      _tag: 'mismatch',
+      reason: `${pkg}@${version}: registry tarball digest ${remote.integrity} does not match the locally packed ${localIntegrity}`,
+    }
+  }
+
+  if (remote.distTag === undefined) {
+    return {
+      _tag: 'pending',
+      reason: `${pkg}: dist-tag "${npmTag}" is absent, so ${version} published but nothing resolves to it`,
+    }
+  }
+
+  if (remote.distTag !== version) {
+    return {
+      _tag: 'pending',
+      reason: `${pkg}: dist-tag "${npmTag}" points at ${remote.distTag}, expected ${version}`,
+    }
+  }
+
+  return { _tag: 'ok' }
+}
+
+/**
+ * Subresource integrity string for a packed tarball, in the form npm reports as
+ * `dist.integrity` — base64 SHA-512, algorithm-prefixed.
+ *
+ * Takes the already-read bytes rather than a path so this stays free of any
+ * filesystem or crypto runtime; callers hash with whatever their platform offers.
+ */
+export const integrityFromBase64Sha512 = (base64Sha512: string): string => `sha512-${base64Sha512}`
+
+/**
+ * Whether npm's `--provenance` flag should be passed for this publish.
+ *
+ * Provenance is minted from the CI job's OIDC identity, so it is only available
+ * on a supported CI provider and is meaningless for a dry run.
+ */
+export const shouldPublishWithProvenance = ({
+  dryRun,
+  isGithubActions,
+}: {
+  readonly dryRun: boolean
+  readonly isGithubActions: boolean
+}): boolean => dryRun === false && isGithubActions === true

--- a/packages/@overeng/npm-release/src/mod.ts
+++ b/packages/@overeng/npm-release/src/mod.ts
@@ -130,26 +130,3 @@ export const registryVerification = ({
 
   return { _tag: 'ok' }
 }
-
-/**
- * Subresource integrity string for a packed tarball, in the form npm reports as
- * `dist.integrity` — base64 SHA-512, algorithm-prefixed.
- *
- * Takes the already-read bytes rather than a path so this stays free of any
- * filesystem or crypto runtime; callers hash with whatever their platform offers.
- */
-export const integrityFromBase64Sha512 = (base64Sha512: string): string => `sha512-${base64Sha512}`
-
-/**
- * Whether npm's `--provenance` flag should be passed for this publish.
- *
- * Provenance is minted from the CI job's OIDC identity, so it is only available
- * on a supported CI provider and is meaningless for a dry run.
- */
-export const shouldPublishWithProvenance = ({
-  dryRun,
-  isGithubActions,
-}: {
-  readonly dryRun: boolean
-  readonly isGithubActions: boolean
-}): boolean => dryRun === false && isGithubActions === true

--- a/packages/@overeng/npm-release/src/verify.ts
+++ b/packages/@overeng/npm-release/src/verify.ts
@@ -1,0 +1,250 @@
+/**
+ * Registry-facing side of verification: reads what npm serves, hashes what we packed,
+ * and drives the pure classification in {@link registryVerification} until the registry
+ * converges or the budget runs out.
+ *
+ * All judgement lives in `mod.ts`; this module only supplies it with facts.
+ */
+
+import { createHash } from 'node:crypto'
+
+import { Command, FileSystem } from '@effect/platform'
+import { Effect, Schema } from 'effect'
+import type { Schedule } from 'effect'
+
+import { registryVerification, type RemoteRegistryState } from './mod.ts'
+
+/** One package to verify. `tarball` is absent when this run did not pack it. */
+export const PlanPackage = Schema.Struct({
+  name: Schema.NonEmptyTrimmedString,
+  tarball: Schema.optional(Schema.NonEmptyTrimmedString),
+}).annotations({ identifier: 'NpmRelease.PlanPackage' })
+
+/** The release a caller wants the registry to agree with. */
+export const VerifyPlan = Schema.Struct({
+  schemaVersion: Schema.Literal(1),
+  version: Schema.NonEmptyTrimmedString,
+  npmTag: Schema.NonEmptyTrimmedString,
+  packages: Schema.NonEmptyArray(PlanPackage),
+}).annotations({ identifier: 'NpmRelease.VerifyPlan' })
+
+export type VerifyPlan = typeof VerifyPlan.Type
+
+/** A package the registry disagreed about, after the convergence budget was spent. */
+export const VerifyFailure = Schema.Struct({
+  package: Schema.String,
+  reason: Schema.String,
+  terminal: Schema.Boolean,
+}).annotations({ identifier: 'NpmRelease.VerifyFailure' })
+
+export type VerifyFailure = typeof VerifyFailure.Type
+
+/** Raised when the plan file cannot be read or does not decode. */
+export class PlanError extends Schema.TaggedError<PlanError>()('PlanError', {
+  path: Schema.String,
+  message: Schema.String,
+}) {}
+
+/** Raised when the registry does not serve the release the plan describes. */
+export class VerificationFailed extends Schema.TaggedError<VerificationFailed>()(
+  'VerificationFailed',
+  {
+    failures: Schema.Array(VerifyFailure),
+    message: Schema.String,
+  },
+) {}
+
+/** Registry state has not converged yet; retried until the budget is spent. */
+class NotConverged extends Schema.TaggedError<NotConverged>()('NotConverged', {
+  reason: Schema.String,
+}) {}
+
+const RegistryManifest = Schema.Struct({
+  version: Schema.String,
+  dist: Schema.optional(Schema.Struct({ integrity: Schema.optional(Schema.String) })),
+})
+
+const RegistryDistTags = Schema.Record({ key: Schema.String, value: Schema.String })
+
+/**
+ * `npm view --json`, with every failure mode reported as absent data.
+ *
+ * npm exits non-zero *and* prints a JSON error object to stdout for an unpublished
+ * version, so neither exit code nor parseability distinguishes "not there yet" from
+ * "broken". Both are absence; the retry budget decides when absence becomes failure.
+ */
+const npmViewJson = Effect.fn('npmViewJson')(function* <A, I>(
+  args: ReadonlyArray<string>,
+  schema: Schema.Schema<A, I>,
+  registry: string,
+) {
+  const raw = yield* Command.make('npm', 'view', ...args, '--json', `--registry=${registry}`).pipe(
+    Command.string,
+    Effect.orElseSucceed(() => ''),
+  )
+
+  return yield* Schema.decodeUnknown(Schema.parseJson(schema))(raw.trim()).pipe(
+    Effect.orElseSucceed(() => undefined),
+  )
+})
+
+/** Read what the registry currently serves for one package version. */
+export const readRegistryState = Effect.fn('readRegistryState')(function* ({
+  name,
+  version,
+  npmTag,
+  registry,
+}: {
+  readonly name: string
+  readonly version: string
+  readonly npmTag: string
+  readonly registry: string
+}) {
+  const manifest = yield* npmViewJson([`${name}@${version}`], RegistryManifest, registry)
+  const distTags = yield* npmViewJson([name, 'dist-tags'], RegistryDistTags, registry)
+
+  return {
+    version: manifest?.version,
+    integrity: manifest?.dist?.integrity,
+    distTag: distTags?.[npmTag],
+  } satisfies RemoteRegistryState
+})
+
+/** npm's `dist.integrity` format: base64 SHA-512 of the tarball, algorithm-prefixed. */
+const tarballIntegrity = Effect.fn('tarballIntegrity')(function* (path: string) {
+  const fs = yield* FileSystem.FileSystem
+  const bytes = yield* fs.readFile(path)
+  return `sha512-${createHash('sha512').update(bytes).digest('base64')}`
+})
+
+/**
+ * Verify one package, retrying only while the registry may still converge.
+ *
+ * A `mismatch` fails immediately — a published npm version is immutable, so waiting
+ * cannot change it, and retrying would turn a clear failure into a silent wait.
+ */
+const verifyPackage = Effect.fn('verifyPackage')(function* ({
+  name,
+  tarball,
+  version,
+  npmTag,
+  registry,
+  schedule,
+}: {
+  readonly name: string
+  readonly tarball: string | undefined
+  readonly version: string
+  readonly npmTag: string
+  readonly registry: string
+  readonly schedule: Schedule.Schedule<unknown, unknown>
+}) {
+  // An unreadable tarball is a caller error, not a registry disagreement, but it still
+  // belongs in the same report so one run surfaces every reason the release is unsound.
+  const localIntegrity =
+    tarball === undefined
+      ? undefined
+      : yield* tarballIntegrity(tarball).pipe(
+          Effect.mapError(
+            (cause) =>
+              new VerificationFailed({
+                failures: [
+                  {
+                    package: name,
+                    reason: `cannot read packed tarball ${tarball}: ${String(cause)}`,
+                    terminal: true,
+                  },
+                ],
+                message: `cannot read packed tarball for ${name}`,
+              }),
+          ),
+        )
+
+  const attempt = Effect.gen(function* () {
+    const remote = yield* readRegistryState({ name, version, npmTag, registry })
+    const result = registryVerification({ pkg: name, version, npmTag, localIntegrity, remote })
+
+    if (result._tag === 'mismatch') {
+      return yield* new VerificationFailed({
+        failures: [{ package: name, reason: result.reason, terminal: true }],
+        message: result.reason,
+      })
+    }
+    if (result._tag === 'pending') return yield* new NotConverged({ reason: result.reason })
+  })
+
+  return yield* attempt.pipe(
+    Effect.retry({ schedule, while: (error) => error._tag === 'NotConverged' }),
+    Effect.catchTag(
+      'NotConverged',
+      (error) =>
+        new VerificationFailed({
+          failures: [
+            {
+              package: name,
+              reason: `${error.reason} — registry did not converge within the verification window`,
+              terminal: false,
+            },
+          ],
+          message: error.reason,
+        }),
+    ),
+  )
+})
+
+/**
+ * Verify every package in the plan, reporting all disagreements rather than the first.
+ *
+ * A release group fails as a unit, so an operator seeing only the first bad package
+ * would fix it and immediately rediscover the next one.
+ */
+export const verifyPlan = Effect.fn('verifyPlan')(function* ({
+  plan,
+  registry,
+  schedule,
+}: {
+  readonly plan: VerifyPlan
+  readonly registry: string
+  readonly schedule: Schedule.Schedule<unknown, unknown>
+}) {
+  const outcomes = yield* Effect.forEach(
+    plan.packages,
+    (pkg) =>
+      verifyPackage({
+        name: pkg.name,
+        tarball: pkg.tarball,
+        version: plan.version,
+        npmTag: plan.npmTag,
+        registry,
+        schedule,
+      }).pipe(Effect.either),
+    { concurrency: 4 },
+  )
+
+  const failures: Array<VerifyFailure> = []
+  for (const outcome of outcomes) {
+    if (outcome._tag === 'Left') failures.push(...outcome.left.failures)
+  }
+
+  if (failures.length > 0) {
+    return yield* new VerificationFailed({
+      failures,
+      message: `${failures.length} of ${plan.packages.length} package(s) did not match the registry`,
+    })
+  }
+})
+
+/** Read and decode a verify plan. */
+export const readPlan = Effect.fn('readPlan')(function* (path: string) {
+  const fs = yield* FileSystem.FileSystem
+  const content = yield* fs
+    .readFileString(path)
+    .pipe(
+      Effect.mapError(
+        (cause) => new PlanError({ path, message: `Cannot read plan: ${String(cause)}` }),
+      ),
+    )
+
+  return yield* Schema.decodeUnknown(Schema.parseJson(VerifyPlan))(content).pipe(
+    Effect.mapError((cause) => new PlanError({ path, message: `Invalid plan: ${cause}` })),
+  )
+})

--- a/packages/@overeng/npm-release/tsconfig.json
+++ b/packages/@overeng/npm-release/tsconfig.json
@@ -1,0 +1,50 @@
+// Generated file - DO NOT EDIT
+// Source: tsconfig.json.genie.ts
+{
+  "compilerOptions": {
+    "target": "ES2024",
+    "lib": ["ES2024"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "allowJs": false,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "plugins": [
+      {
+        "name": "@effect/language-service",
+        "ignoreEffectWarningsInTscExitCode": false,
+        "ignoreEffectSuggestionsInTscExitCode": false,
+        "ignoreEffectErrorsInTscExitCode": false,
+        "includeSuggestionsInTsc": true,
+        "pipeableMinArgCount": 2,
+        "diagnosticSeverity": {
+          "missedPipeableOpportunity": "warning",
+          "schemaUnionOfLiterals": "warning",
+          "anyUnknownInErrorContext": "warning",
+          "preferSchemaOverJson": "warning"
+        }
+      }
+    ],
+    "composite": true,
+    "rootDir": ".",
+    "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/@overeng/npm-release/tsconfig.json.genie.ts
+++ b/packages/@overeng/npm-release/tsconfig.json.genie.ts
@@ -1,0 +1,15 @@
+import {
+  baseTsconfigCompilerOptions,
+  nodeTypes,
+  packageTsconfigCompilerOptions,
+} from '../../../genie/internal.ts'
+import { tsconfigJson, type TSConfigArgs } from '../genie/src/runtime/mod.ts'
+
+export default tsconfigJson({
+  compilerOptions: {
+    ...baseTsconfigCompilerOptions,
+    ...packageTsconfigCompilerOptions,
+    ...nodeTypes,
+  },
+  include: ['src/**/*'],
+} satisfies TSConfigArgs)

--- a/packages/@overeng/npm-release/vitest.config.ts
+++ b/packages/@overeng/npm-release/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+})

--- a/packages/@overeng/tui-stories/nix/build.nix
+++ b/packages/@overeng/tui-stories/nix/build.nix
@@ -21,7 +21,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-ERIKTGAvrxUO705rfDy6k91Vgg1ao9/nnMucFPGtOcI=";
+      "." = mkSharedHash "sha256-Uno1CLNPSYGEVIuQVGp2+BxMwY5nTnMLMVynDc0DEGA=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/tui-stories/nix/build.nix
+++ b/packages/@overeng/tui-stories/nix/build.nix
@@ -21,7 +21,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-Uno1CLNPSYGEVIuQVGp2+BxMwY5nTnMLMVynDc0DEGA=";
+      "." = mkSharedHash "sha256-ZMWlEBQRD+IzISeJjQgH5RDoaDSp0kprWlcn3FkB9xI=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/pnpm-install-contract.json
+++ b/pnpm-install-contract.json
@@ -129,6 +129,7 @@
       "packages/@overeng/notion-md",
       "packages/@overeng/notion-property-write",
       "packages/@overeng/notion-react",
+      "packages/@overeng/npm-release",
       "packages/@overeng/otel-contract",
       "packages/@overeng/oxc-config",
       "packages/@overeng/pty-effect",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1354,9 +1354,21 @@ importers:
 
   packages/@overeng/npm-release:
     devDependencies:
+      '@effect/cli':
+        specifier: 0.75.2
+        version: 0.75.2(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
+      '@effect/platform':
+        specifier: 0.96.2
+        version: 0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4)
+      '@effect/platform-node':
+        specifier: 0.107.0
+        version: 0.107.0(@effect/cluster@0.59.0(2726862cc6f36e3b086be9ebab8bdc40))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@types/node':
         specifier: 26.0.0
         version: 26.0.0
+      effect:
+        specifier: 3.21.4
+        version: 3.21.4
       typescript:
         specifier: 6.0.3
         version: 6.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1352,6 +1352,18 @@ importers:
         specifier: 8.0.16
         version: 8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)
 
+  packages/@overeng/npm-release:
+    devDependencies:
+      '@types/node':
+        specifier: 26.0.0
+        version: 26.0.0
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 4.1.9
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+
   packages/@overeng/otel-contract:
     dependencies:
       '@overeng/content-address':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,6 +27,7 @@ packages:
   - packages/@overeng/notion-md
   - packages/@overeng/notion-property-write
   - packages/@overeng/notion-react
+  - packages/@overeng/npm-release
   - packages/@overeng/otel-contract
   - packages/@overeng/oxc-config
   - packages/@overeng/pty-effect

--- a/tsconfig.check.json
+++ b/tsconfig.check.json
@@ -79,6 +79,9 @@
       "path": "./packages/@overeng/notion-react"
     },
     {
+      "path": "./packages/@overeng/npm-release"
+    },
+    {
       "path": "./packages/@overeng/otel-contract"
     },
     {

--- a/tsconfig.emit.json
+++ b/tsconfig.emit.json
@@ -70,6 +70,9 @@
       "path": "./packages/@overeng/notion-react"
     },
     {
+      "path": "./packages/@overeng/npm-release"
+    },
+    {
       "path": "./packages/@overeng/otel-contract"
     },
     {


### PR DESCRIPTION
## Problem

`npm publish` exiting zero does not mean a release is live. Three things can independently be wrong afterwards, and none of them fail the publish command: the version has not propagated, the served tarball is not the artifact that was packed, or the dist-tag still resolves to the previous version — so `npm install <pkg>` keeps serving the old release.

That last one was unchecked in two of the three places we publish from. "Publish a package group to npm" currently exists three times across two repos, in three languages:

| Implementation | rewrite deps | pack | publish | verify version | digest | dist-tag | provenance |
| --- | --- | --- | --- | --- | --- | --- | --- |
| livestore stable — Effect TS | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| livestore snapshot — inline bash | — | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| livestore-contrib — plain `.mjs` | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ |

The first two only gained digest/dist-tag/provenance in https://github.com/livestorejs/livestore/pull/1504; contrib's gap is https://github.com/livestorejs/livestore-contrib/issues/27. Three copies of the same pipeline, drifting independently, is the case for extracting it.

## Target system

VRS is in `context/npm-release/`, aligned through an interview. Four boundaries were settled:

- **npm-specific by design.** The model is npm's — immutable versions, mutable dist-tags, SRI digests. Another registry is a sibling system, not an extension.
- **Owns the whole pipeline** — rewrite deps → pack → publish → verify → repair. Sharing only the verdict would leave most of the duplication in place, since both publishers hand-roll all four stages (`rewriteSnapshotInternalDependencyRanges` in livestore, `rewriteDependency` in contrib).
- **Never decides a release.** Versions, changelogs, tags and membership come from the caller; this system makes the registry match the plan it is given.
- **A release is a target state, not a transaction.** npm cannot publish a group atomically, so correctness is convergence: every operation idempotent, resuming is an ordinary run, repair is not a mode. This is the load-bearing idea — it justifies idempotency, why repair is in scope, and why `mismatch` is terminal while `pending` retries.

## What this PR actually ships

**The classification layer only** — `registryVerification` plus the provenance condition, as pure functions with zero dependencies and no `effect` peer. The pipeline stages are specified but not implemented.

That gap is recorded as `context/npm-release/.delta/DELTA-001`, not left as silent drift. It stands because neither consumer can take an IO-bearing implementation yet: livestore is on Effect `4.0.0-beta.99` while this repo is on `3.21.4`, and the standing rule at that boundary is to isolate rather than cast across majors (the `react-inspector` catalog exception, #937). Contrib publishes from a plain Node script and is mid-migration.

Shipping the decision layer first closes the highest-value gap — the unchecked dist-tag — without waiting on the migration, and is the substrate the full pipeline needs regardless.

## Validation

- 14 unit tests covering every classification branch, including the dist-tag-lag case this exists for.
- `devenv tasks run check:quick` passes (ts + lint + genie freshness + workspace registry checks).
- `devenv tasks run genie:run` regenerates cleanly.

## Nix note

Adding a workspace package invalidated the pnpm-deps FODs of the six CLI packages plus `oxc-config`. The six were refreshed with `evergreen fod refresh`; `oxc-config` has no evergreen hash-source mapping (`could not determine --hash-source`), so it used the procedure documented in `nix/oxc-config-plugin.nix` — filed as agent feedback so evergreen can cover it.

## Follow-ups

- Implement the pipeline stages and close DELTA-001 after the Effect 4 migration.
- Repoint livestore and livestore-contrib; that is when https://github.com/livestorejs/livestore-contrib/issues/27 gets fixed rather than just tracked.
- DQ1–DQ3 in the spec: credential surface for repair, cross-runtime consumption, package concurrency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | cl1-lagoon |
| `agent_session_id` | 4f0de924-6d8e-4779-9a7d-c30c8fa3d2a4 |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.220 |
| `agent_runtime` | Claude Code 2.1.220 |
| `agent_model` | claude-opus-5 |
| `runtime_profile` | /nix/store/57hz15fbcg9c3hasm0ny3axd5pg33rh3-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/d9hvhhg1k9n3j20dgcch7sz3sg98l377-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | schickling |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@b785b9f |
</details>
<!-- agent-footer:end -->