### PR TITLE
test(tui-react): capture JSON and NDJSON wire baselines

### DIFF
--- a/packages/@overeng/tui-react/test/unit/exit-rendering.test.tsx
+++ b/packages/@overeng/tui-react/test/unit/exit-rendering.test.tsx
@@ -580,6 +580,7 @@ describe('tui-react JSON/NDJSON wire baselines (cross-major invariant)', () => {
             : null,
       })
 
+      // TODO(live-migration:effect-3-4): Effect 4 may print help on stdout here (effect#6313); apply #980 rather than accepting bytes on the machine stream.
       expect(capturedOutput).toMatchInlineSnapshot(`[]`)
       expect(failureBytes).toMatchInlineSnapshot(
         `"{"_tag":"Failure","cause":"ParseError: (parseJson <-> { readonly _tag: \\"WireState\\"; readonly phase: \\"idle\\" | \\"done\\"; readonly text: string; readonly nullable: string | null; readonly note?: string | undefined; readonly items: ReadonlyArray<{ readonly id: string; readonly value: string }> })\\n└─ Type side transformation failure\\n   └─ { readonly _tag: \\"WireState\\"; readonly phase: \\"idle\\" | \\"done\\"; readonly text: string; readonly nullable: string | null; readonly note?: string | undefined; readonly items: ReadonlyArray<{ readonly id: string; readonly value: string }> }\\n      └─ [\\"text\\"]\\n         └─ Expected string, actual null"}"`,

--- a/packages/@overeng/tui-react/test/unit/exit-rendering.test.tsx
+++ b/packages/@overeng/tui-react/test/unit/exit-rendering.test.tsx
@@ -508,6 +508,7 @@ describe('tui-react JSON/NDJSON wire baselines (cross-major invariant)', () => {
     console.log = originalLog
   })
 
+  // TODO(live-migration:effect-3-4): Effect 4 tightens date handling; keep the 2026-02-31 sentinel opaque inside Schema.String rather than normalizing or refreshing these JSON bytes.
   it.effect('emits final JSON as byte-identical raw state', () =>
     Effect.gen(function* () {
       const app = createWireApp()
@@ -526,6 +527,7 @@ describe('tui-react JSON/NDJSON wire baselines (cross-major invariant)', () => {
     ),
   )
 
+  // TODO(live-migration:effect-3-4): Effect 4 tightens date handling; keep the 2026-02-31 sentinel opaque inside Schema.String rather than normalizing or refreshing these NDJSON bytes.
   it.effect('emits progressive NDJSON snapshots as byte-identical lines', () =>
     Effect.gen(function* () {
       const app = createWireApp()
@@ -543,6 +545,7 @@ describe('tui-react JSON/NDJSON wire baselines (cross-major invariant)', () => {
     ),
   )
 
+  // TODO(live-migration:effect-3-4): Effect 4 tightens date handling; keep the 2026-02-31 sentinel opaque inside Schema.String rather than normalizing or refreshing these event bytes.
   it.effect('emits event-mapped progressive NDJSON as byte-identical lines', () =>
     Effect.gen(function* () {
       const app = createWireApp({ eventNdjson: true })

--- a/packages/@overeng/tui-react/test/unit/exit-rendering.test.tsx
+++ b/packages/@overeng/tui-react/test/unit/exit-rendering.test.tsx
@@ -90,6 +90,78 @@ const AppNoInterrupt = createTuiApp({
   reducer: testReducerNoInterrupt,
 })
 
+const WireState = Schema.TaggedStruct('WireState', {
+  phase: Schema.Literal('idle', 'done'),
+  text: Schema.String,
+  nullable: Schema.NullOr(Schema.String),
+  note: Schema.optional(Schema.String),
+  items: Schema.Array(
+    Schema.Struct({
+      id: Schema.String,
+      value: Schema.String,
+    }),
+  ),
+})
+
+type WireState = typeof WireState.Type
+
+const WireAction = Schema.Union(Schema.TaggedStruct('SetWireState', { next: WireState }))
+type WireAction = typeof WireAction.Type
+
+const WireEvent = Schema.TaggedStruct('WireEvent', {
+  from: Schema.Literal('idle', 'done'),
+  to: Schema.Literal('idle', 'done'),
+  text: Schema.String,
+})
+
+const FailurePartitionWire = Schema.parseJson(
+  Schema.Struct({
+    _tag: Schema.Literal('Failure', 'Success'),
+    cause: Schema.NullOr(Schema.String),
+  }),
+)
+
+const initialWireState: WireState = {
+  _tag: 'WireState',
+  phase: 'idle',
+  text: '',
+  nullable: null,
+  items: [],
+}
+
+const finalWireState: WireState = {
+  _tag: 'WireState',
+  phase: 'done',
+  text: 'Line 1\r\nLine 2 世界 NaN 2026-02-31',
+  nullable: null,
+  note: '',
+  items: [
+    { id: 'α', value: '' },
+    { id: 'big', value: '9007199254740991' },
+  ],
+}
+
+const createWireApp = (options?: { readonly eventNdjson?: boolean }) =>
+  createTuiApp<WireState, WireAction>({
+    stateSchema: WireState,
+    actionSchema: WireAction,
+    initial: initialWireState,
+    reducer: ({ action }) => action.next,
+    ...(options?.eventNdjson === true && {
+      ndjson: {
+        eventSchema: WireEvent,
+        fromAction: ({ action, prevState }: { action: WireAction; prevState: WireState }) => [
+          {
+            _tag: 'WireEvent' as const,
+            from: prevState.phase,
+            to: action.next.phase,
+            text: action.next.text,
+          },
+        ],
+      },
+    }),
+  })
+
 // =============================================================================
 // Exit Mode Tests (using createRoot directly)
 // =============================================================================
@@ -418,6 +490,102 @@ describe('Final state output', () => {
       }),
     )
   })
+})
+
+describe('tui-react JSON/NDJSON wire baselines (cross-major invariant)', () => {
+  let originalLog: typeof console.log
+  let capturedOutput: string[]
+
+  beforeEach(() => {
+    originalLog = console.log
+    capturedOutput = []
+    console.log = (msg: string) => {
+      capturedOutput.push(msg)
+    }
+  })
+
+  afterEach(() => {
+    console.log = originalLog
+  })
+
+  it.effect('emits final JSON as byte-identical raw state', () =>
+    Effect.gen(function* () {
+      const app = createWireApp()
+      const tui = yield* app.run()
+      tui.dispatch({ _tag: 'SetWireState', next: finalWireState })
+    }).pipe(
+      Effect.scoped,
+      Effect.provide(testModeLayer('json')),
+      Effect.andThen(() => {
+        expect(capturedOutput).toMatchInlineSnapshot(`
+          [
+            "{"_tag":"WireState","phase":"done","text":"Line 1\\r\\nLine 2 世界 NaN 2026-02-31","nullable":null,"note":"","items":[{"id":"α","value":""},{"id":"big","value":"9007199254740991"}]}",
+          ]
+        `)
+      }),
+    ),
+  )
+
+  it.effect('emits progressive NDJSON snapshots as byte-identical lines', () =>
+    Effect.gen(function* () {
+      const app = createWireApp()
+      const tui = yield* app.run()
+      tui.dispatch({ _tag: 'SetWireState', next: finalWireState })
+    }).pipe(
+      Effect.scoped,
+      Effect.provide(testModeLayer('ndjson')),
+      Effect.andThen(() => {
+        expect(capturedOutput.join('\n')).toMatchInlineSnapshot(`
+          "{"_tag":"WireState","phase":"idle","text":"","nullable":null,"items":[]}
+          {"_tag":"WireState","phase":"done","text":"Line 1\\r\\nLine 2 世界 NaN 2026-02-31","nullable":null,"note":"","items":[{"id":"α","value":""},{"id":"big","value":"9007199254740991"}]}"
+        `)
+      }),
+    ),
+  )
+
+  it.effect('emits event-mapped progressive NDJSON as byte-identical lines', () =>
+    Effect.gen(function* () {
+      const app = createWireApp({ eventNdjson: true })
+      const tui = yield* app.run()
+      tui.dispatch({ _tag: 'SetWireState', next: finalWireState })
+    }).pipe(
+      Effect.scoped,
+      Effect.provide(testModeLayer('ndjson')),
+      Effect.andThen(() => {
+        expect(capturedOutput.join('\n')).toMatchInlineSnapshot(`
+          "{"_tag":"WireState","phase":"idle","text":"","nullable":null,"items":[]}
+          {"_tag":"WireEvent","from":"idle","to":"done","text":"Line 1\\r\\nLine 2 世界 NaN 2026-02-31"}"
+        `)
+      }),
+    ),
+  )
+
+  it.effect('captures JSON encode failures as stable failure JSON', () =>
+    Effect.gen(function* () {
+      const InvalidApp = createTuiApp({
+        stateSchema: WireState,
+        actionSchema: Schema.Struct({ next: Schema.Unknown }),
+        initial: initialWireState,
+        reducer: ({ action }) => action.next as WireState,
+      })
+      const exit = yield* Effect.gen(function* () {
+        const tui = yield* InvalidApp.run()
+        tui.dispatch({ next: { ...finalWireState, text: null } })
+      }).pipe(Effect.scoped, Effect.provide(testModeLayer('json')), Effect.exit)
+      const failureBytes = yield* Schema.encode(FailurePartitionWire)({
+        _tag: exit._tag,
+        cause:
+          exit._tag === 'Failure' && exit.cause !== undefined
+            ? (String(exit.cause).split('\n    at ')[0] ?? '')
+            : null,
+      })
+
+      expect(capturedOutput).toMatchInlineSnapshot(`[]`)
+      expect(failureBytes).toMatchInlineSnapshot(
+        `"{"_tag":"Failure","cause":"ParseError: (parseJson <-> { readonly _tag: \\"WireState\\"; readonly phase: \\"idle\\" | \\"done\\"; readonly text: string; readonly nullable: string | null; readonly note?: string | undefined; readonly items: ReadonlyArray<{ readonly id: string; readonly value: string }> })\\n└─ Type side transformation failure\\n   └─ { readonly _tag: \\"WireState\\"; readonly phase: \\"idle\\" | \\"done\\"; readonly text: string; readonly nullable: string | null; readonly note?: string | undefined; readonly items: ReadonlyArray<{ readonly id: string; readonly value: string }> }\\n      └─ [\\"text\\"]\\n         └─ Expected string, actual null"}"`,
+      )
+    }),
+  )
 })
 
 // =============================================================================


### PR DESCRIPTION
## Problem

Phase 1 needs Effect 3 wire-format baselines for TUI machine-readable output before the Effect 4 cohort flip.

## Goal

Pin byte-identical JSON and NDJSON output at the durable TUI boundary, including the failure partition.

## Decisions

- Adds ordinary additive Vitest coverage in `packages/@overeng/tui-react/test/unit/exit-rendering.test.tsx`.
- Asserts encoded output strings from `json` and `ndjson` modes, not decoded values.
- Covers final JSON, progressive state NDJSON, event-mapped NDJSON, and invalid state encode failure JSON.
- Trims stack frames from the failure partition so the snapshot remains stable and does not capture local paths.
- No runtime behavior changes and no changelog entry; this is a baseline-only Phase 1 capture.

## Verification

- `CI=1 ./node_modules/.bin/vitest run test/unit/exit-rendering.test.tsx`
- `./node_modules/.bin/tsc --noEmit -p tsconfig.json --pretty false`
- `DEVENV_TASK_PASSTHROUGH=1 tsgo --build tsconfig.check.json --pretty false`
- `oxfmt --check packages/@overeng/tui-react/test/unit/exit-rendering.test.tsx`
- `oxlint packages/@overeng/tui-react/test/unit/exit-rendering.test.tsx`
- `git diff --check`
- `CI=1 devenv tasks run check:quick --no-tui`

## Complexity

No added runtime complexity; additive tests only.

## Concerns

The parse-error prose is intentionally pinned as part of the failure partition. Any Effect 4 difference should be reviewed instead of silently rebaselined.

Refs #925

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | co1-glen |
| `agent_session_id` | 09eb82be-a136-4c97-a5f3-14716c8cbe3c |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.145.0 |
| `agent_runtime` | Codex CLI 0.145.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/g70zaf7b08m8pmn4iqxy3a70a2833y23-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/997m3kakbn5dnr72qix3xmfx4pmd6qxd-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-28-schickling-assistant-2026-07-28-baselines-2-tui-wire |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->