### PR TITLE
test(ci-tools): capture CLI contract baselines

### DIFF
--- a/packages/@overeng/ci-tools/src/__snapshots__/cli.contract.test.ts.snap
+++ b/packages/@overeng/ci-tools/src/__snapshots__/cli.contract.test.ts.snap
@@ -1,0 +1,194 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ci-tools CLI contract baselines (status/signal invariant, prose owner-rebaselinable) > invalid deploy mode 1`] = `
+{
+  "signal": null,
+  "status": 1,
+  "stderr": "Expected one of the following cases: prod, pr, draft
+
+",
+  "stdout": "",
+}
+`;
+
+exports[`ci-tools CLI contract baselines (status/signal invariant, prose owner-rebaselinable) > missing required bundle id 1`] = `
+{
+  "signal": null,
+  "status": 1,
+  "stderr": "Expected to find option: '--bundle-id'
+
+Expected to find option: '--input-paths-json'
+
+Expected to find option: '--output-path'
+
+",
+  "stdout": "",
+}
+`;
+
+exports[`ci-tools CLI contract baselines (status/signal invariant, prose owner-rebaselinable) > root help 1`] = `
+{
+  "signal": null,
+  "status": 0,
+  "stderr": "",
+  "stdout": "ci-tools
+
+ci-tools 0.1.0
+
+USAGE
+
+$ ci-tools
+
+DESCRIPTION
+
+CI automation helpers
+
+OPTIONS
+
+--completions sh | bash | fish | zsh
+
+  One of the following: sh, bash, fish, zsh
+
+  Generate a completion script for a specific shell.
+
+  This setting is optional.
+
+--log-level all | trace | debug | info | warning | error | fatal | none
+
+  One of the following: all, trace, debug, info, warning, error, fatal, none
+
+  Sets the minimum log level for a command.
+
+  This setting is optional.
+
+(-h, --help)
+
+  A true or false value.
+
+  Show the help documentation for a command.
+
+  This setting is optional.
+
+--wizard
+
+  A true or false value.
+
+  Start wizard mode for a command.
+
+  This setting is optional.
+
+--version
+
+  A true or false value.
+
+  Show the version of the application.
+
+  This setting is optional.
+
+COMMANDS
+
+  - workflow-report                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         Workflow report bundle, render, and comment-state helpers
+
+  - workflow-report collect-bundle --bundle-id text --input-paths-json text --output-path text [--record-marker text] [--allow-missing-input]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               Collect marked workflow report records into a bundle
+
+  - workflow-report render-comment-body --bundle-path text --comments-path text --comment-body-path text --summary-path text --title text --no-records-message text --state-id text --entry-id text --entry-label text [--created-at-utc text] [--time-zone text] [--managed-marker text]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   Render a managed workflow report comment body
+
+  - workflow-report find-comment --comments-path text --comment-body-path text --comment-id-path text --state-id text [--managed-marker text]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               Find the existing managed workflow report comment
+
+  - deploy                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  Deploy preview provider operations
+
+  - deploy netlify --target text --artifact-dir text [--mode prod | pr | draft] [--display-name text] [--pr integer] [--site-name text] [--site-id-env text] [--auth-token-env text] [--account-slug-env text] [--workspace-filter text] [--workflow-report-output-file text] [--github-output-file text] [--github-env-file text] [--url-env-key text] [--netlify-bin text] [--netlify-api-base-url text] [--missing-auth-policy fail | skip] [--unauthorized-policy fail | skip] [--created-at-utc text] [--e2e-allow-shared-project] [--e2e-reserved-alias-prefix text] [--e2e-verify-path text] [--e2e-verify-text text]                                                                                                                                                Deploy a local static directory to Netlify
+
+  - deploy vercel --target text --artifact-dir text [--artifact-kind static | prebuilt-output] [--mode prod | pr | preview] [--display-name text] [--pr integer] [--alias-prefix text] [--alias-suffix text] --production-domain text... [--project-id-env text] [--org-id-env text] [--auth-token-env text] [--team-id-env text] [--scope-env text] [--protection-bypass-env text] [--workflow-report-output-file text] [--github-output-file text] [--github-env-file text] [--url-env-key text] [--build-prebuilt-output] [--vercel-root-directory text] --build-env text... [--vercel-bin text] [--vercel-api-base-url text] [--created-at-utc text] [--e2e-allow-shared-project] [--e2e-reserved-alias-prefix text] [--e2e-verify-path text] [--e2e-verify-text text]  Deploy a local static directory to Vercel
+
+  - quarantine                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              Quarantine ledger validation and tolerated-failure announcements
+
+  - quarantine validate --ledger text [--today text]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        Fail when a quarantine ledger holds expired or malformed entries
+
+  - quarantine announce --ledger text --key text --label text [--summary-file text]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         Announce a tolerated test failure to the job summary and as an annotation
+
+",
+}
+`;
+
+exports[`ci-tools CLI contract baselines (status/signal invariant, prose owner-rebaselinable) > version 1`] = `
+{
+  "signal": null,
+  "status": 0,
+  "stderr": "",
+  "stdout": "0.1.0
+
+",
+}
+`;
+
+exports[`ci-tools CLI contract baselines (status/signal invariant, prose owner-rebaselinable) > workflow-report help 1`] = `
+{
+  "signal": null,
+  "status": 0,
+  "stderr": "",
+  "stdout": "ci-tools
+
+ci-tools 0.1.0
+
+USAGE
+
+$ workflow-report
+
+DESCRIPTION
+
+Workflow report bundle, render, and comment-state helpers
+
+OPTIONS
+
+--completions sh | bash | fish | zsh
+
+  One of the following: sh, bash, fish, zsh
+
+  Generate a completion script for a specific shell.
+
+  This setting is optional.
+
+--log-level all | trace | debug | info | warning | error | fatal | none
+
+  One of the following: all, trace, debug, info, warning, error, fatal, none
+
+  Sets the minimum log level for a command.
+
+  This setting is optional.
+
+(-h, --help)
+
+  A true or false value.
+
+  Show the help documentation for a command.
+
+  This setting is optional.
+
+--wizard
+
+  A true or false value.
+
+  Start wizard mode for a command.
+
+  This setting is optional.
+
+--version
+
+  A true or false value.
+
+  Show the version of the application.
+
+  This setting is optional.
+
+COMMANDS
+
+  - collect-bundle --bundle-id text --input-paths-json text --output-path text [--record-marker text] [--allow-missing-input]                                                                                                                                              Collect marked workflow report records into a bundle
+
+  - render-comment-body --bundle-path text --comments-path text --comment-body-path text --summary-path text --title text --no-records-message text --state-id text --entry-id text --entry-label text [--created-at-utc text] [--time-zone text] [--managed-marker text]  Render a managed workflow report comment body
+
+  - find-comment --comments-path text --comment-body-path text --comment-id-path text --state-id text [--managed-marker text]                                                                                                                                              Find the existing managed workflow report comment
+
+",
+}
+`;

--- a/packages/@overeng/ci-tools/src/cli.contract.test.ts
+++ b/packages/@overeng/ci-tools/src/cli.contract.test.ts
@@ -19,7 +19,8 @@ const stripAnsi = (output: string) =>
     '',
   )
 
-const normalizeOutput = (output: string) => stripAnsi(output)
+const normalizeOutput = (output: string) =>
+  stripAnsi(output).replace(/ — running from local source \([^)]+\)/gu, '')
 // LIVE-MIGRATION END effect-3-4
 
 const runCli = (...args: ReadonlyArray<string>) => {

--- a/packages/@overeng/ci-tools/src/cli.contract.test.ts
+++ b/packages/@overeng/ci-tools/src/cli.contract.test.ts
@@ -1,0 +1,50 @@
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+const cliPath = fileURLToPath(new URL('../bin/ci-tools.ts', import.meta.url))
+
+/**
+ * CLI contract capture: `status` and `signal` are cross-major invariants; stdout/stderr help,
+ * usage, and error prose are captured for review but may be re-baselined by the ci-tools owner
+ * during Effect 4 repair with an alignment-register entry.
+ * ANSI control bytes are normalized, so colour/styling changes are not gated by this baseline.
+ */
+const stripAnsi = (output: string) =>
+  output.replace(
+    // eslint-disable-next-line no-control-regex -- CLI contract snapshots intentionally normalize terminal control bytes.
+    /[\u001b\u009b][[\]()#;?]*(?:(?:(?:[a-zA-Z\d]*(?:;[a-zA-Z\d]*)*)?\u0007)|(?:(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~]))/gu,
+    '',
+  )
+
+const normalizeOutput = (output: string) => stripAnsi(output)
+
+const runCli = (...args: ReadonlyArray<string>) => {
+  const result = spawnSync('bun', [cliPath, ...args], {
+    encoding: 'utf8',
+    env: { ...process.env, NO_COLOR: '1' },
+  })
+
+  return {
+    status: result.status,
+    signal: result.signal,
+    stdout: normalizeOutput(result.stdout),
+    stderr: normalizeOutput(result.stderr),
+  }
+}
+
+describe('ci-tools CLI contract baselines (status/signal invariant, prose owner-rebaselinable)', () => {
+  it.each([
+    ['root help', ['--help']],
+    ['workflow-report help', ['workflow-report', '--help']],
+    ['version', ['--version']],
+    ['missing required bundle id', ['workflow-report', 'collect-bundle']],
+    [
+      'invalid deploy mode',
+      ['deploy', 'netlify', '--target', 'web', '--artifact-dir', '/tmp', '--mode', 'nope'],
+    ],
+  ] as const)('%s', (_name, args) => {
+    expect(runCli(...args)).toMatchSnapshot()
+  })
+})

--- a/packages/@overeng/ci-tools/src/cli.contract.test.ts
+++ b/packages/@overeng/ci-tools/src/cli.contract.test.ts
@@ -11,6 +11,7 @@ const cliPath = fileURLToPath(new URL('../bin/ci-tools.ts', import.meta.url))
  * during Effect 4 repair with an alignment-register entry.
  * ANSI control bytes are normalized, so colour/styling changes are not gated by this baseline.
  */
+// LIVE-MIGRATION BRIDGE effect-3-4 — DELETE at contraction — https://github.com/overengineeringstudio/effect-utils/issues/925
 const stripAnsi = (output: string) =>
   output.replace(
     // eslint-disable-next-line no-control-regex -- CLI contract snapshots intentionally normalize terminal control bytes.
@@ -19,6 +20,7 @@ const stripAnsi = (output: string) =>
   )
 
 const normalizeOutput = (output: string) => stripAnsi(output)
+// LIVE-MIGRATION END effect-3-4
 
 const runCli = (...args: ReadonlyArray<string>) => {
   const result = spawnSync('bun', [cliPath, ...args], {
@@ -29,8 +31,10 @@ const runCli = (...args: ReadonlyArray<string>) => {
   return {
     status: result.status,
     signal: result.signal,
+    // LIVE-MIGRATION BRIDGE effect-3-4 — DELETE at contraction — https://github.com/overengineeringstudio/effect-utils/issues/925
     stdout: normalizeOutput(result.stdout),
     stderr: normalizeOutput(result.stderr),
+    // LIVE-MIGRATION END effect-3-4
   }
 }
 


### PR DESCRIPTION
## Problem

Phase 1 needs Effect 3 CLI contract baselines for ci-tools before the Effect 4 cohort flip. Exit status and signal are class-1 invariants for CI behavior.

## Goal

Pin status, signal, stdout, and stderr for representative ci-tools CLI paths.

## Decisions

- Adds ordinary additive Vitest coverage in `packages/@overeng/ci-tools/src/cli.contract.test.ts`.
- Spawns the real `ci-tools` Bun entrypoint with `NO_COLOR=1`.
- Captures root help, workflow-report subcommand help, version, missing required arguments, and invalid deploy mode.
- Stores `status`, `signal`, `stdout`, and `stderr` separately in file snapshots.
- Normalizes ANSI control bytes because the current Effect CLI renderer emits them even with `NO_COLOR=1`.
- No runtime behavior changes and no changelog entry; this is a baseline-only Phase 1 capture.

## Finding

Effect CLI v3 emits ANSI control bytes in help output even with `NO_COLOR=1`; this baseline strips ANSI deliberately so color/styling is not gated. If Effect 4 starts respecting `NO_COLOR`, that output diff should be reviewed as formatting/prose churn rather than a status/signal invariant.

## Verification

- `CI=1 ./node_modules/.bin/vitest run src/cli.contract.test.ts`
- `DEVENV_TASK_PASSTHROUGH=1 tsgo --build tsconfig.check.json --pretty false`
- `oxfmt --check packages/@overeng/ci-tools/src/cli.contract.test.ts packages/@overeng/ci-tools/src/__snapshots__/cli.contract.test.ts.snap`
- `oxlint packages/@overeng/ci-tools/src/cli.contract.test.ts`
- `git diff --check`
- `CI=1 devenv tasks run check:quick --no-tui`

## Complexity

No added runtime complexity; additive tests only.

## Concerns

Help and error prose are captured for review but may be rebaselined by the ci-tools owner during Effect 4 repair with an alignment-register entry. Status and signal should not drift silently.

Refs #925

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | co1-glen |
| `agent_session_id` | 09eb82be-a136-4c97-a5f3-14716c8cbe3c |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.145.0 |
| `agent_runtime` | Codex CLI 0.145.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/g70zaf7b08m8pmn4iqxy3a70a2833y23-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/997m3kakbn5dnr72qix3xmfx4pmd6qxd-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-28-2026-07-28-baselines-2-ci-tools-cli-contract |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->