### PR TITLE
fix(effect-4): tie marker checker to alignment register

### DIFF
--- a/context/effect-4/check-baseline-migration-markers.ts
+++ b/context/effect-4/check-baseline-migration-markers.ts
@@ -77,6 +77,48 @@ const riskSignatures = [
   },
 ] as const
 
+/**
+ * Register entries whose risks have no reliable textual fingerprint in a
+ * baseline. Each exception must explain why a signature would be misleading.
+ */
+const noSignatures = [
+  {
+    registerEntry: 'cli-A-nested-terminator-loss',
+    noSignature:
+      'The risk depends on argv parsing semantics, not a distinctive baseline byte sequence.',
+  },
+  {
+    registerEntry: 'cli-B-accepted-grammar-improvements',
+    noSignature:
+      'The accepted grammar cases have no shared textual footprint across CLI baselines.',
+  },
+  {
+    registerEntry: 'cli-C-rendering-and-stdout-breakage',
+    noSignature:
+      'CLI-owned prose and ANSI bytes are intentionally varied and cannot use one safe signature.',
+  },
+  {
+    registerEntry: 'fork-defaults',
+    noSignature:
+      'The identical default scheduling behavior has no changed baseline text to detect.',
+  },
+  {
+    registerEntry: 'equality-structural-default',
+    noSignature:
+      'Structural equality depends on runtime values and assertions, not stable baseline text.',
+  },
+  {
+    registerEntry: 'layer-memoization-freshness-opt-outs',
+    noSignature:
+      'Freshness opt-outs are API choices whose observable counts are covered by the related signature.',
+  },
+  {
+    registerEntry: 'effect-never-idle-timer',
+    noSignature:
+      'Timer registration is a runtime side effect with no reliable baseline-text fingerprint.',
+  },
+] as const
+
 type CallBlock = {
   readonly end: number
   readonly leadingStart: number
@@ -98,6 +140,55 @@ const root =
   rootArgumentIndex === -1
     ? process.cwd()
     : resolve(process.argv[rootArgumentIndex + 1] ?? process.cwd())
+
+const registerFile = 'context/effect-4/alignment-register.md'
+let registerSource: string
+
+try {
+  registerSource = await Bun.file(resolve(root, registerFile)).text()
+} catch (error) {
+  const code =
+    typeof error === 'object' && error !== null && 'code' in error ? String(error.code) : 'unknown'
+  console.error(`FAIL: cannot read ${registerFile} (${code}).`)
+  process.exit(1)
+}
+
+const registerEntries = new Set(
+  [...registerSource.matchAll(/^## ([a-z0-9][a-zA-Z0-9-]*)\s*$/gm)].map((match) => match[1]!),
+)
+const signatureEntries = new Set(riskSignatures.map(({ registerEntry }) => registerEntry))
+const noSignatureEntries = new Set(noSignatures.map(({ registerEntry }) => registerEntry))
+const declaredEntries = new Set([...signatureEntries, ...noSignatureEntries])
+
+const unmappedEntries = [...registerEntries]
+  .filter((entry) => declaredEntries.has(entry) === false)
+  .toSorted()
+const missingRegisterEntries = [...declaredEntries]
+  .filter((entry) => registerEntries.has(entry) === false)
+  .toSorted()
+const conflictingEntries = [...signatureEntries]
+  .filter((entry) => noSignatureEntries.has(entry))
+  .toSorted()
+
+if (
+  unmappedEntries.length > 0 ||
+  missingRegisterEntries.length > 0 ||
+  conflictingEntries.length > 0
+) {
+  for (const entry of unmappedEntries) {
+    console.error(
+      `UNMAPPED: register entry "${entry}" needs a risk signature or justified noSignature declaration.`,
+    )
+  }
+  for (const entry of missingRegisterEntries) {
+    console.error(`STALE: checker declaration references missing register entry "${entry}".`)
+  }
+  for (const entry of conflictingEntries) {
+    console.error(`CONFLICT: register entry "${entry}" has both a signature and noSignature.`)
+  }
+  console.error('FAIL: alignment register and marker checker declarations are inconsistent.')
+  process.exit(1)
+}
 
 const lineAndColumnAt = ({
   source,

--- a/context/effect-4/check-baseline-migration-markers.ts
+++ b/context/effect-4/check-baseline-migration-markers.ts
@@ -36,6 +36,11 @@ const riskSignatures = [
     why: 'Effect 4 changes the rejected-status wrapper and reason shape.',
   },
   {
+    registerEntry: 'cli-A-nested-terminator-loss',
+    regex: /\bargs\s*:\s*\[\s*["']add["']\s*,\s*["']--["']/g,
+    why: 'Effect 4 drops operands after -- for the nested megarepo add command.',
+  },
+  {
     registerEntry: 'fork-copied-options',
     regex: /\b(?:startImmediately|uninterruptible)\b/g,
     why: 'Copied fork options change scheduling and must have a local justification.',
@@ -54,6 +59,16 @@ const riskSignatures = [
     registerEntry: 'layer-memoization-default',
     regex: /\b(?:build|construction|acquisition)Count\b[^\r\n]*\.(?:toBe|toEqual)\(\s*\d+\s*\)/g,
     why: 'Construction-count assertions can change under Effect 4 layer memoization.',
+  },
+  {
+    registerEntry: 'layer-memoization-freshness-opt-outs',
+    regex: /\bLayer\.fresh\b/g,
+    why: 'Layer.fresh explicitly opts out of shared layer memoization.',
+  },
+  {
+    registerEntry: 'layer-memoization-freshness-opt-outs',
+    regex: /\bEffect\.provide\([\s\S]{0,300}\blocal\s*:\s*true\b/g,
+    why: 'A local provide creates an isolated memoization scope.',
   },
   {
     registerEntry: 'rpc-failure-cause-wire-shape',
@@ -83,14 +98,9 @@ const riskSignatures = [
  */
 const noSignatures = [
   {
-    registerEntry: 'cli-A-nested-terminator-loss',
-    noSignature:
-      'The risk depends on argv parsing semantics, not a distinctive baseline byte sequence.',
-  },
-  {
     registerEntry: 'cli-B-accepted-grammar-improvements',
     noSignature:
-      'The accepted grammar cases have no shared textual footprint across CLI baselines.',
+      'Four unrelated grammar forms are accepted; each contract needs its own case-specific signature.',
   },
   {
     registerEntry: 'cli-C-rendering-and-stdout-breakage',
@@ -105,17 +115,12 @@ const noSignatures = [
   {
     registerEntry: 'equality-structural-default',
     noSignature:
-      'Structural equality depends on runtime values and assertions, not stable baseline text.',
-  },
-  {
-    registerEntry: 'layer-memoization-freshness-opt-outs',
-    noSignature:
-      'Freshness opt-outs are API choices whose observable counts are covered by the related signature.',
+      'Structural equality depends on runtime value types, and the register audit found no production Effect equality site.',
   },
   {
     registerEntry: 'effect-never-idle-timer',
     noSignature:
-      'Timer registration is a runtime side effect with no reliable baseline-text fingerprint.',
+      'Process liveness is a runtime side effect; Effect.never is also used as unrelated test-only suspension control, with no production liveness site.',
   },
 ] as const
 
@@ -329,13 +334,27 @@ const findCalls = ({
   const calls: CallBlock[] = []
 
   for (const match of source.matchAll(namePattern)) {
-    const openingOffset = source.indexOf('(', match.index)
-    const end = findMatchingDelimiter({ source, openingOffset, opening: '(', closing: ')' })
+    let openingOffset = source.indexOf('(', match.index)
+    let end = findMatchingDelimiter({ source, openingOffset, opening: '(', closing: ')' })
     if (end === undefined) continue
 
     let titleOffset = openingOffset + 1
     while (/\s/.test(source[titleOffset] ?? '') === true) titleOffset++
-    const title = readStaticString({ source, offset: titleOffset })
+    let title = readStaticString({ source, offset: titleOffset })
+
+    if (title === undefined && callName === 'test' && match[0].includes('.each') === true) {
+      openingOffset = end
+      while (/\s/.test(source[openingOffset] ?? '') === true) openingOffset++
+      if (source[openingOffset] !== '(') continue
+
+      end = findMatchingDelimiter({ source, openingOffset, opening: '(', closing: ')' })
+      if (end === undefined) continue
+
+      titleOffset = openingOffset + 1
+      while (/\s/.test(source[titleOffset] ?? '') === true) titleOffset++
+      title = readStaticString({ source, offset: titleOffset })
+    }
+
     if (title === undefined || title.value.includes('${') === true) continue
 
     const start = match.index + (match[0].match(/^[^\w$]/)?.[0].length ?? 0)


### PR DESCRIPTION
## Problem

The baseline migration marker checker carried hardcoded register labels without reading the alignment register. Removing the register still produced PASS, and register/table drift was silent.

It also ignored parameterized `it.each` baselines, which would have made the forthcoming nested-terminator G1 invisible even with a correct signature.

## Goal

Make the register and checker declarations an enforced consistency boundary while preserving marker scanning across static and parameterized baseline tests.

## Decisions

Parse exact `## <entry-id>` headings from the register. Require every heading to have either a risk signature or an explicit `noSignature` reason. Reject unmapped register entries, stale declarations, and signature/noSignature conflicts. Fail before baseline scanning when the register cannot be read.

`cli-A-nested-terminator-loss` has a narrow signature for the stable G1 `args: ['add', '--', ...]` footprint. The checker now resolves the outer invocation of `it.each(table)(title, callback)`, so that signature is actually scanned. `layer-memoization-freshness-opt-outs` also moved from noSignature to clean signatures for `Layer.fresh` and `Effect.provide(... local: true)`.

Five entries retain explicit `noSignature` reasons because their semantics are intrinsically heterogeneous or runtime-dependent rather than merely lacking a current baseline: the two remaining CLI buckets, `fork-defaults`, `equality-structural-default`, and `effect-never-idle-timer`.

## Verification

Original consistency guard probes:

```text
missing register:
FAIL: cannot read context/effect-4/alignment-register.md (ENOENT).
exit status: 1

unmapped fake heading:
UNMAPPED: register entry "some-new-entry" needs a risk signature or justified noSignature declaration.
FAIL: alignment register and marker checker declarations are inconsistent.
exit status: 1

stale table row:
STALE: checker declaration references missing register entry "non-existent-entry".
FAIL: alignment register and marker checker declarations are inconsistent.
exit status: 1

restored:
PASS: 18 baseline test files contain no unmarked Effect 3 -> 4 risk signatures.
exit status: 0
```

G1 parameterized-baseline probe:

```text
marker present:
PASS: 1 baseline test files contain no unmarked Effect 3 -> 4 risk signatures.

marker removed:
packages/@overeng/megarepo/src/cli.contract.test.ts:6:7 cli-A-nested-terminator-loss [retains nested terminator argv] - Effect 4 drops operands after -- for the nested megarepo add command.
FAIL: 1 unmarked risk signature matches across 1 baseline test files.
exit status: 1
```

Final rebased validation:

```text
bun context/effect-4/check-baseline-migration-markers.ts
PASS: 27 baseline test files contain no unmarked Effect 3 -> 4 risk signatures.

oxfmt --check context/effect-4/check-baseline-migration-markers.ts
All matched files use the correct format.

oxlint --deny-warnings context/effect-4/check-baseline-migration-markers.ts
Found 0 warnings and 0 errors.

devenv tasks run --no-tui check:quick
exit status: 0
```

## Complexity

No new module or dependency. The checker gains one register parser, set-based consistency gate, and a narrow parameterized-test invocation step.

## Concerns

New register entries now intentionally require a checker declaration. Heading identifiers must retain the documented `## <entry-id>` form. Parameterized support covers the repository form `it.each(table)(title, callback)`; tagged-template tables remain outside this checker until a baseline uses them.

## Friction & bottlenecks

The canonical megarepo checkout correctly rejected an in-place branch switch, so all work moved to an isolated branch worktree. Final verification was slow under host saturation but completed without retries.

## Follow-ups

None.

## References

Refs #925.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | co2-col |
| `agent_session_id` | fb45faad-c8dc-40a1-b763-b846910ce2f7 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.145.0 |
| `agent_runtime` | Codex CLI 0.145.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/i8y8b542cyqi385ywcjw5fvsq24f75v4-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/i81qxhzlrzcxrrdwpp6i8hagka2gby8y-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-28-effect4-marker-register-consistency |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->