### PR TITLE
test(agent-session-ingest): capture wire baselines

### DIFF
--- a/packages/@overeng/agent-session-ingest/src/codex.integration.test.ts
+++ b/packages/@overeng/agent-session-ingest/src/codex.integration.test.ts
@@ -205,3 +205,76 @@ Vitest.describe('codex adapter integration', () => {
       }).pipe(Effect.scoped, Effect.provide(TestLayer)),
   )
 })
+
+Vitest.describe('codex adapter wire baselines (cross-major invariant)', () => {
+  Vitest.it.effect('ingests representative Codex JSONL records as byte-identical JSON', () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem
+      const sessionsRoot = yield* fs.makeTempDirectoryScoped()
+      const artifactPath = nodePath.join(sessionsRoot, '2026', '07', '28', 'rollout.jsonl')
+      yield* fs.makeDirectory(nodePath.dirname(artifactPath), { recursive: true })
+
+      const jsonl = [
+        '{"timestamp":"2026-07-28T08:00:00.000Z","type":"session_meta","payload":{"id":"sess_世界","timestamp":"2026-07-28T08:00:00.000Z","cwd":"/tmp/repo with spaces","originator":"","cli_version":"0.145.0","instructions":""}}',
+        '{"timestamp":"2026-07-28T08:00:01.000Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Line 1\\r\\nLine 2 résumé"},{"type":"input_image","detail":"high","file_id":"file_123"}]}}',
+        '{"timestamp":"2026-07-28T08:00:02.000Z","type":"response_item","payload":{"type":"function_call","name":"mcp__server__tool","arguments":"{\\"empty\\":\\"\\",\\"nullable\\":null,\\"unicode\\":\\"東京\\",\\"nan\\":\\"NaN\\",\\"impossibleDate\\":\\"2026-02-31\\"}","call_id":"call_1"}}',
+        '{"timestamp":"2026-07-28T08:00:03.000Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":9007199254740991},"last_token_usage":null,"model_context_window":200000}}}',
+        '{"timestamp":"2026-07-28T08:00:04.000Z","type":"turn_context","payload":{"cwd":"/tmp/repo","approval_policy":"never","sandbox_policy":{"mode":"danger-full-access"},"model":"codex-baseline","effort":""}}',
+        '',
+      ].join('\n')
+      yield* fs.writeFileString(artifactPath, jsonl)
+
+      const adapter = makeCodexAdapter({ sessionsRoot })
+      const artifact = yield* expectSingleArtifact(adapter)
+      const ingested = yield* adapter.ingestArtifact({ artifact, checkpoint: undefined })
+
+      expect(jsonl).toMatchInlineSnapshot(`
+        "{"timestamp":"2026-07-28T08:00:00.000Z","type":"session_meta","payload":{"id":"sess_世界","timestamp":"2026-07-28T08:00:00.000Z","cwd":"/tmp/repo with spaces","originator":"","cli_version":"0.145.0","instructions":""}}
+        {"timestamp":"2026-07-28T08:00:01.000Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Line 1\\r\\nLine 2 résumé"},{"type":"input_image","detail":"high","file_id":"file_123"}]}}
+        {"timestamp":"2026-07-28T08:00:02.000Z","type":"response_item","payload":{"type":"function_call","name":"mcp__server__tool","arguments":"{\\"empty\\":\\"\\",\\"nullable\\":null,\\"unicode\\":\\"東京\\",\\"nan\\":\\"NaN\\",\\"impossibleDate\\":\\"2026-02-31\\"}","call_id":"call_1"}}
+        {"timestamp":"2026-07-28T08:00:03.000Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":9007199254740991},"last_token_usage":null,"model_context_window":200000}}}
+        {"timestamp":"2026-07-28T08:00:04.000Z","type":"turn_context","payload":{"cwd":"/tmp/repo","approval_policy":"never","sandbox_policy":{"mode":"danger-full-access"},"model":"codex-baseline","effort":""}}
+        "
+      `)
+      expect(stringifyJson(ingested.records)).toMatchInlineSnapshot(
+        `"[{"timestamp":"2026-07-28T08:00:00.000Z","type":"session_meta","payload":{"id":"sess_世界","timestamp":"2026-07-28T08:00:00.000Z","cwd":"/tmp/repo with spaces","originator":"","cli_version":"0.145.0","instructions":""}},{"timestamp":"2026-07-28T08:00:01.000Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Line 1\\r\\nLine 2 résumé"},{"type":"input_image","file_id":"file_123","detail":"high"}]}},{"timestamp":"2026-07-28T08:00:02.000Z","type":"response_item","payload":{"type":"function_call","name":"mcp__server__tool","arguments":"{\\"empty\\":\\"\\",\\"nullable\\":null,\\"unicode\\":\\"東京\\",\\"nan\\":\\"NaN\\",\\"impossibleDate\\":\\"2026-02-31\\"}","call_id":"call_1"}},{"timestamp":"2026-07-28T08:00:03.000Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":9007199254740991},"last_token_usage":null,"model_context_window":200000}}},{"timestamp":"2026-07-28T08:00:04.000Z","type":"turn_context","payload":{"cwd":"/tmp/repo","approval_policy":"never","sandbox_policy":{"mode":"danger-full-access"},"model":"codex-baseline","effort":""}}]"`,
+      )
+    }).pipe(Effect.scoped, Effect.provide(TestLayer)),
+  )
+
+  Vitest.it.effect('captures the Codex JSONL decode failure partition as stable JSON', () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem
+      const sessionsRoot = yield* fs.makeTempDirectoryScoped()
+      const artifactPath = nodePath.join(sessionsRoot, 'bad.jsonl')
+      yield* fs.writeFileString(
+        artifactPath,
+        '{"timestamp":null,"type":"response_item","payload":{"type":"function_call","name":"tool","arguments":"{}","call_id":"call_bad"}}\n',
+      )
+
+      const adapter = makeCodexAdapter({ sessionsRoot })
+      const artifact = yield* expectSingleArtifact(adapter)
+      const result = yield* adapter
+        .ingestArtifact({ artifact, checkpoint: undefined })
+        .pipe(Effect.either)
+
+      expect(result._tag).toBe('Left')
+      if (result._tag === 'Left') {
+        expect(result.left._tag).toBe('SessionArtifactDecodeError')
+      }
+      if (result._tag === 'Left' && result.left._tag === 'SessionArtifactDecodeError') {
+        expect(
+          stringifyJson({
+            _tag: result.left._tag,
+            message: result.left.message,
+            sourceId: result.left.sourceId,
+            artifactId: result.left.artifactId,
+            rawRecord: result.left.rawRecord,
+          }),
+        ).toMatchInlineSnapshot(
+          `"{"_tag":"SessionArtifactDecodeError","message":"Failed to decode Codex session record","sourceId":"codex","artifactId":"bad","rawRecord":"{\\"timestamp\\":null,\\"type\\":\\"response_item\\",\\"payload\\":{\\"type\\":\\"function_call\\",\\"name\\":\\"tool\\",\\"arguments\\":\\"{}\\",\\"call_id\\":\\"call_bad\\"}}"}"`,
+        )
+      }
+    }).pipe(Effect.scoped, Effect.provide(TestLayer)),
+  )
+})

