### PR TITLE
test(npm-release): capture CLI contract baselines

### DIFF
--- a/packages/@overeng/npm-release/src/__snapshots__/cli.contract.test.ts.snap
+++ b/packages/@overeng/npm-release/src/__snapshots__/cli.contract.test.ts.snap
@@ -1,0 +1,192 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`npm-release CLI contract baselines (status/signal invariant, prose owner-rebaselinable) > invalid integer 1`] = `
+{
+  "signal": null,
+  "status": 1,
+  "stderr": "'nope' is not a integer
+
+",
+  "stdout": "[time] ERROR (#17): [object Object]
+",
+}
+`;
+
+exports[`npm-release CLI contract baselines (status/signal invariant, prose owner-rebaselinable) > missing required plan 1`] = `
+{
+  "signal": null,
+  "status": 1,
+  "stderr": "Expected to find option: '--plan'
+
+",
+  "stdout": "[time] ERROR (#17): [object Object]
+",
+}
+`;
+
+exports[`npm-release CLI contract baselines (status/signal invariant, prose owner-rebaselinable) > root help 1`] = `
+{
+  "signal": null,
+  "status": 0,
+  "stderr": "",
+  "stdout": "[0;1m[0;37;1mnpm-release[0;1m[0m
+
+npm-release 0.1.0
+
+[0;1mUSAGE[0m
+
+$ npm-release
+
+[0;1mOPTIONS[0m
+
+[0;1m--completions sh | bash | fish | zsh[0m
+
+  One of the following: sh, bash, fish, zsh
+
+  Generate a completion script for a specific shell.
+
+  This setting is optional.
+
+[0;1m--log-level all | trace | debug | info | warning | error | fatal | none[0m
+
+  One of the following: all, trace, debug, info, warning, error, fatal, none
+
+  Sets the minimum log level for a command.
+
+  This setting is optional.
+
+[0;1m(-h, --help)[0m
+
+  A true or false value.
+
+  Show the help documentation for a command.
+
+  This setting is optional.
+
+[0;1m--wizard[0m
+
+  A true or false value.
+
+  Start wizard mode for a command.
+
+  This setting is optional.
+
+[0;1m--version[0m
+
+  A true or false value.
+
+  Show the version of the application.
+
+  This setting is optional.
+
+[0;1mCOMMANDS[0m
+
+  - verify --plan file [--registry text] [--attempts integer] [--delay-seconds integer]  Verify that the registry serves the release described by a plan: version visibility, tarball digest, and dist-tag target.
+
+",
+}
+`;
+
+exports[`npm-release CLI contract baselines (status/signal invariant, prose owner-rebaselinable) > verify help 1`] = `
+{
+  "signal": null,
+  "status": 0,
+  "stderr": "",
+  "stdout": "[0;1m[0;37;1mnpm-release[0;1m[0m
+
+npm-release 0.1.0
+
+[0;1mUSAGE[0m
+
+$ verify --plan file [--registry text] [--attempts integer] [--delay-seconds integer]
+
+[0;1mDESCRIPTION[0m
+
+Verify that the registry serves the release described by a plan: version visibility, tarball digest, and dist-tag target.
+
+[0;1mOPTIONS[0m
+
+[0;1m--plan file[0m
+
+  A file.
+
+  Path to a JSON verify plan: { schemaVersion, version, npmTag, packages }
+
+[0;1m--registry text[0m
+
+  A user-defined piece of text.
+
+  Registry to query
+
+  This setting is optional.
+
+[0;1m--attempts integer[0m
+
+  An integer.
+
+  How many times to re-check a package that has not converged
+
+  This setting is optional.
+
+[0;1m--delay-seconds integer[0m
+
+  An integer.
+
+  Seconds to wait between convergence checks
+
+  This setting is optional.
+
+[0;1m--completions sh | bash | fish | zsh[0m
+
+  One of the following: sh, bash, fish, zsh
+
+  Generate a completion script for a specific shell.
+
+  This setting is optional.
+
+[0;1m--log-level all | trace | debug | info | warning | error | fatal | none[0m
+
+  One of the following: all, trace, debug, info, warning, error, fatal, none
+
+  Sets the minimum log level for a command.
+
+  This setting is optional.
+
+[0;1m(-h, --help)[0m
+
+  A true or false value.
+
+  Show the help documentation for a command.
+
+  This setting is optional.
+
+[0;1m--wizard[0m
+
+  A true or false value.
+
+  Start wizard mode for a command.
+
+  This setting is optional.
+
+[0;1m--version[0m
+
+  A true or false value.
+
+  Show the version of the application.
+
+  This setting is optional.
+
+",
+}
+`;
+
+exports[`npm-release CLI contract baselines (status/signal invariant, prose owner-rebaselinable) > version 1`] = `
+{
+  "signal": null,
+  "status": 0,
+  "stderr": "",
+  "stdout": "0.1.0
+
+",
+}
+`;

--- a/packages/@overeng/npm-release/src/cli.contract.test.ts
+++ b/packages/@overeng/npm-release/src/cli.contract.test.ts
@@ -10,8 +10,10 @@ const cliPath = fileURLToPath(new URL('./cli.ts', import.meta.url))
  * usage, and error prose are captured for review but may be re-baselined by the npm-release owner
  * during Effect 4 repair with an alignment-register entry.
  */
