### PR TITLE
test(effect-path): capture cross-major baselines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **@overeng/effect-path**: add Effect 3 cross-major baselines for PathInfo schema
+  encoding, convention parser failure partitions, and path operation byte output.
+
 - Add a shared CI helper for job-local Cargo targets and `sccache` servers on
   multi-identity self-hosted runners.
 

--- a/packages/@overeng/effect-path/src/baseline.unit.test.ts
+++ b/packages/@overeng/effect-path/src/baseline.unit.test.ts
@@ -1,0 +1,222 @@
+import { NodeContext } from '@effect/platform-node'
+import { Effect, Either, Schema } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import {
+  EffectPath,
+  type AbsoluteFileInfo,
+  type InvalidPathError,
+  type NotAbsoluteError,
+  type NotRelativeError,
+  type ConventionError,
+  type TraversalError,
+  type RelativePath,
+} from './mod.ts'
+
+const summarizeFileInfo = (info: AbsoluteFileInfo) => ({
+  original: info.original,
+  normalized: info.normalized,
+  segments: info.segments,
+  baseName: info.baseName,
+  extension: info.extension,
+  fullExtension: info.fullExtension,
+  parent: {
+    normalized: info.parent.normalized,
+    segments: info.parent.segments,
+    baseName: info.parent.baseName,
+  },
+})
+
+const escapeNullBytes = (path: string): string => path.replaceAll('\0', '\\0')
+
+type ConventionBaselineError =
+  | InvalidPathError
+  | NotAbsoluteError
+  | NotRelativeError
+  | ConventionError
+
+const summarizeConventionError = (error: ConventionBaselineError) => {
+  switch (error._tag) {
+    case 'InvalidPathError':
+      return {
+        _tag: error._tag,
+        message: error.message,
+        path: escapeNullBytes(error.path),
+        position: error.position,
+        reason: error.reason,
+      }
+    case 'NotAbsoluteError':
+      return {
+        _tag: error._tag,
+        message: error.message,
+        path: error.path,
+        suggestedAbsolute: error.suggestedAbsolute,
+      }
+    case 'NotRelativeError':
+      return {
+        _tag: error._tag,
+        absolutePrefix: error.absolutePrefix,
+        message: error.message,
+        path: error.path,
+      }
+    case 'ConventionError':
+      return {
+        _tag: error._tag,
+        expected: error.expected,
+        message: error.message,
+        path: error.path,
+        violation: error.violation,
+      }
+  }
+}
+
+const summarizeTraversalError = (error: TraversalError) => ({
+  _tag: error._tag,
+  escapedTo: error.escapedTo,
+  escapingSegments: error.escapingSegments,
+  message: error.message,
+  path: error.path,
+  sandboxRoot: error.sandboxRoot,
+})
+
+describe('effect-path baselines (cross-major invariant)', () => {
+  it('pins PathInfo schema encoded bytes and re-encoded identity', async () => {
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const normalizedSchema = EffectPath.schema.AbsoluteFileInfo()
+        const originalSchema = EffectPath.schema.AbsoluteFileInfo({ encodeAs: 'original' })
+        const decoded = yield* Schema.decodeUnknown(normalizedSchema)('/repo//pkg/archive.tar.gz')
+
+        return {
+          decoded: summarizeFileInfo(decoded),
+          encodedDefault: yield* Schema.encode(normalizedSchema)(decoded),
+          encodedOriginal: yield* Schema.encode(originalSchema)(decoded),
+        }
+      }),
+    )
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "decoded": {
+          "baseName": "archive",
+          "extension": "gz",
+          "fullExtension": "tar.gz",
+          "normalized": "/repo/pkg/archive.tar.gz",
+          "original": "/repo//pkg/archive.tar.gz",
+          "parent": {
+            "baseName": "pkg",
+            "normalized": "/repo/pkg/",
+            "segments": [
+              "repo",
+              "pkg",
+            ],
+          },
+          "segments": [
+            "repo",
+            "pkg",
+            "archive.tar.gz",
+          ],
+        },
+        "encodedDefault": "/repo/pkg/archive.tar.gz",
+        "encodedOriginal": "/repo//pkg/archive.tar.gz",
+      }
+    `)
+  })
+
+  it('pins convention parser failure partitions', async () => {
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const absoluteFileFromRelative = yield* EffectPath.convention
+          .absoluteFile('relative/file.txt')
+          .pipe(Effect.either)
+        const relativeFileFromAbsolute = yield* EffectPath.convention
+          .relativeFile('/absolute/file.txt')
+          .pipe(Effect.either)
+        const fileFromDirectoryConvention = yield* EffectPath.convention
+          .absoluteFile('/absolute/dir/')
+          .pipe(Effect.either)
+        const invalidPath = yield* EffectPath.convention
+          .relativeFile('bad\0path.txt')
+          .pipe(Effect.either)
+
+        const left = <A>(either: Either.Either<A, ConventionBaselineError>) => {
+          if (Either.isRight(either) === true) {
+            throw new Error('expected parser failure')
+          }
+          return either.left
+        }
+
+        return [
+          left(absoluteFileFromRelative),
+          left(relativeFileFromAbsolute),
+          left(fileFromDirectoryConvention),
+          left(invalidPath),
+        ].map(summarizeConventionError)
+      }).pipe(Effect.provide(NodeContext.layer)),
+    )
+
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "_tag": "NotAbsoluteError",
+          "message": "Expected absolute path",
+          "path": "relative/file.txt",
+          "suggestedAbsolute": undefined,
+        },
+        {
+          "_tag": "NotRelativeError",
+          "absolutePrefix": "/",
+          "message": "Expected relative path",
+          "path": "/absolute/file.txt",
+        },
+        {
+          "_tag": "ConventionError",
+          "expected": "file",
+          "message": "File path must not end with a separator",
+          "path": "/absolute/dir/",
+          "violation": "trailing_slash_on_file",
+        },
+        {
+          "_tag": "InvalidPathError",
+          "message": "Path contains null byte",
+          "path": "bad\\0path.txt",
+          "position": 3,
+          "reason": "null_byte",
+        },
+      ]
+    `)
+  })
+
+  it('pins path operation byte output across join, normalization, and sandbox checks', () => {
+    const root = EffectPath.unsafe.absoluteDir('/repo//root')
+    const joined = EffectPath.ops.join(root, EffectPath.unsafe.relativeFile('src/../index.ts'))
+    const normalized = EffectPath.normalize.lexicalPure(joined)
+    const sandbox = EffectPath.sandbox(EffectPath.unsafe.absoluteDir('/repo/root/'))
+    const allowed = sandbox.resolve(EffectPath.unsafe.relativeFile('src/../index.ts'))
+    const escaped = sandbox.resolve(EffectPath.unsafe.relativeFile('../outside.ts') as RelativePath)
+
+    expect({
+      joined,
+      normalized,
+      allowed: Either.isRight(allowed) === true ? allowed.right : allowed.left,
+      escaped:
+        Either.isLeft(escaped) === true ? summarizeTraversalError(escaped.left) : escaped.right,
+    }).toMatchInlineSnapshot(`
+      {
+        "allowed": "/repo/root/index.ts",
+        "escaped": {
+          "_tag": "TraversalError",
+          "escapedTo": undefined,
+          "escapingSegments": [
+            "..",
+          ],
+          "message": "Path escapes sandbox root: ../outside.ts",
+          "path": "../outside.ts",
+          "sandboxRoot": "/repo/root/",
+        },
+        "joined": "/repo//root/src/../index.ts",
+        "normalized": "/repo/root/index.ts",
+      }
+    `)
+  })
+})


