### PR TITLE
test(tui-stories): capture CLI contract baselines

### DIFF
--- a/packages/@overeng/tui-stories/test/__snapshots__/cli.contract.test.ts.snap
+++ b/packages/@overeng/tui-stories/test/__snapshots__/cli.contract.test.ts.snap
@@ -1,0 +1,184 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`tui-stories CLI contract baselines (status/signal invariant, prose owner-rebaselinable) > invalid width 1`] = `
+{
+  "signal": null,
+  "status": 1,
+  "stderr": "'nope' is not a integer
+
+Error: {"_tag":"InvalidValue","error":{"_tag":"Paragraph","value":{"_tag":"Text","value":"'nope' is not a integer"}}}
+",
+  "stdout": "",
+}
+`;
+
+exports[`tui-stories CLI contract baselines (status/signal invariant, prose owner-rebaselinable) > list help 1`] = `
+{
+  "signal": null,
+  "status": 0,
+  "stderr": "",
+  "stdout": "tui-stories
+
+tui-stories 0.1.0
+
+USAGE
+
+$ list --path text [(-o, --output auto | tty | alt-screen | ci | ci-plain | log | json | ndjson)]
+
+DESCRIPTION
+
+List all discovered stories
+
+OPTIONS
+
+--path text
+
+  A user-defined piece of text.
+
+  Package directory to search for stories
+
+(-o, --output auto | tty | alt-screen | ci | ci-plain | log | json | ndjson)
+
+  One of the following: auto, tty, alt-screen, ci, ci-plain, log, json, ndjson
+
+  Output mode: auto, tty, alt-screen, ci, ci-plain, log, json, ndjson
+
+  This setting is optional.
+
+--completions sh | bash | fish | zsh
+
+  One of the following: sh, bash, fish, zsh
+
+  Generate a completion script for a specific shell.
+
+  This setting is optional.
+
+--log-level all | trace | debug | info | warning | error | fatal | none
+
+  One of the following: all, trace, debug, info, warning, error, fatal, none
+
+  Sets the minimum log level for a command.
+
+  This setting is optional.
+
+(-h, --help)
+
+  A true or false value.
+
+  Show the help documentation for a command.
+
+  This setting is optional.
+
+--wizard
+
+  A true or false value.
+
+  Start wizard mode for a command.
+
+  This setting is optional.
+
+--version
+
+  A true or false value.
+
+  Show the version of the application.
+
+  This setting is optional.
+
+",
+}
+`;
+
+exports[`tui-stories CLI contract baselines (status/signal invariant, prose owner-rebaselinable) > missing path 1`] = `
+{
+  "signal": null,
+  "status": 1,
+  "stderr": "Expected to find option: '--path'
+
+Error: {"_tag":"MissingValue","error":{"_tag":"Paragraph","value":{"_tag":"Text","value":"Expected to find option: '--path'"}}}
+",
+  "stdout": "",
+}
+`;
+
+exports[`tui-stories CLI contract baselines (status/signal invariant, prose owner-rebaselinable) > root help 1`] = `
+{
+  "signal": null,
+  "status": 0,
+  "stderr": "",
+  "stdout": "tui-stories
+
+tui-stories 0.1.0
+
+USAGE
+
+$ tui-stories
+
+DESCRIPTION
+
+Headless TUI story runner — render Storybook stories in the terminal
+
+OPTIONS
+
+--completions sh | bash | fish | zsh
+
+  One of the following: sh, bash, fish, zsh
+
+  Generate a completion script for a specific shell.
+
+  This setting is optional.
+
+--log-level all | trace | debug | info | warning | error | fatal | none
+
+  One of the following: all, trace, debug, info, warning, error, fatal, none
+
+  Sets the minimum log level for a command.
+
+  This setting is optional.
+
+(-h, --help)
+
+  A true or false value.
+
+  Show the help documentation for a command.
+
+  This setting is optional.
+
+--wizard
+
+  A true or false value.
+
+  Start wizard mode for a command.
+
+  This setting is optional.
+
+--version
+
+  A true or false value.
+
+  Show the version of the application.
+
+  This setting is optional.
+
+COMMANDS
+
+  - list --path text [(-o, --output auto | tty | alt-screen | ci | ci-plain | log | json | ndjson)]                                                                                                         List all discovered stories
+
+  - render [(-s, --story text)] --path text [(-w, --width integer)] [(-o, --output auto | tty | alt-screen | ci | ci-plain | log | json | ndjson)] [--final] [--at integer] (-a, --arg text)... <story-id>  Render a story to terminal output
+
+  - inspect --path text [(-o, --output auto | tty | alt-screen | ci | ci-plain | log | json | ndjson)] <story-id>                                                                                           Inspect story metadata and available args
+
+",
+}
+`;
+
+exports[`tui-stories CLI contract baselines (status/signal invariant, prose owner-rebaselinable) > version 1`] = `
+{
+  "signal": null,
+  "status": 0,
+  "stderr": "",
+  "stdout": "0.1.0
+
+",
+}
+`;

