### PR TITLE
test(tui-stories): capture render wire baselines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 - **@overeng/effect-path**: add Effect 3 cross-major baselines for PathInfo schema
   encoding, convention parser failure partitions, and path operation byte output.
+- **@overeng/tui-stories**: add Effect 3 cross-major baselines for schema-encoded
+  JSON, NDJSON timeline output, and durable output-state decode failures.
 
 - Add a shared CI helper for job-local Cargo targets and `sccache` servers on
   multi-identity self-hosted runners.

--- a/packages/@overeng/tui-stories/test/render-wire-baseline.test.ts
+++ b/packages/@overeng/tui-stories/test/render-wire-baseline.test.ts
@@ -1,0 +1,383 @@
+import { Either, Effect, Schema } from 'effect'
+import React from 'react'
+import { describe, expect, it } from 'vitest'
+
+import { InspectApp } from '../src/cli/renderers/InspectOutput/app.ts'
+import { InspectState } from '../src/cli/renderers/InspectOutput/schema.ts'
+import {
+  createSimpleState,
+  createWithArgsState,
+} from '../src/cli/renderers/InspectOutput/stories/_fixtures.ts'
+import { ListApp } from '../src/cli/renderers/ListOutput/app.ts'
+import { ListState } from '../src/cli/renderers/ListOutput/schema.ts'
+import { createDefaultState } from '../src/cli/renderers/ListOutput/stories/_fixtures.ts'
+import { RenderApp } from '../src/cli/renderers/RenderOutput/app.ts'
+import { RenderState, type RenderStateType } from '../src/cli/renderers/RenderOutput/schema.ts'
+import type { CapturedStoryProps } from '../src/StoryCapture.ts'
+import { renderStory } from '../src/StoryRenderer.ts'
+
+const TestView = () => React.createElement('span')
+
+const captured = ({
+  app,
+  initialState,
+  timeline = [],
+  command,
+}: {
+  readonly app: unknown
+  readonly initialState: unknown
+  readonly timeline?: CapturedStoryProps['timeline']
+  readonly command: string
+}): CapturedStoryProps => ({
+  app: app as CapturedStoryProps['app'],
+  View: TestView,
+  initialState,
+  timeline,
+  command,
+})
+
+const summarizeDecodeFailure = (error: unknown) => ({
+  name: error instanceof Error ? error.name : typeof error,
+  message: error instanceof Error ? error.message : String(error),
+})
+
+const createRenderingState = (timelineMode: string): RenderStateType => ({
+  _tag: 'Rendering',
+  storyId: 'CLI/Sync/Fetch/FetchResults',
+  width: 80,
+  timelineMode,
+})
+
+const createErrorState = (): RenderStateType => ({
+  _tag: 'Error',
+  storyId: 'CLI/NonExistent/Missing',
+  message: 'Story not found: "CLI/NonExistent/Missing"',
+})
+
+describe('tui-stories baselines (cross-major invariant)', () => {
+  it('pins schema-encoded JSON output bytes for list and inspect surfaces', async () => {
+    const listOutput = await Effect.runPromise(
+      renderStory({
+        captured: captured({
+          app: ListApp,
+          initialState: createDefaultState(),
+          command: 'tui-stories list --path packages/@overeng/megarepo',
+        }),
+        width: 80,
+        timelineMode: 'initial',
+        output: 'json',
+      }),
+    )
+    const inspectOutput = await Effect.runPromise(
+      renderStory({
+        captured: captured({
+          app: InspectApp,
+          initialState: createWithArgsState(),
+          command:
+            'tui-stories inspect CLI/Exec/Running/RunningVerboseParallel --path packages/@overeng/megarepo',
+        }),
+        width: 80,
+        timelineMode: 'initial',
+        output: 'json',
+      }),
+    )
+
+    expect({ inspectOutput, listOutput }).toMatchInlineSnapshot(`
+      {
+        "inspectOutput": "{
+        "id": "CLI/Exec/Running/RunningVerboseParallel",
+        "title": "CLI/Exec/Running",
+        "name": "RunningVerboseParallel",
+        "filePath": "packages/@overeng/megarepo/src/cli/renderers/ExecOutput/stories/Running.stories.tsx",
+        "args": [
+          {
+            "name": "height",
+            "controlType": "range",
+            "description": "Terminal height in pixels",
+            "defaultValue": "400"
+          },
+          {
+            "name": "interactive",
+            "controlType": "boolean",
+            "description": "Enable animated timeline playback",
+            "defaultValue": "false"
+          },
+          {
+            "name": "playbackSpeed",
+            "controlType": "range",
+            "description": "Playback speed multiplier",
+            "defaultValue": "1",
+            "conditional": "interactive"
+          },
+          {
+            "name": "verbose",
+            "controlType": "boolean",
+            "description": "--verbose: show detailed information",
+            "defaultValue": "true"
+          },
+          {
+            "name": "mode",
+            "controlType": "select",
+            "description": "--mode flag",
+            "defaultValue": "\\"parallel\\"",
+            "options": [
+              "parallel",
+              "sequential"
+            ]
+          },
+          {
+            "name": "member",
+            "controlType": "text",
+            "description": "--member / -m flag",
+            "defaultValue": "\\"\\""
+          }
+        ],
+        "hasTimeline": true,
+        "timelineEventCount": 8
+      }",
+        "listOutput": "{
+        "groups": [
+          {
+            "title": "Components/StatusIcon",
+            "stories": [
+              {
+                "name": "SuccessCheck",
+                "hasTimeline": false,
+                "argCount": 0
+              },
+              {
+                "name": "ErrorCross",
+                "hasTimeline": false,
+                "argCount": 0
+              },
+              {
+                "name": "ActiveSpinner",
+                "hasTimeline": false,
+                "argCount": 0
+              }
+            ]
+          },
+          {
+            "title": "Components/Summary",
+            "stories": [
+              {
+                "name": "AllSuccess",
+                "hasTimeline": false,
+                "argCount": 0
+              },
+              {
+                "name": "WithErrors",
+                "hasTimeline": false,
+                "argCount": 0
+              },
+              {
+                "name": "DryRunMode",
+                "hasTimeline": false,
+                "argCount": 0
+              }
+            ]
+          },
+          {
+            "title": "Components/TaskItem",
+            "stories": [
+              {
+                "name": "AllStates",
+                "hasTimeline": false,
+                "argCount": 0
+              },
+              {
+                "name": "SingleActive",
+                "hasTimeline": false,
+                "argCount": 0
+              }
+            ]
+          },
+          {
+            "title": "CLI/Status/Basic",
+            "stories": [
+              {
+                "name": "Default",
+                "hasTimeline": false,
+                "argCount": 3
+              },
+              {
+                "name": "WithErrors",
+                "hasTimeline": false,
+                "argCount": 3
+              },
+              {
+                "name": "EmptyWorkspace",
+                "hasTimeline": false,
+                "argCount": 3
+              }
+            ]
+          },
+          {
+            "title": "CLI/Exec/Running",
+            "stories": [
+              {
+                "name": "RunningVerboseParallel",
+                "hasTimeline": true,
+                "argCount": 6
+              },
+              {
+                "name": "RunningVerboseSequential",
+                "hasTimeline": true,
+                "argCount": 6
+              }
+            ]
+          },
+          {
+            "title": "CLI/Sync/Fetch",
+            "stories": [
+              {
+                "name": "FetchResults",
+                "hasTimeline": true,
+                "argCount": 8
+              },
+              {
+                "name": "FetchNested",
+                "hasTimeline": true,
+                "argCount": 8
+              },
+              {
+                "name": "FetchIssues",
+                "hasTimeline": true,
+                "argCount": 8
+              }
+            ]
+          },
+          {
+            "title": "CLI/Add/Results",
+            "stories": [
+              {
+                "name": "AddDefault",
+                "hasTimeline": true,
+                "argCount": 6
+              },
+              {
+                "name": "AddWithSyncCloned",
+                "hasTimeline": true,
+                "argCount": 6
+              },
+              {
+                "name": "AddWithSyncError",
+                "hasTimeline": true,
+                "argCount": 6
+              }
+            ]
+          }
+        ],
+        "skippedCount": 3,
+        "packagePath": "packages/@overeng/megarepo"
+      }",
+      }
+    `)
+  })
+
+  it('pins timeline NDJSON bytes and final JSON bytes for render output', async () => {
+    const renderTimeline = [
+      {
+        at: 0,
+        action: { _tag: 'SetState', state: createRenderingState('final') },
+      },
+      {
+        at: 250,
+        action: { _tag: 'SetState', state: createErrorState() },
+      },
+    ] as const
+    const renderCaptured = captured({
+      app: RenderApp,
+      initialState: createRenderingState('initial'),
+      timeline: renderTimeline,
+      command: 'tui-stories render CLI/NonExistent/Missing --path packages/@overeng/megarepo',
+    })
+
+    const ndjsonOutput = await Effect.runPromise(
+      renderStory({
+        captured: renderCaptured,
+        width: 80,
+        timelineMode: 'initial',
+        output: 'ndjson',
+      }),
+    )
+    const finalJsonOutput = await Effect.runPromise(
+      renderStory({
+        captured: renderCaptured,
+        width: 80,
+        timelineMode: 'final',
+        output: 'json',
+      }),
+    )
+
+    expect({ finalJsonOutput, ndjsonOutput }).toMatchInlineSnapshot(`
+      {
+        "finalJsonOutput": "{
+        "_tag": "Error",
+        "storyId": "CLI/NonExistent/Missing",
+        "message": "Story not found: \\"CLI/NonExistent/Missing\\""
+      }",
+        "ndjsonOutput": "{"at":0,"state":{"_tag":"Rendering","storyId":"CLI/Sync/Fetch/FetchResults","width":80,"timelineMode":"initial"}}
+      {"at":0,"action":{"_tag":"SetState","state":{"_tag":"Rendering","storyId":"CLI/Sync/Fetch/FetchResults","width":80,"timelineMode":"final"}},"state":{"_tag":"Rendering","storyId":"CLI/Sync/Fetch/FetchResults","width":80,"timelineMode":"final"}}
+      {"at":250,"action":{"_tag":"SetState","state":{"_tag":"Error","storyId":"CLI/NonExistent/Missing","message":"Story not found: \\"CLI/NonExistent/Missing\\""}},"state":{"_tag":"Error","storyId":"CLI/NonExistent/Missing","message":"Story not found: \\"CLI/NonExistent/Missing\\""}}",
+      }
+    `)
+  })
+
+  it('pins schema decode failure partitions for durable output states', () => {
+    const failures = {
+      inspect: Schema.decodeUnknownEither(InspectState)({
+        ...createSimpleState(),
+        timelineEventCount: '0',
+      }),
+      list: Schema.decodeUnknownEither(ListState)({
+        ...createDefaultState(),
+        skippedCount: '3',
+      }),
+      render: Schema.decodeUnknownEither(RenderState)({
+        _tag: 'Complete',
+        storyId: 'CLI/Status/Basic/Default',
+        width: '80',
+        timelineMode: 'initial',
+        renderedLines: [],
+      }),
+    }
+
+    const entries = Object.entries(failures) as ReadonlyArray<readonly [string, unknown]>
+
+    // TODO(live-migration:effect-3-4): rebaseline Effect 4 parse-tree prose if schema decode failures still preserve the same failure partitions.
+    expect(
+      Object.fromEntries(
+        entries.map(([name, result]) => {
+          const either = result as Either.Either<unknown, unknown>
+          if (Either.isRight(either) === true) {
+            throw new Error(`expected ${name} decode failure`)
+          }
+          return [name, summarizeDecodeFailure(either.left)]
+        }),
+      ),
+    ).toMatchInlineSnapshot(`
+      {
+        "inspect": {
+          "message": "{ readonly id: string; readonly title: string; readonly name: string; readonly filePath: string; readonly args: ReadonlyArray<{ readonly name: string; readonly controlType: string; readonly description?: string | undefined; readonly defaultValue?: string | undefined; readonly options?: ReadonlyArray<string> | undefined; readonly conditional?: string | undefined }>; readonly hasTimeline: boolean; readonly timelineEventCount: number }
+      └─ ["timelineEventCount"]
+         └─ Expected number, actual "0"",
+          "name": "ParseError",
+        },
+        "list": {
+          "message": "{ readonly groups: ReadonlyArray<{ readonly title: string; readonly stories: ReadonlyArray<{ readonly name: string; readonly hasTimeline: boolean; readonly argCount: number }> }>; readonly skippedCount: number; readonly packagePath: string }
+      └─ ["skippedCount"]
+         └─ Expected number, actual "3"",
+          "name": "ParseError",
+        },
+        "render": {
+          "message": "{ readonly _tag: "Rendering"; readonly storyId: string; readonly width: number; readonly timelineMode: string } | { readonly _tag: "Complete"; readonly storyId: string; readonly width: number; readonly timelineMode: string; readonly renderedLines: ReadonlyArray<string> } | { readonly _tag: "Error"; readonly storyId: string; readonly message: string }
+      └─ { readonly _tag: "Complete"; readonly storyId: string; readonly width: number; readonly timelineMode: string; readonly renderedLines: ReadonlyArray<string> }
+         └─ ["width"]
+            └─ Expected number, actual "80"",
+          "name": "ParseError",
+        },
+      }
+    `)
+  })
+})


