### PR TITLE
Keep immutable legacy lanes compatible with default-ref policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
           DEFAULT_REFS_JSON: '{"livestorejs/livestore":"dev"}'
           VERIFY_REACHABLE: '0'
           NORMALIZE_GIT_BRANCH_REFS: '0'
+          ALLOW_LEGACY_MEMBER_COMMIT_REFS: '0'
         run: |
           nix shell nixpkgs#nodejs_24 -c node <<'NODE'
           const fs = require('node:fs')
@@ -74,6 +75,7 @@ jobs:
           const defaultRef = process.env.DEFAULT_REF || 'main'
           const defaultRefs = new Map(Object.entries(JSON.parse(process.env.DEFAULT_REFS_JSON || '{}')).map(([repo, ref]) => [repo.toLowerCase(), ref]))
           const verifyReachable = process.env.VERIFY_REACHABLE === '1'
+          const allowLegacyMemberCommitRefs = process.env.ALLOW_LEGACY_MEMBER_COMMIT_REFS === '1'
           const violations = []
 
           const repoKey = (repo) => repo.owner.toLowerCase() + '/' + repo.repo.toLowerCase()
@@ -81,6 +83,12 @@ jobs:
           const normalizeGitBranchRefs = process.env.NORMALIZE_GIT_BRANCH_REFS === '1'
           const normalizeRef = (ref) => normalizeGitBranchRefs && ref.startsWith('refs/heads/') ? ref.slice('refs/heads/'.length) : ref
           const expectedRefFor = (repo) => normalizeRef(defaultRefs.get(repoKey(repo)) || defaultRef)
