### PR TITLE
Isolate Rust build state across self-hosted CI identities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Add a shared CI helper for job-local Cargo targets and `sccache` servers on
+  multi-identity self-hosted runners.
+
 ### Fixed
 
 - **@overeng/utils-dev/otelite**: make live capture inspection poll for the

--- a/genie/ci-scripts/prepare-job-local-rust-state.sh
+++ b/genie/ci-scripts/prepare-job-local-rust-state.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Generated file - DO NOT EDIT
+# Source: prepare-job-local-rust-state.sh.genie.ts
+
+
+# Source this helper at the task boundary. Ambient job-level Cargo state can be
+# materialized during environment bootstrap by a different process identity.
+: "${RUNNER_TEMP:?RUNNER_TEMP is required}"
+: "${GITHUB_RUN_ID:?GITHUB_RUN_ID is required}"
+: "${GITHUB_RUN_ATTEMPT:?GITHUB_RUN_ATTEMPT is required}"
+: "${GITHUB_JOB:?GITHUB_JOB is required}"
+: "${RUNNER_NAME:?RUNNER_NAME is required}"
+
+export CARGO_TARGET_DIR="$RUNNER_TEMP/cargo-target-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT-$GITHUB_JOB"
+mkdir -p "$CARGO_TARGET_DIR"
+
+# sccache's default TCP server is host-wide. A short per-runner UDS prevents a
+# server owned by one self-hosted runner identity from creating another job's
+# Cargo artifacts while retaining reuse through the shared cache directory.
+sccache_server_key="$(printf '%s' "$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT-$GITHUB_JOB-$RUNNER_NAME" | git hash-object --stdin | cut -c1-16)"
+export SCCACHE_SERVER_UDS="$RUNNER_TEMP/sc-$sccache_server_key.sock"
+unset sccache_server_key

--- a/genie/ci-scripts/prepare-job-local-rust-state.sh.genie.ts
+++ b/genie/ci-scripts/prepare-job-local-rust-state.sh.genie.ts
@@ -1,0 +1,3 @@
+import { ciWorkflowSupportFiles } from '../ci-workflow/support-files.ts'
+
+export default ciWorkflowSupportFiles.jobLocalRustState.output

