### PR TITLE
test(notion-effect-schema): capture canonical wire baselines

### DIFF
--- a/packages/@overeng/notion-effect-schema/src/properties/canonical-codec.unit.test.ts
+++ b/packages/@overeng/notion-effect-schema/src/properties/canonical-codec.unit.test.ts
@@ -400,6 +400,7 @@ describe('canonical decode (golden byte-identity)', () => {
 })
 
 describe('canonical wire baselines (cross-major invariant)', () => {
+  // TODO(live-migration:effect-3-4): Effect 4 may reject v3's raw 2026-02-31 date (effect#6608); adjudicate the date contract instead of refreshing this baseline.
   it('decodes a representative property map to byte-identical canonical JSON', async () => {
     const decoded = await Effect.runPromise(
       codec.decodePageProperties({

--- a/packages/@overeng/notion-effect-schema/src/properties/canonical-codec.unit.test.ts
+++ b/packages/@overeng/notion-effect-schema/src/properties/canonical-codec.unit.test.ts
@@ -457,6 +457,7 @@ describe('canonical wire baselines (cross-major invariant)', () => {
     )
   })
 
+  // TODO(live-migration:effect-3-4): Effect 4 reassigns Schema.Date; preserve these ISO Notion wire strings with the approved DateFromString mapping rather than refreshing the bytes.
   it('encodes a representative write patch to byte-identical Notion JSON', async () => {
     const patch = await Effect.runPromise(
       encodeCanonicalPatch({

--- a/packages/@overeng/notion-effect-schema/src/properties/canonical-codec.unit.test.ts
+++ b/packages/@overeng/notion-effect-schema/src/properties/canonical-codec.unit.test.ts
@@ -399,7 +399,7 @@ describe('canonical decode (golden byte-identity)', () => {
   })
 })
 
-describe('canonical wire baselines (Effect 3)', () => {
+describe('canonical wire baselines (cross-major invariant)', () => {
   it('decodes a representative property map to byte-identical canonical JSON', async () => {
     const decoded = await Effect.runPromise(
       codec.decodePageProperties({

--- a/packages/@overeng/notion-effect-schema/src/properties/canonical-codec.unit.test.ts
+++ b/packages/@overeng/notion-effect-schema/src/properties/canonical-codec.unit.test.ts
@@ -399,6 +399,132 @@ describe('canonical decode (golden byte-identity)', () => {
   })
 })
 
+describe('canonical wire baselines (Effect 3)', () => {
+  it('decodes a representative property map to byte-identical canonical JSON', async () => {
+    const decoded = await Effect.runPromise(
+      codec.decodePageProperties({
+        Title: {
+          id: 'title-id',
+          type: 'title',
+          title: [{ plain_text: 'Hello ' }, { plain_text: '世界' }],
+        },
+        Due: {
+          id: 'date-id',
+          type: 'date',
+          date: { start: '2026-05-25T10:15:30.000Z' },
+        },
+        'Impossible Date': {
+          id: 'bad-date-id',
+          type: 'date',
+          date: { start: '2026-02-31' },
+        },
+        'Absent Date': {
+          id: 'empty-date-id',
+          type: 'date',
+          date: null,
+        },
+        Select: {
+          id: 'select-id',
+          type: 'select',
+          select: { id: 'option-id', name: '', color: 'blue' },
+        },
+        'Select Without Option Id': {
+          id: 'select-name-id',
+          type: 'select',
+          select: { name: 'Backlog' },
+        },
+        Email: {
+          id: 'email-id',
+          type: 'email',
+          email: null,
+        },
+        File: {
+          id: 'file-id',
+          type: 'files',
+          files: [{ name: 'résumé.pdf', external: { url: 'https://example.com/résumé.pdf' } }],
+        },
+        'Dropped Unsupported': {
+          id: 'button-id',
+          type: 'button',
+          button: {},
+        },
+      }),
+    )
+
+    expect(JSON.stringify(decoded)).toMatchInlineSnapshot(
+      `"{"Title":{"_tag":"title","plainText":"Hello 世界"},"Due":{"_tag":"date","start":"2026-05-25T10:15:30.000Z","end":null},"Impossible Date":{"_tag":"date","start":"2026-02-31","end":null},"Absent Date":{"_tag":"empty"},"Select":{"_tag":"select","option":{"_tag":"CanonicalOptionValue","id":"option-id","name":"","color":"blue"}},"Select Without Option Id":{"_tag":"select","option":{"_tag":"CanonicalOptionValue","name":"Backlog"}},"Email":{"_tag":"email","value":null},"File":{"_tag":"files","files":[{"_tag":"CanonicalFileValue","name":"résumé.pdf","identityHash":"sha256:06673ae69feae64882e27bccbd3a018924435dc16321bcf11613cbaad6952dd1","externalUrl":"https://example.com/résumé.pdf"}]}}"`,
+    )
+  })
+
+  it('encodes a representative write patch to byte-identical Notion JSON', async () => {
+    const patch = await Effect.runPromise(
+      encodeCanonicalPatch({
+        title: { _tag: 'title', plainText: 'Hello 世界' },
+        dateWithEnd: {
+          _tag: 'date',
+          start: dateTimeUtc('2026-05-25T10:15:30.000Z'),
+          end: dateTimeUtc('2026-05-26T10:15:30.000Z'),
+        },
+        dateWithoutEnd: {
+          _tag: 'date',
+          start: dateTimeUtc('2026-05-25T00:00:00.000Z'),
+          end: null,
+        },
+        selectFull: { _tag: 'select', option: opt('', { id: 'option-id', color: 'blue' }) },
+        selectNameOnly: { _tag: 'select', option: opt('Backlog') },
+        selectNull: { _tag: 'select', option: null },
+        multi: {
+          _tag: 'multi_select',
+          options: [opt('Plain'), opt('Colored', { id: 'colored-id', color: 'green' })],
+        },
+        emailNull: { _tag: 'email', value: null },
+        file: {
+          _tag: 'files',
+          files: [
+            {
+              _tag: 'CanonicalFileValue',
+              name: 'résumé.pdf',
+              identityHash: 'sha256:ignored-by-encoder',
+              externalUrl: 'https://example.com/résumé.pdf',
+            },
+          ],
+        },
+      }),
+    )
+
+    expect(JSON.stringify(patch)).toMatchInlineSnapshot(
+      `"{"title":{"title":[{"type":"text","text":{"content":"Hello 世界"}}]},"dateWithEnd":{"date":{"start":"2026-05-25T10:15:30.000Z","end":"2026-05-26T10:15:30.000Z"}},"dateWithoutEnd":{"date":{"start":"2026-05-25T00:00:00.000Z"}},"selectFull":{"select":{"id":"option-id","name":"","color":"blue"}},"selectNameOnly":{"select":{"name":"Backlog"}},"selectNull":{"select":null},"multi":{"multi_select":[{"name":"Plain"},{"id":"colored-id","name":"Colored","color":"green"}]},"emailNull":{"email":null},"file":{"files":[{"type":"external","name":"résumé.pdf","external":{"url":"https://example.com/résumé.pdf"}}]}}"`,
+    )
+  })
+
+  it('captures the encode failure partition as stable JSON', async () => {
+    const failureJson = async (value: CanonicalPropertyValue) => {
+      const exit = await Effect.runPromiseExit(encodeCanonicalPatch({ value }))
+      const error =
+        Exit.isFailure(exit) === true
+          ? (exit.cause as { error?: CanonicalEncodeError }).error
+          : undefined
+      expect(error).toBeInstanceOf(CanonicalEncodeError)
+      return JSON.stringify({
+        _tag: error?._tag,
+        tag: error?.tag,
+        reason: error?.reason,
+        message: error?.message,
+      })
+    }
+
+    expect(await failureJson({ _tag: 'computed', valueHash: 'sha256:abc' })).toMatchInlineSnapshot(
+      `"{"_tag":"Notion.CanonicalEncodeError","tag":"computed","reason":"computed","message":"Computed Notion properties cannot be written"}"`,
+    )
+    expect(await failureJson({ _tag: 'files', files: [] })).toMatchInlineSnapshot(
+      `"{"_tag":"Notion.CanonicalEncodeError","tag":"files","reason":"unsupported_remote_shape","message":"Files property writes require explicit external URL or modeled file_upload identity for every file"}"`,
+    )
+    expect(await failureJson({ _tag: 'empty' })).toMatchInlineSnapshot(
+      `"{"_tag":"Notion.CanonicalEncodeError","tag":"empty","reason":"unsupported_remote_shape","message":"Canonical empty property writes need additional remote shape information"}"`,
+    )
+  })
+})
+
 const dateTimeUtc = (iso: string): DateTime.Utc => Schema.decodeSync(Schema.DateTimeUtc)(iso)
 
 type Opt = Extract<CanonicalPropertyValue, { _tag: 'select' }>['option'] & object


### PR DESCRIPTION
**Problem**
Effect 4 migration validation needs Effect 3 golden wire baselines for durable boundaries before any cohort flip. The Notion canonical property codec is a high-risk boundary because byte-level details such as key order, omitted fields, `null`, and Date strings feed downstream change detection.

**Goal**
Add ordinary Effect 3 tests that pin the canonical property JSON and Notion write payload bytes for representative high-risk cases.

**Decisions**
This PR only extends the existing `notion-effect-schema` canonical codec tests. It asserts `JSON.stringify(...)` output directly rather than decoded values, so ordering, omission, and `null` behavior are covered. The fixtures include Date strings, missing Date end fields, an impossible Date string currently accepted by this raw codec, unicode strings, empty strings, `null`, omitted option fields, unsupported dropped input, and encode failure cases.

**Verification**
- `CI=1 devenv tasks run test:notion-effect-schema --no-tui` passed.
- `CI=1 devenv tasks run check:quick --no-tui` passed.
- `git diff --check` passed.

**Complexity**
No new complexity: additive inline-snapshot coverage in an existing test file.

**Concerns**
No behavior changes. `CHANGELOG.md` is intentionally untouched because this is migration baseline capture and shared release metadata is outside this package slice.

**Friction & bottlenecks**
While initially based on a local `main` worktree, the branch inherited an unpublished local commit and had to be rebased with `--onto origin/main` so this PR contains only the baseline commit. An early `check:quick` run against that local-main base also reported generated label drift; direct `genie:check` passed after the branch was corrected.

**Follow-ups**
Continue Phase 1 baseline capture in separate package PRs for the next durable boundaries.

**References**
Refs #925.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | co1-bell |
| `agent_session_id` | ffda51fb-5fd0-4d0f-8ae4-712efa8b6df7 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.145.0 |
| `agent_runtime` | Codex CLI 0.145.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/ph8rlhdj25mg71v81jsfzy6dq4xpcs9m-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/lsykz8x5481xrpbgk280xh3pypk1c5jy-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-28-baselines-1-notion-wire |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@3649b53 |
</details>
<!-- agent-footer:end -->