### PR TITLE
Fix observability capture by pinning the task bridge executable

### DIFF
--- a/context/otelite/spec.md
+++ b/context/otelite/spec.md
@@ -277,7 +277,8 @@ optionally, a task profile. The module:
   exports the store-pinned `OTEL_SPAN_BIN` used by shared task wrappers so
   nested devenv evaluation does not depend on ambient `PATH`;
 - sends native devenv spans over OTLP/gRPC and effect-utils task spans over
-  OTLP/HTTP to one invocation-scoped otelite capture;
+  OTLP/HTTP to one invocation-scoped otelite capture, preferring otelite's
+  per-invocation HTTP endpoint over any ambient collector endpoint;
 - emits low-cardinality `devenv.project.name` on effect-utils task spans;
 - provides `otel:profile:<name>` for retained diagnostic captures and
   `otel:verify:<name>` for a hermetic, automatically cleaned shape check; and

--- a/context/otelite/spec.md
+++ b/context/otelite/spec.md
@@ -273,7 +273,9 @@ exercise the real receiver and the real binary (per house rules).
 task tracing and otelite. A consumer supplies a stable project name and,
 optionally, a task profile. The module:
 
-- adds the bootstrap-safe `otel-span` and Nix-built `otelite` binaries;
+- adds the bootstrap-safe `otel-span` and Nix-built `otelite` binaries, and
+  exports the store-pinned `OTEL_SPAN_BIN` used by shared task wrappers so
+  nested devenv evaluation does not depend on ambient `PATH`;
 - sends native devenv spans over OTLP/gRPC and effect-utils task spans over
   OTLP/HTTP to one invocation-scoped otelite capture;
 - emits low-cardinality `devenv.project.name` on effect-utils task spans;

--- a/nix/devenv-modules/observability.nix
+++ b/nix/devenv-modules/observability.nix
@@ -64,15 +64,12 @@ let
 
           # Native devenv uses OTLP/gRPC while the temporary task-phase
           # producer uses OTLP/HTTP. Otelite owns the isolated capture.
-          # Nested devenv tasks must use the module-owned bridge even when
-          # the caller's shell does not expose otel-span.
           # shellcheck disable=SC2016
           env \
             -u DEVENV_TRACE_TO \
             -u OTEL_TASK_TRACEPARENT \
             -u TRACEPARENT \
             -u OTEL_SHELL_ENTRY_NS \
-            PATH=${lib.makeBinPath [ otelSpan ]}:"$PATH" \
             ${otelite}/bin/otelite run \
               --out "$capture_dir/capture" \
               --protocol grpc \
@@ -189,7 +186,12 @@ in
     }
   );
 
