### PR TITLE
test(notion-cli): capture CLI contract baselines

### DIFF
--- a/packages/@overeng/notion-cli/src/__snapshots__/cli.contract.test.ts.snap
+++ b/packages/@overeng/notion-cli/src/__snapshots__/cli.contract.test.ts.snap
@@ -1,0 +1,241 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`notion-cli CLI contract baselines (status/signal invariant, prose owner-rebaselinable) > db help 1`] = `
+{
+  "signal": null,
+  "status": 0,
+  "stderr": "",
+  "stdout": "notion
+
+notion 0.1.0
+
+USAGE
+
+$ db
+
+DESCRIPTION
+
+Database operations and SQLite replica sync
+
+OPTIONS
+
+--completions sh | bash | fish | zsh
+
+  One of the following: sh, bash, fish, zsh
+
+  Generate a completion script for a specific shell.
+
+  This setting is optional.
+
+--log-level all | trace | debug | info | warning | error | fatal | none
+
+  One of the following: all, trace, debug, info, warning, error, fatal, none
+
+  Sets the minimum log level for a command.
+
+  This setting is optional.
+
+(-h, --help)
+
+  A true or false value.
+
+  Show the help documentation for a command.
+
+  This setting is optional.
+
+--wizard
+
+  A true or false value.
+
+  Start wizard mode for a command.
+
+  This setting is optional.
+
+--version
+
+  A true or false value.
+
+  Show the version of the application.
+
+  This setting is optional.
+
+COMMANDS
+
+  - info [(-t, --token text)] [(-o, --output auto | tty | alt-screen | ci | ci-plain | log | json | ndjson)] <database-id>                                                                                                                                                                                                                     Display information about a Notion database
+
+  - track [--sqlite file] [--root-id text] [--data-source-id text] [--workspace-root directory] [--mode local | remote | shared] [--dry-run] [--limit integer] [--no-materialize-bodies] [<remote-ref>] [<workspace-root>]                                                                                                                     Adopt a Notion data source into a workspace (the adoption verb)
+
+  - sync [--sqlite file] [--root-id text] [--data-source-id text] [--workspace-root directory] [--dry-run] [--watch] [--state file] [--max-cycles integer] [--watch-priority development | normal | low-priority] [--webhook none | tailscale | manual] [--webhook-required] [--non-interactive] [--no-materialize-bodies] [<workspace-root>]  Reconcile an established workspace, or run the watch daemon with --watch
+
+  - export [--sqlite file] [--root-id text] [--data-source-id text] [--workspace-root directory] [--output file] [--refresh] [--format ndjson | json] [--require-clean] [--dry-run] [--no-materialize-bodies] [<workspace-root>]                                                                                                               Export rows, schema, and sync metadata from SQLite
+
+  - status [--sqlite file] [--root-id text] [--data-source-id text] [--workspace-root directory] [<workspace-root>]                                                                                                                                                                                                                            Print workspace sync status
+
+  - conflicts                                                                                                                                                                                                                                                                                                                                  Inspect and resolve SQLite sync conflicts
+
+  - conflicts list [--sqlite file] [--root-id text] [--data-source-id text] [--workspace-root directory]                                                                                                                                                                                                                                       List unresolved conflicts
+
+  - conflicts resolve [--sqlite file] [--root-id text] [--data-source-id text] [--workspace-root directory] [--conflict-id text] [--strategy keep-remote | keep-local | manual] [--value-json text] [--dry-run]                                                                                                                                Resolve a conflict
+
+  - forget [--sqlite file] [--root-id text] [--data-source-id text] [--workspace-root directory] [--page-id text] [--dry-run]                                                                                                                                                                                                                  Archive or forget a page locally
+
+  - restore [--sqlite file] [--root-id text] [--data-source-id text] [--workspace-root directory] [--page-id text] [--dry-run]                                                                                                                                                                                                                 Restore a forgotten page locally
+
+  - doctor [--sqlite file] [--root-id text] [--data-source-id text] [--workspace-root directory]                                                                                                                                                                                                                                               Print diagnostics
+
+",
+}
+`;
+
+exports[`notion-cli CLI contract baselines (status/signal invariant, prose owner-rebaselinable) > invalid integer 1`] = `
+{
+  "signal": null,
+  "status": 1,
+  "stderr": "'nope' is not a integer
+
+",
+  "stdout": "[time] ERROR (#84):
+  Error: {"_tag":"InvalidValue","error":{"_tag":"Paragraph","value":{"_tag":"Text","value":"'nope' is not a integer"}}}
+",
+}
+`;
+
+exports[`notion-cli CLI contract baselines (status/signal invariant, prose owner-rebaselinable) > missing required database id 1`] = `
+{
+  "signal": null,
+  "status": 1,
+  "stderr": "Missing argument <database-id>
+
+",
+  "stdout": "[time] ERROR (#84):
+  Error: {"_tag":"MissingValue","error":{"_tag":"Paragraph","value":{"_tag":"Text","value":"Missing argument <database-id>"}}}
+",
+}
+`;
+
+exports[`notion-cli CLI contract baselines (status/signal invariant, prose owner-rebaselinable) > root help 1`] = `
+{
+  "signal": null,
+  "status": 0,
+  "stderr": "",
+  "stdout": "notion
+
+notion 0.1.0
+
+USAGE
+
+$ notion
+
+DESCRIPTION
+
+Notion CLI - database operations, schema generation, and markdown sync
+
+OPTIONS
+
+--completions sh | bash | fish | zsh
+
+  One of the following: sh, bash, fish, zsh
+
+  Generate a completion script for a specific shell.
+
+  This setting is optional.
+
+--log-level all | trace | debug | info | warning | error | fatal | none
+
+  One of the following: all, trace, debug, info, warning, error, fatal, none
+
+  Sets the minimum log level for a command.
+
+  This setting is optional.
+
+(-h, --help)
+
+  A true or false value.
+
+  Show the help documentation for a command.
+
+  This setting is optional.
+
+--wizard
+
+  A true or false value.
+
+  Start wizard mode for a command.
+
+  This setting is optional.
+
+--version
+
+  A true or false value.
+
+  Show the version of the application.
+
+  This setting is optional.
+
+COMMANDS
+
+  - edit [--frontmatter] [--read-only] <page>                                                                                                                                                                                                                                                                                                     Edit a Notion page in $EDITOR via an ephemeral .nmd session, then push the change through the sync engine; \`--read-only\` inspects without pushing
+
+  - schema                                                                                                                                                                                                                                                                                                                                        Schema generation commands
+
+  - schema generate (-o, --output file) [(-n, --name text)] [(-t, --token text)] [--transform text] [(-d, --dry-run)] [(-w, --include-write)] [--typed-options] [--schema-meta] [--no-schema-meta] [(-a, --include-api)] [--writable] [--output-mode auto | tty | alt-screen | ci | ci-plain | log | json | ndjson] <database-id>                 Generate Effect schema from a Notion database
+
+  - schema introspect [(-t, --token text)] [(-o, --output auto | tty | alt-screen | ci | ci-plain | log | json | ndjson)] <database-id>                                                                                                                                                                                                           Introspect a Notion database and display its schema
+
+  - schema generate-config [(-c, --config file)] [(-t, --token text)] [(-d, --dry-run)] [--writable] [(-o, --output auto | tty | alt-screen | ci | ci-plain | log | json | ndjson)]                                                                                                                                                               Generate schemas for all databases in a config file
+
+  - schema diff (-f, --file file) [(-t, --token text)] [--exit-code] [(-o, --output auto | tty | alt-screen | ci | ci-plain | log | json | ndjson)] <database-id>                                                                                                                                                                                 Compare a Notion database schema with a generated file to detect drift
+
+  - db                                                                                                                                                                                                                                                                                                                                            Database operations and SQLite replica sync
+
+  - db info [(-t, --token text)] [(-o, --output auto | tty | alt-screen | ci | ci-plain | log | json | ndjson)] <database-id>                                                                                                                                                                                                                     Display information about a Notion database
+
+  - db track [--sqlite file] [--root-id text] [--data-source-id text] [--workspace-root directory] [--mode local | remote | shared] [--dry-run] [--limit integer] [--no-materialize-bodies] [<remote-ref>] [<workspace-root>]                                                                                                                     Adopt a Notion data source into a workspace (the adoption verb)
+
+  - db sync [--sqlite file] [--root-id text] [--data-source-id text] [--workspace-root directory] [--dry-run] [--watch] [--state file] [--max-cycles integer] [--watch-priority development | normal | low-priority] [--webhook none | tailscale | manual] [--webhook-required] [--non-interactive] [--no-materialize-bodies] [<workspace-root>]  Reconcile an established workspace, or run the watch daemon with --watch
+
+  - db export [--sqlite file] [--root-id text] [--data-source-id text] [--workspace-root directory] [--output file] [--refresh] [--format ndjson | json] [--require-clean] [--dry-run] [--no-materialize-bodies] [<workspace-root>]                                                                                                               Export rows, schema, and sync metadata from SQLite
+
+  - db status [--sqlite file] [--root-id text] [--data-source-id text] [--workspace-root directory] [<workspace-root>]                                                                                                                                                                                                                            Print workspace sync status
+
+  - db conflicts                                                                                                                                                                                                                                                                                                                                  Inspect and resolve SQLite sync conflicts
+
+  - db db conflicts list [--sqlite file] [--root-id text] [--data-source-id text] [--workspace-root directory]                                                                                                                                                                                                                                    List unresolved conflicts
+
+  - db db conflicts resolve [--sqlite file] [--root-id text] [--data-source-id text] [--workspace-root directory] [--conflict-id text] [--strategy keep-remote | keep-local | manual] [--value-json text] [--dry-run]                                                                                                                             Resolve a conflict
+
+  - db forget [--sqlite file] [--root-id text] [--data-source-id text] [--workspace-root directory] [--page-id text] [--dry-run]                                                                                                                                                                                                                  Archive or forget a page locally
+
+  - db restore [--sqlite file] [--root-id text] [--data-source-id text] [--workspace-root directory] [--page-id text] [--dry-run]                                                                                                                                                                                                                 Restore a forgotten page locally
+
+  - db doctor [--sqlite file] [--root-id text] [--data-source-id text] [--workspace-root directory]                                                                                                                                                                                                                                               Print diagnostics
+
+  - md                                                                                                                                                                                                                                                                                                                                            Frictionless Notion enhanced Markdown sync, local object GC, and editor surfaces
+
+  - md track [--as text] [--dry-run] <page-id-or-url> [<path>]                                                                                                                                                                                                                                                                                    Track an existing Notion page as a local .nmd file (the only command taking a page id)
+
+  - md status [(-r, --recursive)] [--concurrency integer] [--json] <path>...                                                                                                                                                                                                                                                                      Read-only: report the live in-sync decision per file in git-porcelain words (never mutates)
+
+  - md sync [--watch] [--poll-interval-ms integer] [(-r, --recursive)] [--concurrency integer] [--force] [--allow-delete-unknown-blocks] [--allow-review-markup] [--gc-objects] [--dry-run] [--json] <path>...                                                                                                                                    Reconcile self-describing .nmd files toward in-sync; dispatch per file on frontmatter \`source\`
+
+  - md gc [(-r, --recursive)] [--prune] <path>...                                                                                                                                                                                                                                                                                                 Garbage-collect unreachable .notion-md/objects files (dry-run by default; pass --prune to delete)
+
+  - md cat [--frontmatter] <page>                                                                                                                                                                                                                                                                                                                 Print a Notion page as editor Markdown (\`# title\` + body) with the base hash on stderr; \`--frontmatter\` dumps the full \`.nmd\` envelope
+
+  - md put [--base-hash text] [--force] <page>                                                                                                                                                                                                                                                                                                    Write editor Markdown from stdin (\`# title\` + body) back to a Notion page; guarded by --base-hash, or --force to override concurrency
+
+  - md edit [--frontmatter] [--read-only] <page>                                                                                                                                                                                                                                                                                                  Edit a Notion page in $EDITOR via an ephemeral .nmd session, then push the change through the sync engine; \`--read-only\` inspects without pushing
+
+",
+}
+`;
+
+exports[`notion-cli CLI contract baselines (status/signal invariant, prose owner-rebaselinable) > version 1`] = `
+{
+  "signal": null,
+  "status": 0,
+  "stderr": "",
+  "stdout": "0.1.0
+",
+}
+`;

