### PR TITLE
test(effect-schema-form-aria): capture cross-major baselines

### DIFF
--- a/nix/oxc-config-plugin.nix
+++ b/nix/oxc-config-plugin.nix
@@ -29,7 +29,7 @@ let
     pnpm = pinnedPnpm;
   };
   packageDir = "packages/@overeng/oxc-config";
-  pnpmDepsHash = "sha256-G03QfAiCQ00xQlzdJP/pB9GElp6PDUZ5Qbfav8OE7GU=";
+  pnpmDepsHash = "sha256-0EpX7HQHfu4XyZjO/0N4QjOKaFXNB3F/iEUzGesURjM=";
 
   srcPath =
     if builtins.isAttrs src && builtins.hasAttr "outPath" src then

--- a/packages/@overeng/ci-tools/nix/build.nix
+++ b/packages/@overeng/ci-tools/nix/build.nix
@@ -19,7 +19,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-Zi/GWjsz7mFG9W/oDC49SX6kv8FnR/lNJxRWgJ+Xl2o=";
+      "." = mkSharedHash "sha256-KOHU2Wf4qIAeis7nZKdJRBA192SYTpgn+ztjCEbSVVk=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/effect-schema-form-aria/package.json
+++ b/packages/@overeng/effect-schema-form-aria/package.json
@@ -25,6 +25,7 @@
     "@storybook/react-vite": "10.4.6",
     "@tailwindcss/vite": "4.3.1",
     "@types/react": "19.2.17",
+    "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "6.0.2",
     "effect": "3.21.4",
     "react": "19.2.7",

