### PR TITLE
test(effect-schema-form): capture cross-major baselines

### DIFF
--- a/nix/oxc-config-plugin.nix
+++ b/nix/oxc-config-plugin.nix
@@ -29,7 +29,7 @@ let
     pnpm = pinnedPnpm;
   };
   packageDir = "packages/@overeng/oxc-config";
-  pnpmDepsHash = "sha256-q96MVwA5bTt96ucoYdLGOJvVdmlISZfQ4Ua3frB3CNU=";
+  pnpmDepsHash = "sha256-G03QfAiCQ00xQlzdJP/pB9GElp6PDUZ5Qbfav8OE7GU=";
 
   srcPath =
     if builtins.isAttrs src && builtins.hasAttr "outPath" src then

--- a/packages/@overeng/ci-tools/nix/build.nix
+++ b/packages/@overeng/ci-tools/nix/build.nix
@@ -19,7 +19,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-C9PMArMRavbdPppbAq3p5HV7VWU7sWeWGwuK1QS1a4w=";
+      "." = mkSharedHash "sha256-Zi/GWjsz7mFG9W/oDC49SX6kv8FnR/lNJxRWgJ+Xl2o=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/effect-schema-form/package.json
+++ b/packages/@overeng/effect-schema-form/package.json
@@ -14,8 +14,10 @@
   },
   "devDependencies": {
     "@types/react": "19.2.17",
+    "@types/react-dom": "19.2.3",
     "effect": "3.21.4",
     "react": "19.2.7",
+    "react-dom": "19.2.7",
     "typescript": "6.0.3",
     "vitest": "4.1.9"
   },

