### PR TITLE
test(megarepo): capture JSON wire baselines

### DIFF
--- a/packages/@overeng/megarepo/src/lib/__snapshots__/json-wire-baseline.test.ts.snap
+++ b/packages/@overeng/megarepo/src/lib/__snapshots__/json-wire-baseline.test.ts.snap
@@ -1,0 +1,392 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`megarepo wire baselines (cross-major invariant) > captures megarepo config JSON bytes and failure partition 1`] = `
+{
+  "byteIdentical": true,
+  "decoded": MegarepoConfig {
+    "$schema": "https://example.invalid/megarepo.schema.json",
+    "generators": GeneratorsConfig {
+      "vscode": VscodeGeneratorConfig {
+        "color": "#123abc",
+        "colorEnvVar": "MEGAREPO_COLOR",
+        "enabled": true,
+        "exclude": [
+          "tmp",
+          "unicode-ß",
+        ],
+        "settings": {
+          "editor.formatOnSave": true,
+          "nullable": null,
+          "terminal.integrated.defaultProfile.linux": "bash
+zsh",
+        },
+      },
+    },
+    "lockSync": LockSyncConfig {
+      "enabled": false,
+      "exclude": [
+        "unicode-ß",
+      ],
+      "sharedInputSource": "nixpkgs",
+    },
+    "members": {
+      "": "./empty-name",
+      "unicode-ß": "https://github.com/example/unicode#feature/ß",
+      "windows": "../windows
+path",
+    },
+  },
+  "encoded": "{
+  "$schema": "https://example.invalid/megarepo.schema.json",
+  "members": {
+    "": "./empty-name",
+    "unicode-ß": "https://github.com/example/unicode#feature/ß",
+    "windows": "../windows\\r\\npath"
+  },
+  "generators": {
+    "vscode": {
+      "enabled": true,
+      "exclude": [
+        "tmp",
+        "unicode-ß"
+      ],
+      "color": "#123abc",
+      "colorEnvVar": "MEGAREPO_COLOR",
+      "settings": {
+        "editor.formatOnSave": true,
+        "terminal.integrated.defaultProfile.linux": "bash\\r\\nzsh",
+        "nullable": null
+      }
+    }
+  },
+  "lockSync": {
+    "enabled": false,
+    "exclude": [
+      "unicode-ß"
+    ],
+    "sharedInputSource": "nixpkgs"
+  }
+}",
+  "reencoded": "{
+  "$schema": "https://example.invalid/megarepo.schema.json",
+  "members": {
+    "": "./empty-name",
+    "unicode-ß": "https://github.com/example/unicode#feature/ß",
+    "windows": "../windows\\r\\npath"
+  },
+  "generators": {
+    "vscode": {
+      "enabled": true,
+      "exclude": [
+        "tmp",
+        "unicode-ß"
+      ],
+      "color": "#123abc",
+      "colorEnvVar": "MEGAREPO_COLOR",
+      "settings": {
+        "editor.formatOnSave": true,
+        "terminal.integrated.defaultProfile.linux": "bash\\r\\nzsh",
+        "nullable": null
+      }
+    }
+  },
+  "lockSync": {
+    "enabled": false,
+    "exclude": [
+      "unicode-ß"
+    ],
+    "sharedInputSource": "nixpkgs"
+  }
+}",
+}
+`;
+
+exports[`megarepo wire baselines (cross-major invariant) > captures megarepo config JSON bytes and failure partition 2`] = `
+{
+  "missingMembers": {
+    "_tag": "failed",
+    "error": "(parseJson <-> (MegarepoConfig (Encoded side) <-> MegarepoConfig))
+└─ Type side transformation failure
+   └─ (MegarepoConfig (Encoded side) <-> MegarepoConfig)
+      └─ Encoded side transformation failure
+         └─ MegarepoConfig (Encoded side)
+            └─ ["members"]
+               └─ is missing",
+  },
+  "nullDocument": {
+    "_tag": "failed",
+    "error": "(parseJson <-> (MegarepoConfig (Encoded side) <-> MegarepoConfig))
+└─ Type side transformation failure
+   └─ (MegarepoConfig (Encoded side) <-> MegarepoConfig)
+      └─ Encoded side transformation failure
+         └─ Expected MegarepoConfig (Encoded side), actual null",
+  },
+  "nullMemberSource": {
+    "_tag": "failed",
+    "error": "(parseJson <-> (MegarepoConfig (Encoded side) <-> MegarepoConfig))
+└─ Type side transformation failure
+   └─ (MegarepoConfig (Encoded side) <-> MegarepoConfig)
+      └─ Encoded side transformation failure
+         └─ MegarepoConfig (Encoded side)
+            └─ ["members"]
+               └─ { readonly [x: string]: string }
+                  └─ ["bad"]
+                     └─ Expected string, actual null",
+  },
+}
+`;
+
+exports[`megarepo wire baselines (cross-major invariant) > captures megarepo lock JSON bytes and failure partition 1`] = `
+{
+  "byteIdentical": true,
+  "decoded": LockFile {
+    "members": {
+      "out-of-range-date-string": LockedMember {
+        "commit": "ffffffffffffffffffffffffffffffffffffffff",
+        "lockedAt": "99999-99-99T99:99:99.999Z",
+        "pinned": false,
+        "ref": "main",
+        "url": "git@github.com:example/out-of-range.git",
+      },
+      "unicode-ß": LockedMember {
+        "commit": "0123456789abcdef0123456789abcdef01234567",
+        "lockedAt": "2026-07-28T11:50:00.000Z",
+        "pinned": true,
+        "ref": "feature/ß",
+        "url": "https://github.com/example/unicode",
+      },
+    },
+    "version": 1,
+  },
+  "encoded": "{
+  "version": 1,
+  "members": {
+    "unicode-ß": {
+      "url": "https://github.com/example/unicode",
+      "ref": "feature/ß",
+      "commit": "0123456789abcdef0123456789abcdef01234567",
+      "pinned": true,
+      "lockedAt": "2026-07-28T11:50:00.000Z"
+    },
+    "out-of-range-date-string": {
+      "url": "git@github.com:example/out-of-range.git",
+      "ref": "main",
+      "commit": "ffffffffffffffffffffffffffffffffffffffff",
+      "pinned": false,
+      "lockedAt": "99999-99-99T99:99:99.999Z"
+    }
+  }
+}",
+  "reencoded": "{
+  "version": 1,
+  "members": {
+    "unicode-ß": {
+      "url": "https://github.com/example/unicode",
+      "ref": "feature/ß",
+      "commit": "0123456789abcdef0123456789abcdef01234567",
+      "pinned": true,
+      "lockedAt": "2026-07-28T11:50:00.000Z"
+    },
+    "out-of-range-date-string": {
+      "url": "git@github.com:example/out-of-range.git",
+      "ref": "main",
+      "commit": "ffffffffffffffffffffffffffffffffffffffff",
+      "pinned": false,
+      "lockedAt": "99999-99-99T99:99:99.999Z"
+    }
+  }
+}",
+}
+`;
+
+exports[`megarepo wire baselines (cross-major invariant) > captures megarepo lock JSON bytes and failure partition 2`] = `
+{
+  "missingPinned": {
+    "_tag": "failed",
+    "error": "(parseJson <-> (LockFile (Encoded side) <-> LockFile))
+└─ Type side transformation failure
+   └─ (LockFile (Encoded side) <-> LockFile)
+      └─ Encoded side transformation failure
+         └─ LockFile (Encoded side)
+            └─ ["members"]
+               └─ { readonly [x: string]: (LockedMember (Encoded side) <-> LockedMember) }
+                  └─ ["repo"]
+                     └─ (LockedMember (Encoded side) <-> LockedMember)
+                        └─ Encoded side transformation failure
+                           └─ LockedMember (Encoded side)
+                              └─ ["pinned"]
+                                 └─ is missing",
+  },
+  "nullDocument": {
+    "_tag": "failed",
+    "error": "(parseJson <-> (LockFile (Encoded side) <-> LockFile))
+└─ Type side transformation failure
+   └─ (LockFile (Encoded side) <-> LockFile)
+      └─ Encoded side transformation failure
+         └─ Expected LockFile (Encoded side), actual null",
+  },
+  "nullMembers": {
+    "_tag": "failed",
+    "error": "(parseJson <-> (LockFile (Encoded side) <-> LockFile))
+└─ Type side transformation failure
+   └─ (LockFile (Encoded side) <-> LockFile)
+      └─ Encoded side transformation failure
+         └─ LockFile (Encoded side)
+            └─ ["members"]
+               └─ Expected { readonly [x: string]: (LockedMember (Encoded side) <-> LockedMember) }, actual null",
+  },
+}
+`;
+
+exports[`megarepo wire baselines (cross-major invariant) > captures megarepo store state JSON bytes and failure partition 1`] = `
+{
+  "byteIdentical": true,
+  "decoded": {
+    "_tag": "Gc",
+    "activeWorktreeCount": 1,
+    "basePath": "/store/root",
+    "completedRepoCount": 1,
+    "discoveredWorktreeCount": 3,
+    "done": true,
+    "dryRun": true,
+    "interrupted": false,
+    "processedCount": 2,
+    "repoCount": 2,
+    "results": [
+      {
+        "message": "protected by workspace registry",
+        "path": "/store/root/github.com/example/unicode/refs/heads/feature/ß",
+        "reason": "live",
+        "ref": "feature/ß",
+        "refType": "heads",
+        "repo": "example/unicode",
+        "status": "kept",
+      },
+      {
+        "actualHeadBranch": "feature/old",
+        "path": "/store/root/github.com/example/commit/refs/commits/0123456789abcdef0123456789abcdef01234567",
+        "pathRef": "main",
+        "recoverPath": "/store/root/.archive/example-commit",
+        "ref": "0123456789abcdef0123456789abcdef01234567",
+        "refType": "commits",
+        "repo": "example/commit",
+        "status": "archived",
+      },
+    ],
+    "showForceHint": false,
+    "statusMessage": "gc complete",
+    "warning": {
+      "message": "line one
+line two",
+      "type": "custom",
+    },
+  },
+  "encoded": "{
+  "_tag": "Gc",
+  "basePath": "/store/root",
+  "results": [
+    {
+      "repo": "example/unicode",
+      "ref": "feature/ß",
+      "refType": "heads",
+      "path": "/store/root/github.com/example/unicode/refs/heads/feature/ß",
+      "status": "kept",
+      "message": "protected by workspace registry",
+      "reason": "live"
+    },
+    {
+      "repo": "example/commit",
+      "ref": "0123456789abcdef0123456789abcdef01234567",
+      "refType": "commits",
+      "path": "/store/root/github.com/example/commit/refs/commits/0123456789abcdef0123456789abcdef01234567",
+      "status": "archived",
+      "recoverPath": "/store/root/.archive/example-commit",
+      "pathRef": "main",
+      "actualHeadBranch": "feature/old"
+    }
+  ],
+  "dryRun": true,
+  "warning": {
+    "type": "custom",
+    "message": "line one\\r\\nline two"
+  },
+  "showForceHint": false,
+  "processedCount": 2,
+  "repoCount": 2,
+  "completedRepoCount": 1,
+  "discoveredWorktreeCount": 3,
+  "activeWorktreeCount": 1,
+  "statusMessage": "gc complete",
+  "done": true,
+  "interrupted": false
+}",
+  "reencoded": "{
+  "_tag": "Gc",
+  "basePath": "/store/root",
+  "results": [
+    {
+      "repo": "example/unicode",
+      "ref": "feature/ß",
+      "refType": "heads",
+      "path": "/store/root/github.com/example/unicode/refs/heads/feature/ß",
+      "status": "kept",
+      "message": "protected by workspace registry",
+      "reason": "live"
+    },
+    {
+      "repo": "example/commit",
+      "ref": "0123456789abcdef0123456789abcdef01234567",
+      "refType": "commits",
+      "path": "/store/root/github.com/example/commit/refs/commits/0123456789abcdef0123456789abcdef01234567",
+      "status": "archived",
+      "recoverPath": "/store/root/.archive/example-commit",
+      "pathRef": "main",
+      "actualHeadBranch": "feature/old"
+    }
+  ],
+  "dryRun": true,
+  "warning": {
+    "type": "custom",
+    "message": "line one\\r\\nline two"
+  },
+  "showForceHint": false,
+  "processedCount": 2,
+  "repoCount": 2,
+  "completedRepoCount": 1,
+  "discoveredWorktreeCount": 3,
+  "activeWorktreeCount": 1,
+  "statusMessage": "gc complete",
+  "done": true,
+  "interrupted": false
+}",
+}
+`;
+
+exports[`megarepo wire baselines (cross-major invariant) > captures megarepo store state JSON bytes and failure partition 2`] = `
+{
+  "nullDocument": {
+    "_tag": "failed",
+    "error": "(parseJson <-> { readonly _tag: "Ls"; readonly basePath: string; readonly repos: ReadonlyArray<{ readonly relativePath: string }> } | { readonly _tag: "Status"; readonly basePath: string; readonly repoCount: number; readonly worktreeCount: number; readonly diskUsage?: string | undefined; readonly worktrees: ReadonlyArray<{ readonly repo: string; readonly ref: string; readonly refType: "heads" | "tags" | "commits"; readonly path: string; readonly issues: ReadonlyArray<{ readonly type: "dirty" | "unpushed" | "ref_mismatch" | "missing_bare" | "broken_worktree" | "orphaned"; readonly severity: "error" | "warning" | "info"; readonly message: string }> }> } | { readonly _tag: "Fetch"; readonly basePath: string; readonly results: ReadonlyArray<{ readonly path: string; readonly status: "fetched" | "error"; readonly message?: string | undefined }>; readonly elapsedMs: number } | { readonly _tag: "Gc"; readonly basePath: string; readonly results: ReadonlyArray<{ readonly repo: string; readonly ref: string; readonly refType: "heads" | "tags" | "commits"; readonly path: string; readonly status: "removed" | "skipped_dirty" | "skipped_in_use" | "error" | "archived" | "reaped" | "kept"; readonly message?: string | undefined; readonly reason?: string | undefined; readonly recoverPath?: string | undefined; readonly pathRef?: string | undefined; readonly actualHeadBranch?: string | undefined }>; readonly dryRun: boolean; readonly warning?: { readonly type: "not_in_megarepo" | "only_current_megarepo" | "custom"; readonly message?: string | undefined } | undefined; readonly showForceHint: boolean; readonly processedCount?: number | undefined; readonly repoCount?: number | undefined; readonly completedRepoCount?: number | undefined; readonly discoveredWorktreeCount?: number | undefined; readonly activeWorktreeCount?: number | undefined; readonly statusMessage?: string | undefined; readonly done?: boolean | undefined; readonly interrupted?: boolean | undefined } | { readonly _tag: "Add"; readonly status: "added" | "already_exists" | "created"; readonly source: string; readonly ref: string; readonly commit?: string | undefined; readonly path: string } | { readonly _tag: "WorktreeNew"; readonly source: string; readonly ref: string; readonly path: string; readonly commit?: string | undefined; readonly autoBootstrap: boolean; readonly branchCreated: boolean } | { readonly _tag: "Fix"; readonly basePath: string; readonly results: ReadonlyArray<{ readonly memberName: string; readonly issueType: string; readonly status: "fixed" | "skipped" | "error"; readonly message: string }>; readonly dryRun: boolean; readonly noIssues: boolean } | { readonly _tag: "Error"; readonly error: string; readonly message: string; readonly source?: string | undefined } | { readonly _tag: "Interrupted" })
+└─ Type side transformation failure
+   └─ Expected { readonly _tag: "Ls"; readonly basePath: string; readonly repos: ReadonlyArray<{ readonly relativePath: string }> } | { readonly _tag: "Status"; readonly basePath: string; readonly repoCount: number; readonly worktreeCount: number; readonly diskUsage?: string | undefined; readonly worktrees: ReadonlyArray<{ readonly repo: string; readonly ref: string; readonly refType: "heads" | "tags" | "commits"; readonly path: string; readonly issues: ReadonlyArray<{ readonly type: "dirty" | "unpushed" | "ref_mismatch" | "missing_bare" | "broken_worktree" | "orphaned"; readonly severity: "error" | "warning" | "info"; readonly message: string }> }> } | { readonly _tag: "Fetch"; readonly basePath: string; readonly results: ReadonlyArray<{ readonly path: string; readonly status: "fetched" | "error"; readonly message?: string | undefined }>; readonly elapsedMs: number } | { readonly _tag: "Gc"; readonly basePath: string; readonly results: ReadonlyArray<{ readonly repo: string; readonly ref: string; readonly refType: "heads" | "tags" | "commits"; readonly path: string; readonly status: "removed" | "skipped_dirty" | "skipped_in_use" | "error" | "archived" | "reaped" | "kept"; readonly message?: string | undefined; readonly reason?: string | undefined; readonly recoverPath?: string | undefined; readonly pathRef?: string | undefined; readonly actualHeadBranch?: string | undefined }>; readonly dryRun: boolean; readonly warning?: { readonly type: "not_in_megarepo" | "only_current_megarepo" | "custom"; readonly message?: string | undefined } | undefined; readonly showForceHint: boolean; readonly processedCount?: number | undefined; readonly repoCount?: number | undefined; readonly completedRepoCount?: number | undefined; readonly discoveredWorktreeCount?: number | undefined; readonly activeWorktreeCount?: number | undefined; readonly statusMessage?: string | undefined; readonly done?: boolean | undefined; readonly interrupted?: boolean | undefined } | { readonly _tag: "Add"; readonly status: "added" | "already_exists" | "created"; readonly source: string; readonly ref: string; readonly commit?: string | undefined; readonly path: string } | { readonly _tag: "WorktreeNew"; readonly source: string; readonly ref: string; readonly path: string; readonly commit?: string | undefined; readonly autoBootstrap: boolean; readonly branchCreated: boolean } | { readonly _tag: "Fix"; readonly basePath: string; readonly results: ReadonlyArray<{ readonly memberName: string; readonly issueType: string; readonly status: "fixed" | "skipped" | "error"; readonly message: string }>; readonly dryRun: boolean; readonly noIssues: boolean } | { readonly _tag: "Error"; readonly error: string; readonly message: string; readonly source?: string | undefined } | { readonly _tag: "Interrupted" }, actual null",
+  },
+  "nullOptionalMessage": {
+    "_tag": "failed",
+    "error": "(parseJson <-> { readonly _tag: "Ls"; readonly basePath: string; readonly repos: ReadonlyArray<{ readonly relativePath: string }> } | { readonly _tag: "Status"; readonly basePath: string; readonly repoCount: number; readonly worktreeCount: number; readonly diskUsage?: string | undefined; readonly worktrees: ReadonlyArray<{ readonly repo: string; readonly ref: string; readonly refType: "heads" | "tags" | "commits"; readonly path: string; readonly issues: ReadonlyArray<{ readonly type: "dirty" | "unpushed" | "ref_mismatch" | "missing_bare" | "broken_worktree" | "orphaned"; readonly severity: "error" | "warning" | "info"; readonly message: string }> }> } | { readonly _tag: "Fetch"; readonly basePath: string; readonly results: ReadonlyArray<{ readonly path: string; readonly status: "fetched" | "error"; readonly message?: string | undefined }>; readonly elapsedMs: number } | { readonly _tag: "Gc"; readonly basePath: string; readonly results: ReadonlyArray<{ readonly repo: string; readonly ref: string; readonly refType: "heads" | "tags" | "commits"; readonly path: string; readonly status: "removed" | "skipped_dirty" | "skipped_in_use" | "error" | "archived" | "reaped" | "kept"; readonly message?: string | undefined; readonly reason?: string | undefined; readonly recoverPath?: string | undefined; readonly pathRef?: string | undefined; readonly actualHeadBranch?: string | undefined }>; readonly dryRun: boolean; readonly warning?: { readonly type: "not_in_megarepo" | "only_current_megarepo" | "custom"; readonly message?: string | undefined } | undefined; readonly showForceHint: boolean; readonly processedCount?: number | undefined; readonly repoCount?: number | undefined; readonly completedRepoCount?: number | undefined; readonly discoveredWorktreeCount?: number | undefined; readonly activeWorktreeCount?: number | undefined; readonly statusMessage?: string | undefined; readonly done?: boolean | undefined; readonly interrupted?: boolean | undefined } | { readonly _tag: "Add"; readonly status: "added" | "already_exists" | "created"; readonly source: string; readonly ref: string; readonly commit?: string | undefined; readonly path: string } | { readonly _tag: "WorktreeNew"; readonly source: string; readonly ref: string; readonly path: string; readonly commit?: string | undefined; readonly autoBootstrap: boolean; readonly branchCreated: boolean } | { readonly _tag: "Fix"; readonly basePath: string; readonly results: ReadonlyArray<{ readonly memberName: string; readonly issueType: string; readonly status: "fixed" | "skipped" | "error"; readonly message: string }>; readonly dryRun: boolean; readonly noIssues: boolean } | { readonly _tag: "Error"; readonly error: string; readonly message: string; readonly source?: string | undefined } | { readonly _tag: "Interrupted" })
+└─ Type side transformation failure
+   └─ { readonly _tag: "Ls"; readonly basePath: string; readonly repos: ReadonlyArray<{ readonly relativePath: string }> } | { readonly _tag: "Status"; readonly basePath: string; readonly repoCount: number; readonly worktreeCount: number; readonly diskUsage?: string | undefined; readonly worktrees: ReadonlyArray<{ readonly repo: string; readonly ref: string; readonly refType: "heads" | "tags" | "commits"; readonly path: string; readonly issues: ReadonlyArray<{ readonly type: "dirty" | "unpushed" | "ref_mismatch" | "missing_bare" | "broken_worktree" | "orphaned"; readonly severity: "error" | "warning" | "info"; readonly message: string }> }> } | { readonly _tag: "Fetch"; readonly basePath: string; readonly results: ReadonlyArray<{ readonly path: string; readonly status: "fetched" | "error"; readonly message?: string | undefined }>; readonly elapsedMs: number } | { readonly _tag: "Gc"; readonly basePath: string; readonly results: ReadonlyArray<{ readonly repo: string; readonly ref: string; readonly refType: "heads" | "tags" | "commits"; readonly path: string; readonly status: "removed" | "skipped_dirty" | "skipped_in_use" | "error" | "archived" | "reaped" | "kept"; readonly message?: string | undefined; readonly reason?: string | undefined; readonly recoverPath?: string | undefined; readonly pathRef?: string | undefined; readonly actualHeadBranch?: string | undefined }>; readonly dryRun: boolean; readonly warning?: { readonly type: "not_in_megarepo" | "only_current_megarepo" | "custom"; readonly message?: string | undefined } | undefined; readonly showForceHint: boolean; readonly processedCount?: number | undefined; readonly repoCount?: number | undefined; readonly completedRepoCount?: number | undefined; readonly discoveredWorktreeCount?: number | undefined; readonly activeWorktreeCount?: number | undefined; readonly statusMessage?: string | undefined; readonly done?: boolean | undefined; readonly interrupted?: boolean | undefined } | { readonly _tag: "Add"; readonly status: "added" | "already_exists" | "created"; readonly source: string; readonly ref: string; readonly commit?: string | undefined; readonly path: string } | { readonly _tag: "WorktreeNew"; readonly source: string; readonly ref: string; readonly path: string; readonly commit?: string | undefined; readonly autoBootstrap: boolean; readonly branchCreated: boolean } | { readonly _tag: "Fix"; readonly basePath: string; readonly results: ReadonlyArray<{ readonly memberName: string; readonly issueType: string; readonly status: "fixed" | "skipped" | "error"; readonly message: string }>; readonly dryRun: boolean; readonly noIssues: boolean } | { readonly _tag: "Error"; readonly error: string; readonly message: string; readonly source?: string | undefined } | { readonly _tag: "Interrupted" }
+      └─ { readonly _tag: "Error"; readonly error: string; readonly message: string; readonly source?: string | undefined }
+         └─ ["message"]
+            └─ Expected string, actual null",
+  },
+  "unknownTag": {
+    "_tag": "failed",
+    "error": "(parseJson <-> { readonly _tag: "Ls"; readonly basePath: string; readonly repos: ReadonlyArray<{ readonly relativePath: string }> } | { readonly _tag: "Status"; readonly basePath: string; readonly repoCount: number; readonly worktreeCount: number; readonly diskUsage?: string | undefined; readonly worktrees: ReadonlyArray<{ readonly repo: string; readonly ref: string; readonly refType: "heads" | "tags" | "commits"; readonly path: string; readonly issues: ReadonlyArray<{ readonly type: "dirty" | "unpushed" | "ref_mismatch" | "missing_bare" | "broken_worktree" | "orphaned"; readonly severity: "error" | "warning" | "info"; readonly message: string }> }> } | { readonly _tag: "Fetch"; readonly basePath: string; readonly results: ReadonlyArray<{ readonly path: string; readonly status: "fetched" | "error"; readonly message?: string | undefined }>; readonly elapsedMs: number } | { readonly _tag: "Gc"; readonly basePath: string; readonly results: ReadonlyArray<{ readonly repo: string; readonly ref: string; readonly refType: "heads" | "tags" | "commits"; readonly path: string; readonly status: "removed" | "skipped_dirty" | "skipped_in_use" | "error" | "archived" | "reaped" | "kept"; readonly message?: string | undefined; readonly reason?: string | undefined; readonly recoverPath?: string | undefined; readonly pathRef?: string | undefined; readonly actualHeadBranch?: string | undefined }>; readonly dryRun: boolean; readonly warning?: { readonly type: "not_in_megarepo" | "only_current_megarepo" | "custom"; readonly message?: string | undefined } | undefined; readonly showForceHint: boolean; readonly processedCount?: number | undefined; readonly repoCount?: number | undefined; readonly completedRepoCount?: number | undefined; readonly discoveredWorktreeCount?: number | undefined; readonly activeWorktreeCount?: number | undefined; readonly statusMessage?: string | undefined; readonly done?: boolean | undefined; readonly interrupted?: boolean | undefined } | { readonly _tag: "Add"; readonly status: "added" | "already_exists" | "created"; readonly source: string; readonly ref: string; readonly commit?: string | undefined; readonly path: string } | { readonly _tag: "WorktreeNew"; readonly source: string; readonly ref: string; readonly path: string; readonly commit?: string | undefined; readonly autoBootstrap: boolean; readonly branchCreated: boolean } | { readonly _tag: "Fix"; readonly basePath: string; readonly results: ReadonlyArray<{ readonly memberName: string; readonly issueType: string; readonly status: "fixed" | "skipped" | "error"; readonly message: string }>; readonly dryRun: boolean; readonly noIssues: boolean } | { readonly _tag: "Error"; readonly error: string; readonly message: string; readonly source?: string | undefined } | { readonly _tag: "Interrupted" })
+└─ Type side transformation failure
+   └─ { readonly _tag: "Ls"; readonly basePath: string; readonly repos: ReadonlyArray<{ readonly relativePath: string }> } | { readonly _tag: "Status"; readonly basePath: string; readonly repoCount: number; readonly worktreeCount: number; readonly diskUsage?: string | undefined; readonly worktrees: ReadonlyArray<{ readonly repo: string; readonly ref: string; readonly refType: "heads" | "tags" | "commits"; readonly path: string; readonly issues: ReadonlyArray<{ readonly type: "dirty" | "unpushed" | "ref_mismatch" | "missing_bare" | "broken_worktree" | "orphaned"; readonly severity: "error" | "warning" | "info"; readonly message: string }> }> } | { readonly _tag: "Fetch"; readonly basePath: string; readonly results: ReadonlyArray<{ readonly path: string; readonly status: "fetched" | "error"; readonly message?: string | undefined }>; readonly elapsedMs: number } | { readonly _tag: "Gc"; readonly basePath: string; readonly results: ReadonlyArray<{ readonly repo: string; readonly ref: string; readonly refType: "heads" | "tags" | "commits"; readonly path: string; readonly status: "removed" | "skipped_dirty" | "skipped_in_use" | "error" | "archived" | "reaped" | "kept"; readonly message?: string | undefined; readonly reason?: string | undefined; readonly recoverPath?: string | undefined; readonly pathRef?: string | undefined; readonly actualHeadBranch?: string | undefined }>; readonly dryRun: boolean; readonly warning?: { readonly type: "not_in_megarepo" | "only_current_megarepo" | "custom"; readonly message?: string | undefined } | undefined; readonly showForceHint: boolean; readonly processedCount?: number | undefined; readonly repoCount?: number | undefined; readonly completedRepoCount?: number | undefined; readonly discoveredWorktreeCount?: number | undefined; readonly activeWorktreeCount?: number | undefined; readonly statusMessage?: string | undefined; readonly done?: boolean | undefined; readonly interrupted?: boolean | undefined } | { readonly _tag: "Add"; readonly status: "added" | "already_exists" | "created"; readonly source: string; readonly ref: string; readonly commit?: string | undefined; readonly path: string } | { readonly _tag: "WorktreeNew"; readonly source: string; readonly ref: string; readonly path: string; readonly commit?: string | undefined; readonly autoBootstrap: boolean; readonly branchCreated: boolean } | { readonly _tag: "Fix"; readonly basePath: string; readonly results: ReadonlyArray<{ readonly memberName: string; readonly issueType: string; readonly status: "fixed" | "skipped" | "error"; readonly message: string }>; readonly dryRun: boolean; readonly noIssues: boolean } | { readonly _tag: "Error"; readonly error: string; readonly message: string; readonly source?: string | undefined } | { readonly _tag: "Interrupted" }
+      └─ { readonly _tag: "Ls" | "Status" | "Fetch" | "Gc" | "Add" | "WorktreeNew" | "Fix" | "Error" | "Interrupted" }
+         └─ ["_tag"]
+            └─ Expected "Ls" | "Status" | "Fetch" | "Gc" | "Add" | "WorktreeNew" | "Fix" | "Error" | "Interrupted", actual "Unknown"",
+  },
+}
+`;

