### PR TITLE
test(effect-rpc-tanstack): capture RPC wire baselines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 
 - Add a shared CI helper for job-local Cargo targets and `sccache` servers on
   multi-identity self-hosted runners.
+- **@overeng/effect-rpc-tanstack**: capture Effect 3 cross-major baselines for
+  SSR `Exit` JSON encoding and native HTTP RPC NDJSON request/response failure
+  partitions.
 
 ### Fixed
 

--- a/packages/@overeng/effect-rpc-tanstack/src/__snapshots__/rpc-wire-baseline.test.ts.snap
+++ b/packages/@overeng/effect-rpc-tanstack/src/__snapshots__/rpc-wire-baseline.test.ts.snap
@@ -1,0 +1,351 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`effect-rpc-tanstack RPC wire baselines (cross-major invariant) > captures HTTP RPC NDJSON bytes and failure partition 1`] = `
+{
+  "requestWire": {
+    "byteIdentical": true,
+    "decoded": {
+      "domainFailure": "{"_tag":"Request","id":"2","tag":"GetGreeting","payload":{"userId":"","note":""},"headers":[]}
+",
+      "invalidEnvelope": "{"_tag":"Request","id":"5"}
+",
+      "invalidId": "{"_tag":"Request","id":"req-invalid-id","tag":"GetGreeting","payload":{"userId":"ada-ß","note":null},"headers":[]}
+",
+      "invalidPayload": "{"_tag":"Request","id":"3","tag":"GetGreeting","payload":{"userId":123},"headers":[]}
+",
+      "success": "{"_tag":"Request","id":"1","tag":"GetGreeting","payload":{"userId":"ada-ß","note":null},"headers":[]}
+",
+      "unknownTag": "{"_tag":"Request","id":"4","tag":"UnknownRpc","payload":{},"headers":[]}
+",
+    },
+    "encoded": "{
+  "success": "{\\"_tag\\":\\"Request\\",\\"id\\":\\"1\\",\\"tag\\":\\"GetGreeting\\",\\"payload\\":{\\"userId\\":\\"ada-ß\\",\\"note\\":null},\\"headers\\":[]}\\n",
+  "domainFailure": "{\\"_tag\\":\\"Request\\",\\"id\\":\\"2\\",\\"tag\\":\\"GetGreeting\\",\\"payload\\":{\\"userId\\":\\"\\",\\"note\\":\\"\\"},\\"headers\\":[]}\\n",
+  "invalidPayload": "{\\"_tag\\":\\"Request\\",\\"id\\":\\"3\\",\\"tag\\":\\"GetGreeting\\",\\"payload\\":{\\"userId\\":123},\\"headers\\":[]}\\n",
+  "unknownTag": "{\\"_tag\\":\\"Request\\",\\"id\\":\\"4\\",\\"tag\\":\\"UnknownRpc\\",\\"payload\\":{},\\"headers\\":[]}\\n",
+  "invalidEnvelope": "{\\"_tag\\":\\"Request\\",\\"id\\":\\"5\\"}\\n",
+  "invalidId": "{\\"_tag\\":\\"Request\\",\\"id\\":\\"req-invalid-id\\",\\"tag\\":\\"GetGreeting\\",\\"payload\\":{\\"userId\\":\\"ada-ß\\",\\"note\\":null},\\"headers\\":[]}\\n"
+}",
+    "reencoded": "{
+  "success": "{\\"_tag\\":\\"Request\\",\\"id\\":\\"1\\",\\"tag\\":\\"GetGreeting\\",\\"payload\\":{\\"userId\\":\\"ada-ß\\",\\"note\\":null},\\"headers\\":[]}\\n",
+  "domainFailure": "{\\"_tag\\":\\"Request\\",\\"id\\":\\"2\\",\\"tag\\":\\"GetGreeting\\",\\"payload\\":{\\"userId\\":\\"\\",\\"note\\":\\"\\"},\\"headers\\":[]}\\n",
+  "invalidPayload": "{\\"_tag\\":\\"Request\\",\\"id\\":\\"3\\",\\"tag\\":\\"GetGreeting\\",\\"payload\\":{\\"userId\\":123},\\"headers\\":[]}\\n",
+  "unknownTag": "{\\"_tag\\":\\"Request\\",\\"id\\":\\"4\\",\\"tag\\":\\"UnknownRpc\\",\\"payload\\":{},\\"headers\\":[]}\\n",
+  "invalidEnvelope": "{\\"_tag\\":\\"Request\\",\\"id\\":\\"5\\"}\\n",
+  "invalidId": "{\\"_tag\\":\\"Request\\",\\"id\\":\\"req-invalid-id\\",\\"tag\\":\\"GetGreeting\\",\\"payload\\":{\\"userId\\":\\"ada-ß\\",\\"note\\":null},\\"headers\\":[]}\\n"
+}",
+  },
+  "requests": {
+    "domainFailure": "{"_tag":"Request","id":"2","tag":"GetGreeting","payload":{"userId":"","note":""},"headers":[]}
+",
+    "invalidEnvelope": "{"_tag":"Request","id":"5"}
+",
+    "invalidId": "{"_tag":"Request","id":"req-invalid-id","tag":"GetGreeting","payload":{"userId":"ada-ß","note":null},"headers":[]}
+",
+    "invalidPayload": "{"_tag":"Request","id":"3","tag":"GetGreeting","payload":{"userId":123},"headers":[]}
+",
+    "success": "{"_tag":"Request","id":"1","tag":"GetGreeting","payload":{"userId":"ada-ß","note":null},"headers":[]}
+",
+    "unknownTag": "{"_tag":"Request","id":"4","tag":"UnknownRpc","payload":{},"headers":[]}
+",
+  },
+  "responseWire": {
+    "byteIdentical": true,
+    "decoded": {
+      "domainFailure": {
+        "body": "{"_tag":"Exit","requestId":"2","exit":{"_tag":"Failure","cause":{"_tag":"Fail","error":{"reason":"missing-user","userId":"","_tag":"GreetingError"}}}}
+",
+        "contentType": "application/ndjson",
+        "status": 200,
+      },
+      "invalidEnvelope": {
+        "body": "{"_tag":"Defect","defect":"Unknown request tag: "}
+",
+        "contentType": "application/ndjson",
+        "status": 200,
+      },
+      "invalidId": {
+        "body": "{"_tag":"Defect","defect":{"name":"SyntaxError","message":"Cannot convert req-invalid-id to a BigInt"}}
+",
+        "contentType": "application/ndjson",
+        "status": 200,
+      },
+      "invalidPayload": {
+        "body": "{"_tag":"Exit","requestId":"3","exit":{"_tag":"Failure","cause":{"_tag":"Die","defect":"{ readonly userId: string; readonly note: string | null }\\n└─ [\\"userId\\"]\\n   └─ Expected string, actual 123"}}}
+",
+        "contentType": "application/ndjson",
+        "status": 200,
+      },
+      "success": {
+        "body": "{"_tag":"Exit","requestId":"1","exit":{"_tag":"Success","value":{"message":"hello ada-ß","empty":"","unicode":"Grüße ß"}}}
+",
+        "contentType": "application/ndjson",
+        "status": 200,
+      },
+      "unknownTag": {
+        "body": "{"_tag":"Defect","defect":"Unknown request tag: UnknownRpc"}
+",
+        "contentType": "application/ndjson",
+        "status": 200,
+      },
+    },
+    "encoded": "{
+  "success": {
+    "status": 200,
+    "contentType": "application/ndjson",
+    "body": "{\\"_tag\\":\\"Exit\\",\\"requestId\\":\\"1\\",\\"exit\\":{\\"_tag\\":\\"Success\\",\\"value\\":{\\"message\\":\\"hello ada-ß\\",\\"empty\\":\\"\\",\\"unicode\\":\\"Grüße ß\\"}}}\\n"
+  },
+  "domainFailure": {
+    "status": 200,
+    "contentType": "application/ndjson",
+    "body": "{\\"_tag\\":\\"Exit\\",\\"requestId\\":\\"2\\",\\"exit\\":{\\"_tag\\":\\"Failure\\",\\"cause\\":{\\"_tag\\":\\"Fail\\",\\"error\\":{\\"reason\\":\\"missing-user\\",\\"userId\\":\\"\\",\\"_tag\\":\\"GreetingError\\"}}}}\\n"
+  },
+  "invalidPayload": {
+    "status": 200,
+    "contentType": "application/ndjson",
+    "body": "{\\"_tag\\":\\"Exit\\",\\"requestId\\":\\"3\\",\\"exit\\":{\\"_tag\\":\\"Failure\\",\\"cause\\":{\\"_tag\\":\\"Die\\",\\"defect\\":\\"{ readonly userId: string; readonly note: string | null }\\\\n└─ [\\\\\\"userId\\\\\\"]\\\\n   └─ Expected string, actual 123\\"}}}\\n"
+  },
+  "unknownTag": {
+    "status": 200,
+    "contentType": "application/ndjson",
+    "body": "{\\"_tag\\":\\"Defect\\",\\"defect\\":\\"Unknown request tag: UnknownRpc\\"}\\n"
+  },
+  "invalidEnvelope": {
+    "status": 200,
+    "contentType": "application/ndjson",
+    "body": "{\\"_tag\\":\\"Defect\\",\\"defect\\":\\"Unknown request tag: \\"}\\n"
+  },
+  "invalidId": {
+    "status": 200,
+    "contentType": "application/ndjson",
+    "body": "{\\"_tag\\":\\"Defect\\",\\"defect\\":{\\"name\\":\\"SyntaxError\\",\\"message\\":\\"Cannot convert req-invalid-id to a BigInt\\"}}\\n"
+  }
+}",
+    "reencoded": "{
+  "success": {
+    "status": 200,
+    "contentType": "application/ndjson",
+    "body": "{\\"_tag\\":\\"Exit\\",\\"requestId\\":\\"1\\",\\"exit\\":{\\"_tag\\":\\"Success\\",\\"value\\":{\\"message\\":\\"hello ada-ß\\",\\"empty\\":\\"\\",\\"unicode\\":\\"Grüße ß\\"}}}\\n"
+  },
+  "domainFailure": {
+    "status": 200,
+    "contentType": "application/ndjson",
+    "body": "{\\"_tag\\":\\"Exit\\",\\"requestId\\":\\"2\\",\\"exit\\":{\\"_tag\\":\\"Failure\\",\\"cause\\":{\\"_tag\\":\\"Fail\\",\\"error\\":{\\"reason\\":\\"missing-user\\",\\"userId\\":\\"\\",\\"_tag\\":\\"GreetingError\\"}}}}\\n"
+  },
+  "invalidPayload": {
+    "status": 200,
+    "contentType": "application/ndjson",
+    "body": "{\\"_tag\\":\\"Exit\\",\\"requestId\\":\\"3\\",\\"exit\\":{\\"_tag\\":\\"Failure\\",\\"cause\\":{\\"_tag\\":\\"Die\\",\\"defect\\":\\"{ readonly userId: string; readonly note: string | null }\\\\n└─ [\\\\\\"userId\\\\\\"]\\\\n   └─ Expected string, actual 123\\"}}}\\n"
+  },
+  "unknownTag": {
+    "status": 200,
+    "contentType": "application/ndjson",
+    "body": "{\\"_tag\\":\\"Defect\\",\\"defect\\":\\"Unknown request tag: UnknownRpc\\"}\\n"
+  },
+  "invalidEnvelope": {
+    "status": 200,
+    "contentType": "application/ndjson",
+    "body": "{\\"_tag\\":\\"Defect\\",\\"defect\\":\\"Unknown request tag: \\"}\\n"
+  },
+  "invalidId": {
+    "status": 200,
+    "contentType": "application/ndjson",
+    "body": "{\\"_tag\\":\\"Defect\\",\\"defect\\":{\\"name\\":\\"SyntaxError\\",\\"message\\":\\"Cannot convert req-invalid-id to a BigInt\\"}}\\n"
+  }
+}",
+  },
+  "responses": {
+    "domainFailure": {
+      "body": "{"_tag":"Exit","requestId":"2","exit":{"_tag":"Failure","cause":{"_tag":"Fail","error":{"reason":"missing-user","userId":"","_tag":"GreetingError"}}}}
+",
+      "contentType": "application/ndjson",
+      "status": 200,
+    },
+    "invalidEnvelope": {
+      "body": "{"_tag":"Defect","defect":"Unknown request tag: "}
+",
+      "contentType": "application/ndjson",
+      "status": 200,
+    },
+    "invalidId": {
+      "body": "{"_tag":"Defect","defect":{"name":"SyntaxError","message":"Cannot convert req-invalid-id to a BigInt"}}
+",
+      "contentType": "application/ndjson",
+      "status": 200,
+    },
+    "invalidPayload": {
+      "body": "{"_tag":"Exit","requestId":"3","exit":{"_tag":"Failure","cause":{"_tag":"Die","defect":"{ readonly userId: string; readonly note: string | null }\\n└─ [\\"userId\\"]\\n   └─ Expected string, actual 123"}}}
+",
+      "contentType": "application/ndjson",
+      "status": 200,
+    },
+    "success": {
+      "body": "{"_tag":"Exit","requestId":"1","exit":{"_tag":"Success","value":{"message":"hello ada-ß","empty":"","unicode":"Grüße ß"}}}
+",
+      "contentType": "application/ndjson",
+      "status": 200,
+    },
+    "unknownTag": {
+      "body": "{"_tag":"Defect","defect":"Unknown request tag: UnknownRpc"}
+",
+      "contentType": "application/ndjson",
+      "status": 200,
+    },
+  },
+}
+`;
+
+exports[`effect-rpc-tanstack RPC wire baselines (cross-major invariant) > captures SSR Exit JSON bytes and re-encoded identity 1`] = `
+{
+  "decoded": {
+    "defectMatch": {
+      "_tag": "defect",
+      "message": "loader defect ß",
+    },
+    "failureError": {
+      "_id": "Option",
+      "_tag": "Some",
+      "value": {
+        "_tag": "GreetingError",
+        "reason": "missing-user",
+        "userId": "",
+      },
+    },
+    "failureMatch": {
+      "_tag": "GreetingError",
+      "reason": "missing-user",
+      "userId": "",
+    },
+    "successGetOrThrow": {
+      "empty": "",
+      "message": "hello ß",
+      "nested": {
+        "absentIsOmitted": undefined,
+        "explicitNull": null,
+      },
+    },
+  },
+  "failures": {
+    "invalidExitTag": {
+      "_tag": "failed",
+      "error": "(ExitEncoded<unknown, unknown, Defect> <-> Exit<unknown, unknown>)
+└─ Encoded side transformation failure
+   └─ ExitEncoded<unknown, unknown, Defect>
+      └─ { readonly _tag: "Failure" | "Success" }
+         └─ ["_tag"]
+            └─ Expected "Failure" | "Success", actual "NotAnExit"",
+    },
+    "missingFailureCause": {
+      "_tag": "failed",
+      "error": "(ExitEncoded<unknown, unknown, Defect> <-> Exit<unknown, unknown>)
+└─ Encoded side transformation failure
+   └─ ExitEncoded<unknown, unknown, Defect>
+      └─ { readonly _tag: "Failure"; readonly cause: CauseEncoded<unknown> }
+         └─ ["cause"]
+            └─ is missing",
+    },
+  },
+  "wire": {
+    "byteIdentical": true,
+    "decoded": {
+      "defect": {
+        "_tag": "Failure",
+        "cause": {
+          "_tag": "Die",
+          "defect": {
+            "message": "loader defect ß",
+            "name": "Error",
+          },
+        },
+      },
+      "failure": {
+        "_tag": "Failure",
+        "cause": {
+          "_tag": "Fail",
+          "error": {
+            "_tag": "GreetingError",
+            "reason": "missing-user",
+            "userId": "",
+          },
+        },
+      },
+      "success": {
+        "_tag": "Success",
+        "value": {
+          "empty": "",
+          "message": "hello ß",
+          "nested": {
+            "explicitNull": null,
+          },
+        },
+      },
+    },
+    "encoded": "{
+  "success": {
+    "_tag": "Success",
+    "value": {
+      "message": "hello ß",
+      "empty": "",
+      "nested": {
+        "explicitNull": null
+      }
+    }
+  },
+  "failure": {
+    "_tag": "Failure",
+    "cause": {
+      "_tag": "Fail",
+      "error": {
+        "reason": "missing-user",
+        "userId": "",
+        "_tag": "GreetingError"
+      }
+    }
+  },
+  "defect": {
+    "_tag": "Failure",
+    "cause": {
+      "_tag": "Die",
+      "defect": {
+        "name": "Error",
+        "message": "loader defect ß"
+      }
+    }
+  }
+}",
+    "reencoded": "{
+  "success": {
+    "_tag": "Success",
+    "value": {
+      "message": "hello ß",
+      "empty": "",
+      "nested": {
+        "explicitNull": null
+      }
+    }
+  },
+  "failure": {
+    "_tag": "Failure",
+    "cause": {
+      "_tag": "Fail",
+      "error": {
+        "reason": "missing-user",
+        "userId": "",
+        "_tag": "GreetingError"
+      }
+    }
+  },
+  "defect": {
+    "_tag": "Failure",
+    "cause": {
+      "_tag": "Die",
+      "defect": {
+        "name": "Error",
+        "message": "loader defect ß"
+      }
+    }
+  }
+}",
+  },
+}
+`;

