### PR TITLE
fix(react-inspector): restore the upstream MIT notice

### DIFF
--- a/packages/@overeng/react-inspector/LICENSE
+++ b/packages/@overeng/react-inspector/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 Xiaoyi Chen 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/@overeng/react-inspector/LICENSE
+++ b/packages/@overeng/react-inspector/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
-Copyright (c) 2017 Xiaoyi Chen 
+Copyright (c) 2017 Xiaoyi Chen
+Copyright (c) 2024-2026 Johannes Schickling
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/@overeng/react-inspector/package.json
+++ b/packages/@overeng/react-inspector/package.json
@@ -2,6 +2,7 @@
   "name": "@overeng/react-inspector",
   "version": "9.0.0",
   "description": "Browser DevTools-style React inspectors with native Effect 4 Schema support",
+  "license": "MIT",
   "type": "module",
   "exports": {
     ".": "./src/index.tsx"

--- a/packages/@overeng/react-inspector/package.json.genie.ts
+++ b/packages/@overeng/react-inspector/package.json.genie.ts
@@ -71,6 +71,12 @@ export default packageJson(
     /** Forked from react-inspector v8.0.0 (https://github.com/nicksenger/react-inspector) */
     version: '9.0.0',
     description: 'Browser DevTools-style React inspectors with native Effect 4 Schema support',
+    /**
+     * Fork of react-inspector, MIT (c) 2017 Xiaoyi Chen. The upstream notice is
+     * required in all copies, so `LICENSE` ships with the package — the standalone
+     * fork repo carries both and this copy had dropped them during a sync.
+     */
+    license: 'MIT',
     type: 'module',
     exports: {
       '.': exportEntry('./src/index.tsx', { environment: 'browser' }),


### PR DESCRIPTION
`@overeng/react-inspector` is a fork of [react-inspector](https://github.com/storybookjs/react-inspector) (MIT, © 2017 Xiaoyi Chen), recorded in the package's `UPSTREAM.md`. It shipped with **no `LICENSE` file and no `license` field**.

The standalone fork repo `overengineeringstudio/react-inspector` carries both — this copy dropped them during a sync, so the divergence is a copy gap rather than a licensing decision.

## Why it matters

The MIT notice must accompany "all copies or substantial portions of the Software". The package is `publishConfig.access: public` and not `private`, so any publish would distribute the fork without attribution. npm includes `LICENSE` in the tarball regardless of `files`, so restoring the file is sufficient.

## Changes

- `LICENSE` — copied verbatim from the fork source repo
- `license: 'MIT'` in `package.json.genie.ts`, with the provenance noted inline

## Context

Found while evaluating whether `@livestore/devtools-react` could depend on or vendor this package (livestorejs/livestore#1497). The missing notice blocked redistribution on both paths, so it needed fixing regardless of which was chosen.

Two adjacent observations, not addressed here:

- `UPSTREAM.md` names `storybookjs/react-inspector` as the fork parent while the manifest comment names `nicksenger/react-inspector`. Worth reconciling for attribution accuracy.
- `@overeng/utils` also has no licence declaration. It is not a fork, so this is a policy question rather than a compliance gap — but it becomes relevant if that package is ever published, which `@overeng/react-inspector` peer-depends on it at `workspace:^`.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | cl1-reef |
| `agent_session_id` | f54dccb2-7cbf-4ab6-af33-c23c984cc1a3 |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.220 |
| `agent_runtime` | Claude Code 2.1.220 |
| `agent_model` | claude-opus-5 |
| `runtime_profile` | /nix/store/g65ryv9zcr8acxxjlpgcrynh8d7s7qwn-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/hiw5ggfjp9mr78vbrq30i77ypfyixv32-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-28-2026-07-28-devtools-prereqs |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->