--- a/packages/@overeng/effect-schema-form/package.json.genie.ts
+++ b/packages/@overeng/effect-schema-form/package.json.genie.ts
@@ -13,7 +13,14 @@ const deps = catalog.compose({
   workspace: workspaceMember({ memberPath: 'packages/@overeng/effect-schema-form' }),
   devDependencies: {
     external: {
-      ...catalog.pick(...peerDepNames, '@types/react', 'typescript', 'vitest'),
+      ...catalog.pick(
+        ...peerDepNames,
+        '@types/react',
+        '@types/react-dom',
+        'react-dom',
+        'typescript',
+        'vitest',
+      ),
     },
   },
   peerDependencies: {

--- a/packages/@overeng/effect-schema-form/src/mod.unit.test.tsx
+++ b/packages/@overeng/effect-schema-form/src/mod.unit.test.tsx
@@ -217,7 +217,7 @@ describe('effect-schema-form baselines (cross-major invariant)', () => {
           }}
         />,
       ),
-    ).toThrowError('renderer boom')
+    ).toThrow('renderer boom')
   })
 
   it('formats representative and awkward literal labels byte-identically', () => {

--- a/packages/@overeng/effect-schema-form/src/mod.unit.test.tsx
+++ b/packages/@overeng/effect-schema-form/src/mod.unit.test.tsx
@@ -1,0 +1,234 @@
+import { Schema } from 'effect'
+import type { ReactNode } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  analyzeSchema,
+  analyzeTaggedStruct,
+  formatLiteralLabel,
+  getStructProperties,
+  SchemaForm,
+  SchemaFormProvider,
+  useFieldMeta,
+  useSchemaForm,
+  useSchemaFormContext,
+} from './mod.ts'
+import type { FieldMeta, PropertyInfo } from './types.ts'
+
+const metaBytes = (meta: FieldMeta): string =>
+  JSON.stringify({
+    type: meta.type,
+    title: meta.title,
+    description: meta.description,
+    literals: meta.literals,
+    isOptional: meta.isOptional,
+    innerAstTag: meta.innerSchema.ast._tag,
+  })
+
+const propertyBytes = (properties: readonly PropertyInfo[]): string =>
+  JSON.stringify(
+    properties.map(({ key, meta }) => ({
+      key,
+      meta: JSON.parse(metaBytes(meta)),
+    })),
+  )
+
+describe('effect-schema-form baselines (cross-major invariant)', () => {
+  const Contact = Schema.TaggedStruct('Contact', {
+    name: Schema.String.annotations({
+      title: 'Display name',
+      description: 'Shown to other people',
+    }),
+    age: Schema.optional(Schema.Int.annotations({ title: 'Age' })),
+    role: Schema.Literal('admin', 'guest'),
+    active: Schema.Boolean,
+    unsupported: Schema.Tuple(Schema.String),
+  })
+
+  const value: typeof Contact.Type = {
+    _tag: 'Contact',
+    name: 'Ada <世界>',
+    role: 'guest',
+    active: false,
+    unsupported: [''],
+  }
+
+  it('encodes schema introspection metadata with the current optional and unknown partitions', () => {
+    const cases = {
+      annotatedString: analyzeSchema(
+        Schema.String.annotations({ title: 'Title', description: 'Description' }),
+      ),
+      optionalInt: analyzeSchema(Schema.UndefinedOr(Schema.Int)),
+      literalUnion: analyzeSchema(Schema.Literal('', 'kebab-case', '東京')),
+      struct: analyzeSchema(Schema.Struct({ value: Schema.String })),
+      tuple: analyzeSchema(Schema.Tuple(Schema.String)),
+      unknown: analyzeSchema(Schema.Unknown),
+    }
+
+    expect(
+      JSON.stringify(
+        Object.fromEntries(
+          Object.entries(cases).map(([key, meta]) => [key, JSON.parse(metaBytes(meta))]),
+        ),
+      ),
+    ).toMatchInlineSnapshot(
+      `"{"annotatedString":{"type":"string","title":"Title","description":"Description","isOptional":false,"innerAstTag":"StringKeyword"},"optionalInt":{"type":"number","title":"int","description":"an integer","isOptional":true,"innerAstTag":"Refinement"},"literalUnion":{"type":"literal","literals":["","kebab-case","東京"],"isOptional":false,"innerAstTag":"Union"},"struct":{"type":"struct","isOptional":false,"innerAstTag":"TypeLiteral"},"tuple":{"type":"unknown","isOptional":false,"innerAstTag":"TupleType"},"unknown":{"type":"unknown","title":"unknown","isOptional":false,"innerAstTag":"UnknownKeyword"}}"`,
+    )
+  })
+
+  it('encodes struct and tagged-struct property discovery in declaration order', () => {
+    const properties = getStructProperties(Contact)
+    const tagged = analyzeTaggedStruct(Contact)
+
+    expect(
+      JSON.stringify({
+        properties: JSON.parse(propertyBytes(properties)),
+        tagged: {
+          isTagged: tagged.isTagged,
+          tagValue: tagged.tagValue,
+          contentKeys: tagged.contentProperties.map(({ key }) => key),
+        },
+        nonStructProperties: getStructProperties(Schema.String).length,
+        nonTagged: analyzeTaggedStruct(Schema.Struct({ value: Schema.String })).isTagged,
+      }),
+    ).toMatchInlineSnapshot(
+      `"{"properties":[{"key":"_tag","meta":{"type":"literal","literals":["Contact"],"isOptional":false,"innerAstTag":"Literal"}},{"key":"name","meta":{"type":"string","title":"Display name","description":"Shown to other people","isOptional":false,"innerAstTag":"StringKeyword"}},{"key":"age","meta":{"type":"number","title":"Age","description":"an integer","isOptional":true,"innerAstTag":"Refinement"}},{"key":"role","meta":{"type":"literal","literals":["admin","guest"],"isOptional":false,"innerAstTag":"Union"}},{"key":"active","meta":{"type":"boolean","title":"boolean","description":"a boolean","isOptional":false,"innerAstTag":"BooleanKeyword"}},{"key":"unsupported","meta":{"type":"unknown","isOptional":false,"innerAstTag":"TupleType"}}],"tagged":{"isTagged":true,"tagValue":"Contact","contentKeys":["name","age","role","active","unsupported"]},"nonStructProperties":0,"nonTagged":false}"`,
+    )
+  })
+
+  it('renders byte-identical markup with tag filtering, prop precedence, and unknown fallback', () => {
+    const html = renderToStaticMarkup(
+      <SchemaFormProvider
+        renderers={{
+          string: ({ fieldKey, value: fieldValue, meta }) => (
+            <label data-source="context" data-key={fieldKey} title={meta.description}>
+              {meta.title}:{String(fieldValue)}
+            </label>
+          ),
+          number: ({ fieldKey, value: fieldValue }) => (
+            <output data-key={fieldKey}>{String(fieldValue)}</output>
+          ),
+          literal: ({ fieldKey, value: fieldValue }) => (
+            <output data-key={fieldKey}>{String(fieldValue)}</output>
+          ),
+          boolean: ({ fieldKey, value: fieldValue }) => (
+            <output data-key={fieldKey}>{String(fieldValue)}</output>
+          ),
+          unknown: ({ fieldKey, value: fieldValue }) => (
+            <pre data-key={fieldKey}>{JSON.stringify(fieldValue)}</pre>
+          ),
+        }}
+      >
+        <SchemaForm
+          schema={Contact}
+          value={value}
+          onChange={vi.fn()}
+          renderers={{
+            string: ({ fieldKey, value: fieldValue }) => (
+              <input data-source="prop" data-key={fieldKey} value={String(fieldValue)} readOnly />
+            ),
+          }}
+          wrapper={({ children, tagInfo }) => (
+            <section data-tag={tagInfo.tagValue}>{children}</section>
+          )}
+        />
+      </SchemaFormProvider>,
+    )
+
+    expect(html).toMatchInlineSnapshot(
+      `"<section data-tag="Contact"><div><input data-source="prop" data-key="name" readOnly="" value="Ada &lt;世界&gt;"/></div><div><output data-key="age">undefined</output></div><div><output data-key="role">guest</output></div><div><output data-key="active">false</output></div><div><pre data-key="unsupported">[&quot;&quot;]</pre></div></section>"`,
+    )
+  })
+
+  it('renders the current empty output for unsupported roots and missing renderers', () => {
+    const unsupportedRoot = renderToStaticMarkup(
+      <SchemaForm
+        schema={Schema.String as unknown as Schema.Schema<Record<string, unknown>>}
+        value={{}}
+        onChange={vi.fn()}
+      />,
+    )
+    const missingRenderer = renderToStaticMarkup(
+      <SchemaForm
+        schema={Schema.Struct({ value: Schema.String })}
+        value={{ value: 'unrendered' }}
+        onChange={vi.fn()}
+      />,
+    )
+
+    expect(JSON.stringify({ unsupportedRoot, missingRenderer })).toMatchInlineSnapshot(
+      `"{"unsupportedRoot":"","missingRenderer":"<div></div>"}"`,
+    )
+  })
+
+  it('encodes hook metadata, context, reads, and shallow change payloads through SSR', () => {
+    const changes: unknown[] = []
+
+    const Probe = (): ReactNode => {
+      const context = useSchemaFormContext()
+      const fieldMeta = useFieldMeta(Schema.UndefinedOr(Schema.Number)).meta
+      const form = useSchemaForm({
+        schema: Schema.Struct({
+          name: Schema.String,
+          note: Schema.optional(Schema.String),
+        }),
+        value: { name: 'before', note: '' },
+        onChange: (next) => changes.push(next),
+      })
+      form.setValue('name', 'after')
+      form.setValues({ note: '東京' })
+
+      return (
+        <output>
+          {JSON.stringify({
+            hasStringRenderer: context?.renderers.string !== undefined,
+            fieldMeta: JSON.parse(metaBytes(fieldMeta)),
+            keys: form.fields.map(({ key }) => key),
+            name: form.getValue('name'),
+            tagged: form.tagInfo.isTagged,
+          })}
+        </output>
+      )
+    }
+
+    const html = renderToStaticMarkup(
+      <SchemaFormProvider renderers={{ string: () => null }}>
+        <Probe />
+      </SchemaFormProvider>,
+    )
+
+    expect(JSON.stringify({ html, changes })).toMatchInlineSnapshot(
+      `"{"html":"<output>{&quot;hasStringRenderer&quot;:true,&quot;fieldMeta&quot;:{&quot;type&quot;:&quot;number&quot;,&quot;title&quot;:&quot;number&quot;,&quot;description&quot;:&quot;a number&quot;,&quot;isOptional&quot;:true,&quot;innerAstTag&quot;:&quot;NumberKeyword&quot;},&quot;keys&quot;:[&quot;name&quot;,&quot;note&quot;],&quot;name&quot;:&quot;before&quot;,&quot;tagged&quot;:false}</output>","changes":[{"name":"after","note":""},{"name":"before","note":"東京"}]}"`,
+    )
+  })
+
+  it('keeps renderer exceptions in the synchronous defect partition', () => {
+    expect(() =>
+      renderToStaticMarkup(
+        <SchemaForm
+          schema={Schema.Struct({ value: Schema.String })}
+          value={{ value: 'boom' }}
+          onChange={vi.fn()}
+          renderers={{
+            string: () => {
+              throw new Error('renderer boom')
+            },
+          }}
+        />,
+      ),
+    ).toThrowError('renderer boom')
+  })
+
+  it('formats representative and awkward literal labels byte-identically', () => {
+    expect(
+      JSON.stringify(
+        ['', 'my-option', 'someValue', 'snake_case', 'two--gaps', 'UPPER', '東京_value'].map(
+          (input) => [input, formatLiteralLabel(input)],
+        ),
+      ),
+    ).toMatchInlineSnapshot(
+      `"[["",""],["my-option","My Option"],["someValue","Some Value"],["snake_case","Snake Case"],["two--gaps","Two  Gaps"],["UPPER","Upper"],["東京_value","東京 Value"]]"`,
+    )
+  })
+})

--- a/packages/@overeng/effect-schema-form/vitest.config.ts
+++ b/packages/@overeng/effect-schema-form/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+// The root project config does not resolve correctly from this package task's cwd.
+export default defineConfig({
+  test: {
+    include: ['src/**/*.unit.test.ts', 'src/**/*.unit.test.tsx'],
+  },
+})

--- a/packages/@overeng/genie/nix/build.nix
+++ b/packages/@overeng/genie/nix/build.nix
@@ -26,7 +26,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-n/uFcGEfTSILmy082La4Na3q8wrV0D1dLILnFRGwyKs=";
+      "." = mkSharedHash "sha256-r+dyp2qx9RfpBDiADwWUTBttq2xSPwa0naneD8Z6xwg=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/megarepo/nix/build.nix
+++ b/packages/@overeng/megarepo/nix/build.nix
@@ -24,7 +24,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-TDZ/r/5c0amGWcpU/ePdVAB90NbSDR7mVgZqPYtxMyk=";
+      "." = mkSharedHash "sha256-2hSO33hhpyw5rDVG1VyGU1ZNqYbI9wXeliZGEFyZgwk=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     smokeTestArgs = [ "--help" ];

--- a/packages/@overeng/notion-cli/nix/build.nix
+++ b/packages/@overeng/notion-cli/nix/build.nix
@@ -33,7 +33,7 @@ let
     installRuntimeWorkspace = true;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-oSUwsCA2UB6gUu6HK+QBhjclg7x/tXOnmN6QeWU5b74=";
+      "." = mkSharedHash "sha256-EKZSkvZaYUzGN6SGenxDKwxzTu5e8dGsXflgJhO0+wQ=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/notion-md/nix/build.nix
+++ b/packages/@overeng/notion-md/nix/build.nix
@@ -20,7 +20,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-fj+Jd7wOTIi/kJtMYzHgFaWsXr3Vjli9/PMv1mkdadI=";
+      "." = mkSharedHash "sha256-yGWT8EAEtXXWznTYS+I+PqmdvNYK71yOaQgvpavMXLM=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/npm-release/nix/build.nix
+++ b/packages/@overeng/npm-release/nix/build.nix
@@ -20,7 +20,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-U3SzvoQUzLyM9EPQBdleezcDvIEpUZLQctXS0039NZw=";
+      "." = mkSharedHash "sha256-WwIN1QKp9exwgFHeh/aeb1gr74FrjW6BkOWsmpmSW2I=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/tui-stories/nix/build.nix
+++ b/packages/@overeng/tui-stories/nix/build.nix
@@ -21,7 +21,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-ZMWlEBQRD+IzISeJjQgH5RDoaDSp0kprWlcn3FkB9xI=";
+      "." = mkSharedHash "sha256-JUvxjhlweuLelffcFyhaXnVbdLhq2hPr4futdRgW5n4=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -401,12 +401,18 @@ importers:
       '@types/react':
         specifier: 19.2.17
         version: 19.2.17
+      '@types/react-dom':
+        specifier: 19.2.3
+        version: 19.2.3(@types/react@19.2.17)
       effect:
         specifier: 3.21.4
         version: 3.21.4
       react:
         specifier: 19.2.7
         version: 19.2.7
+      react-dom:
+        specifier: 19.2.7
+        version: 19.2.7(react@19.2.7)
       typescript:
         specifier: 6.0.3
         version: 6.0.3


### PR DESCRIPTION
## Problem

`effect-schema-form` had no tests, so an Effect 4 migration could silently change its observable schema introspection, rendered markup, state-update payloads, or failure partition.

## Goal

Capture the package's current Effect 3 behavior as additive characterization tests that remain fixed during the cross-major flip.

## Decisions

- Name the suite `effect-schema-form baselines (cross-major invariant)` so failures during wave repair are treated as migration regressions rather than snapshots to update.
- Pin exact metadata JSON, SSR markup, context/state payload bytes, literal-label formatting, unsupported-root output, missing-renderer output, and the synchronous renderer-defect partition.
- Add only the test-only React DOM dependencies needed to render the existing public surface.
- Add a package-local Vitest config because the root workspace project config does not resolve correctly from this package task's cwd.
- Refresh the eight root-lock-derived pnpm FOD hashes mechanically affected by the shared lockfile change; there is no unrelated Nix behavior change.

## Verification

- `CI=1 node_modules/.bin/vitest run` from `packages/@overeng/effect-schema-form`: 7/7 passed.
- `node_modules/.bin/tsc --noEmit -p tsconfig.json --pretty false`: passed.
- `CI=1 devenv tasks run check:quick --no-tui`: passed.
- `oxfmt --check` on the authored package files: passed.
- `git diff --check`: passed.
- `nix build .#oxlint-npm --no-link`: passed with the refreshed plugin-bundle hash.
- Evergreen refreshed and verified the eight lock-derived FOD hashes.

## Complexity

Low runtime risk: this adds tests and test-only dependencies; production source is unchanged. The lockfile importer and derived Nix hashes account for the mechanical repository-wide diff.

## Concerns

These tests intentionally preserve awkward current behavior, including empty output for unsupported root schemas and synchronous defects from throwing renderers. They characterize behavior; they do not endorse it.

## Friction & bottlenecks

The instrumented lint gate exposed the new test's deprecated `toThrowError` matcher even though an uninstrumented direct invocation did not. The test now uses the supported behavior-equivalent `toThrow` matcher, and both the focused lint task and aggregate `check:quick` pass.

## Follow-ups

- Test-task wiring is handled separately in #992.
- `effect-schema-form-aria` remains a separate package/PR.

## References

- #925
- #992

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | co2-comet |
| `agent_session_id` | 7c71fe09-b408-4f01-beca-75afbbe788ec |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.145.0 |
| `agent_runtime` | Codex CLI 0.145.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/g70zaf7b08m8pmn4iqxy3a70a2833y23-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/997m3kakbn5dnr72qix3xmfx4pmd6qxd-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-28-thincov-effect-schema-form |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->