### PR TITLE
test(genie): capture CLI contract baselines

### DIFF
--- a/packages/@overeng/genie/src/__snapshots__/cli.contract.test.ts.snap
+++ b/packages/@overeng/genie/src/__snapshots__/cli.contract.test.ts.snap
@@ -1,0 +1,177 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`genie CLI contract baselines (status/signal invariant, prose owner-rebaselinable) > invalid phase 1`] = `
+{
+  "signal": null,
+  "status": 1,
+  "stderr": "Expected one of the following cases: bootstrap, design-time
+
+Error: {"_tag":"InvalidValue","error":{"_tag":"Paragraph","value":{"_tag":"Text","value":"Expected one of the following cases: bootstrap, design-time"}}}
+",
+  "stdout": "",
+}
+`;
+
+exports[`genie CLI contract baselines (status/signal invariant, prose owner-rebaselinable) > missing option value 1`] = `
+{
+  "signal": null,
+  "status": 1,
+  "stderr": "Received unknown argument: '--cwd'
+
+Error: {"_tag":"InvalidValue","error":{"_tag":"Paragraph","value":{"_tag":"Text","value":"Received unknown argument: '--cwd'"}}}
+",
+  "stdout": "",
+}
+`;
+
+exports[`genie CLI contract baselines (status/signal invariant, prose owner-rebaselinable) > root help 1`] = `
+{
+  "signal": null,
+  "status": 0,
+  "stderr": "",
+  "stdout": "genie
+
+genie 0.1.0
+
+USAGE
+
+$ genie [--cwd text] [--watch] [--writeable] [--check] [--dry-run] [--defer-validation] [--phase bootstrap | design-time] [--oxfmt-config file] [(-o, --output auto | tty | alt-screen | ci | ci-plain | log | json | ndjson)]
+
+OPTIONS
+
+--cwd text
+
+  A user-defined piece of text.
+
+  Working directory to search for .genie.ts files
+
+  This setting is optional.
+
+--watch
+
+  A true or false value.
+
+  Watch for changes and regenerate automatically
+
+  This setting is optional.
+
+  This setting is optional.
+
+--writeable
+
+  A true or false value.
+
+  Generate files as writable (default: read-only)
+
+  This setting is optional.
+
+  This setting is optional.
+
+--check
+
+  A true or false value.
+
+  Check if generated files are up to date (for CI)
+
+  This setting is optional.
+
+  This setting is optional.
+
+--dry-run
+
+  A true or false value.
+
+  Preview changes without writing files
+
+  This setting is optional.
+
+  This setting is optional.
+
+--defer-validation
+
+  A true or false value.
+
+  Generate projections before a repair step; the caller must finish with genie --check
+
+  This setting is optional.
+
+  This setting is optional.
+
+--phase bootstrap | design-time
+
+  One of the following: bootstrap, design-time
+
+  Only run generators declaring this phase (bootstrap runs before install; default: all phases)
+
+  This setting is optional.
+
+--oxfmt-config file
+
+  A file.
+
+  Path to oxfmt config file (default: .oxfmtrc.json or oxfmt.json)
+
+  This setting is optional.
+
+(-o, --output auto | tty | alt-screen | ci | ci-plain | log | json | ndjson)
+
+  One of the following: auto, tty, alt-screen, ci, ci-plain, log, json, ndjson
+
+  Output mode: auto, tty, alt-screen, ci, ci-plain, log, json, ndjson
+
+  This setting is optional.
+
+--completions sh | bash | fish | zsh
+
+  One of the following: sh, bash, fish, zsh
+
+  Generate a completion script for a specific shell.
+
+  This setting is optional.
+
+--log-level all | trace | debug | info | warning | error | fatal | none
+
+  One of the following: all, trace, debug, info, warning, error, fatal, none
+
+  Sets the minimum log level for a command.
+
+  This setting is optional.
+
+(-h, --help)
+
+  A true or false value.
+
+  Show the help documentation for a command.
+
+  This setting is optional.
+
+--wizard
+
+  A true or false value.
+
+  Start wizard mode for a command.
+
+  This setting is optional.
+
+--version
+
+  A true or false value.
+
+  Show the version of the application.
+
+  This setting is optional.
+
+",
+}
+`;
+
+exports[`genie CLI contract baselines (status/signal invariant, prose owner-rebaselinable) > version 1`] = `
+{
+  "signal": null,
+  "status": 0,
+  "stderr": "",
+  "stdout": "0.1.0
+
+",
+}
+`;