--- a/packages/@overeng/megarepo/src/lib/json-wire-baseline.test.ts
+++ b/packages/@overeng/megarepo/src/lib/json-wire-baseline.test.ts
@@ -73,6 +73,7 @@ describe('megarepo wire baselines (cross-major invariant)', () => {
     }).toMatchSnapshot()
   })
 
+  // TODO(live-migration:effect-3-4): Keep lockedAt as a persisted plain string; normalizing it during Effect 4 repair would remove this gate's coverage.
   it('captures megarepo lock JSON bytes and failure partition', () => {
     expect(
       roundTrip(LockFile, {

--- a/packages/@overeng/megarepo/src/lib/json-wire-baseline.test.ts
+++ b/packages/@overeng/megarepo/src/lib/json-wire-baseline.test.ts
@@ -1,0 +1,158 @@
+import { Schema } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import { StoreState } from '../cli/renderers/StoreOutput/schema.ts'
+import { MegarepoConfig } from './config.ts'
+import { LockFile } from './lock.ts'
+
+const encodeJson = <A, I>(schema: Schema.Schema<A, I, never>, value: A): string =>
+  Schema.encodeSync(Schema.parseJson(schema, { space: 2 }))(value)
+
+const decodeJson = <A, I>(schema: Schema.Schema<A, I, never>, encoded: string): A =>
+  Schema.decodeUnknownSync(Schema.parseJson(schema))(encoded)
+
+const roundTrip = <A, I>(schema: Schema.Schema<A, I, never>, value: A) => {
+  const encoded = encodeJson(schema, value)
+  const decoded = decodeJson(schema, encoded)
+  const reencoded = encodeJson(schema, decoded)
+
+  return {
+    encoded,
+    decoded,
+    reencoded,
+    byteIdentical: reencoded === encoded,
+  }
+}
+
+const decodeFailure = <A, I>(schema: Schema.Schema<A, I, never>, encoded: string) => {
+  try {
+    return { _tag: 'decoded' as const, value: decodeJson(schema, encoded) }
+  } catch (error) {
+    return {
+      _tag: 'failed' as const,
+      error: error instanceof Error ? String(error) : String(error),
+    }
+  }
+}
+
+describe('megarepo wire baselines (cross-major invariant)', () => {
+  it('captures megarepo config JSON bytes and failure partition', () => {
+    expect(
+      roundTrip(MegarepoConfig, {
+        $schema: 'https://example.invalid/megarepo.schema.json',
+        members: {
+          '': './empty-name',
+          'unicode-ß': 'https://github.com/example/unicode#feature/ß',
+          windows: '../windows\r\npath',
+        },
+        generators: {
+          vscode: {
+            enabled: true,
+            exclude: ['tmp', 'unicode-ß'],
+            color: '#123abc',
+            colorEnvVar: 'MEGAREPO_COLOR',
+            settings: {
+              'editor.formatOnSave': true,
+              'terminal.integrated.defaultProfile.linux': 'bash\r\nzsh',
+              nullable: null,
+            },
+          },
+        },
+        lockSync: {
+          enabled: false,
+          exclude: ['unicode-ß'],
+          sharedInputSource: 'nixpkgs',
+        },
+      }),
+    ).toMatchSnapshot()
+
+    expect({
+      nullDocument: decodeFailure(MegarepoConfig, 'null'),
+      missingMembers: decodeFailure(MegarepoConfig, '{}'),
+      nullMemberSource: decodeFailure(MegarepoConfig, '{"members":{"bad":null}}'),
+    }).toMatchSnapshot()
+  })
+
+  it('captures megarepo lock JSON bytes and failure partition', () => {
+    expect(
+      roundTrip(LockFile, {
+        version: 1,
+        members: {
+          'unicode-ß': {
+            url: 'https://github.com/example/unicode',
+            ref: 'feature/ß',
+            commit: '0123456789abcdef0123456789abcdef01234567',
+            pinned: true,
+            lockedAt: '2026-07-28T11:50:00.000Z',
+          },
+          'out-of-range-date-string': {
+            url: 'git@github.com:example/out-of-range.git',
+            ref: 'main',
+            commit: 'ffffffffffffffffffffffffffffffffffffffff',
+            pinned: false,
+            lockedAt: '99999-99-99T99:99:99.999Z',
+          },
+        },
+      }),
+    ).toMatchSnapshot()
+
+    expect({
+      nullDocument: decodeFailure(LockFile, 'null'),
+      missingPinned: decodeFailure(
+        LockFile,
+        '{"version":1,"members":{"repo":{"url":"https://github.com/example/repo","ref":"main","commit":"0123456789abcdef0123456789abcdef01234567","lockedAt":"2026-07-28T11:50:00.000Z"}}}',
+      ),
+      nullMembers: decodeFailure(LockFile, '{"version":1,"members":null}'),
+    }).toMatchSnapshot()
+  })
+
+  it('captures megarepo store state JSON bytes and failure partition', () => {
+    expect(
+      roundTrip(StoreState, {
+        _tag: 'Gc',
+        basePath: '/store/root',
+        dryRun: true,
+        showForceHint: false,
+        warning: {
+          type: 'custom',
+          message: 'line one\r\nline two',
+        },
+        results: [
+          {
+            repo: 'example/unicode',
+            ref: 'feature/ß',
+            refType: 'heads',
+            path: '/store/root/github.com/example/unicode/refs/heads/feature/ß',
+            status: 'kept',
+            reason: 'live',
+            message: 'protected by workspace registry',
+          },
+          {
+            repo: 'example/commit',
+            ref: '0123456789abcdef0123456789abcdef01234567',
+            refType: 'commits',
+            path: '/store/root/github.com/example/commit/refs/commits/0123456789abcdef0123456789abcdef01234567',
+            status: 'archived',
+            recoverPath: '/store/root/.archive/example-commit',
+            pathRef: 'main',
+            actualHeadBranch: 'feature/old',
+          },
+        ],
+        processedCount: 2,
+        repoCount: 2,
+        completedRepoCount: 1,
+        discoveredWorktreeCount: 3,
+        activeWorktreeCount: 1,
+        statusMessage: 'gc complete',
+        done: true,
+        interrupted: false,
+      }),
+    ).toMatchSnapshot()
+
+    expect({
+      nullDocument: decodeFailure(StoreState, 'null'),
+      unknownTag: decodeFailure(StoreState, '{"_tag":"Unknown"}'),
+      nullOptionalMessage: decodeFailure(StoreState, '{"_tag":"Error","error":"E","message":null}'),
+    }).toMatchSnapshot()
+  })
+})

--- a/packages/@overeng/megarepo/src/lib/json-wire-baseline.test.ts
+++ b/packages/@overeng/megarepo/src/lib/json-wire-baseline.test.ts
@@ -36,6 +36,7 @@ const decodeFailure = <A, I>(schema: Schema.Schema<A, I, never>, encoded: string
 }
 
 describe('megarepo wire baselines (cross-major invariant)', () => {
+  // TODO(live-migration:effect-3-4): Effect 4 renders SchemaError(...) for these failures; preserve the structural partition and adjudicate internal-only text before re-baselining.
   it('captures megarepo config JSON bytes and failure partition', () => {
     expect(
       roundTrip(MegarepoConfig, {
@@ -107,6 +108,7 @@ describe('megarepo wire baselines (cross-major invariant)', () => {
     }).toMatchSnapshot()
   })
 
+  // TODO(live-migration:effect-3-4): Effect 4 renders SchemaError(...) for these failures; preserve the structural partition and adjudicate internal-only text before re-baselining.
   it('captures megarepo store state JSON bytes and failure partition', () => {
     expect(
       roundTrip(StoreState, {


### PR DESCRIPTION
## Problem

Phase 1 needs Effect 3 wire baselines for megarepo durable JSON before the Effect 4 cohort flip. The lock, config, and store state boundaries are persisted or emitted as JSON and must remain byte-observable through the migration.

## Goal

Capture representative `megarepo` JSON behavior as ordinary additive Vitest coverage on Effect 3.

## Decisions

- Adds `packages/@overeng/megarepo/src/lib/json-wire-baseline.test.ts` plus Vitest snapshots.
- Captures encoded bytes, decoded values, and re-encoded byte identity for `MegarepoConfig`, `LockFile`, and `StoreState`.
- Includes awkward values: empty string keys, `null`, unicode, CRLF, and an out-of-range date string.
- Captures failure partitions for `null` documents, absent required keys, and invalid union/tag/field shapes.

## Verification

- PASS: `CI=1 ./node_modules/.bin/vitest run src/lib/json-wire-baseline.test.ts` from `packages/@overeng/megarepo`.
- PASS: `oxfmt --check packages/@overeng/megarepo/src/lib/json-wire-baseline.test.ts packages/@overeng/megarepo/src/lib/__snapshots__/json-wire-baseline.test.ts.snap`.
- PASS: `oxlint packages/@overeng/megarepo/src/lib/json-wire-baseline.test.ts`.
- PASS: `git diff --check`.
- PASS: `CI=1 devenv tasks run ts:check --no-tui`.
- PASS: `CI=1 devenv tasks run check:quick --no-tui`.

## Complexity

No new runtime complexity; additive baseline tests only.

## Concerns

The lock baseline intentionally records that `lockedAt` is currently a plain string, not a date-validating field.

## Friction & bottlenecks

The first broad `check:quick` attempt surfaced only a terse `ts:check` failure; a direct compiler diagnostic showed the helper generic needed to restrict schema context to `never`. Fixed before the final green gate.

## Follow-ups

Continue Phase 1 baseline PRs for `notion-md` state-store/tree-index JSON and `notion-datasource-sync` SQLite/replica encoding.

## References

Refs #925.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | co1-ravine |
| `agent_session_id` | a5820d1a-682d-4d0d-9457-f5eae7017cd4 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.145.0 |
| `agent_runtime` | Codex CLI 0.145.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/g70zaf7b08m8pmn4iqxy3a70a2833y23-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/997m3kakbn5dnr72qix3xmfx4pmd6qxd-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-28-2026-07-28-baselines-4-megarepo-json |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->