### PR TITLE
test(restate-effect): capture wire baselines

### DIFF
--- a/packages/@overeng/restate-effect/src/error/error-transport.test.ts
+++ b/packages/@overeng/restate-effect/src/error/error-transport.test.ts
@@ -59,6 +59,13 @@ const simulateIngressFailure = (error: NotFound): RestateError => {
   })
 }
 
+const terminalEnvelopeBytes = (terminal: restate.TerminalError): string =>
+  JSON.stringify({
+    code: terminal.code,
+    message: terminal.message,
+    metadata: terminal.metadata,
+  })
+
 describe('error transport (contract layer, server-free)', () => {
   it('toTerminal encodes the _tag + fields in the body with the per-error errorCode', () => {
     const terminal = toTerminal({
@@ -200,5 +207,74 @@ describe('error transport (contract layer, server-free)', () => {
     })
     expect(out).not.toBeInstanceOf(restate.TerminalError)
     expect(out).toBeInstanceOf(Foreign)
+  })
+})
+
+describe('error transport wire baselines (cross-major invariant)', () => {
+  it('encodes declared terminal errors into stable terminal message bytes', () => {
+    const terminal = toTerminal({
+      cause: Cause.fail(new NotFound({ id: 'x_1' })),
+      errorSchema: NotFoundSchema,
+    })
+
+    expect(terminal).toBeInstanceOf(restate.TerminalError)
+    const t = terminal as restate.TerminalError
+    expect(
+      JSON.stringify({
+        code: t.code,
+        message: t.message,
+        metadata: t.metadata,
+      }),
+    ).toMatchInlineSnapshot(
+      `"{"code":404,"message":"{\\"id\\":\\"x_1\\",\\"_tag\\":\\"NotFound\\"}","metadata":{"_tag":"NotFound"}}"`,
+    )
+  })
+
+  it('wraps terminal errors in stable ingress envelope bytes', () => {
+    const terminal = toTerminal({
+      cause: Cause.fail(new NotFound({ id: 'x_2' })),
+      errorSchema: NotFoundSchema,
+    })
+
+    expect(terminal).toBeInstanceOf(restate.TerminalError)
+    expect(terminalEnvelopeBytes(terminal as restate.TerminalError)).toMatchInlineSnapshot(
+      `"{"code":404,"message":"{\\"id\\":\\"x_2\\",\\"_tag\\":\\"NotFound\\"}","metadata":{"_tag":"NotFound"}}"`,
+    )
+  })
+
+  it('keeps invalid terminal bodies in the raw transport failure partition', async () => {
+    const invalidEnvelope = JSON.stringify({
+      code: 500,
+      message: JSON.stringify({ _tag: 'NotFound', id: null }),
+      metadata: { _tag: 'NotFound' },
+    })
+    const unrelated = new RestateError({
+      reason: 'IngressFailed',
+      method: 'call(registry.lookup)',
+      cause: new clients.HttpCallError(500, invalidEnvelope, 'Request failed: 500'),
+    })
+    const exit = await Effect.runPromiseExit(
+      Effect.fail(unrelated).pipe(decodeTerminalError({ contract: Registry, method: 'lookup' })),
+    )
+
+    expect(Exit.isFailure(exit)).toBe(true)
+    if (Exit.isFailure(exit) === true) {
+      const failure = Cause.failureOption(exit.cause)
+      expect(failure._tag).toBe('Some')
+      if (failure._tag === 'Some') {
+        expect(failure.value).toBeInstanceOf(RestateError)
+        expect(
+          JSON.stringify({
+            responseText:
+              failure.value instanceof RestateError &&
+              failure.value.cause instanceof clients.HttpCallError
+                ? failure.value.cause.responseText
+                : null,
+          }),
+        ).toMatchInlineSnapshot(
+          `"{"responseText":"{\\"code\\":500,\\"message\\":\\"{\\\\\\"_tag\\\\\\":\\\\\\"NotFound\\\\\\",\\\\\\"id\\\\\\":null}\\",\\"metadata\\":{\\"_tag\\":\\"NotFound\\"}}"}"`,
+        )
+      }
+    }
   })
 })

--- a/packages/@overeng/restate-effect/src/schema/Serde.test.ts
+++ b/packages/@overeng/restate-effect/src/schema/Serde.test.ts
@@ -92,6 +92,7 @@ describe('effectSerde wire baselines (cross-major invariant)', () => {
     }),
   })
 
