### PR TITLE
Fix cross-repo Effect identity with peer-safe materialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **@overeng/genie/package-json**: allow consumers to materialize selected
+  cross-repository workspace dependencies with the `file:` protocol. This lets
+  pnpm resolve singleton peers such as Effect from the consuming install graph
+  instead of following a foreign repository symlink with a second physical
+  peer installation.
+
 - **@overeng/utils-dev/otelite**: make live capture inspection poll for the
   observable row condition for up to 500 ms. This absorbs exporter scheduling
   and OTLP round-trip delay on contended CI hosts without consumer-specific

--- a/packages/@overeng/genie/src/runtime/package-json/catalog.ts
+++ b/packages/@overeng/genie/src/runtime/package-json/catalog.ts
@@ -13,7 +13,10 @@ import type { WorkspaceIdentity, WorkspaceMetadata, WorkspacePackageLike } from 
 export type CatalogInput = Record<string, string>
 
 type WorkspaceDependencyMap<TWorkspace extends readonly WorkspacePackageLike[]> = {
-  [TPkg in TWorkspace[number] as Extract<TPkg['data']['name'], string>]: 'workspace:^'
+  [TPkg in TWorkspace[number] as Extract<TPkg['data']['name'], string>]:
+    | 'workspace:^'
+    | `link:repos/${string}`
+    | `file:repos/${string}`
 }
 
 type DependencyBucket<
@@ -21,6 +24,15 @@ type DependencyBucket<
   TExternal extends CatalogInput,
 > = {
   workspace?: TWorkspace
+  /**
+   * Protocol overrides for dependencies owned by another repository.
+   *
+   * Use `file` when pnpm must materialize the package with the consumer's peer
+   * graph instead of following a source symlink with its repository-local peers.
+   */
+  crossRepoProtocols?: Partial<
+    Record<Extract<TWorkspace[number]['data']['name'], string>, 'link' | 'file'>
+  >
   /** Already-picked external dependencies, typically from `catalog.pick(...)`. */
   external?: TExternal
 }
@@ -325,18 +337,47 @@ const createComposeFn =
     const runtimeExternal = dependencies?.external ?? ({} as TDependenciesExternal)
     const supportExternal = devDependencies?.external ?? ({} as TDevDependenciesExternal)
     const peerExternal = peerDependencies?.external ?? ({} as TPeerDependenciesExternal)
-    const workspaceDepVersion = (pkg: WorkspacePackageLike): string =>
-      pkg.meta.workspace.repoName === workspace.repoName
-        ? 'workspace:^'
-        : `link:repos/${pkg.meta.workspace.repoName}/${pkg.meta.workspace.memberPath}`
+    const workspaceDepVersion = ({
+      pkg,
+      crossRepoProtocols,
+    }: {
+      pkg: WorkspacePackageLike
+      crossRepoProtocols: Partial<Record<string, 'link' | 'file'>> | undefined
+    }): string => {
+      if (pkg.meta.workspace.repoName === workspace.repoName) return 'workspace:^'
+
+      const protocol =
+        pkg.data.name === undefined ? 'link' : (crossRepoProtocols?.[pkg.data.name] ?? 'link')
+      return `${protocol}:repos/${pkg.meta.workspace.repoName}/${pkg.meta.workspace.memberPath}`
+    }
     const runtimeWorkspaceDependencies = Object.fromEntries(
       runtimeWorkspace.flatMap((pkg) =>
-        pkg.data.name === undefined ? [] : [[pkg.data.name, workspaceDepVersion(pkg)] as const],
+        pkg.data.name === undefined
+          ? []
+          : [
+              [
+                pkg.data.name,
+                workspaceDepVersion({
+                  pkg,
+                  crossRepoProtocols: dependencies?.crossRepoProtocols,
+                }),
+              ] as const,
+            ],
       ),
     ) as WorkspaceDependencyMap<TDependenciesWorkspace>
     const supportWorkspaceDependencies = Object.fromEntries(
       supportWorkspace.flatMap((pkg) =>
-        pkg.data.name === undefined ? [] : [[pkg.data.name, workspaceDepVersion(pkg)] as const],
+        pkg.data.name === undefined
+          ? []
+          : [
+              [
+                pkg.data.name,
+                workspaceDepVersion({
+                  pkg,
+                  crossRepoProtocols: devDependencies?.crossRepoProtocols,
+                }),
+              ] as const,
+            ],
       ),
     ) as WorkspaceDependencyMap<TDevDependenciesWorkspace>
     /** Workspace packages already listed as explicit deps — skip their registry versions from inherited peers */

