### PR TITLE
test(megarepo): capture CLI contract baselines

### DIFF
--- a/packages/@overeng/megarepo/src/__snapshots__/cli.contract.test.ts.snap
+++ b/packages/@overeng/megarepo/src/__snapshots__/cli.contract.test.ts.snap
@@ -1,0 +1,248 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`megarepo CLI contract baselines (status/signal invariant, prose owner-rebaselinable) > invalid shell 1`] = `
+{
+  "signal": null,
+  "status": 1,
+  "stderr": "Expected one of the following cases: bash, zsh, fish
+
+Error: {"_tag":"InvalidValue","error":{"_tag":"Paragraph","value":{"_tag":"Text","value":"Expected one of the following cases: bash, zsh, fish"}}}
+",
+  "stdout": "",
+}
+`;
+
+exports[`megarepo CLI contract baselines (status/signal invariant, prose owner-rebaselinable) > missing required repo 1`] = `
+{
+  "signal": null,
+  "status": 1,
+  "stderr": "Missing argument <repo>
+
+Error: {"_tag":"MissingValue","error":{"_tag":"Paragraph","value":{"_tag":"Text","value":"Missing argument <repo>"}}}
+",
+  "stdout": "",
+}
+`;
+
+exports[`megarepo CLI contract baselines (status/signal invariant, prose owner-rebaselinable) > root help 1`] = `
+{
+  "signal": null,
+  "status": 0,
+  "stderr": "",
+  "stdout": "mr
+
+mr 0.1.0
+
+USAGE
+
+$ mr [--cwd text]
+
+DESCRIPTION
+
+Multi-repo workspace management tool
+
+OPTIONS
+
+--cwd text
+
+  A user-defined piece of text.
+
+  Override the working directory
+
+  This setting is optional.
+
+--completions sh | bash | fish | zsh
+
+  One of the following: sh, bash, fish, zsh
+
+  Generate a completion script for a specific shell.
+
+  This setting is optional.
+
+--log-level all | trace | debug | info | warning | error | fatal | none
+
+  One of the following: all, trace, debug, info, warning, error, fatal, none
+
+  Sets the minimum log level for a command.
+
+  This setting is optional.
+
+(-h, --help)
+
+  A true or false value.
+
+  Show the help documentation for a command.
+
+  This setting is optional.
+
+--wizard
+
+  A true or false value.
+
+  Start wizard mode for a command.
+
+  This setting is optional.
+
+--version
+
+  A true or false value.
+
+  Show the version of the application.
+
+  This setting is optional.
+
+COMMANDS
+
+  - init [(-o, --output auto | tty | alt-screen | ci | ci-plain | log | json | ndjson)]                                                                                                                                                                                                                                                Initialize a new megarepo in the current directory
+
+  - root [(-o, --output auto | tty | alt-screen | ci | ci-plain | log | json | ndjson)]                                                                                                                                                                                                                                                Print the megarepo root directory
+
+  - env [--shell bash | zsh | fish] [(-o, --output auto | tty | alt-screen | ci | ci-plain | log | json | ndjson)]                                                                                                                                                                                                                     Output environment variables for shell integration
+
+  - status [(-o, --output auto | tty | alt-screen | ci | ci-plain | log | json | ndjson)] [--all]                                                                                                                                                                                                                                      Show workspace status and member states
+
+  - ls [(-o, --output auto | tty | alt-screen | ci | ci-plain | log | json | ndjson)] [--all]                                                                                                                                                                                                                                          List all members in the megarepo
+
+  - check [--all] [--json]                                                                                                                                                                                                                                                                                                             Check that the megarepo is structurally valid
+
+  - fetch [(-o, --output auto | tty | alt-screen | ci | ci-plain | log | json | ndjson)] [--dry-run] [(-f, --force)] [--all] [--only text] [--skip text] [--git-protocol ssh | https | auto] [--worktree-mode commit | tracking | auto] [--lock-sync auto | off | direct | recursive] [(-v, --verbose)] [--apply] [--create-branches]  Remote → Lock: fetch upstream refs, resolve commits, write lock. Use --apply to also materialize workspace.
+
+  - apply [(-o, --output auto | tty | alt-screen | ci | ci-plain | log | json | ndjson)] [--dry-run] [(-f, --force)] [--all] [--only text] [--skip text] [--git-protocol ssh | https | auto] [--worktree-mode commit | tracking | auto] [--lock-sync auto | off | direct | recursive] [(-v, --verbose)]                                Lock → Workspace: create worktrees from lock, symlink, nix lock sync, generators. Never writes lock.
+
+  - lock [(-o, --output auto | tty | alt-screen | ci | ci-plain | log | json | ndjson)] [--dry-run] [(-f, --force)] [--all] [--only text] [--skip text] [--git-protocol ssh | https | auto] [(-v, --verbose)]                                                                                                                          Workspace → Lock: record current worktree HEAD commits into megarepo.lock.
+
+  - add [(-n, --name text)] [(-s, --sync)] [(-o, --output auto | tty | alt-screen | ci | ci-plain | log | json | ndjson)] <repo>                                                                                                                                                                                                       Add a new member repository
+
+  - config                                                                                                                                                                                                                                                                                                                             Configuration operations: push refs, pin/unpin members
+
+  - config push-refs [(-o, --output auto | tty | alt-screen | ci | ci-plain | log | json | ndjson)] [--dry-run] [--all] [--only text]                                                                                                                                                                                                  Propagate member refs from this megarepo to nested megarepo configs
+
+  - config pin [(-c, --checkout text)] [--dry-run] [(-o, --output auto | tty | alt-screen | ci | ci-plain | log | json | ndjson)] <member>                                                                                                                                                                                             Pin a member to a specific ref
+
+  - config unpin [(-o, --output auto | tty | alt-screen | ci | ci-plain | log | json | ndjson)] <member>                                                                                                                                                                                                                               Unpin a member to allow updates
+
+  - exec [(-o, --output auto | tty | alt-screen | ci | ci-plain | log | json | ndjson)] [(-m, --member text)] [--mode parallel | sequential] [(-v, --verbose)] <command>                                                                                                                                                               Execute a command in member directories
+
+  - store                                                                                                                                                                                                                                                                                                                              Manage the shared git store
+
+  - store add [(-o, --output auto | tty | alt-screen | ci | ci-plain | log | json | ndjson)] <source>                                                                                                                                                                                                                                  Add a repository to the store (without adding to megarepo)
+
+  - store ls [(-o, --output auto | tty | alt-screen | ci | ci-plain | log | json | ndjson)]                                                                                                                                                                                                                                            List repositories in the store
+
+  - store status [(-o, --output auto | tty | alt-screen | ci | ci-plain | log | json | ndjson)]                                                                                                                                                                                                                                        Show store status and detect issues
+
+  - store fetch [(-o, --output auto | tty | alt-screen | ci | ci-plain | log | json | ndjson)]                                                                                                                                                                                                                                         Fetch all repositories in the store
+
+  - store gc [(-o, --output auto | tty | alt-screen | ci | ci-plain | log | json | ndjson)] [--dry-run] [(-f, --force)] [--all]                                                                                                                                                                                                        Garbage collect unused worktrees
+
+  - store fix [(-o, --output auto | tty | alt-screen | ci | ci-plain | log | json | ndjson)] [--dry-run] [<member>]                                                                                                                                                                                                                    Fix store issues
+
+  - store worktree                                                                                                                                                                                                                                                                                                                     Manage worktrees in the store
+
+  - store store worktree new [--ref text] [--base text] [--commit text] [--porcelain] [(-o, --output auto | tty | alt-screen | ci | ci-plain | log | json | ndjson)] <repo>                                                                                                                                                            Create a new worktree in the store
+
+  - generate                                                                                                                                                                                                                                                                                                                           Generate configuration files
+
+  - generate all [(-o, --output auto | tty | alt-screen | ci | ci-plain | log | json | ndjson)]                                                                                                                                                                                                                                        Generate all configured outputs
+
+  - generate schema [(-o, --output auto | tty | alt-screen | ci | ci-plain | log | json | ndjson)] [(-p, --output-path text)]                                                                                                                                                                                                          Generate JSON schema for megarepo.json
+
+  - generate vscode [(-o, --output auto | tty | alt-screen | ci | ci-plain | log | json | ndjson)] [--exclude text]                                                                                                                                                                                                                    Generate VS Code workspace file
+
+  - deps [(-o, --output auto | tty | alt-screen | ci | ci-plain | log | json | ndjson)]                                                                                                                                                                                                                                                Show the Nix input dependency graph between megarepo members.
+
+",
+}
+`;
+
+exports[`megarepo CLI contract baselines (status/signal invariant, prose owner-rebaselinable) > store help 1`] = `
+{
+  "signal": null,
+  "status": 0,
+  "stderr": "",
+  "stdout": "mr
+
+mr 0.1.0
+
+USAGE
+
+$ store
+
+DESCRIPTION
+
+Manage the shared git store
+
+OPTIONS
+
+--completions sh | bash | fish | zsh
+
+  One of the following: sh, bash, fish, zsh
+
+  Generate a completion script for a specific shell.
+
+  This setting is optional.
+
+--log-level all | trace | debug | info | warning | error | fatal | none
+
+  One of the following: all, trace, debug, info, warning, error, fatal, none
+
+  Sets the minimum log level for a command.
+
+  This setting is optional.
+
+(-h, --help)
+
+  A true or false value.
+
+  Show the help documentation for a command.
+
+  This setting is optional.
+
+--wizard
+
+  A true or false value.
+
+  Start wizard mode for a command.
+
+  This setting is optional.
+
+--version
+
+  A true or false value.
+
+  Show the version of the application.
+
+  This setting is optional.
+
+COMMANDS
+
+  - add [(-o, --output auto | tty | alt-screen | ci | ci-plain | log | json | ndjson)] <source>                                                                  Add a repository to the store (without adding to megarepo)
+
+  - ls [(-o, --output auto | tty | alt-screen | ci | ci-plain | log | json | ndjson)]                                                                            List repositories in the store
+
+  - status [(-o, --output auto | tty | alt-screen | ci | ci-plain | log | json | ndjson)]                                                                        Show store status and detect issues
+
+  - fetch [(-o, --output auto | tty | alt-screen | ci | ci-plain | log | json | ndjson)]                                                                         Fetch all repositories in the store
+
+  - gc [(-o, --output auto | tty | alt-screen | ci | ci-plain | log | json | ndjson)] [--dry-run] [(-f, --force)] [--all]                                        Garbage collect unused worktrees
+
+  - fix [(-o, --output auto | tty | alt-screen | ci | ci-plain | log | json | ndjson)] [--dry-run] [<member>]                                                    Fix store issues
+
+  - worktree                                                                                                                                                     Manage worktrees in the store
+
+  - worktree new [--ref text] [--base text] [--commit text] [--porcelain] [(-o, --output auto | tty | alt-screen | ci | ci-plain | log | json | ndjson)] <repo>  Create a new worktree in the store
+
+",
+}
+`;
+
+exports[`megarepo CLI contract baselines (status/signal invariant, prose owner-rebaselinable) > version 1`] = `
+{
+  "signal": null,
+  "status": 0,
+  "stderr": "",
+  "stdout": "0.1.0
+
+",
+}
+`;

