### PR TITLE
test(ci-tools): capture workflow-report wire baselines

### DIFF
--- a/packages/@overeng/ci-tools/src/workflow-report.test.ts
+++ b/packages/@overeng/ci-tools/src/workflow-report.test.ts
@@ -135,12 +135,14 @@ describe('ci-tools workflow-report wire baselines (cross-major invariant)', () =
     },
   })
 
+  // TODO(live-migration:effect-3-4): Effect 4 reassigns Schema.Date and tightens date handling; preserve timestamp wire strings and keep impossibleDate opaque rather than refreshing this line.
   it('encodes marked report lines as byte-identical JSON', () => {
     expect(encodeWorkflowReportRecordLine(wireRecord)).toMatchInlineSnapshot(
       `"WORKFLOW_REPORT_V1: {"_tag":"WorkflowReportRecord","schemaVersion":1,"id":"deploy-web:世界","kind":"deploy-preview","subject":{"id":"web","label":"Website | Primary"},"status":"failure","title":"Preview failed","summary":"Line 1\\r\\nLine 2 résumé","createdAtUtc":"2026-07-28T08:00:00.000Z","links":[{"label":"Log","url":"https://example.invalid/log?attempt=1","primary":false},{"label":"Preview","url":"https://preview.example.invalid","primary":true}],"data":{"empty":"","nullable":null,"unicode":"東京","impossibleDate":"2026-02-31","largeInteger":9007199254740991}}"`,
     )
   })
 