--- a/packages/@overeng/effect-schema-form-aria/package.json.genie.ts
+++ b/packages/@overeng/effect-schema-form-aria/package.json.genie.ts
@@ -26,6 +26,7 @@ const runtimeDeps = catalog.compose({
         '@storybook/react-vite',
         '@tailwindcss/vite',
         '@types/react',
+        '@types/react-dom',
         '@vitejs/plugin-react',
         'storybook',
         'tailwindcss',

--- a/packages/@overeng/effect-schema-form-aria/src/mod.unit.test.tsx
+++ b/packages/@overeng/effect-schema-form-aria/src/mod.unit.test.tsx
@@ -1,0 +1,184 @@
+import { Schema } from 'effect'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  AriaSchemaForm,
+  BooleanField,
+  FieldGroup,
+  FieldGroupEmpty,
+  FieldWrapper,
+  LiteralField,
+  NumberField,
+  TextField,
+  UnknownField,
+} from './mod.ts'
+
+describe('effect-schema-form-aria baselines (cross-major invariant)', () => {
+  it('renders text, boolean, and field wrapper bytes for empty, unicode, hinted, and disabled values', () => {
+    const html = renderToStaticMarkup(
+      <FieldGroup label="Primitives <世界>" className="outer">
+        <TextField
+          id="email"
+          label="Email"
+          value=""
+          onChange={vi.fn()}
+          hint="résumé@example.com"
+          type="email"
+          placeholder="you@example.com"
+          isDisabled
+        />
+        <BooleanField
+          id="enabled"
+          label="Enabled"
+          value={false}
+          onChange={vi.fn()}
+          hint=""
+          isDisabled
+        />
+        <FieldWrapper description={undefined}>
+          <span>bare</span>
+        </FieldWrapper>
+      </FieldGroup>,
+    )
+
+    expect(html).toMatchInlineSnapshot(
+      `"<div class="rounded-lg border border-border bg-surface p-4 outer" data-rac="" role="group"><header class="text-sm font-medium text-ink mb-3">Primitives &lt;世界&gt;</header><div class="grid gap-4"><div class="grid gap-1.5" data-rac="" data-disabled="true"><label class="text-sm text-ink" id="react-aria-_R_6H1_" for="react-aria-_R_6_">Email</label><input type="email" disabled="" placeholder="you@example.com" id="email" aria-labelledby="react-aria-_R_6H1_" aria-describedby="react-aria-_R_6H3_ react-aria-_R_6H4_" class="w-full px-2.5 py-2 text-sm rounded border border-border bg-input text-ink placeholder:text-subtle-ink focus:outline-none focus:ring-1 focus:ring-primary disabled:opacity-50 disabled:cursor-not-allowed" data-rac="" data-disabled="true" value=""/><span class="text-[12px] text-subtle-ink" id="react-aria-_R_6H3_" slot="description">résumé@example.com</span></div><div class="grid gap-1.5"><div><div class="text-sm text-ink" data-rac="" data-disabled="true"><label data-react-aria-pressable="true" class="group flex items-center gap-2 cursor-pointer" data-rac="" data-disabled="true"><span style="border:0;clip:rect(0 0 0 0);clip-path:inset(50%);height:1px;margin:-1px;overflow:hidden;padding:0;position:absolute;width:1px;white-space:nowrap"><input id="enabled" aria-describedby="react-aria-_R_q_ react-aria-_R_qH1_" disabled="" type="checkbox" data-react-aria-pressable="true"/></span><div class="size-4 shrink-0 rounded border border-border bg-input group-data-[selected]:bg-primary group-data-[selected]:border-primary flex items-center justify-center transition-colors"><svg viewBox="0 0 12 12" class="size-3 text-white opacity-0 group-data-[selected]:opacity-100 transition-opacity" aria-hidden="true"><path d="M3 6l2 2 4-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"></path></svg></div><span>Enabled</span></label></div></div><div class="min-h-[16px] text-[12px] text-subtle-ink"></div></div><div class="grid gap-1.5"><div><span>bare</span></div><div class="min-h-[16px] text-[12px] text-subtle-ink"></div></div></div></div>"`,
+    )
+  })
+
+  it('renders required and optional number field bytes across undefined, zero, and disabled states', () => {
+    const html = renderToStaticMarkup(
+      <div>
+        <NumberField
+          id="required"
+          label="Required"
+          value={undefined}
+          onChange={vi.fn()}
+          hint="NaN boundary"
+        />
+        <NumberField
+          id="optional-off"
+          label="Optional off"
+          value={undefined}
+          onChange={vi.fn()}
+          isOptional
+        />
+        <NumberField
+          id="optional-zero"
+          label="Optional zero"
+          value={0}
+          onChange={vi.fn()}
+          isOptional
+          isDisabled
+        />
+      </div>,
+    )
+
+    expect(html).toMatchInlineSnapshot(
+      `"<div><div class="grid gap-1.5" data-rac=""><label class="text-sm text-ink" id="react-aria-_R_1H2_" for="react-aria-_R_1_">Required</label><input aria-labelledby="react-aria-_R_1H2_" id="required" type="text" autoComplete="off" inputMode="numeric" autoCorrect="off" spellCheck="false" tabindex="0" aria-describedby="react-aria-_R_1H4_ react-aria-_R_1H5_" aria-roledescription="Number field" class="w-full px-2.5 py-2 text-sm rounded border border-border bg-input text-ink focus:outline-none focus:ring-1 focus:ring-primary disabled:opacity-50 disabled:cursor-not-allowed" data-rac="" value=""/><span class="text-[12px] text-subtle-ink" id="react-aria-_R_1H4_" slot="description">NaN boundary</span></div><div class="grid gap-1.5"><div><div class="flex items-center gap-2"><label for="optional-off" class="text-sm text-ink whitespace-nowrap">Optional off</label><input id="optional-off" type="number" disabled="" class="w-20 px-2 py-0.5 text-sm rounded border border-border bg-input text-ink focus:outline-none focus:ring-1 focus:ring-primary disabled:opacity-50" value=""/><button type="button" role="switch" aria-checked="false" title="Click to enable" class="size-4 shrink-0 rounded border border-border flex items-center justify-center hover:bg-surface-raised disabled:opacity-50"></button></div></div><div class="min-h-[16px] text-[12px] text-subtle-ink"></div></div><div class="grid gap-1.5"><div><div class="flex items-center gap-2"><label for="optional-zero" class="text-sm text-ink whitespace-nowrap">Optional zero</label><input id="optional-zero" type="number" disabled="" class="w-20 px-2 py-0.5 text-sm rounded border border-border bg-input text-ink focus:outline-none focus:ring-1 focus:ring-primary disabled:opacity-50" value="0"/><button type="button" role="switch" aria-checked="true" title="Click to disable (set to undefined)" disabled="" class="size-4 shrink-0 rounded border border-border flex items-center justify-center hover:bg-surface-raised disabled:opacity-50"><svg width="10" height="10" viewBox="0 0 12 12" class="text-accent" aria-hidden="true"><path d="M3 6l2 2 4-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"></path></svg></button></div></div><div class="min-h-[16px] text-[12px] text-subtle-ink"></div></div></div>"`,
+    )
+  })
+
+  it('renders segmented literal bytes at the five-option boundary including optional empty selection', () => {
+    const html = renderToStaticMarkup(
+      <LiteralField
+        id="role"
+        label="Role"
+        value={undefined}
+        onChange={vi.fn()}
+        literals={['', 'admin', 'someValue', '東京']}
+        hint=""
+        isOptional
+      />,
+    )
+
+    expect(html).toMatchInlineSnapshot(
+      `"<div class="grid gap-1.5"><div><div class="grid gap-1"><span class="text-sm text-ink">Role</span><div class="flex rounded-lg border border-border overflow-hidden" data-rac="" aria-label="Role" role="radiogroup" aria-orientation="horizontal" aria-disabled="false" data-orientation="horizontal"><button class="flex-1 px-3 py-1.5 text-sm text-ink bg-surface hover:bg-surface-raised data-[selected]:bg-primary data-[selected]:text-white transition-colors border-r border-border last:border-r-0" data-rac="" type="button" tabindex="0" data-react-aria-pressable="true" role="radio" aria-checked="true" data-selected="true">—</button><button class="flex-1 px-3 py-1.5 text-sm text-ink bg-surface hover:bg-surface-raised data-[selected]:bg-primary data-[selected]:text-white transition-colors border-r border-border last:border-r-0" data-rac="" type="button" tabindex="0" data-react-aria-pressable="true" role="radio" aria-checked="true" data-selected="true"></button><button class="flex-1 px-3 py-1.5 text-sm text-ink bg-surface hover:bg-surface-raised data-[selected]:bg-primary data-[selected]:text-white transition-colors border-r border-border last:border-r-0" data-rac="" type="button" tabindex="0" data-react-aria-pressable="true" role="radio" aria-checked="false">Admin</button><button class="flex-1 px-3 py-1.5 text-sm text-ink bg-surface hover:bg-surface-raised data-[selected]:bg-primary data-[selected]:text-white transition-colors border-r border-border last:border-r-0" data-rac="" type="button" tabindex="0" data-react-aria-pressable="true" role="radio" aria-checked="false">Some Value</button><button class="flex-1 px-3 py-1.5 text-sm text-ink bg-surface hover:bg-surface-raised data-[selected]:bg-primary data-[selected]:text-white transition-colors border-r border-border last:border-r-0" data-rac="" type="button" tabindex="0" data-react-aria-pressable="true" role="radio" aria-checked="false">東京</button></div></div></div><div class="min-h-[16px] text-[12px] text-subtle-ink"></div></div>"`,
+    )
+  })
+
+  it('renders select literal bytes above the segmented boundary with an out-of-domain value', () => {
+    const html = renderToStaticMarkup(
+      <LiteralField
+        id="many"
+        label={undefined}
+        value="missing"
+        onChange={vi.fn()}
+        literals={['one', 'two', 'three', 'four', 'five', 'six']}
+        hint="Choose"
+        isOptional
+        isDisabled
+      />,
+    )
+
+    expect(html).toMatchInlineSnapshot(
+      `"<template><span class="text-[12px] text-subtle-ink">Choose</span></template><div class="grid gap-1.5" data-rac="" data-disabled="true"><button id="many" class="w-full px-2.5 py-2 text-sm rounded border border-border bg-input text-ink text-left flex items-center justify-between focus:outline-none focus:ring-1 focus:ring-primary disabled:opacity-50" data-rac="" type="button" disabled="" data-react-aria-pressable="true" aria-labelledby="react-aria-_R_2H7_ react-aria-_R_2H3_" aria-describedby="react-aria-_R_2H5_ react-aria-_R_2H6_" aria-haspopup="listbox" aria-expanded="false" data-disabled="true"><span id="react-aria-_R_2H7_" class="flex-1" data-rac="" data-placeholder="true">Select an item</span><svg viewBox="0 0 16 16" class="size-4 text-subtle-ink" aria-hidden="true"><path d="M4 6l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none"></path></svg></button><span class="text-[12px] text-subtle-ink">Choose</span><div style="border:0;clip:rect(0 0 0 0);clip-path:inset(50%);height:1px;margin:-1px;overflow:hidden;padding:0;position:fixed;width:1px;white-space:nowrap;top:0;left:0" aria-hidden="true" data-react-aria-prevent-focus="true" data-a11y-ignore="aria-hidden-focus" data-testid="hidden-select-container"><label><select tabindex="-1" disabled=""><option value="" label=" "> </option><option value="">— Select —</option><option value="one">One</option><option value="two">Two</option><option value="three">Three</option><option value="four">Four</option><option value="five">Five</option><option value="six">Six</option></select></label></div></div>"`,
+    )
+  })
+
+  it('renders unsupported and empty-group bytes instead of failing', () => {
+    const html = renderToStaticMarkup(
+      <div>
+        <UnknownField
+          fieldKey="items"
+          meta={{
+            type: 'unknown',
+            title: undefined,
+            description: undefined,
+            literals: undefined,
+            isOptional: false,
+            innerSchema: Schema.Tuple(Schema.String),
+          }}
+        />
+        <FieldGroupEmpty label="Empty Group" />
+        <FieldGroupEmpty label="Custom" message="" className="extra" />
+      </div>,
+    )
+
+    expect(html).toMatchInlineSnapshot(
+      `"<div><div class="grid gap-1.5 p-2 border border-border rounded bg-surface"><span class="text-[13px] text-muted-ink">items</span><span class="text-[12px] text-subtle-ink italic">Unsupported schema type: unknown</span></div><div class="rounded-lg border border-border/50 bg-surface/30 p-3 " data-rac="" role="group"><header class="text-sm font-medium text-ink mb-2">Empty Group</header><span class="text-xs text-subtle-ink italic">No additional options</span></div><div class="rounded-lg border border-border/50 bg-surface/30 p-3 extra" data-rac="" role="group"><header class="text-sm font-medium text-ink mb-2">Custom</header><span class="text-xs text-subtle-ink italic"></span></div></div>"`,
+    )
+  })
+
+  it('renders a complete tagged schema form as byte-identical markup', () => {
+    const FormSchema = Schema.TaggedStruct('contact_preferences', {
+      name: Schema.String.annotations({ title: 'Name', description: 'Unicode accepted' }),
+      count: Schema.optional(Schema.Number).annotations({ title: 'Count' }),
+      enabled: Schema.Boolean,
+      mode: Schema.Literal('email', 'push-notification'),
+      items: Schema.Tuple(Schema.String),
+    })
+
+    const html = renderToStaticMarkup(
+      <AriaSchemaForm
+        schema={FormSchema}
+        value={{
+          _tag: 'contact_preferences',
+          name: 'Ada 世界',
+          enabled: false,
+          mode: 'push-notification',
+          items: [''],
+        }}
+        onChange={vi.fn()}
+        className="custom"
+      />,
+    )
+
+    expect(html).toMatchInlineSnapshot(
+      `"<div class="rounded-lg border border-border/50 bg-surface/30 p-3 custom" data-rac="" role="group"><header class="text-sm font-medium text-ink mb-3">Contact Preferences</header><div class="grid gap-4"><div class="grid gap-4 "><div><div class="grid gap-1.5" data-rac=""><label class="text-sm text-ink" id="react-aria-_R_6H1_" for="react-aria-_R_6_">Name</label><input type="text" placeholder="" tabindex="0" id="schema-form-name" aria-labelledby="react-aria-_R_6H1_" aria-describedby="react-aria-_R_6H3_ react-aria-_R_6H4_" class="w-full px-2.5 py-2 text-sm rounded border border-border bg-input text-ink placeholder:text-subtle-ink focus:outline-none focus:ring-1 focus:ring-primary disabled:opacity-50 disabled:cursor-not-allowed" data-rac="" value="Ada 世界"/><span class="text-[12px] text-subtle-ink" id="react-aria-_R_6H3_" slot="description">Unicode accepted</span></div></div><div><div class="grid gap-1.5"><div><div class="flex items-center gap-2"><label for="schema-form-count" class="text-sm text-ink whitespace-nowrap">Count</label><input id="schema-form-count" type="number" disabled="" class="w-20 px-2 py-0.5 text-sm rounded border border-border bg-input text-ink focus:outline-none focus:ring-1 focus:ring-primary disabled:opacity-50" value=""/><button type="button" role="switch" aria-checked="false" title="Click to enable" class="size-4 shrink-0 rounded border border-border flex items-center justify-center hover:bg-surface-raised disabled:opacity-50"></button></div></div><div class="min-h-[16px] text-[12px] text-subtle-ink">a number</div></div></div><div><div class="grid gap-1.5"><div><div class="text-sm text-ink" data-rac=""><label data-react-aria-pressable="true" class="group flex items-center gap-2 cursor-pointer" data-rac=""><span style="border:0;clip:rect(0 0 0 0);clip-path:inset(50%);height:1px;margin:-1px;overflow:hidden;padding:0;position:absolute;width:1px;white-space:nowrap"><input id="schema-form-enabled" aria-describedby="react-aria-_R_1e_ react-aria-_R_1eH1_" type="checkbox" data-react-aria-pressable="true" tabindex="0"/></span><div class="size-4 shrink-0 rounded border border-border bg-input group-data-[selected]:bg-primary group-data-[selected]:border-primary flex items-center justify-center transition-colors"><svg viewBox="0 0 12 12" class="size-3 text-white opacity-0 group-data-[selected]:opacity-100 transition-opacity" aria-hidden="true"><path d="M3 6l2 2 4-5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"></path></svg></div><span>boolean</span></label></div></div><div class="min-h-[16px] text-[12px] text-subtle-ink">a boolean</div></div></div><div><div class="grid gap-1.5"><div><div class="grid gap-1"><span class="text-sm text-ink">mode</span><div class="flex rounded-lg border border-border overflow-hidden" data-rac="" aria-label="mode" role="radiogroup" aria-orientation="horizontal" aria-disabled="false" data-orientation="horizontal"><button class="flex-1 px-3 py-1.5 text-sm text-ink bg-surface hover:bg-surface-raised data-[selected]:bg-primary data-[selected]:text-white transition-colors border-r border-border last:border-r-0" data-rac="" type="button" tabindex="0" data-react-aria-pressable="true" role="radio" aria-checked="false">Email</button><button class="flex-1 px-3 py-1.5 text-sm text-ink bg-surface hover:bg-surface-raised data-[selected]:bg-primary data-[selected]:text-white transition-colors border-r border-border last:border-r-0" data-rac="" type="button" tabindex="0" data-react-aria-pressable="true" role="radio" aria-checked="true" data-selected="true">Push Notification</button></div></div></div><div class="min-h-[16px] text-[12px] text-subtle-ink"></div></div></div><div><div class="grid gap-1.5 p-2 border border-border rounded bg-surface"><span class="text-[13px] text-muted-ink">items</span><span class="text-[12px] text-subtle-ink italic">Unsupported schema type: unknown</span></div></div></div></div></div>"`,
+    )
+  })
+
+  it('keeps invalid schema roots in the empty-render partition', () => {
+    const html = renderToStaticMarkup(
+      <AriaSchemaForm
+        schema={Schema.String as unknown as Schema.Schema<Record<string, unknown>>}
+        value={{}}
+        onChange={vi.fn()}
+      />,
+    )
+
+    expect(html).toMatchInlineSnapshot(`"<div class="grid gap-4 "></div>"`)
+  })
+})

--- a/packages/@overeng/effect-schema-form-aria/vitest.config.ts
+++ b/packages/@overeng/effect-schema-form-aria/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+// The root project config does not resolve correctly from this package task's cwd.
+export default defineConfig({
+  test: {
+    include: ['src/**/*.unit.test.ts', 'src/**/*.unit.test.tsx'],
+  },
+})

--- a/packages/@overeng/genie/nix/build.nix
+++ b/packages/@overeng/genie/nix/build.nix
@@ -26,7 +26,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-r+dyp2qx9RfpBDiADwWUTBttq2xSPwa0naneD8Z6xwg=";
+      "." = mkSharedHash "sha256-DbFTw0rg9x++24H73gC0mh6Hio480Vzw4DcciBiFWj8=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/megarepo/nix/build.nix
+++ b/packages/@overeng/megarepo/nix/build.nix
@@ -24,7 +24,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-2hSO33hhpyw5rDVG1VyGU1ZNqYbI9wXeliZGEFyZgwk=";
+      "." = mkSharedHash "sha256-qC8Zwf/5v9EOEplQe7nYC0ZsbIBqBPun5Qo/cUEsiDo=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     smokeTestArgs = [ "--help" ];

--- a/packages/@overeng/notion-cli/nix/build.nix
+++ b/packages/@overeng/notion-cli/nix/build.nix
@@ -33,7 +33,7 @@ let
     installRuntimeWorkspace = true;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-EKZSkvZaYUzGN6SGenxDKwxzTu5e8dGsXflgJhO0+wQ=";
+      "." = mkSharedHash "sha256-h4QW7C8huONRRAoB7S0mN4+DCzbvLd/onGyz7G9O83I=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/notion-md/nix/build.nix
+++ b/packages/@overeng/notion-md/nix/build.nix
@@ -20,7 +20,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-yGWT8EAEtXXWznTYS+I+PqmdvNYK71yOaQgvpavMXLM=";
+      "." = mkSharedHash "sha256-LAC9pK+sG1r5o5fUea8XNQexsl4gda0JpVzOYndD5EU=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/npm-release/nix/build.nix
+++ b/packages/@overeng/npm-release/nix/build.nix
@@ -20,7 +20,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-WwIN1QKp9exwgFHeh/aeb1gr74FrjW6BkOWsmpmSW2I=";
+      "." = mkSharedHash "sha256-evw+K1akyqdC5nttRINpUF3xlZ1ASp1qsdrNs4lKVQ0=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/tui-stories/nix/build.nix
+++ b/packages/@overeng/tui-stories/nix/build.nix
@@ -21,7 +21,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-JUvxjhlweuLelffcFyhaXnVbdLhq2hPr4futdRgW5n4=";
+      "." = mkSharedHash "sha256-LK4w3JOeRzBwcVNzCpcMFv7nv2dEOX6yPVnvGJNXxG8=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -441,6 +441,9 @@ importers:
       '@types/react':
         specifier: 19.2.17
         version: 19.2.17
+      '@types/react-dom':
+        specifier: 19.2.3
+        version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: 6.0.2
         version: 6.0.2(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))