--- a/packages/@overeng/tui-stories/test/cli.contract.test.ts
+++ b/packages/@overeng/tui-stories/test/cli.contract.test.ts
@@ -1,0 +1,55 @@
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+const cliPath = fileURLToPath(new URL('../bin/tui-stories.tsx', import.meta.url))
+
+/**
+ * CLI contract capture: `status` and `signal` are cross-major invariants; stdout/stderr help,
+ * usage, and error prose are captured for review but may be re-baselined by the tui-stories owner
+ * during Effect 4 repair with an alignment-register entry.
+ * ANSI control bytes are normalized, so colour/styling changes are not gated by this baseline.
+ * The local-source version suffix and log timestamps are normalized, so version-string content and
+ * log timing are not gated by this baseline.
+ */
+const stripAnsi = (output: string) =>
+  output.replace(
+    // eslint-disable-next-line no-control-regex -- CLI contract snapshots intentionally normalize terminal control bytes.
+    /[\u001b\u009b][[\]()#;?]*(?:(?:(?:[a-zA-Z\d]*(?:;[a-zA-Z\d]*)*)?\u0007)|(?:(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~]))/gu,
+    '',
+  )
+
+const normalizeOutput = (output: string) =>
+  stripAnsi(output)
+    .replace(/ — running from local source \([^)]+\)/gu, '')
+    .replace(/^\[\d{2}:\d{2}:\d{2}\.\d{3}\]/gmu, '[time]')
+
+const runCli = (...args: ReadonlyArray<string>) => {
+  const result = spawnSync('bun', [cliPath, ...args], {
+    encoding: 'utf8',
+    env: { ...process.env, NO_COLOR: '1' },
+  })
+
+  return {
+    status: result.status,
+    signal: result.signal,
+    stdout: normalizeOutput(result.stdout),
+    stderr: normalizeOutput(result.stderr),
+  }
+}
+
+describe('tui-stories CLI contract baselines (status/signal invariant, prose owner-rebaselinable)', () => {
+  it.each([
+    ['root help', ['--help']],
+    ['list help', ['list', '--help']],
+    ['version', ['--version']],
+    ['missing path', ['list']],
+    [
+      'invalid width',
+      ['render', 'Story', '--path', 'packages/@overeng/tui-stories', '--width', 'nope'],
+    ],
+  ] as const)('%s', (_name, args) => {
+    expect(runCli(...args)).toMatchSnapshot()
+  })
+})

--- a/packages/@overeng/tui-stories/test/cli.contract.test.ts
+++ b/packages/@overeng/tui-stories/test/cli.contract.test.ts
@@ -13,6 +13,7 @@ const cliPath = fileURLToPath(new URL('../bin/tui-stories.tsx', import.meta.url)
  * The local-source version suffix and log timestamps are normalized, so version-string content and
  * log timing are not gated by this baseline.
  */
+// LIVE-MIGRATION BRIDGE effect-3-4 — DELETE at contraction — https://github.com/overengineeringstudio/effect-utils/issues/925
 const stripAnsi = (output: string) =>
   output.replace(
     // eslint-disable-next-line no-control-regex -- CLI contract snapshots intentionally normalize terminal control bytes.
@@ -24,6 +25,7 @@ const normalizeOutput = (output: string) =>
   stripAnsi(output)
     .replace(/ — running from local source \([^)]+\)/gu, '')
     .replace(/^\[\d{2}:\d{2}:\d{2}\.\d{3}\]/gmu, '[time]')
+// LIVE-MIGRATION END effect-3-4
 
 const runCli = (...args: ReadonlyArray<string>) => {
   const result = spawnSync('bun', [cliPath, ...args], {
@@ -34,8 +36,10 @@ const runCli = (...args: ReadonlyArray<string>) => {
   return {
     status: result.status,
     signal: result.signal,
+    // LIVE-MIGRATION BRIDGE effect-3-4 — DELETE at contraction — https://github.com/overengineeringstudio/effect-utils/issues/925
     stdout: normalizeOutput(result.stdout),
     stderr: normalizeOutput(result.stderr),
+    // LIVE-MIGRATION END effect-3-4
   }
 }
 


### PR DESCRIPTION
## Problem

Phase 1 needs Effect 3 CLI contract baselines for `tui-stories` before the Effect 4 cohort flip. Status and signal are class-1 invariants; help/error prose is captured for owner-approved rebaselining during wave repair.

## Goal

Capture representative `tui-stories` CLI behavior as ordinary additive Vitest coverage on Effect 3.

## Decisions

- Adds `packages/@overeng/tui-stories/test/cli.contract.test.ts` plus Vitest snapshots.
- Spawns the real Bun entrypoint at `packages/@overeng/tui-stories/bin/tui-stories.tsx`.
- Captures root help, `list` subcommand help, version, missing required `--path`, and invalid `render --width` value.
- Stores `status`, `signal`, `stdout`, and `stderr` separately in snapshots.
- Normalizes ANSI control bytes, local-source version suffixes, and log timestamps; those prose details are not gated by this baseline.

## Verification

- PASS: `CI=1 ./node_modules/.bin/vitest run test/cli.contract.test.ts` from `packages/@overeng/tui-stories`.
- PASS: `oxfmt --check packages/@overeng/tui-stories/test/cli.contract.test.ts packages/@overeng/tui-stories/test/__snapshots__/cli.contract.test.ts.snap`.
- PASS: `oxlint packages/@overeng/tui-stories/test/cli.contract.test.ts`.
- PASS: `git diff --check`.
- PASS: `CI=1 devenv tasks run check:quick --no-tui`.

## Complexity

No new runtime complexity; additive baseline tests only.

## Concerns

The snapshots intentionally assert parser-level failures before story discovery or rendering side effects run.

## Friction & bottlenecks

Fresh worktree dependency materialization was required before the real Bun entrypoint could resolve workspace packages.

## Follow-ups

Continue Phase 1 baseline PRs for megarepo durable JSON, `notion-md` durable JSON, and `notion-datasource-sync` SQLite/replica encoding.

## References

Refs #925.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | co1-ravine |
| `agent_session_id` | a5820d1a-682d-4d0d-9457-f5eae7017cd4 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.145.0 |
| `agent_runtime` | Codex CLI 0.145.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/g70zaf7b08m8pmn4iqxy3a70a2833y23-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/997m3kakbn5dnr72qix3xmfx4pmd6qxd-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-28-2026-07-28-baselines-4-tui-stories-cli |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->