### PR DESCRIPTION
## Problem

`@overeng/effect-path` has schema, parser-failure, and path-operation surfaces that need Effect 3 baselines before the Effect 4 flip. A predecessor had the baseline mostly written, but it still failed `check:quick` on lint/type issues in error serialization.

## Goal

Capture the current Effect 3 observable behavior for `effect-path` so the migration can detect byte or failure-partition drift.

## Decisions

- Add the suite under `src/` because this package's Vitest include is `src/**/*.test.ts`.
- Pin `PathInfo` schema decode/encode bytes for normalized and original encodings.
- Pin convention parser failure partitions with explicit error serialization, including non-enumerable `TaggedError.message`.
- Pin path operation output for join, lexical normalization, sandbox success, and sandbox traversal failure.

## Verification

- PASS: `CI=1 devenv tasks run test:effect-path --refresh-task-cache --show-output --no-tui --verbose` reported `Test Files 2 passed (2)` and `Tests 72 passed (72)`.
- PASS: `CI=1 devenv tasks run check:quick --no-tui --verbose`.
- PASS: `bun context/effect-4/check-baseline-migration-markers.ts` reported `PASS: 12 baseline test files contain no unmarked Effect 3 -> 4 risk signatures.`
- PASS: `git diff --check`.

## Complexity

No runtime complexity; this adds one additive baseline test file and a changelog entry.

## Concerns

The snapshots intentionally pin current Effect 3 parser and traversal error message text.

## Friction & bottlenecks

The initial plain `git push` failed because branchy tracks `origin/main`; pushing with `git push origin HEAD` succeeded.

## Follow-ups

None.

## References

Refs #925.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | co1-orca |
| `agent_session_id` | c2bf664d-83f5-4803-a0d7-a24dc77feb17 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.145.0 |
| `agent_runtime` | Codex CLI 0.145.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/i8y8b542cyqi385ywcjw5fvsq24f75v4-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/i81qxhzlrzcxrrdwpp6i8hagka2gby8y-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-28-2026-07-28-effect-path-baseline-finish |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->