### PR DESCRIPTION
## Problem

`effect-schema-form-aria` had no tests, so an Effect 4 migration could silently change its rendered accessibility markup, value-state partitions, literal presentation, or unsupported-schema behavior.

## Goal

Capture the package's current Effect 3 behavior as permanent cross-major characterization baselines.

## Decisions

- Name the suite `effect-schema-form-aria baselines (cross-major invariant)` so failures during the major flip are treated as regressions rather than snapshots to update.
- Pin exact SSR bytes for primitive fields, required and optional number states, segmented and select literal modes, unsupported fields, empty groups, a complete tagged form, and invalid-root rendering.
- Preserve awkward current output, including the duplicate selected empty literal buttons and the disabled out-of-domain select placeholder.
- Add the package-local minimum Vitest config because the root project config does not resolve from this package task's cwd.
- Add `@types/react-dom` as a test-only development dependency. The eight Nix hash changes are the mechanical consequence of its shared-lockfile importer change across lock-derived FODs.

## Verification

- From a committed verification worktree combining this commit with the still-open test-task wiring in #992: `CI=1 devenv tasks run test:effect-schema-form-aria --mode single --show-output --no-tui` passed. Vitest telemetry records 7 tests and 0 failures.
- `CI=1 devenv tasks run check:quick --no-tui`: passed (TypeScript and lint only).
- Focused package Vitest run: 7/7 passed.
- Focused authored-file oxlint: 0 warnings/errors.
- Authored test formatting and `git diff --check`: passed.
- Evergreen refreshed and verified the eight lock-derived FOD hashes.

## Complexity

Low runtime risk: production source is unchanged. The package-local test config and test-only type dependency are the minimum support needed for the permanent baseline.

## Concerns

The exact markup includes generated React Aria identifiers. That is intentional: this boundary protects the encoded SSR output that consumers receive today.

## Friction & bottlenecks

A fresh verification worktree required `pnpm:install` before the package task could resolve Vitest. After committed-lockfile materialization, the unchanged task passed.

## Follow-ups

- Test-task wiring remains isolated in #992 and must land for main/CI to expose this package task.

## References

- #925
- #992

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | co2-comet |
| `agent_session_id` | 7c71fe09-b408-4f01-beca-75afbbe788ec |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.145.0 |
| `agent_runtime` | Codex CLI 0.145.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/g70zaf7b08m8pmn4iqxy3a70a2833y23-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/997m3kakbn5dnr72qix3xmfx4pmd6qxd-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-28-thincov-effect-schema-form-aria |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->