### PR TITLE
test(utils): pin non-recursive watch membership

### DIFF
--- a/context/effect-4/baseline-operations.md
+++ b/context/effect-4/baseline-operations.md
@@ -27,6 +27,11 @@ Read the newest `tmp/otel-scrape/summaries/test-<pkg>*.summary.json` and check `
 embed `running from local source (<sha>, <age>)` in help and version output, absent in a dirty
 tree. PR #991 passed when opened and failed later for exactly this reason.
 
+**Repeated task runs can be cached.** When proving flake resistance with multiple invocations, the
+devenv task cache can silently return a stale empty `{}` result after the first real run. Use
+`--refresh-task-cache` for counted repeats, and still read each fresh summary JSON before trusting
+the pass rate.
+
 ## Test tasks must exist
 
 `devenv.nix` generates a `test:<pkg>` task only for packages listed in `packagesWithTests`. There is

--- a/packages/@overeng/utils/src/node/file-system-backing.unit.test.ts
+++ b/packages/@overeng/utils/src/node/file-system-backing.unit.test.ts
@@ -4,18 +4,7 @@ import * as path from 'node:path'
 
 import { FileSystem, Path } from '@effect/platform'
 import { NodeContext } from '@effect/platform-node'
-import {
-  Chunk,
-  Context,
-  Data,
-  Deferred,
-  Duration,
-  Effect,
-  Layer,
-  Queue,
-  Schema,
-  Stream,
-} from 'effect'
+import { Context, Data, Deferred, Duration, Effect, Fiber, Layer, Schema, Stream } from 'effect'
 import { expect } from 'vitest'
 
 import { DistributedSemaphoreBacking } from '@overeng/effect-distributed-lock'
@@ -108,6 +97,12 @@ const watchEventPath = (event: FileSystem.WatchEvent): string | undefined =>
 class WatchEventTimeout extends Data.TaggedError('WatchEventTimeout')<{
   readonly fileName: string
 }> {}
+
+interface WatchWaiter {
+  readonly fileName: string
+  readonly resume: (effect: Effect.Effect<FileSystem.WatchEvent, WatchEventTimeout>) => void
+  timeout: ReturnType<typeof setTimeout>
+}
 
 Vitest.describe('FileSystemBacking', () => {
   Vitest.describe('DistributedSemaphore finalizers', () => {
@@ -924,43 +919,71 @@ Vitest.describe('FileSystemBacking', () => {
         const directBefore = 'direct-before.lock'
         const directAfter = 'direct-after.lock'
         const nestedChild = 'nested-child.lock'
-        const events = yield* Queue.unbounded<FileSystem.WatchEvent>()
         const observed: Array<FileSystem.WatchEvent> = []
+        const waiters: Array<WatchWaiter> = []
 
         const awaitObservedPath = (
           fileName: string,
         ): Effect.Effect<FileSystem.WatchEvent, WatchEventTimeout> =>
-          Effect.gen(function* () {
-            const event = yield* Queue.take(events).pipe(
-              Effect.timeoutFail({
-                duration: Duration.seconds(5),
-                onTimeout: () => new WatchEventTimeout({ fileName }),
-              }),
-            )
-            observed.push(event)
-
-            if (path.basename(watchEventPath(event) ?? '') === fileName) {
-              return event
+          Effect.async<FileSystem.WatchEvent, WatchEventTimeout>((resume) => {
+            const waiter: WatchWaiter = {
+              fileName,
+              resume,
+              timeout: setTimeout(
+                () => {
+                  const index = waiters.indexOf(waiter)
+                  if (index >= 0) {
+                    waiters.splice(index, 1)
+                  }
+                  resume(Effect.fail(new WatchEventTimeout({ fileName })))
+                },
+                Duration.toMillis(Duration.seconds(5)),
+              ),
             }
 
-            return yield* awaitObservedPath(fileName)
+            waiters.push(waiter)
+
+            return Effect.sync(() => {
+              clearTimeout(waiter.timeout)
+              const index = waiters.indexOf(waiter)
+              if (index >= 0) {
+                waiters.splice(index, 1)
+              }
+            })
           })
 
-        yield* fsService.watch(watchDir).pipe(
-          Stream.runForEach((event) => Queue.offer(events, event)),
-          Effect.forkScoped,
-        )
+        const recordEvent = (event: FileSystem.WatchEvent): Effect.Effect<void> =>
+          Effect.sync(() => {
+            observed.push(event)
 
+            const eventName = path.basename(watchEventPath(event) ?? '')
+            const matchingWaiters = waiters.filter((waiter) => waiter.fileName === eventName)
+            for (const waiter of matchingWaiters) {
+              clearTimeout(waiter.timeout)
+              const index = waiters.indexOf(waiter)
+              if (index >= 0) {
+                waiters.splice(index, 1)
+              }
+              waiter.resume(Effect.succeed(event))
+            }
+          })
+
+        const watchFiber = yield* fsService
+          .watch(watchDir)
+          .pipe(Stream.runForEach(recordEvent), Effect.fork)
+
+        const directBeforeFiber = yield* awaitObservedPath(directBefore).pipe(Effect.fork)
         yield* fsService.writeFileString(path.join(watchDir, directBefore), 'direct')
-        yield* awaitObservedPath(directBefore)
+        yield* Fiber.join(directBeforeFiber)
 
+        const directAfterFiber = yield* awaitObservedPath(directAfter).pipe(Effect.fork)
         yield* fsService.makeDirectory(nestedDir)
         yield* fsService.writeFileString(path.join(nestedDir, nestedChild), 'nested')
         yield* fsService.writeFileString(path.join(watchDir, directAfter), 'settled')
-        yield* awaitObservedPath(directAfter)
+        yield* Fiber.join(directAfterFiber)
+        yield* Fiber.interrupt(watchFiber)
 
-        const queued = Chunk.toReadonlyArray(yield* Queue.takeAll(events))
-        const observedPathNames = [...observed, ...queued]
+        const observedPathNames = observed
           .map(watchEventPath)
           .filter((eventPath): eventPath is string => eventPath !== undefined)
           .map((eventPath) => path.basename(eventPath))

--- a/packages/@overeng/utils/src/node/file-system-backing.unit.test.ts
+++ b/packages/@overeng/utils/src/node/file-system-backing.unit.test.ts
@@ -910,7 +910,7 @@ Vitest.describe('FileSystemBacking', () => {
     )
   })
 
-  Vitest.describe('onPermitsReleased', () => {
+  Vitest.describe('FileSystem.watch membership', () => {
     Vitest.it.effect('watches direct children but not nested children without recursion', () =>
       Effect.gen(function* () {
         const fsService = yield* FileSystem.FileSystem
@@ -1009,7 +1009,9 @@ Vitest.describe('FileSystemBacking', () => {
         expect(observedPathNames).not.toContain(nestedChild)
       }).pipe(Effect.provide(NodeContext.layer), Effect.scoped),
     )
+  })
 
+  Vitest.describe('onPermitsReleased', () => {
     Vitest.it.effect('completes when watched directory is deleted (no hang)', () =>
       Effect.gen(function* () {
         const fsService = yield* FileSystem.FileSystem

--- a/packages/@overeng/utils/src/node/file-system-backing.unit.test.ts
+++ b/packages/@overeng/utils/src/node/file-system-backing.unit.test.ts
@@ -973,15 +973,26 @@ Vitest.describe('FileSystemBacking', () => {
           .pipe(Stream.runForEach(recordEvent), Effect.fork)
         yield* Effect.yieldNow()
 
-        const directBeforeFiber = yield* awaitObservedPath(directBefore).pipe(Effect.fork)
-        yield* fsService.writeFileString(path.join(watchDir, directBefore), 'direct')
-        yield* Fiber.join(directBeforeFiber)
+        const writeDirectFileUntilObserved = (fileName: string, content: string) =>
+          Effect.gen(function* () {
+            const eventFiber = yield* awaitObservedPath(fileName).pipe(Effect.fork)
 
-        const directAfterFiber = yield* awaitObservedPath(directAfter).pipe(Effect.fork)
+            for (const attempt of [1, 2, 3, 4, 5]) {
+              yield* fsService.writeFileString(
+                path.join(watchDir, fileName),
+                `${content}-${attempt}`,
+              )
+              yield* Effect.yieldNow()
+            }
+
+            return yield* Fiber.join(eventFiber)
+          })
+
+        yield* writeDirectFileUntilObserved(directBefore, 'direct')
+
         yield* fsService.makeDirectory(nestedDir)
         yield* fsService.writeFileString(path.join(nestedDir, nestedChild), 'nested')
-        yield* fsService.writeFileString(path.join(watchDir, directAfter), 'settled')
-        yield* Fiber.join(directAfterFiber)
+        yield* writeDirectFileUntilObserved(directAfter, 'settled')
         yield* Fiber.interrupt(watchFiber)
 
         const observedPathNames = observed

--- a/packages/@overeng/utils/src/node/file-system-backing.unit.test.ts
+++ b/packages/@overeng/utils/src/node/file-system-backing.unit.test.ts
@@ -4,7 +4,18 @@ import * as path from 'node:path'
 
 import { FileSystem, Path } from '@effect/platform'
 import { NodeContext } from '@effect/platform-node'
-import { Context, Deferred, Duration, Effect, Layer, Schema, Stream } from 'effect'
+import {
+  Chunk,
+  Context,
+  Data,
+  Deferred,
+  Duration,
+  Effect,
+  Layer,
+  Queue,
+  Schema,
+  Stream,
+} from 'effect'
 import { expect } from 'vitest'
 
 import { DistributedSemaphoreBacking } from '@overeng/effect-distributed-lock'
@@ -90,6 +101,13 @@ const makeNodeFsLayer = (): Layer.Layer<FileSystem.FileSystem | Path.Path> => {
 }
 
 const TestLayer = makeNodeFsLayer()
+
+const watchEventPath = (event: FileSystem.WatchEvent): string | undefined =>
+  'path' in event && typeof event.path === 'string' ? event.path : undefined
+
+class WatchEventTimeout extends Data.TaggedError('WatchEventTimeout')<{
+  readonly fileName: string
+}> {}
 
 Vitest.describe('FileSystemBacking', () => {
   Vitest.describe('DistributedSemaphore finalizers', () => {
@@ -898,6 +916,65 @@ Vitest.describe('FileSystemBacking', () => {
   })
 
   Vitest.describe('onPermitsReleased', () => {
+    Vitest.it.effect('watches direct children but not nested children without recursion', () =>
+      Effect.gen(function* () {
+        const fsService = yield* FileSystem.FileSystem
+        const watchDir = yield* fsService.makeTempDirectory()
+        const nestedDir = path.join(watchDir, 'sub')
+        const directBefore = 'direct-before.lock'
+        const directAfter = 'direct-after.lock'
+        const nestedChild = 'nested-child.lock'
+        const events = yield* Queue.unbounded<FileSystem.WatchEvent>()
+        const observed: Array<FileSystem.WatchEvent> = []
+
+        const awaitObservedPath = (
+          fileName: string,
+        ): Effect.Effect<FileSystem.WatchEvent, WatchEventTimeout> =>
+          Effect.gen(function* () {
+            const event = yield* Queue.take(events).pipe(
+              Effect.timeoutFail({
+                duration: Duration.seconds(5),
+                onTimeout: () => new WatchEventTimeout({ fileName }),
+              }),
+            )
+            observed.push(event)
+
+            if (path.basename(watchEventPath(event) ?? '') === fileName) {
+              return event
+            }
+
+            return yield* awaitObservedPath(fileName)
+          })
+
+        yield* fsService.watch(watchDir).pipe(
+          Stream.runForEach((event) => Queue.offer(events, event)),
+          Effect.forkScoped,
+        )
+
+        yield* fsService.writeFileString(path.join(watchDir, directBefore), 'direct')
+        yield* awaitObservedPath(directBefore)
+
+        yield* fsService.makeDirectory(nestedDir)
+        yield* fsService.writeFileString(path.join(nestedDir, nestedChild), 'nested')
+        yield* fsService.writeFileString(path.join(watchDir, directAfter), 'settled')
+        yield* awaitObservedPath(directAfter)
+
+        const queued = Chunk.toReadonlyArray(yield* Queue.takeAll(events))
+        const observedPathNames = [...observed, ...queued]
+          .map(watchEventPath)
+          .filter((eventPath): eventPath is string => eventPath !== undefined)
+          .map((eventPath) => path.basename(eventPath))
+
+        expect(observedPathNames).toContain(directBefore)
+        expect(observedPathNames).toContain(directAfter)
+        // TODO(live-migration:effect-3-4): beta.102 removes the recursive option and always watches
+        // recursively — this nested-child assertion is EXPECTED to fail at the flip. Do NOT rebaseline:
+        // it is the signal that the compatibility shim (register entry
+        // filesystem-watch-recursive-option-removed) is still owed.
+        expect(observedPathNames).not.toContain(nestedChild)
+      }).pipe(Effect.provide(NodeContext.layer), Effect.scoped),
+    )
+
     Vitest.it.effect('completes when watched directory is deleted (no hang)', () =>
       Effect.gen(function* () {
         const fsService = yield* FileSystem.FileSystem

--- a/packages/@overeng/utils/src/node/file-system-backing.unit.test.ts
+++ b/packages/@overeng/utils/src/node/file-system-backing.unit.test.ts
@@ -971,6 +971,7 @@ Vitest.describe('FileSystemBacking', () => {
         const watchFiber = yield* fsService
           .watch(watchDir)
           .pipe(Stream.runForEach(recordEvent), Effect.fork)
+        yield* Effect.yieldNow()
 
         const directBeforeFiber = yield* awaitObservedPath(directBefore).pipe(Effect.fork)
         yield* fsService.writeFileString(path.join(watchDir, directBefore), 'direct')


### PR DESCRIPTION
**Problem**
Effect 4 beta.102 removes the recursive watch option and always watches recursively. The current Effect 3 baseline did not assert whether a non-recursive directory watch observes nested child changes, so the flip could widen watch scope as timing flakiness.

**Goal**
Pin Effect 3 watch membership in `@overeng/utils`: direct children are observed, nested children are not observed for the non-recursive watch path.

**Decisions**
The baseline lives in `packages/@overeng/utils/src/node/file-system-backing.unit.test.ts`, next to the lowest-level file-system backing watch tests. It uses the real `NodeContext.layer` watch stream, positively observes direct-child events, records all watch events through a real bounded waiter, and marks the nested-child assertion with the live-migration TODO required for the Effect 4 flip.
The settle barrier assumes that if the same non-recursive watch stream produced a nested-child event, it would deliver that event before the later observed `directAfter` event; if a backend violated that ordering, this test could false-pass.

**Verification**
- `oxfmt packages/@overeng/utils/src/node/file-system-backing.unit.test.ts`
- `oxlint packages/@overeng/utils/src/node/file-system-backing.unit.test.ts` -> 0 warnings, 0 errors
- `devenv tasks run check:quick --no-tui` -> passed
- `CI=1 devenv tasks run test:utils --mode single --show-output --no-tui --refresh-task-cache` -> 5 fresh runs, all passed
- Follow-up after review: `CI=1 devenv tasks run test:utils --mode single --show-output --no-tui --refresh-task-cache` -> `test-utils.1875535.summary.json`, `vitest.tests=147`, `vitest.failures=0`

Summary JSON counts:

| run | summary | vitest.tests | vitest.failures |
| --- | --- | ---: | ---: |
| 1 | `test-utils.1528738.summary.json` | 147 | 0 |
| 2 | `test-utils.1532653.summary.json` | 147 | 0 |
| 3 | `test-utils.1536176.summary.json` | 147 | 0 |
| 4 | `test-utils.1539498.summary.json` | 147 | 0 |
| 5 | `test-utils.1544463.summary.json` | 147 | 0 |

Pass rate: 5/5. Effect 3 non-recursive watch observed direct child changes and did not observe the nested child.

**Complexity**
No new production complexity. The test has a small real-timer waiter because the test runner can use Effect's test clock; this keeps zero-event runs failing with a targeted error instead of Vitest's generic timeout.

**Concerns**
No watch call sites or compatibility shim changed. This baseline is expected to fail at the Effect 4 flip until the `filesystem-watch-recursive-option-removed` compatibility work is done.

**Friction & bottlenecks**
Host saturation made task output slow/stale-looking. Validation was serialized, and `--refresh-task-cache` was required to get five distinct managed test executions rather than cached task responses.

**Follow-ups**
Implement the compatibility shim for alignment-register entry `filesystem-watch-recursive-option-removed` before flipping the cohort.

**References**
Refs #925.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | co1-ether |
| `agent_session_id` | ee07c1e8-b641-4b63-bfeb-70e46077278e |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.145.0 |
| `agent_runtime` | Codex CLI 0.145.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/i8y8b542cyqi385ywcjw5fvsq24f75v4-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/i81qxhzlrzcxrrdwpp6i8hagka2gby8y-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-28-effect-4-gap-watch |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->