-  env.OTEL_DEVENV_PROJECT = project;
+  env = {
+    OTEL_DEVENV_PROJECT = project;
+    # Devenv task execution may reconstruct PATH independently of the capture
+    # process, so task wrappers resolve the module-owned bridge explicitly.
+    OTEL_SPAN_BIN = "${otelSpan}/bin/otel-span";
+  };
   packages = [
     otelSpan
     otelite

--- a/nix/devenv-modules/observability.nix
+++ b/nix/devenv-modules/observability.nix
@@ -64,12 +64,15 @@ let
 
           # Native devenv uses OTLP/gRPC while the temporary task-phase
           # producer uses OTLP/HTTP. Otelite owns the isolated capture.
+          # Nested devenv tasks must use the module-owned bridge even when
+          # the caller's shell does not expose otel-span.
           # shellcheck disable=SC2016
           env \
             -u DEVENV_TRACE_TO \
             -u OTEL_TASK_TRACEPARENT \
             -u TRACEPARENT \
             -u OTEL_SHELL_ENTRY_NS \
+            PATH=${lib.makeBinPath [ otelSpan ]}:"$PATH" \
             ${otelite}/bin/otelite run \
               --out "$capture_dir/capture" \
               --protocol grpc \

--- a/nix/devenv-modules/tasks/README.md
+++ b/nix/devenv-modules/tasks/README.md
@@ -39,9 +39,11 @@ imports = [
 The default `backend = "ambient"` adds only `otel-span`, otelite, and the
 `otel:profile:setup` / `otel:verify:setup` tasks. Task wrappers resolve the
 module-owned bridge through `OTEL_SPAN_BIN`, so nested devenv task environments
-do not depend on ambient `PATH`. The module intentionally avoids the full local
-observability stack. Override `profile` to capture a different task graph, or
-set `profile = null` when only the packages and project attribution are needed.
+do not depend on ambient `PATH`; capture tasks also prefer otelite's
+invocation-scoped HTTP endpoint over a repository's ambient collector endpoint.
+The module intentionally avoids the full local observability stack. Override
+`profile` to capture a different task graph, or set `profile = null` when only
+the packages and project attribution are needed.
 
 ### Characteristics:
 

--- a/nix/devenv-modules/tasks/README.md
+++ b/nix/devenv-modules/tasks/README.md
@@ -37,10 +37,11 @@ imports = [
 ```
 
 The default `backend = "ambient"` adds only `otel-span`, otelite, and the
-`otel:profile:setup` / `otel:verify:setup` tasks. It intentionally avoids the
-full local observability stack. Override `profile` to capture a different task
-graph, or set `profile = null` when only the packages and project attribution
-are needed.
+`otel:profile:setup` / `otel:verify:setup` tasks. Task wrappers resolve the
+module-owned bridge through `OTEL_SPAN_BIN`, so nested devenv task environments
+do not depend on ambient `PATH`. The module intentionally avoids the full local
+observability stack. Override `profile` to capture a different task graph, or
+set `profile = null` when only the packages and project attribution are needed.
 
 ### Characteristics:
 

--- a/nix/devenv-modules/tasks/lib/trace.nix
+++ b/nix/devenv-modules/tasks/lib/trace.nix
@@ -40,7 +40,7 @@
 #
 { lib }:
 let
-  otelCanEmitShell = ''command -v "''${OTEL_SPAN_BIN:-otel-span}" >/dev/null 2>&1 && { [ -n "''${OTEL_EXPORTER_OTLP_ENDPOINT:-}" ] || { [ -n "''${OTEL_SPAN_SPOOL_DIR:-}" ] && [ -d "''${OTEL_SPAN_SPOOL_DIR:-}" ]; }; }'';
+  otelCanEmitShell = ''command -v "''${OTEL_SPAN_BIN:-otel-span}" >/dev/null 2>&1 && { [ -n "''${OTELITE_HTTP_ENDPOINT:-''${OTEL_EXPORTER_OTLP_ENDPOINT:-}}" ] || { [ -n "''${OTEL_SPAN_SPOOL_DIR:-}" ] && [ -d "''${OTEL_SPAN_SPOOL_DIR:-}" ]; }; }'';
 
   # Shell condition: an OTEL task trace context is actually ACTIVE — OTEL delivery
   # is available (otelCanEmitShell) AND a well-formed W3C traceparent is present
@@ -171,7 +171,8 @@ let
       if [ -n "''${OTEL_DEVENV_PROJECT:-}" ]; then
         _otel_project_attr=(--attr "devenv.project.name=$OTEL_DEVENV_PROJECT")
       fi
-      "''${OTEL_SPAN_BIN:-otel-span}" run "effect-utils-devenv" "devenv.task.exec" \
+      OTEL_EXPORTER_OTLP_ENDPOINT="''${OTELITE_HTTP_ENDPOINT:-''${OTEL_EXPORTER_OTLP_ENDPOINT:-}}" \
+        "''${OTEL_SPAN_BIN:-otel-span}" run "effect-utils-devenv" "devenv.task.exec" \
         "''${_otel_project_attr[@]}" \
         --attr "tool.name=devenv" \
         --attr "task.name=${taskName}" \
@@ -196,7 +197,8 @@ let
       if [ -n "''${OTEL_DEVENV_PROJECT:-}" ]; then
         _otel_project_attr=(--attr "devenv.project.name=$OTEL_DEVENV_PROJECT")
       fi
-      "''${OTEL_SPAN_BIN:-otel-span}" run "effect-utils-devenv" "devenv.task.status" \
+      OTEL_EXPORTER_OTLP_ENDPOINT="''${OTELITE_HTTP_ENDPOINT:-''${OTEL_EXPORTER_OTLP_ENDPOINT:-}}" \
+        "''${OTEL_SPAN_BIN:-otel-span}" run "effect-utils-devenv" "devenv.task.status" \
         "''${_otel_project_attr[@]}" \
         --attr "tool.name=devenv" \
         --attr "task.name=${taskName}" \

--- a/nix/devenv-modules/tasks/lib/trace.nix
+++ b/nix/devenv-modules/tasks/lib/trace.nix
@@ -40,7 +40,7 @@
 #
 { lib }:
 let
-  otelCanEmitShell = ''command -v otel-span >/dev/null 2>&1 && { [ -n "''${OTEL_EXPORTER_OTLP_ENDPOINT:-}" ] || { [ -n "''${OTEL_SPAN_SPOOL_DIR:-}" ] && [ -d "''${OTEL_SPAN_SPOOL_DIR:-}" ]; }; }'';
+  otelCanEmitShell = ''command -v "''${OTEL_SPAN_BIN:-otel-span}" >/dev/null 2>&1 && { [ -n "''${OTEL_EXPORTER_OTLP_ENDPOINT:-}" ] || { [ -n "''${OTEL_SPAN_SPOOL_DIR:-}" ] && [ -d "''${OTEL_SPAN_SPOOL_DIR:-}" ]; }; }'';
 
   # Shell condition: an OTEL task trace context is actually ACTIVE — OTEL delivery
   # is available (otelCanEmitShell) AND a well-formed W3C traceparent is present
@@ -171,7 +171,7 @@ let
       if [ -n "''${OTEL_DEVENV_PROJECT:-}" ]; then
         _otel_project_attr=(--attr "devenv.project.name=$OTEL_DEVENV_PROJECT")
       fi
-      otel-span run "effect-utils-devenv" "devenv.task.exec" \
+      "''${OTEL_SPAN_BIN:-otel-span}" run "effect-utils-devenv" "devenv.task.exec" \
         "''${_otel_project_attr[@]}" \
         --attr "tool.name=devenv" \
         --attr "task.name=${taskName}" \
@@ -196,7 +196,7 @@ let
       if [ -n "''${OTEL_DEVENV_PROJECT:-}" ]; then
         _otel_project_attr=(--attr "devenv.project.name=$OTEL_DEVENV_PROJECT")
       fi
-      otel-span run "effect-utils-devenv" "devenv.task.status" \
+      "''${OTEL_SPAN_BIN:-otel-span}" run "effect-utils-devenv" "devenv.task.status" \
         "''${_otel_project_attr[@]}" \
         --attr "tool.name=devenv" \
         --attr "task.name=${taskName}" \

--- a/nix/devenv-modules/tasks/shared/tests/otel-instr-gating.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/otel-instr-gating.test.sh
@@ -77,7 +77,7 @@ nix eval --impure --raw --expr "
 custom_otel_span="$tmpdir/custom-otel-span"
 cat > "$custom_otel_span" <<'EOF'
 #!/usr/bin/env bash
-printf '%s\n' "$*" > "$OTEL_TEST_MARKER"
+printf 'endpoint=%s\nargs=%s\n' "$OTEL_EXPORTER_OTLP_ENDPOINT" "$*" > "$OTEL_TEST_MARKER"
 EOF
 chmod +x "$custom_otel_span"
 
@@ -85,10 +85,13 @@ marker="$tmpdir/task-bridge-marker"
 env -i \
   PATH="$(dirname "$BASH")" \
   OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318 \
+  OTELITE_HTTP_ENDPOINT=http://127.0.0.1:9876 \
   OTEL_SPAN_BIN="$custom_otel_span" \
   OTEL_TEST_MARKER="$marker" \
   "$BASH" "$task_exec"
-grep -q '^run effect-utils-devenv devenv.task.exec ' "$marker" \
+grep -q '^endpoint=http://127.0.0.1:9876$' "$marker" \
+  || fail "task/capture-endpoint: trace.exec should prefer the invocation-scoped otelite endpoint"
+grep -q '^args=run effect-utils-devenv devenv.task.exec ' "$marker" \
   || fail "task/pinned-bridge: trace.exec should invoke OTEL_SPAN_BIN outside PATH"
 
 # Common env for the "binaries present + delivery available" baseline. Each case

--- a/nix/devenv-modules/tasks/shared/tests/otel-instr-gating.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/otel-instr-gating.test.sh
@@ -62,6 +62,35 @@ vitest_prelude="$tmpdir/prelude-vitest.sh"
 eval_instr_prelude oxlint > "$oxlint_prelude"
 eval_instr_prelude vitest > "$vitest_prelude"
 
+# Task-level wrappers must honor the module-pinned bridge even when no
+# `otel-span` command is available through PATH. This models nested devenv task
+# evaluation, which may reconstruct PATH independently of its parent process.
+task_exec="$tmpdir/task-exec.sh"
+nix eval --impure --raw --expr "
+  let
+    flake = builtins.getFlake (toString $ROOT);
+    pkgs = import flake.inputs.nixpkgs { system = builtins.currentSystem; };
+    trace = import $ROOT/nix/devenv-modules/tasks/lib/trace.nix { lib = pkgs.lib; };
+  in trace.exec \"test:task\" \"exit 0\"
+" > "$task_exec"
+
+custom_otel_span="$tmpdir/custom-otel-span"
+cat > "$custom_otel_span" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "$OTEL_TEST_MARKER"
+EOF
+chmod +x "$custom_otel_span"
+
+marker="$tmpdir/task-bridge-marker"
+env -i \
+  PATH="$(dirname "$BASH")" \
+  OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318 \
+  OTEL_SPAN_BIN="$custom_otel_span" \
+  OTEL_TEST_MARKER="$marker" \
+  "$BASH" "$task_exec"
+grep -q '^run effect-utils-devenv devenv.task.exec ' "$marker" \
+  || fail "task/pinned-bridge: trace.exec should invoke OTEL_SPAN_BIN outside PATH"
+
 # Common env for the "binaries present + delivery available" baseline. Each case
 # below overrides exactly one trigger.
 base_env=(


### PR DESCRIPTION
## Problem

The shared devenv observability capture could export native devenv spans while
silently missing the Effect task bridge. Nested task evaluation may reconstruct
`PATH`, and a repository-level collector default may replace otelite's
invocation-scoped HTTP endpoint. In Overeng, those boundaries produced 15
native spans without the connected `devenv.task.exec` child.

## Solution

- Export the store-pinned `OTEL_SPAN_BIN`; shared task wrappers prefer it while
  retaining `otel-span` on `PATH` as the standalone fallback.
- During an otelite capture, prefer `OTELITE_HTTP_ENDPOINT` over an ambient
  `OTEL_EXPORTER_OTLP_ENDPOINT`. Normal non-capture task execution keeps its
  existing collector configuration.

This composes the module-owned bridge and capture transport without imposing a
PATH layout or fixed port on consumers.

## Validation

- `bash nix/devenv-modules/tasks/shared/tests/otel-instr-gating.test.sh`
  - proves the pinned bridge works with `otel-span` absent from `PATH`
  - proves the invocation-scoped otelite endpoint wins over an ambient endpoint
- `devenv tasks run lint:nix --mode before --no-tui`
- `devenv tasks run lint:check:format --mode single --no-tui`
- `devenv tasks run otel:verify:setup --mode single --no-tui`
  - 16 spans
  - one trace
  - native `setup:gate` parent connected to
    `effect-utils-devenv/devenv.task.exec`

## Trade-offs / follow-up

The explicit executable variable is scoped to repositories importing the
observability module; consumers using only the shared task modules retain the
existing transparent PATH fallback. Endpoint precedence changes only while
otelite supplies its invocation-scoped endpoint. The task-phase bridge remains
temporary pending native devenv support tracked by cachix/devenv#3037.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | co3-nova |
| `agent_session_id` | fabbecde-5efe-4752-b82d-3bde982ab17f |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.145.0 |
| `agent_runtime` | Codex CLI 0.145.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/g65ryv9zcr8acxxjlpgcrynh8d7s7qwn-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/hiw5ggfjp9mr78vbrq30i77ypfyixv32-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-27-observability-path |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->