--- a/packages/@overeng/effect-rpc-tanstack/src/rpc-wire-baseline.test.ts
+++ b/packages/@overeng/effect-rpc-tanstack/src/rpc-wire-baseline.test.ts
@@ -78,6 +78,7 @@ const decodeExitFailure = (encoded: unknown) => {
 }
 
 describe('effect-rpc-tanstack RPC wire baselines (cross-major invariant)', () => {
+  // TODO(live-migration:effect-3-4): Effect 4 changes every failure cause from an object to an array; land #979's versioned compatibility server before updating these SSR Exit assertions.
   it('captures SSR Exit JSON bytes and re-encoded identity', () => {
     const exits = {
       success: encodeExit(
@@ -120,6 +121,7 @@ describe('effect-rpc-tanstack RPC wire baselines (cross-major invariant)', () =>
     }).toMatchSnapshot()
   })
 
+  // TODO(live-migration:effect-3-4): Effect 4 changes every failure cause from an object to an array; land #979's versioned compatibility server before updating these HTTP assertions.
   it('captures HTTP RPC NDJSON bytes and failure partition', async () => {
     const handlers = Api.toLayer(
       Effect.succeed(

--- a/packages/@overeng/effect-rpc-tanstack/src/rpc-wire-baseline.test.ts
+++ b/packages/@overeng/effect-rpc-tanstack/src/rpc-wire-baseline.test.ts
@@ -1,0 +1,204 @@
+import { Rpc, RpcGroup } from '@effect/rpc'
+import { Effect, Exit, Schema } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import { encodeExit, decodeExit, makeEffectLoaderResult } from './router.ts'
+import { makeHandler } from './server.ts'
+
+class GreetingError extends Schema.TaggedError<GreetingError>()('GreetingError', {
+  reason: Schema.Literal('missing-user', 'blocked'),
+  userId: Schema.String,
+}) {}
+
+const GetGreeting = Rpc.make('GetGreeting', {
+  payload: {
+    userId: Schema.String,
+    note: Schema.NullOr(Schema.String),
+  },
+  success: Schema.Struct({
+    message: Schema.String,
+    empty: Schema.String,
+    unicode: Schema.String,
+  }),
+  error: GreetingError,
+})
+
+const Api = RpcGroup.make(GetGreeting)
+
+const encodeJsonBytes = (value: unknown): string => JSON.stringify(value, null, 2)
+
+const jsonWireRoundTrip = (value: unknown) => {
+  const encoded = encodeJsonBytes(value)
+  const decoded = JSON.parse(encoded) as unknown
+  const reencoded = encodeJsonBytes(decoded)
+
+  return {
+    encoded,
+    decoded,
+    reencoded,
+    byteIdentical: reencoded === encoded,
+  }
+}
+
+const requestBytes = (value: unknown): string => `${JSON.stringify(value)}\n`
+
+const rpcPost = async ({
+  handler,
+  body,
+}: {
+  readonly handler: (request: Request) => Promise<Response>
+  readonly body: string
+}) => {
+  const request = new Request('http://localhost/api/rpc', {
+    method: 'POST',
+    headers: { 'content-type': 'application/ndjson' },
+    body,
+  })
+  const response = await handler(request)
+
+  return {
+    status: response.status,
+    contentType: response.headers.get('content-type'),
+    body: await response.text(),
+  }
+}
+
+const decodeExitFailure = (encoded: unknown) => {
+  try {
+    return {
+      _tag: 'decoded' as const,
+      value: decodeExit(encoded as Parameters<typeof decodeExit>[0]),
+    }
+  } catch (error) {
+    return {
+      _tag: 'failed' as const,
+      error: error instanceof Error ? String(error) : String(error),
+    }
+  }
+}
+
+describe('effect-rpc-tanstack RPC wire baselines (cross-major invariant)', () => {
+  it('captures SSR Exit JSON bytes and re-encoded identity', () => {
+    const exits = {
+      success: encodeExit(
+        Exit.succeed({
+          message: 'hello ß',
+          empty: '',
+          nested: { absentIsOmitted: undefined, explicitNull: null },
+        }),
+      ),
+      failure: encodeExit(Exit.fail(new GreetingError({ reason: 'missing-user', userId: '' }))),
+      defect: encodeExit(Exit.die(new Error('loader defect ß'))),
+    }
+
+    const successResult = makeEffectLoaderResult<typeof exits.success, GreetingError>(exits.success)
+    const failureResult = makeEffectLoaderResult<unknown, GreetingError>(exits.failure)
+    const defectResult = makeEffectLoaderResult<unknown, unknown>(exits.defect)
+
+    expect({
+      wire: jsonWireRoundTrip(exits),
+      decoded: {
+        successGetOrThrow: successResult.getOrThrow(),
+        failureError: failureResult.error,
+        failureMatch: failureResult.match<unknown>({
+          onSuccess: (value) => ({ _tag: 'success', value }),
+          onFailure: (error) => ({ _tag: error._tag, reason: error.reason, userId: error.userId }),
+        }),
+        defectMatch: defectResult.match<unknown>({
+          onSuccess: (value) => ({ _tag: 'success', value }),
+          onFailure: (error) => ({ _tag: 'failure', error }),
+          onDefect: (defect) => ({
+            _tag: 'defect',
+            message: defect instanceof Error ? defect.message : String(defect),
+          }),
+        }),
+      },
+      failures: {
+        invalidExitTag: decodeExitFailure({ _tag: 'NotAnExit', value: null }),
+        missingFailureCause: decodeExitFailure({ _tag: 'Failure' }),
+      },
+    }).toMatchSnapshot()
+  })
+
+  it('captures HTTP RPC NDJSON bytes and failure partition', async () => {
+    const handlers = Api.toLayer(
+      Effect.succeed(
+        Api.of({
+          GetGreeting: ({ userId, note }) =>
+            userId === ''
+              ? Effect.fail(new GreetingError({ reason: 'missing-user', userId }))
+              : Effect.succeed({
+                  message: `hello ${userId}`,
+                  empty: note ?? '',
+                  unicode: 'Grüße ß',
+                }),
+        }),
+      ),
+    )
+
+    const { handler, dispose } = makeHandler({
+      group: Api,
+      handlerLayer: handlers,
+      disableTracing: true,
+    })
+
+    const requests = {
+      success: requestBytes({
+        _tag: 'Request',
+        id: '1',
+        tag: 'GetGreeting',
+        payload: { userId: 'ada-ß', note: null },
+        headers: [],
+      }),
+      domainFailure: requestBytes({
+        _tag: 'Request',
+        id: '2',
+        tag: 'GetGreeting',
+        payload: { userId: '', note: '' },
+        headers: [],
+      }),
+      invalidPayload: requestBytes({
+        _tag: 'Request',
+        id: '3',
+        tag: 'GetGreeting',
+        payload: { userId: 123, note: undefined },
+        headers: [],
+      }),
+      unknownTag: requestBytes({
+        _tag: 'Request',
+        id: '4',
+        tag: 'UnknownRpc',
+        payload: {},
+        headers: [],
+      }),
+      invalidEnvelope: `${JSON.stringify({ _tag: 'Request', id: '5' })}\n`,
+      invalidId: requestBytes({
+        _tag: 'Request',
+        id: 'req-invalid-id',
+        tag: 'GetGreeting',
+        payload: { userId: 'ada-ß', note: null },
+        headers: [],
+      }),
+    }
+
+    try {
+      const responses = {
+        success: await rpcPost({ handler, body: requests.success }),
+        domainFailure: await rpcPost({ handler, body: requests.domainFailure }),
+        invalidPayload: await rpcPost({ handler, body: requests.invalidPayload }),
+        unknownTag: await rpcPost({ handler, body: requests.unknownTag }),
+        invalidEnvelope: await rpcPost({ handler, body: requests.invalidEnvelope }),
+        invalidId: await rpcPost({ handler, body: requests.invalidId }),
+      }
+
+      expect({
+        requests,
+        responses,
+        requestWire: jsonWireRoundTrip(requests),
+        responseWire: jsonWireRoundTrip(responses),
+      }).toMatchSnapshot()
+    } finally {
+      await dispose()
+    }
+  })
+})


### PR DESCRIPTION
## Problem

`effect-rpc-tanstack` exposes an encoded RPC/SSR boundary that must survive the Effect 4 flip without silent wire-shape drift. The HTTP RPC protocol is already known to be fragile around failure-cause wire shape, so this package needs an Effect 3 baseline before migration.

## Goal

Capture current Effect 3 behavior for the package's encoded SSR `Exit` surface and native HTTP RPC NDJSON request/response surface.

## Decisions

- Adds `src/rpc-wire-baseline.test.ts` under the package-relative `src/**/*.test.ts` include.
- Snapshots `encodeExit` output for success, typed failure, and defect exits, plus decode failure partitions for invalid encoded exits.
- Snapshots fixed NDJSON RPC request bytes and handler responses for success, typed domain failure, invalid payload, unknown tag, missing envelope tag, and invalid request id.
- Asserts JSON encode/decode/re-encode byte identity for the captured request and response records.
- Keeps this as additive baseline coverage only; no production source changes.

## Verification

- PASS: `CI=1 devenv tasks run check:quick --no-tui`.
- PASS: `CI=1 devenv tasks run test:effect-rpc-tanstack --no-tui` on committed worktree `12eebb2da`.
- PASS: package-relative collection check from `packages/@overeng/effect-rpc-tanstack`: `CI=1 ./node_modules/.bin/vitest run --config vitest.config.ts` reported `Test Files 3 passed (3)` and `Tests 5 passed (5)`.
- PASS: package-local TypeScript check: `./node_modules/.bin/tsc --noEmit -p tsconfig.json --pretty false`.
- PASS: `git diff --check`.

## Complexity

No runtime complexity; this adds one colocated test file and snapshots.

## Concerns

The snapshots intentionally pin current failure shapes, including invalid payloads returning an RPC `Exit` with a `Die` cause and malformed request ids returning a top-level `Defect`.

## Friction & bottlenecks

The managed package test task exited 0 but did not print the Vitest count in bounded output, so I ran the package-relative Vitest command separately to prove collection.

## Follow-ups

None for this slice.

## References

Refs #925, #979.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | co1-vale |
| `agent_session_id` | cbf1cd38-f24b-48eb-9639-30b032e7336c |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.145.0 |
| `agent_runtime` | Codex CLI 0.145.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/i8y8b542cyqi385ywcjw5fvsq24f75v4-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/i81qxhzlrzcxrrdwpp6i8hagka2gby8y-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-28-2026-07-28-baselines-7-effect-rpc-tanstack-wire |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->