--- a/packages/@overeng/agent-session-ingest/src/codex.integration.test.ts
+++ b/packages/@overeng/agent-session-ingest/src/codex.integration.test.ts
@@ -207,6 +207,7 @@ Vitest.describe('codex adapter integration', () => {
 })
 
 Vitest.describe('codex adapter wire baselines (cross-major invariant)', () => {
+  // TODO(live-migration:effect-3-4): Effect 4 reassigns Schema.Date and tightens date handling; preserve timestamp wire strings and keep impossibleDate opaque rather than refreshing these JSONL bytes.
   Vitest.it.effect('ingests representative Codex JSONL records as byte-identical JSON', () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem

--- a/packages/@overeng/agent-session-ingest/src/services.integration.test.ts
+++ b/packages/@overeng/agent-session-ingest/src/services.integration.test.ts
@@ -1,9 +1,11 @@
+import { FileSystem } from '@effect/platform'
 import { NodeContext } from '@effect/platform-node'
 import { Layer, Ref, Schema, Effect } from 'effect'
 import { expect } from 'vitest'
 
 import { Vitest } from '@overeng/utils-dev/node-vitest'
 
+import { stringifyJson } from './adapters.integration-test-helpers.ts'
 import type { IngestionCheckpoint, SessionSourceAdapter } from './schema/core.ts'
 import {
   ArtifactDescriptor,
@@ -11,7 +13,11 @@ import {
   IngestionCheckpoint as IngestionCheckpointSchema,
   SourceId,
 } from './schema/core.ts'
-import { buildCheckpointKey, CheckpointStore } from './services/CheckpointStore.ts'
+import {
+  buildCheckpointKey,
+  CheckpointStore,
+  makeFileCheckpointStore,
+} from './services/CheckpointStore.ts'
 import { ingestSource } from './services/SessionIngestor.ts'
 
 const makeCheckpoint = (options: {
@@ -124,5 +130,95 @@ Vitest.describe('agent-session-ingest services', () => {
       ).toBe('AppendOnlyCursor')
       expect(saved.find((checkpoint) => checkpoint.artifactId === 'target-artifact')).toBeDefined()
     }),
+  )
+})
+
+Vitest.describe('checkpoint store wire baselines (cross-major invariant)', () => {
+  Vitest.it.effect('persists and reloads checkpoint JSONL as byte-identical records', () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem
+      const tempDir = yield* fs.makeTempDirectoryScoped()
+      const checkpointPath = `${tempDir}/checkpoints.jsonl`
+
+      const checkpointStore = yield* makeFileCheckpointStore({ path: checkpointPath })
+      const checkpoints = [
+        yield* Schema.decodeUnknown(IngestionCheckpointSchema)({
+          sourceId: 'codex',
+          artifactId: '2026/07/28/rollout',
+          path: '/var/lib/agent/sessions/2026/07/28/rollout.jsonl',
+          status: 'stable',
+          cursor: {
+            _tag: 'AppendOnlyCursor',
+            offsetBytes: 321,
+            contentVersion: {
+              sizeBytes: 654,
+              modifiedAtEpochMs: 1785225600123,
+              headHash: 'fnv1a:00000000',
+              tailHash: 'fnv1a:ffffffff',
+            },
+          },
+          updatedAtEpochMs: 1785225600456,
+        }),
+        yield* Schema.decodeUnknown(IngestionCheckpointSchema)({
+          sourceId: 'opencode',
+          artifactId: 'thread:世界',
+          path: '/var/lib/agent/opencode.db',
+          status: 'open',
+          cursor: {
+            _tag: 'UpdatedAtCursor',
+            updatedAtEpochMs: 1785225600789,
+            lastRecordKey: '',
+            contentVersion: {
+              sizeBytes: 9007199254740991,
+              modifiedAtEpochMs: 1785225600999,
+              tailHash: 'fnv1a:résumé',
+            },
+          },
+          updatedAtEpochMs: 1785225601111,
+        }),
+      ]
+
+      yield* checkpointStore.saveAll(checkpoints)
+
+      const bytes = yield* fs.readFileString(checkpointPath)
+      const loaded = yield* checkpointStore.list()
+      expect(bytes).toMatchInlineSnapshot(`
+        "{"sourceId":"codex","artifactId":"2026/07/28/rollout","path":"/var/lib/agent/sessions/2026/07/28/rollout.jsonl","status":"stable","cursor":{"_tag":"AppendOnlyCursor","offsetBytes":321,"contentVersion":{"sizeBytes":654,"modifiedAtEpochMs":1785225600123,"headHash":"fnv1a:00000000","tailHash":"fnv1a:ffffffff"}},"updatedAtEpochMs":1785225600456}
+        {"sourceId":"opencode","artifactId":"thread:世界","path":"/var/lib/agent/opencode.db","status":"open","cursor":{"_tag":"UpdatedAtCursor","updatedAtEpochMs":1785225600789,"lastRecordKey":"","contentVersion":{"sizeBytes":9007199254740991,"modifiedAtEpochMs":1785225600999,"tailHash":"fnv1a:résumé"}},"updatedAtEpochMs":1785225601111}"
+      `)
+      expect(stringifyJson(loaded)).toMatchInlineSnapshot(
+        `"[{"sourceId":"codex","artifactId":"2026/07/28/rollout","path":"/var/lib/agent/sessions/2026/07/28/rollout.jsonl","status":"stable","cursor":{"_tag":"AppendOnlyCursor","offsetBytes":321,"contentVersion":{"sizeBytes":654,"modifiedAtEpochMs":1785225600123,"headHash":"fnv1a:00000000","tailHash":"fnv1a:ffffffff"}},"updatedAtEpochMs":1785225600456},{"sourceId":"opencode","artifactId":"thread:世界","path":"/var/lib/agent/opencode.db","status":"open","cursor":{"_tag":"UpdatedAtCursor","updatedAtEpochMs":1785225600789,"lastRecordKey":"","contentVersion":{"sizeBytes":9007199254740991,"modifiedAtEpochMs":1785225600999,"tailHash":"fnv1a:résumé"}},"updatedAtEpochMs":1785225601111}]"`,
+      )
+    }).pipe(Effect.scoped, Effect.provide(NodeContext.layer)),
+  )
+
+  Vitest.it.effect('captures checkpoint decode failures as stable JSON', () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem
+      const tempDir = yield* fs.makeTempDirectoryScoped()
+      const checkpointPath = `${tempDir}/checkpoints.jsonl`
+      yield* fs.writeFileString(
+        checkpointPath,
+        [
+          '{"sourceId":"codex","artifactId":"","path":"/tmp/session.jsonl","status":"stable","cursor":{"_tag":"AppendOnlyCursor","offsetBytes":0,"contentVersion":{"sizeBytes":0,"modifiedAtEpochMs":0,"tailHash":"fnv1a:0"}},"updatedAtEpochMs":0}',
+          '',
+        ].join('\n'),
+      )
+
+      const checkpointStore = yield* makeFileCheckpointStore({ path: checkpointPath })
+      const result = yield* checkpointStore.list().pipe(Effect.either)
+
+      expect(result._tag).toBe('Left')
+      if (result._tag === 'Left') {
+        expect(
+          stringifyJson({
+            _tag: result.left._tag,
+            message: result.left.message,
+          }),
+        ).toMatchInlineSnapshot(
+          `"{"_tag":"SessionCheckpointDecodeError","message":"Failed to decode checkpoint entry"}"`,
+        )
+      }
+    }).pipe(Effect.scoped, Effect.provide(NodeContext.layer)),
   )
 })