--- a/packages/@overeng/megarepo/src/cli.contract.test.ts
+++ b/packages/@overeng/megarepo/src/cli.contract.test.ts
@@ -13,6 +13,7 @@ const cliPath = fileURLToPath(new URL('../bin/mr.ts', import.meta.url))
  * The local-source version suffix is normalized, so version-string content is not gated by this
  * baseline.
  */
+// LIVE-MIGRATION BRIDGE effect-3-4 — DELETE at contraction — https://github.com/overengineeringstudio/effect-utils/issues/925
 const stripAnsi = (output: string) =>
   output.replace(
     // eslint-disable-next-line no-control-regex -- CLI contract snapshots intentionally normalize terminal control bytes.
@@ -22,6 +23,7 @@ const stripAnsi = (output: string) =>
 
 const normalizeOutput = (output: string) =>
   stripAnsi(output).replace(/ — running from local source \([^)]+\)/gu, '')
+// LIVE-MIGRATION END effect-3-4
 
 const runCli = (...args: ReadonlyArray<string>) => {
   const result = spawnSync('bun', [cliPath, ...args], {
@@ -32,8 +34,10 @@ const runCli = (...args: ReadonlyArray<string>) => {
   return {
     status: result.status,
     signal: result.signal,
+    // LIVE-MIGRATION BRIDGE effect-3-4 — DELETE at contraction — https://github.com/overengineeringstudio/effect-utils/issues/925
     stdout: normalizeOutput(result.stdout),
     stderr: normalizeOutput(result.stderr),
+    // LIVE-MIGRATION END effect-3-4
   }
 }
 

--- a/packages/@overeng/megarepo/src/cli.contract.test.ts
+++ b/packages/@overeng/megarepo/src/cli.contract.test.ts
@@ -1,0 +1,45 @@
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+const cliPath = fileURLToPath(new URL('../bin/mr.ts', import.meta.url))
+
+/**
+ * CLI contract capture: `status` and `signal` are cross-major invariants; stdout/stderr help,
+ * usage, and error prose are captured for review but may be re-baselined by the megarepo owner
+ * during Effect 4 repair with an alignment-register entry.
+ * ANSI control bytes are normalized, so colour/styling changes are not gated by this baseline.
+ */
+const stripAnsi = (output: string) =>
+  output.replace(
+    // eslint-disable-next-line no-control-regex -- CLI contract snapshots intentionally normalize terminal control bytes.
+    /[\u001b\u009b][[\]()#;?]*(?:(?:(?:[a-zA-Z\d]*(?:;[a-zA-Z\d]*)*)?\u0007)|(?:(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~]))/gu,
+    '',
+  )
+
+const runCli = (...args: ReadonlyArray<string>) => {
+  const result = spawnSync('bun', [cliPath, ...args], {
+    encoding: 'utf8',
+    env: { ...process.env, NO_COLOR: '1' },
+  })
+
+  return {
+    status: result.status,
+    signal: result.signal,
+    stdout: stripAnsi(result.stdout),
+    stderr: stripAnsi(result.stderr),
+  }
+}
+
+describe('megarepo CLI contract baselines (status/signal invariant, prose owner-rebaselinable)', () => {
+  it.each([
+    ['root help', ['--help']],
+    ['store help', ['store', '--help']],
+    ['version', ['--version']],
+    ['missing required repo', ['add']],
+    ['invalid shell', ['env', '--shell', 'nope']],
+  ] as const)('%s', (_name, args) => {
+    expect(runCli(...args)).toMatchSnapshot()
+  })
+})

--- a/packages/@overeng/megarepo/src/cli.contract.test.ts
+++ b/packages/@overeng/megarepo/src/cli.contract.test.ts
@@ -10,6 +10,8 @@ const cliPath = fileURLToPath(new URL('../bin/mr.ts', import.meta.url))
  * usage, and error prose are captured for review but may be re-baselined by the megarepo owner
  * during Effect 4 repair with an alignment-register entry.
  * ANSI control bytes are normalized, so colour/styling changes are not gated by this baseline.
+ * The local-source version suffix is normalized, so version-string content is not gated by this
+ * baseline.
  */
 const stripAnsi = (output: string) =>
   output.replace(
@@ -17,6 +19,9 @@ const stripAnsi = (output: string) =>
     /[\u001b\u009b][[\]()#;?]*(?:(?:(?:[a-zA-Z\d]*(?:;[a-zA-Z\d]*)*)?\u0007)|(?:(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~]))/gu,
     '',
   )
+
+const normalizeOutput = (output: string) =>
+  stripAnsi(output).replace(/ — running from local source \([^)]+\)/gu, '')
 
 const runCli = (...args: ReadonlyArray<string>) => {
   const result = spawnSync('bun', [cliPath, ...args], {
@@ -27,8 +32,8 @@ const runCli = (...args: ReadonlyArray<string>) => {
   return {
     status: result.status,
     signal: result.signal,
-    stdout: stripAnsi(result.stdout),
-    stderr: stripAnsi(result.stderr),
+    stdout: normalizeOutput(result.stdout),
+    stderr: normalizeOutput(result.stderr),
   }
 }
 


### PR DESCRIPTION
## Problem

Phase 1 needs Effect 3 CLI contract baselines for `megarepo` before the Effect 4 cohort flip. Status and signal are class-1 invariants for command behavior, while help/error prose is reviewable and owner-rebaselinable during wave repair.

## Goal

Capture representative `mr` CLI behavior as ordinary additive Vitest coverage on Effect 3.

## Decisions

- Adds `packages/@overeng/megarepo/src/cli.contract.test.ts` plus Vitest snapshots.
- Spawns the real Bun entrypoint at `packages/@overeng/megarepo/bin/mr.ts`.
- Captures root help, `store` subcommand help, version, missing required `add` argument, and invalid `env --shell` value.
- Stores `status`, `signal`, `stdout`, and `stderr` separately in snapshots.
- Normalizes ANSI control bytes, so color/styling is not gated by this baseline.
- Normalizes the local-source version suffix, so version-string content is not gated by this baseline.

## Verification

- PASS: `CI=1 ./node_modules/.bin/vitest run src/cli.contract.test.ts` from `packages/@overeng/megarepo`.
- PASS: `oxfmt --check src/cli.contract.test.ts src/__snapshots__/cli.contract.test.ts.snap` from `packages/@overeng/megarepo`.
- PASS: `oxlint src/cli.contract.test.ts` from `packages/@overeng/megarepo`.
- PASS: `git diff --check`.
- PASS: `CI=1 devenv tasks run check:quick --no-tui`.

## Complexity

No new runtime complexity; additive baseline tests only.

## Concerns

`mr --version` and help output can embed a commit SHA plus relative age when running from local source, so that suffix is inherently not byte-stable. Status and signal remain raw and are not normalized.

## Friction & bottlenecks

An attempted `check:all` exposed the local-source version suffix drift after the first commit: pre-commit snapshots saw plain `0.1.0`, while post-commit package execution saw `0.1.0 — running from local source (<sha>, <age>)`. The baseline now normalizes that volatile suffix and documents the coverage hole.

## Follow-ups

Continue Phase 1 baseline PRs for the remaining CLI packages and durable boundaries.

## References

Refs #925.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | co1-onyx |
| `agent_session_id` | 8b890528-dfe9-42b2-be66-a4647a4cdfd8 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.145.0 |
| `agent_runtime` | Codex CLI 0.145.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/g70zaf7b08m8pmn4iqxy3a70a2833y23-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/997m3kakbn5dnr72qix3xmfx4pmd6qxd-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-28-2026-07-28-baselines-3-megarepo-cli |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->