### PR TITLE
test: wire missing package test tasks

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -186,128 +186,73 @@ let
     "context/effect/socket"
   ];
 
-  # Packages that have vitest tests (subset of allPackages)
-  # Each package uses its own vitest from node_modules (self-contained)
-  packagesWithTests = [
-    {
-      path = "packages/@overeng/agent-session-ingest";
-      name = "agent-session-ingest";
-    }
-    {
-      path = "packages/@overeng/content-address";
-      name = "content-address";
-    }
-    {
-      path = "packages/@overeng/effect-ai-claude-cli";
-      name = "effect-ai-claude-cli";
-    }
-    {
-      path = "packages/@overeng/effect-distributed-lock";
-      name = "effect-distributed-lock";
-    }
-    {
-      path = "packages/@overeng/effect-path";
-      name = "effect-path";
-    }
-    {
-      path = "packages/@overeng/effect-rpc-tanstack";
-      name = "effect-rpc-tanstack";
-    }
-    {
-      path = "packages/@overeng/effect-schema-form";
-      name = "effect-schema-form";
-    }
-    {
-      path = "packages/@overeng/effect-schema-form-aria";
-      name = "effect-schema-form-aria";
-    }
-    {
-      path = "packages/@overeng/genie";
-      name = "genie";
-    }
-    {
-      path = "packages/@overeng/kdl";
-      name = "kdl";
-    }
-    {
-      path = "packages/@overeng/kdl-effect";
-      name = "kdl-effect";
-    }
-    {
-      path = "packages/@overeng/megarepo";
-      name = "megarepo";
+  packageTestQuarantine = { };
+  validatedPackageTestQuarantine = lib.mapAttrs (
+    name: quarantine:
+    if quarantine ? reason && quarantine ? issue then
+      quarantine
+    else
+      throw "packageTestQuarantine.${name} must include reason and issue"
+  ) packageTestQuarantine;
+  packageTestOverrides = {
+    megarepo = {
       vitestArgs = "--exclude src/cli/store-gc-cold.integration.test.ts";
-    }
-    {
-      path = "packages/@overeng/notion-cli";
-      name = "notion-cli";
-    }
-    {
-      path = "packages/@overeng/notion-datasource-sync";
-      name = "notion-datasource-sync";
-    }
-    {
-      path = "packages/@overeng/notion-effect-client";
-      name = "notion-effect-client";
-    }
-    {
-      path = "packages/@overeng/notion-effect-schema";
-      name = "notion-effect-schema";
-    }
-    {
-      path = "packages/@overeng/notion-md";
-      name = "notion-md";
-    }
-    {
-      path = "packages/@overeng/notion-property-write";
-      name = "notion-property-write";
-    }
-    {
-      path = "packages/@overeng/notion-react";
-      name = "notion-react";
-    }
-    {
-      path = "packages/@overeng/npm-release";
-      name = "npm-release";
-    }
-    {
-      path = "packages/@overeng/oxc-config";
-      name = "oxc-config";
-    }
-    {
-      path = "packages/@overeng/pty-effect";
-      name = "pty-effect";
+    };
+    pty-effect = {
       after = [ "pnpm:link-native-node-packages" ];
-    }
-    {
-      path = "packages/@overeng/restate-effect";
-      name = "restate-effect";
-    }
-    {
-      path = "packages/@overeng/tui-core";
-      name = "tui-core";
-    }
-    {
-      path = "packages/@overeng/tui-react";
-      name = "tui-react";
-    }
-    {
-      path = "packages/@overeng/tui-stories";
-      name = "tui-stories";
-    }
-    {
-      path = "packages/@overeng/utils";
-      name = "utils";
-    }
-    {
-      path = "packages/@overeng/utils-dev";
-      name = "utils-dev";
-    }
-    {
-      path = "packages/@overeng/ci-tools";
-      name = "ci-tools";
-    }
-  ];
+    };
+  };
+  packagesRoot = ./. + "/packages/@overeng";
+  hasTestFiles =
+    root:
+    let
+      scan =
+        dir:
+        if builtins.pathExists dir then
+          let
+            entries = builtins.readDir dir;
+            names = builtins.attrNames entries;
+          in
+          builtins.any (
+            name:
+            let
+              entryType = entries.${name};
+              child = dir + "/${name}";
+            in
+            if entryType == "regular" then
+              builtins.match ".*\\.test\\.tsx?" name != null
+            else if entryType == "directory" then
+              scan child
+            else
+              false
+          ) names
+        else
+          false;
+    in
+    scan (root + "/src") || scan (root + "/test");
+  # Packages that have Vitest tests are discovered from the filesystem. If a
+  # package with tests is excluded, it must be visible debt in packageTestQuarantine.
+  packagesWithTests =
+    let
+      packageNames = builtins.filter (
+        name:
+        let
+          root = packagesRoot + "/${name}";
+        in
+        (builtins.readDir packagesRoot).${name} == "directory"
+        && builtins.pathExists (root + "/package.json")
+        && hasTestFiles root
+        && !(builtins.hasAttr name validatedPackageTestQuarantine)
+      ) (builtins.attrNames (builtins.readDir packagesRoot));
+    in
+    map (
+      name:
+      {
+        path = "packages/@overeng/${name}";
+        inherit name;
+      }
+      // (packageTestOverrides.${name} or { })
+    ) packageNames;
 
   # Packages that have storybook (subset of allPackages)
   packagesWithStorybook = [

--- a/devenv.nix
+++ b/devenv.nix
@@ -190,6 +190,10 @@ let
   # Each package uses its own vitest from node_modules (self-contained)
   packagesWithTests = [
     {
+      path = "packages/@overeng/agent-session-ingest";
+      name = "agent-session-ingest";
+    }
+    {
       path = "packages/@overeng/content-address";
       name = "content-address";
     }
@@ -208,6 +212,14 @@ let
     {
       path = "packages/@overeng/effect-rpc-tanstack";
       name = "effect-rpc-tanstack";
+    }
+    {
+      path = "packages/@overeng/effect-schema-form";
+      name = "effect-schema-form";
+    }
+    {
+      path = "packages/@overeng/effect-schema-form-aria";
+      name = "effect-schema-form-aria";
     }
     {
       path = "packages/@overeng/genie";
@@ -254,7 +266,10 @@ let
       path = "packages/@overeng/notion-react";
       name = "notion-react";
     }
-
+    {
+      path = "packages/@overeng/npm-release";
+      name = "npm-release";
+    }
     {
       path = "packages/@overeng/oxc-config";
       name = "oxc-config";

--- a/packages/@overeng/effect-react/test/external-store.test.tsx
+++ b/packages/@overeng/effect-react/test/external-store.test.tsx
@@ -39,7 +39,7 @@ describe('makeSubscriptionRefStore', () => {
     await Effect.runPromise(Effect.yieldNow())
 
     expect(store.getSnapshot()).toBe(2)
-    expect(notifications).toEqual([2])
+    expect(notifications).toEqual([1, 2])
 
     unsubscribe()
   })


### PR DESCRIPTION
**Problem**

The package test graph used a hand-maintained list, so packages with tests could silently be absent from CI. The audit found six uncollected packages; four were pre-existing gaps unrelated to the Effect 4 migration: `effect-react`, `notion-core`, `otel-contract`, and `react-inspector`.

**Goal**

Make package test task wiring derive from the package tree so “has tests” means “has a test task”, and make any future exclusion explicit debt instead of silent absence.

**Decisions**

- Replace the hand-maintained `packagesWithTests` list with Nix-time discovery under `packages/@overeng`.
- Detect `*.test.ts` / `*.test.tsx` under package `src/` and `test/` trees.
- Preserve existing task overrides for `megarepo` and `pty-effect`.
- Add a fail-closed `packageTestQuarantine` shape: a future exclusion must include both `reason` and `issue` inline or Nix evaluation fails.
- Do not quarantine `otel-contract`; the managed task passes and direct Vitest was a false failure because it lacked the task environment.
- Do not quarantine `effect-react`; fixed the stale assertion in `test/external-store.test.tsx` from `[2]` to `[1, 2]`, matching `SubscriptionRef` delivery of the current value plus later changes.

**Verification**

- PASS: `devenv tasks list --no-tui` shows discovered tasks for the audited packages including `test:effect-react`, `test:notion-core`, `test:otel-contract`, and `test:react-inspector`.
- PASS: forced managed package task sweep, sequentially running each discovered `test:<package>` with `CI=1 devenv tasks run test:<package> --mode single --refresh-task-cache --show-output --no-tui`.
- PASS: `CI=1 devenv tasks run check:quick --no-tui`.
- PASS: `git diff --check`.
- NOTE: `bun context/effect-4/check-baseline-migration-markers.ts` could not be run on this branch because that path is absent after `git fetch --all --prune`; `git ls-tree -r origin/main --name-only` also does not contain it.

Managed-package task count evidence:

| package | count |
| --- | --- |
| `agent-session-ingest` | 6 files, 41 tests |
| `ci-tools` | 8 files, 50 tests (2 skipped) |
| `content-address` | 1 file, 17 tests |
| `effect-ai-claude-cli` | 1 file, 24 tests |
| `effect-distributed-lock` | 1 file, 1 test |
| `effect-path` | 1 file, 69 tests |
| `effect-react` | 1 file, 2 tests |
| `effect-rpc-tanstack` | 2 files, 3 tests |
| `genie` | 27 files, 383 tests |
| `kdl` | 1 file, 336 tests (4 skipped) |
| `kdl-effect` | 1 file, 15 tests |
| `megarepo` | 34 files, 612 tests |
| `notion-cli` | 7 files, 56 tests |
| `notion-core` | 6 files, 50 tests |
| `notion-datasource-sync` | 38 files, 643 tests (15 skipped) |
| `notion-effect-client` | 16 files, 180 tests |
| `notion-effect-schema` | 6 files, 249 tests |
| `notion-md` | 27 files, 368 tests |
| `notion-property-write` | 3 files, 38 tests |
| `notion-react` | 23 files, 319 tests (1 skipped) |
| `npm-release` | 1 file, 9 tests |
| `otel-contract` | 8 files, 126 tests (2 skipped) |
| `oxc-config` | 16 files, 323 tests |
| `pty-effect` | 3 files, 28 tests |
| `react-inspector` | 6 files, 35 tests |
| `restate-effect` | 35 files, 171 tests |
| `tui-core` | 1 file, 7 tests |
| `tui-react` | 21 files, 228 tests |
| `tui-stories` | 4 files, 28 tests |
| `utils` | 16 files, 146 tests |
| `utils-dev` | 6 files, 31 tests |

**Complexity**

Moderate Nix eval-time discovery replaces a stale manual list. The tradeoff is intentional: package-test omissions now require an explicit quarantine entry instead of being invisible.

**Concerns**

The count extraction needed package-environment runs because raw direct Vitest is not equivalent to the managed task environment for packages such as `genie` and `otel-contract`.

**Friction & bottlenecks**

Initial verification attempts stalled while the machine was oversubscribed. Once the load cleared, the managed package tasks passed. Direct Vitest produced false failures for environment-sensitive packages, so the managed task is the authority.

**Follow-ups**

None for this wiring slice.

**References**

Refs #925, #987, #989, #990, #1010.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | co1-vale |
| `agent_session_id` | cbf1cd38-f24b-48eb-9639-30b032e7336c |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.145.0 |
| `agent_runtime` | Codex CLI 0.145.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/i8y8b542cyqi385ywcjw5fvsq24f75v4-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/i81qxhzlrzcxrrdwpp6i8hagka2gby8y-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-28-thincov-test-wiring |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->