### PR TITLE
Drop lint:nix:workflow-commands — the premise behind it was measured wrong

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- **devenv-modules**: remove `lint:nix:workflow-commands` and correct the task-output
+  documentation. The guard was added on the belief that devenv discards a task's stdout, so a
+  workflow command emitted there never reached the runner. That was measured in a shell with
+  `CLAUDECODE=1`, which puts devenv in implicit AI-agent quiet mode — a mode that never applies
+  on a GitHub runner. Measured on `ubuntu-latest`: a `::warning::` from a task's stdout becomes
+  an annotation with no opt-in at all, identically to one from stderr or from the step itself.
+  The existing `>&2` redirects are kept — stderr is a fine channel for diagnostics and churning
+  them back would buy nothing — but they are a style choice now, not a requirement.
+
 - **devenv observability**: add a lightweight `devenvModules.observability`
   adapter that captures native devenv OTLP/gRPC and effect-utils OTLP/HTTP task
   spans in one isolated otelite trace. Consumers get consistent

--- a/nix/devenv-modules/tasks/README.md
+++ b/nix/devenv-modules/tasks/README.md
@@ -127,25 +127,23 @@ Helper functions used by task modules:
 
 ## Task Output
 
-devenv does not forward a task's **stdout** to the caller — on success or on
-failure, and regardless of `--show-output` or `DEVENV_TASK_PASSTHROUGH`. Its
-**stderr** is forwarded in every case.
+devenv renders a task's **stderr** by default. Its **stdout** is rendered only
+when the run opts in — `showOutput = true` on the task, `--show-output`, or
+`--verbose`.
 
-So anything a task emits for the operator, and every GitHub workflow command,
-must go to stderr:
+That is about what devenv prints to a console, not about what escapes the
+process. **Both streams reach a GitHub runner.** Measured on `ubuntu-latest`
+with devenv 2.1.2: a `::warning::` emitted from a task became an annotation from
+stdout with no opt-in, from stdout with `showOutput = true`, and from stderr —
+all three indistinguishable from one emitted by the step itself. So workflow
+commands work from either stream, and log grouping does too.
 
