### PR TITLE
test(effect-path): pin platform error partitions

### DIFF
--- a/packages/@overeng/effect-path/src/baseline.unit.test.ts
+++ b/packages/@overeng/effect-path/src/baseline.unit.test.ts
@@ -7,6 +7,7 @@ import {
   EffectPath,
   type AbsoluteFileInfo,
   type InvalidPathError,
+  type NotAFileError,
   type NotAbsoluteError,
   type NotRelativeError,
   type ConventionError,
@@ -96,7 +97,14 @@ const summarizePlatformError = (error: PlatformError.PlatformError) => ({
   method: error.method,
 })
 
-const summarizePathError = (error: PathNotFoundError | PermissionError, normalizeRoot: string) => {
+type VerifiedFileBaselineError =
+  | InvalidPathError
+  | NotAFileError
+  | NotAbsoluteError
+  | PathNotFoundError
+  | PermissionError
+
+const summarizePathError = (error: VerifiedFileBaselineError, normalizeRoot: string) => {
   switch (error._tag) {
     case 'PathNotFoundError':
       return {
@@ -110,6 +118,8 @@ const summarizePathError = (error: PathNotFoundError | PermissionError, normaliz
         operation: error.operation,
         message: error.message.replace(normalizeRoot, '<tmp>'),
       }
+    default:
+      throw new Error(`expected filesystem failure, received ${error._tag}`)
   }
 }
 

--- a/packages/@overeng/effect-path/src/baseline.unit.test.ts
+++ b/packages/@overeng/effect-path/src/baseline.unit.test.ts
@@ -1,3 +1,4 @@
+import { FileSystem, type Error as PlatformError } from '@effect/platform'
 import { NodeContext } from '@effect/platform-node'
 import { Effect, Either, Schema } from 'effect'
 import { describe, expect, it } from 'vitest'
@@ -9,6 +10,8 @@ import {
   type NotAbsoluteError,
   type NotRelativeError,
   type ConventionError,
+  type PathNotFoundError,
+  type PermissionError,
   type TraversalError,
   type RelativePath,
 } from './mod.ts'
@@ -79,6 +82,37 @@ const summarizeTraversalError = (error: TraversalError) => ({
   sandboxRoot: error.sandboxRoot,
 })
 
+const left = <A, E>(either: Either.Either<A, E>, message = 'expected failure'): E => {
+  if (Either.isRight(either) === true) {
+    throw new Error(message)
+  }
+  return either.left
+}
+
+const summarizePlatformError = (error: PlatformError.PlatformError) => ({
+  _tag: error._tag,
+  reason: error._tag === 'SystemError' ? error.reason : undefined,
+  module: error.module,
+  method: error.method,
+})
+
+const summarizePathError = (error: PathNotFoundError | PermissionError, normalizeRoot: string) => {
+  switch (error._tag) {
+    case 'PathNotFoundError':
+      return {
+        _tag: error._tag,
+        expectedType: error.expectedType,
+        message: error.message.replace(normalizeRoot, '<tmp>'),
+      }
+    case 'PermissionError':
+      return {
+        _tag: error._tag,
+        operation: error.operation,
+        message: error.message.replace(normalizeRoot, '<tmp>'),
+      }
+  }
+}
+
 describe('effect-path baselines (cross-major invariant)', () => {
   it('pins PathInfo schema encoded bytes and re-encoded identity', async () => {
     const result = await Effect.runPromise(
@@ -138,13 +172,6 @@ describe('effect-path baselines (cross-major invariant)', () => {
         const invalidPath = yield* EffectPath.convention
           .relativeFile('bad\0path.txt')
           .pipe(Effect.either)
-
-        const left = <A>(either: Either.Either<A, ConventionBaselineError>) => {
-          if (Either.isRight(either) === true) {
-            throw new Error('expected parser failure')
-          }
-          return either.left
-        }
 
         return [
           left(absoluteFileFromRelative),
@@ -219,4 +246,110 @@ describe('effect-path baselines (cross-major invariant)', () => {
       }
     `)
   })
+
+  it('pins real ENOENT and EEXIST platform failure fields and the public missing-path partition', async () => {
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem
+        const root = yield* fs.makeTempDirectoryScoped()
+        const missing = `${root}/missing.txt`
+
+        const enoent = left(yield* fs.stat(missing).pipe(Effect.either))
+        const missingPath = left(
+          yield* EffectPath.verified.absoluteFile(missing).pipe(Effect.either),
+        )
+        // effect-path has no public create/write API or EEXIST branch. This real failure pins the
+        // platform wrapper fields only; it does not claim a package-owned EEXIST partition.
+        const eexist = left(yield* fs.makeDirectory(root).pipe(Effect.either))
+
+        return {
+          enoent: {
+            platform: summarizePlatformError(enoent),
+            public: summarizePathError(missingPath, root),
+          },
+          eexist: {
+            platform: summarizePlatformError(eexist),
+          },
+        }
+      }).pipe(Effect.scoped, Effect.provide(NodeContext.layer)),
+    )
+
+    // TODO(live-migration:effect-3-4): v4 replaces SystemError with PlatformError (register entry
+    // platform-error-wrapper). Resolve by updating the tag while keeping this partition and these
+    // inner fields identical — a change in WHICH branch fires is a real regression, not a rename.
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "eexist": {
+          "platform": {
+            "_tag": "SystemError",
+            "method": "makeDirectory",
+            "module": "FileSystem",
+            "reason": "AlreadyExists",
+          },
+        },
+        "enoent": {
+          "platform": {
+            "_tag": "SystemError",
+            "method": "stat",
+            "module": "FileSystem",
+            "reason": "NotFound",
+          },
+          "public": {
+            "_tag": "PathNotFoundError",
+            "expectedType": "any",
+            "message": "Path not found: <tmp>/missing.txt",
+          },
+        },
+      }
+    `)
+  })
+
+  it.skipIf(process.getuid?.() === 0)(
+    'pins real EACCES platform fields and the public permission partition',
+    async () => {
+      const result = await Effect.runPromise(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem
+          const root = yield* fs.makeTempDirectoryScoped()
+          const blocked = `${root}/blocked`
+          const blockedFile = `${blocked}/data.txt`
+
+          yield* fs.makeDirectory(blocked)
+          yield* fs.writeFileString(blockedFile, 'blocked')
+          yield* fs.chmod(blocked, 0o000)
+
+          return yield* Effect.gen(function* () {
+            const eacces = left(yield* fs.stat(blockedFile).pipe(Effect.either))
+            const permission = left(
+              yield* EffectPath.verified.absoluteFile(blockedFile).pipe(Effect.either),
+            )
+
+            return {
+              platform: summarizePlatformError(eacces),
+              public: summarizePathError(permission, root),
+            }
+          }).pipe(Effect.ensuring(fs.chmod(blocked, 0o700).pipe(Effect.ignore)))
+        }).pipe(Effect.scoped, Effect.provide(NodeContext.layer)),
+      )
+
+      // TODO(live-migration:effect-3-4): v4 replaces SystemError with PlatformError (register entry
+      // platform-error-wrapper). Resolve by updating the tag while keeping this partition and these
+      // inner fields identical — a change in WHICH branch fires is a real regression, not a rename.
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "platform": {
+            "_tag": "SystemError",
+            "method": "stat",
+            "module": "FileSystem",
+            "reason": "PermissionDenied",
+          },
+          "public": {
+            "_tag": "PermissionError",
+            "message": "Permission denied: <tmp>/blocked/data.txt",
+            "operation": "stat",
+          },
+        }
+      `)
+    },
+  )
 })


### PR DESCRIPTION
## Problem

Phase 1 did not exercise real platform filesystem failures through `effect-path`, so the Effect 4 `SystemError` to `PlatformError` repair could misclassify `NotFound` or `PermissionDenied` while the existing baselines remained green.

## Goal

Pin the Effect 3 platform error fields and the package-owned ENOENT/EACCES failure partitions before the cohort flip.

## Decisions

- Use real filesystem operations only; no mocked errno values.
- ENOENT pins `SystemError` / `NotFound` / `FileSystem.stat` and the public `PathNotFoundError` partition.
- EACCES pins `SystemError` / `PermissionDenied` / `FileSystem.stat` and the public `PermissionError` partition. It is skipped only for uid 0, where permission bits cannot honestly provoke EACCES. The validation host ran as uid 1000, so this case executed.
- `effect-path` has no public create/write API, zero EEXIST/`AlreadyExists` branches, and its production `SystemError` branches classify only `NotFound` and `PermissionDenied`. The real EEXIST case therefore pins only the platform wrapper fields (`AlreadyExists`, `FileSystem.makeDirectory`); it does not claim coverage of a package-owned EEXIST branch.
- Prompt PTY adjudication: do not pin raw transcript bytes, but do add a permanent real-PTY semantic gate before the flip. The shared probe was stable across five same-major repetitions, but it currently exists only in the untracked prototype area and therefore does not run at the flip. A tracked gate should project the transcript to caller-visible behavior: selected value, Quit classification, cooked/raw restoration, and cursor/bell cleanup. Megarepo has no raw-terminal parser or promised ANSI byte contract, so exact SGR/reset sequences should remain excluded.

## Verification

- `CI=1 devenv tasks run test:effect-path --mode single --show-output --no-tui`
  - committed head: `055e2b78658645771ba0ea1de79ae236336381f0`
  - summary: `tmp/otel-scrape/summaries/test-effect-path.2713210.summary.json`
  - `vitest.tests=74`
  - `vitest.failures=0`
- `CI=1 devenv tasks run ts:check:strict --no-tui` passed on the committed head.
  - summary: `tmp/otel-scrape/summaries/ts-check-strict.2687204.summary.json`
- `devenv tasks run lint:fix --no-tui` passed.
- `devenv tasks run lint:check:oxlint --no-tui` passed with zero diagnostics.
- `CI=1 devenv tasks run check:all --no-tui` was attempted on the saturated shared host and failed in unrelated repository-wide tasks (`otel:verify:setup`, `ts:check:strict`, and downstream dependency gating). The scoped committed package task above is green.

## Complexity

No production complexity; one baseline file gains real-filesystem fixtures and normalized temporary paths.

## Concerns

The EEXIST assertion is intentionally narrower than the ENOENT/EACCES assertions: it proves wrapper-field stability only. Prompt ANSI bytes should remain ungated, but Prompt semantics are also not yet pinned in a tracked test; G4 remains open until that semantic gate lands.

## Friction & bottlenecks

The shared 32-core host was about 5x oversubscribed during validation. The repository-wide gate took 704 seconds and failed outside this diff; package verification was kept serialized.

## Follow-ups

The Effect 4 flip must update the outer platform error tag while preserving the pinned partitions and inner fields. Before the flip, add a tracked real-PTY Prompt semantic gate without snapshotting transcript bytes. Treat `NO_COLOR` as a separate assertion only after observing its current interactive Prompt behavior, because cursor-control ANSI may remain required.

## References

Refs #925.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | co2-brass |
| `agent_session_id` | b84bae1e-3194-4f29-86c8-d391c7a47596 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.145.0 |
| `agent_runtime` | Codex CLI 0.145.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/i8y8b542cyqi385ywcjw5fvsq24f75v4-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/i81qxhzlrzcxrrdwpp6i8hagka2gby8y-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-28-gap-plat-platform-error |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->