### PR TITLE
docs: correct install task command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Use `devenv tasks run <task>` (devenv tasks) to execute tasks with dependencies:
 - **Linting**: `devenv tasks run lint:check` or `devenv tasks run lint:fix`
 - **Testing**: `devenv tasks run test:run` (all) or `devenv tasks run test:<pkg>` (single package) or `devenv tasks run test:watch` or `devenv tasks run test:integration`
 - **Build**: `devenv tasks run ts:build`
-- **Install**: `devenv tasks run bun:install`
+- **Install**: `devenv tasks run pnpm:install`
 - **Genie**: `devenv tasks run genie:run` or `devenv tasks run genie:watch` or `devenv tasks run genie:check`
 - **Check all**: `devenv tasks run check:quick` (ts + lint) or `devenv tasks run check:all` (ts + lint + test)
 


### PR DESCRIPTION
## Problem

The development-command docs direct contributors and agents to `bun:install`, but that task does not exist. The repository's actual install task is `pnpm:install`.

## Goal

Make the documented install command match the task graph.

## Verification

From the committed worktree:

- `rg -n '\*\*Install\*\*' AGENTS.md CLAUDE.md` shows `devenv tasks run pnpm:install` at line 13 through both paths.
- `devenv tasks list` contains `pnpm:install` and does not contain `bun:install`.
- `git diff --check` passes.

## Complexity

No new complexity; this is a one-line documentation correction. `CLAUDE.md` is a symlink to `AGENTS.md`, so the single source-line change fixes both documented paths.

## Concerns

None.

## Friction & bottlenecks

`devenv tasks list` does not support a JSON output flag, so task presence was verified against its plain-text output.

## Follow-ups

None.

## References

Closes #1001

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | co2-comet |
| `agent_session_id` | 7c71fe09-b408-4f01-beca-75afbbe788ec |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.145.0 |
| `agent_runtime` | Codex CLI 0.145.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/g70zaf7b08m8pmn4iqxy3a70a2833y23-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/997m3kakbn5dnr72qix3xmfx4pmd6qxd-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-28-fix-install-task-docs |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->