### PR TITLE
Add Effect 4 migration findings and marker checker

### DIFF
--- a/context/effect-4/alignment-register.md
+++ b/context/effect-4/alignment-register.md
@@ -217,3 +217,36 @@
 - **Blast radius:** long-lived PTY, Restate, and agent-ingestion processes plus
   idle/hibernating runtimes.
 - **Status:** allowlisted in `patterns/effect-never-idle/scenario.json`.
+
+## filesystem-watch-recursive-option-removed
+
+- **Bucket:** C — REAL BREAKAGE WE MUST PRESERVE OR SHIM.
+- **Difference:** v3 `FileSystem.watch(path, { recursive: false })` observes only direct children.
+  In beta.102 the option is removed from both `FileSystem.watch` and `WatchBackend.register`, and
+  the shared Node implementation calls `node:fs.watch` with `{ recursive: true }`
+  unconditionally. The Bun FileSystem layer delegates to that implementation.
+- **Decision:** do not accept the widened watch scope. Restore recursive control upstream or
+  preserve non-recursive behavior with a compatibility FileSystem/watch shim before migrating
+  affected loops.
+- **Blast radius:** `megarepo` and `genie` watch modes. Unexpected nested events can trigger
+  spurious rebuilds or watch loops and present as timing flakiness rather than a clear migration
+  failure.
+- **Status:** REQUIRED COMPATIBILITY WORK; allowlisted at the one stable nested-path membership
+  trace path. Raw event ordering is deliberately not gated after five same-major runs produced
+  four unique v3 traces and three unique v4 traces. No matching upstream issue was found; a draft
+  report is in `recipes/filesystem-watch-ordering.md` pending orchestrator duplicate review.
+
+## prompt-pty-ansi-rendering
+
+- **Bucket:** C — REAL BYTE DIFFERENCE REQUIRING OWNER REVIEW.
+- **Difference:** under a real PTY, beta.102 `Prompt.select` emits shorter ANSI SGR/reset sequences.
+  The selection transcript changes from 452 to 356 bytes and the Ctrl-C transcript from 136 to
+  104 bytes.
+- **Decision:** do not blanket-rebaseline. Preserve exact bytes for raw-terminal parsers and
+  snapshots; a package may accept the v4 rendering only after its PTY, inline-renderer, cleanup,
+  and visual contracts pass.
+- **Blast radius:** `tui-react`, `pty-effect`, and any CLI snapshot or terminal parser built on
+  Effect Prompt.
+- **Status:** two exact transcript paths allowlisted. Raw-mode lifecycle, key and Escape decoding,
+  resize 80x24 -> 101x37, selected value, Quit behavior, bell, cursor restoration, and cleanup are
+  identical across five same-major repetitions.