-```nix
-echo "::warning::pnpm store was rebuilt from scratch" >&2
-```
-
-On stdout the same line is silently discarded: it never reaches the job log, and
-GitHub never turns it into an annotation or a log group. `lint:nix:workflow-commands`
-fails the build on any `echo "::…"` here that is missing `>&2`.
-
-Stdout is not a reliable channel in either direction: a direct `devenv tasks run`
-of a failing task discarded its stdout too, while a failing *dependency* task's
-stdout does appear in devenv's error summary in CI. Rather than depend on which
-case applies, put anything you need to read on stderr.
+One caveat worth knowing when debugging locally: devenv selects quiet verbosity
+when it detects `CLAUDECODE` / `OPENCODE_CLIENT` / `AI_AGENT`, and in 2.1.2 that
+also suppresses `showOutput`
+([cachix/devenv#3038](https://github.com/cachix/devenv/issues/3038)). A task's
+stdout can therefore look missing inside a coding agent while being perfectly
+visible in CI. Use `DEVENV_NO_AI_AGENT=1` or `--verbose` when measuring.
 
 ## Adding New Tasks
 

--- a/nix/devenv-modules/tasks/shared/lint-nix.nix
+++ b/nix/devenv-modules/tasks/shared/lint-nix.nix
@@ -94,25 +94,6 @@ let
   };
 
   otherTasks = {
-    # devenv discards a task's stdout, so a GitHub workflow command echoed there
-    # never reaches the runner and never becomes an annotation or a log group.
-    # stderr is forwarded, so that is where these have to go. Without this guard
-    # the mistake is invisible: the emit looks correct and simply does nothing.
-    "lint:nix:workflow-commands" = {
-      description = "Check GitHub workflow commands in task definitions go to stderr";
-      exec = trace.exec "lint:nix:workflow-commands" ''
-        offenders=$(${git} ls-files 'nix/devenv-modules/*.nix' 'nix/devenv-modules/*.sh' \
-          | xargs grep -nE "(echo|printf)( +-[A-Za-z]+)* +['\"]::" \
-          | grep -v '>&2' || true)
-
-        if [ -n "$offenders" ]; then
-          echo "Workflow commands must be written to stderr; devenv discards task stdout." >&2
-          echo "Append '>&2' to each line below:" >&2
-          echo "$offenders" >&2
-          exit 1
-        fi
-      '';
-    };
     "lint:nix:eval-warnings" = lib.mkIf hasEvalTargets {
       description = "Check for Nix evaluation warnings (deprecated APIs)";
       exec = trace.exec "lint:nix:eval-warnings" "${evalScript} ${evalTargetsArgs}";
@@ -122,7 +103,6 @@ let
       after = [
         "lint:nix:format"
         "lint:nix:deadcode"
-        "lint:nix:workflow-commands"
       ]
       ++ lib.optional hasEvalTargets "lint:nix:eval-warnings";
     };


### PR DESCRIPTION
## Problem

#969 added `lint:nix:workflow-commands` and redirected six emit sites to stderr, on the
belief that devenv discards a task's stdout — so a GitHub workflow command emitted there
never reached the runner and never became an annotation.

**That belief was wrong, and I introduced it.** The measurement behind it was taken in a
shell with `CLAUDECODE=1`, which puts devenv into implicit AI-agent quiet mode. Quiet mode
suppresses console *rendering* of task stdout; it says nothing about what escapes the
process, and it never applies on a GitHub runner. I never checked the CI case.

## Goal

Stop enforcing a rule against a channel that works, and document what was actually measured.

## Verification

A probe on `ubuntu-latest` with devenv 2.1.2, emitting the same `::warning::` four ways
([workflow](https://github.com/schickling-repros/2026-07-devenv-task-stdout-discarded/blob/main/.github/workflows/annotation-probe.yml),
[run](https://github.com/schickling-repros/2026-07-devenv-task-stdout-discarded/actions/runs/30297762510)):

```
line  129  ##[warning]STEP-STDOUT          control — emitted by the step itself
line 1023  ##[warning]STDOUT-SHOWOUTPUT    task stdout, showOutput = true
line 1049  ##[warning]STDOUT-PLAIN         task stdout, NO opt-in
line 1075  ##[warning]STDERR-PLAIN         task stderr
```

All four became annotations. The task-stdout lines arrive unprefixed and parsed, identical
to the control — so `::group::` works from stdout too.

Locally, with agent quiet mode disabled, `--show-output` / `showOutput = true` / `--verbose`
all surface stdout as documented. The upstream defect that remains
([cachix/devenv#3038](https://github.com/cachix/devenv/issues/3038)) is that the explicit
opt-in is suppressed under agent quiet mode — a local debugging annoyance, not a CI problem.

`nixfmt --check` clean; the module still evaluates.

## Decisions

**The `>&2` redirects stay.** Both channels reach the runner, stderr is a reasonable place
for diagnostics, and reverting six working lines would be churn. They are a style choice
now rather than a requirement, and the README says so.

**The README section is rewritten rather than deleted**, because the agent-quiet caveat is
genuinely worth knowing: a task's stdout looks missing inside a coding agent while being
perfectly visible in CI. That is exactly the trap that produced #969.

## Concerns

This removes a required check. Nothing regresses — it was guarding against a non-problem —
but if you would rather keep a guard while the upstream issue is open, the honest version
would target *local* debugging ergonomics, not CI correctness, and I would not make it an
error.

## Follow-ups

- #971 drops its TypeScript counterpart (`overeng/no-stdout-workflow-command`) for the same
  reason; the quarantine contract there is unaffected.
- The Blockers entry tracking this has been cancelled as withdrawn.

## References

- Reverts the guard from #969
- Refs cachix/devenv#3038

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | cl1-iris |
| `agent_session_id` | f0a25af9-c1ee-48a5-add1-5ea39125b283 |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.220 |
| `agent_runtime` | Claude Code 2.1.220 |
| `agent_model` | claude-opus-5 |
| `runtime_profile` | /nix/store/g65ryv9zcr8acxxjlpgcrynh8d7s7qwn-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/hiw5ggfjp9mr78vbrq30i77ypfyixv32-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-27-drop-stdout-guard |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->