### PR TITLE
Stabilize live otelite inspection under CI contention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **@overeng/utils-dev/otelite**: make live capture inspection poll for the
+  observable row condition for up to 500 ms. This absorbs exporter scheduling
+  and OTLP round-trip delay on contended CI hosts without consumer-specific
+  sleeps, while still bounding genuinely empty captures.
+
 - Allow pnpm-state cache consumers to narrow the lockfile hash expression, avoiding recursive workspace scans after dependency projection.
 
 - **devenv deploy tasks**: make the reusable Netlify and Vercel task modules

--- a/context/otelite/decisions/0015-test-integration-architecture.md
+++ b/context/otelite/decisions/0015-test-integration-architecture.md
@@ -46,11 +46,13 @@ infeasible — an in-process receiver cannot cross forked workers.
 ## Read-after-write visibility (cross-cutting)
 
 Under heavy CPU oversubscription an independent `inspect` reader can transiently
-see 0 rows although the span is already durably written (write-before-ack);
-recovered by a ~2 ms retry, and 0 failures single-threaded. So the capture/assert
-helper does a **bounded short-poll retry** (~tens of ms). Follow-up: confirm the
-sink flushes per line so live mid-capture reads are coherent without leaning on
-the retry (the more principled fix). Capture itself never lost a span in any run.
+see 0 rows. The receiver still writes before acknowledging each export, but the
+producer's batch timer and OTLP POST can be delayed before that acknowledgement;
+this is not only filesystem read-after-write latency. The capture/assert helper
+therefore polls the observable row condition for a bounded 500 ms, returning as
+soon as a row is visible. This avoids consumer-owned sleeps while preserving a
+finite failure bound for genuinely empty captures. Capture itself never lost a
+span in any run.
 
 ## D3 coupling: consumer-owned, one demonstrator
 

--- a/packages/@overeng/utils-dev/src/otelite/Otelite.ts
+++ b/packages/@overeng/utils-dev/src/otelite/Otelite.ts
@@ -313,13 +313,14 @@ export class Otelite extends Effect.Service<Otelite>()('@overeng/utils-dev/oteli
      * The sink writes each export with a raw `write_all` to the file *before*
      * acking (no `BufWriter`), so a captured span is durable in the file the
      * instant the POST returns. But an independent reader process started right
-     * after can still transiently observe 0 rows for a few ms — pure scheduler /
-     * fs-visibility latency between the writing process's `write_all` and the
-     * reader's `open`+`read` landing. So we re-read a handful of times over a few
-     * tens of ms before concluding the capture is genuinely empty. A real empty
-     * capture costs the full (still small, bounded) budget exactly once.
+     * after can still transiently observe 0 rows. Under host contention that
+     * window includes exporter scheduling and the OTLP POST round-trip, not only
+     * filesystem visibility after `write_all`. Poll the observable condition for
+     * a bounded 500 ms instead of assuming the producer finishes within a fixed
+     * sleep. A non-empty capture returns on its first visible row; a genuinely
+     * empty live capture pays the bounded budget exactly once.
      */
-    const liveRowRetry = Schedule.recurs(5).pipe(Schedule.addDelay(() => '8 millis'))
+    const liveRowRetry = Schedule.recurs(20).pipe(Schedule.addDelay(() => '25 millis'))
 
     /**
      * A scoped, receiver-only capture (`otelite capture`). Yields a


### PR DESCRIPTION
## Problem

`captureInProcessTrace` could report an empty trace on a heavily contended CI
host even though the instrumented RPC completed successfully. The helper waited
one exporter interval plus a fixed margin, while live `inspect` only retried for
roughly 40 ms. That budget covered filesystem visibility but not delayed
exporter scheduling and the OTLP POST round-trip.

This surfaced downstream as a reproducible Discord RPC tracing flake after
adopting the shared otelite harness.

## Solution

- keep the receiver's write-before-ack durability contract unchanged
- make live row inspection poll the observable condition for a bounded 500 ms
- return immediately once any matching row is visible
- update the owning otelite architecture decision and changelog

Consumers continue using the shared harness; no consumer-specific sleep or
retry is added.

## Validation

- `devenv shell -- env DEVENV_TASK_PASSTHROUGH=1 pnpm --filter @overeng/utils-dev exec vitest run src/otelite/Otelite.test.ts` (11/11)
- `devenv tasks run ts:check lint:check --mode all --show-output`

## Trade-offs / follow-up

A genuinely empty live capture now takes up to 500 ms to return instead of
roughly 40 ms. Non-empty captures still return on the first visible row. This is
bounded polling because the current OTel Effect tracer exposes no public
force-flush handle.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | co3-nova |
| `agent_session_id` | fabbecde-5efe-4752-b82d-3bde982ab17f |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.145.0 |
| `agent_runtime` | Codex CLI 0.145.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/g65ryv9zcr8acxxjlpgcrynh8d7s7qwn-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/hiw5ggfjp9mr78vbrq30i77ypfyixv32-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-28-2026-07-28-otelite-flush |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->