--- a/context/effect-4/alignment-register.md
+++ b/context/effect-4/alignment-register.md
@@ -1,0 +1,219 @@
+# Alignment Register
+
+## schema-date
+
+- **Difference:** v4 `Schema.Date` validates Date instances, while v3 `Schema.Date`
+  represented ISO-string wire encoding.
+- **Proposed decision:** Treat this as no intended behaviour change. Migrate v3
+  `Schema.Date` wire sites to `Schema.DateFromString` on effect `4.0.0-beta.102`.
+- **Blast radius:** Date wire codecs and custom transforms in session ingestion,
+  Notion property codecs, and path/schema helpers.
+- **Status:** proven for accepted ISO input and encoded wire string on beta.102;
+  the earlier beta.99 `Schema.isDateValid` mapping is stale because the check is
+  no longer exported and `Schema.Date` now rejects invalid Date instances.
+
+## schema-date-invalid-message
+
+- **Difference:** Invalid Date/null parse messages differ. v3 emits parse tree
+  text; v4 emits `SchemaError(...)` text.
+- **Proposed decision:** Do not treat this as a globally accepted difference.
+  Accept only for internal structural failure checks. For user-facing or
+  snapshotted boundaries, add an explicit formatter/normalizer or preserve the
+  old text before flipping.
+- **Blast radius:** schema decode errors and tests that assert exact parse
+  messages.
+- **Audit evidence:** Repo grep found no snapshots containing the specific v3
+  Date parse-tree text or v4 `SchemaError(...)` text. A focused multiline grep
+  across `notion-effect-schema`, `notion-datasource-sync`, `notion-cli`, and
+  `tui-react` found snapshots of generated code, canonical JSON, renderer output,
+  and store/event projections, but none of schema parse-error text. Structural
+  decode-failure tests in `notion-effect-schema` and `notion-property-write`
+  assert failure shape only. User-facing/stringified-error boundaries do exist:
+  `notion-cli` TUI `SetError` paths stringify errors, `notion-datasource-sync`
+  JSON error envelopes and manifest namespace diagnostics stringify failures,
+  `tui-react` renders tagged/stringified errors, and `restate-effect` formats
+  `ParseError` via `ParseResult.TreeFormatter`.
+- **Status:** allowlisted only as a harness classification in
+  `patterns/schema-date/scenario.json`; migration acceptance requires auditing
+  the user-facing boundaries above.
+
+## cli-A-nested-terminator-loss
+
+- **Bucket:** A — SUSPECTED V4 BUG.
+- **Difference:** under a nested command, v4 beta.99 and beta.102 drop all argv after `--`. A
+  required child positional supplied after the terminator becomes missing; an already-satisfied
+  child silently loses its trailing operands.
+- **Source confirmation:** the lexer preserves trailing operands
+  (`effect/src/unstable/cli/internal/lexer.ts:24-40`), but parser recursion constructs the child
+  input with `trailingOperands: []` (`internal/parser.ts:87`) and attaches the originals to the
+  parent parse record (`internal/parser.ts:97`).
+- **Decision:** report upstream and do not migrate affected commands until fixed upstream or
+  locally patched.
+- **Blast radius:** dash-prefixed positional values in nested commands, including `megarepo`
+  add/exec/pin/store, Notion database/schema commands, and TUI story render/inspect.
+- **Status:** ESCALATED to the orchestrator with a minimal deterministic reproduction; confirmed
+  against beta.102 after the related positional-overflow fix `c917bb94a` (#6561), which did not
+  touch `internal/parser.ts`. Four exact diff paths are allowlisted only to freeze the
+  characterization.
+
+## cli-B-accepted-grammar-improvements
+
+- **Bucket:** B — INTENDED V4 IMPROVEMENT WE ACCEPT.
+- **Differences accepted:** reject separated negative domain integers; accept clustered short
+  aliases; accept `--flag=value` for repeated flags; strictly reject unknown flags after a
+  variadic positional.
+- **Decision:** accept these grammar changes. Current integer options model counts, delays, widths,
+  timestamps, concurrency, limits, and PR numbers. No tracked effect-utils command uses variadic
+  positional `Args`, so the strict-unknown variadic case has no current production consumer.
+- **Blast radius:** negative integer invocations in `npm-release`, `ci-tools`, `tui-stories`,
+  Notion/TUI helpers; newly valid alias clusters in `megarepo`, `notion-cli`, and `tui-stories`;
+  newly valid equals-form repeated flags in `ci-tools` and `tui-stories`.
+- **Status:** ACCEPTED for migration planning; 17 exact trace paths document the new grammar.
+
+## cli-C-rendering-and-stdout-breakage
+
+- **Bucket:** C — REAL BREAKAGE WE MUST PRESERVE OR SHIM.
+- **Difference:** v4 changes root/nested help, version bytes, validation wording, ANSI, newline
+  count, and stdout/stderr placement. Validation failures print full help to stdout where v3
+  stdout was empty.
+- **Decision:** preserve with compatibility rendering or explicitly rebaseline per CLI owner.
+  Regardless of wording, keep validation help off stdout for JSON/NDJSON-producing commands.
+- **Blast radius:** all audited binaries: `megarepo`, `notion-cli`, `genie`, `ci-tools`,
+  `npm-release`, and `tui-stories`. `notion-cli` already preserves root version bytes via its own
+  fast path; the other five delegate version rendering to Effect CLI.
+- **Status:** REQUIRED COMPATIBILITY WORK; 13 exact output paths are gated on beta.102. Two were
+  added for excess-positional rejection: both v3 and v4 exit `1`, but diagnostics and
+  help-on-stdout differ. No existing path changed bucket from beta.99.
+
+## platform-error-wrapper
+
+- **Difference:** FileSystem ENOENT, EEXIST, and EACCES failures change outer `_tag` from v3
+  `SystemError` to v4 `PlatformError`.
+- **Proposed decision:** Accept the v4 wrapper and rewrite error handling to match the wrapper then
+  inspect its reason. Preserve the inner reason tag, module, and method; the probe shows those
+  fields remain identical for all three errors.
+- **Blast radius:** process/filesystem error branches in `agent-session-ingest`, `megarepo`,
+  `restate-effect`, `ci-tools`, `effect-path`, `utils`, and their tests.
+- **Status:** allowlisted at exactly three outer-tag paths; all successful Path/read/write/stat
+  observations and inner error fields are identical.
+
+## http-client-status-error-wrapper
+
+- **Difference:** `HttpClientResponse.filterStatusOk` changes a rejected 418 from v3
+  `ResponseError` / `reason: "StatusCode"` to v4 `HttpClientError` /
+  `reason._tag: "StatusCodeError"`.
+- **Proposed decision:** Accept the v4 wrapper and rewrite every response-error handler to inspect
+  the wrapped reason. Preserve the status and body behavior; the 200 status/body and rejected 418
+  status are identical in the local-server probe.
+- **Blast radius:** HTTP retry, telemetry, and response classification branches using
+  `catchTag("ResponseError")` or string reason checks.
+- **Status:** two error-shape paths allowlisted; success behavior and numeric status are identical.
+
+## fork-defaults
+
+- **Difference:** No default startup-order difference was observed for v3
+  `Effect.fork` vs v4 `Effect.forkChild`.
+- **Proposed decision:** Migrate default child forks mechanically without adding
+  `{ startImmediately: true, uninterruptible: "inherit" }`.
+- **Blast radius:** background workers, RPC/websocket helpers, process wrappers,
+  Playwright helpers, and tests that rely on startup order.
+- **Status:** default case proven identical.
+
+## fork-copied-options
+
+- **Difference:** Copying `{ startImmediately: true }` to v4 moves `child-start`
+  before the parent records `after-fork`.
+- **Proposed decision:** Treat blanket copied options as a behaviour change and
+  remove them unless the call site explicitly wants immediate startup.
+- **Blast radius:** any migrated fork where a worker copied options to preserve
+  imagined v3 behaviour.
+- **Status:** allowlisted as a negative-control diff in
+  `patterns/fork-defaults/scenario.json`.
+
+## equality-structural-default
+
+- **Difference:** v4 structurally compares plain objects, arrays, maps, sets,
+  dates, and regexps; v3 used reference equality for these values.
+- **Proposed decision:** Accept structural equality as the v4 default, but audit
+  dedup/cache/change-detection code for identity-sensitive sites.
+- **Blast radius:** Effect `HashSet`/`HashMap`, `Equal.equals`, cache keys, and
+  any custom collection membership checks.
+- **Status:** allowlisted in `patterns/equality/scenario.json`.
+
+## equality-nan
+
+- **Difference:** v4 treats `NaN` as equal to `NaN`; v3 did not.
+- **Proposed decision:** Accept unless a numeric cache or validation path used
+  `NaN` inequality as a sentinel.
+- **Blast radius:** numeric dedup, cache invalidation, and schema/property tests
+  with `NaN` sentinels.
+- **Status:** allowlisted in `patterns/equality/scenario.json`.
+
+## equality-by-reference-opt-out
+
+- **Difference:** v4 adds `Equal.byReference` as an explicit identity-equality
+  opt-out, returning a Proxy rather than the original object.
+- **Proposed decision:** Use only where identity equality is load-bearing; prefer
+  `byReference` for safety and `byReferenceUnsafe` only when the proxy identity
+  cost is unacceptable and object mutation is controlled.
+- **Blast radius:** identity-sensitive caches and sets.
+- **Status:** documented in `patterns/equality/RECIPE.md`.
+
+## layer-memoization-default
+
+- **Difference:** v3 rebuilt the same layer twice across separate
+  `Effect.provide` calls; v4 memoizes across those provides and builds once.
+- **Proposed decision:** Accept v4 shared memoization for application wiring, but
+  audit tests/resource factories for call sites where fresh construction is
+  observable.
+- **Blast radius:** test layers, scoped resources, process/RPC clients, caches,
+  and service factories.
+- **Status:** allowlisted in `patterns/layer-memoization/scenario.json`.
+
+## layer-memoization-freshness-opt-outs
+
+- **Difference:** v4 adds `{ local: true }`; `Layer.fresh` remains the portable
+  freshness escape hatch.
+- **Proposed decision:** Use `Layer.fresh` for a local layer that must rebuild;
+  use `{ local: true }` when an entire provided layer subtree needs its own memo
+  map.
+- **Blast radius:** test harnesses and per-request/per-run resources.
+- **Status:** `Layer.fresh` matches v3 count; `{ local: true }` documented as
+  v4-only.
+
+## rpc-failure-cause-wire-shape
+
+- **Difference:** v3 RPC failure envelopes encode Cause as a recursive object;
+  v4 encodes the flattened Cause reasons array. A tagged failure therefore
+  changes bytes from `{"cause":{"_tag":"Fail",...}}` to
+  `{"cause":[{"_tag":"Fail",...}]}`.
+- **Proposed decision:** Accept the v4 envelope only for atomically upgraded
+  internal peers. Require an explicit protocol version or compatibility adapter
+  anywhere peers can run different majors or envelopes are persisted.
+- **Blast radius:** every RPC error response, including unary exits and streaming
+  exits.
+- **Status:** allowlisted in `patterns/rpc-payload-codecs/scenario.json`;
+  payload bytes and decoded handler values are otherwise identical.
+
+## browser-testing-barrel
+
+- **Difference:** a static re-export from v4 `effect/testing` reaches
+  `node:assert`; the representative v3 runtime/testing facade remained
+  browser-bundleable.
+- **Proposed decision:** Remove testing exports from public runtime/browser
+  facades and use direct `effect/testing/*` imports in test files.
+- **Blast radius:** all browser-facing packages and any shared Effect facade.
+- **Status:** allowlisted characterization in
+  `patterns/browser-builtin-leakage/scenario.json`; the runtime-only facade
+  passes the Node-builtin-forbidden bundle gate on both majors.
+
+## effect-never-idle-timer
+
+- **Difference:** v3 `Effect.never` registers one long interval; v4 parks the
+  fiber without a timer.
+- **Proposed decision:** Accept the v4 runtime improvement. Do not recreate the
+  timer; use the platform main runner or a real owned resource when a process
+  must stay alive.
+- **Blast radius:** long-lived PTY, Restate, and agent-ingestion processes plus
+  idle/hibernating runtimes.
+- **Status:** allowlisted in `patterns/effect-never-idle/scenario.json`.

--- a/context/effect-4/baseline-operations.md
+++ b/context/effect-4/baseline-operations.md
@@ -1,0 +1,98 @@
+# Operational notes for writing Phase 1 baselines
+
+Techniques and traps accumulated while capturing the Effect 3 baselines that gate the Effect 4
+cohort flip (#925). Written down because each was discovered the expensive way, and most are
+invisible until they bite.
+
+The recurring theme: **several failure modes here look exactly like success.** A test task that
+does not exist, a test file that is never collected, and a validation command that does not run
+tests all present as green.
+
+## Validation
+
+**`check:quick` is TypeScript + lint only. It does not run tests.** For a test-only PR it proves
+almost nothing. It was cited as validation on many baseline PRs before this was noticed.
+
+The real signal, on a **committed** worktree:
+
+```sh
+CI=1 devenv tasks run test:<pkg> --mode single --show-output --no-tui
+```
+
+**Confirm the test count, not the exit code.** Exit 0 is compatible with collecting zero tests.
+Read the newest `tmp/otel-scrape/summaries/test-<pkg>*.summary.json` and check `vitest.tests` and
+`vitest.failures`.
+
+**Commit before validating.** Some output only appears post-commit — `megarepo` and `ci-tools`
+embed `running from local source (<sha>, <age>)` in help and version output, absent in a dirty
+tree. PR #991 passed when opened and failed later for exactly this reason.
+
+## Test tasks must exist
+
+`devenv.nix` generates a `test:<pkg>` task only for packages listed in `packagesWithTests`. There is
+no root vitest run in the task graph, so **a package absent from that list is never tested by CI**,
+however green everything looks. Four packages were in that state; #992 adds them.
+
+To validate a baseline for a package whose task does not yet exist on `main`, build a
+verification-only worktree rather than stacking the wiring into the baseline PR:
+
+1. fresh `branchy` worktree from your committed baseline
+2. cherry-pick the wiring commit (`6a4792019` for #992)
+3. `pnpm:install` against the committed lock
+4. run `test:<pkg>` and read the summary JSON
+
+## Vitest collection
+
+Include patterns are **package-relative and differ per package**. Invoking Vitest from the repo root
+can report *no tests* while appearing to pass. Observed: `tui-stories` uses `test/**`,
+`notion-datasource-sync` uses `src/**/*.test.ts`.
+
+Most packages need **no** `vitest.config.ts` — repo convention is that it exists only where genuinely
+required. The two form packages are the exception: the root workspace config resolves projects
+relative to the package task cwd and fails at startup there, so each needs a minimal local config
+(`src/**/*.unit.test.ts[x]`) with a one-line comment explaining why. **Do not add one unless the
+package task proves it is needed** — an unnecessary config is future confusion.
+
+## Lockfile changes cascade across FODs
+
+A dev-dependency addition invalidates every lockfile-derived fixed-output derivation — **eight** of
+them (`flake.nix:199-214`). `evergreen fod chase-fod-closure` cannot help: it requires
+`passthru.evergreen.fodGraph.v1` metadata the consumers lack. Refresh per attr instead.
+
+Package attrs:
+
+```sh
+evergreen fod --hash-source packages/@overeng/<pkg>/nix/build.nix \
+  --flake-ref .#<pkg> refresh --name <pkg>-unwrapped --linux-system x86_64-linux
+```
+
+Plugin bundle:
+
+```sh
+evergreen fod --hash-source nix/oxc-config-plugin.nix \
+  --flake-ref .#oxc-config-plugin-pnpm-deps refresh \
+  --name oxc-config-plugin-pnpm-deps --linux-system x86_64-linux
+```
+
+Post-write warnings about `build.nix` requiring `src` are expected. Verify **exactly** those eight
+files changed — anything else is drift, not our cascade. `nix build .#oxlint-npm --no-link` verifies
+the plugin bundle. All refreshed hashes belong in the **same PR** as the dependency change that
+caused them; splitting leaves `main` unbuildable between merges.
+
+## Lint
+
+The gate lints `packages`, `scripts`, `context` only — not `genie/` or root `*.genie.ts`, which
+carry pre-existing errors (#995). A bare repo-wide `oxlint` therefore reports failures the gate does
+not enforce.
+
+The instrumented lint task catches rules that a direct `oxlint` invocation does not — it flagged a
+deprecated Vitest `toThrowError` (use `toThrow`) that direct linting missed. It also identifies the
+offending file by **filename hash rather than path**, which makes a real single-line error present
+as "nonzero with no readable diagnostics".
+
+## What gets a migration marker
+
+Baselines are **permanent gates**, so they carry no `LIVE-MIGRATION BRIDGE` block. A specific
+assertion that pins v3 behaviour we expect v4 to change gets an inline
+`TODO(live-migration:effect-3-4)` instead — resolved rather than deleted. Only genuinely temporary
+workarounds get bridge blocks. See the bridge register in #925.

--- a/context/effect-4/baseline-operations.md
+++ b/context/effect-4/baseline-operations.md
@@ -44,7 +44,7 @@ verification-only worktree rather than stacking the wiring into the baseline PR:
 ## Vitest collection
 
 Include patterns are **package-relative and differ per package**. Invoking Vitest from the repo root
-can report *no tests* while appearing to pass. Observed: `tui-stories` uses `test/**`,
+can report _no tests_ while appearing to pass. Observed: `tui-stories` uses `test/**`,
 `notion-datasource-sync` uses `src/**/*.test.ts`.
 
 Most packages need **no** `vitest.config.ts` — repo convention is that it exists only where genuinely

--- a/context/effect-4/check-baseline-migration-markers.ts
+++ b/context/effect-4/check-baseline-migration-markers.ts
@@ -1,0 +1,414 @@
+#!/usr/bin/env bun
+
+import { resolve } from 'node:path'
+
+const marker = 'TODO(live-migration:effect-3-4)'
+
+/**
+ * Auditable fingerprints of baseline bytes or assertions whose Effect 3 shape
+ * is called out by the alignment register. Keep these expressions narrow:
+ * this checker points at migration decisions, not every use of the API.
+ */
+const riskSignatures = [
+  {
+    registerEntry: 'schema-date',
+    regex: /\b\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z\b/g,
+    why: 'ISO-8601 wire strings can be affected by the Schema.Date reassignment.',
+  },
+  {
+    registerEntry: 'schema-date',
+    regex: /\b\d{4}-02-(?:30|31)\b/g,
+    why: 'Impossible date strings exercise the tightened date-validation boundary.',
+  },
+  {
+    registerEntry: 'schema-date-invalid-message',
+    regex: /Expected [^\r\n]+, actual [^\r\n]+/g,
+    why: 'Effect 3 parse-tree text changes to SchemaError(...) rendering in Effect 4.',
+  },
+  {
+    registerEntry: 'platform-error-wrapper',
+    regex: /["'](?:_tag["']\s*:\s*["'])?SystemError["']/g,
+    why: 'Effect 4 changes the outer platform error tag to PlatformError.',
+  },
+  {
+    registerEntry: 'http-client-status-error-wrapper',
+    regex: /["']ResponseError["']|["']StatusCode["']/g,
+    why: 'Effect 4 changes the rejected-status wrapper and reason shape.',
+  },
+  {
+    registerEntry: 'fork-copied-options',
+    regex: /\b(?:startImmediately|uninterruptible)\b/g,
+    why: 'Copied fork options change scheduling and must have a local justification.',
+  },
+  {
+    registerEntry: 'equality-nan',
+    regex: /\bEqual\.equals\(\s*NaN\s*,\s*NaN\s*\)/g,
+    why: 'Effect 4 changes Effect equality for NaN.',
+  },
+  {
+    registerEntry: 'equality-by-reference-opt-out',
+    regex: /\bEqual\.byReference(?:Unsafe)?\b/g,
+    why: 'The Effect 4 identity-equality opt-out changes object identity.',
+  },
+  {
+    registerEntry: 'layer-memoization-default',
+    regex: /\b(?:build|construction|acquisition)Count\b[^\r\n]*\.(?:toBe|toEqual)\(\s*\d+\s*\)/g,
+    why: 'Construction-count assertions can change under Effect 4 layer memoization.',
+  },
+  {
+    registerEntry: 'rpc-failure-cause-wire-shape',
+    regex: /(?:\\+)?"cause(?:\\+)?"\s*:\s*(?:\\+)?\{/g,
+    why: 'Effect 3 encodes RPC failure cause as an object; Effect 4 uses an array.',
+  },
+  {
+    registerEntry: 'browser-testing-barrel',
+    regex: /["']node:assert(?:\/strict)?["']/g,
+    why: 'The Effect 4 testing barrel can leak node:assert into browser bundles.',
+  },
+  {
+    registerEntry: 'filesystem-watch-recursive-option-removed',
+    regex: /\bwatch\([\s\S]{0,300}\brecursive\s*:\s*(?:false|true)\b/g,
+    why: 'Effect 4 removes recursive watch control and widens Node watch scope.',
+  },
+  {
+    registerEntry: 'prompt-pty-ansi-rendering',
+    regex: /(?:\\u001b|\\x1b|\\x1B)\[[0-9;?]*[ -/]*[@-~]/g,
+    why: 'Effect 4 Prompt changes exact PTY ANSI rendering bytes.',
+  },
+] as const
+
+type CallBlock = {
+  readonly end: number
+  readonly leadingStart: number
+  readonly start: number
+  readonly title: string
+}
+
+type Finding = {
+  readonly column: number
+  readonly file: string
+  readonly line: number
+  readonly registerEntry: string
+  readonly testTitle: string | undefined
+  readonly why: string
+}
+
+const rootArgumentIndex = process.argv.indexOf('--root')
+const root =
+  rootArgumentIndex === -1
+    ? process.cwd()
+    : resolve(process.argv[rootArgumentIndex + 1] ?? process.cwd())
+
+const lineAndColumnAt = ({
+  source,
+  offset,
+}: {
+  readonly source: string
+  readonly offset: number
+}) => {
+  const before = source.slice(0, offset)
+  const lines = before.split('\n')
+  return {
+    column: (lines.at(-1)?.length ?? 0) + 1,
+    line: lines.length,
+  }
+}
+
+const findMatchingDelimiter = ({
+  source,
+  openingOffset,
+  opening,
+  closing,
+}: {
+  readonly source: string
+  readonly openingOffset: number
+  readonly opening: string
+  readonly closing: string
+}) => {
+  let depth = 0
+  let quote: '"' | "'" | '`' | undefined
+  let escaped = false
+  let lineComment = false
+  let blockComment = false
+
+  for (let index = openingOffset; index < source.length; index++) {
+    const character = source[index]
+    const next = source[index + 1]
+
+    if (lineComment === true) {
+      if (character === '\n') lineComment = false
+      continue
+    }
+    if (blockComment === true) {
+      if (character === '*' && next === '/') {
+        blockComment = false
+        index++
+      }
+      continue
+    }
+    if (quote !== undefined) {
+      if (escaped === true) {
+        escaped = false
+      } else if (character === '\\') {
+        escaped = true
+      } else if (character === quote) {
+        quote = undefined
+      }
+      continue
+    }
+    if (character === '/' && next === '/') {
+      lineComment = true
+      index++
+      continue
+    }
+    if (character === '/' && next === '*') {
+      blockComment = true
+      index++
+      continue
+    }
+    if (character === '"' || character === "'" || character === '`') {
+      quote = character
+      continue
+    }
+    if (character === opening) depth++
+    if (character === closing) {
+      depth--
+      if (depth === 0) return index + 1
+    }
+  }
+
+  return undefined
+}
+
+const readStaticString = ({
+  source,
+  offset,
+}: {
+  readonly source: string
+  readonly offset: number
+}) => {
+  const quote = source[offset]
+  if (quote !== '"' && quote !== "'" && quote !== '`') return undefined
+
+  let escaped = false
+  for (let index = offset + 1; index < source.length; index++) {
+    const character = source[index]
+    if (escaped === true) {
+      escaped = false
+    } else if (character === '\\') {
+      escaped = true
+    } else if (character === quote) {
+      return {
+        end: index + 1,
+        value: source.slice(offset + 1, index),
+      }
+    }
+  }
+
+  return undefined
+}
+
+const attachedCommentStart = ({
+  source,
+  callStart,
+}: {
+  readonly source: string
+  readonly callStart: number
+}) => {
+  const lineStart = source.lastIndexOf('\n', callStart - 1) + 1
+  const previousLineEnd = lineStart - 1
+  if (previousLineEnd < 0) return callStart
+
+  const previousLineStart = source.lastIndexOf('\n', previousLineEnd - 1) + 1
+  const previousLine = source.slice(previousLineStart, previousLineEnd).trim()
+  return previousLine.startsWith('//') === true ? previousLineStart : callStart
+}
+
+const findCalls = ({
+  source,
+  callName,
+}: {
+  readonly source: string
+  readonly callName: 'describe' | 'test'
+}) => {
+  const namePattern =
+    callName === 'describe'
+      ? /(?:^|[^\w$])(?:[A-Za-z_$][\w$]*\.)?describe(?:\.\w+)*\s*\(/g
+      : /(?:^|[^\w$])(?:(?:[A-Za-z_$][\w$]*\.)?(?:it|test))(?:\.\w+)*\s*\(/g
+  const calls: CallBlock[] = []
+
+  for (const match of source.matchAll(namePattern)) {
+    const openingOffset = source.indexOf('(', match.index)
+    const end = findMatchingDelimiter({ source, openingOffset, opening: '(', closing: ')' })
+    if (end === undefined) continue
+
+    let titleOffset = openingOffset + 1
+    while (/\s/.test(source[titleOffset] ?? '') === true) titleOffset++
+    const title = readStaticString({ source, offset: titleOffset })
+    if (title === undefined || title.value.includes('${') === true) continue
+
+    const start = match.index + (match[0].match(/^[^\w$]/)?.[0].length ?? 0)
+    calls.push({
+      end,
+      leadingStart: attachedCommentStart({ source, callStart: start }),
+      start,
+      title: title.value,
+    })
+  }
+
+  return calls
+}
+
+const hasMarker = ({ source, test }: { readonly source: string; readonly test: CallBlock }) =>
+  source.slice(test.leadingStart, test.end).includes(marker)
+
+const baselineTestsIn = (source: string) => {
+  const baselineDescribes = findCalls({ source, callName: 'describe' }).filter((block) =>
+    /(?:baseline|cross-major)/i.test(block.title),
+  )
+  const tests = findCalls({ source, callName: 'test' })
+
+  return tests.filter((test) =>
+    baselineDescribes.some((describe) => test.start > describe.start && test.end < describe.end),
+  )
+}
+
+const collectSignatureFindings = ({
+  file,
+  source,
+  test,
+}: {
+  readonly file: string
+  readonly source: string
+  readonly test: CallBlock | undefined
+}) => {
+  if (test !== undefined && hasMarker({ source, test }) === true) return []
+
+  const findings: Finding[] = []
+  const searchable = test === undefined ? source : source.slice(test.start, test.end)
+  const searchableOffset = test === undefined ? 0 : test.start
+
+  for (const signature of riskSignatures) {
+    for (const match of searchable.matchAll(signature.regex)) {
+      const offset = searchableOffset + match.index
+      const location = lineAndColumnAt({ source, offset })
+      findings.push({
+        ...location,
+        file,
+        registerEntry: signature.registerEntry,
+        testTitle: test?.title,
+        why: signature.why,
+      })
+    }
+  }
+
+  return findings
+}
+
+const testGlobs = [
+  'packages/@overeng/**/*.test.ts',
+  'packages/@overeng/**/*.test.tsx',
+  'packages/@overeng/**/*.spec.ts',
+  'packages/@overeng/**/*.spec.tsx',
+] as const
+
+const testFiles = (
+  await Promise.all(
+    testGlobs.map(async (pattern) => Array.fromAsync(new Bun.Glob(pattern).scan({ cwd: root }))),
+  )
+)
+  .flat()
+  .toSorted()
+
+const baselineFileEntries = await Promise.all(
+  testFiles.map(async (file) => {
+    const source = await Bun.file(resolve(root, file)).text()
+    return [file, { source, tests: baselineTestsIn(source) }] as const
+  }),
+)
+
+const baselineFiles = new Map<
+  string,
+  {
+    readonly source: string
+    readonly tests: readonly CallBlock[]
+  }
+>(baselineFileEntries.filter(([, baseline]) => baseline.tests.length > 0))
+
+const findings: Finding[] = []
+
+for (const [file, baseline] of baselineFiles) {
+  for (const test of baseline.tests) {
+    findings.push(
+      ...collectSignatureFindings({
+        file,
+        source: baseline.source,
+        test,
+      }),
+    )
+  }
+}
+
+const snapshotFiles = await Array.fromAsync(
+  new Bun.Glob('packages/@overeng/**/__snapshots__/*.snap').scan({ cwd: root }),
+)
+const snapshotFileEntries = await Promise.all(
+  snapshotFiles.map(async (file) => [file, await Bun.file(resolve(root, file)).text()] as const),
+)
+
+for (const [file, source] of snapshotFileEntries) {
+  const testFileName = file.replace('/__snapshots__/', '/').replace(/\.snap$/, '')
+  const baseline = baselineFiles.get(testFileName)
+  if (baseline === undefined) continue
+
+  const entryStarts = [...source.matchAll(/^exports\[`/gm)].map((match) => match.index)
+  for (const [entryIndex, entryStart] of entryStarts.entries()) {
+    const entryEnd = entryStarts[entryIndex + 1] ?? source.length
+    const entry = source.slice(entryStart, entryEnd)
+    const key = readStaticString({ source: entry, offset: entry.indexOf('`') })
+    if (key === undefined) continue
+
+    const test = baseline.tests.find((candidate) => key.value.includes(` > ${candidate.title} `))
+    if (test === undefined) continue
+    if (hasMarker({ source: baseline.source, test }) === true) continue
+
+    for (const signature of riskSignatures) {
+      for (const match of entry.matchAll(signature.regex)) {
+        const offset = entryStart + match.index
+        const location = lineAndColumnAt({ source, offset })
+        findings.push({
+          ...location,
+          file,
+          registerEntry: signature.registerEntry,
+          testTitle: test.title,
+          why: signature.why,
+        })
+      }
+    }
+  }
+}
+
+findings.sort(
+  (left, right) =>
+    left.file.localeCompare(right.file) ||
+    left.line - right.line ||
+    left.column - right.column ||
+    left.registerEntry.localeCompare(right.registerEntry),
+)
+
+if (findings.length === 0) {
+  console.log(
+    `PASS: ${baselineFiles.size} baseline test files contain no unmarked Effect 3 -> 4 risk signatures.`,
+  )
+} else {
+  for (const finding of findings) {
+    const testSuffix = finding.testTitle === undefined ? '' : ` [${finding.testTitle}]`
+    console.error(
+      `${finding.file}:${finding.line}:${finding.column} ${finding.registerEntry}${testSuffix} - ${finding.why}`,
+    )
+  }
+  console.error(
+    `FAIL: ${findings.length} unmarked risk signature matches across ${baselineFiles.size} baseline test files.`,
+  )
+  process.exitCode = 1
+}

--- a/context/effect-4/idiom-catalog.md
+++ b/context/effect-4/idiom-catalog.md
@@ -10,22 +10,22 @@ is explicit. Public paths below are repository-relative.
 
 Ranked by value, not by raw site count.
 
-| rank | pattern | coupling | verified local surface | recommendation | owner decision |
-| ---: | --- | --- | --- | --- | --- |
-| 1 | Preserve Schema encoded contracts while adopting v4 codecs/checks | MUST-CHANGE | 234 wire-sensitive occurrences / 91 files / 22 packages; broader Schema-shape surface is 723 / 160 / 24 | **ADOPT-DURING** | approve / reject |
-| 2 | `Context.Service` + explicit named layers + direct `yield*` | MUST-CHANGE | 57 service definitions/usages / 42 files / 13 packages | **ADOPT-DURING** | approve / reject |
-| 3 | Yield Effectable child-process commands; delete executor/start plumbing | TOUCHING-ANYWAY | 47 command/executor occurrences across 17 files / 7 packages | **ADOPT-DURING** | approve / reject |
-| 4 | Use v4 fork defaults; add options only when a two-major probe requires them | TOUCHING-ANYWAY | 48 fork/forkScoped sites / 28 files / 12 packages | **ADOPT-DURING** | approve / reject |
-| 5 | Replace unsafe `FiberRef` toggle with `Context.Reference` | MUST-CHANGE | 3 operations in one `utils` file | **ADOPT-DURING** | approve / reject |
-| 6 | `Effect.async` -> `Effect.callback`, preserving cancellation registration | MUST-CHANGE | 15 sites / 8 files / 4 packages | **ADOPT-DURING** | approve / reject |
-| 7 | Native v4 Schema class/array/check/annotation forms | MUST-CHANGE | includes 187 `Schema.TaggedError` sites / 63 files / 21 packages | **ADOPT-DURING** | approve / reject |
-| 8 | Canonical v4 catch names, without reason-model redesign | MUST-CHANGE | 112 `catchAll` + 7 `catchAllCause`, 52 files / 14 packages | **ADOPT-DURING** | approve / reject |
-| 9 | Module-owned concurrency constructors (`Semaphore.make`) | MUST-CHANGE | 2 sites / 2 packages | **ADOPT-DURING** | approve / reject |
-| 10 | Broad layer-graph composition cleanup | INDEPENDENT | 795 `Effect.provide` occurrences / 202 files; heat concentrated in megarepo, Restate, Notion, TUI | **ADOPT-AFTER** | approve / reject |
-| 11 | Convert functions returning `Effect.gen` to named `Effect.fn` | INDEPENDENT | 35 clear sites / 23 files / 9 packages; 519 `Effect.fn` sites already exist | **ADOPT-AFTER** | approve / reject |
-| 12 | Replace existing errors with reason-bearing errors | INDEPENDENT | no bounded mechanical surface; error-heavy packages span most of repo | **SKIP** for migration | approve / reject |
-| 13 | Add an Effect facade analogous to `@livestore/utils/effect` | INDEPENDENT | no equivalent facade; Effect imports span 31 packages | **SKIP** | approve / reject |
-| 14 | Broadly rewrite combinator pipelines into `Effect.gen` | INDEPENDENT | `Effect.gen` already occurs in 314 files | **SKIP** | approve / reject |
+| rank | pattern                                                                     | coupling        | verified local surface                                                                                  | recommendation         | owner decision   |
+| ---: | --------------------------------------------------------------------------- | --------------- | ------------------------------------------------------------------------------------------------------- | ---------------------- | ---------------- |
+|    1 | Preserve Schema encoded contracts while adopting v4 codecs/checks           | MUST-CHANGE     | 234 wire-sensitive occurrences / 91 files / 22 packages; broader Schema-shape surface is 723 / 160 / 24 | **ADOPT-DURING**       | approve / reject |
+|    2 | `Context.Service` + explicit named layers + direct `yield*`                 | MUST-CHANGE     | 57 service definitions/usages / 42 files / 13 packages                                                  | **ADOPT-DURING**       | approve / reject |
+|    3 | Yield Effectable child-process commands; delete executor/start plumbing     | TOUCHING-ANYWAY | 47 command/executor occurrences across 17 files / 7 packages                                            | **ADOPT-DURING**       | approve / reject |
+|    4 | Use v4 fork defaults; add options only when a two-major probe requires them | TOUCHING-ANYWAY | 48 fork/forkScoped sites / 28 files / 12 packages                                                       | **ADOPT-DURING**       | approve / reject |
+|    5 | Replace unsafe `FiberRef` toggle with `Context.Reference`                   | MUST-CHANGE     | 3 operations in one `utils` file                                                                        | **ADOPT-DURING**       | approve / reject |
+|    6 | `Effect.async` -> `Effect.callback`, preserving cancellation registration   | MUST-CHANGE     | 15 sites / 8 files / 4 packages                                                                         | **ADOPT-DURING**       | approve / reject |
+|    7 | Native v4 Schema class/array/check/annotation forms                         | MUST-CHANGE     | includes 187 `Schema.TaggedError` sites / 63 files / 21 packages                                        | **ADOPT-DURING**       | approve / reject |
+|    8 | Canonical v4 catch names, without reason-model redesign                     | MUST-CHANGE     | 112 `catchAll` + 7 `catchAllCause`, 52 files / 14 packages                                              | **ADOPT-DURING**       | approve / reject |
+|    9 | Module-owned concurrency constructors (`Semaphore.make`)                    | MUST-CHANGE     | 2 sites / 2 packages                                                                                    | **ADOPT-DURING**       | approve / reject |
+|   10 | Broad layer-graph composition cleanup                                       | INDEPENDENT     | 795 `Effect.provide` occurrences / 202 files; heat concentrated in megarepo, Restate, Notion, TUI       | **ADOPT-AFTER**        | approve / reject |
+|   11 | Convert functions returning `Effect.gen` to named `Effect.fn`               | INDEPENDENT     | 35 clear sites / 23 files / 9 packages; 519 `Effect.fn` sites already exist                             | **ADOPT-AFTER**        | approve / reject |
+|   12 | Replace existing errors with reason-bearing errors                          | INDEPENDENT     | no bounded mechanical surface; error-heavy packages span most of repo                                   | **SKIP** for migration | approve / reject |
+|   13 | Add an Effect facade analogous to `@livestore/utils/effect`                 | INDEPENDENT     | no equivalent facade; Effect imports span 31 packages                                                   | **SKIP**               | approve / reject |
+|   14 | Broadly rewrite combinator pipelines into `Effect.gen`                      | INDEPENDENT     | `Effect.gen` already occurs in 314 files                                                                | **SKIP**               | approve / reject |
 
 ## Cheapest high-value set: approve these five
 
@@ -51,36 +51,36 @@ whose success criterion would be “looks nicer.”
 `#1321` are closed migration **issues**, not PRs (`gh pr view` cannot resolve them; `gh issue view`
 does). The actual package PRs, listed by landing PR #1383, are:
 
-| issue | actual PR | slice |
-| ---: | ---: | --- |
-| #1319 | #1342 | webmesh |
-| #1314 | #1343 | common |
-| #1339 | #1349 | common-cf |
-| #1317 | #1350 | sync-cf |
-| #1340 | #1344 | effect-playwright |
-| #1341 | #1345 | sqlite-wasm |
-| #1316 | #1352 | adapter-web |
-| #1315 | #1353 | livestore core |
-| #1318 | #1354 | react |
-| #1320 | #1355 | docs/examples/tests/perf |
-| #1321 | #1359 | finalization |
+| issue | actual PR | slice                    |
+| ----: | --------: | ------------------------ |
+| #1319 |     #1342 | webmesh                  |
+| #1314 |     #1343 | common                   |
+| #1339 |     #1349 | common-cf                |
+| #1317 |     #1350 | sync-cf                  |
+| #1340 |     #1344 | effect-playwright        |
+| #1341 |     #1345 | sqlite-wasm              |
+| #1316 |     #1352 | adapter-web              |
+| #1315 |     #1353 | livestore core           |
+| #1318 |     #1354 | react                    |
+| #1320 |     #1355 | docs/examples/tests/perf |
+| #1321 |     #1359 | finalization             |
 
 PRs #1322, #1323, and #1332 are correctly numbered in the brief. The complete landing PR is #1383.
 
 ### Adopted versus deferred
 
-| LiveStore choice | evidence | implication here |
-| --- | --- | --- |
-| Adopted direct import topology and mechanical API names first | PR #1323; commits `c96100d11`, `11fe7d887` | Keep mechanical rewrites separate from judgment-heavy recipes. |
-| Adopted `Context.Service`, callback constructors, RPC-native workers, and explicit layers where v4 required structural change | PR #1332; `utils/src/browser/Opfs/Opfs.ts:222-226`; `utils/src/browser/WebLock.ts:49-73` | These are admissible during migration when the v3 behavior trace is locked first. |
-| Adopted v4 layer composition in worker boot paths | PR #1352 | Restrict to touched/required graphs; do not use this as license for repo-wide graph redesign. |
-| Changed an async-iterator implementation when the old bridge raced under v4 | PR #1353 | This is a behavior repair, not an idiom precedent; it required focused tests. |
-| Deferred fork-option audit | #1356 / PR #1369, commit `87fecd4a` | The copied compatibility options were unnecessary; probe before adding any. |
-| Deferred and then deleted v3 MessageChannel scheduler | #1357 / PR #1370, commit `55bf025f` | Delete a local runtime shim only when v4 owns the same policy and callers do not require a distinct one. |
-| Deferred Vitest config work | #1358 / PR #1368 | Tool config is separable follow-up work, not an Effect source idiom. |
-| Deferred Schema-native table redesign | recovered `contributor-docs/effect-4.md`; open PR #1308 still exists | Redesign is not behavior-preserving migration work. |
-| Did not broadly adopt `Effect.fn` | local lexical comparison: dev 116 -> main 84 `Effect.fn`; functions returning `Effect.gen` 20 -> 18 | Upstream preference was not treated as migration scope. |
-| Retained and adapted the facade rather than newly choosing it | facade imports dev 372 -> main 299; current facade `utils/src/effect/mod.ts:3-129` | A pre-existing boundary is not evidence that effect-utils should introduce one. |
+| LiveStore choice                                                                                                              | evidence                                                                                            | implication here                                                                                         |
+| ----------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| Adopted direct import topology and mechanical API names first                                                                 | PR #1323; commits `c96100d11`, `11fe7d887`                                                          | Keep mechanical rewrites separate from judgment-heavy recipes.                                           |
+| Adopted `Context.Service`, callback constructors, RPC-native workers, and explicit layers where v4 required structural change | PR #1332; `utils/src/browser/Opfs/Opfs.ts:222-226`; `utils/src/browser/WebLock.ts:49-73`            | These are admissible during migration when the v3 behavior trace is locked first.                        |
+| Adopted v4 layer composition in worker boot paths                                                                             | PR #1352                                                                                            | Restrict to touched/required graphs; do not use this as license for repo-wide graph redesign.            |
+| Changed an async-iterator implementation when the old bridge raced under v4                                                   | PR #1353                                                                                            | This is a behavior repair, not an idiom precedent; it required focused tests.                            |
+| Deferred fork-option audit                                                                                                    | #1356 / PR #1369, commit `87fecd4a`                                                                 | The copied compatibility options were unnecessary; probe before adding any.                              |
+| Deferred and then deleted v3 MessageChannel scheduler                                                                         | #1357 / PR #1370, commit `55bf025f`                                                                 | Delete a local runtime shim only when v4 owns the same policy and callers do not require a distinct one. |
+| Deferred Vitest config work                                                                                                   | #1358 / PR #1368                                                                                    | Tool config is separable follow-up work, not an Effect source idiom.                                     |
+| Deferred Schema-native table redesign                                                                                         | recovered `contributor-docs/effect-4.md`; open PR #1308 still exists                                | Redesign is not behavior-preserving migration work.                                                      |
+| Did not broadly adopt `Effect.fn`                                                                                             | local lexical comparison: dev 116 -> main 84 `Effect.fn`; functions returning `Effect.gen` 20 -> 18 | Upstream preference was not treated as migration scope.                                                  |
+| Retained and adapted the facade rather than newly choosing it                                                                 | facade imports dev 372 -> main 299; current facade `utils/src/effect/mod.ts:3-129`                  | A pre-existing boundary is not evidence that effect-utils should introduce one.                          |
 
 The first three deferred items were handled immediately after the landing stack. That supports a
 short, named post-migration idiom phase; it does not support mixing redesign into the green-up
@@ -127,12 +127,13 @@ auto-generated `.Default`, and inline `dependencies`
 **v4 form:**
 
 ```ts
-class Otelite extends Context.Service<Otelite, Service>()("...") {
+class Otelite extends Context.Service<Otelite, Service>()('...') {
   static readonly layer = Layer.effect(this, make).pipe(Layer.provide(NodeContext.layer))
 }
-const otelite = yield* Otelite
-yield* otelite.capture(options)
+const otelite = yield * Otelite
+yield * otelite.capture(options)
 ```
+
 **Why better:** v4 deletes accessor proxies that erase generic/overloaded method types and deletes
 implicit dependency wiring. The resulting service requirement and layer graph are explicit and
 locally typechecked (`effect/migration/services.md:63-140,142-199`). LiveStore used this structural
@@ -156,10 +157,14 @@ call `Command.exitCode`.
 **v4 form:**
 
 ```ts
-const handle = yield* ChildProcess.make("claude", args, {
-  stdin: "pipe", stdout: "pipe", stderr: "pipe"
-})
-const exitCode = yield* handle.exitCode
+const handle =
+  yield *
+  ChildProcess.make('claude', args, {
+    stdin: 'pipe',
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+const exitCode = yield * handle.exitCode
 ```
 
 Use `ChildProcessSpawner` only for its higher-level collection helpers or a custom spawn
@@ -210,12 +215,13 @@ must cite its differential trace.
 **v4 form:**
 
 ```ts
-const ScopeDebugEnabled = Context.Reference<boolean>(".../ScopeDebugEnabled", {
-  defaultValue: () => false
+const ScopeDebugEnabled = Context.Reference<boolean>('.../ScopeDebugEnabled', {
+  defaultValue: () => false,
 })
-const enabled = yield* ScopeDebugEnabled
+const enabled = yield * ScopeDebugEnabled
 const run = Effect.provideService(effect, ScopeDebugEnabled, true)
 ```
+
 **Why better:** removes unsafe construction and models fiber-local configuration through the v4
 context/reference mechanism. This is precisely the v4 replacement for FiberRef-based application
 state (`migration/fiberref.md:1-10,50-82`).
@@ -386,15 +392,15 @@ rewrite makes the old structure materially harder to read.
 
 ## Dangerous during-migration attractions
 
-| attractive change | why dangerous | rule |
-| --- | --- | --- |
-| Named `Effect.fn` everywhere | intentionally adds spans / changes stacks | separate post-migration telemetry change |
-| Compose every layer graph | v4 memoization can change acquisition count even if types pass | instrument constructors/finalizers first |
-| Add fork compatibility options | LiveStore proved its copied options unnecessary; scheduling is subtle | defaults unless a two-major trace fails |
-| “Improve” Schema models while changing constructors | wire/default/null/optional behavior can typecheck and drift | preserve encoded fixtures byte-for-byte |
-| Introduce reason errors | changes public and encoded error shape | separate API design |
-| Add a facade | changes dependency/bundle/public-type boundaries | reject for effect-utils |
-| Copy `react-inspector`'s variadic `union` helper | hides v4 native array form and perpetuates v3 calling style | use native arrays directly |
+| attractive change                                   | why dangerous                                                         | rule                                     |
+| --------------------------------------------------- | --------------------------------------------------------------------- | ---------------------------------------- |
+| Named `Effect.fn` everywhere                        | intentionally adds spans / changes stacks                             | separate post-migration telemetry change |
+| Compose every layer graph                           | v4 memoization can change acquisition count even if types pass        | instrument constructors/finalizers first |
+| Add fork compatibility options                      | LiveStore proved its copied options unnecessary; scheduling is subtle | defaults unless a two-major trace fails  |
+| “Improve” Schema models while changing constructors | wire/default/null/optional behavior can typecheck and drift           | preserve encoded fixtures byte-for-byte  |
+| Introduce reason errors                             | changes public and encoded error shape                                | separate API design                      |
+| Add a facade                                        | changes dependency/bundle/public-type boundaries                      | reject for effect-utils                  |
+| Copy `react-inspector`'s variadic `union` helper    | hides v4 native array form and perpetuates v3 calling style           | use native arrays directly               |
 
 ## What `react-inspector` should teach the rest of the repo
 

--- a/context/effect-4/idiom-catalog.md
+++ b/context/effect-4/idiom-catalog.md
@@ -1,0 +1,442 @@
+# Effect 4 idioms: decision-ready adoption catalog
+
+Identity: `org.schickling.eu.effect-4.idioms`
+
+All repository work was read-only. Counts are lexical over package TS/TSX and include tests/examples.
+`VERIFIED` means inspected in the supplied checkouts or GitHub metadata on 2026-07-28; `INFERRED`
+is explicit. Public paths below are repository-relative.
+
+## Owner decision table
+
+Ranked by value, not by raw site count.
+
+| rank | pattern | coupling | verified local surface | recommendation | owner decision |
+| ---: | --- | --- | --- | --- | --- |
+| 1 | Preserve Schema encoded contracts while adopting v4 codecs/checks | MUST-CHANGE | 234 wire-sensitive occurrences / 91 files / 22 packages; broader Schema-shape surface is 723 / 160 / 24 | **ADOPT-DURING** | approve / reject |
+| 2 | `Context.Service` + explicit named layers + direct `yield*` | MUST-CHANGE | 57 service definitions/usages / 42 files / 13 packages | **ADOPT-DURING** | approve / reject |
+| 3 | Yield Effectable child-process commands; delete executor/start plumbing | TOUCHING-ANYWAY | 47 command/executor occurrences across 17 files / 7 packages | **ADOPT-DURING** | approve / reject |
+| 4 | Use v4 fork defaults; add options only when a two-major probe requires them | TOUCHING-ANYWAY | 48 fork/forkScoped sites / 28 files / 12 packages | **ADOPT-DURING** | approve / reject |
+| 5 | Replace unsafe `FiberRef` toggle with `Context.Reference` | MUST-CHANGE | 3 operations in one `utils` file | **ADOPT-DURING** | approve / reject |
+| 6 | `Effect.async` -> `Effect.callback`, preserving cancellation registration | MUST-CHANGE | 15 sites / 8 files / 4 packages | **ADOPT-DURING** | approve / reject |
+| 7 | Native v4 Schema class/array/check/annotation forms | MUST-CHANGE | includes 187 `Schema.TaggedError` sites / 63 files / 21 packages | **ADOPT-DURING** | approve / reject |
+| 8 | Canonical v4 catch names, without reason-model redesign | MUST-CHANGE | 112 `catchAll` + 7 `catchAllCause`, 52 files / 14 packages | **ADOPT-DURING** | approve / reject |
+| 9 | Module-owned concurrency constructors (`Semaphore.make`) | MUST-CHANGE | 2 sites / 2 packages | **ADOPT-DURING** | approve / reject |
+| 10 | Broad layer-graph composition cleanup | INDEPENDENT | 795 `Effect.provide` occurrences / 202 files; heat concentrated in megarepo, Restate, Notion, TUI | **ADOPT-AFTER** | approve / reject |
+| 11 | Convert functions returning `Effect.gen` to named `Effect.fn` | INDEPENDENT | 35 clear sites / 23 files / 9 packages; 519 `Effect.fn` sites already exist | **ADOPT-AFTER** | approve / reject |
+| 12 | Replace existing errors with reason-bearing errors | INDEPENDENT | no bounded mechanical surface; error-heavy packages span most of repo | **SKIP** for migration | approve / reject |
+| 13 | Add an Effect facade analogous to `@livestore/utils/effect` | INDEPENDENT | no equivalent facade; Effect imports span 31 packages | **SKIP** | approve / reject |
+| 14 | Broadly rewrite combinator pipelines into `Effect.gen` | INDEPENDENT | `Effect.gen` already occurs in 314 files | **SKIP** | approve / reject |
+
+## Cheapest high-value set: approve these five
+
+1. **Schema contract-first rewrite.** It addresses the largest silent-breakage class and turns the
+   existing differential harness into a byte-level acceptance oracle.
+2. **Explicit v4 services/layers.** The API must change anyway; doing the full v4 form deletes
+   generated accessors/dependency wiring instead of recreating them locally.
+3. **Effectable commands.** This is the best deletion opportunity: v4 makes commands effects, so
+   most explicit executor/start plumbing is obsolete.
+4. **Default fork semantics backed by probes.** This avoids LiveStore's demonstrated compatibility
+   cargo cult and makes non-default scheduling policy locally justified.
+5. **`Context.Reference` for `ScopeDebugEnabled`.** One contained migration deletes
+   `FiberRef.unsafeMake` while preserving the intended inherited, fiber-local toggle.
+
+These five are reviewable as recipes with differential proofs. They do not include broad cleanup
+whose success criterion would be “looks nicer.”
+
+## What LiveStore actually did
+
+### Source correction
+
+**VERIFIED:** the brief's `#1339`, `#1340`, `#1341`, `#1316`, `#1315`, `#1318`, `#1320`, and
+`#1321` are closed migration **issues**, not PRs (`gh pr view` cannot resolve them; `gh issue view`
+does). The actual package PRs, listed by landing PR #1383, are:
+
+| issue | actual PR | slice |
+| ---: | ---: | --- |
+| #1319 | #1342 | webmesh |
+| #1314 | #1343 | common |
+| #1339 | #1349 | common-cf |
+| #1317 | #1350 | sync-cf |
+| #1340 | #1344 | effect-playwright |
+| #1341 | #1345 | sqlite-wasm |
+| #1316 | #1352 | adapter-web |
+| #1315 | #1353 | livestore core |
+| #1318 | #1354 | react |
+| #1320 | #1355 | docs/examples/tests/perf |
+| #1321 | #1359 | finalization |
+
+PRs #1322, #1323, and #1332 are correctly numbered in the brief. The complete landing PR is #1383.
+
+### Adopted versus deferred
+
+| LiveStore choice | evidence | implication here |
+| --- | --- | --- |
+| Adopted direct import topology and mechanical API names first | PR #1323; commits `c96100d11`, `11fe7d887` | Keep mechanical rewrites separate from judgment-heavy recipes. |
+| Adopted `Context.Service`, callback constructors, RPC-native workers, and explicit layers where v4 required structural change | PR #1332; `utils/src/browser/Opfs/Opfs.ts:222-226`; `utils/src/browser/WebLock.ts:49-73` | These are admissible during migration when the v3 behavior trace is locked first. |
+| Adopted v4 layer composition in worker boot paths | PR #1352 | Restrict to touched/required graphs; do not use this as license for repo-wide graph redesign. |
+| Changed an async-iterator implementation when the old bridge raced under v4 | PR #1353 | This is a behavior repair, not an idiom precedent; it required focused tests. |
+| Deferred fork-option audit | #1356 / PR #1369, commit `87fecd4a` | The copied compatibility options were unnecessary; probe before adding any. |
+| Deferred and then deleted v3 MessageChannel scheduler | #1357 / PR #1370, commit `55bf025f` | Delete a local runtime shim only when v4 owns the same policy and callers do not require a distinct one. |
+| Deferred Vitest config work | #1358 / PR #1368 | Tool config is separable follow-up work, not an Effect source idiom. |
+| Deferred Schema-native table redesign | recovered `contributor-docs/effect-4.md`; open PR #1308 still exists | Redesign is not behavior-preserving migration work. |
+| Did not broadly adopt `Effect.fn` | local lexical comparison: dev 116 -> main 84 `Effect.fn`; functions returning `Effect.gen` 20 -> 18 | Upstream preference was not treated as migration scope. |
+| Retained and adapted the facade rather than newly choosing it | facade imports dev 372 -> main 299; current facade `utils/src/effect/mod.ts:3-129` | A pre-existing boundary is not evidence that effect-utils should introduce one. |
+
+The first three deferred items were handled immediately after the landing stack. That supports a
+short, named post-migration idiom phase; it does not support mixing redesign into the green-up
+critical path.
+
+## Catalog
+
+### 1. Contract-first Schema v4 codecs and checks
+
+**v3 form:** persisted JSON is commonly encoded through
+`Schema.encode(Schema.parseJson(stateSchema))`, e.g.
+`packages/@overeng/tui-react/src/effect/TuiApp.tsx:716-795`; Date transforms use
+`Schema.DateFromSelf`, e.g. `packages/@overeng/notion-effect-schema/src/properties/audit.ts:49-53`.
+**v4 form:** use `Schema.fromJsonString(schema)` (or `Schema.UnknownFromJsonString`) and choose Date
+semantics explicitly: v3 `Schema.Date` wire behavior becomes
+plain `Schema.DateFromString` **at beta.102** (`Schema.isDateValid` was removed after beta.99 and `Schema.Date` now rejects invalid dates natively); v3 self-Date becomes v4 `Schema.Date`.
+Use `Schema.toCodecJson` at transport boundaries that require JSON-safe representations.
+**Why better:** v4 separates value schemas, string codecs, JSON codecs, and checks. The benefit is
+not naming: the encoded boundary becomes explicit and cannot accidentally inherit the wrong Date
+meaning. Upstream warns that `Schema.Date` can still typecheck while accepting different input
+(`migration/schema.md:91-113`). LiveStore experienced exactly that after landing: PR #1436 /
+`ddd1aa16c`.
+
+**Coupled to the migration?** MUST-CHANGE.
+**Blast radius:** VERIFIED 234 occurrences of `parseJson`, Date/DateFromSelf, or `optionalWith`
+across 91 files / 22 packages. High-risk boundaries are enumerated in worker 3: Notion canonical
+JSON/frontmatter/SQLite, agent JSONL/checkpoints, TUI JSON/NDJSON, megarepo durable JSON, Restate
+serde, and CI reports.
+**Differential proof:** for every durable/wire schema, feed identical encoded fixtures to v3/v4;
+assert decoded normalized value, re-encoded exact UTF-8 bytes/key omission/default behavior, and
+the same invalid-input success/failure partition. Include valid/invalid dates, absent/undefined/null,
+pretty-print spacing, and JSON-only transforms. A semantic-only equality assertion is insufficient.
+**Recommendation:** **ADOPT-DURING** — this is the highest-value behavior-preserving recipe and must
+be completed boundary by boundary, never by compile-only replacement.
+
+### 2. `Context.Service`, explicit layers, and direct service yields
+
+**v3 form:** `Otelite` and `OteliteTestHarness` use `Effect.Service`, `accessors: true`,
+auto-generated `.Default`, and inline `dependencies`
+(`packages/@overeng/utils-dev/src/otelite/Otelite.ts:149-152`;
+`test-harness.ts:200-205,356-369`). Other services use
+`class X extends Context.Tag(id)<X, Shape>()`, e.g.
+`packages/@overeng/notion-md/src/state-store.ts:243`.
+**v4 form:**
+
+```ts
+class Otelite extends Context.Service<Otelite, Service>()("...") {
+  static readonly layer = Layer.effect(this, make).pipe(Layer.provide(NodeContext.layer))
+}
+const otelite = yield* Otelite
+yield* otelite.capture(options)
+```
+**Why better:** v4 deletes accessor proxies that erase generic/overloaded method types and deletes
+implicit dependency wiring. The resulting service requirement and layer graph are explicit and
+locally typechecked (`effect/migration/services.md:63-140,142-199`). LiveStore used this structural
+form in PR #1332; its OPFS service is explicit at `utils/src/browser/Opfs/Opfs.ts:222-226`.
+
+**Coupled to the migration?** MUST-CHANGE.
+**Blast radius:** VERIFIED 57 service-form occurrences / 42 files / 13 packages. Restate is largest
+(11 files); then `utils-dev`, `utils`, and megarepo (4 each).
+**Differential proof:** for each service recipe, record constructor count/order, acquired resources,
+method results/errors, finalizer order, and dependency requests. Run with production and test
+layers. The v4 trace must match v3, including whether dependencies are built once or per scope.
+**Recommendation:** **ADOPT-DURING** — do the native v4 structure rather than recreating `.Default`
+or accessor proxies; use lowercase `layer` / descriptive variants consistently.
+
+### 3. Effectable child-process commands
+
+**v3 form:** yield `CommandExecutor`, then call `executor.start(command)`, e.g.
+`packages/@overeng/effect-ai-claude-cli/src/claude-cli.ts:213-246`; similar plumbing exists in
+`utils-dev/src/otelite/Otelite.ts:149-176`. `utils/src/node/cmd.ts:452-468` builds a command only to
+call `Command.exitCode`.
+**v4 form:**
+
+```ts
+const handle = yield* ChildProcess.make("claude", args, {
+  stdin: "pipe", stdout: "pipe", stderr: "pipe"
+})
+const exitCode = yield* handle.exitCode
+```
+
+Use `ChildProcessSpawner` only for its higher-level collection helpers or a custom spawn
+implementation; a `ChildProcess.Command` is itself an Effect.
+**Why better:** deletes an otherwise redundant service lookup and start adapter; the command value
+now directly describes construction plus spawning. Upstream explicitly makes commands Effectable
+(`migration/v3-to-v4.md:6344-6386`). LiveStore PR #1332 deleted its old serialized
+`ChildProcessRunner` abstraction when v4 RPC/worker primitives superseded it.
+
+**Coupled to the migration?** TOUCHING-ANYWAY (`CommandExecutor` is renamed and command options are
+reshaped).
+**Blast radius:** VERIFIED 47 command/executor occurrences across 17 files / 7 packages; megarepo
+and genie dominate. Do not delete `utils/cmd` wholesale: its log mirroring, process-group kill, and
+flush behavior at `cmd.ts:475-598` is repo policy not supplied by v4.
+**Differential proof:** exact argv/env/cwd/shell/stdin bytes, stdout/stderr ordering, exit code,
+spawn failure classification, interruption signal/escalation, process-group teardown, and scoped
+finalizer completion. For `utils/cmd`, include partial final lines and concurrent stdout/stderr.
+**Recommendation:** **ADOPT-DURING** — delete only executor/start boilerplate made obsolete by
+Effectable commands; retain proven policy wrappers.
+
+### 4. Default fork semantics; no speculative compatibility options
+
+**v3 form:** `Effect.fork(effect)` and unchanged `forkScoped` sites, e.g.
+`packages/@overeng/notion-md/src/webhook.unit.test.ts:115` and
+`packages/@overeng/utils/src/node/cmd.ts:557-567`.
+**v4 form:** `Effect.forkChild(effect)`, `Effect.forkDetach(effect)`, `Effect.forkScoped(effect)`;
+omit `{ startImmediately, uninterruptible }` unless a local two-major probe proves a difference
+that must be preserved.
+**Why better:** each name states lifecycle ownership, and default options avoid undocumented
+scheduler/interruptibility policy. LiveStore initially copied
+`{ startImmediately: true, uninterruptible: "inherit" }`, then direct probes showed defaults
+matched v3 and PR #1369 removed the options from 50+ runtime/test call sites.
+
+**Coupled to the migration?** TOUCHING-ANYWAY for renamed `fork`/`forkDaemon`.
+**Blast radius:** VERIFIED 48 `fork`/`forkScoped` sites / 28 files / 12 packages, concentrated in
+TUI, Notion, utils, and Restate. No existing explicit compatibility options were found.
+**Differential proof:** trace pre-fork, child first instruction, parent continuation, readiness
+barrier, interruption, finalizer, and join/await order in fresh processes. For command/TUI/sync
+paths, test shutdown at each in-flight transition and max concurrency. LiveStore PRs #1386 and
+#1405 demonstrate why “tests pass once” is inadequate.
+**Recommendation:** **ADOPT-DURING** — approve a rule forbidding speculative options; any exception
+must cite its differential trace.
+
+### 5. `Context.Reference` for the scope-debug toggle
+
+**v3 form:** `FiberRef.unsafeMake(false)`, `FiberRef.get`, and `Effect.locally` in
+`packages/@overeng/utils/src/isomorphic/ScopeDebugger.ts:10,27-45,62-68,171-176`.
+**v4 form:**
+
+```ts
+const ScopeDebugEnabled = Context.Reference<boolean>(".../ScopeDebugEnabled", {
+  defaultValue: () => false
+})
+const enabled = yield* ScopeDebugEnabled
+const run = Effect.provideService(effect, ScopeDebugEnabled, true)
+```
+**Why better:** removes unsafe construction and models fiber-local configuration through the v4
+context/reference mechanism. This is precisely the v4 replacement for FiberRef-based application
+state (`migration/fiberref.md:1-10,50-82`).
+
+**Coupled to the migration?** MUST-CHANGE.
+**Blast radius:** VERIFIED one file, three FiberRef operations, one exported reference.
+**Differential proof:** parent default false; nested override true; child inherits true; sibling and
+post-scope value remain false; finalizer logs occur exactly when enabled; concurrent fibers do not
+leak values.
+**Recommendation:** **ADOPT-DURING** — contained, high-confidence deletion of an unsafe v3 primitive.
+
+### 6. `Effect.callback` with preserved cancellation
+
+**v3 form:** `Effect.async((resume, signal) => ...)`, for example Web Locks at
+`packages/@overeng/utils/src/browser/web-lock.ts:96-159`.
+**v4 form:** identical registration logic under `Effect.callback`; if registration owns a listener
+or handle, return its Effect cleanup action rather than hiding cleanup elsewhere.
+**Why better:** the name states the source is callback-driven, and v4 permits effectful cleanup
+from registration. Upstream says resume/AbortSignal semantics are otherwise the same
+(`migration/v3-to-v4.md:9506-9508,11615-11625`). LiveStore made the exact WebLock rename in PR
+#1332 (`dev WebLock.ts:50-74` -> `main WebLock.ts:49-73`) without restructuring it.
+
+**Coupled to the migration?** MUST-CHANGE.
+**Blast radius:** VERIFIED 15 sites / 8 files / 4 packages (`restate-effect`, `utils`,
+`notion-datasource-sync`, `notion-md`).
+**Differential proof:** registration timing, single resume, AbortSignal state, external listener
+removal, late callback after interruption, error/defect channel, and no leaked lock/listener.
+**Recommendation:** **ADOPT-DURING** — mechanical rename by default; adopt returned cleanup only
+where the v3 recipe proves equivalent ownership.
+
+### 7. Native v4 Schema forms, including `TaggedErrorClass`
+
+**v3 form:** `Schema.TaggedError`, variadic `Schema.Literal`/`Schema.Union`,
+`Schema.filter`, and `Schema.annotations`; representative error:
+`packages/@overeng/effect-path/src/errors.ts:15-34`.
+**v4 form:** `Schema.TaggedErrorClass`; `Schema.Literals([...])`; `Schema.Union([...])`;
+`Schema.check(Schema.makeFilter(...))` or `Schema.refine`; `.annotate(...)`.
+**Why better:** mostly not “better”—these are v4's canonical typed constructors. The actual benefit
+is refusing compatibility helpers that hide v4 shapes. `react-inspector` deliberately uses native
+array `Schema.Union(members)` and `Schema.check(...)`
+(`src/schema/lineage.ts:62-83`; `effect4.unit.test.tsx:52-68`), although its local variadic `union`
+helper should not become a repo convention.
+
+**Coupled to the migration?** MUST-CHANGE.
+**Blast radius:** VERIFIED 187 `Schema.TaggedError` occurrences / 63 files / 21 packages. The wider
+constructor/check/annotation lexical surface is 723 occurrences / 160 files / 24 packages.
+**Differential proof:** constructor `_tag`, own/enumerable keys, `instanceof`, yield behavior,
+encoded/decoded bytes, annotations/formatter output, and identical pass/fail sets for every check.
+**Recommendation:** **ADOPT-DURING** — native v4 forms only; reject a compatibility facade/helper
+unless it preserves a deliberate public API.
+
+### 8. Canonical catch names without changing the error model
+
+**v3 form:** `Effect.catchAll` / `catchAllCause`, e.g.
+`packages/@overeng/utils/src/node/file-system-backing.ts:77` and
+`packages/@overeng/utils/src/isomorphic/ScopeDebugger.ts:102`.
+**v4 form:** `Effect.catch` / `catchCause`. Keep `catchTag(s)` where already used. Only use
+`catchFilter` when migrating an actual v3 `catchSome`; do not introduce reason errors here.
+**Why better:** purely canonical naming; no independent design value. Upstream's rename table is
+`migration/error-handling.md:1-19`.
+
+**Coupled to the migration?** MUST-CHANGE.
+**Blast radius:** VERIFIED 112 `catchAll` plus 7 `catchAllCause` sites, 52 files / 14 packages.
+There are no current `catchSome*` sites.
+**Differential proof:** same success/failure/defect/interrupt exits and same handler invocation
+count for representative tagged, untagged, cause, and interruption cases.
+**Recommendation:** **ADOPT-DURING** — approve as mechanical migration, not as an idiom project.
+
+### 9. Module-owned semaphore constructor
+
+**v3 form:** `yield* Effect.makeSemaphore(1)` in
+`packages/@overeng/effect-distributed-lock/src/DistributedSemaphore.ts:182` and
+`packages/@overeng/megarepo/src/lib/store-lock.ts:81`.
+**v4 form:** `yield* Semaphore.make(1)`.
+**Why better:** namespace ownership makes the primitive discoverable and avoids an overloaded
+Effect namespace; behavior benefit is purely organizational.
+
+**Coupled to the migration?** MUST-CHANGE.
+**Blast radius:** VERIFIED two sites / two packages.
+**Differential proof:** permit count, FIFO/contention order, interruption while waiting, release
+after success/failure/interruption, and no concurrent critical-section overlap.
+**Recommendation:** **ADOPT-DURING** — cheap required rewrite with an existing strong lock suite.
+
+### 10. Broad layer composition
+
+**v3 form:** nested separate provides, e.g. megarepo status provides `outputModeLayer` then
+`StoreLayer` (`packages/@overeng/megarepo/src/cli/commands/status.ts:510-533`).
+**v4 form:** build a named composed layer and provide once; where v3 intentionally rebuilt a layer,
+use `Layer.fresh` or `Effect.provide(layer, { local: true })`.
+**Why better:** a named graph exposes ownership/dependencies and prevents accidental duplicate
+construction. But v4 already changes memoization across separate provides, so a cosmetic rewrite
+can conceal a behavior change (`migration/layer-memoization.md:3-11,44-98`).
+
+**Coupled to the migration?** INDEPENDENT, except explicit `Effect.Service.dependencies` rewrites.
+**Blast radius:** VERIFIED 795 `Effect.provide` occurrences in 202 files. Worker 3's heat table puts
+the largest review burden in megarepo, Restate, Notion, utils, and TUI.
+**Differential proof:** constructor/finalizer counts and order, resource identity, test isolation,
+failure acquisition/release, and overlapping layer reuse. Without those counters it cannot be
+proven behavior-preserving.
+**Recommendation:** **ADOPT-AFTER** — during migration, compose only layers already structurally
+touched and add `local`/`fresh` where required to preserve v3 counts.
+
+### 11. Named `Effect.fn`
+
+**v3 form:** functions returning `Effect.gen`, e.g.
+`packages/@overeng/notion-md/src/reconcile.ts:197-225`.
+**v4 form:** `const assertReviewMarkupAllowed = Effect.fn("...")(function* (opts) { ... }, ...)`.
+**Why better:** upstream says names improve stack traces and automatically attach tracing spans
+(`LLMS.md:50-82`). This repo already uses `Effect.fn` extensively.
+
+**Coupled to the migration?** INDEPENDENT.
+**Blast radius:** VERIFIED 35 clear return/arrow `Effect.gen` sites / 23 files / 9 packages, versus
+519 existing `Effect.fn` occurrences.
+**Differential proof:** values/exits may match, but named `Effect.fn` intentionally changes
+spans/stack traces. If normalized traces include telemetry, “changes nothing” is impossible.
+**Recommendation:** **ADOPT-AFTER** as an explicitly observable telemetry/diagnostics change, not
+under the no-behavior-change migration claim. LiveStore did not mass-adopt it.
+
+### 12. Reason-bearing errors
+
+**v3 form:** flat tagged errors such as `InvalidPathError.reason: InvalidPathReason`
+(`packages/@overeng/effect-path/src/errors.ts:15-34`).
+**v4 form:** a parent tagged error with tagged reason classes, handled via
+`Effect.catchReason(s)` / `unwrapReason`.
+**Why better:** valuable when callers share a stable parent error but need typed recovery for
+specific reasons. It changes public types, constructors, schema bytes, matching, and error
+transport.
+
+**Coupled to the migration?** INDEPENDENT.
+**Blast radius:** INFERRED broad and unbounded; must be selected domain by domain.
+**Differential proof:** cannot truthfully prove “no behavior change” for public/wire errors because
+the encoded/type shape intentionally changes.
+**Recommendation:** **SKIP** in this epic; propose separate API-design work only where a consumer
+problem justifies it.
+
+### 13. Repository-wide Effect facade
+
+**v3 form:** each package imports `effect` / `@effect/*` directly; no effect-utils equivalent of a
+central re-export facade was found.
+**v4 form:** route imports through a new facade analogous to LiveStore's
+`packages/@livestore/utils/src/effect/mod.ts:3-129`.
+**Why better:** centralizes import topology for an application monorepo, but creates a dependency
+funnel and obscures stable/testing/unstable/browser boundaries in a multi-package utility repo.
+LiveStore's facade also caused a real browser failure when it re-exported `effect/testing` and
+pulled `node:assert` (PR #1433 / `8c453ef94`).
+
+**Coupled to the migration?** INDEPENDENT.
+**Blast radius:** all Effect-using packages and downstream import policy.
+**Differential proof:** runtime values can be checked, but package graph, tree-shaking, browser
+bundling, duplicate identity, and public type declarations are observable. A facade is not
+behavior-neutral.
+**Recommendation:** **SKIP** — use v4 package boundaries directly. LiveStore's facade is an adapted
+pre-existing architecture, not a migration idiom to copy.
+
+### 14. Broad combinator-to-generator rewrite
+
+**v3 form:** existing `pipe`/`flatMap`/`map` chains.
+**v4 form:** `Effect.gen` with `yield*`.
+**Why better:** can improve sequential readability, but is stylistic when the chain is already
+clear; may alter laziness/evaluation placement if rewritten carelessly.
+
+**Coupled to the migration?** INDEPENDENT.
+**Blast radius:** enormous; `Effect.gen` already occurs in 314 files, so the repository has no
+missing-generator problem.
+**Differential proof:** possible per function, but review and harness cost dwarfs value.
+**Recommendation:** **SKIP** as a migration initiative; allow local use only when a mandatory v4
+rewrite makes the old structure materially harder to read.
+
+## Dangerous during-migration attractions
+
+| attractive change | why dangerous | rule |
+| --- | --- | --- |
+| Named `Effect.fn` everywhere | intentionally adds spans / changes stacks | separate post-migration telemetry change |
+| Compose every layer graph | v4 memoization can change acquisition count even if types pass | instrument constructors/finalizers first |
+| Add fork compatibility options | LiveStore proved its copied options unnecessary; scheduling is subtle | defaults unless a two-major trace fails |
+| “Improve” Schema models while changing constructors | wire/default/null/optional behavior can typecheck and drift | preserve encoded fixtures byte-for-byte |
+| Introduce reason errors | changes public and encoded error shape | separate API design |
+| Add a facade | changes dependency/bundle/public-type boundaries | reject for effect-utils |
+| Copy `react-inspector`'s variadic `union` helper | hides v4 native array form and perpetuates v3 calling style | use native arrays directly |
+
+## What `react-inspector` should teach the rest of the repo
+
+**Copy selectively (VERIFIED):**
+
+- native v4 array `Schema.Union(members)` (`src/schema/lineage.ts:62-83`);
+- composable v4 `Schema.check` predicates and explicit formatter override
+  (`src/schema/effect4.unit.test.tsx:52-68`;
+  `test-d/exact-optional-consumer.ts:18-20`);
+- `Schema.Top` at a public schema boundary and exact-optional consumer compilation
+  (`src/object-inspector/ObjectInspector.tsx:112-123`; `test-d/exact-optional-consumer.ts:6-20`).
+
+**Do not generalize:** it is a deliberately isolated v4 package and mostly pure Schema/UI code. It
+does not validate v4 services, layers, scopes, forks, process, CLI, RPC, or durable codecs for the
+connected remainder. Its local variadic `union` helper is migration ergonomics, not a house idiom.
+
+## Phasing consequence
+
+**INFERRED but strong:** approving the ADOPT-DURING rows does not require abandoning the epic's
+single-green-up structure. Each approved pattern must become a named recipe with:
+
+1. a real v3 fixture/call site;
+2. the proposed v4 refactored form;
+3. a normalized differential trace schema;
+4. a red-on-divergence adversarial case;
+5. package ownership and exact allowed surface.
+
+Run mechanical renames first, then approved recipes within package slices. Keep `Effect.fn`, broad
+layer cleanup, reason errors, and all redesign in an explicit post-migration phase. This matches the
+useful part of LiveStore's adopted/deferred split while improving on its late discovery of wire,
+shutdown, and bundling regressions.
+
+## Uncertainty / not covered
+
+- VERIFIED PR bodies and current/pre-migration checkouts establish what LiveStore changed, but no
+  formal retrospective exists; motives beyond explicit PR prose/follow-up issues remain inference.
+- Lexical counts are prioritization evidence, not AST-precise semantic counts.
+- No differential harness was executed and `tmp/effect4-proto/` was not touched, per instruction.
+- Whether any nested `Effect.provide` currently relies on duplicate construction is unanswerable
+  without the proposed constructor/finalizer probes.
+- No private information was used or included.
+
+## PRIVATE
+
+None.

--- a/context/effect-4/platform-patch-analysis.md
+++ b/context/effect-4/platform-patch-analysis.md
@@ -133,10 +133,7 @@ Add a client tracing configuration hook used by both internal loops, for
 example a context reference receiving direction and normalized header name:
 
 ```ts
-type HeaderAttributePredicate = (
-  direction: "request" | "response",
-  name: string
-) => boolean
+type HeaderAttributePredicate = (direction: 'request' | 'response', name: string) => boolean
 ```
 
 It can default to `true` for compatibility. Effect-utils would provide a

--- a/context/effect-4/platform-patch-analysis.md
+++ b/context/effect-4/platform-patch-analysis.md
@@ -1,0 +1,224 @@
+# Effect 4 header-allowlist patch: recommendation
+
+Identity: `org.schickling.eu.effect-4.patch`  
+Target: `effect@4.0.0-beta.102`
+
+## Verdict
+
+**The patch cannot retire through `HttpClientRequest.updateHeaders` or
+`removeHeader`; it must be re-expressed.**
+
+Use a minimal beta.102 `effect` core patch at the two header-attribute loops as
+the migration-critical-path measure, and bring a configurable upstream header
+attribute predicate/allowlist proposal to Effect. Do not implement the behavior
+as a `utils` wrapper: a faithful wrapper would have to replace Effect's complete
+client tracing lifecycle and would be a much larger, silently drift-prone fork.
+
+## Q1: exact patched-v3 behavior
+
+The existing patch defines one case-insensitive allowlist used for both request
+and response span attributes:
+
+1. `content-type`
+2. `content-length`
+3. `date`
+4. `x-request-id`
+5. `x-notion-request-id`
+6. `retry-after`
+7. `x-ratelimit-remaining`
+
+Request lifecycle:
+
+- `@effect/platform@0.96.2` creates the `http.client` span and adds method,
+  server, URL, path, scheme, and query attributes.
+- It reads `Headers.currentRedactedNames`, redacts the request header values,
+  then iterates the resulting header record.
+- The patch emits only allowlisted names as
+  `http.request.header.<name> = String(redactedValue)`.
+- This happens before trace-context headers are added and before the request is
+  handed to the transport, so generated `b3`/`traceparent` headers are not
+  captured as request header attributes.
+
+Response lifecycle:
+
+- On a successful transport response it first adds
+  `http.response.status_code`.
+- It redacts the response headers using the request-time redaction set, then
+  emits only allowlisted names as
+  `http.response.header.<name> = String(redactedValue)`.
+- This occurs before the response is returned/wrapped.
+
+With the patch, non-allowlisted attributes are absent, including headers whose
+values would otherwise be represented as `"<redacted>"`. Without the patch,
+both loops emit every request/response header name after value redaction.
+
+## Q2: why the beta.102 combinators cannot express it
+
+At beta.102:
+
+- `HttpClientRequest.updateHeaders` reconstructs the immutable request with
+  `f(self.headers)` as its actual headers
+  (`src/unstable/http/HttpClientRequest.ts:384-407`).
+- `removeHeader` is just `updateHeaders(self, Headers.remove(key))`
+  (`HttpClientRequest.ts:415-433`).
+- `HttpClient.make` traces the resulting request headers at
+  `src/unstable/http/HttpClient.ts:841-845`, then passes that same request to
+  the transport at line 850.
+- The response header loop is internal to `HttpClient.make` at lines 853-858.
+  No request combinator can observe or filter it.
+
+Probe:
+
+```text
+tmp/patch-probe/probe.ts
+command: bun tmp/patch-probe/probe.ts
+effect: 4.0.0-beta.102
+```
+
+The baseline sent all original application headers and emitted:
+
+```json
+{
+  "http.request.header.authorization": "<redacted>",
+  "http.request.header.content-type": "application/json",
+  "http.request.header.x-noise": "noise",
+  "http.request.header.x-request-id": "request-123",
+  "http.response.header.content-type": "text/plain",
+  "http.response.header.date": "Tue, 28 Jul 2026 10:00:00 GMT",
+  "http.response.header.set-cookie": "<redacted>",
+  "http.response.header.x-response-noise": "noise"
+}
+```
+
+Applying an allowlist with
+`HttpClient.mapRequest(client, HttpClientRequest.updateHeaders(filterHeaders))`:
+
+- removed `authorization` and `x-noise` from the actual transport request;
+- removed their request span attributes;
+- still emitted `http.response.header.set-cookie = "<redacted>"`;
+- still emitted `http.response.header.x-response-noise = "noise"`.
+
+Therefore the candidate both changes functional HTTP behavior and fails to
+reproduce patched-v3 telemetry behavior.
+
+## Exact beta.102 header emission and value-redaction behavior
+
+`HttpClient.make` emits one span attribute for **every header name present**:
+
+- request: `http.request.header.<lowercase-name>`;
+- successful response: `http.response.header.<lowercase-name>`.
+
+`Headers.CurrentRedactedNames` defaults to `authorization`, `cookie`,
+`set-cookie`, and `x-api-key`
+(`src/unstable/http/Headers.ts:714-733`). Those four values are emitted as the
+literal string `"<redacted>"`; their attributes are not omitted. Every other
+header value is emitted raw unless the application has added its name/pattern
+to `CurrentRedactedNames`.
+
+`CurrentRedactedNames` is a configurable `Context.Reference`, so consumers can
+extend or replace that list to protect additional values. The remaining gap is
+separate from value redaction: even after a value is redacted, consumers have
+no supported way to suppress the request or response header attribute itself.
+Header-name presence, telemetry shape, and per-span attribute cardinality
+therefore remain uncontrollable.
+
+The response side is the decisive API gap: there is no response-header
+attribute hook at all.
+
+## Q3: minimal alternative, ranked
+
+### 1. Upstream configurable predicate/allowlist (principled destination)
+
+Add a client tracing configuration hook used by both internal loops, for
+example a context reference receiving direction and normalized header name:
+
+```ts
+type HeaderAttributePredicate = (
+  direction: "request" | "response",
+  name: string
+) => boolean
+```
+
+It can default to `true` for compatibility. Effect-utils would provide a
+predicate backed by the existing seven-name allowlist. This separates
+transmission headers from telemetry policy and covers the currently
+unreachable response path.
+
+### 2. Local beta.102 core patch (recommended migration measure)
+
+Patch `effect/dist/unstable/http/HttpClient.js` at the equivalent request and
+response loops (runtime lines 264-266 and 274-276 in the installed beta.102
+artifact), using the same seven-name `Set` and the same case-insensitive
+`continue` checks as patched v3. Mirror it in
+`effect/src/unstable/http/HttpClient.ts` if the package patch convention keeps
+published source consistent.
+
+This is the smallest faithful change: it preserves transport, trace
+propagation, span lifecycle, response wrapping, interruption behavior, and all
+non-header attributes. It must be re-derived on every beta bump, but patch
+failure is loud and beta.102 is hard-pinned.
+
+### 3. `utils` wrapper (not recommended)
+
+`HttpClient.transform` runs outside the internal postprocess and receives no
+span handle; span attributes cannot be deleted after the internal response
+loop. A wrapper would have to disable built-in tracing and reproduce span
+creation, URL attributes, request redaction, trace-context propagation, parent
+span wiring, response status/headers, failures, interruption, and scoped
+response behavior.
+
+That wrapper may keep compiling across beta bumps, but it can silently diverge
+from Effect's tracing semantics. The core patch is mechanically more brittle
+but behaviorally safer and much smaller.
+
+## Upstream status
+
+Do not file a new issue: Effect-TS/effect#6363 already requests this exact
+header-attribute predicate and is open.
+
+Draft PR Effect-TS/effect#6697 implements `HttpClient.TracerHeaderFilter` with a
+`constTrue` default, applies it to both request and response loops, and tests
+default inclusion plus selective suppression on both paths.
+
+The local beta.102 core patch remains the migration bridge while #6697 is
+unmerged. It should be designed for direct deletion as soon as an Effect
+release containing the upstream reference is adopted.
+
+## Q4: differential proof required for the re-expressed patch
+
+Run patched v3 and patched v4 as separate processes with identical synthetic
+inputs and recording in-memory OpenTelemetry exporters. Use a low-level client
+runner so no network normalization can differ between processes.
+
+Each side should emit normalized JSON containing:
+
+1. the transport-received application request headers;
+2. the returned response headers;
+3. the complete client span name/status and sorted attributes.
+
+Fixture matrix:
+
+- all seven allowlisted names on request and response paths;
+- mixed-case input names, asserting normalized attribute names;
+- non-allowlisted non-sensitive request and response headers;
+- default-redacted `authorization` on request and `set-cookie` on response,
+  asserting the attributes are **absent**, not `"<redacted>"`;
+- a custom header added to the redaction set, also asserting absence;
+- trace propagation enabled, asserting the transport receives propagation
+  headers while those injected headers are not added to header attributes.
+
+Gates:
+
+- v3-v4 normalized JSON bytes are identical;
+- all original application request headers reach transport unchanged;
+- returned response headers are unchanged;
+- exactly the seven-name intersection is present under
+  `http.request.header.*` / `http.response.header.*`;
+- status, URL, method, parentage, propagation, and error behavior remain
+  unchanged.
+
+## Second patch
+
+`@myobie/pty@0.10.0` is unrelated to Effect: it only changes two
+`@xterm/addon-serialize` default imports to namespace imports for ESM export
+compatibility.

--- a/context/effect-4/recipes/browser-builtin-leakage.md
+++ b/context/effect-4/recipes/browser-builtin-leakage.md
@@ -1,12 +1,12 @@
 # Pattern: browser-builtin-leakage
 
-**Area:** Browser bundling  **Kind:** semantic CI gate  **Our usage:** browser entries in
+**Area:** Browser bundling **Kind:** semantic CI gate **Our usage:** browser entries in
 `effect-react`, `notion-react`, `tui-react`, `react-inspector`, and `effect-schema-form*`.
 
 ## v3
 
 ```ts
-export { Schema, TestClock } from "effect"
+export { Schema, TestClock } from 'effect'
 ```
 
 The representative v3 facade bundles for the browser without resolving a Node builtin.
@@ -15,10 +15,10 @@ The representative v3 facade bundles for the browser without resolving a Node bu
 
 ```ts
 // Runtime facade:
-export { Schema } from "effect"
+export { Schema } from 'effect'
 
 // Tests import directly; never re-export this from a runtime/browser facade:
-import { TestSchema } from "effect/testing"
+import { TestSchema } from 'effect/testing'
 ```
 
 ## Equivalence

--- a/context/effect-4/recipes/browser-builtin-leakage.md
+++ b/context/effect-4/recipes/browser-builtin-leakage.md
@@ -1,0 +1,55 @@
+# Pattern: browser-builtin-leakage
+
+**Area:** Browser bundling  **Kind:** semantic CI gate  **Our usage:** browser entries in
+`effect-react`, `notion-react`, `tui-react`, `react-inspector`, and `effect-schema-form*`.
+
+## v3
+
+```ts
+export { Schema, TestClock } from "effect"
+```
+
+The representative v3 facade bundles for the browser without resolving a Node builtin.
+
+## v4
+
+```ts
+// Runtime facade:
+export { Schema } from "effect"
+
+// Tests import directly; never re-export this from a runtime/browser facade:
+import { TestSchema } from "effect/testing"
+```
+
+## Equivalence
+
+```sh
+bun run run:pattern browser-builtin-leakage
+```
+
+ALLOWLISTED characterization: both runtime facades bundle. The deliberately contaminated v3 facade
+also bundles, while v4 is rejected because `effect/testing` reaches `node:assert`.
+
+This must remain a CI gate: bundle every public browser/runtime entry with `platform: "browser"` and
+an explicit resolver that fails on every `node:` import. The command must return non-zero on a
+forbidden builtin; logging an error while returning success is not a gate.
+
+## Intended differences (alignment register entries)
+
+- v4 testing barrels can be Node-only transitive dependencies — intentional package topology, not
+  an application behavior to preserve — keep testing exports out of runtime facades and accept the
+  narrower public surface — affects all browser-facing packages.
+
+## Gotchas
+
+- Tree shaking does not make a static re-export safe. The resolver must load the re-exported module
+  before it can determine what is unused.
+- Typecheck is not evidence for browser compatibility.
+- Test helpers should use direct `effect/testing/*` imports in test files; do not expose them from a
+  runtime facade for import convenience.
+- Gate source/public entry points, not only one hand-written fixture.
+
+## Codemod rule
+
+None. Import relocation in test files is mechanical, but deciding which public re-exports to remove
+is an API-boundary change.

--- a/context/effect-4/recipes/child-process-backpressure.md
+++ b/context/effect-4/recipes/child-process-backpressure.md
@@ -1,0 +1,69 @@
+# Pattern: child-process-backpressure
+
+**Area:** Platform / child process  **Kind:** semantic  **Our usage:** `pty-effect` and `megarepo`
+consume long-running child stdout/stderr streams and must not lose, reorder, or deadlock output.
+
+## v3
+
+```ts
+const executor = yield* CommandExecutor.CommandExecutor
+const child = yield* executor.start(Command.make("bun", "producer.ts", ...args))
+```
+
+## v4
+
+```ts
+const child = yield* ChildProcess.make("bun", ["producer.ts", ...args])
+```
+
+Both sides consume stdout, stderr, and exit status concurrently inside the child scope.
+
+## Equivalence
+
+```sh
+bun run run child-process-backpressure
+```
+
+Result: **IDENTICAL**. Five repetitions of the invariant trace on each side produced the same
+SHA-256, `c00e83de3a514a69999f05f4a54e7446eeaf7c15591c50c4a108f8d94e9b5e51`.
+
+The large alternating case crosses pipe buffers with 3,145,728 bytes on each stream:
+
+- stdout SHA-256 `e6c8ce3c4a4a41f01e5ed73ef32824c5f3bdb592a260feff59e0706ae9cba03d`
+- stderr SHA-256 `b4e692ad7957e2375594c3baaf91a6f437d2a9e5cc93d697b0f62c30f64bd657`
+
+The slow-consumer case delays every pull by 3 ms and still completes with 8,388,608 stdout bytes,
+exit 0, and SHA-256
+`558e18543f7631f2b35f841b318c578e1aa5d1c37a6ce676f153b4e0232f682c`.
+The order-sensitive whole-stream hashes prove no per-stream loss or reordering.
+
+## Non-deterministic raw boundary
+
+The initial characterization retained each OS chunk boundary and the observed cross-stream
+consumer order. Five identical runs produced five unique v3 trace hashes and five unique v4 trace
+hashes. Chunk sizes, per-chunk hashes, and stdout/stderr scheduling vary within one major.
+
+Chunk boundaries and exact cross-stream interleaving are therefore **NOT GATED**. Stable invariants
+are gated instead: whole-stream bytes/hash, per-stream producer order, both-stream observation,
+cross-stream progress, multiple chunks, exit status, and lossless slow-consumer completion. This
+follows the harness README's I/O invariant rule.
+
+## Intended differences (alignment register entries)
+
+None. The invariant contract is identical.
+
+## Gotchas
+
+- Always consume stdout and stderr concurrently with exit status. Sequential collection can
+  deadlock once either OS pipe fills.
+- A small-output test does not exercise backpressure. The slow case emits 8 MiB and intentionally
+  delays consumption.
+- Do not snapshot OS chunk sizes or cross-stream scheduling; both are non-deterministic and are not
+  application-level contracts.
+- Keep stdout and stderr whole-stream hashes separate. Concatenating or merging them would erase
+  stream identity and make scheduling look like data reordering.
+
+## Codemod rule
+
+No broad codemod beyond constructor syntax. Preserve scoped lifetime and concurrent consumption,
+then replay the owning package's large-output invariant baseline.

--- a/context/effect-4/recipes/child-process-backpressure.md
+++ b/context/effect-4/recipes/child-process-backpressure.md
@@ -1,19 +1,19 @@
 # Pattern: child-process-backpressure
 
-**Area:** Platform / child process  **Kind:** semantic  **Our usage:** `pty-effect` and `megarepo`
+**Area:** Platform / child process **Kind:** semantic **Our usage:** `pty-effect` and `megarepo`
 consume long-running child stdout/stderr streams and must not lose, reorder, or deadlock output.
 
 ## v3
 
 ```ts
-const executor = yield* CommandExecutor.CommandExecutor
-const child = yield* executor.start(Command.make("bun", "producer.ts", ...args))
+const executor = yield * CommandExecutor.CommandExecutor
+const child = yield * executor.start(Command.make('bun', 'producer.ts', ...args))
 ```
 
 ## v4
 
 ```ts
-const child = yield* ChildProcess.make("bun", ["producer.ts", ...args])
+const child = yield * ChildProcess.make('bun', ['producer.ts', ...args])
 ```
 
 Both sides consume stdout, stderr, and exit status concurrently inside the child scope.

--- a/context/effect-4/recipes/cli-contract.md
+++ b/context/effect-4/recipes/cli-contract.md
@@ -1,32 +1,40 @@
 # Pattern: cli-contract
 
-**Area:** CLI  **Kind:** semantic  **Our usage:** 53 `@effect/cli` imports across operator-facing
+**Area:** CLI **Kind:** semantic **Our usage:** 53 `@effect/cli` imports across operator-facing
 CLIs including `megarepo`, `notion-cli`, `genie`, `ci-tools`, `npm-release`, and TUI packages.
 
 ## v3
 
 ```ts
-import { Args, Command, Options } from "@effect/cli"
+import { Args, Command, Options } from '@effect/cli'
 
-const command = Command.make("deploy", {
-  target: Args.text({ name: "target" }),
-  mode: Options.choice("mode", ["fast", "safe"])
-}, handler)
+const command = Command.make(
+  'deploy',
+  {
+    target: Args.text({ name: 'target' }),
+    mode: Options.choice('mode', ['fast', 'safe']),
+  },
+  handler,
+)
 
-const program = Command.run(command, { name: "tool", version: "1.2.3" })(process.argv)
+const program = Command.run(command, { name: 'tool', version: '1.2.3' })(process.argv)
 ```
 
 ## v4
 
 ```ts
-import { Argument, Command, Flag } from "effect/unstable/cli"
+import { Argument, Command, Flag } from 'effect/unstable/cli'
 
-const command = Command.make("deploy", {
-  target: Argument.string("target"),
-  mode: Flag.choice("mode", ["fast", "safe"])
-}, handler)
+const command = Command.make(
+  'deploy',
+  {
+    target: Argument.string('target'),
+    mode: Flag.choice('mode', ['fast', 'safe']),
+  },
+  handler,
+)
 
-const program = Command.runWith(command, { version: "1.2.3" })(process.argv.slice(2))
+const program = Command.runWith(command, { version: '1.2.3' })(process.argv.slice(2))
 ```
 
 ## Equivalence
@@ -49,15 +57,15 @@ not turn category A or C into accepted migration behavior.
 
 Observed changes:
 
-| Bucket | Cases | Exact paths | Decision |
-| --- | --- | --- | --- |
-| A: suspected v4 bug | `--` under nested subcommands, with variadic or required child positional | `$[5].stdout`, `$[12].{exitCode,stderr,stdout}` | Report upstream; do not migrate affected commands until fixed or locally patched |
-| B: accept improvement | reject separated negative integers | `$[6].{exitCode,stderr,stdout}`, `$[13].{exitCode,stderr,stdout}` | Accept for current domain integers: counts, delays, widths, timestamps, concurrency, limits, and PR numbers |
-| B: accept improvement | clustered aliases (`-vq`) | `$[7].stdout`, `$[14].{exitCode,stderr,stdout}` | Accept standard clustered-short grammar |
-| B: accept improvement | equals-form repeated flags | `$[4].stdout`, `$[15].{exitCode,stderr,stdout}` | Accept standard `--flag=value` grammar |
-| B: accept improvement | strict unknown flag after a variadic positional | `$[9].{exitCode,stderr,stdout}` | Accept; no tracked effect-utils command uses variadic positional `Args` |
-| C: preserve or shim | root/nested help and version bytes | `$[0].stdout`, `$[1].stdout`, `$[2].stdout` | Preserve/rebaseline per CLI owner; exact stdout is a public contract |
-| C: preserve or shim | validation diagnostics and stdout placement | `$[8].{stderr,stdout}`, `$[10].{stderr,stdout}`, `$[11].{stderr,stdout}`, `$[16].{stderr,stdout}` | Keep validation failures off machine-readable stdout; compatibility-format or explicitly rebaseline stderr |
+| Bucket                | Cases                                                                     | Exact paths                                                                                       | Decision                                                                                                    |
+| --------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| A: suspected v4 bug   | `--` under nested subcommands, with variadic or required child positional | `$[5].stdout`, `$[12].{exitCode,stderr,stdout}`                                                   | Report upstream; do not migrate affected commands until fixed or locally patched                            |
+| B: accept improvement | reject separated negative integers                                        | `$[6].{exitCode,stderr,stdout}`, `$[13].{exitCode,stderr,stdout}`                                 | Accept for current domain integers: counts, delays, widths, timestamps, concurrency, limits, and PR numbers |
+| B: accept improvement | clustered aliases (`-vq`)                                                 | `$[7].stdout`, `$[14].{exitCode,stderr,stdout}`                                                   | Accept standard clustered-short grammar                                                                     |
+| B: accept improvement | equals-form repeated flags                                                | `$[4].stdout`, `$[15].{exitCode,stderr,stdout}`                                                   | Accept standard `--flag=value` grammar                                                                      |
+| B: accept improvement | strict unknown flag after a variadic positional                           | `$[9].{exitCode,stderr,stdout}`                                                                   | Accept; no tracked effect-utils command uses variadic positional `Args`                                     |
+| C: preserve or shim   | root/nested help and version bytes                                        | `$[0].stdout`, `$[1].stdout`, `$[2].stdout`                                                       | Preserve/rebaseline per CLI owner; exact stdout is a public contract                                        |
+| C: preserve or shim   | validation diagnostics and stdout placement                               | `$[8].{stderr,stdout}`, `$[10].{stderr,stdout}`, `$[11].{stderr,stdout}`, `$[16].{stderr,stdout}` | Keep validation failures off machine-readable stdout; compatibility-format or explicitly rebaseline stderr  |
 
 ### Category A source confirmation
 
@@ -70,15 +78,15 @@ missing-required failure when the escaped positional is the required child argum
 
 ### Actual effect-utils command audit
 
-| Behavior | Commands with observable exposure | Evidence and impact |
-| --- | --- | --- |
-| help bytes | all six audited binaries | `megarepo/src/cli/mod.ts:51-80`, `notion-cli/src/cli.ts:63-80`, `genie/bin/genie.tsx:29-44`, `ci-tools/bin/ci-tools.ts:25-39`, `npm-release/src/cli.ts:58-84`, `tui-stories/bin/tui-stories.tsx:20-31`; Nix smoke tests execute help for `megarepo`, `notion-cli`, `ci-tools`, and `npm-release` but mostly assert success/presence, not bytes |
-| version bytes | `megarepo`, `genie`, `ci-tools`, `npm-release`, `tui-stories` | all delegate `--version` to Effect CLI and would change to `name v<version>`; `notion-cli` is protected by its explicit one-line root-version fast path at `notion-cli/src/cli.ts:33-38,173-180` |
-| nested `--` data loss | `megarepo`, `notion-cli`, `tui-stories` positional subcommands | required positionals exist at `megarepo/src/cli/commands/{add.ts:58-63,exec.ts:23-29,pin.ts:59-63}`, `notion-cli/src/commands/{db/mod.ts:29-35,schema/mod.ts:84-87}`, and `tui-stories/src/cli/{render.ts:14-17,inspect.ts:13-16}`; a dash-prefixed value supplied via `--` becomes missing |
-| negative integers | `npm-release`, `ci-tools`, `tui-stories`, plus Notion/TUI helpers | concrete flags: `npm-release` attempts/delay, `ci-tools` PR number, `tui-stories` width/timeline `at`; workspace-wide integer search also finds Notion poll/concurrency/limit and TUI example durations |
-| clustered aliases | `megarepo`, `notion-cli`, `tui-stories` | these own multiple short aliases; formerly-invalid clusters can now invoke handlers. `genie`, `ci-tools`, and `npm-release` define no command aliases in the audited sources |
-| equals repeated flags | `ci-tools`, `tui-stories` | v4 newly accepts equals form for `ci-tools` production-domain/build-env and `tui-stories --arg`; existing separate-form invocations are unchanged |
-| unknown flags | every command | tracked commands have no variadic positional `Args`, so exit remains 1; the real change is v4 full help on stdout plus new stderr wording |
+| Behavior              | Commands with observable exposure                                 | Evidence and impact                                                                                                                                                                                                                                                                                                                            |
+| --------------------- | ----------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| help bytes            | all six audited binaries                                          | `megarepo/src/cli/mod.ts:51-80`, `notion-cli/src/cli.ts:63-80`, `genie/bin/genie.tsx:29-44`, `ci-tools/bin/ci-tools.ts:25-39`, `npm-release/src/cli.ts:58-84`, `tui-stories/bin/tui-stories.tsx:20-31`; Nix smoke tests execute help for `megarepo`, `notion-cli`, `ci-tools`, and `npm-release` but mostly assert success/presence, not bytes |
+| version bytes         | `megarepo`, `genie`, `ci-tools`, `npm-release`, `tui-stories`     | all delegate `--version` to Effect CLI and would change to `name v<version>`; `notion-cli` is protected by its explicit one-line root-version fast path at `notion-cli/src/cli.ts:33-38,173-180`                                                                                                                                               |
+| nested `--` data loss | `megarepo`, `notion-cli`, `tui-stories` positional subcommands    | required positionals exist at `megarepo/src/cli/commands/{add.ts:58-63,exec.ts:23-29,pin.ts:59-63}`, `notion-cli/src/commands/{db/mod.ts:29-35,schema/mod.ts:84-87}`, and `tui-stories/src/cli/{render.ts:14-17,inspect.ts:13-16}`; a dash-prefixed value supplied via `--` becomes missing                                                    |
+| negative integers     | `npm-release`, `ci-tools`, `tui-stories`, plus Notion/TUI helpers | concrete flags: `npm-release` attempts/delay, `ci-tools` PR number, `tui-stories` width/timeline `at`; workspace-wide integer search also finds Notion poll/concurrency/limit and TUI example durations                                                                                                                                        |
+| clustered aliases     | `megarepo`, `notion-cli`, `tui-stories`                           | these own multiple short aliases; formerly-invalid clusters can now invoke handlers. `genie`, `ci-tools`, and `npm-release` define no command aliases in the audited sources                                                                                                                                                                   |
+| equals repeated flags | `ci-tools`, `tui-stories`                                         | v4 newly accepts equals form for `ci-tools` production-domain/build-env and `tui-stories --arg`; existing separate-form invocations are unchanged                                                                                                                                                                                              |
+| unknown flags         | every command                                                     | tracked commands have no variadic positional `Args`, so exit remains 1; the real change is v4 full help on stdout plus new stderr wording                                                                                                                                                                                                      |
 
 `megarepo`'s `rewriteHelpSubcommand(process.argv)` does not mitigate the terminator bug. It returns
 non-`help` argv unchanged (`utils/src/node/cli-help-rewrite.ts:2-8`), so

--- a/context/effect-4/recipes/cli-contract.md
+++ b/context/effect-4/recipes/cli-contract.md
@@ -1,0 +1,134 @@
+# Pattern: cli-contract
+
+**Area:** CLI  **Kind:** semantic  **Our usage:** 53 `@effect/cli` imports across operator-facing
+CLIs including `megarepo`, `notion-cli`, `genie`, `ci-tools`, `npm-release`, and TUI packages.
+
+## v3
+
+```ts
+import { Args, Command, Options } from "@effect/cli"
+
+const command = Command.make("deploy", {
+  target: Args.text({ name: "target" }),
+  mode: Options.choice("mode", ["fast", "safe"])
+}, handler)
+
+const program = Command.run(command, { name: "tool", version: "1.2.3" })(process.argv)
+```
+
+## v4
+
+```ts
+import { Argument, Command, Flag } from "effect/unstable/cli"
+
+const command = Command.make("deploy", {
+  target: Argument.string("target"),
+  mode: Flag.choice("mode", ["fast", "safe"])
+}, handler)
+
+const program = Command.runWith(command, { version: "1.2.3" })(process.argv.slice(2))
+```
+
+## Equivalence
+
+```sh
+bun run run cli-contract
+```
+
+The pattern launches each CLI in a child process and compares exact stdout bytes, exact stderr
+bytes, and exit status for help, version, valid parsing, terminators, repeated flags, negative
+numbers, clustered short flags, Unicode, excess positional arguments, and four validation errors.
+This is a reusable snapshot gate: any unallowlisted text or exit-code change makes the runner
+fail.
+
+Result against beta.102: **ALLOWLISTED, 34 exact diff paths, 0 unexpected**. Every path is
+classified below as
+`A` suspected v4 bug, `B` consciously accepted v4 grammar improvement, or `C` real breakage that
+requires compatibility rendering/shimming. The allowlist freezes the characterization; it does
+not turn category A or C into accepted migration behavior.
+
+Observed changes:
+
+| Bucket | Cases | Exact paths | Decision |
+| --- | --- | --- | --- |
+| A: suspected v4 bug | `--` under nested subcommands, with variadic or required child positional | `$[5].stdout`, `$[12].{exitCode,stderr,stdout}` | Report upstream; do not migrate affected commands until fixed or locally patched |
+| B: accept improvement | reject separated negative integers | `$[6].{exitCode,stderr,stdout}`, `$[13].{exitCode,stderr,stdout}` | Accept for current domain integers: counts, delays, widths, timestamps, concurrency, limits, and PR numbers |
+| B: accept improvement | clustered aliases (`-vq`) | `$[7].stdout`, `$[14].{exitCode,stderr,stdout}` | Accept standard clustered-short grammar |
+| B: accept improvement | equals-form repeated flags | `$[4].stdout`, `$[15].{exitCode,stderr,stdout}` | Accept standard `--flag=value` grammar |
+| B: accept improvement | strict unknown flag after a variadic positional | `$[9].{exitCode,stderr,stdout}` | Accept; no tracked effect-utils command uses variadic positional `Args` |
+| C: preserve or shim | root/nested help and version bytes | `$[0].stdout`, `$[1].stdout`, `$[2].stdout` | Preserve/rebaseline per CLI owner; exact stdout is a public contract |
+| C: preserve or shim | validation diagnostics and stdout placement | `$[8].{stderr,stdout}`, `$[10].{stderr,stdout}`, `$[11].{stderr,stdout}`, `$[16].{stderr,stdout}` | Keep validation failures off machine-readable stdout; compatibility-format or explicitly rebaseline stderr |
+
+### Category A source confirmation
+
+The v4 lexer correctly stores everything after `--` in `trailingOperands`
+(`effect/src/unstable/cli/internal/lexer.ts:24-40`). The recursive parser then constructs the
+child input with `trailingOperands: []` (`internal/parser.ts:87`) and puts the original trailing
+operands on the parent parse record (`internal/parser.ts:97`). A nested child therefore never
+sees them. The probe confirms both data loss after an already-satisfied positional and a false
+missing-required failure when the escaped positional is the required child argument.
+
+### Actual effect-utils command audit
+
+| Behavior | Commands with observable exposure | Evidence and impact |
+| --- | --- | --- |
+| help bytes | all six audited binaries | `megarepo/src/cli/mod.ts:51-80`, `notion-cli/src/cli.ts:63-80`, `genie/bin/genie.tsx:29-44`, `ci-tools/bin/ci-tools.ts:25-39`, `npm-release/src/cli.ts:58-84`, `tui-stories/bin/tui-stories.tsx:20-31`; Nix smoke tests execute help for `megarepo`, `notion-cli`, `ci-tools`, and `npm-release` but mostly assert success/presence, not bytes |
+| version bytes | `megarepo`, `genie`, `ci-tools`, `npm-release`, `tui-stories` | all delegate `--version` to Effect CLI and would change to `name v<version>`; `notion-cli` is protected by its explicit one-line root-version fast path at `notion-cli/src/cli.ts:33-38,173-180` |
+| nested `--` data loss | `megarepo`, `notion-cli`, `tui-stories` positional subcommands | required positionals exist at `megarepo/src/cli/commands/{add.ts:58-63,exec.ts:23-29,pin.ts:59-63}`, `notion-cli/src/commands/{db/mod.ts:29-35,schema/mod.ts:84-87}`, and `tui-stories/src/cli/{render.ts:14-17,inspect.ts:13-16}`; a dash-prefixed value supplied via `--` becomes missing |
+| negative integers | `npm-release`, `ci-tools`, `tui-stories`, plus Notion/TUI helpers | concrete flags: `npm-release` attempts/delay, `ci-tools` PR number, `tui-stories` width/timeline `at`; workspace-wide integer search also finds Notion poll/concurrency/limit and TUI example durations |
+| clustered aliases | `megarepo`, `notion-cli`, `tui-stories` | these own multiple short aliases; formerly-invalid clusters can now invoke handlers. `genie`, `ci-tools`, and `npm-release` define no command aliases in the audited sources |
+| equals repeated flags | `ci-tools`, `tui-stories` | v4 newly accepts equals form for `ci-tools` production-domain/build-env and `tui-stories --arg`; existing separate-form invocations are unchanged |
+| unknown flags | every command | tracked commands have no variadic positional `Args`, so exit remains 1; the real change is v4 full help on stdout plus new stderr wording |
+
+`megarepo`'s `rewriteHelpSubcommand(process.argv)` does not mitigate the terminator bug. It returns
+non-`help` argv unchanged (`utils/src/node/cli-help-rewrite.ts:2-8`), so
+`mr add -- -dash-prefixed-repo` still reaches the broken v4 parser. For the custom
+`mr help add` form it appends `--help`; if the input itself contains `--`, the appended help flag
+lands after the terminator and is among the operands stranded on the parent. Normal
+`mr help add` remains a straightforward rewrite to `mr add --help`.
+
+## Intended differences (alignment register entries)
+
+- **A:** escalate nested-subcommand terminator loss upstream and block affected migration slices
+  on an upstream fix or explicit local patch.
+- **B:** accept negative-integer rejection, clustered aliases, equals-form repeated flags, and
+  strict unknown-flag handling for the unused variadic-positional shape.
+- **C:** preserve or explicitly rebaseline help/version/error bytes. Independently of wording,
+  validation help must not be added to stdout for commands whose success output is JSON/NDJSON.
+
+The fresh beta.102 classification count is **A: 4 paths, B: 17 paths, C: 13 paths**. No existing
+path changed bucket from beta.99. Two existing category-C stderr values improved wording:
+invalid-choice and invalid-integer errors no longer duplicate `Expected`. Commit `c917bb94a`
+(#6561) adds excess-positional rejection; the new gate case shows both v3 and beta.102 exit `1`,
+so it restores v3 semantics rather than introducing a new exit-code break. Its diagnostic bytes
+and help-on-stdout behavior add two category-C paths.
+
+## Gotchas
+
+- v4 `Command.run` reads arguments from the `Stdio` service. The v3-compatible explicit-argv
+  runner is `Command.runWith`; keeping the old name changes behavior without a type-level cue.
+- v4 accepts arguments and flags in the `Command.make` config record, using `Argument` and `Flag`.
+- Help text, validation text, stdout/stderr placement, and process status are external contracts,
+  not implementation details.
+- `process.argv` includes the runtime and script on v3; the explicit v4 `runWith` input is the
+  already-trimmed CLI argument array.
+- `NO_COLOR=1` did not remove v3 ANSI help bytes in this probe. A gate that strips ANSI would hide
+  a real output-contract change.
+- Variadic arguments interact with flag recognition differently across majors. Test flags both
+  before and after positional operands.
+- The `--` loss is not a formatter issue or an expected parser redesign; it is source-confirmed
+  child-recursion data loss in beta.99 and still reproduces on beta.102. The intervening
+  positional-overflow fix (`c917bb94a`, #6561) changed leftover validation in
+  `internal/command.ts` but did not touch the faulty `internal/parser.ts` recursion.
+- v4 help-on-error is intentional library control flow: `showHelp` logs the full help document to
+  stdout before logging validation errors to stderr
+  (`effect/src/unstable/cli/Command.ts:2157-2169`). It is category C compatibility work, not an
+  upstream parser bug.
+- Interactive `Prompt.select` behavior is **NOT COVERED**. The repo has a live use in
+  `megarepo/src/cli/commands/engine.ts`; it needs a deterministic scripted-Terminal or PTY gate
+  before that command is migrated.
+
+## Codemod rule
+
+No general codemod. Import and identifier renames are mechanical, but runner selection, argument
+shape, repetition semantics, and byte-level CLI output require a per-command snapshot gate.

--- a/context/effect-4/recipes/effect-never-idle.md
+++ b/context/effect-4/recipes/effect-never-idle.md
@@ -1,0 +1,48 @@
+# Pattern: effect-never-idle
+
+**Area:** Runtime / process lifetime  **Kind:** semantic  **Our usage:** long-lived workers in
+`pty-effect`, `restate-effect`, and `agent-session-ingest`.
+
+## v3
+
+```ts
+const fiber = Effect.runFork(Effect.never)
+```
+
+Effect 3 implements `Effect.never` with a `2 ** 31 - 1` millisecond interval and clears it on
+interruption.
+
+## v4
+
+```ts
+const fiber = Effect.runFork(Effect.never)
+```
+
+The source is unchanged, but Effect 4 parks the fiber without registering a timer.
+
+## Equivalence
+
+```sh
+bun run run:pattern effect-never-idle
+```
+
+ALLOWLISTED: the v3 trace reports one interval and v4 reports zero. Both fibers remain suspended
+until interrupted.
+
+## Intended differences (alignment register entries)
+
+- v4 no longer keeps the host alive with an idle timer — this is an intended runtime improvement —
+  accept v4 behavior and make process ownership explicit with the platform main runner or a real
+  resource — affects long-lived agent, PTY, and Restate processes.
+
+## Gotchas
+
+- Do not add a synthetic timer to imitate v3. That would undo the hibernation and idle-resource
+  improvement.
+- If a process relied on `Effect.never` rather than its main runner or an actual server handle to
+  stay alive, the lifetime contract was implicit and needs an explicit runtime-level test.
+- A unit test that only checks that the fiber is suspended cannot see the host timer difference.
+
+## Codemod rule
+
+None. The source form is identical and the difference is runtime semantics.

--- a/context/effect-4/recipes/effect-never-idle.md
+++ b/context/effect-4/recipes/effect-never-idle.md
@@ -1,6 +1,6 @@
 # Pattern: effect-never-idle
 
-**Area:** Runtime / process lifetime  **Kind:** semantic  **Our usage:** long-lived workers in
+**Area:** Runtime / process lifetime **Kind:** semantic **Our usage:** long-lived workers in
 `pty-effect`, `restate-effect`, and `agent-session-ingest`.
 
 ## v3

--- a/context/effect-4/recipes/equality.md
+++ b/context/effect-4/recipes/equality.md
@@ -1,0 +1,46 @@
+# Pattern: equality
+
+**Area:** Equality and HashSet/HashMap membership  **Kind:** semantic  **Our usage:** direct
+`Equal.equals` is low-volume, but equality semantics flow into dedup, cache keys,
+set membership, and change detection.
+
+## v3
+
+```ts
+Equal.equals({ x: 1 }, { x: 1 }) // false
+HashSet.size(HashSet.fromIterable([{ x: 1 }, { x: 1 }])) // 2
+```
+
+## v4
+
+```ts
+Equal.equals({ x: 1 }, { x: 1 }) // true
+HashSet.size(HashSet.fromIterable([{ x: 1 }, { x: 1 }])) // 1
+Equal.equals(Equal.byReference({ x: 1 }), { x: 1 }) // false
+```
+
+## Equivalence
+
+Command:
+
+```sh
+bun run run equality
+```
+
+Result: semantic diffs are allowlisted for plain objects, arrays, maps, sets,
+dates, regexps, `NaN`, and HashSet membership/dedup outcomes.
+
+## Intended differences (alignment register entries)
+
+- v4 structural equality is useful by default but changes identity-sensitive
+  caches and dedup. Proposed decision: accept structural equality unless the site
+  is demonstrably identity-sensitive; use `Equal.byReference` or
+  `Equal.byReferenceUnsafe` only at those sites.
+
+## Gotchas
+
+- JavaScript `Set`/`Map` still use JS identity semantics; Effect `HashSet` and
+  `HashMap` use Effect equality.
+- `Equal.byReference` returns a Proxy. The probe records `proxySameReference:
+  false`, so code relying on object identity should prefer `byReferenceUnsafe`
+  only after checking mutation/ownership risk.

--- a/context/effect-4/recipes/equality.md
+++ b/context/effect-4/recipes/equality.md
@@ -1,6 +1,6 @@
 # Pattern: equality
 
-**Area:** Equality and HashSet/HashMap membership  **Kind:** semantic  **Our usage:** direct
+**Area:** Equality and HashSet/HashMap membership **Kind:** semantic **Our usage:** direct
 `Equal.equals` is low-volume, but equality semantics flow into dedup, cache keys,
 set membership, and change detection.
 
@@ -42,5 +42,5 @@ dates, regexps, `NaN`, and HashSet membership/dedup outcomes.
 - JavaScript `Set`/`Map` still use JS identity semantics; Effect `HashSet` and
   `HashMap` use Effect equality.
 - `Equal.byReference` returns a Proxy. The probe records `proxySameReference:
-  false`, so code relying on object identity should prefer `byReferenceUnsafe`
+false`, so code relying on object identity should prefer `byReferenceUnsafe`
   only after checking mutation/ownership risk.

--- a/context/effect-4/recipes/filesystem-watch-ordering.md
+++ b/context/effect-4/recipes/filesystem-watch-ordering.md
@@ -1,14 +1,14 @@
 # Pattern: filesystem-watch-ordering
 
-**Area:** Platform / FileSystem watch  **Kind:** semantic / real breakage  **Our usage:**
+**Area:** Platform / FileSystem watch **Kind:** semantic / real breakage **Our usage:**
 `megarepo` and `genie` watch modes depend on event membership and non-recursive boundaries.
 
 ## v3
 
 ```ts
-import { FileSystem } from "@effect/platform"
+import { FileSystem } from '@effect/platform'
 
-const fs = yield* FileSystem.FileSystem
+const fs = yield * FileSystem.FileSystem
 const directChildren = fs.watch(root, { recursive: false })
 const wholeTree = fs.watch(root, { recursive: true })
 ```
@@ -16,9 +16,9 @@ const wholeTree = fs.watch(root, { recursive: true })
 ## v4
 
 ```ts
-import { FileSystem } from "effect"
+import { FileSystem } from 'effect'
 
-const fs = yield* FileSystem.FileSystem
+const fs = yield * FileSystem.FileSystem
 const wholeTree = fs.watch(root)
 ```
 
@@ -62,7 +62,7 @@ described in the harness README.
 
 Upstream duplicate check found no issue describing this beta.102 regression. The closest issues
 are Effect-TS/effect#2986, the closed request that originally added the option, and #5913, an open
-v3 issue about accidentally falling back to *non-recursive* watching through layer order. Neither
+v3 issue about accidentally falling back to _non-recursive_ watching through layer order. Neither
 covers removal plus forced recursion.
 
 ### Draft upstream report (do not file without orchestrator review)

--- a/context/effect-4/recipes/filesystem-watch-ordering.md
+++ b/context/effect-4/recipes/filesystem-watch-ordering.md
@@ -1,0 +1,118 @@
+# Pattern: filesystem-watch-ordering
+
+**Area:** Platform / FileSystem watch  **Kind:** semantic / real breakage  **Our usage:**
+`megarepo` and `genie` watch modes depend on event membership and non-recursive boundaries.
+
+## v3
+
+```ts
+import { FileSystem } from "@effect/platform"
+
+const fs = yield* FileSystem.FileSystem
+const directChildren = fs.watch(root, { recursive: false })
+const wholeTree = fs.watch(root, { recursive: true })
+```
+
+## v4
+
+```ts
+import { FileSystem } from "effect"
+
+const fs = yield* FileSystem.FileSystem
+const wholeTree = fs.watch(root)
+```
+
+There is no beta.102 equivalent for `recursive: false`.
+
+## Equivalence
+
+```sh
+bun run run filesystem-watch-ordering
+```
+
+Result: **ALLOWLISTED, 1 exact path, 0 unexpected**. The invariant trace gates create /
+modify / delete-action path membership, rapid-write coalescing, recursive membership, rename and
+delete-recreate convergence. All stable invariants match except
+the non-recursive boundary: v4 additionally reports `nested/child.txt`.
+
+The first raw ordered probe was intentionally repeated before classification. Five identical runs
+produced four unique v3 trace hashes and three unique v4 trace hashes. Create/update order and the
+number of coalesced rapid-write events varied within a major. Exact event order is therefore
+**NOT GATED**. The final probe waits for and compares stable membership/convergence invariants, as
+described in the harness README.
+
+## Intended differences (alignment register entries)
+
+- `filesystem-watch-recursive-option-removed`: **real breakage, not accepted**. Restore the option
+  upstream or preserve non-recursive behavior with a migration shim before porting affected watch
+  loops. Silently widening a watch can trigger spurious rebuilds or watch loops.
+
+## Precise beta.102 characterization
+
+- Type level: core `FileSystem.watch` changed from
+  `(path, options?: WatchOptions)` to `(path)`; `WatchOptions` is gone.
+- Backend abstraction: `WatchBackend.register` also receives no recursive selection, so a custom
+  backend cannot recover the call-site option through the standard interface.
+- Node runtime: `@effect/platform-node-shared` calls `node:fs.watch(path, { recursive: true })`
+  unconditionally.
+- Bun runtime: `@effect/platform-bun` delegates its FileSystem layer to the same shared Node
+  implementation, so it has the same forced-recursive behavior.
+- The installed target contains no other runtime FileSystem adapter to characterize. The core
+  option removal still applies to every implementation of the beta.102 service interface.
+
+Upstream duplicate check found no issue describing this beta.102 regression. The closest issues
+are Effect-TS/effect#2986, the closed request that originally added the option, and #5913, an open
+v3 issue about accidentally falling back to *non-recursive* watching through layer order. Neither
+covers removal plus forced recursion.
+
+### Draft upstream report (do not file without orchestrator review)
+
+**Title:** Effect 4 beta.102 removes `FileSystem.watch` recursive control and forces recursive Node watches
+
+**Body:**
+
+> In Effect 3.21.4, `FileSystem.watch(path, { recursive: false })` observes only direct children
+> and `{ recursive: true }` observes nested paths. In Effect 4.0.0-beta.102, the `WatchOptions`
+> parameter is removed from `FileSystem.watch` and `WatchBackend.register`, while
+> `@effect/platform-node-shared/NodeFileSystem` calls `node:fs.watch` with
+> `{ recursive: true }` unconditionally. `@effect/platform-bun` delegates to that layer.
+>
+> Reproduction: create `root/nested`, watch `root`, then create `nested/child.txt` followed by
+> `root/direct.txt`. v3 with `{ recursive: false }` reports only `direct.txt`; beta.102 reports
+> both paths, and there is no typed way to request the v3 behavior.
+>
+> This silently widens watch scope and can cause spurious rebuilds or watch loops. Please restore
+> a recursive option through the core interface, `WatchBackend`, and Node implementation, with
+> `false` preserving the v3 non-recursive behavior.
+
+## Repository tag-dependency audit
+
+Four production `FileSystem.watch` consumers were checked:
+
+- `genie` watch mode and both `notion-md` watchers filter by path and re-read state; they do not
+  branch on `Create` / `Update` / `Remove`.
+- `megarepo` StoreLock explicitly removes `onPermitsReleased` from the filesystem semaphore
+  backing and uses polling, specifically to avoid `fs.watch` edge cases.
+- `utils/src/node/file-system-backing.ts` does filter semaphore wakeups to `Update | Remove` and
+  ignores `Create`. Genie target locks use this backing. This is a pre-existing fragile
+  optimization because tag classification is unreliable.
+
+The distributed semaphore always races the push stream against a 100 ms polling acquisition loop.
+A missed or misclassified push event therefore adds polling latency but does not lose correctness
+or liveness. Hardening the filter to treat any event for the watched lock directory as a wakeup is
+separate pre-existing work, not part of this migration slice.
+
+## Gotchas
+
+- OS watch event order, coalescing, and even delete `Remove` classification are non-deterministic
+  within one Effect major. Gate path membership and final convergence, not exact tags, order, or
+  event count.
+- Rename may be surfaced as platform `rename` events that Effect classifies after an asynchronous
+  stat; do not assume a portable create/remove pair ordering.
+- A passing recursive watcher does not prove non-recursive behavior remains available.
+
+## Codemod rule
+
+No codemod. Any v3 call passing `recursive: false`, or relying on the default non-recursive
+behavior, requires semantic mitigation. Calls explicitly using `recursive: true` may drop the
+option only after their invariant replay passes.

--- a/context/effect-4/recipes/fork-defaults.md
+++ b/context/effect-4/recipes/fork-defaults.md
@@ -1,19 +1,19 @@
 # Pattern: fork-defaults
 
-**Area:** Forking and scheduler startup  **Kind:** semantic  **Our usage:** `Effect.fork`,
+**Area:** Forking and scheduler startup **Kind:** semantic **Our usage:** `Effect.fork`,
 `forkScoped`, and daemon-like background work appear in process, RPC, Playwright,
 TUI, and integration-test code.
 
 ## v3
 
 ```ts
-const fiber = yield* effect.pipe(Effect.fork)
+const fiber = yield * effect.pipe(Effect.fork)
 ```
 
 ## v4
 
 ```ts
-const fiber = yield* effect.pipe(Effect.forkChild)
+const fiber = yield * effect.pipe(Effect.forkChild)
 ```
 
 ## Equivalence

--- a/context/effect-4/recipes/fork-defaults.md
+++ b/context/effect-4/recipes/fork-defaults.md
@@ -1,0 +1,55 @@
+# Pattern: fork-defaults
+
+**Area:** Forking and scheduler startup  **Kind:** semantic  **Our usage:** `Effect.fork`,
+`forkScoped`, and daemon-like background work appear in process, RPC, Playwright,
+TUI, and integration-test code.
+
+## v3
+
+```ts
+const fiber = yield* effect.pipe(Effect.fork)
+```
+
+## v4
+
+```ts
+const fiber = yield* effect.pipe(Effect.forkChild)
+```
+
+## Equivalence
+
+Command:
+
+```sh
+bun run run fork-defaults
+```
+
+Result: default child-fork startup ordering is identical:
+
+```text
+before-fork -> after-fork -> child-start -> joined
+```
+
+The same probe also includes the copied-options negative control. Adding
+`{ startImmediately: true, uninterruptible: "inherit" }` on the v4 side changes
+ordering to:
+
+```text
+before-fork -> child-start -> after-fork -> joined
+```
+
+Those two ordering diffs are allowlisted only to keep this pattern runnable; they
+are not approved behaviour changes.
+
+## Intended differences (alignment register entries)
+
+- None for the default migration. The proposed decision is `Effect.fork` ->
+  `Effect.forkChild` without copied options unless a call site has its own
+  semantic reason.
+
+## Gotchas
+
+- Do not cargo-cult `startImmediately: true` into every migrated fork. The probe
+  shows it changes observable ordering.
+- `Effect.forkDaemon` maps to `Effect.forkDetach`, but this pattern only proves
+  child fork startup order. Detached lifetime still needs a separate probe.

--- a/context/effect-4/recipes/layer-memoization.md
+++ b/context/effect-4/recipes/layer-memoization.md
@@ -1,0 +1,51 @@
+# Pattern: layer-memoization
+
+**Area:** Services and Layers  **Kind:** semantic  **Our usage:** tests and runtime setup use
+`Effect.provide`, `Layer.effect`, `Layer.scoped`, and composed live/test layers.
+
+## v3
+
+```ts
+program.pipe(Effect.provide(Live), Effect.provide(Live))
+// acquire runs twice
+```
+
+## v4
+
+```ts
+program.pipe(Effect.provide(Live), Effect.provide(Live))
+// acquire runs once
+
+program.pipe(Effect.provide(Live, { local: true }), Effect.provide(Live))
+// acquire runs twice
+
+program.pipe(Effect.provide(Layer.fresh(Live)), Effect.provide(Live))
+// acquire runs twice
+```
+
+## Equivalence
+
+Command:
+
+```sh
+bun run run layer-memoization
+```
+
+Result: default separate provides differ (`v3: 2`, `v4: 1`) and are allowlisted
+as a semantic change. `Layer.fresh` preserves v3 construction count. v4
+`{ local: true }` is available and also restores the v3 count when applied to the
+inner provide.
+
+## Intended differences (alignment register entries)
+
+- v4 shared memoization is accepted for normal application wiring, but tests and
+  resource factories that require fresh state must use `Layer.fresh` or
+  `{ local: true }`.
+
+## Gotchas
+
+- A careless migration can silently reduce resource construction from two to one.
+  That is usually good for live resources but wrong for tests expecting isolated
+  state.
+- The placement of `{ local: true }` matters. In this probe, the inner provide is
+  the placement that restores the v3 construction count.

--- a/context/effect-4/recipes/layer-memoization.md
+++ b/context/effect-4/recipes/layer-memoization.md
@@ -1,6 +1,6 @@
 # Pattern: layer-memoization
 
-**Area:** Services and Layers  **Kind:** semantic  **Our usage:** tests and runtime setup use
+**Area:** Services and Layers **Kind:** semantic **Our usage:** tests and runtime setup use
 `Effect.provide`, `Layer.effect`, `Layer.scoped`, and composed live/test layers.
 
 ## v3

--- a/context/effect-4/recipes/platform-child-process.md
+++ b/context/effect-4/recipes/platform-child-process.md
@@ -1,0 +1,57 @@
+# Pattern: platform-child-process
+
+**Area:** Platform / process  **Kind:** semantic  **Our usage:** process and command APIs are
+load-bearing in `utils`, `megarepo`, `ci-tools`, `agent-session-ingest`, and integration tests.
+
+## v3
+
+```ts
+import { Command, CommandExecutor } from "@effect/platform"
+
+const executor = yield* CommandExecutor.CommandExecutor
+const child = yield* executor.start(Command.make("tool", ...args))
+const code = yield* child.exitCode
+```
+
+## v4
+
+```ts
+import { ChildProcess } from "effect/unstable/process"
+
+const child = yield* ChildProcess.make("tool", args)
+const code = yield* child.exitCode
+```
+
+## Equivalence
+
+```sh
+bun run run platform-child-process
+```
+
+The probe compares a non-zero exit with exact stdout/stderr streams and an explicit SIGTERM flow
+with a trapped exit/status. Result: **IDENTICAL**. Both versions preserve exit `7`, separate
+stdout/stderr bytes, SIGTERM delivery, trapped exit `23`, and termination stderr.
+
+## Intended differences (alignment register entries)
+
+None expected: API construction changes should not change process bytes, exit codes, or signal
+behavior.
+
+## Gotchas
+
+- v4 commands are directly Effectable and require a Scope; do not retain a handle outside the
+  scope that owns the process.
+- Constructor options are flattened. Translate cwd/env/shell/stdin/stdout/stderr at construction,
+  not by searching for one-to-one post-construction combinators.
+- Collect stdout and stderr concurrently with exit status or a child can block on a full pipe.
+- The two streams are compared separately. Cross-stream wall-clock interleaving is platform
+  scheduling and is not asserted by this deterministic probe.
+- `Terminal` input/rendering and interactive PTY behavior are **NOT COVERED**; they require a
+  deterministic pseudo-terminal fixture. Large-output backpressure and chunk boundaries are also
+  **NOT COVERED** by the small exact-byte streams here.
+
+## Codemod rule
+
+No general codemod. `Command.make(name, ...args)` becomes
+`ChildProcess.make(name, args, options)`, but executor access, scope ownership, stream collection,
+and kill options require semantic repair.

--- a/context/effect-4/recipes/platform-child-process.md
+++ b/context/effect-4/recipes/platform-child-process.md
@@ -1,25 +1,25 @@
 # Pattern: platform-child-process
 
-**Area:** Platform / process  **Kind:** semantic  **Our usage:** process and command APIs are
+**Area:** Platform / process **Kind:** semantic **Our usage:** process and command APIs are
 load-bearing in `utils`, `megarepo`, `ci-tools`, `agent-session-ingest`, and integration tests.
 
 ## v3
 
 ```ts
-import { Command, CommandExecutor } from "@effect/platform"
+import { Command, CommandExecutor } from '@effect/platform'
 
-const executor = yield* CommandExecutor.CommandExecutor
-const child = yield* executor.start(Command.make("tool", ...args))
-const code = yield* child.exitCode
+const executor = yield * CommandExecutor.CommandExecutor
+const child = yield * executor.start(Command.make('tool', ...args))
+const code = yield * child.exitCode
 ```
 
 ## v4
 
 ```ts
-import { ChildProcess } from "effect/unstable/process"
+import { ChildProcess } from 'effect/unstable/process'
 
-const child = yield* ChildProcess.make("tool", args)
-const code = yield* child.exitCode
+const child = yield * ChildProcess.make('tool', args)
+const code = yield * child.exitCode
 ```
 
 ## Equivalence

--- a/context/effect-4/recipes/platform-filesystem.md
+++ b/context/effect-4/recipes/platform-filesystem.md
@@ -1,28 +1,28 @@
 # Pattern: platform-filesystem
 
-**Area:** Platform  **Kind:** semantic  **Our usage:** the platform family has 183 imports; process
+**Area:** Platform **Kind:** semantic **Our usage:** the platform family has 183 imports; process
 and filesystem-heavy packages include `agent-session-ingest`, `megarepo`, `restate-effect`,
 `ci-tools`, `effect-path`, and `utils`.
 
 ## v3
 
 ```ts
-import { FileSystem, Path } from "@effect/platform"
-import { NodeContext } from "@effect/platform-node"
+import { FileSystem, Path } from '@effect/platform'
+import { NodeContext } from '@effect/platform-node'
 
-const fs = yield* FileSystem.FileSystem
-const path = yield* Path.Path
+const fs = yield * FileSystem.FileSystem
+const path = yield * Path.Path
 const program = effect.pipe(Effect.provide(NodeContext.layer))
 ```
 
 ## v4
 
 ```ts
-import { FileSystem, Path } from "effect"
-import { NodeServices } from "@effect/platform-node"
+import { FileSystem, Path } from 'effect'
+import { NodeServices } from '@effect/platform-node'
 
-const fs = yield* FileSystem.FileSystem
-const path = yield* Path.Path
+const fs = yield * FileSystem.FileSystem
+const path = yield * Path.Path
 const program = effect.pipe(Effect.provide(NodeServices.layer))
 ```
 

--- a/context/effect-4/recipes/platform-filesystem.md
+++ b/context/effect-4/recipes/platform-filesystem.md
@@ -1,0 +1,58 @@
+# Pattern: platform-filesystem
+
+**Area:** Platform  **Kind:** semantic  **Our usage:** the platform family has 183 imports; process
+and filesystem-heavy packages include `agent-session-ingest`, `megarepo`, `restate-effect`,
+`ci-tools`, `effect-path`, and `utils`.
+
+## v3
+
+```ts
+import { FileSystem, Path } from "@effect/platform"
+import { NodeContext } from "@effect/platform-node"
+
+const fs = yield* FileSystem.FileSystem
+const path = yield* Path.Path
+const program = effect.pipe(Effect.provide(NodeContext.layer))
+```
+
+## v4
+
+```ts
+import { FileSystem, Path } from "effect"
+import { NodeServices } from "@effect/platform-node"
+
+const fs = yield* FileSystem.FileSystem
+const path = yield* Path.Path
+const program = effect.pipe(Effect.provide(NodeServices.layer))
+```
+
+## Equivalence
+
+```sh
+bun run run platform-filesystem
+```
+
+The probe compares path operations, write/read/stat bytes, and normalized ENOENT, EEXIST, and
+EACCES error fields. Result: **ALLOWLISTED, 3 exact paths, 0 unexpected**. All successful
+operations are identical. Each failure preserves reason, module, and method; only the outer tag
+changes from v3 `SystemError` to v4 `PlatformError`.
+
+## Intended differences (alignment register entries)
+
+- `platform-error-wrapper`: accept the deliberate v4 outer wrapper, but rewrite every old
+  `_tag === "SystemError"` / `catchTag("SystemError")` branch to match `PlatformError` and inspect
+  its reason. The inner ENOENT/EEXIST/EACCES taxonomy is unchanged in this probe.
+
+## Gotchas
+
+- v4 wraps platform failures in `PlatformError`; old `_tag`/reason matching must move through the
+  wrapper or use `instanceof`.
+- `Path` is a mechanical import move, but it normally arrives through a platform context whose
+  composition changed from `NodeContext.layer` to `NodeServices.layer`.
+- This probe uses deterministic local read/write/stat operations. Watch event ordering is
+  **NOT COVERED** and needs a package-level gate where watchers are used.
+
+## Codemod rule
+
+`import { Path } from "@effect/platform"` may become `import { Path } from "effect"` when it is the
+only imported platform symbol. FileSystem provider and error-handler rewrites are semantic.

--- a/context/effect-4/recipes/platform-http-status.md
+++ b/context/effect-4/recipes/platform-http-status.md
@@ -1,0 +1,57 @@
+# Pattern: platform-http-status
+
+**Area:** Platform / HttpClient  **Kind:** semantic  **Our usage:** direct HttpClient imports are
+low-volume, but HTTP failure matching is a control-flow boundary in clients and telemetry.
+
+## v3
+
+```ts
+import { HttpClient, HttpClientResponse } from "@effect/platform"
+
+const response = yield* HttpClient.get(url).pipe(
+  Effect.flatMap(HttpClientResponse.filterStatusOk)
+)
+```
+
+Rejected status fails with `ResponseError`, `reason: "StatusCode"`.
+
+## v4
+
+```ts
+import { HttpClient, HttpClientResponse } from "effect/unstable/http"
+
+const response = yield* HttpClient.get(url).pipe(
+  Effect.flatMap(HttpClientResponse.filterStatusOk)
+)
+```
+
+Rejected status fails with `HttpClientError` wrapping `StatusCodeError`.
+
+## Equivalence
+
+```sh
+bun run run platform-http-status
+```
+
+A deterministic local server returns exact 200 and 418 bodies. The 2xx status/body branch is
+identical. The 418 status remains identical, while the error wrapper and reason tag differ at two
+explicitly allowlisted paths.
+
+## Intended differences (alignment register entries)
+
+- Accept the v4 error wrapper, but rewrite `catchTag("ResponseError")` and
+  `error.reason === "StatusCode"` branches to match `HttpClientError` and inspect
+  `error.reason._tag === "StatusCodeError"`.
+
+## Gotchas
+
+- `HttpClient.get` itself does not turn every non-2xx response into failure; this probe exercises
+  `filterStatusOk`, the API whose rejection shape changed.
+- Tests that only assert the numeric status miss the control-flow break: old `catchTag` handlers
+  stop matching even though the status is still 418.
+- Keep local deterministic servers in migration gates; real network failures add unrelated drift.
+
+## Codemod rule
+
+The import move is mechanical. Error-handler rewrites are semantic and must be paired with a
+non-2xx branch test.

--- a/context/effect-4/recipes/platform-http-status.md
+++ b/context/effect-4/recipes/platform-http-status.md
@@ -1,16 +1,14 @@
 # Pattern: platform-http-status
 
-**Area:** Platform / HttpClient  **Kind:** semantic  **Our usage:** direct HttpClient imports are
+**Area:** Platform / HttpClient **Kind:** semantic **Our usage:** direct HttpClient imports are
 low-volume, but HTTP failure matching is a control-flow boundary in clients and telemetry.
 
 ## v3
 
 ```ts
-import { HttpClient, HttpClientResponse } from "@effect/platform"
+import { HttpClient, HttpClientResponse } from '@effect/platform'
 
-const response = yield* HttpClient.get(url).pipe(
-  Effect.flatMap(HttpClientResponse.filterStatusOk)
-)
+const response = yield * HttpClient.get(url).pipe(Effect.flatMap(HttpClientResponse.filterStatusOk))
 ```
 
 Rejected status fails with `ResponseError`, `reason: "StatusCode"`.
@@ -18,11 +16,9 @@ Rejected status fails with `ResponseError`, `reason: "StatusCode"`.
 ## v4
 
 ```ts
-import { HttpClient, HttpClientResponse } from "effect/unstable/http"
+import { HttpClient, HttpClientResponse } from 'effect/unstable/http'
 
-const response = yield* HttpClient.get(url).pipe(
-  Effect.flatMap(HttpClientResponse.filterStatusOk)
-)
+const response = yield * HttpClient.get(url).pipe(Effect.flatMap(HttpClientResponse.filterStatusOk))
 ```
 
 Rejected status fails with `HttpClientError` wrapping `StatusCodeError`.

--- a/context/effect-4/recipes/rpc-payload-codecs.md
+++ b/context/effect-4/recipes/rpc-payload-codecs.md
@@ -1,6 +1,6 @@
 # Pattern: rpc-payload-codecs
 
-**Area:** RPC boundary  **Kind:** semantic  **Our usage:** 11 `@effect/rpc` import sites plus
+**Area:** RPC boundary **Kind:** semantic **Our usage:** 11 `@effect/rpc` import sites plus
 `effect-rpc-tanstack`.
 
 ## v3
@@ -51,7 +51,7 @@ failure and message.
   JSON-projected schemas. Payload-only coverage is incomplete.
 - Compare `JSON.stringify(encoded)` or transport bytes, not only decoded values.
 - `Rpc.fromTaggedRequest` was removed. Rebuild the RPC explicitly with `Rpc.make(tag, { payload,
-  success, error })`; do not cast the old tagged request class into the new API.
+success, error })`; do not cast the old tagged request class into the new API.
 - Real clone/native-RPC transports need a separate real-runtime byte-boundary test; this in-process
   prototype cannot prove structured-clone compatibility.
 

--- a/context/effect-4/recipes/rpc-payload-codecs.md
+++ b/context/effect-4/recipes/rpc-payload-codecs.md
@@ -1,0 +1,61 @@
+# Pattern: rpc-payload-codecs
+
+**Area:** RPC boundary  **Kind:** semantic  **Our usage:** 11 `@effect/rpc` import sites plus
+`effect-rpc-tanstack`.
+
+## v3
+
+```ts
+const encoded = Schema.encodeSync(rpc.payloadSchema)(payload)
+const decoded = Schema.decodeUnknownSync(rpc.payloadSchema)(encoded)
+```
+
+Effect 3 RPC clients encoded the declared payload schema directly.
+
+## v4
+
+```ts
+const codec = Schema.toCodecJson(rpc.payloadSchema)
+const encoded = Schema.encodeSync(codec)(payload)
+const decoded = Schema.decodeUnknownSync(codec)(encoded)
+```
+
+Effect 4 RPC clients and servers explicitly use the JSON codec projection.
+
+## Equivalence
+
+```sh
+bun run run:pattern rpc-payload-codecs
+```
+
+Payloads are IDENTICAL at beta.99 for exact JSON bytes and decoded handler values across
+missing/present optional fields, `null`, `Option` none/some, unions, and both unary and streaming
+payload schemas.
+
+Two byte differences are ALLOWLISTED: unary and streaming tagged-failure envelopes change from the
+v3 recursive Cause object to the v4 flat reasons array. Both decode back to the identical tagged
+failure and message.
+
+## Intended differences (alignment register entries)
+
+- RPC failure Cause bytes change from `{"_tag":"Fail",...}` to
+  `[{"_tag":"Fail",...}]` — v4 flattened Cause representation — accept this only for atomically
+  upgraded/internal RPC peers; require a protocol version or compatibility adapter anywhere peers
+  can run different majors or envelopes are persisted — blast radius is every RPC error boundary.
+
+## Gotchas
+
+- A custom transport receives the encoded RPC message. Before calling a handler, decode
+  `request.payload` with `Schema.decodeUnknownEffect(Schema.toCodecJson(rpc.payloadSchema))`.
+- Encode unary exits, streaming chunks, streaming exits, and parse failures with their corresponding
+  JSON-projected schemas. Payload-only coverage is incomplete.
+- Compare `JSON.stringify(encoded)` or transport bytes, not only decoded values.
+- `Rpc.fromTaggedRequest` was removed. Rebuild the RPC explicitly with `Rpc.make(tag, { payload,
+  success, error })`; do not cast the old tagged request class into the new API.
+- Real clone/native-RPC transports need a separate real-runtime byte-boundary test; this in-process
+  prototype cannot prove structured-clone compatibility.
+
+## Codemod rule
+
+None. The import path changes mechanically from `@effect/rpc` to `effect/unstable/rpc`, but
+`Rpc.fromTaggedRequest` removal and custom dispatch decoding require schema-aware rewrites.

--- a/context/effect-4/recipes/runtime-fiber-context.md
+++ b/context/effect-4/recipes/runtime-fiber-context.md
@@ -1,35 +1,31 @@
 # Pattern: runtime-fiber-context
 
-**Area:** Runtime and FiberRef  **Kind:** semantic  **Our usage:** runtime calls are concentrated in
+**Area:** Runtime and FiberRef **Kind:** semantic **Our usage:** runtime calls are concentrated in
 `restate-effect` (30 lexical sites), `effect-react` (11), and `tui-react` (11); the custom
 FiberRef is localized to `utils`.
 
 ## v3
 
 ```ts
-const Local = FiberRef.unsafeMake("default")
+const Local = FiberRef.unsafeMake('default')
 
-const runtime = yield* Effect.runtime<AppServices>()
+const runtime = yield * Effect.runtime<AppServices>()
 const fiber = Runtime.runFork(runtime)(program)
 
-const child = yield* Effect.fork(
-  program.pipe(Effect.locally(Local, "child"))
-)
+const child = yield * Effect.fork(program.pipe(Effect.locally(Local, 'child')))
 ```
 
 ## v4
 
 ```ts
-const Local = Context.Reference("Local", {
-  defaultValue: () => "default"
+const Local = Context.Reference('Local', {
+  defaultValue: () => 'default',
 })
 
-const services = yield* Effect.context<AppServices>()
+const services = yield * Effect.context<AppServices>()
 const fiber = Effect.runForkWith(services)(program)
 
-const child = yield* Effect.forkChild(
-  program.pipe(Effect.provideService(Local, "child"))
-)
+const child = yield * Effect.forkChild(program.pipe(Effect.provideService(Local, 'child')))
 ```
 
 ## Equivalence

--- a/context/effect-4/recipes/runtime-fiber-context.md
+++ b/context/effect-4/recipes/runtime-fiber-context.md
@@ -1,0 +1,65 @@
+# Pattern: runtime-fiber-context
+
+**Area:** Runtime and FiberRef  **Kind:** semantic  **Our usage:** runtime calls are concentrated in
+`restate-effect` (30 lexical sites), `effect-react` (11), and `tui-react` (11); the custom
+FiberRef is localized to `utils`.
+
+## v3
+
+```ts
+const Local = FiberRef.unsafeMake("default")
+
+const runtime = yield* Effect.runtime<AppServices>()
+const fiber = Runtime.runFork(runtime)(program)
+
+const child = yield* Effect.fork(
+  program.pipe(Effect.locally(Local, "child"))
+)
+```
+
+## v4
+
+```ts
+const Local = Context.Reference("Local", {
+  defaultValue: () => "default"
+})
+
+const services = yield* Effect.context<AppServices>()
+const fiber = Effect.runForkWith(services)(program)
+
+const child = yield* Effect.forkChild(
+  program.pipe(Effect.provideService(Local, "child"))
+)
+```
+
+## Equivalence
+
+```sh
+bun run run runtime-fiber-context
+```
+
+Result: **IDENTICAL**. The captured v4 Context carries both the required service and the current
+Reference value into `runForkWith`. A child-local override is observed by the child and does not
+leak back into the parent, matching the v3 Runtime/FiberRef behavior.
+
+## Intended differences (alignment register entries)
+
+None for the covered capture/fork/override flow.
+
+## Gotchas
+
+- `Runtime.Runtime<R>` is removed; storing a runtime in application state becomes storing
+  `Context.Context<R>`, and every runner call changes from `Runtime.runFork(runtime)` to
+  `Effect.runForkWith(context)`.
+- A v3 Runtime snapshot included runtime flags and FiberRefs. The replacement Context must be
+  captured inside all required service/Reference provisions; an empty or prematurely captured
+  Context silently loses overrides.
+- `FiberRef.set` has no direct mutation-style replacement. Restructure the remaining computation
+  under `Effect.provideService(Reference, value)`.
+- v4 `Effect.fork` was renamed to `forkChild`; do not accidentally choose detached lifetime
+  semantics while performing the runtime rewrite.
+
+## Codemod rule
+
+No general codemod. Import/name rewrites are mechanical, but moving FiberRef mutation into a
+lexically scoped provider changes program structure and must be reviewed at each site.

--- a/context/effect-4/recipes/schema-date.md
+++ b/context/effect-4/recipes/schema-date.md
@@ -1,6 +1,6 @@
 # Pattern: schema-date
 
-**Area:** Schema wire format  **Kind:** semantic (conditional rewrite)  **Our usage:** `Schema.DateTimeUtc`,
+**Area:** Schema wire format **Kind:** semantic (conditional rewrite) **Our usage:** `Schema.DateTimeUtc`,
 `Schema.DateFromSelf`, and date transforms appear in agent-session, Notion codecs, and path schemas.
 
 ## v3

--- a/context/effect-4/recipes/schema-date.md
+++ b/context/effect-4/recipes/schema-date.md
@@ -1,0 +1,81 @@
+# Pattern: schema-date
+
+**Area:** Schema wire format  **Kind:** semantic (conditional rewrite)  **Our usage:** `Schema.DateTimeUtc`,
+`Schema.DateFromSelf`, and date transforms appear in agent-session, Notion codecs, and path schemas.
+
+## v3
+
+```ts
+const decode = Schema.decodeUnknownEither(Schema.Date)
+const encode = Schema.encodeEither(Schema.Date)
+```
+
+## v4
+
+```ts
+const DateWire = Schema.DateFromString
+const decode = Schema.decodeUnknownEither(DateWire)
+const encode = Schema.encodeEither(DateWire)
+```
+
+## Equivalence
+
+Command:
+
+```sh
+bun run run schema-date
+```
+
+Result: encoded wire strings and accept/reject outcomes are equivalent after
+using `Schema.DateFromString` on effect `4.0.0-beta.102`. The only differences
+are allowlisted parse-message text changes for invalid inputs. That allowlist is
+a harness classification, not blanket migration acceptance.
+
+## Intended differences (alignment register entries)
+
+- v4 invalid-date parse messages use `SchemaError(...)`; v3 prints a parse-tree
+  message. Proposed decision: accept only for internal structural failure
+  checks. User-facing or snapshotted boundaries must preserve/normalize the
+  message or intentionally sign off on the text change.
+- Audit result: no current snapshot contains the specific v3 Date parse-tree text
+  or v4 `SchemaError(...)` text. Structural failure tests in
+  `notion-effect-schema` and `notion-property-write` do not inspect text.
+  User-facing/stringified-error boundaries exist in `notion-cli`,
+  `notion-datasource-sync`, `tui-react`, and `restate-effect`, so they need
+  migration-time review before this difference is accepted at the boundary.
+
+## Gotchas
+
+- This is a rename trap: `Schema.Date` still exists in v4 but means a Date
+  instance schema, not the v3 ISO-string wire schema.
+- In effect `4.0.0-beta.102`, `Schema.Date` rejects invalid Date instances and
+  `Schema.DateFromString` decodes through that stricter Date schema. The beta.99
+  mapping `Schema.DateFromString.check(Schema.isDateValid())` is stale because
+  `Schema.isDateValid` is no longer exported.
+- Value-level assertions are insufficient because a decoded Date can look right
+  while the encoded wire contract changed.
+- The harness first used the wrong v4 port (`Schema.Date`) and reported 14
+  unexpected diffs, proving the oracle catches this migration hazard.
+
+## Codemod rule (mechanical patterns only)
+
+Where v3 `Schema.Date` is used as a wire schema, rewrite:
+
+```ts
+Schema.Date
+```
+
+to:
+
+```ts
+Schema.DateFromString
+```
+
+Do not apply this blindly to v3 `Schema.DateFromSelf` or v4 code that already
+expects a Date instance input.
+
+A site is a wire schema when its encoded input is JSON/string data crossing a
+process, persistence, API, file, config, test fixture, or `Schema.encode*` /
+`Schema.decodeUnknown*` boundary. Do not apply this rule when callers already
+pass Date instances directly and the encoded side is not part of the observable
+contract.

--- a/context/effect-4/recipes/scope-cache-lifetime.md
+++ b/context/effect-4/recipes/scope-cache-lifetime.md
@@ -1,0 +1,57 @@
+# Pattern: scope-cache-lifetime
+
+**Area:** Scope and finalizers  **Kind:** semantic  **Our usage:** cached and pooled clients,
+especially `effect-distributed-lock`.
+
+## v3
+
+```ts
+Effect.scoped(
+  Effect.gen(function*() {
+    const cached = yield* Effect.acquireRelease(acquireClient, releaseClient)
+    yield* Effect.scoped(handleRequest(cached))
+    yield* handleRequest(cached)
+  })
+)
+```
+
+## v4
+
+```ts
+Effect.scoped(
+  Effect.gen(function*() {
+    const cached = yield* Effect.acquireRelease(acquireClient, releaseClient)
+    yield* Effect.scoped(handleRequest(cached))
+    yield* handleRequest(cached)
+  })
+)
+```
+
+The source form is unchanged. The migration obligation is to preserve which scope owns acquisition.
+
+## Equivalence
+
+```sh
+bun run run:pattern scope-cache-lifetime
+```
+
+IDENTICAL. Both traces prove that the request finalizer runs when its request scope exits, the
+cached client remains usable by a second request, and the client releases exactly once when the
+server scope exits.
+
+## Intended differences (alignment register entries)
+
+- None.
+
+## Gotchas
+
+- Creating a cached client in the first request scope is invalid even if the cache itself has a
+  server lifetime: the cached value is finalized with the request and later lookups return a dead
+  resource.
+- Anchor both the cache and its lookup/acquisition effect to the long-lived owner scope.
+- Assert exact acquire/release order and cardinality. A value-level “second request succeeded” test
+  alone does not detect double release at teardown.
+
+## Codemod rule
+
+None. Scope ownership cannot be inferred mechanically from syntax.

--- a/context/effect-4/recipes/scope-cache-lifetime.md
+++ b/context/effect-4/recipes/scope-cache-lifetime.md
@@ -1,17 +1,17 @@
 # Pattern: scope-cache-lifetime
 
-**Area:** Scope and finalizers  **Kind:** semantic  **Our usage:** cached and pooled clients,
+**Area:** Scope and finalizers **Kind:** semantic **Our usage:** cached and pooled clients,
 especially `effect-distributed-lock`.
 
 ## v3
 
 ```ts
 Effect.scoped(
-  Effect.gen(function*() {
+  Effect.gen(function* () {
     const cached = yield* Effect.acquireRelease(acquireClient, releaseClient)
     yield* Effect.scoped(handleRequest(cached))
     yield* handleRequest(cached)
-  })
+  }),
 )
 ```
 
@@ -19,11 +19,11 @@ Effect.scoped(
 
 ```ts
 Effect.scoped(
-  Effect.gen(function*() {
+  Effect.gen(function* () {
     const cached = yield* Effect.acquireRelease(acquireClient, releaseClient)
     yield* Effect.scoped(handleRequest(cached))
     yield* handleRequest(cached)
-  })
+  }),
 )
 ```
 

--- a/context/effect-4/recipes/services-context.md
+++ b/context/effect-4/recipes/services-context.md
@@ -1,0 +1,67 @@
+# Pattern: services-context
+
+**Area:** Services and Layers  **Kind:** semantic  **Our usage:** service definitions occur in
+14 packages; the densest slices are `restate-effect`, `utils`, `megarepo`, and Notion packages.
+
+## v3
+
+```ts
+class Greeter extends Effect.Service<Greeter>()("Greeter", {
+  accessors: true,
+  dependencies: [Prefix.Default],
+  effect: Effect.gen(function*() {
+    const prefix = yield* Prefix
+    return { greet: (name: string) => Effect.succeed(`${prefix.value}, ${name}`) }
+  })
+}) {}
+
+const result = yield* Greeter.greet("Ada")
+const program = effect.pipe(Effect.provide(Greeter.Default))
+```
+
+## v4
+
+```ts
+class Greeter extends Context.Service<Greeter>()("Greeter", {
+  make: Effect.gen(function*() {
+    const prefix = yield* Prefix
+    return { greet: (name: string) => Effect.succeed(`${prefix.value}, ${name}`) }
+  })
+}) {
+  static readonly layer = Layer.effect(this, this.make).pipe(
+    Layer.provide(Prefix.layer)
+  )
+}
+
+const result = yield* Greeter.use((greeter) => greeter.greet("Ada"))
+const program = effect.pipe(Effect.provide(Greeter.layer))
+```
+
+## Equivalence
+
+```sh
+bun run run services-context
+```
+
+Result: **IDENTICAL**. The explicit v4 layer constructs the service once, resolves its dependency
+before both calls, and produces the same ordered results as v3's generated `.Default` layer.
+
+## Intended differences (alignment register entries)
+
+None. The migration should preserve construction count and resolution order.
+
+## Gotchas
+
+- v4 removes generated accessor proxies. Rewrite `Service.method(args)` to
+  `Service.use((service) => service.method(args))`, or preferably yield the service once.
+- `dependencies` and generated `.Default` layers are gone. Each dependency must be wired into an
+  explicit `Layer.effect(Service, Service.make)`.
+- Do not replace an old `.Default` layer with `Layer.effect` alone: that leaves constructor
+  dependencies in the layer input and shifts failures to integration.
+- Preserve layer sharing/freshness decisions separately; v4 layer memoization has its own
+  differential pattern.
+
+## Codemod rule
+
+No general codemod. The class header and option names are mechanical, but layer dependency wiring
+and accessor call-site rewrites are semantic and must be reviewed with the service's constructor.

--- a/context/effect-4/recipes/services-context.md
+++ b/context/effect-4/recipes/services-context.md
@@ -1,39 +1,37 @@
 # Pattern: services-context
 
-**Area:** Services and Layers  **Kind:** semantic  **Our usage:** service definitions occur in
+**Area:** Services and Layers **Kind:** semantic **Our usage:** service definitions occur in
 14 packages; the densest slices are `restate-effect`, `utils`, `megarepo`, and Notion packages.
 
 ## v3
 
 ```ts
-class Greeter extends Effect.Service<Greeter>()("Greeter", {
+class Greeter extends Effect.Service<Greeter>()('Greeter', {
   accessors: true,
   dependencies: [Prefix.Default],
-  effect: Effect.gen(function*() {
+  effect: Effect.gen(function* () {
     const prefix = yield* Prefix
     return { greet: (name: string) => Effect.succeed(`${prefix.value}, ${name}`) }
-  })
+  }),
 }) {}
 
-const result = yield* Greeter.greet("Ada")
+const result = yield * Greeter.greet('Ada')
 const program = effect.pipe(Effect.provide(Greeter.Default))
 ```
 
 ## v4
 
 ```ts
-class Greeter extends Context.Service<Greeter>()("Greeter", {
-  make: Effect.gen(function*() {
+class Greeter extends Context.Service<Greeter>()('Greeter', {
+  make: Effect.gen(function* () {
     const prefix = yield* Prefix
     return { greet: (name: string) => Effect.succeed(`${prefix.value}, ${name}`) }
-  })
+  }),
 }) {
-  static readonly layer = Layer.effect(this, this.make).pipe(
-    Layer.provide(Prefix.layer)
-  )
+  static readonly layer = Layer.effect(this, this.make).pipe(Layer.provide(Prefix.layer))
 }
 
-const result = yield* Greeter.use((greeter) => greeter.greet("Ada"))
+const result = yield * Greeter.use((greeter) => greeter.greet('Ada'))
 const program = effect.pipe(Effect.provide(Greeter.layer))
 ```
 

--- a/context/effect-4/recipes/shutdown-drain.md
+++ b/context/effect-4/recipes/shutdown-drain.md
@@ -1,0 +1,54 @@
+# Pattern: shutdown-drain
+
+**Area:** Runtime shutdown and interruption  **Kind:** semantic  **Our usage:** background pushers,
+queues, and single-owner drains.
+
+## v3
+
+```ts
+// Application-level close state plus an in-band sentinel:
+closed = true
+yield* Queue.offer(queue, End)
+```
+
+The sole consumer finishes the in-flight item and every item ahead of the sentinel. Producers
+reject offers after `closed` becomes true.
+
+## v4
+
+```ts
+const queue = yield* Queue.unbounded<Item, Cause.Done>()
+yield* Queue.end(queue)
+```
+
+`Queue.end` stops new offers while retaining queued items for the sole consumer to drain.
+
+## Equivalence
+
+```sh
+bun run run:pattern shutdown-drain
+```
+
+IDENTICAL. With item 1 held in flight, items 2 and 3 queued, and shutdown requested, both traces
+finish `1, 2, 3` in order, reject item 4, and report maximum handler concurrency of one.
+
+## Intended differences (alignment register entries)
+
+- None in the observable drain contract. The v4 queue has a first-class end state, replacing the
+  v3 application-level sentinel and close flag.
+
+## Gotchas
+
+- Do not interrupt the sole consumer in a scope finalizer and then start a second “drain” consumer.
+  That loses ownership and can reorder or duplicate work.
+- `Queue.shutdown` is destructive cancellation; `Queue.end` is graceful completion. Use the latter
+  for a drain contract.
+- The close/end transition must be uninterruptible with respect to ownership handoff. Failure of a
+  queued operation must fail teardown rather than silently report successful shutdown.
+- Keep deterministic barriers around “first item in flight” and “remaining items queued”; sleeps do
+  not prove this boundary.
+
+## Codemod rule
+
+None. Replacing an application sentinel with `Queue.end` requires proving producer rejection,
+consumer ownership, failure propagation, and ordering.

--- a/context/effect-4/recipes/shutdown-drain.md
+++ b/context/effect-4/recipes/shutdown-drain.md
@@ -1,6 +1,6 @@
 # Pattern: shutdown-drain
 
-**Area:** Runtime shutdown and interruption  **Kind:** semantic  **Our usage:** background pushers,
+**Area:** Runtime shutdown and interruption **Kind:** semantic **Our usage:** background pushers,
 queues, and single-owner drains.
 
 ## v3
@@ -8,7 +8,7 @@ queues, and single-owner drains.
 ```ts
 // Application-level close state plus an in-band sentinel:
 closed = true
-yield* Queue.offer(queue, End)
+yield * Queue.offer(queue, End)
 ```
 
 The sole consumer finishes the in-flight item and every item ahead of the sentinel. Producers
@@ -17,8 +17,8 @@ reject offers after `closed` becomes true.
 ## v4
 
 ```ts
-const queue = yield* Queue.unbounded<Item, Cause.Done>()
-yield* Queue.end(queue)
+const queue = yield * Queue.unbounded<Item, Cause.Done>()
+yield * Queue.end(queue)
 ```
 
 `Queue.end` stops new offers while retaining queued items for the sole consumer to drain.

--- a/context/effect-4/recipes/terminal-prompt-pty.md
+++ b/context/effect-4/recipes/terminal-prompt-pty.md
@@ -1,0 +1,69 @@
+# Pattern: terminal-prompt-pty
+
+**Area:** Platform / Terminal / CLI Prompt  **Kind:** semantic  **Our usage:** `tui-react` and
+`pty-effect` depend on raw-mode lifecycle, key decoding, resize behavior, interrupts, and terminal
+control bytes.
+
+## v3
+
+```ts
+import { Prompt } from "@effect/cli"
+import { Terminal } from "@effect/platform"
+import { NodeContext } from "@effect/platform-node"
+```
+
+## v4
+
+```ts
+import { Terminal } from "effect"
+import { Prompt } from "effect/unstable/cli"
+import { NodeServices } from "@effect/platform-node"
+```
+
+## Equivalence
+
+This probe genuinely requires an interactive terminal. Each side is run under util-linux
+`script`, which allocates a pseudo-terminal; piped stdin is not an adequate substitute.
+
+```sh
+bun run run terminal-prompt-pty
+```
+
+Result: **ALLOWLISTED, 2 exact paths, 0 unexpected**. Five same-major repetitions were stable on
+each side.
+
+Identical semantic observations:
+
+- stdin transitions cooked -> raw -> cooked (`false`, `true`, `false`);
+- `a`, Up (`ESC [ A`), standalone Escape, and Ctrl-C decode to the same input/key/modifier fields;
+- a real PTY resize plus `SIGWINCH` changes Terminal dimensions from 80x24 to 101x37;
+- Effect interruption restores cooked mode;
+- Down + Enter selects `beta`;
+- Ctrl-C quits Prompt, rings the bell, restores cursor visibility, and restores cooked mode.
+
+The two allowlisted paths preserve exact PTY transcript bytes and expose a rendering difference:
+Prompt selection is 452 bytes in v3 versus 356 in v4; interrupted Prompt is 136 versus 104. v4
+uses shorter ANSI SGR/reset sequences. Visible text and semantic cleanup are unchanged, but encoded
+bytes are not.
+
+## Intended differences (alignment register entries)
+
+- `prompt-pty-ansi-rendering`: keep this as a migration review item, not a blanket accepted
+  difference. Raw-byte snapshots, parsers, and inline-renderer cleanup may depend on the sequence
+  shape. A package may accept the shorter v4 rendering only after its PTY and visual contracts pass.
+
+## Gotchas
+
+- Never test `Terminal` / `Prompt` behavior through ordinary pipes: `stdin.isTTY`, raw mode,
+  cursor control, and resize behavior would all be bypassed.
+- Resize requires changing PTY dimensions and delivering `SIGWINCH`; changing dimensions alone
+  can leave Node/Bun's cached `stdout.columns` and `stdout.rows` stale.
+- v4 removes `Terminal.isTTY` from the service interface. The runtime TTY observation remains
+  available from the platform stream, but call sites using the service member need semantic repair.
+- `QuitException` becomes `QuitError`; the probe normalizes the class name to the shared `Quit`
+  behavior while preserving exact output bytes.
+
+## Codemod rule
+
+Prompt and Terminal import moves are mechanical only after the owning package's real-PTY replay
+passes. Do not rebaseline ANSI snapshots or replace raw-mode lifecycle code mechanically.

--- a/context/effect-4/recipes/terminal-prompt-pty.md
+++ b/context/effect-4/recipes/terminal-prompt-pty.md
@@ -1,23 +1,23 @@
 # Pattern: terminal-prompt-pty
 
-**Area:** Platform / Terminal / CLI Prompt  **Kind:** semantic  **Our usage:** `tui-react` and
+**Area:** Platform / Terminal / CLI Prompt **Kind:** semantic **Our usage:** `tui-react` and
 `pty-effect` depend on raw-mode lifecycle, key decoding, resize behavior, interrupts, and terminal
 control bytes.
 
 ## v3
 
 ```ts
-import { Prompt } from "@effect/cli"
-import { Terminal } from "@effect/platform"
-import { NodeContext } from "@effect/platform-node"
+import { Prompt } from '@effect/cli'
+import { Terminal } from '@effect/platform'
+import { NodeContext } from '@effect/platform-node'
 ```
 
 ## v4
 
 ```ts
-import { Terminal } from "effect"
-import { Prompt } from "effect/unstable/cli"
-import { NodeServices } from "@effect/platform-node"
+import { Terminal } from 'effect'
+import { Prompt } from 'effect/unstable/cli'
+import { NodeServices } from '@effect/platform-node'
 ```
 
 ## Equivalence

--- a/context/effect-4/recipes/tracer-span-shape.md
+++ b/context/effect-4/recipes/tracer-span-shape.md
@@ -1,0 +1,61 @@
+# Pattern: tracer-span-shape
+
+**Area:** Observability boundary  **Kind:** semantic CI gate  **Our usage:** `otel-contract`,
+OpenTelemetry integration, and published weaver semantic conventions.
+
+## v3
+
+```ts
+import * as OtelTracer from "@effect/opentelemetry/Tracer"
+
+const tracerService = Layer.succeed(OtelTracer.OtelTracer, otelTracer)
+const tracing = OtelTracer.layerWithoutOtelTracer.pipe(Layer.provideMerge(tracerService))
+program.pipe(Effect.provide(tracing))
+```
+
+## v4
+
+```ts
+import * as OtelTracer from "@effect/opentelemetry/OtelTracer"
+
+const tracerService = Layer.succeed(OtelTracer.OtelTracer, otelTracer)
+const tracing = OtelTracer.layerWithoutOtelTracer.pipe(Layer.provideMerge(tracerService))
+program.pipe(Effect.provide(tracing))
+```
+
+## Equivalence
+
+```sh
+bun run run:pattern tracer-span-shape
+```
+
+IDENTICAL. Under a canonical non-recording OpenTelemetry tracer, both majors complete successfully,
+report `isRecording() === false`, and export no spans. Under an SDK recording tracer, both export
+the same ordered child/parent spans, contract attributes, parent relation, and status.
+
+This is a durable contract gate. It should snapshot normalized span names, contract attributes,
+nesting, and status under both recording and non-recording providers. Any mismatch must fail CI.
+
+## Intended differences (alignment register entries)
+
+- None.
+
+## Gotchas
+
+- Never read SDK-private fields such as `_duration` or `_performanceStartTime`. Canonical no-op
+  spans omit them. Measure application timing from a local monotonic clock.
+- A no-op span must use OpenTelemetry's canonical invalid span context. Do not fabricate trace or
+  span IDs.
+- A test that only installs an SDK provider misses the no-provider production boundary.
+- Normalize nondeterministic IDs and timing, but do not normalize away span names, parent
+  relationships, status, or contract attributes.
+- The module rename is `@effect/opentelemetry/Tracer` to `@effect/opentelemetry/OtelTracer`.
+
+## Codemod rule
+
+```text
+import * as Tracer from "@effect/opentelemetry/Tracer"
+-> import * as OtelTracer from "@effect/opentelemetry/OtelTracer"
+```
+
+Review identifier aliases and service-layer construction after the import rewrite.

--- a/context/effect-4/recipes/tracer-span-shape.md
+++ b/context/effect-4/recipes/tracer-span-shape.md
@@ -1,12 +1,12 @@
 # Pattern: tracer-span-shape
 
-**Area:** Observability boundary  **Kind:** semantic CI gate  **Our usage:** `otel-contract`,
+**Area:** Observability boundary **Kind:** semantic CI gate **Our usage:** `otel-contract`,
 OpenTelemetry integration, and published weaver semantic conventions.
 
 ## v3
 
 ```ts
-import * as OtelTracer from "@effect/opentelemetry/Tracer"
+import * as OtelTracer from '@effect/opentelemetry/Tracer'
 
 const tracerService = Layer.succeed(OtelTracer.OtelTracer, otelTracer)
 const tracing = OtelTracer.layerWithoutOtelTracer.pipe(Layer.provideMerge(tracerService))
@@ -16,7 +16,7 @@ program.pipe(Effect.provide(tracing))
 ## v4
 
 ```ts
-import * as OtelTracer from "@effect/opentelemetry/OtelTracer"
+import * as OtelTracer from '@effect/opentelemetry/OtelTracer'
 
 const tracerService = Layer.succeed(OtelTracer.OtelTracer, otelTracer)
 const tracing = OtelTracer.layerWithoutOtelTracer.pipe(Layer.provideMerge(tracerService))

--- a/context/effect-4/recipes/vitest-collection.md
+++ b/context/effect-4/recipes/vitest-collection.md
@@ -1,0 +1,58 @@
+# Pattern: vitest-collection
+
+**Area:** Testing  **Kind:** semantic CI gate  **Our usage:** 63 `@effect/vitest` import sites and
+Schema-derived property tests.
+
+## v3
+
+```ts
+live.prop("record", { count: Schema.Int, payload: Payload }, ({ count, payload }) =>
+  Effect.sync(() => assertPayload(count, payload)))
+```
+
+## v4
+
+```ts
+live.prop("record", { count: Schema.Int, payload: Payload }, ({ count, payload }) =>
+  Effect.sync(() => assertPayload(count, payload)))
+```
+
+At beta.99 the public form is unchanged; `@effect/vitest` normalizes record values with
+`Schema.toArbitrary`.
+
+## Equivalence
+
+```sh
+bun run run:pattern vitest-collection
+```
+
+IDENTICAL. Both majors collect one array-form and one record-form property test, then execute all
+four schema shapes: primitive integer, primitive string, struct, and optional struct field. The
+normalized report is two suites/tests passed with no collection failure.
+
+The gate must execute Vitest as a child process from a cold invocation. Calling a property helper
+inside an already-collected test cannot detect collection-time failures.
+
+## Intended differences (alignment register entries)
+
+- None. The beta.98 record-form regression is fixed in target beta.99.
+
+## Gotchas
+
+- Keep both array and record forms; the upstream regression affected only record normalization.
+- Assert process exit status. A CI cell that prints the collection error but exits zero is not a
+  gate.
+- `@effect/vitest` remains a separate package at the unified Effect version; core test primitives
+  move to direct `effect/testing/*` modules.
+- Plain synchronous `prop` and Effectful `live.prop` have different Schema support; use the API
+  actually present in effect-utils rather than assuming they normalize identically.
+
+## Codemod rule
+
+For test primitives only:
+
+```text
+effect/FastCheck -> effect/testing/FastCheck
+```
+
+Keep runner imports from `@effect/vitest`; do not rewrite them to `effect/testing`.

--- a/context/effect-4/recipes/vitest-collection.md
+++ b/context/effect-4/recipes/vitest-collection.md
@@ -1,20 +1,22 @@
 # Pattern: vitest-collection
 
-**Area:** Testing  **Kind:** semantic CI gate  **Our usage:** 63 `@effect/vitest` import sites and
+**Area:** Testing **Kind:** semantic CI gate **Our usage:** 63 `@effect/vitest` import sites and
 Schema-derived property tests.
 
 ## v3
 
 ```ts
-live.prop("record", { count: Schema.Int, payload: Payload }, ({ count, payload }) =>
-  Effect.sync(() => assertPayload(count, payload)))
+live.prop('record', { count: Schema.Int, payload: Payload }, ({ count, payload }) =>
+  Effect.sync(() => assertPayload(count, payload)),
+)
 ```
 
 ## v4
 
 ```ts
-live.prop("record", { count: Schema.Int, payload: Payload }, ({ count, payload }) =>
-  Effect.sync(() => assertPayload(count, payload)))
+live.prop('record', { count: Schema.Int, payload: Payload }, ({ count, payload }) =>
+  Effect.sync(() => assertPayload(count, payload)),
+)
 ```
 
 At beta.99 the public form is unchanged; `@effect/vitest` normalizes record values with

--- a/context/effect-4/register-verification.md
+++ b/context/effect-4/register-verification.md
@@ -8,21 +8,20 @@ An independent pass attacked every entry in `alignment-register.md`, trying to *
 user-facing, durable, or cross-process boundary.
 
 An allowlist entry claims a difference does not matter. Several entries carried caveats —
-*"allow only where callers do not snapshot the parser message"*, *"accept only for atomically
-upgraded internal peers"* — that had never been checked against this repository. This pass
+_"allow only where callers do not snapshot the parser message"_, _"accept only for atomically
+upgraded internal peers"_ — that had never been checked against this repository. This pass
 checked them.
 
 **Result: 10 UPHELD, 2 REFUTED-PARTIAL.**
 
 ## Must reclassify before migration starts
 
-| entry | why it is not an accepted difference |
-| --- | --- |
+| entry                          | why it is not an accepted difference                                                               |
+| ------------------------------ | -------------------------------------------------------------------------------------------------- |
 | `rpc-failure-cause-wire-shape` | browser/server HTTP protocol, independent deploys, no version field; **both** cross-decodes reject |
-| `schema-date-invalid-message` | parser text embedded verbatim in an HTTP 400 payload, making it an API surface |
+| `schema-date-invalid-message`  | parser text embedded verbatim in an HTTP 400 payload, making it an API surface                     |
 
 ---
-
 
 Adversarial verification of every entry in `alignment-register.md`. `UPHELD`
 means the repository search found no user-facing, durable, or cross-process
@@ -312,20 +311,20 @@ No process currently relies on `Effect.never`'s incidental v3 timer handle.
 
 ## Summary
 
-| Entry | Verdict | Boundary found |
-| --- | --- | --- |
-| `schema-date` | UPHELD | Exact ISO durable bytes preserved by proposed mapping |
-| `schema-date-invalid-message` | REFUTED-PARTIAL | Restate caller-facing HTTP error text |
-| `fork-defaults` | UPHELD | None |
-| `fork-copied-options` | UPHELD | None; negative control remains valid |
-| `equality-structural-default` | UPHELD | None |
-| `equality-nan` | UPHELD | None |
-| `equality-by-reference-opt-out` | UPHELD | None |
-| `layer-memoization-default` | UPHELD | None matching duplicate nested provide |
-| `layer-memoization-freshness-opt-outs` | UPHELD | No justified opt-out site |
-| `rpc-failure-cause-wire-shape` | REFUTED-PARTIAL | HTTP RPC and SSR browser/server protocol |
-| `browser-testing-barrel` | UPHELD | No browser testing-barrel contamination |
-| `effect-never-idle-timer` | UPHELD | None |
+| Entry                                  | Verdict         | Boundary found                                        |
+| -------------------------------------- | --------------- | ----------------------------------------------------- |
+| `schema-date`                          | UPHELD          | Exact ISO durable bytes preserved by proposed mapping |
+| `schema-date-invalid-message`          | REFUTED-PARTIAL | Restate caller-facing HTTP error text                 |
+| `fork-defaults`                        | UPHELD          | None                                                  |
+| `fork-copied-options`                  | UPHELD          | None; negative control remains valid                  |
+| `equality-structural-default`          | UPHELD          | None                                                  |
+| `equality-nan`                         | UPHELD          | None                                                  |
+| `equality-by-reference-opt-out`        | UPHELD          | None                                                  |
+| `layer-memoization-default`            | UPHELD          | None matching duplicate nested provide                |
+| `layer-memoization-freshness-opt-outs` | UPHELD          | No justified opt-out site                             |
+| `rpc-failure-cause-wire-shape`         | REFUTED-PARTIAL | HTTP RPC and SSR browser/server protocol              |
+| `browser-testing-barrel`               | UPHELD          | No browser testing-barrel contamination               |
+| `effect-never-idle-timer`              | UPHELD          | None                                                  |
 
 ## Entries that must be reclassified before migration starts
 

--- a/context/effect-4/register-verification.md
+++ b/context/effect-4/register-verification.md
@@ -1,0 +1,338 @@
+<!-- Findings authored by the verification pass; transcribed here because the verifier role
+     is not permitted to author under context/. Content is verbatim below the summary. -->
+
+# Alignment register — adversarial verification
+
+An independent pass attacked every entry in `alignment-register.md`, trying to **refute** each
+"accepted difference" by finding a real call site where the v3/v4 difference is observable at a
+user-facing, durable, or cross-process boundary.
+
+An allowlist entry claims a difference does not matter. Several entries carried caveats —
+*"allow only where callers do not snapshot the parser message"*, *"accept only for atomically
+upgraded internal peers"* — that had never been checked against this repository. This pass
+checked them.
+
+**Result: 10 UPHELD, 2 REFUTED-PARTIAL.**
+
+## Must reclassify before migration starts
+
+| entry | why it is not an accepted difference |
+| --- | --- |
+| `rpc-failure-cause-wire-shape` | browser/server HTTP protocol, independent deploys, no version field; **both** cross-decodes reject |
+| `schema-date-invalid-message` | parser text embedded verbatim in an HTTP 400 payload, making it an API surface |
+
+---
+
+
+Adversarial verification of every entry in `alignment-register.md`. `UPHELD`
+means the repository search found no user-facing, durable, or cross-process
+counterexample. It does not waive the migration tests named below.
+
+## schema-date
+
+**Verdict:** UPHELD
+
+**Search performed:** `rg -n 'Schema\.Date\b|Schema\.DateFromString|DateFromSelf|DateTimeUtc' packages`;
+read every non-story `Schema.Date` site and the Restate serde round-trip tests.
+
+**Evidence:** `packages/@overeng/restate-effect/src/schema/Serde.test.ts:22-35`
+asserts that the v3 `Schema.Date` decoded `Date` encodes to the exact ISO wire
+string and round-trips. The property test at
+`packages/@overeng/restate-effect/src/schema/Serde.test.ts:118-129` exercises
+the same transformed schema through the generic durable serde. Production
+Notion value schemas already use decoded-date schemas such as
+`packages/@overeng/notion-effect-schema/src/properties/date.ts:142-151`.
+
+No accepted-input or encoded-byte counterexample was found. Keep the proposed
+`Schema.DateFromString.check(Schema.isDateValid())` mapping and the exact-byte
+Restate serde test.
+
+## schema-date-invalid-message
+
+**Verdict:** REFUTED-PARTIAL
+
+**Search performed:** Searched the four named snapshot suites for
+`toMatchSnapshot`, `toMatchInlineSnapshot`, `ParseError`, `SchemaError`,
+`TreeFormatter`, and `SetError`; searched production schema decoders followed
+by `String(error)`, `.message`, JSON error output, or terminal transport.
+
+**Evidence:** None of the named snapshots captures Date parser text:
+`packages/@overeng/notion-effect-schema/src/properties/descriptor.unit.test.ts:98-122`
+asserts only failure shape; the snapshots in
+`packages/@overeng/notion-cli/src/codegen.unit.test.ts:142-981` are generated
+code; and `packages/@overeng/tui-react/test/unit/exit-rendering.test.tsx:119-653`
+captures renderer output for explicitly constructed errors.
+
+The caveat is nevertheless observable. Restate's generic serde governs handler
+input/output, state, durable step results, awakeables, and durable promises
+(`packages/@overeng/restate-effect/src/schema/Serde.ts:9-25`). For an ingress
+decode failure it embeds `ParseResult.TreeFormatter.formatErrorSync` verbatim
+in a caller-facing `TerminalError(400)`
+(`packages/@overeng/restate-effect/src/schema/Serde.ts:126-144`). That serde is
+installed on public ingress calls and handler inputs
+(`packages/@overeng/restate-effect/src/clients/InvocationPolicy.ts:107-126`,
+`packages/@overeng/restate-effect/src/endpoint/Endpoint.ts:267`). A contract
+using the supported transformed Date schema therefore exposes the changed
+parser text over HTTP even though no repository snapshot currently pins it.
+
+Before migration, the HTTP 400 message contains Effect 3's parse-tree rendering
+after the stable prefix `serde decode failed: `. After migration the same
+invalid bytes produce Effect 4's `SchemaError(...)` rendering after that prefix.
+Status and classification stay 400, but the response message payload changes;
+clients, logs, support tooling, or assertions that display/store it observe the
+difference.
+
+**If refuted:** This is a user-facing wire error-message change. Define a stable
+Restate decode-error envelope/formatter owned by `restate-effect` (stable code,
+schema identifier/path, and migration-independent summary) rather than sending
+Effect's parser rendering. Add an ingress test with invalid Date input that
+asserts the stable HTTP error body on both majors. Internal corrupt-journal
+defects may retain framework diagnostics because they are not caller contracts.
+
+## fork-defaults
+
+**Verdict:** UPHELD
+
+**Search performed:** `rg -n 'Effect\.fork\b|Effect\.forkScoped|Effect\.forkDaemon'`
+over `tui-react`, `notion-md`, `restate-effect`, `utils`, `pty-effect`, and
+`agent-session-ingest`; read every production hit where ordering could matter.
+
+**Evidence:** The strongest ordering-sensitive site deliberately forks the URL
+wait before executing the navigation action
+(`packages/@overeng/utils/src/node/playwright/page.ts:216-235`). TUI input tests
+explicitly `yieldNow` before injecting input
+(`packages/@overeng/tui-react/test/unit/terminal-input.test.ts:42-56`).
+Production watch loops fork producers and then block on their queue
+(`packages/@overeng/notion-md/src/cli-program.ts:348-378`,
+`packages/@overeng/notion-md/src/batch.ts:460-519`). None asserts or exposes a
+parent/child trace ordering beyond the default case proven equal by the
+prototype.
+
+## fork-copied-options
+
+**Verdict:** UPHELD
+
+**Search performed:** The fork search above plus searches for
+`startImmediately`, `uninterruptible`, and fork option objects in all packages.
+
+**Evidence:** No current call site supplies either copied option. The
+ordering-sensitive Playwright helper at
+`packages/@overeng/utils/src/node/playwright/page.ts:216-235` is a concrete
+reason not to introduce an unreviewed scheduling change.
+
+The entry is correctly a negative control: migrate defaults mechanically and
+require a call-site-specific behavioral test before adding immediate startup.
+
+## equality-structural-default
+
+**Verdict:** UPHELD
+
+**Search performed:** `rg -n '\b(Equal|HashSet|HashMap|MutableHashMap|MutableHashSet)\b' packages`;
+then searched `dedupe`, `distinct`, `cacheKey`, `memo`, and membership sites,
+distinguishing native JavaScript `Map`/`Set` from Effect collections.
+
+**Evidence:** No package uses `Equal.equals`, `HashSet`, or object-keyed Effect
+`HashMap`. The only production Effect `HashMap` values are logger annotations:
+`packages/@overeng/utils/src/browser/BroadcastLogger.ts:76-188`,
+`packages/@overeng/utils/src/node/FileLogger.ts:9-232`, and
+`packages/@overeng/utils/src/node/cmd.ts:516`; their keys are log annotation
+strings, not identity-sensitive domain objects. The many Notion
+dedup/membership sites use native key strings and native `Set`/`Map`, whose
+semantics do not change with Effect 4.
+
+No real site relying on reference inequality was found.
+
+## equality-nan
+
+**Verdict:** UPHELD
+
+**Search performed:** `rg -n '\bNaN\b|Number\.isNaN|isNaN\(' packages`, then
+cross-checked all results against the Effect equality/collection search.
+
+**Evidence:** No `NaN` reaches Effect equality or an Effect collection. The
+browser number field uses `NaN` only as a React Aria empty-value sentinel and
+immediately converts it back to `undefined`
+(`packages/@overeng/effect-schema-form-aria/src/components/NumberField.tsx:97-98`).
+Other production sites branch with `Number.isNaN`; Restate's durable property
+tests explicitly restrict JSON numbers to `Schema.Finite`
+(`packages/@overeng/restate-effect/src/schema/Serde.test.ts:131-145`).
+
+## equality-by-reference-opt-out
+
+**Verdict:** UPHELD
+
+**Search performed:** Same Effect equality/collection inventory as the two
+preceding entries, plus `byReference` / `byReferenceUnsafe`.
+
+**Evidence:** No current identity-sensitive Effect collection site and no
+current opt-out call were found. There is therefore no justified migration
+site for either API. Keep this entry as a narrowly scoped escape hatch; do not
+apply it speculatively.
+
+## layer-memoization-default
+
+**Verdict:** UPHELD
+
+**Search performed:** Searched all packages for `Effect.provide`, `Layer.effect`,
+`Layer.scoped`, `Layer.unwrap*`, `Layer.fresh`, and `acquireRelease`; inspected
+stateful file logger, browser logger, Notion gateway, Restate endpoint, test
+layers, and repeated layer identifiers. Also ran a sibling-provide probe because
+`genie` provides one lock layer to two sequential effects: both v3 and v4 built
+twice; the prototype difference requires duplicate nested provides.
+
+**Evidence:** Observable resources exist, for example the acquired file
+descriptor in `packages/@overeng/utils/src/node/FileLogger.ts:55-75`, the
+`BroadcastChannel` in
+`packages/@overeng/utils/src/browser/BroadcastLogger.ts:210-222`, and the
+throttled Notion client in
+`packages/@overeng/notion-datasource-sync/src/gateway/notion.ts:1589-1615`.
+No production/test call wraps the same required service in two nested
+`Effect.provide` calls with the same stateful layer. Sequential sibling provides
+such as `packages/@overeng/genie/src/core/generation.ts:740-760` do not exhibit
+the v4 sharing behavior.
+
+No fresh-construction boundary matching the prototype's changed topology was
+found.
+
+## layer-memoization-freshness-opt-outs
+
+**Verdict:** UPHELD
+
+**Search performed:** Same layer inventory as above, specifically searching
+`Layer.fresh`, `{ local: true }`, resource factories, and per-test/per-request
+layers.
+
+**Evidence:** No current `Layer.fresh`/local-memo call and no duplicate nested
+provide requiring one was found. The existing tests generally construct a new
+fake layer per test or provide one layer once around the test effect. Apply an
+opt-out only if a migrated call site first demonstrates the v4 construction
+count differs.
+
+## rpc-failure-cause-wire-shape
+
+**Verdict:** REFUTED-PARTIAL
+
+**Search performed:** Searched all source for `@effect/rpc`, `RpcClient`,
+`RpcServer`, `Schema.Exit`, `cause`, serde/persistence, and replay. Read the
+Effect RPC HTTP client/server and TanStack SSR exit paths. Inspected beta.99
+`RpcMessage`, `RpcClient`, and serialization source for a protocol version.
+Ran the prototype plus direct cross-decodes of each encoded failure through the
+opposite major's exit schema.
+
+**Evidence:** Restate is not affected by this particular envelope. Its durable
+boundary schema-encodes application values directly to JSON
+(`packages/@overeng/restate-effect/src/schema/Serde.ts:9-13,80-103`), and its
+error transport uses a separate tagged-error JSON body
+(`packages/@overeng/restate-effect/src/error/error-transport.test.ts:34-75`).
+No `@effect/rpc` import exists in `restate-effect`, `pty-effect`, or
+`agent-session-ingest`.
+
+The actual cross-process counterexample is `effect-rpc-tanstack`. Its public
+client accepts an arbitrary URL and constructs an HTTP RPC protocol
+(`packages/@overeng/effect-rpc-tanstack/src/client.ts:14-30,49-79`); its server
+constructs the matching web handler
+(`packages/@overeng/effect-rpc-tanstack/src/server.ts:75-100`). The browser and
+server can be deployed independently, and cached browser JS makes atomic
+upgrade unenforceable. The package also has a second server-to-browser Cause
+boundary: route loaders encode `Schema.Exit` for SSR and browser code decodes
+it (`packages/@overeng/effect-rpc-tanstack/src/router.ts:15-41,222-235`).
+
+Beta.99's encoded request/response types have no version or negotiation field
+(`effect@4.0.0-beta.99/src/unstable/rpc/RpcMessage.ts:60-69,256-286`). Direct
+cross-decode results were symmetric: v3 rejected the v4 cause array and v4
+rejected the v3 cause object (`SchemaError(Expected array, got {...})`).
+Therefore neither an unadapted server-first nor client-first rollout preserves
+failure handling.
+
+**If refuted:** Add an explicit protocol marker; Effect beta.99 does not supply
+one. The object-vs-array difference is mechanically detectable, so upgraded
+clients/servers can normalize both forms at the serialization boundary, but a
+client-only shim cannot repair cached v3 clients. Deploy a compatibility server
+first: route by a versioned URL or request header, default missing markers to
+v3-shaped failures, and emit v4 arrays only to marked v4 clients. Then deploy v4
+clients that send the marker and defensively accept both forms; retire v3 only
+after the browser-cache horizon and compatibility telemetry. Apply the same
+versioning/dual-decode rule to SSR `ExitEncoded`.
+
+`effect-rpc-tanstack` may stay in Wave 0 only if Wave 0 means repository-graph
+independence and this protocol/deployment gate is explicit. It is independently
+mergeable but not independently deploy-safe.
+
+## browser-testing-barrel
+
+**Verdict:** UPHELD
+
+**Search performed:** Ran
+`rg -n --glob '*.{ts,tsx,mts,cts}' 'effect/testing|node:assert|from .*(test|Test)|export \* from|export \{.*\} from'`
+over `effect-react`, `notion-react`, `tui-react`, `react-inspector`,
+`effect-schema-form`, `effect-schema-form-aria`, and `utils`. Then read every
+`exportEntry(..., { environment: 'browser' })` in those packages' generated
+sources and recursively followed its source barrel imports/re-exports. This
+would have found a direct Effect testing import, a local test-helper re-export,
+or a transitive Node-builtin import from any browser facade. A repository-wide
+`rg -n 'effect/testing' packages` was the final backstop.
+
+**Evidence:** No browser entry imports or re-exports Effect's testing barrel.
+The browser exports are explicitly identified in the package generators:
+`packages/@overeng/effect-react/package.json.genie.ts:45-47`,
+`packages/@overeng/notion-react/package.json.genie.ts:57-69`,
+`packages/@overeng/react-inspector/package.json.genie.ts:75-76`,
+`packages/@overeng/effect-schema-form/package.json.genie.ts:28-29`,
+`packages/@overeng/effect-schema-form-aria/package.json.genie.ts:48-49`, and
+`packages/@overeng/utils/package.json.genie.ts:61-80`.
+
+`tui-react` does re-export its own test helpers from the main barrel
+(`packages/@overeng/tui-react/src/mod.tsx:233-256`), but that export is
+explicitly Node-only (`packages/@overeng/tui-react/package.json.genie.ts:79-83`)
+and the helper imports normal `effect`, not `effect/testing`
+(`packages/@overeng/tui-react/src/effect/testing.tsx:22-35`). It is cleanup
+debt under the proposed facade rule, not a browser `node:assert` contamination.
+
+## effect-never-idle-timer
+
+**Verdict:** UPHELD
+
+**Search performed:** Searched `pty-effect`, `restate-effect`,
+`agent-session-ingest`, `tui-react`, `notion-md`, and
+`notion-datasource-sync` for `Effect.never`, `runFork`, `runPromise`, and
+`NodeRuntime.runMain`; read every production `Effect.never` hit and long-lived
+entry point.
+
+**Evidence:** There is no production `Effect.never` use in the named long-lived
+packages. The hits are test-only suspension controls, e.g.
+`packages/@overeng/tui-react/test/unit/exit-rendering.test.tsx:399-409` and
+`packages/@overeng/notion-datasource-sync/src/e2e/daemon.e2e.test.ts:2048-2076`.
+Long-lived CLIs use the platform runner
+(`packages/@overeng/notion-md/src/cli.ts:34-54`,
+`packages/@overeng/notion-datasource-sync/src/cli/main.ts:3227-3312`), and the
+Restate endpoint is a launched scoped server layer
+(`packages/@overeng/restate-effect/src/endpoint/Endpoint.ts:849-876`).
+
+No process currently relies on `Effect.never`'s incidental v3 timer handle.
+
+## Summary
+
+| Entry | Verdict | Boundary found |
+| --- | --- | --- |
+| `schema-date` | UPHELD | Exact ISO durable bytes preserved by proposed mapping |
+| `schema-date-invalid-message` | REFUTED-PARTIAL | Restate caller-facing HTTP error text |
+| `fork-defaults` | UPHELD | None |
+| `fork-copied-options` | UPHELD | None; negative control remains valid |
+| `equality-structural-default` | UPHELD | None |
+| `equality-nan` | UPHELD | None |
+| `equality-by-reference-opt-out` | UPHELD | None |
+| `layer-memoization-default` | UPHELD | None matching duplicate nested provide |
+| `layer-memoization-freshness-opt-outs` | UPHELD | No justified opt-out site |
+| `rpc-failure-cause-wire-shape` | REFUTED-PARTIAL | HTTP RPC and SSR browser/server protocol |
+| `browser-testing-barrel` | UPHELD | No browser testing-barrel contamination |
+| `effect-never-idle-timer` | UPHELD | None |
+
+## Entries that must be reclassified before migration starts
+
+- `rpc-failure-cause-wire-shape` — from accepted-for-atomic-peers to a mandatory
+  versioned compatibility and deployment gate for `effect-rpc-tanstack`,
+  including its SSR Exit boundary. Atomic browser/server upgrade is impossible
+  to guarantee.
+- `schema-date-invalid-message` — from an unresolved allowlist caveat to a
+  required stable caller-facing error contract at Restate ingress. The lack of
+  an existing snapshot does not make raw framework parser text unobservable.

--- a/context/effect-4/tsgo-compatibility.md
+++ b/context/effect-4/tsgo-compatibility.md
@@ -1,0 +1,115 @@
+# tsgo probe findings
+
+Identity: `org.schickling.eu.effect-4.tsgo`
+
+## Verdict
+
+VERIFIED: the current Nix-pinned `effect-tsgo` is sufficient for the Effect 4 migration blocker.
+
+| Question | Answer | Evidence |
+| --- | --- | --- |
+| Current pin handles `effect@4.0.0-beta.102` module layout? | Yes | Probe dependency is `effect` `4.0.0-beta.102`; package exports include `effect/testing`, `effect/unstable/cli`, `effect/unstable/http`, `effect/unstable/httpapi`, `effect/unstable/observability`, `effect/unstable/process`, `effect/unstable/rpc`, plus wildcard root subpaths such as `effect/Schema` and `effect/Result`. See `tmp/tsgo-probe/q1/node_modules/effect/package.json:2-4`, `:29-55`; probe imports at `tmp/tsgo-probe/q1/src/index.ts:1-10`. |
+| Current pin emits Effect diagnostics under v4? | Yes | Hardened probe emitted warning, suggestion, and error diagnostics under `effect@4.0.0-beta.102`; see command/output below. |
+| Gate degraded to errors-only? | No | Warning-only and suggestion-only category probes each exited `2`, proving both categories still affect `tsgo --build` exit code when the repo-equivalent ignore flags are `false`. |
+| Minimum viable tsgo revision | Current pin suffices | Locked rev remains viable: `flake.lock:98-104` pins `Effect-TS/tsgo` `8d34c0a2d603a4b963b85ffccd4322c0ef74f472`; evaluated current attr was `/nix/store/m59qqc61pdii7xfjnpfzjas5fx0z2ggx-effect-tsgo`, version `7.0.0-dev+effect-tsgo.0.14.5`. |
+| Effect 3 advisory delta from newer tsgo | NOT MEASURED | De-scoped by orchestrator after Q1: since current pin works, a tsgo bump is not on the Effect 4 critical path. No candidate tsgo build and no whole-repo Effect 3 typecheck were run. |
+
+## Probe Setup
+
+VERIFIED: the probe is throwaway and outside tracked files (`tmp/tsgo-probe/q1`). `git status --short` had no tracked changes.
+
+`tmp/tsgo-probe/q1/tsconfig.json:26-40` mirrors the repo's Effect language-service plugin shape:
+
+```json
+{
+  "name": "@effect/language-service",
+  "ignoreEffectWarningsInTscExitCode": false,
+  "ignoreEffectSuggestionsInTscExitCode": false,
+  "ignoreEffectErrorsInTscExitCode": false,
+  "includeSuggestionsInTsc": true,
+  "pipeableMinArgCount": 2,
+  "diagnosticSeverity": {
+    "missedPipeableOpportunity": "warning",
+    "schemaUnionOfLiterals": "warning",
+    "anyUnknownInErrorContext": "warning",
+    "preferSchemaOverJson": "warning"
+  }
+}
+```
+
+Repo source evidence for the same derived config:
+
+| File | Lines | Meaning |
+| --- | ---: | --- |
+| `genie/external.ts` | 736, 772-775 | `effectDiagnosticsGate = { warnings: true, suggestions: true }`; the generated ignore flags are `!effectDiagnosticsGate.*`, so both warning and suggestion ignore flags derive to `false`; errors ignore flag is hardcoded `false`. |
+| `tmp/tsgo-probe/tsgo-source/internal/effectconfigraw/hooks.go` | 76-83 | tsgo reads `ignoreEffectSuggestionsInTscExitCode`, `ignoreEffectWarningsInTscExitCode`, and `ignoreEffectErrorsInTscExitCode` from the plugin entry when present. |
+| `tmp/tsgo-probe/tsgo-source/testdata/baselines/reference/README.md` | 214-231 | tsgo docs: `includeSuggestionsInTsc` controls suggestion visibility; `ignoreEffectSuggestionsInTscExitCode`, `ignoreEffectWarningsInTscExitCode`, and `ignoreEffectErrorsInTscExitCode` control whether each category affects the tsc exit code. |
+
+## Q1 Commands And Output
+
+Pinned compiler:
+
+```sh
+nix eval --raw .#packages.$(nix eval --impure --raw --expr builtins.currentSystem).effect-tsgo.outPath
+# /nix/store/m59qqc61pdii7xfjnpfzjas5fx0z2ggx-effect-tsgo
+
+/nix/store/m59qqc61pdii7xfjnpfzjas5fx0z2ggx-effect-tsgo/bin/tsgo --version
+# Version 7.0.0-dev+effect-tsgo.0.14.5
+```
+
+Hardened module-layout + all-category diagnostic probe:
+
+```sh
+/nix/store/m59qqc61pdii7xfjnpfzjas5fx0z2ggx-effect-tsgo/bin/tsgo --build tsconfig.json --force --pretty false
+# exit=2
+# src/index.ts(38,14): warning TS377030: This has unknown in the requirements channel which is not recommended.
+# Only service identifiers should appear in the requirements channel. effect(anyUnknownInErrorContext)
+# src/index.ts(38,35): suggestion TS377017: This Effect.gen contains a single return statement. effect(unnecessaryEffectGen)
+# src/index.ts(39,10): warning TS377030: This has unknown in the requirements channel which is not recommended.
+# Only service identifiers should appear in the requirements channel. effect(anyUnknownInErrorContext)
+# src/index.ts(48,1): error TS377001: This Effect value is neither yielded nor used in an assignment. effect(floatingEffect)
+```
+
+Category-isolated gate probes:
+
+```sh
+/nix/store/m59qqc61pdii7xfjnpfzjas5fx0z2ggx-effect-tsgo/bin/tsgo --build tsconfig.warning.json --force --pretty false
+# exit=2
+# src/warning.ts(4,14): warning TS377030: This has unknown in the requirements channel which is not recommended.
+# Only service identifiers should appear in the requirements channel. effect(anyUnknownInErrorContext)
+# src/warning.ts(5,10): warning TS377030: This has unknown in the requirements channel which is not recommended.
+# Only service identifiers should appear in the requirements channel. effect(anyUnknownInErrorContext)
+
+/nix/store/m59qqc61pdii7xfjnpfzjas5fx0z2ggx-effect-tsgo/bin/tsgo --build tsconfig.suggestion.json --force --pretty false
+# exit=2
+# src/suggestion.ts(3,29): suggestion TS377017: This Effect.gen contains a single return statement. effect(unnecessaryEffectGen)
+```
+
+## Q4 Waiver Knobs
+
+VERIFIED: the real relaxation knobs are the `ignoreEffect*InTscExitCode` plugin fields, not `diagnosticSeverity`.
+
+| Desired gate | Values |
+| --- | --- |
+| Strict current repo gate | `ignoreEffectWarningsInTscExitCode: false`, `ignoreEffectSuggestionsInTscExitCode: false`, `ignoreEffectErrorsInTscExitCode: false` |
+| Errors-only waiver | `ignoreEffectWarningsInTscExitCode: true`, `ignoreEffectSuggestionsInTscExitCode: true`, `ignoreEffectErrorsInTscExitCode: false` |
+| Keep suggestion output visible while waiving exit-code impact | Leave `includeSuggestionsInTsc: true` |
+| Source change that would produce the waiver | In `genie/external.ts`, set `effectDiagnosticsGate` to `{ warnings: false, suggestions: false }`; generated plugin values at `:772-775` then become `true`, `true`, `false`. Do not edit generated `package.json`/`tsconfig` files directly. |
+
+The comment at `genie/external.ts:724-725` is misleading: it says "both fields are true" while the derived plugin fields at `genie/external.ts:772-775` are the inverse ignore flags. The current strict behavior is produced by those generated ignore fields being `false`.
+
+## Recommendation
+
+Land the Effect 4 flip against the existing pinned `effect-tsgo` first. A tsgo bump is optional, independent, and deferrable because the current pin resolves the v4 subpath layout and preserves error/warning/suggestion gate behavior on `effect@4.0.0-beta.102`.
+
+Do not combine a tsgo bump with the Effect 4 flip. If a later optional tsgo bump is desired, measure it as a separate Effect 3 PR because a newer compiler may surface diagnostics unrelated to Effect 4.
+
+Contingency if the migration branch hits a large advisory backlog: use the errors-only waiver by flipping `effectDiagnosticsGate` warnings/suggestions to `false` in `genie/external.ts`, regenerate, and keep `ignoreEffectErrorsInTscExitCode: false`.
+
+## Not Covered
+
+- Newer tsgo revision history since `8d34c0a`.
+- Effect 3 advisory delta under newer tsgo.
+- Whole-repo typecheck with newer tsgo.
+
+These were explicitly stopped by orchestrator after Q1 made the tsgo bump non-critical.

--- a/context/effect-4/tsgo-compatibility.md
+++ b/context/effect-4/tsgo-compatibility.md
@@ -6,13 +6,13 @@ Identity: `org.schickling.eu.effect-4.tsgo`
 
 VERIFIED: the current Nix-pinned `effect-tsgo` is sufficient for the Effect 4 migration blocker.
 
-| Question | Answer | Evidence |
-| --- | --- | --- |
-| Current pin handles `effect@4.0.0-beta.102` module layout? | Yes | Probe dependency is `effect` `4.0.0-beta.102`; package exports include `effect/testing`, `effect/unstable/cli`, `effect/unstable/http`, `effect/unstable/httpapi`, `effect/unstable/observability`, `effect/unstable/process`, `effect/unstable/rpc`, plus wildcard root subpaths such as `effect/Schema` and `effect/Result`. See `tmp/tsgo-probe/q1/node_modules/effect/package.json:2-4`, `:29-55`; probe imports at `tmp/tsgo-probe/q1/src/index.ts:1-10`. |
-| Current pin emits Effect diagnostics under v4? | Yes | Hardened probe emitted warning, suggestion, and error diagnostics under `effect@4.0.0-beta.102`; see command/output below. |
-| Gate degraded to errors-only? | No | Warning-only and suggestion-only category probes each exited `2`, proving both categories still affect `tsgo --build` exit code when the repo-equivalent ignore flags are `false`. |
-| Minimum viable tsgo revision | Current pin suffices | Locked rev remains viable: `flake.lock:98-104` pins `Effect-TS/tsgo` `8d34c0a2d603a4b963b85ffccd4322c0ef74f472`; evaluated current attr was `/nix/store/m59qqc61pdii7xfjnpfzjas5fx0z2ggx-effect-tsgo`, version `7.0.0-dev+effect-tsgo.0.14.5`. |
-| Effect 3 advisory delta from newer tsgo | NOT MEASURED | De-scoped by orchestrator after Q1: since current pin works, a tsgo bump is not on the Effect 4 critical path. No candidate tsgo build and no whole-repo Effect 3 typecheck were run. |
+| Question                                                   | Answer               | Evidence                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| ---------------------------------------------------------- | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Current pin handles `effect@4.0.0-beta.102` module layout? | Yes                  | Probe dependency is `effect` `4.0.0-beta.102`; package exports include `effect/testing`, `effect/unstable/cli`, `effect/unstable/http`, `effect/unstable/httpapi`, `effect/unstable/observability`, `effect/unstable/process`, `effect/unstable/rpc`, plus wildcard root subpaths such as `effect/Schema` and `effect/Result`. See `tmp/tsgo-probe/q1/node_modules/effect/package.json:2-4`, `:29-55`; probe imports at `tmp/tsgo-probe/q1/src/index.ts:1-10`. |
+| Current pin emits Effect diagnostics under v4?             | Yes                  | Hardened probe emitted warning, suggestion, and error diagnostics under `effect@4.0.0-beta.102`; see command/output below.                                                                                                                                                                                                                                                                                                                                     |
+| Gate degraded to errors-only?                              | No                   | Warning-only and suggestion-only category probes each exited `2`, proving both categories still affect `tsgo --build` exit code when the repo-equivalent ignore flags are `false`.                                                                                                                                                                                                                                                                             |
+| Minimum viable tsgo revision                               | Current pin suffices | Locked rev remains viable: `flake.lock:98-104` pins `Effect-TS/tsgo` `8d34c0a2d603a4b963b85ffccd4322c0ef74f472`; evaluated current attr was `/nix/store/m59qqc61pdii7xfjnpfzjas5fx0z2ggx-effect-tsgo`, version `7.0.0-dev+effect-tsgo.0.14.5`.                                                                                                                                                                                                                 |
+| Effect 3 advisory delta from newer tsgo                    | NOT MEASURED         | De-scoped by orchestrator after Q1: since current pin works, a tsgo bump is not on the Effect 4 critical path. No candidate tsgo build and no whole-repo Effect 3 typecheck were run.                                                                                                                                                                                                                                                                          |
 
 ## Probe Setup
 
@@ -39,11 +39,11 @@ VERIFIED: the probe is throwaway and outside tracked files (`tmp/tsgo-probe/q1`)
 
 Repo source evidence for the same derived config:
 
-| File | Lines | Meaning |
-| --- | ---: | --- |
-| `genie/external.ts` | 736, 772-775 | `effectDiagnosticsGate = { warnings: true, suggestions: true }`; the generated ignore flags are `!effectDiagnosticsGate.*`, so both warning and suggestion ignore flags derive to `false`; errors ignore flag is hardcoded `false`. |
-| `tmp/tsgo-probe/tsgo-source/internal/effectconfigraw/hooks.go` | 76-83 | tsgo reads `ignoreEffectSuggestionsInTscExitCode`, `ignoreEffectWarningsInTscExitCode`, and `ignoreEffectErrorsInTscExitCode` from the plugin entry when present. |
-| `tmp/tsgo-probe/tsgo-source/testdata/baselines/reference/README.md` | 214-231 | tsgo docs: `includeSuggestionsInTsc` controls suggestion visibility; `ignoreEffectSuggestionsInTscExitCode`, `ignoreEffectWarningsInTscExitCode`, and `ignoreEffectErrorsInTscExitCode` control whether each category affects the tsc exit code. |
+| File                                                                |        Lines | Meaning                                                                                                                                                                                                                                          |
+| ------------------------------------------------------------------- | -----------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `genie/external.ts`                                                 | 736, 772-775 | `effectDiagnosticsGate = { warnings: true, suggestions: true }`; the generated ignore flags are `!effectDiagnosticsGate.*`, so both warning and suggestion ignore flags derive to `false`; errors ignore flag is hardcoded `false`.              |
+| `tmp/tsgo-probe/tsgo-source/internal/effectconfigraw/hooks.go`      |        76-83 | tsgo reads `ignoreEffectSuggestionsInTscExitCode`, `ignoreEffectWarningsInTscExitCode`, and `ignoreEffectErrorsInTscExitCode` from the plugin entry when present.                                                                                |
+| `tmp/tsgo-probe/tsgo-source/testdata/baselines/reference/README.md` |      214-231 | tsgo docs: `includeSuggestionsInTsc` controls suggestion visibility; `ignoreEffectSuggestionsInTscExitCode`, `ignoreEffectWarningsInTscExitCode`, and `ignoreEffectErrorsInTscExitCode` control whether each category affects the tsc exit code. |
 
 ## Q1 Commands And Output
 
@@ -89,12 +89,12 @@ Category-isolated gate probes:
 
 VERIFIED: the real relaxation knobs are the `ignoreEffect*InTscExitCode` plugin fields, not `diagnosticSeverity`.
 
-| Desired gate | Values |
-| --- | --- |
-| Strict current repo gate | `ignoreEffectWarningsInTscExitCode: false`, `ignoreEffectSuggestionsInTscExitCode: false`, `ignoreEffectErrorsInTscExitCode: false` |
-| Errors-only waiver | `ignoreEffectWarningsInTscExitCode: true`, `ignoreEffectSuggestionsInTscExitCode: true`, `ignoreEffectErrorsInTscExitCode: false` |
-| Keep suggestion output visible while waiving exit-code impact | Leave `includeSuggestionsInTsc: true` |
-| Source change that would produce the waiver | In `genie/external.ts`, set `effectDiagnosticsGate` to `{ warnings: false, suggestions: false }`; generated plugin values at `:772-775` then become `true`, `true`, `false`. Do not edit generated `package.json`/`tsconfig` files directly. |
+| Desired gate                                                  | Values                                                                                                                                                                                                                                       |
+| ------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Strict current repo gate                                      | `ignoreEffectWarningsInTscExitCode: false`, `ignoreEffectSuggestionsInTscExitCode: false`, `ignoreEffectErrorsInTscExitCode: false`                                                                                                          |
+| Errors-only waiver                                            | `ignoreEffectWarningsInTscExitCode: true`, `ignoreEffectSuggestionsInTscExitCode: true`, `ignoreEffectErrorsInTscExitCode: false`                                                                                                            |
+| Keep suggestion output visible while waiving exit-code impact | Leave `includeSuggestionsInTsc: true`                                                                                                                                                                                                        |
+| Source change that would produce the waiver                   | In `genie/external.ts`, set `effectDiagnosticsGate` to `{ warnings: false, suggestions: false }`; generated plugin values at `:772-775` then become `true`, `true`, `false`. Do not edit generated `package.json`/`tsconfig` files directly. |
 
 The comment at `genie/external.ts:724-725` is misleading: it says "both fields are true" while the derived plugin fields at `genie/external.ts:772-775` are the inverse ignore flags. The current strict behavior is produced by those generated ignore fields being `false`.
 

--- a/context/effect-4/wave0-peer-resolution.md
+++ b/context/effect-4/wave0-peer-resolution.md
@@ -1,0 +1,61 @@
+# Wave 0 peer-resolution finding
+
+Identity: `org.schickling.eu.effect-4.wave0`
+
+## Verdict
+
+Wave 0 is not viable under the repository's strict peer-dependency contract.
+
+`@overeng/react-inspector` proves only that an importer-local `effect` core version can coexist
+with the repository's Effect 3 core. It does not prove that a package needing a still-separate
+Effect ecosystem package can flip independently.
+
+## Smallest reproduction: `@overeng/npm-release`
+
+The faithful Effect 4 port requires:
+
+- `effect@4.0.0-beta.102`
+- `@effect/platform-node@4.0.0-beta.102`
+
+The package-local catalog resolved its importer to the correct pair:
+
+```yaml
+'@effect/platform-node':
+  specifier: 4.0.0-beta.102
+  version: 4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.11.1)
+effect:
+  specifier: 4.0.0-beta.102
+  version: 4.0.0-beta.102
+```
+
+The authoritative lock update nevertheless failed `ERR_PNPM_PEER_DEP_ISSUES` in both directions:
+
+- Effect 3 workspace packages requiring `@effect/platform-node@^0.107.0` were checked against
+  `@effect/platform-node@4.0.0-beta.102`.
+- `@effect/platform-node@4.0.0-beta.102` requiring `effect@^4.0.0-beta.102` was checked against
+  `effect@3.21.4`.
+
+The root duplicate-exception mechanism validates resolved identities after lock generation; it
+does not waive or partition pnpm's strict peer validation. Weakening `strictPeerDependencies` or
+globally allowing cross-major peer ranges would remove the guardrail that detected the invalid
+mixed cohort.
+
+Changing this private package to direct-only / peer-free dependencies would be temporary
+dependency-boundary scaffolding with a later revert obligation, so it was rejected.
+
+## Remaining candidates
+
+- `context/effect/socket` directly requires the still-separate
+  `@effect/platform-node` package (and currently also `@effect/platform` / `@effect/rpc`).
+- `context/opentui` directly requires the still-separate `@effect-atom/atom` and
+  `@effect-atom/atom-react` packages; its generator also owns overrides for the v3
+  `@effect/platform`, `@effect/experimental`, and `@effect/rpc` cohort.
+
+Neither remaining candidate is core-only. Therefore no package in the proposed three-package
+wave can flip independently.
+
+## Integration constraint
+
+The cohort flip must move `effect` core and every still-separate `@effect/*` / Effect ecosystem
+package together in the same lockfile transition. A partial cohort cannot satisfy the repository's
+strict peer contract.


### PR DESCRIPTION
Phase 0 of the Effect 3 → 4 migration (#925): the durable findings that the flip and every downstream repo depend on. Documentation and one checker script — **no source or config changes**.

## What is here

- **`recipes/`** — 20 per-pattern v3→v4 recipes with equivalence evidence, gotchas, and codemod rules for the mechanical ones
- **`alignment-register.md`** — every intended v3/v4 behaviour difference with a proposed decision and blast radius. The sign-off artifact
- **`register-verification.md`** — an adversarial pass that tried to *refute* each accepted difference. 10 upheld, **2 refuted**
- **`idiom-catalog.md`** — 14 refactor patterns with adopt/defer/skip dispositions, evidence drawn from LiveStore's completed migration
- **`tsgo-compatibility.md`** — the pinned compiler handles `beta.102` and all three diagnostic categories still gate, so no compiler bump is on the critical path
- **`platform-patch-analysis.md`** — why the `@effect/platform` header patch cannot retire, and the upstream PR that would let it
- **`wave0-peer-resolution.md`** — why incremental per-package flipping is impossible under strict peers
- **`baseline-operations.md`** — traps found while writing the Phase 1 baselines, several of which look exactly like success
- **`check-baseline-migration-markers.ts`** — a checker that derives risk signatures from the alignment register and fails on unmarked assertions

## Why it is worth reading rather than skimming

These were produced by a differential harness that runs Effect 3 and Effect 4 as separate processes and diffs normalized behaviour traces. It proved itself on a known regression — a naive `Schema.Date` port failed with 14 diffs before the corrected port went green.

Two results changed the plan:

- **`tracer-span-shape` is IDENTICAL** under recording *and* non-recording tracers, so `otel-contract`'s published contract is unaffected
- **fork defaults are identical**, so the compatibility options LiveStore cargo-culted are unnecessary — a negative control that saved us from importing their debt

And the adversarial pass refuted two entries that had looked safe: the RPC failure envelope changes shape across a versionless browser/server protocol, and Restate embeds parser text verbatim in an HTTP 400 payload. Both now have mitigations (#979, #978) and baselines that fail loudly at the flip.

## Checker

```sh
bun context/effect-4/check-baseline-migration-markers.ts
```

Derives its signature table from `alignment-register.md`, so it stays correct as the register grows rather than drifting from it. It already found gaps in PRs that had been annotated by hand.

Refs #925

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | cl1-heron |
| `agent_session_id` | 54711470-ae7e-4322-a3e2-129a2689a097 |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.220 |
| `agent_runtime` | Claude Code 2.1.220 |
| `agent_model` | claude-opus-5 |
| `runtime_profile` | /nix/store/xg6r3nkr7spjyg2gbl3zprqbsag3fsjc-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/2vkpfkkbc9hjmcwknzkv62v2i44an8mz-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling/2026-07-28-effect-4 |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->