--- a/genie/ci-workflow.ts
+++ b/genie/ci-workflow.ts
@@ -90,6 +90,7 @@ export {
   nixBinaryCachesExtraConf,
   nixExtraConf,
   preparedCiRuntimeScriptsDir,
+  prepareJobLocalRustState,
   runDevenvTasksBefore,
   standardCIEnv,
   workspaceLocalNixCachePath,
@@ -148,6 +149,8 @@ export {
   type WorkflowReportPublisherStepOptions,
 } from './ci-workflow/reporting.ts'
 export {
+  ciWorkflowJobLocalRustStateScript,
+  ciWorkflowJobLocalRustStateScriptPath,
   ciWorkflowNixGcRaceRetryScriptPath,
   ciWorkflowNixGcRaceRetryWrapperPath,
   ciWorkflowSupportFiles,

--- a/genie/ci-workflow/shared.ts
+++ b/genie/ci-workflow/shared.ts
@@ -330,6 +330,7 @@ export const runDevenvTasksBeforeWithOptions = (
 
 export const defaultCiRuntimeScriptsDir = 'genie/ci-scripts'
 export const preparedCiRuntimeScriptsDir = '${{ runner.temp }}/genie-ci-scripts'
+export const prepareJobLocalRustState = `. "${preparedCiRuntimeScriptsDir}/prepare-job-local-rust-state.sh"`
 
 export type GcRaceRetryOptions = {
   readonly command: string

--- a/genie/ci-workflow/support-files.ts
+++ b/genie/ci-workflow/support-files.ts
@@ -12,6 +12,8 @@ const textArtifact = (content: string): GenieOutput<string> =>
 export const ciWorkflowNixGcRaceRetryScriptPath = 'genie/ci-scripts/nix-gc-race-retry.sh'
 export const ciWorkflowNixGcRaceRetryWrapperPath =
   'genie/ci-scripts/run-with-nix-gc-race-retry.sh'
+export const ciWorkflowJobLocalRustStateScriptPath =
+  'genie/ci-scripts/prepare-job-local-rust-state.sh'
 
 export const ciWorkflowNixGcRaceRetryScript = String.raw`#!/usr/bin/env bash
 
@@ -182,7 +184,31 @@ script_dir="$(cd -- "$(dirname -- "${dollar}{BASH_SOURCE[0]}")" && pwd)"
 
 run_nix_gc_race_retry "$label" bash -euo pipefail -c "$command"`
 
+export const ciWorkflowJobLocalRustStateScript = String.raw`#!/usr/bin/env bash
+
+# Source this helper at the task boundary. Ambient job-level Cargo state can be
+# materialized during environment bootstrap by a different process identity.
+: "${dollar}{RUNNER_TEMP:?RUNNER_TEMP is required}"
+: "${dollar}{GITHUB_RUN_ID:?GITHUB_RUN_ID is required}"
+: "${dollar}{GITHUB_RUN_ATTEMPT:?GITHUB_RUN_ATTEMPT is required}"
+: "${dollar}{GITHUB_JOB:?GITHUB_JOB is required}"
+: "${dollar}{RUNNER_NAME:?RUNNER_NAME is required}"
+
+export CARGO_TARGET_DIR="${dollar}RUNNER_TEMP/cargo-target-${dollar}GITHUB_RUN_ID-${dollar}GITHUB_RUN_ATTEMPT-${dollar}GITHUB_JOB"
+mkdir -p "$CARGO_TARGET_DIR"
+
+# sccache's default TCP server is host-wide. A short per-runner UDS prevents a
+# server owned by one self-hosted runner identity from creating another job's
+# Cargo artifacts while retaining reuse through the shared cache directory.
+sccache_server_key="$(printf '%s' "${dollar}GITHUB_RUN_ID-${dollar}GITHUB_RUN_ATTEMPT-${dollar}GITHUB_JOB-${dollar}RUNNER_NAME" | git hash-object --stdin | cut -c1-16)"
+export SCCACHE_SERVER_UDS="${dollar}RUNNER_TEMP/sc-${dollar}sccache_server_key.sock"
+unset sccache_server_key`
+
 export const ciWorkflowSupportFiles = {
+  jobLocalRustState: {
+    path: ciWorkflowJobLocalRustStateScriptPath,
+    output: textArtifact(ciWorkflowJobLocalRustStateScript),
+  },
   nixGcRaceRetry: {
     path: ciWorkflowNixGcRaceRetryScriptPath,
     output: textArtifact(ciWorkflowNixGcRaceRetryScript),


### PR DESCRIPTION
## Problem

`sccache` uses a host-wide TCP server by default. Concurrent self-hosted runner identities can therefore ask a server owned by another identity to materialize artifacts in a fresh Cargo target, leaving the invoking Cargo process unable to write its own dep-info files. Downstream workflows that inline the isolation policy also pay the YAML cost once per job and can exceed GitHub Actions admission limits.

## Goal

Provide one compact, reusable effect-utils composition that keeps mutable Rust build ownership job-local while preserving shared compiler-cache reuse.

## Decisions

- Source a generated support file at the task boundary so its exports remain in the caller environment.
- Key the short sccache UDS by run, attempt, job, and runner identity; matrix jobs cannot share a server accidentally.
- Keep the cache directory shared; isolate only Cargo targets and compiler-server ownership.

## Verification

- `devenv tasks run ts:check lint:check --mode all --show-output` — pass.
- Generated-file validation and `bash -n genie/ci-scripts/prepare-job-local-rust-state.sh` — pass.
- Sourced-script smoke — target created and a platform-safe short socket path exported.
- Full CI: https://github.com/overengineeringstudio/effect-utils/actions/runs/30382520639 (one unrelated Restate timing failure is being rerun).
- Downstream dotfiles `test/crosstask-core` passed after server isolation; generated workflow shrank from 525,621 to 519,098 bytes after adopting this helper.

## Complexity

One small generated shell support file replaces repeated downstream workflow policy. This is less total complexity and composes through the existing `prepareCiScriptsStep` mechanism.

## Concerns

The helper must be sourced, not executed. `RUNNER_TEMP`, GitHub run metadata, and `RUNNER_NAME` are required deliberately so an incomplete identity cannot collapse back to shared state.

## Friction & bottlenecks

The failure required several CI iterations because fresh Cargo target paths still became cross-owned; the missing dimension was sccache server identity. Inline remediation then crossed GitHub’s 512 KiB workflow admission limit, motivating this shared support-file form.

## Follow-ups

None required for this helper. Consumers should replace inline Rust-isolation policy with `prepareJobLocalRustState`.

## References

- Downstream adoption: schickling/dotfiles#1331
- sccache client/server configuration: https://github.com/mozilla/sccache/blob/main/docs/Configuration.md