+          const immutableCommitRef = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i
+          const isAllowedLegacyMemberRef = ({ memberName, ref }) =>
+            allowLegacyMemberCommitRefs &&
+            typeof memberName === 'string' &&
+            memberName.endsWith('-legacy') &&
+            immutableCommitRef.test(ref)
 
           const githubRepoFromUrl = (url) => {
             const match = url.match(/github\.com[/:]([^/]+)\/([^/#?]+?)(?:\.git)?(?:[#?].*)?$/)
@@ -135,6 +143,7 @@ jobs:
             const expectedRef = expectedRefFor(repo)
             const normalizedRef = normalizeRef(ref)
             if (normalizedRef === expectedRef) return
+            if (isAllowedLegacyMemberRef({ memberName, ref: normalizedRef })) return
             violations.push({
               type: 'ref',
               file,
@@ -360,6 +369,12 @@ jobs:
             for (const [memberName, member] of Object.entries((lock && lock.members) || {})) {
               const repo = typeof member.url === 'string' ? githubRepoFromUrl(member.url) : undefined
               if (!repo || !isFirstParty(repo)) continue
+              if (
+                typeof member.ref === 'string' &&
+                isAllowedLegacyMemberRef({ memberName, ref: normalizeRef(member.ref) })
+              ) {
+                continue
+              }
               const expectedRef = expectedRefFor(repo)
               const remote = 'https://github.com/' + repo.owner + '/' + repo.repo + '.git'
               const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'default-ref-policy-'))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 
 - Add a shared CI helper for job-local Cargo targets and `sccache` servers on
   multi-identity self-hosted runners.
+- **genie/ci-workflow**: let default-ref policy consumers explicitly admit
+  immutable commit refs for named `*-legacy` megarepo members, while keeping
+  branches, tags, and ordinary members on the canonical default ref.
 
 ### Fixed
 

--- a/context/workflows/release-workflow.md
+++ b/context/workflows/release-workflow.md
@@ -162,6 +162,14 @@ the only job that writes contents and pull-requests.
 - `source-policy` — optional first-party ref policy job (LiveStore
   uses `livestoreDefaultRefPolicyJob`). Omitted when
   `sourcePolicyJob: false`.
+
+The shared default-ref policy remains strict by default. A megarepo that must
+compose an older dependency major may opt into
+`allowLegacyMemberCommitRefs`; the exception applies only to `*-legacy`
+megarepo members whose refs are immutable 40- or 64-character commit IDs.
+Named branches, tags, and ordinary members remain subject to the configured
+default-ref policy.
+
 - `create-release-pr` — runs only on `workflow_dispatch` with
   `mode == create-release-pr`. Runs `setupSteps`, generates the
   release plan from Changesets, opens or refreshes the

--- a/genie/ci-workflow/megarepo.ts
+++ b/genie/ci-workflow/megarepo.ts
@@ -165,6 +165,12 @@ export type DefaultRefPolicyCheckStepOptions = {
   readonly defaultRefs?: Readonly<Record<string, string>>
   readonly verifyReachable?: boolean
   readonly normalizeGitBranchRefs?: boolean
+  /**
+   * Permit an explicitly named `*-legacy` megarepo member to use an immutable
+   * 40- or 64-character commit ref. This is intentionally narrower than a
+   * general ref allowlist: branch refs and non-legacy members still fail.
+   */
+  readonly allowLegacyMemberCommitRefs?: boolean
 }
 
 const defaultRefPolicyCheckScript = String.raw`const fs = require('node:fs')
@@ -177,6 +183,7 @@ const firstPartyOwners = new Set(JSON.parse(process.env.FIRST_PARTY_OWNERS_JSON)
 const defaultRef = process.env.DEFAULT_REF || 'main'
 const defaultRefs = new Map(Object.entries(JSON.parse(process.env.DEFAULT_REFS_JSON || '{}')).map(([repo, ref]) => [repo.toLowerCase(), ref]))
 const verifyReachable = process.env.VERIFY_REACHABLE === '1'
+const allowLegacyMemberCommitRefs = process.env.ALLOW_LEGACY_MEMBER_COMMIT_REFS === '1'
 const violations = []
 
 const repoKey = (repo) => repo.owner.toLowerCase() + '/' + repo.repo.toLowerCase()
@@ -184,6 +191,12 @@ const isFirstParty = (repo) => firstPartyOwners.has(repo.owner.toLowerCase())
 const normalizeGitBranchRefs = process.env.NORMALIZE_GIT_BRANCH_REFS === '1'
 const normalizeRef = (ref) => normalizeGitBranchRefs && ref.startsWith('refs/heads/') ? ref.slice('refs/heads/'.length) : ref
 const expectedRefFor = (repo) => normalizeRef(defaultRefs.get(repoKey(repo)) || defaultRef)
+const immutableCommitRef = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i
+const isAllowedLegacyMemberRef = ({ memberName, ref }) =>
+  allowLegacyMemberCommitRefs &&
+  typeof memberName === 'string' &&
+  memberName.endsWith('-legacy') &&
+  immutableCommitRef.test(ref)
 
 const githubRepoFromUrl = (url) => {
   const match = url.match(/github\.com[/:]([^/]+)\/([^/#?]+?)(?:\.git)?(?:[#?].*)?$/)
@@ -238,6 +251,7 @@ const addRefViolation = ({ file, repo, ref, field, inputName, memberName }) => {
   const expectedRef = expectedRefFor(repo)
   const normalizedRef = normalizeRef(ref)
   if (normalizedRef === expectedRef) return
+  if (isAllowedLegacyMemberRef({ memberName, ref: normalizedRef })) return
   violations.push({
     type: 'ref',
     file,
@@ -463,6 +477,12 @@ if (verifyReachable) {
   for (const [memberName, member] of Object.entries((lock && lock.members) || {})) {
     const repo = typeof member.url === 'string' ? githubRepoFromUrl(member.url) : undefined
     if (!repo || !isFirstParty(repo)) continue
+    if (
+      typeof member.ref === 'string' &&
+      isAllowedLegacyMemberRef({ memberName, ref: normalizeRef(member.ref) })
+    ) {
+      continue
+    }
     const expectedRef = expectedRefFor(repo)
     const remote = 'https://github.com/' + repo.owner + '/' + repo.repo + '.git'
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'default-ref-policy-'))
@@ -514,6 +534,7 @@ export const defaultRefPolicyCheckStep = (opts: DefaultRefPolicyCheckStepOptions
     DEFAULT_REFS_JSON: JSON.stringify(opts.defaultRefs ?? {}),
     VERIFY_REACHABLE: opts.verifyReachable === true ? '1' : '0',
     NORMALIZE_GIT_BRANCH_REFS: opts.normalizeGitBranchRefs === true ? '1' : '0',
+    ALLOW_LEGACY_MEMBER_COMMIT_REFS: opts.allowLegacyMemberCommitRefs === true ? '1' : '0',
   },
   run: `nix shell nixpkgs#nodejs_24 -c node <<'NODE'
 ${defaultRefPolicyCheckScript}

--- a/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
@@ -421,6 +421,18 @@ describe('ci workflow pnpm cache defaults', () => {
     expect(defaultRefPolicyCheckStepSource).toContain("ref.startsWith('refs/heads/')")
   })
 
+  it('allows only explicitly opted-in immutable legacy member refs', () => {
+    expect(defaultRefPolicyCheckStepSource).toContain('allowLegacyMemberCommitRefs?: boolean')
+    expect(defaultRefPolicyCheckStepSource).toContain('ALLOW_LEGACY_MEMBER_COMMIT_REFS')
+    expect(defaultRefPolicyCheckStepSource).toContain("memberName.endsWith('-legacy')")
+    expect(defaultRefPolicyCheckStepSource).toContain(
+      'const immutableCommitRef = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i',
+    )
+    expect(defaultRefPolicyCheckStepSource).toContain(
+      'isAllowedLegacyMemberRef({ memberName, ref: normalizedRef })',
+    )
+  })
+
   it('retries temporary git repository cleanup after reachability checks', () => {
     expect(defaultRefPolicyCheckStepSource).toContain(
       'fs.rmSync(tmp, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })',


### PR DESCRIPTION
## Problem

The shared first-party default-ref policy treats every non-default member ref as
temporary drift. That is correct for ordinary composition, but it also rejects
intentional dual-major workspaces where a named legacy lane must remain on an
immutable historical commit while the canonical lane follows `main`.

Without a narrow contract for that case, consumers must either weaken the
owner-level policy, duplicate the generated check, or incorrectly advance legacy
packages across an incompatible dependency major.

## Solution

- Add opt-in `allowLegacyMemberCommitRefs` composition to
  `defaultRefPolicyCheckStep`.
- Admit only megarepo members named `*-legacy`.
- Admit only immutable 40- or 64-character commit IDs.
- Keep branch refs, tags, flake/devenv inputs, and ordinary members subject to
  the existing default-ref policy.
- Apply the same exception to optional reachability validation.
- Document the contract and cover its generated source shape.
- Preserve the three concurrent changelog entries and remove literal conflict
  markers that reached `main` through #1009 while this branch was updating.

The policy default remains strict, so existing consumers do not change behavior.

## Validation

- `devenv shell -- bun test packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts` - 51 passed
- `devenv tasks run lint:fix`
- `devenv tasks run check:quick` - passed after both `main` reconciliations
- `git diff --check`
- `rg '^(<<<<<<<|=======|>>>>>>>)' CHANGELOG.md` - no matches

## Tradeoffs

This deliberately uses a naming convention instead of a general-purpose
allowlist. That keeps the exception low-boilerplate and reviewable while
preventing arbitrary temporary refs from becoming policy exemptions.