### PR DESCRIPTION
## Problem

Phase 1 needs Effect 3 wire-format baselines for agent-session durable ingestion boundaries before the Effect 4 cohort flip.

## Goal

Pin byte-identical Codex JSONL, decoded Codex record JSON, checkpoint JSONL, loaded checkpoint JSON, and the decode-failure partitions.

## Decisions

- Adds ordinary additive Vitest coverage in `packages/@overeng/agent-session-ingest/src/codex.integration.test.ts` and `packages/@overeng/agent-session-ingest/src/services.integration.test.ts`.
- Asserts encoded byte strings via raw JSONL fixture bytes and schema-backed JSON encoders, not decoded object equality.
- Covers representative Codex records with unicode, CRLF escaping, empty strings, nulls, large integer boundaries, and impossible-date strings.
- Covers checkpoint persistence/load ordering plus artifact and checkpoint decode failures.
- No runtime behavior changes and no changelog entry; this is a baseline-only Phase 1 capture.

## Verification

- `CI=1 ./node_modules/.bin/vitest run src/codex.integration.test.ts src/services.integration.test.ts`
- `DEVENV_TASK_PASSTHROUGH=1 tsgo --build tsconfig.check.json --pretty false`
- `oxfmt --check packages/@overeng/agent-session-ingest/src/codex.integration.test.ts packages/@overeng/agent-session-ingest/src/services.integration.test.ts`
- `oxlint packages/@overeng/agent-session-ingest/src/codex.integration.test.ts packages/@overeng/agent-session-ingest/src/services.integration.test.ts`
- `git diff --check`
- `CI=1 devenv tasks run check:quick --no-tui`

## Complexity

No added runtime complexity; additive tests only.

## Concerns

Failure partition prose is intentionally pinned. Any Effect 4 difference should be reviewed instead of silently rebaselined.

Refs #925

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | co1-glen |
| `agent_session_id` | 09eb82be-a136-4c97-a5f3-14716c8cbe3c |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.145.0 |
| `agent_runtime` | Codex CLI 0.145.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/g70zaf7b08m8pmn4iqxy3a70a2833y23-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/997m3kakbn5dnr72qix3xmfx4pmd6qxd-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-28-schickling-assistant-2026-07-28-baselines-2-agent-session-wire |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->