--- a/packages/@overeng/notion-cli/src/cli.contract.test.ts
+++ b/packages/@overeng/notion-cli/src/cli.contract.test.ts
@@ -1,0 +1,52 @@
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+const cliPath = fileURLToPath(new URL('./cli.ts', import.meta.url))
+
+/**
+ * CLI contract capture: `status` and `signal` are cross-major invariants; stdout/stderr help,
+ * usage, and error prose are captured for review but may be re-baselined by the notion-cli owner
+ * during Effect 4 repair with an alignment-register entry.
+ * ANSI control bytes are normalized, so colour/styling changes are not gated by this baseline.
+ * The local-source version suffix and log timestamps are normalized, so version-string content and
+ * log timing are not gated by this baseline.
+ */
+const stripAnsi = (output: string) =>
+  output.replace(
+    // eslint-disable-next-line no-control-regex -- CLI contract snapshots intentionally normalize terminal control bytes.
+    /[\u001b\u009b][[\]()#;?]*(?:(?:(?:[a-zA-Z\d]*(?:;[a-zA-Z\d]*)*)?\u0007)|(?:(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~]))/gu,
+    '',
+  )
+
+const normalizeOutput = (output: string) =>
+  stripAnsi(output)
+    .replace(/ — running from local source \([^)]+\)/gu, '')
+    .replace(/^\[\d{2}:\d{2}:\d{2}\.\d{3}\]/gmu, '[time]')
+
+const runCli = (...args: ReadonlyArray<string>) => {
+  const result = spawnSync('bun', [cliPath, ...args], {
+    encoding: 'utf8',
+    env: { ...process.env, NO_COLOR: '1' },
+  })
+
+  return {
+    status: result.status,
+    signal: result.signal,
+    stdout: normalizeOutput(result.stdout),
+    stderr: normalizeOutput(result.stderr),
+  }
+}
+
+describe('notion-cli CLI contract baselines (status/signal invariant, prose owner-rebaselinable)', () => {
+  it.each([
+    ['root help', ['--help']],
+    ['db help', ['db', '--help']],
+    ['version', ['--version']],
+    ['missing required database id', ['db', 'info']],
+    ['invalid integer', ['md', 'status', '--concurrency', 'nope', 'page.nmd']],
+  ] as const)('%s', (_name, args) => {
+    expect(runCli(...args)).toMatchSnapshot()
+  })
+})