### PR DESCRIPTION
## Problem

`@overeng/tui-stories` already has CLI contract coverage, but its schema-encoded renderer output still needed a Phase 1 Effect 3 baseline. The package exposes JSON and NDJSON durable output through `renderStory`, plus schema decode failure partitions for output states.

## Goal

Capture current Effect 3 JSON, NDJSON, and durable output-state decode behavior so the Effect 4 flip can prove the renderer surface remains behavior-preserving.

## Decisions

- Add the suite under `test/` because this package's Vitest include is `test/**/*.test.ts`.
- Avoid duplicating the existing CLI contract from #998.
- Use the real `ListApp`, `InspectApp`, and `RenderApp` schemas/reducers with fixture states.
- Mark the parse-tree prose assertion with `TODO(live-migration:effect-3-4)` because the marker registry identifies this Effect 3 schema error text as expected to change at the flip.

## Verification

- PASS: `CI=1 devenv tasks run test:tui-stories --mode single --refresh-task-cache --show-output --no-tui --verbose` reported `Test Files 5 passed (5)` and `Tests 31 passed (31)`. Baseline delta from the brief's pre-baseline count is +1 file / +3 tests.
- PASS: `CI=1 devenv tasks run check:quick --no-tui --verbose`.
- PASS: `bun context/effect-4/check-baseline-migration-markers.ts` reported `PASS: 12 baseline test files contain no unmarked Effect 3 -> 4 risk signatures.`
- PASS: `git diff --check`.

## Complexity

No runtime complexity; this adds one additive baseline test file and a changelog entry.

## Concerns

The schema decode failure snapshot pins Effect 3 parse-tree prose. The inline migration TODO makes the expected rebaseline action explicit for contraction.

## Friction & bottlenecks

The documented default task form pulls upstream batch dependencies for this package and started unrelated package tests. After package install materialization, the package task was run in `--mode single` to exercise the `test:tui-stories` task itself and confirm the package-local count.

## Follow-ups

None.

## References

Refs #925, #998.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | co1-orca |
| `agent_session_id` | c2bf664d-83f5-4803-a0d7-a24dc77feb17 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.145.0 |
| `agent_runtime` | Codex CLI 0.145.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/i8y8b542cyqi385ywcjw5fvsq24f75v4-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/i81qxhzlrzcxrrdwpp6i8hagka2gby8y-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-28-2026-07-28-tui-stories-baseline-finish |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->