+  // TODO(live-migration:effect-3-4): Effect 4 reassigns Schema.Date; use the approved DateFromString mapping to preserve the ISO wire bytes instead of refreshing this baseline.
   it('serializes representative input bytes with stable key order and null/absent partition', () => {
     const serde = effectSerde({ schema: WireBaseline })
     const value = {
@@ -155,6 +156,7 @@ describe('effectSerde wire baselines (cross-major invariant)', () => {
     `)
   })
 
+  // TODO(live-migration:effect-3-4): Effect 4 renders SchemaError(...) here; re-baseline only after confirming this remains an internal structural failure outside #978's stable ingress envelope.
   it('keeps internal decode failures out of the ingress 400 transport partition', () => {
     const serde = internalSerde({ schema: Schema.Struct({ n: Schema.Number }) })
 

--- a/packages/@overeng/restate-effect/src/schema/Serde.test.ts
+++ b/packages/@overeng/restate-effect/src/schema/Serde.test.ts
@@ -8,6 +8,9 @@ import { Restate } from './Annotations.ts'
 import { aesGcmCipher } from './Redaction.ts'
 import { effectSerde, ingressSerde, internalSerde } from './Serde.ts'
 
+const textDecoder = new TextDecoder()
+const textEncoder = new TextEncoder()
+
 describe('effectSerde', () => {
   it('round-trips a plain struct', () => {
     const schema = Schema.Struct({ name: Schema.String, age: Schema.Number })
@@ -72,6 +75,100 @@ describe('effectSerde', () => {
       expect.unreachable('expected a thrown defect')
     } catch (error) {
       expect(error).not.toBeInstanceOf(restate.TerminalError)
+    }
+  })
+})
+
+describe('effectSerde wire baselines (cross-major invariant)', () => {
+  const WireBaseline = Schema.Struct({
+    at: Schema.Date,
+    note: Schema.optional(Schema.String),
+    nullable: Schema.NullOr(Schema.String),
+    empty: Schema.String,
+    tags: Schema.Array(Schema.String),
+    nested: Schema.Struct({
+      impossibleDate: Schema.String,
+      unicode: Schema.String,
+    }),
+  })
+
+  it('serializes representative input bytes with stable key order and null/absent partition', () => {
+    const serde = effectSerde({ schema: WireBaseline })
+    const value = {
+      at: new Date('2026-06-08T12:00:00.000Z'),
+      nullable: null,
+      empty: '',
+      tags: ['alpha', 'ümlaut', '2026-02-31'],
+      nested: {
+        impossibleDate: '2026-02-31',
+        unicode: 'Grüße 東京',
+      },
+    }
+
+    const bytes = serde.serialize(value)
+
+    expect(textDecoder.decode(bytes)).toMatchInlineSnapshot(
+      `"{"at":"2026-06-08T12:00:00.000Z","nullable":null,"empty":"","tags":["alpha","ümlaut","2026-02-31"],"nested":{"impossibleDate":"2026-02-31","unicode":"Grüße 東京"}}"`,
+    )
+    expect(JSON.stringify(serde.deserialize(bytes))).toMatchInlineSnapshot(
+      `"{"at":"2026-06-08T12:00:00.000Z","nullable":null,"empty":"","tags":["alpha","ümlaut","2026-02-31"],"nested":{"impossibleDate":"2026-02-31","unicode":"Grüße 東京"}}"`,
+    )
+  })
+
+  it('serializes undefined input as empty bytes without a JSON content type', () => {
+    const serde = effectSerde({ schema: Schema.Void })
+
+    expect(serde.contentType).toBeUndefined()
+    expect(textDecoder.decode(serde.serialize(undefined))).toMatchInlineSnapshot(`""`)
+    expect(serde.deserialize(new Uint8Array())).toBeUndefined()
+  })
+
+  it('captures ingress decode failure transport bytes for invalid input', () => {
+    const serde = ingressSerde({ schema: Schema.Struct({ n: Schema.Number }) })
+    const cases = {
+      wrongType: JSON.stringify({ n: 'not-a-number' }),
+      malformedJson: '{"n":',
+    } as const
+    const failures: Record<string, string> = {}
+
+    for (const [name, wire] of Object.entries(cases)) {
+      try {
+        serde.deserialize(textEncoder.encode(wire))
+        expect.unreachable(`expected TerminalError for ${name}`)
+      } catch (error) {
+        expect(error).toBeInstanceOf(restate.TerminalError)
+        const terminal = error as restate.TerminalError
+        failures[name] = JSON.stringify({
+          code: terminal.code,
+          message: terminal.message,
+          metadata: terminal.metadata ?? null,
+        })
+      }
+    }
+
+    expect(failures).toMatchInlineSnapshot(`
+      {
+        "malformedJson": "{"code":400,"message":"serde decode failed: Unexpected end of JSON input","metadata":{}}",
+        "wrongType": "{"code":400,"message":"serde decode failed: { readonly n: number }\\n└─ [\\"n\\"]\\n   └─ Expected number, actual \\"not-a-number\\"","metadata":{}}",
+      }
+    `)
+  })
+
+  it('keeps internal decode failures out of the ingress 400 transport partition', () => {
+    const serde = internalSerde({ schema: Schema.Struct({ n: Schema.Number }) })
+
+    try {
+      serde.deserialize(textEncoder.encode(JSON.stringify({ n: 'not-a-number' })))
+      expect.unreachable('expected a raw parse failure')
+    } catch (error) {
+      expect(
+        JSON.stringify({
+          terminal: error instanceof restate.TerminalError,
+          message: error instanceof Error ? error.message : String(error),
+        }),
+      ).toMatchInlineSnapshot(
+        `"{"terminal":false,"message":"{ readonly n: number }\\n└─ [\\"n\\"]\\n   └─ Expected number, actual \\"not-a-number\\""}"`,
+      )
     }
   })
 })

--- a/packages/@overeng/restate-effect/src/schema/Serde.test.ts
+++ b/packages/@overeng/restate-effect/src/schema/Serde.test.ts
@@ -123,6 +123,7 @@ describe('effectSerde wire baselines (cross-major invariant)', () => {
     expect(serde.deserialize(new Uint8Array())).toBeUndefined()
   })
 
+  // TODO(live-migration:effect-3-4): Effect 4 renders SchemaError(...) here; use #978's stable error envelope instead of refreshing the v3 HTTP 400 parser text.
   it('captures ingress decode failure transport bytes for invalid input', () => {
     const serde = ingressSerde({ schema: Schema.Struct({ n: Schema.Number }) })
     const cases = {


### PR DESCRIPTION
## Summary
- Add cross-major wire-format baselines for @overeng/restate-effect serde bytes.
- Pin ingress 400 decode failure envelopes, including parser text for malformed and wrong-type input.
- Pin terminal error body/envelope bytes and the invalid terminal-body transport partition.

## Validation
- PASS: CI=1 node_modules/.bin/vitest run src/schema/Serde.test.ts src/error/error-transport.test.ts (from packages/@overeng/restate-effect)
- PASS: CI=1 devenv tasks run check:quick --no-tui
- PASS: git diff --check

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | co1-bell |
| `agent_session_id` | ffda51fb-5fd0-4d0f-8ae4-712efa8b6df7 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.145.0 |
| `agent_runtime` | Codex CLI 0.145.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/ph8rlhdj25mg71v81jsfzy6dq4xpcs9m-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/lsykz8x5481xrpbgk280xh3pypk1c5jy-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-28-baselines-1-restate-serde |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@3649b53 |
</details>
<!-- agent-footer:end -->