### PR TITLE
docs: correct install task command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Use `devenv tasks run <task>` (devenv tasks) to execute tasks with dependencies:
 - **Linting**: `devenv tasks run lint:check` or `devenv tasks run lint:fix`
 - **Testing**: `devenv tasks run test:run` (all) or `devenv tasks run test:<pkg>` (single package) or `devenv tasks run test:watch` or `devenv tasks run test:integration`
 - **Build**: `devenv tasks run ts:build`
-- **Install**: `devenv tasks run bun:install`
+- **Install**: `devenv tasks run pnpm:install`
 - **Genie**: `devenv tasks run genie:run` or `devenv tasks run genie:watch` or `devenv tasks run genie:check`
 - **Check all**: `devenv tasks run check:quick` (ts + lint) or `devenv tasks run check:all` (ts + lint + test)
 


### PR DESCRIPTION
## Problem

The contributor instructions named `bun:install`, but that devenv task does not exist. The surrounding documentation already says pnpm is temporarily responsible for installs.

## Goal

Make both instruction entry points direct contributors to the real `pnpm:install` task. (`CLAUDE.md` is a symlink to `AGENTS.md`, so this is one tracked-line change.)

## Verification

- `devenv --no-tui tasks list | rg '^.*pnpm:install'` found `pnpm:install (has status check)`.
- `rg -n 'bun:install|pnpm:install' AGENTS.md CLAUDE.md` found `pnpm:install` at line 13 in both files and no `bun:install`.
- `git diff --check` passed.

## Complexity

No new complexity.

## Concerns

None.

## Friction & bottlenecks

The stale onboarding command repeatedly sent agents to a nonexistent task; #1001 tracks the correction. No performance bottleneck was involved.

## Follow-ups

None.

## References

Closes #1001.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | co3-steel |
| `agent_session_id` | ce0090ad-94df-4515-9139-7546cc9921df |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.145.0 |
| `agent_runtime` | Codex CLI 0.145.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/g70zaf7b08m8pmn4iqxy3a70a2833y23-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/997m3kakbn5dnr72qix3xmfx4pmd6qxd-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-28-effect4-install-doc |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->