+// LIVE-MIGRATION BRIDGE effect-3-4 — DELETE at contraction — https://github.com/overengineeringstudio/effect-utils/issues/925
 const normalizeLogTime = (output: string) =>
   output.replace(/^\[\d{2}:\d{2}:\d{2}\.\d{3}\]/gm, '[time]')
+// LIVE-MIGRATION END effect-3-4
 
 const runCli = (...args: ReadonlyArray<string>) => {
   const result = spawnSync('bun', [cliPath, ...args], {
@@ -22,8 +24,10 @@ const runCli = (...args: ReadonlyArray<string>) => {
   return {
     status: result.status,
     signal: result.signal,
+    // LIVE-MIGRATION BRIDGE effect-3-4 — DELETE at contraction — https://github.com/overengineeringstudio/effect-utils/issues/925
     stdout: normalizeLogTime(result.stdout),
     stderr: normalizeLogTime(result.stderr),
+    // LIVE-MIGRATION END effect-3-4
   }
 }
 

--- a/packages/@overeng/npm-release/src/cli.contract.test.ts
+++ b/packages/@overeng/npm-release/src/cli.contract.test.ts
@@ -1,0 +1,40 @@
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+const cliPath = fileURLToPath(new URL('./cli.ts', import.meta.url))
+
+/**
+ * CLI contract capture: `status` and `signal` are cross-major invariants; stdout/stderr help,
+ * usage, and error prose are captured for review but may be re-baselined by the npm-release owner
+ * during Effect 4 repair with an alignment-register entry.
+ */
+const normalizeLogTime = (output: string) =>
+  output.replace(/^\[\d{2}:\d{2}:\d{2}\.\d{3}\]/gm, '[time]')
+
+const runCli = (...args: ReadonlyArray<string>) => {
+  const result = spawnSync('bun', [cliPath, ...args], {
+    encoding: 'utf8',
+    env: { ...process.env, NO_COLOR: '1' },
+  })
+
+  return {
+    status: result.status,
+    signal: result.signal,
+    stdout: normalizeLogTime(result.stdout),
+    stderr: normalizeLogTime(result.stderr),
+  }
+}
+
+describe('npm-release CLI contract baselines (status/signal invariant, prose owner-rebaselinable)', () => {
+  it.each([
+    ['root help', ['--help']],
+    ['verify help', ['verify', '--help']],
+    ['version', ['--version']],
+    ['missing required plan', ['verify']],
+    ['invalid integer', ['verify', '--plan', 'plan.json', '--attempts', 'nope']],
+  ] as const)('%s', (_name, args) => {
+    expect(runCli(...args)).toMatchSnapshot()
+  })
+})


### PR DESCRIPTION
**Problem**
Effect 4 migration validation needs Phase 1 baselines captured on Effect 3 before migration work can usefully compare CLI behavior. A prior wave-0 npm-release migration was cancelled, but it had already produced a useful standalone CLI contract baseline.

**Goal**
Recover that npm-release CLI contract baseline as ordinary Effect 3 test coverage. This PR does not migrate npm-release; it only captures the current CLI contract for the Phase 1 gate.

**Decisions**
The test spawns the real CLI through Bun with `NO_COLOR=1`, normalizes log timestamps, and snapshots `status`, `signal`, `stdout`, and `stderr` separately. The file header and describe name explicitly distinguish strict invariants from owner-rebaselinable prose: exit `status` and `signal` are cross-major invariants, while help/usage/error prose may be re-baselined during Effect 4 repair with an alignment-register entry.

**Verification**
- PASS: `CI=1 ./node_modules/.bin/vitest run src/cli.contract.test.ts` from `packages/@overeng/npm-release` (1 file, 5 tests).
- PASS: `CI=1 devenv tasks run check:quick --no-tui`.
- PASS: `oxfmt --check packages/@overeng/npm-release/src/cli.contract.test.ts packages/@overeng/npm-release/src/__snapshots__/cli.contract.test.ts.snap`.
- PASS: `oxlint packages/@overeng/npm-release/src/cli.contract.test.ts`.
- PASS: `git diff --check`.

**Complexity**
No new runtime complexity: additive CLI contract test and Vitest snapshot only.

**Concerns**
The snapshot intentionally captures ANSI help/prose bytes even though those prose bytes may change under Effect 4. The annotation is part of the contract so wave repair can tell which fields are invariant and which require owner-approved re-baselining.

**Friction & bottlenecks**
Initial validation hit repeated Determinate cache `narinfo` HTTP 502s while entering `devenv shell`; this was logged as agent feedback. A retry later succeeded after dependency materialization through `devenv tasks run pnpm:install --no-tui`.

**Follow-ups**
Continue the remaining Phase 1 durable boundary baseline queue in separate package PRs.

**References**
Refs #925.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | co1-glen |
| `agent_session_id` | 09eb82be-a136-4c97-a5f3-14716c8cbe3c |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.145.0 |
| `agent_runtime` | Codex CLI 0.145.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/g70zaf7b08m8pmn4iqxy3a70a2833y23-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/997m3kakbn5dnr72qix3xmfx4pmd6qxd-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-28-schickling-assistant-2026-07-28-baselines-2-npm-release-cli |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->