+  // TODO(live-migration:effect-3-4): Effect 4 reassigns Schema.Date and tightens date handling; preserve timestamp wire strings and keep impossibleDate opaque rather than refreshing this bundle.
   it('encodes report bundles as byte-identical pretty JSON', () => {
     const bundle = createWorkflowReportBundle({
       bundleId: 'deploy-preview',
@@ -194,6 +196,7 @@ describe('ci-tools workflow-report wire baselines (cross-major invariant)', () =
     `)
   })
 
+  // TODO(live-migration:effect-3-4): Effect 4 reassigns Schema.Date and tightens date handling; preserve timestamp wire strings and keep impossibleDate opaque in the hidden managed state.
   it('encodes managed comment state as byte-identical Markdown', () => {
     const state = deriveWorkflowReportManagedState({
       stateId: 'deploy-preview',
@@ -289,6 +292,7 @@ describe('ci-tools workflow-report wire baselines (cross-major invariant)', () =
     `)
   })
 
+  // TODO(live-migration:effect-3-4): Effect 4 reassigns Schema.Date; keep generatedAtUtc as the existing ISO wire contract while preserving this custom failure message.
   it('captures workflow-report decode failures as stable JSON', () => {
     let failureJson = '{"_tag":"UnexpectedSuccess"}'
     try {

--- a/packages/@overeng/ci-tools/src/workflow-report.test.ts
+++ b/packages/@overeng/ci-tools/src/workflow-report.test.ts
@@ -111,6 +111,201 @@ describe('marked workflow report JSONL parsing', () => {
   })
 })
 
+describe('ci-tools workflow-report wire baselines (cross-major invariant)', () => {
+  const wireRecord = decodeWorkflowReportRecord({
+    _tag: 'WorkflowReportRecord',
+    schemaVersion: 1,
+    id: 'deploy-web:世界',
+    kind: 'deploy-preview',
+    subject: { id: 'web', label: 'Website | Primary' },
+    status: 'failure',
+    title: 'Preview failed',
+    summary: 'Line 1\r\nLine 2 résumé',
+    createdAtUtc: '2026-07-28T08:00:00.000Z',
+    links: [
+      { label: 'Log', url: 'https://example.invalid/log?attempt=1', primary: false },
+      { label: 'Preview', url: 'https://preview.example.invalid', primary: true },
+    ],
+    data: {
+      empty: '',
+      nullable: null,
+      unicode: '東京',
+      impossibleDate: '2026-02-31',
+      largeInteger: 9007199254740991,
+    },
+  })
+
+  it('encodes marked report lines as byte-identical JSON', () => {
+    expect(encodeWorkflowReportRecordLine(wireRecord)).toMatchInlineSnapshot(
+      `"WORKFLOW_REPORT_V1: {"_tag":"WorkflowReportRecord","schemaVersion":1,"id":"deploy-web:世界","kind":"deploy-preview","subject":{"id":"web","label":"Website | Primary"},"status":"failure","title":"Preview failed","summary":"Line 1\\r\\nLine 2 résumé","createdAtUtc":"2026-07-28T08:00:00.000Z","links":[{"label":"Log","url":"https://example.invalid/log?attempt=1","primary":false},{"label":"Preview","url":"https://preview.example.invalid","primary":true}],"data":{"empty":"","nullable":null,"unicode":"東京","impossibleDate":"2026-02-31","largeInteger":9007199254740991}}"`,
+    )
+  })
+
+  it('encodes report bundles as byte-identical pretty JSON', () => {
+    const bundle = createWorkflowReportBundle({
+      bundleId: 'deploy-preview',
+      generatedAtUtc: '2026-07-28T08:01:00.000Z',
+      records: [wireRecord],
+    })
+
+    expect(encodeWorkflowReportBundleJson(bundle)).toMatchInlineSnapshot(`
+      "{
+        "_tag": "WorkflowReportBundle",
+        "schemaVersion": 1,
+        "bundleId": "deploy-preview",
+        "generatedAtUtc": "2026-07-28T08:01:00.000Z",
+        "records": [
+          {
+            "_tag": "WorkflowReportRecord",
+            "schemaVersion": 1,
+            "id": "deploy-web:世界",
+            "kind": "deploy-preview",
+            "subject": {
+              "id": "web",
+              "label": "Website | Primary"
+            },
+            "status": "failure",
+            "title": "Preview failed",
+            "summary": "Line 1\\r\\nLine 2 résumé",
+            "createdAtUtc": "2026-07-28T08:00:00.000Z",
+            "links": [
+              {
+                "label": "Log",
+                "url": "https://example.invalid/log?attempt=1",
+                "primary": false
+              },
+              {
+                "label": "Preview",
+                "url": "https://preview.example.invalid",
+                "primary": true
+              }
+            ],
+            "data": {
+              "empty": "",
+              "nullable": null,
+              "unicode": "東京",
+              "impossibleDate": "2026-02-31",
+              "largeInteger": 9007199254740991
+            }
+          }
+        ]
+      }
+      "
+    `)
+  })
+
+  it('encodes managed comment state as byte-identical Markdown', () => {
+    const state = deriveWorkflowReportManagedState({
+      stateId: 'deploy-preview',
+      entryId: 'commit-a',
+      entryLabel: 'Commit abc1234',
+      createdAtUtc: '2026-07-28T08:02:00.000Z',
+      records: [wireRecord],
+    })
+
+    expect(
+      renderWorkflowReportCommentBody({
+        title: 'Deploy Previews',
+        noRecordsMessage: 'No previews were deployed.',
+        state,
+      }),
+    ).toMatchInlineSnapshot(`
+      "## Deploy Previews
+
+      | Subject | Status | Report | Details | Updated |
+      | --- | --- | --- | --- | --- |
+      | Website \\| Primary | failure | [Preview failed](https://preview.example.invalid) | Line 1
+      <br>Line 2 résumé | 2026-07-28 10:00 CEST |
+
+      <details>
+      <summary>Report history</summary>
+
+      ### Commit abc1234 · 2026-07-28 10:02 CEST
+
+      | Subject | Status | Report | Details | Updated |
+      | --- | --- | --- | --- | --- |
+      | Website \\| Primary | failure | [Preview failed](https://preview.example.invalid) | Line 1
+      <br>Line 2 résumé | 2026-07-28 10:00 CEST |
+
+      </details>
+
+      <!-- workflow-report:managed -->
+      <!-- workflow-report:state
+      {
+        "_tag": "WorkflowReportManagedState",
+        "schemaVersion": 1,
+        "stateId": "deploy-preview",
+        "timeZone": "Europe/Berlin",
+        "recordOrder": [
+          "web"
+        ],
+        "entries": [
+          {
+            "_tag": "WorkflowReportManagedEntry",
+            "entryId": "commit-a",
+            "label": "Commit abc1234",
+            "createdAtUtc": "2026-07-28T08:02:00.000Z",
+            "records": [
+              {
+                "_tag": "WorkflowReportRecord",
+                "schemaVersion": 1,
+                "id": "deploy-web:世界",
+                "kind": "deploy-preview",
+                "subject": {
+                  "id": "web",
+                  "label": "Website | Primary"
+                },
+                "status": "failure",
+                "title": "Preview failed",
+                "summary": "Line 1\\r\\nLine 2 résumé",
+                "createdAtUtc": "2026-07-28T08:00:00.000Z",
+                "links": [
+                  {
+                    "label": "Log",
+                    "url": "https://example.invalid/log?attempt=1",
+                    "primary": false
+                  },
+                  {
+                    "label": "Preview",
+                    "url": "https://preview.example.invalid",
+                    "primary": true
+                  }
+                ],
+                "data": {
+                  "empty": "",
+                  "nullable": null,
+                  "unicode": "東京",
+                  "impossibleDate": "2026-02-31",
+                  "largeInteger": 9007199254740991
+                }
+              }
+            ]
+          }
+        ]
+      }
+
+      -->
+      "
+    `)
+  })
+
+  it('captures workflow-report decode failures as stable JSON', () => {
+    let failureJson = '{"_tag":"UnexpectedSuccess"}'
+    try {
+      decodeWorkflowReportBundleJson(
+        '{"_tag":"WorkflowReportBundle","schemaVersion":2,"bundleId":"deploy-preview","generatedAtUtc":"2026-07-28T08:01:00Z","records":[]}',
+      )
+    } catch (cause) {
+      const message = cause instanceof Error ? cause.message : String(cause)
+      failureJson = JSON.stringify({ _tag: 'DecodeFailure', message })
+    }
+
+    expect(failureJson).toMatchInlineSnapshot(
+      `"{"_tag":"DecodeFailure","message":"WorkflowReportBundle.schemaVersion must be 1"}"`,
+    )
+  })
+})
+
 describe('managed workflow report comments', () => {
   it('derives, renders, and extracts managed state from hidden structured JSON', () => {
     const state = deriveWorkflowReportManagedState({


### PR DESCRIPTION
## Problem

Phase 1 needs Effect 3 wire-format baselines for ci-tools workflow-report output before the Effect 4 cohort flip.

## Goal

Pin byte-identical workflow-report record lines, bundle JSON, managed comment Markdown/state JSON, and the decode-failure partition.

## Decisions

- Adds ordinary additive Vitest coverage in `packages/@overeng/ci-tools/src/workflow-report.test.ts`.
- Asserts encoded strings emitted by the workflow-report encoder/rendering functions, not decoded object equality.
- Covers marked `WORKFLOW_REPORT_V1` lines, pretty bundle JSON, managed GitHub comment body with hidden state, and invalid bundle decode failure JSON.
- Uses synthetic public-safe fixture values with unicode, CRLF escaping, nulls, empty strings, markdown escaping, and large integer boundaries.
- No runtime behavior changes and no changelog entry; this is a baseline-only Phase 1 capture.

## Verification

- `CI=1 ./node_modules/.bin/vitest run src/workflow-report.test.ts`
- `DEVENV_TASK_PASSTHROUGH=1 tsgo --build tsconfig.check.json --pretty false`
- `oxfmt --check packages/@overeng/ci-tools/src/workflow-report.test.ts`
- `oxlint packages/@overeng/ci-tools/src/workflow-report.test.ts`
- `git diff --check`
- `CI=1 devenv tasks run check:quick --no-tui`

## Complexity

No added runtime complexity; additive tests only.

## Concerns

The decode-error message is intentionally pinned as part of the failure partition. Any Effect 4 difference should be reviewed instead of silently rebaselined.

Refs #925

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | co1-glen |
| `agent_session_id` | 09eb82be-a136-4c97-a5f3-14716c8cbe3c |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.145.0 |
| `agent_runtime` | Codex CLI 0.145.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/g70zaf7b08m8pmn4iqxy3a70a2833y23-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/997m3kakbn5dnr72qix3xmfx4pmd6qxd-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-28-2026-07-28-baselines-2-ci-tools-wire |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->