--- a/packages/@overeng/genie/src/cli.contract.test.ts
+++ b/packages/@overeng/genie/src/cli.contract.test.ts
@@ -1,0 +1,51 @@
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+const cliPath = fileURLToPath(new URL('../bin/genie.tsx', import.meta.url))
+
+/**
+ * CLI contract capture: `status` and `signal` are cross-major invariants; stdout/stderr help,
+ * usage, and error prose are captured for review but may be re-baselined by the genie owner during
+ * Effect 4 repair with an alignment-register entry.
+ * ANSI control bytes are normalized, so colour/styling changes are not gated by this baseline.
+ * The local-source version suffix and log timestamps are normalized, so version-string content and
+ * log timing are not gated by this baseline.
+ */
+const stripAnsi = (output: string) =>
+  output.replace(
+    // eslint-disable-next-line no-control-regex -- CLI contract snapshots intentionally normalize terminal control bytes.
+    /[\u001b\u009b][[\]()#;?]*(?:(?:(?:[a-zA-Z\d]*(?:;[a-zA-Z\d]*)*)?\u0007)|(?:(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~]))/gu,
+    '',
+  )
+
+const normalizeOutput = (output: string) =>
+  stripAnsi(output)
+    .replace(/ — running from local source \([^)]+\)/gu, '')
+    .replace(/^\[\d{2}:\d{2}:\d{2}\.\d{3}\]/gmu, '[time]')
+
+const runCli = (...args: ReadonlyArray<string>) => {
+  const result = spawnSync('bun', [cliPath, ...args], {
+    encoding: 'utf8',
+    env: { ...process.env, NO_COLOR: '1' },
+  })
+
+  return {
+    status: result.status,
+    signal: result.signal,
+    stdout: normalizeOutput(result.stdout),
+    stderr: normalizeOutput(result.stderr),
+  }
+}
+
+describe('genie CLI contract baselines (status/signal invariant, prose owner-rebaselinable)', () => {
+  it.each([
+    ['root help', ['--help']],
+    ['version', ['--version']],
+    ['missing option value', ['--cwd']],
+    ['invalid phase', ['--phase', 'nope', '--dry-run']],
+  ] as const)('%s', (_name, args) => {
+    expect(runCli(...args)).toMatchSnapshot()
+  })
+})

--- a/packages/@overeng/genie/src/cli.contract.test.ts
+++ b/packages/@overeng/genie/src/cli.contract.test.ts
@@ -13,6 +13,7 @@ const cliPath = fileURLToPath(new URL('../bin/genie.tsx', import.meta.url))
  * The local-source version suffix and log timestamps are normalized, so version-string content and
  * log timing are not gated by this baseline.
  */
+// LIVE-MIGRATION BRIDGE effect-3-4 — DELETE at contraction — https://github.com/overengineeringstudio/effect-utils/issues/925
 const stripAnsi = (output: string) =>
   output.replace(
     // eslint-disable-next-line no-control-regex -- CLI contract snapshots intentionally normalize terminal control bytes.
@@ -24,6 +25,7 @@ const normalizeOutput = (output: string) =>
   stripAnsi(output)
     .replace(/ — running from local source \([^)]+\)/gu, '')
     .replace(/^\[\d{2}:\d{2}:\d{2}\.\d{3}\]/gmu, '[time]')
+// LIVE-MIGRATION END effect-3-4
 
 const runCli = (...args: ReadonlyArray<string>) => {
   const result = spawnSync('bun', [cliPath, ...args], {
@@ -34,8 +36,10 @@ const runCli = (...args: ReadonlyArray<string>) => {
   return {
     status: result.status,
     signal: result.signal,
+    // LIVE-MIGRATION BRIDGE effect-3-4 — DELETE at contraction — https://github.com/overengineeringstudio/effect-utils/issues/925
     stdout: normalizeOutput(result.stdout),
     stderr: normalizeOutput(result.stderr),
+    // LIVE-MIGRATION END effect-3-4
   }
 }
 


### PR DESCRIPTION
## Problem

Phase 1 needs Effect 3 CLI contract baselines for `genie` before the Effect 4 cohort flip. Status and signal are class-1 invariants; help/error prose is captured for owner-approved rebaselining during wave repair.

## Goal

Capture representative `genie` CLI behavior as ordinary additive Vitest coverage on Effect 3.

## Decisions

- Adds `packages/@overeng/genie/src/cli.contract.test.ts` plus Vitest snapshots.
- Spawns the real Bun entrypoint at `packages/@overeng/genie/bin/genie.tsx`.
- Captures root help, version, missing option value, and invalid `--phase` value.
- Omits subcommand help because the real `genieCommand` exposes no subcommands.
- Stores `status`, `signal`, `stdout`, and `stderr` separately in snapshots.
- Normalizes ANSI control bytes, local-source version suffixes, and log timestamps; those prose details are not gated by this baseline.

## Verification

- PASS: `CI=1 ./node_modules/.bin/vitest run src/cli.contract.test.ts` from `packages/@overeng/genie`.
- PASS: `oxfmt --check packages/@overeng/genie/src/cli.contract.test.ts packages/@overeng/genie/src/__snapshots__/cli.contract.test.ts.snap`.
- PASS: `oxlint packages/@overeng/genie/src/cli.contract.test.ts`.
- PASS: `git diff --check`.
- PASS: `CI=1 devenv tasks run check:quick --no-tui`.

## Complexity

No new runtime complexity; additive baseline tests only.

## Concerns

`genie --cwd` without a value is classified by the current Effect 3 parser as an unknown argument rather than a missing value. This PR snapshots that behavior instead of correcting it.

## Friction & bottlenecks

Fresh worktree dependency materialization was required before the real Bun entrypoint could resolve workspace packages.

## Follow-ups

Continue Phase 1 baseline PRs for `tui-stories`, megarepo durable JSON, `notion-md` durable JSON, and `notion-datasource-sync` SQLite/replica encoding.

## References

Refs #925.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | co1-ravine |
| `agent_session_id` | a5820d1a-682d-4d0d-9457-f5eae7017cd4 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.145.0 |
| `agent_runtime` | Codex CLI 0.145.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/g70zaf7b08m8pmn4iqxy3a70a2833y23-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/997m3kakbn5dnr72qix3xmfx4pmd6qxd-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-28-2026-07-28-baselines-4-genie-cli |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->