--- a/packages/@overeng/notion-cli/src/cli.contract.test.ts
+++ b/packages/@overeng/notion-cli/src/cli.contract.test.ts
@@ -13,6 +13,7 @@ const cliPath = fileURLToPath(new URL('./cli.ts', import.meta.url))
  * The local-source version suffix and log timestamps are normalized, so version-string content and
  * log timing are not gated by this baseline.
  */
+// LIVE-MIGRATION BRIDGE effect-3-4 — DELETE at contraction — https://github.com/overengineeringstudio/effect-utils/issues/925
 const stripAnsi = (output: string) =>
   output.replace(
     // eslint-disable-next-line no-control-regex -- CLI contract snapshots intentionally normalize terminal control bytes.
@@ -24,6 +25,7 @@ const normalizeOutput = (output: string) =>
   stripAnsi(output)
     .replace(/ — running from local source \([^)]+\)/gu, '')
     .replace(/^\[\d{2}:\d{2}:\d{2}\.\d{3}\]/gmu, '[time]')
+// LIVE-MIGRATION END effect-3-4
 
 const runCli = (...args: ReadonlyArray<string>) => {
   const result = spawnSync('bun', [cliPath, ...args], {
@@ -34,8 +36,10 @@ const runCli = (...args: ReadonlyArray<string>) => {
   return {
     status: result.status,
     signal: result.signal,
+    // LIVE-MIGRATION BRIDGE effect-3-4 — DELETE at contraction — https://github.com/overengineeringstudio/effect-utils/issues/925
     stdout: normalizeOutput(result.stdout),
     stderr: normalizeOutput(result.stderr),
+    // LIVE-MIGRATION END effect-3-4
   }
 }
 


### PR DESCRIPTION
## Problem

Phase 1 needs Effect 3 CLI contract baselines for `notion-cli` before the Effect 4 cohort flip. Status and signal are class-1 invariants; help/error prose is captured for review and owner-approved rebaselining during wave repair.

## Goal

Capture representative `notion` CLI behavior as ordinary additive Vitest coverage on Effect 3.

## Decisions

- Adds `packages/@overeng/notion-cli/src/cli.contract.test.ts` plus Vitest snapshots.
- Spawns the real Bun entrypoint at `packages/@overeng/notion-cli/src/cli.ts`.
- Captures root help, `db` subcommand help, version, missing `db info` database id, and invalid `md status --concurrency` value.
- Stores `status`, `signal`, `stdout`, and `stderr` separately in snapshots.
- Normalizes ANSI control bytes, so color/styling is not gated by this baseline.
- Normalizes local-source version suffixes and log timestamps, so version-string content and log timing are not gated by this baseline.

## Verification

- PASS: `CI=1 ./node_modules/.bin/vitest run src/cli.contract.test.ts` from `packages/@overeng/notion-cli`.
- PASS: `oxfmt --check packages/@overeng/notion-cli/src/cli.contract.test.ts packages/@overeng/notion-cli/src/__snapshots__/cli.contract.test.ts.snap`.
- PASS: `oxlint packages/@overeng/notion-cli/src/cli.contract.test.ts`.
- PASS: `git diff --check`.
- PASS: `CI=1 devenv tasks run check:quick --no-tui`.

## Complexity

No new runtime complexity; additive baseline tests only.

## Concerns

The error path logs include wall-clock timestamps. Those timestamps are normalized before snapshotting; status and signal remain raw.

## Friction & bottlenecks

None beyond the expected fresh-worktree dependency materialization.

## Follow-ups

Continue Phase 1 baseline PRs for the remaining CLI packages and durable boundaries.

## References

Refs #925.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | co1-onyx |
| `agent_session_id` | 8b890528-dfe9-42b2-be66-a4647a4cdfd8 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.145.0 |
| `agent_runtime` | Codex CLI 0.145.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/g70zaf7b08m8pmn4iqxy3a70a2833y23-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/997m3kakbn5dnr72qix3xmfx4pmd6qxd-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-28-2026-07-28-baselines-3-notion-cli |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->