--- a/packages/@overeng/genie/src/runtime/package-json/catalog.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/package-json/catalog.unit.test.ts
@@ -408,6 +408,44 @@ describe('defineCatalog', () => {
       })
     })
 
+    it('materializes selected cross-repo dependencies for consumer peer resolution', () => {
+      const foreignRepo = createTempRepo('packages/shared')
+      const shared = packageJson(
+        {
+          name: '@foreign/shared',
+          version: '1.0.0',
+        },
+        catalog.compose({
+          workspace: workspace({
+            repoName: foreignRepo.repoName,
+            memberPath: 'packages/shared',
+          }),
+          peerDependencies: {
+            external: catalog.pick('effect'),
+          },
+        }),
+      )
+
+      const composed = catalog.compose({
+        workspace: workspace({
+          repoName: repo.repoName,
+          memberPath: 'packages/app',
+        }),
+        dependencies: {
+          workspace: [shared],
+          crossRepoProtocols: {
+            '@foreign/shared': 'file',
+          },
+        },
+        mode: 'install',
+      })
+
+      expect(composed.dependencies).toEqual({
+        '@foreign/shared': `file:repos/${foreignRepo.repoName}/packages/shared`,
+        effect: '3.19.14',
+      })
+    })
+
     it('installs inherited peers explicitly in install mode', () => {
       const utilsComposition = catalog.compose({
         workspace: workspace({

--- a/packages/@overeng/genie/src/runtime/package-json/mod.ts
+++ b/packages/@overeng/genie/src/runtime/package-json/mod.ts
@@ -615,12 +615,13 @@ const sortExports = (
 
 /** Prefixes for internal dependencies that use absolute repo paths */
 const INTERNAL_FILE_PREFIX = 'file:packages/'
+const INTERNAL_REPO_FILE_PREFIX = 'file:repos/'
 const INTERNAL_LINK_PREFIX = 'link:packages/'
 const INTERNAL_REPO_LINK_PREFIX = 'link:repos/'
 
 /**
  * Resolve dependency versions, converting internal repo-absolute paths to relative paths.
- * Handles `file:packages/...`, `link:packages/...`, and `link:repos/...` (cross-repo) prefixes.
+ * Handles package-local and cross-repo `file:` / `link:` prefixes.
  */
 const resolveDeps = ({
   deps,
@@ -633,7 +634,10 @@ const resolveDeps = ({
 
   const resolved: Record<string, string> = {}
   for (const [name, version] of Object.entries(deps).toSorted(([a], [b]) => a.localeCompare(b))) {
-    if (version.startsWith(INTERNAL_FILE_PREFIX) === true) {
+    if (
+      version.startsWith(INTERNAL_FILE_PREFIX) === true ||
+      version.startsWith(INTERNAL_REPO_FILE_PREFIX) === true
+    ) {
       const targetLocation = version.slice('file:'.length)
       const relativePath = relativeRepoPath({
         from: currentLocation,


### PR DESCRIPTION
## Problem

Genie composes dependencies from foreign megarepo members as source `link:`
dependencies. That is correct for ordinary source sharing, but it bypasses
pnpm's consumer-side peer materialization. Identity-sensitive peers such as
Effect can therefore be loaded from two physical installations even when both
repositories declare the same version, producing incompatible Context tags.

This was reproduced by the dotfiles Forge consumer while validating the
observability rollout.

## Solution

- Add a typed `crossRepoProtocols` override to `catalog.compose` dependency
  buckets while preserving `link` as the default.
- Support repo-absolute `file:repos/...` dependency paths in package-json
  rendering.
- Cover consumer-side materialization and inherited peer installation in the
  Genie unit suite.
- Document the fix in the changelog.

The consumer can now select `file` only for the foreign package whose singleton
peer graph must be resolved locally; other cross-repository dependencies keep
their existing live-link behavior.

## Validation

- `devenv tasks run test:genie --mode single --show-output`
  - 27 files passed
  - 384 tests passed
- `devenv tasks run check:quick --show-output`
- Consumer experiment: pnpm emitted a peer-qualified `file:` lockfile snapshot,
  installed no nested `effect`, and cleared all Forge Electron Effect identity
  errors.

## Trade-offs / follow-up

`file:` materialization trades live source-link behavior for peer-graph
correctness on explicitly selected dependencies. The default remains unchanged.

Supports overengineeringstudio/effect-utils#925.
