### PR TITLE
Prevent projected workspaces from timing out pnpm cache keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow pnpm-state cache consumers to narrow the lockfile hash expression, avoiding recursive workspace scans after dependency projection.
+
 - **devenv deploy tasks**: make the reusable Netlify and Vercel task modules
   compose their shared workflow-report task dependency. Generated preview
   workflows can now collect and publish deploy records without every consumer

--- a/genie/ci-workflow/setup.ts
+++ b/genie/ci-workflow/setup.ts
@@ -582,8 +582,10 @@ export const pnpmStateCacheVersion = 'v2'
 /** Default pnpm-state key namespace when a repo does not set its own. */
 export const defaultPnpmStateKeyPrefix = 'pnpm-state'
 
-const pnpmStateCachePrimaryKey = (keyPrefix: string) =>
-  `${keyPrefix}-${pnpmStateCacheVersion}-${'${{ runner.os }}'}-${'${{ runner.arch }}'}-${"${{ hashFiles('**/pnpm-lock.yaml') }}"}`
+const defaultPnpmStateHashFilesExpression = "${{ hashFiles('**/pnpm-lock.yaml') }}"
+
+const pnpmStateCachePrimaryKey = (keyPrefix: string, hashFilesExpression: string) =>
+  `${keyPrefix}-${pnpmStateCacheVersion}-${'${{ runner.os }}'}-${'${{ runner.arch }}'}-${hashFilesExpression}`
 
 /**
  * Restore the workspace-local pnpm state snapshot before any install work runs.
@@ -599,10 +601,12 @@ const pnpmStateCachePrimaryKey = (keyPrefix: string) =>
  */
 export const restorePnpmStateStep = (opts?: {
   keyPrefix?: string
+  hashFilesExpression?: string
   stepId?: string
   path?: string
 }) => {
   const keyPrefix = opts?.keyPrefix ?? defaultPnpmStateKeyPrefix
+  const hashFilesExpression = opts?.hashFilesExpression ?? defaultPnpmStateHashFilesExpression
   const path = opts?.path ?? workspaceLocalPnpmStatePaths
 
   return {
@@ -613,7 +617,7 @@ export const restorePnpmStateStep = (opts?: {
       path,
       // The fetched state contents are platform-specific, so the cache must
       // isolate both OS and CPU architecture to avoid cross-platform corruption.
-      key: pnpmStateCachePrimaryKey(keyPrefix),
+      key: pnpmStateCachePrimaryKey(keyPrefix, hashFilesExpression),
     },
   }
 }
@@ -626,10 +630,12 @@ export const restorePnpmStateStep = (opts?: {
  */
 export const savePnpmStateStep = (opts?: {
   keyPrefix?: string
+  hashFilesExpression?: string
   restoreStepId?: string
   path?: string
 }) => {
   const keyPrefix = opts?.keyPrefix ?? defaultPnpmStateKeyPrefix
+  const hashFilesExpression = opts?.hashFilesExpression ?? defaultPnpmStateHashFilesExpression
   const restoreStepId = opts?.restoreStepId ?? 'restore-pnpm-state'
   const path = opts?.path ?? workspaceLocalPnpmStatePaths
 
@@ -643,7 +649,7 @@ export const savePnpmStateStep = (opts?: {
       // not allow nesting `${{ ... }}` inside a fallback string of another
       // expression, so deriving the key once in TypeScript keeps the emitted
       // workflow expression valid.
-      key: pnpmStateCachePrimaryKey(keyPrefix),
+      key: pnpmStateCachePrimaryKey(keyPrefix, hashFilesExpression),
     },
   }
 }

--- a/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
@@ -277,6 +277,9 @@ describe('ci workflow pnpm cache defaults', () => {
     expect(restorePnpmStateStepSource).toContain(
       'const keyPrefix = opts?.keyPrefix ?? defaultPnpmStateKeyPrefix',
     )
+    expect(restorePnpmStateStepSource).toContain(
+      'const hashFilesExpression = opts?.hashFilesExpression ?? defaultPnpmStateHashFilesExpression',
+    )
     expect(restorePnpmStateStepSource).toContain("name: 'Restore pnpm state'")
     expect(restorePnpmStateStepSource).not.toContain("'restore-keys':")
   })
@@ -284,7 +287,15 @@ describe('ci workflow pnpm cache defaults', () => {
   it('centralizes the pnpm state cache contract version at v2', () => {
     expect(ciWorkflowSource).toContain("export const pnpmStateCacheVersion = 'v2'")
     expect(ciWorkflowSource).toContain("export const defaultPnpmStateKeyPrefix = 'pnpm-state'")
+    expect(ciWorkflowSource).toContain(
+      `const defaultPnpmStateHashFilesExpression = "\${{ hashFiles('**/pnpm-lock.yaml') }}"`,
+    )
     expect(ciWorkflowSource).toContain('`${keyPrefix}-${pnpmStateCacheVersion}-')
+  })
+
+  it('allows repositories to narrow pnpm state hashing without redefining cache steps', () => {
+    expect(ciWorkflowSource).toContain('hashFilesExpression?: string')
+    expect(ciWorkflowSource).toContain('pnpmStateCachePrimaryKey(keyPrefix, hashFilesExpression)')
   })
 
   it('defaults the pnpm store to a workspace-relative path stable across jobs', () => {


### PR DESCRIPTION
## Problem

The shared pnpm-state cache helper always hashed `**/pnpm-lock.yaml`. In megarepos that materialize dependency worktrees during CI, GitHub's `hashFiles` expression recursively scanned the projected graph and could exceed its 120-second limit. The job's actual test command would pass, then cache-key evaluation would turn the lane red.

## Solution

- keep the recursive lockfile expression as the backwards-compatible default
- allow `restorePnpmStateStep` and `savePnpmStateStep` callers to provide a narrower `hashFilesExpression`
- use the same expression for restore and save so cache identity remains symmetric
- cover the option in the shared CI workflow helper tests

Consumers with one authoritative root lockfile can now pass `${{ hashFiles('pnpm-lock.yaml') }}` without redefining either cache step.

## Validation

- `devenv tasks run lint:check ts:check --no-tui`
- `devenv tasks run test:genie --no-tui`
- `git diff --check`

## Trade-offs

The default is unchanged, so existing consumers retain current cache identity. Narrowing is explicit because only the consumer can identify which lockfile set is authoritative for its projected workspace.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | co3-nova |
| `agent_session_id` | fabbecde-5efe-4752-b82d-3bde982ab17f |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.145.0 |
| `agent_runtime` | Codex CLI 0.145.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/g65ryv9zcr8acxxjlpgcrynh8d7s7qwn-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/hiw5ggfjp9mr78vbrq30i77ypfyixv32-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling/fix/pnpm-key |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->