### PR TITLE
test(megarepo): pin nested terminator argv on Effect 3

### DIFF
--- a/context/effect-4/alignment-register.md
+++ b/context/effect-4/alignment-register.md
@@ -43,6 +43,12 @@
 - **Difference:** under a nested command, v4 beta.99 and beta.102 drop all argv after `--`. A
   required child positional supplied after the terminator becomes missing; an already-satisfied
   child silently loses its trailing operands.
+- **Measured Effect 3 baseline:** `mr add` delivers the first token after `--` byte-for-byte to
+  its positional handler, including dash-prefixed values and values matching parent or child flag
+  names. It does not unconditionally accept every trailing token: because `add` declares one
+  positional, multiple tokens preserve order only until that arity is exhausted, then the second
+  token is rejected as an unknown argument. Bare `mr add --` remains the distinct missing-argument
+  case.
 - **Source confirmation:** the lexer preserves trailing operands
   (`effect/src/unstable/cli/internal/lexer.ts:24-40`), but parser recursion constructs the child
   input with `trailingOperands: []` (`internal/parser.ts:87`) and attaches the originals to the

--- a/packages/@overeng/megarepo/src/cli.contract.test.ts
+++ b/packages/@overeng/megarepo/src/cli.contract.test.ts
@@ -1,9 +1,18 @@
 import { spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import { describe, expect, it } from 'vitest'
+import { afterAll, describe, expect, it } from 'vitest'
 
 const cliPath = fileURLToPath(new URL('../bin/mr.ts', import.meta.url))
+const workspaceRoot = mkdtempSync(join(tmpdir(), 'megarepo-cli-contract-'))
+writeFileSync(join(workspaceRoot, 'megarepo.kdl'), 'members {\n}\n')
+
+afterAll(() => {
+  rmSync(workspaceRoot, { recursive: true, force: true })
+})
 
 /**
  * CLI contract capture: `status` and `signal` are cross-major invariants; stdout/stderr help,
@@ -50,5 +59,54 @@ describe('megarepo CLI contract baselines (status/signal invariant, prose owner-
     ['invalid shell', ['env', '--shell', 'nope']],
   ] as const)('%s', (_name, args) => {
     expect(runCli(...args)).toMatchSnapshot()
+  })
+
+  it.each([
+    {
+      name: 'dash-prefixed operand',
+      args: ['add', '--', '--not-a-flag'],
+      stdout:
+        '{"_tag":"Error","error":"invalid_repo","message":"Invalid repo reference: --not-a-flag"}\n',
+      stderr: 'AddCommandError: Invalid repo reference (mr 0.1.0)\n',
+    },
+    {
+      name: 'parent flag-name collision',
+      args: ['add', '--', '--cwd'],
+      stdout: '{"_tag":"Error","error":"invalid_repo","message":"Invalid repo reference: --cwd"}\n',
+      stderr: 'AddCommandError: Invalid repo reference (mr 0.1.0)\n',
+    },
+    {
+      name: 'subcommand flag-name collision',
+      args: ['add', '--', '--name'],
+      stdout:
+        '{"_tag":"Error","error":"invalid_repo","message":"Invalid repo reference: --name"}\n',
+      stderr: 'AddCommandError: Invalid repo reference (mr 0.1.0)\n',
+    },
+    {
+      name: 'multiple operands preserve order until positional arity is exhausted',
+      args: ['add', '--', '--first', '--name', '--last'],
+      stdout: '',
+      stderr:
+        `Received unknown argument: '--name'\n\n` +
+        `Error: {"_tag":"InvalidValue","error":{"_tag":"Paragraph","value":` +
+        `{"_tag":"Text","value":"Received unknown argument: '--name'"}}}\n`,
+    },
+    {
+      name: 'empty trailing operands',
+      args: ['add', '--'],
+      stdout: '',
+      stderr:
+        'Missing argument <repo>\n\nError: {"_tag":"MissingValue","error":{"_tag":"Paragraph","value":{"_tag":"Text","value":"Missing argument <repo>"}}}\n',
+    },
+  ])('retains nested terminator argv: $name', ({ args, stdout, stderr }) => {
+    // TODO(live-migration:effect-3-4): v4 beta.102 drops argv after `--` for nested commands
+    // (effect#6690). Do NOT rebaseline — this failing is the gate working. Resolve by landing the
+    // upstream fix or the local parser patch, then re-run; the values here should be unchanged.
+    expect(runCli('--cwd', workspaceRoot, ...args)).toEqual({
+      status: 1,
+      signal: null,
+      stdout,
+      stderr,
+    })
   })
 })


### PR DESCRIPTION
## Problem

Effect 4 beta.102 drops all argv after `--` for nested subcommands (effect#6690), but the repository had no real CLI contract test pinning Effect 3 behavior. The migration could therefore lose user operands while existing baselines stayed green.

## Goal

Capture the current Effect 3 behavior through the real `mr add` argv path so the Effect 4 flip fails if trailing operands are dropped.

## Decisions

- Exercise the existing `mr add` command rather than a synthetic parser fixture.
- Assert status, signal, stdout, and stderr so the gate proves what reached the handler, not merely that the process exited.
- Run against a test-owned minimal megarepo root so the baseline does not depend on checkout state.
- Keep the assertion permanently and mark its migration-scoped expectation with `TODO(live-migration:effect-3-4)`.

Measured Effect 3 behavior:

- `mr add -- --not-a-flag` delivers `--not-a-flag` byte-for-byte to the handler.
- Parent (`--cwd`) and subcommand (`--name`) flag-name collisions after `--` are delivered as operands.
- With multiple operands, order is preserved until `add`'s one-positional arity is exhausted; the second operand is reported as the unexpected argument.
- Bare `mr add --` remains the distinct missing-argument case.

## Verification

- `devenv tasks run lint:fix:format --no-tui`
- `devenv tasks run lint:check:oxlint --no-tui`
- `bun context/effect-4/check-baseline-migration-markers.ts`
  - `PASS: 27 baseline test files contain no unmarked Effect 3 -> 4 risk signatures.`
- `CI=1 devenv tasks run test:megarepo --mode single --show-output --no-tui --refresh-task-cache`
  - newest `tmp/otel-scrape/summaries/test-megarepo*.summary.json`
  - `vitest.tests = 625`
  - `vitest.failures = 0`
  - child exit code `0`

The test ran from committed revision `6fb747e915f9374f832b752bc5e19dbe0e9bb2dd`.

## Complexity

No new production complexity; this adds one table-driven contract baseline.

## Concerns

This test is intentionally expected to fail on the initial beta.102 flip. That failure is the gate working. Rebaselining would destroy the protection; resolve effect#6690 via the upstream fix or local parser patch while keeping these values unchanged.

`findMegarepoRoot` runs before `parseRepoRef` for the single-operand cases. The baseline therefore supplies its own minimal config file and is entitled to depend only on that test-owned root—not ambient members, locks, symlinks, store contents, network access, or checkout configuration.

## Friction & bottlenecks

The host was heavily oversubscribed during verification. The final authoritative package run completed in 54.1 seconds; an earlier diagnostic run took 279.5 seconds and correctly exposed two stderr/stdout expectation mistakes.

## Follow-ups

- Land the effect#6690 fix before flipping the repository to Effect 4 beta.102.

## References

- Refs #925
- Refs #1018
- Upstream: https://github.com/Effect-TS/effect/issues/6690

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | co3-poplar |
| `agent_session_id` | d5f127f3-ed8e-4a07-98d4-baa82735dff0 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.145.0 |
| `agent_runtime` | Codex CLI 0.145.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/i8y8b542cyqi385ywcjw5fvsq24f75v4-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/i81qxhzlrzcxrrdwpp6i8hagka2gby8y-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-28-effect-4-gap-cli |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->