### PR TITLE
test(effect-4): enforce baseline gates after managed tests

### DIFF
--- a/context/effect-4/check-baseline-test-collection.ts
+++ b/context/effect-4/check-baseline-test-collection.ts
@@ -2,26 +2,29 @@
 
 import { existsSync } from 'node:fs'
 import { appendFile } from 'node:fs/promises'
-import { basename, resolve } from 'node:path'
+import { basename, isAbsolute, relative, resolve, sep } from 'node:path'
 
-type SummaryRecord = {
-  readonly name?: unknown
-  readonly value?: unknown
+type BaselineFile = {
+  readonly file: string
+  readonly packageName: string
 }
 
-type PackageResult =
+type FileResult =
   | {
-      readonly failures: number
-      readonly packageName: string
-      readonly summary: string
-      readonly tests: number
+      readonly collectedTests: number
+      readonly file: string
+      readonly report: string
     }
   | {
+      readonly collectedTests?: number
       readonly error: string
-      readonly failures?: number
-      readonly packageName: string
-      readonly tests?: number
+      readonly file: string
     }
+
+type VitestFileResult = {
+  readonly assertionResults?: unknown
+  readonly name?: unknown
+}
 
 const argumentValue = (name: string) => {
   const index = process.argv.indexOf(name)
@@ -29,10 +32,7 @@ const argumentValue = (name: string) => {
 }
 
 const root = resolve(argumentValue('--root') ?? process.cwd())
-const summaryDirectory = resolve(
-  root,
-  argumentValue('--summary-dir') ?? 'tmp/otel-scrape/summaries',
-)
+const reportDirectory = resolve(root, argumentValue('--report-dir') ?? 'tmp/otel-scrape/summaries')
 
 const testGlobs = [
   'packages/@overeng/**/*.test.ts',
@@ -54,143 +54,166 @@ const testFiles = (
   .flat()
   .toSorted()
 
-const baselinePackages = new Set<string>()
-
 const testFileSources = await Promise.all(
   testFiles.map(async (file) => [file, await Bun.file(resolve(root, file)).text()] as const),
 )
 
-for (const [file, source] of testFileSources) {
-  const hasBaselineDescribe = Array.from(source.matchAll(baselineDescribePattern)).some((match) =>
-    /(?:baseline|cross-major)/i.test(match[2] ?? ''),
+const baselineFiles = testFileSources
+  .filter(([, source]) =>
+    Array.from(source.matchAll(baselineDescribePattern)).some((match) =>
+      /(?:baseline|cross-major)/i.test(match[2] ?? ''),
+    ),
   )
-  const packageName = packageNameFrom(file)
-  if (hasBaselineDescribe === true && packageName !== undefined) {
-    baselinePackages.add(packageName)
-  }
-}
+  .map(([file]): BaselineFile | undefined => {
+    const packageName = packageNameFrom(file)
+    return packageName === undefined ? undefined : { file, packageName }
+  })
+  .filter((file): file is BaselineFile => file !== undefined)
+  .toSorted((left, right) => left.file.localeCompare(right.file))
 
-const metricValue = ({
-  records,
-  metric,
-}: {
-  readonly metric: string
-  readonly records: readonly SummaryRecord[]
-}) => records.find((record) => record.name === metric)?.value
+const baselineFilesByPackage = Map.groupBy(baselineFiles, (file) => file.packageName)
 
-const missingSummaryError = () =>
-  `missing managed-task summary in ${summaryDirectory}; was the test task run in an installed worktree?`
+const missingReportError = (packageName: string) =>
+  `missing managed Vitest JSON report for test:${packageName} in ${reportDirectory}; was the test task run in an installed worktree?`
 
-const readPackageResult = async (packageName: string): Promise<PackageResult> => {
-  const summaries =
-    existsSync(summaryDirectory) === false
+const newestReportFor = async (packageName: string) => {
+  const reports =
+    existsSync(reportDirectory) === false
       ? []
       : await Array.fromAsync(
-          new Bun.Glob(`test-${packageName}*.summary.json`).scan({
+          new Bun.Glob(`test-${packageName}*.vitest.json`).scan({
             absolute: true,
-            cwd: summaryDirectory,
+            cwd: reportDirectory,
           }),
         )
 
-  if (summaries.length === 0) {
-    return {
-      error: missingSummaryError(),
-      packageName,
-    }
-  }
-
-  const summariesByNewest = await Promise.all(
-    summaries.map(async (summary) => ({
-      modifiedAt: (await Bun.file(summary).stat()).mtimeMs,
-      summary,
+  const reportsByNewest = await Promise.all(
+    reports.map(async (report) => ({
+      modifiedAt: (await Bun.file(report).stat()).mtimeMs,
+      report,
     })),
   )
-  summariesByNewest.sort(
-    (left, right) =>
-      right.modifiedAt - left.modifiedAt || right.summary.localeCompare(left.summary),
+  reportsByNewest.sort(
+    (left, right) => right.modifiedAt - left.modifiedAt || right.report.localeCompare(left.report),
   )
-  const summary = summariesByNewest[0]?.summary
-  if (summary === undefined) {
-    return {
-      error: missingSummaryError(),
-      packageName,
-    }
+  return reportsByNewest[0]?.report
+}
+
+const repoPathFromReportName = ({
+  name,
+  packageName,
+}: {
+  readonly name: string
+  readonly packageName: string
+}) => {
+  const normalizedName = name.replaceAll('\\', '/')
+  const absolute =
+    isAbsolute(name) === true
+      ? name
+      : normalizedName.startsWith('packages/') === true
+        ? resolve(root, normalizedName)
+        : resolve(root, 'packages', '@overeng', packageName, normalizedName)
+  const repoPath = relative(root, absolute).split(sep).join('/')
+  return repoPath.startsWith('../') === true ? undefined : repoPath
+}
+
+const failFiles = ({
+  files,
+  error,
+}: {
+  readonly error: string
+  readonly files: readonly BaselineFile[]
+}): readonly FileResult[] => files.map(({ file }) => ({ error, file }))
+
+const readPackageResults = async ({
+  packageName,
+  files,
+}: {
+  readonly files: readonly BaselineFile[]
+  readonly packageName: string
+}): Promise<readonly FileResult[]> => {
+  const report = await newestReportFor(packageName)
+  if (report === undefined) {
+    return failFiles({ files, error: missingReportError(packageName) })
   }
 
   let decoded: unknown
   try {
-    decoded = await Bun.file(summary).json()
+    decoded = await Bun.file(report).json()
   } catch (cause) {
-    return {
-      error: `${basename(summary)} is not valid JSON: ${String(cause)}`,
-      packageName,
-    }
+    return failFiles({
+      files,
+      error: `${basename(report)} is not valid JSON: ${String(cause)}`,
+    })
   }
 
-  const records =
+  const testResults =
     typeof decoded === 'object' &&
     decoded !== null &&
-    'adapter' in decoded &&
-    typeof decoded.adapter === 'object' &&
-    decoded.adapter !== null &&
-    'records' in decoded.adapter &&
-    Array.isArray(decoded.adapter.records) === true
-      ? (decoded.adapter.records as readonly SummaryRecord[])
-      : []
-  const tests = metricValue({ records, metric: 'vitest.tests' })
-  const failures = metricValue({ records, metric: 'vitest.failures' })
-
-  if (
-    typeof tests !== 'number' ||
-    Number.isFinite(tests) === false ||
-    Number.isInteger(tests) === false ||
-    tests < 0
-  ) {
-    return {
-      error: `${basename(summary)} has no non-negative integer vitest.tests metric`,
-      packageName,
-    }
-  }
-  if (
-    typeof failures !== 'number' ||
-    Number.isFinite(failures) === false ||
-    Number.isInteger(failures) === false ||
-    failures < 0
-  ) {
-    return {
-      error: `${basename(summary)} has no non-negative integer vitest.failures metric`,
-      packageName,
-    }
-  }
-  if (tests === 0) {
-    return {
-      error: `${basename(summary)} reports vitest.tests=0 (vitest.failures=${failures})`,
-      failures,
-      packageName,
-      tests,
-    }
+    'testResults' in decoded &&
+    Array.isArray(decoded.testResults) === true
+      ? (decoded.testResults as readonly VitestFileResult[])
+      : undefined
+  if (testResults === undefined) {
+    return failFiles({
+      files,
+      error: `${basename(report)} has no testResults array`,
+    })
   }
 
-  return {
-    failures,
-    packageName,
-    summary: basename(summary),
-    tests,
+  const collectedByFile = new Map<string, number>()
+  for (const testResult of testResults) {
+    if (
+      typeof testResult.name !== 'string' ||
+      Array.isArray(testResult.assertionResults) === false
+    ) {
+      continue
+    }
+    const file = repoPathFromReportName({ name: testResult.name, packageName })
+    if (file === undefined) continue
+    collectedByFile.set(file, (collectedByFile.get(file) ?? 0) + testResult.assertionResults.length)
   }
+  const reportTests = [...collectedByFile.values()].reduce((sum, count) => sum + count, 0)
+
+  return files.map(({ file }): FileResult => {
+    const collectedTests = collectedByFile.get(file)
+    if (collectedTests === undefined) {
+      return {
+        error: `${basename(report)} does not contain this baseline file (${reportTests} tests collected from other files)`,
+        file,
+      }
+    }
+    if (collectedTests === 0) {
+      return {
+        collectedTests,
+        error: `${basename(report)} reports zero collected tests for this baseline file (${reportTests} tests collected across the package)`,
+        file,
+      }
+    }
+    return {
+      collectedTests,
+      file,
+      report: basename(report),
+    }
+  })
 }
 
-const results = await Promise.all(
-  baselinePackages.values().toArray().toSorted().map(readPackageResult),
+const results = (
+  await Promise.all(
+    [...baselineFilesByPackage.entries()].map(([packageName, files]) =>
+      readPackageResults({ packageName, files }),
+    ),
+  )
 )
+  .flat()
+  .toSorted((left, right) => left.file.localeCompare(right.file))
 const failed = results.filter((result) => 'error' in result)
 
 for (const result of results) {
   if ('error' in result) {
-    console.error(`FAIL ${result.packageName}: ${result.error}`)
+    console.error(`FAIL ${result.file}: ${result.error}`)
   } else {
-    console.log(
-      `PASS ${result.packageName}: vitest.tests=${result.tests} vitest.failures=${result.failures} (${result.summary})`,
-    )
+    console.log(`PASS ${result.file}: collectedTests=${result.collectedTests} (${result.report})`)
   }
 }
 
@@ -202,16 +225,16 @@ const appendGitHubStepSummary = async () => {
   if (stepSummary === undefined || stepSummary.length === 0) return
 
   const rows = results.map((result) => {
-    const tests = typeof result.tests === 'number' ? String(result.tests) : '-'
-    const failures = typeof result.failures === 'number' ? String(result.failures) : '-'
-    const evidence = 'error' in result ? `FAIL: ${result.error}` : `PASS: ${result.summary}`
-    return `| ${markdownCell(result.packageName)} | ${tests} | ${failures} | ${markdownCell(evidence)} |`
+    const collectedTests =
+      typeof result.collectedTests === 'number' ? String(result.collectedTests) : '-'
+    const evidence = 'error' in result ? `FAIL: ${result.error}` : `PASS: ${result.report}`
+    return `| ${markdownCell(result.file)} | ${collectedTests} | ${markdownCell(evidence)} |`
   })
   const table = [
     '## Effect 4 baseline test collection',
     '',
-    '| Package | vitest.tests | vitest.failures | Evidence |',
-    '| --- | ---: | ---: | --- |',
+    '| Baseline file | Collected tests | Evidence |',
+    '| --- | ---: | --- |',
     ...rows,
     '',
   ].join('\n')
@@ -220,7 +243,7 @@ const appendGitHubStepSummary = async () => {
     await appendFile(stepSummary, table)
   } catch (cause) {
     console.warn(
-      `WARN: could not append Effect 4 baseline counts to GITHUB_STEP_SUMMARY; gate enforcement is unchanged: ${String(cause)}`,
+      `WARN: could not append Effect 4 baseline file counts to GITHUB_STEP_SUMMARY; gate enforcement is unchanged: ${String(cause)}`,
     )
   }
 }
@@ -229,11 +252,11 @@ await appendGitHubStepSummary()
 
 if (failed.length === 0) {
   console.log(
-    `PASS: ${baselinePackages.size} baseline packages have managed-task summaries with collected tests.`,
+    `PASS: ${baselineFiles.length} baseline files each contributed at least one collected test.`,
   )
 } else {
   console.error(
-    `FAIL: ${failed.length}/${baselinePackages.size} baseline packages lack proof of collected tests.`,
+    `FAIL: ${failed.length}/${baselineFiles.length} baseline files lack proof of collected tests.`,
   )
   process.exitCode = 1
 }

--- a/context/effect-4/check-baseline-test-collection.ts
+++ b/context/effect-4/check-baseline-test-collection.ts
@@ -1,0 +1,198 @@
+#!/usr/bin/env bun
+
+import { existsSync } from 'node:fs'
+import { basename, resolve } from 'node:path'
+
+type SummaryRecord = {
+  readonly name?: unknown
+  readonly value?: unknown
+}
+
+type PackageResult =
+  | {
+      readonly failures: number
+      readonly packageName: string
+      readonly summary: string
+      readonly tests: number
+    }
+  | {
+      readonly error: string
+      readonly packageName: string
+    }
+
+const argumentValue = (name: string) => {
+  const index = process.argv.indexOf(name)
+  return index === -1 ? undefined : process.argv[index + 1]
+}
+
+const root = resolve(argumentValue('--root') ?? process.cwd())
+const summaryDirectory = resolve(
+  root,
+  argumentValue('--summary-dir') ?? 'tmp/otel-scrape/summaries',
+)
+
+const testGlobs = [
+  'packages/@overeng/**/*.test.ts',
+  'packages/@overeng/**/*.test.tsx',
+  'packages/@overeng/**/*.spec.ts',
+  'packages/@overeng/**/*.spec.tsx',
+] as const
+
+const baselineDescribePattern =
+  /(?:^|[^\w$])(?:[A-Za-z_$][\w$]*\.)?describe(?:\.\w+)*\s*\(\s*(['"`])((?:(?!\1)[\s\S])*?)\1/g
+
+const packageNameFrom = (file: string) => file.split('/')[2]
+
+const testFiles = (
+  await Promise.all(
+    testGlobs.map(async (pattern) => Array.fromAsync(new Bun.Glob(pattern).scan({ cwd: root }))),
+  )
+)
+  .flat()
+  .toSorted()
+
+const baselinePackages = new Set<string>()
+
+const testFileSources = await Promise.all(
+  testFiles.map(async (file) => [file, await Bun.file(resolve(root, file)).text()] as const),
+)
+
+for (const [file, source] of testFileSources) {
+  const hasBaselineDescribe = Array.from(source.matchAll(baselineDescribePattern)).some((match) =>
+    /(?:baseline|cross-major)/i.test(match[2] ?? ''),
+  )
+  const packageName = packageNameFrom(file)
+  if (hasBaselineDescribe === true && packageName !== undefined) {
+    baselinePackages.add(packageName)
+  }
+}
+
+const metricValue = ({
+  records,
+  metric,
+}: {
+  readonly metric: string
+  readonly records: readonly SummaryRecord[]
+}) => records.find((record) => record.name === metric)?.value
+
+const readPackageResult = async (packageName: string): Promise<PackageResult> => {
+  const summaries =
+    existsSync(summaryDirectory) === false
+      ? []
+      : await Array.fromAsync(
+          new Bun.Glob(`test-${packageName}*.summary.json`).scan({
+            absolute: true,
+            cwd: summaryDirectory,
+          }),
+        )
+
+  if (summaries.length === 0) {
+    return {
+      error: `missing managed-task summary in ${summaryDirectory}`,
+      packageName,
+    }
+  }
+
+  const summariesByNewest = await Promise.all(
+    summaries.map(async (summary) => ({
+      modifiedAt: (await Bun.file(summary).stat()).mtimeMs,
+      summary,
+    })),
+  )
+  summariesByNewest.sort(
+    (left, right) =>
+      right.modifiedAt - left.modifiedAt || right.summary.localeCompare(left.summary),
+  )
+  const summary = summariesByNewest[0]?.summary
+  if (summary === undefined) {
+    return {
+      error: `missing managed-task summary in ${summaryDirectory}`,
+      packageName,
+    }
+  }
+
+  let decoded: unknown
+  try {
+    decoded = await Bun.file(summary).json()
+  } catch (cause) {
+    return {
+      error: `${basename(summary)} is not valid JSON: ${String(cause)}`,
+      packageName,
+    }
+  }
+
+  const records =
+    typeof decoded === 'object' &&
+    decoded !== null &&
+    'adapter' in decoded &&
+    typeof decoded.adapter === 'object' &&
+    decoded.adapter !== null &&
+    'records' in decoded.adapter &&
+    Array.isArray(decoded.adapter.records) === true
+      ? (decoded.adapter.records as readonly SummaryRecord[])
+      : []
+  const tests = metricValue({ records, metric: 'vitest.tests' })
+  const failures = metricValue({ records, metric: 'vitest.failures' })
+
+  if (
+    typeof tests !== 'number' ||
+    Number.isFinite(tests) === false ||
+    Number.isInteger(tests) === false ||
+    tests < 0
+  ) {
+    return {
+      error: `${basename(summary)} has no non-negative integer vitest.tests metric`,
+      packageName,
+    }
+  }
+  if (
+    typeof failures !== 'number' ||
+    Number.isFinite(failures) === false ||
+    Number.isInteger(failures) === false ||
+    failures < 0
+  ) {
+    return {
+      error: `${basename(summary)} has no non-negative integer vitest.failures metric`,
+      packageName,
+    }
+  }
+  if (tests === 0) {
+    return {
+      error: `${basename(summary)} reports vitest.tests=0 (vitest.failures=${failures})`,
+      packageName,
+    }
+  }
+
+  return {
+    failures,
+    packageName,
+    summary: basename(summary),
+    tests,
+  }
+}
+
+const results = await Promise.all(
+  baselinePackages.values().toArray().toSorted().map(readPackageResult),
+)
+const failed = results.filter((result) => 'error' in result)
+
+for (const result of results) {
+  if ('error' in result) {
+    console.error(`FAIL ${result.packageName}: ${result.error}`)
+  } else {
+    console.log(
+      `PASS ${result.packageName}: vitest.tests=${result.tests} vitest.failures=${result.failures} (${result.summary})`,
+    )
+  }
+}
+
+if (failed.length === 0) {
+  console.log(
+    `PASS: ${baselinePackages.size} baseline packages have managed-task summaries with collected tests.`,
+  )
+} else {
+  console.error(
+    `FAIL: ${failed.length}/${baselinePackages.size} baseline packages lack proof of collected tests.`,
+  )
+  process.exitCode = 1
+}

--- a/context/effect-4/check-baseline-test-collection.ts
+++ b/context/effect-4/check-baseline-test-collection.ts
@@ -75,6 +75,9 @@ const metricValue = ({
   readonly records: readonly SummaryRecord[]
 }) => records.find((record) => record.name === metric)?.value
 
+const missingSummaryError = () =>
+  `missing managed-task summary in ${summaryDirectory}; was the test task run in an installed worktree?`
+
 const readPackageResult = async (packageName: string): Promise<PackageResult> => {
   const summaries =
     existsSync(summaryDirectory) === false
@@ -88,7 +91,7 @@ const readPackageResult = async (packageName: string): Promise<PackageResult> =>
 
   if (summaries.length === 0) {
     return {
-      error: `missing managed-task summary in ${summaryDirectory}`,
+      error: missingSummaryError(),
       packageName,
     }
   }
@@ -106,7 +109,7 @@ const readPackageResult = async (packageName: string): Promise<PackageResult> =>
   const summary = summariesByNewest[0]?.summary
   if (summary === undefined) {
     return {
-      error: `missing managed-task summary in ${summaryDirectory}`,
+      error: missingSummaryError(),
       packageName,
     }
   }

--- a/context/effect-4/check-baseline-test-collection.ts
+++ b/context/effect-4/check-baseline-test-collection.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 
 import { existsSync } from 'node:fs'
+import { appendFile } from 'node:fs/promises'
 import { basename, resolve } from 'node:path'
 
 type SummaryRecord = {
@@ -17,7 +18,9 @@ type PackageResult =
     }
   | {
       readonly error: string
+      readonly failures?: number
       readonly packageName: string
+      readonly tests?: number
     }
 
 const argumentValue = (name: string) => {
@@ -162,7 +165,9 @@ const readPackageResult = async (packageName: string): Promise<PackageResult> =>
   if (tests === 0) {
     return {
       error: `${basename(summary)} reports vitest.tests=0 (vitest.failures=${failures})`,
+      failures,
       packageName,
+      tests,
     }
   }
 
@@ -188,6 +193,39 @@ for (const result of results) {
     )
   }
 }
+
+const markdownCell = (value: string) =>
+  value.replaceAll('\\', '\\\\').replaceAll('|', '\\|').replaceAll('\n', ' ')
+
+const appendGitHubStepSummary = async () => {
+  const stepSummary = process.env.GITHUB_STEP_SUMMARY
+  if (stepSummary === undefined || stepSummary.length === 0) return
+
+  const rows = results.map((result) => {
+    const tests = typeof result.tests === 'number' ? String(result.tests) : '-'
+    const failures = typeof result.failures === 'number' ? String(result.failures) : '-'
+    const evidence = 'error' in result ? `FAIL: ${result.error}` : `PASS: ${result.summary}`
+    return `| ${markdownCell(result.packageName)} | ${tests} | ${failures} | ${markdownCell(evidence)} |`
+  })
+  const table = [
+    '## Effect 4 baseline test collection',
+    '',
+    '| Package | vitest.tests | vitest.failures | Evidence |',
+    '| --- | ---: | ---: | --- |',
+    ...rows,
+    '',
+  ].join('\n')
+
+  try {
+    await appendFile(stepSummary, table)
+  } catch (cause) {
+    console.warn(
+      `WARN: could not append Effect 4 baseline counts to GITHUB_STEP_SUMMARY; gate enforcement is unchanged: ${String(cause)}`,
+    )
+  }
+}
+
+await appendGitHubStepSummary()
 
 if (failed.length === 0) {
   console.log(

--- a/context/effect-4/check-baseline-test-collection.ts
+++ b/context/effect-4/check-baseline-test-collection.ts
@@ -6,7 +6,7 @@ import { basename, isAbsolute, relative, resolve, sep } from 'node:path'
 
 type BaselineFile = {
   readonly file: string
-  readonly packageName: string
+  readonly registration?: TestTaskRegistration
 }
 
 type FileResult =
@@ -26,6 +26,11 @@ type VitestFileResult = {
   readonly name?: unknown
 }
 
+type TestTaskRegistration = {
+  readonly packagePath: string
+  readonly taskName: string
+}
+
 const argumentValue = (name: string) => {
   const index = process.argv.indexOf(name)
   return index === -1 ? undefined : process.argv[index + 1]
@@ -33,6 +38,27 @@ const argumentValue = (name: string) => {
 
 const root = resolve(argumentValue('--root') ?? process.cwd())
 const reportDirectory = resolve(root, argumentValue('--report-dir') ?? 'tmp/otel-scrape/summaries')
+const taskRegistryPath = argumentValue('--task-registry')
+if (taskRegistryPath === undefined) {
+  throw new Error('--task-registry is required')
+}
+
+const decodedTaskRegistry: unknown = await Bun.file(taskRegistryPath).json()
+if (
+  Array.isArray(decodedTaskRegistry) === false ||
+  decodedTaskRegistry.some(
+    (registration) =>
+      typeof registration !== 'object' ||
+      registration === null ||
+      !('packagePath' in registration) ||
+      typeof registration.packagePath !== 'string' ||
+      !('taskName' in registration) ||
+      typeof registration.taskName !== 'string',
+  ) === true
+) {
+  throw new Error(`${taskRegistryPath} is not a valid baseline test task registry`)
+}
+const taskRegistry = decodedTaskRegistry as readonly TestTaskRegistration[]
 
 const testGlobs = [
   'packages/@overeng/**/*.test.ts',
@@ -43,8 +69,6 @@ const testGlobs = [
 
 const baselineDescribePattern =
   /(?:^|[^\w$])(?:[A-Za-z_$][\w$]*\.)?describe(?:\.\w+)*\s*\(\s*(['"`])((?:(?!\1)[\s\S])*?)\1/g
-
-const packageNameFrom = (file: string) => file.split('/')[2]
 
 const testFiles = (
   await Promise.all(
@@ -58,93 +82,59 @@ const testFileSources = await Promise.all(
   testFiles.map(async (file) => [file, await Bun.file(resolve(root, file)).text()] as const),
 )
 
+const registrationFor = (file: string) =>
+  taskRegistry
+    .filter(({ packagePath }) => file.startsWith(`${packagePath}/`))
+    .toSorted((left, right) => right.packagePath.length - left.packagePath.length)[0]
+
 const baselineFiles = testFileSources
   .filter(([, source]) =>
     Array.from(source.matchAll(baselineDescribePattern)).some((match) =>
       /(?:baseline|cross-major)/i.test(match[2] ?? ''),
     ),
   )
-  .map(([file]): BaselineFile | undefined => {
-    const packageName = packageNameFrom(file)
-    return packageName === undefined ? undefined : { file, packageName }
-  })
-  .filter((file): file is BaselineFile => file !== undefined)
+  .map(([file]): BaselineFile => ({ file, registration: registrationFor(file) }))
   .toSorted((left, right) => left.file.localeCompare(right.file))
 
-const baselineFilesByPackage = Map.groupBy(baselineFiles, (file) => file.packageName)
-
-const missingReportError = (packageName: string) =>
-  `missing managed Vitest JSON report for test:${packageName} in ${reportDirectory}; was the test task run in an installed worktree?`
-
-const newestReportFor = async (packageName: string) => {
-  const reports =
-    existsSync(reportDirectory) === false
-      ? []
-      : await Array.fromAsync(
-          new Bun.Glob(`test-${packageName}*.vitest.json`).scan({
-            absolute: true,
-            cwd: reportDirectory,
-          }),
-        )
-
-  const reportsByNewest = await Promise.all(
-    reports.map(async (report) => ({
-      modifiedAt: (await Bun.file(report).stat()).mtimeMs,
-      report,
-    })),
-  )
-  reportsByNewest.sort(
-    (left, right) => right.modifiedAt - left.modifiedAt || right.report.localeCompare(left.report),
-  )
-  return reportsByNewest[0]?.report
-}
-
-const repoPathFromReportName = ({
-  name,
-  packageName,
-}: {
-  readonly name: string
-  readonly packageName: string
-}) => {
+const repoPathFromReportName = (name: string) => {
   const normalizedName = name.replaceAll('\\', '/')
   const absolute =
     isAbsolute(name) === true
       ? name
       : normalizedName.startsWith('packages/') === true
         ? resolve(root, normalizedName)
-        : resolve(root, 'packages', '@overeng', packageName, normalizedName)
+        : undefined
+  if (absolute === undefined) return undefined
   const repoPath = relative(root, absolute).split(sep).join('/')
   return repoPath.startsWith('../') === true ? undefined : repoPath
 }
 
-const failFiles = ({
-  files,
-  error,
-}: {
-  readonly error: string
-  readonly files: readonly BaselineFile[]
-}): readonly FileResult[] => files.map(({ file }) => ({ error, file }))
+const taskFileStem = (taskName: string) =>
+  taskName.replaceAll(':', '-').replaceAll('/', '-').replaceAll(' ', '-').replaceAll('.', '_')
 
-const readPackageResults = async ({
-  packageName,
+const readTaskResults = async ({
   files,
+  registration,
 }: {
   readonly files: readonly BaselineFile[]
-  readonly packageName: string
+  readonly registration: TestTaskRegistration
 }): Promise<readonly FileResult[]> => {
-  const report = await newestReportFor(packageName)
-  if (report === undefined) {
-    return failFiles({ files, error: missingReportError(packageName) })
+  const report = resolve(reportDirectory, `${taskFileStem(registration.taskName)}.vitest.json`)
+  if (existsSync(report) === false) {
+    return files.map(({ file }) => ({
+      error: `missing exact report ${basename(report)} for registered task ${registration.taskName}`,
+      file,
+    }))
   }
 
   let decoded: unknown
   try {
     decoded = await Bun.file(report).json()
   } catch (cause) {
-    return failFiles({
-      files,
+    return files.map(({ file }) => ({
       error: `${basename(report)} is not valid JSON: ${String(cause)}`,
-    })
+      file,
+    }))
   }
 
   const testResults =
@@ -155,10 +145,10 @@ const readPackageResults = async ({
       ? (decoded.testResults as readonly VitestFileResult[])
       : undefined
   if (testResults === undefined) {
-    return failFiles({
-      files,
+    return files.map(({ file }) => ({
       error: `${basename(report)} has no testResults array`,
-    })
+      file,
+    }))
   }
 
   const collectedByFile = new Map<string, number>()
@@ -169,7 +159,7 @@ const readPackageResults = async ({
     ) {
       continue
     }
-    const file = repoPathFromReportName({ name: testResult.name, packageName })
+    const file = repoPathFromReportName(testResult.name)
     if (file === undefined) continue
     collectedByFile.set(file, (collectedByFile.get(file) ?? 0) + testResult.assertionResults.length)
   }
@@ -186,7 +176,7 @@ const readPackageResults = async ({
     if (collectedTests === 0) {
       return {
         collectedTests,
-        error: `${basename(report)} reports zero collected tests for this baseline file (${reportTests} tests collected across the package)`,
+        error: `${basename(report)} reports zero collected tests for this baseline file (${reportTests} tests collected across the registered task)`,
         file,
       }
     }
@@ -198,15 +188,29 @@ const readPackageResults = async ({
   })
 }
 
-const results = (
+const unregisteredResults: readonly FileResult[] = baselineFiles
+  .filter(({ registration }) => registration === undefined)
+  .map(({ file }) => ({
+    error: 'no registered managed test task owns this baseline file',
+    file,
+  }))
+const filesByTask = Map.groupBy(
+  baselineFiles.filter(
+    (file): file is BaselineFile & { readonly registration: TestTaskRegistration } =>
+      file.registration !== undefined,
+  ),
+  ({ registration }) => registration.taskName,
+)
+const registeredResults = (
   await Promise.all(
-    [...baselineFilesByPackage.entries()].map(([packageName, files]) =>
-      readPackageResults({ packageName, files }),
+    [...filesByTask.values()].map((files) =>
+      readTaskResults({ files, registration: files[0]!.registration }),
     ),
   )
+).flat()
+const results = [...unregisteredResults, ...registeredResults].toSorted((left, right) =>
+  left.file.localeCompare(right.file),
 )
-  .flat()
-  .toSorted((left, right) => left.file.localeCompare(right.file))
 const failed = results.filter((result) => 'error' in result)
 
 for (const result of results) {

--- a/devenv.nix
+++ b/devenv.nix
@@ -691,11 +691,13 @@ in
 
   # `test:run` executes after its package-task dependencies, so both Effect 4
   # gates see the complete managed-test summary directory in CI.
-  tasks."test:run".exec = trace.exec "test:run" ''
-    set -euo pipefail
-    ${pkgs.bun}/bin/bun context/effect-4/check-baseline-migration-markers.ts
-    ${pkgs.bun}/bin/bun context/effect-4/check-baseline-test-collection.ts
-  '';
+  tasks."test:run".exec = lib.mkForce (
+    trace.exec "test:run" ''
+      set -euo pipefail
+      ${pkgs.bun}/bin/bun context/effect-4/check-baseline-migration-markers.ts
+      ${pkgs.bun}/bin/bun context/effect-4/check-baseline-test-collection.ts
+    ''
+  );
 
   # Keep git-hook installation out of the shell-entry path.
   # If needed, install with `devenv tasks run devenv:git-hooks:install`.

--- a/devenv.nix
+++ b/devenv.nix
@@ -253,6 +253,14 @@ let
       }
       // (packageTestOverrides.${name} or { })
     ) packageNames;
+  baselineTestTaskRegistry = pkgs.writeText "effect4-baseline-test-task-registry.json" (
+    builtins.toJSON (
+      map (pkg: {
+        packagePath = pkg.path;
+        taskName = "test:${pkg.name}";
+      }) packagesWithTests
+    )
+  );
 
   # Packages that have storybook (subset of allPackages)
   packagesWithStorybook = [
@@ -696,7 +704,8 @@ in
     trace.exec "test:run" ''
       set -euo pipefail
       ${pkgs.bun}/bin/bun context/effect-4/check-baseline-migration-markers.ts
-      ${pkgs.bun}/bin/bun context/effect-4/check-baseline-test-collection.ts
+      ${pkgs.bun}/bin/bun context/effect-4/check-baseline-test-collection.ts \
+        --task-registry ${baselineTestTaskRegistry}
     ''
   );
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -689,6 +689,14 @@ in
     "dependency-materialization:evidence:check"
   ];
 
+  # `test:run` executes after its package-task dependencies, so both Effect 4
+  # gates see the complete managed-test summary directory in CI.
+  tasks."test:run".exec = trace.exec "test:run" ''
+    set -euo pipefail
+    ${pkgs.bun}/bin/bun context/effect-4/check-baseline-migration-markers.ts
+    ${pkgs.bun}/bin/bun context/effect-4/check-baseline-test-collection.ts
+  '';
+
   # Keep git-hook installation out of the shell-entry path.
   # If needed, install with `devenv tasks run devenv:git-hooks:install`.
   # TODO(cachix/git-hooks.nix#688): remove this once the upstream git-hooks.nix issue

--- a/devenv.nix
+++ b/devenv.nix
@@ -378,6 +378,7 @@ in
       packages = packagesWithTests;
       extraTests = [ "devenv-modules:test" ];
       packageConcurrency = 4;
+      retainVitestJson = true;
     })
     (taskModules.storybook {
       packages = packagesWithStorybook;

--- a/nix/devenv-modules/tasks/shared/test.nix
+++ b/nix/devenv-modules/tasks/shared/test.nix
@@ -101,7 +101,7 @@ let
         _vitest_collection_args=(
           --reporter=default
           --reporter=json
-          "--outputFile.json=$_vitest_collection_dir/${taskFileStem name}.$$.vitest.json"
+          "--outputFile.json=$_vitest_collection_dir/${taskFileStem name}.vitest.json"
         )
       ''}
       "''${_otel_instr[@]}" "$(resolve_package_bin vitest vitest)" run --testTimeout 30000 --hookTimeout 30000 "''${_vitest_collection_args[@]}" ${extraArgs}

--- a/nix/devenv-modules/tasks/shared/test.nix
+++ b/nix/devenv-modules/tasks/shared/test.nix
@@ -36,6 +36,7 @@
   installTask ? "pnpm:install",
   extraTests ? [ ],
   packageConcurrency ? null,
+  retainVitestJson ? false,
 }:
 { lib, pkgs, ... }:
 let
@@ -52,6 +53,22 @@ let
     else
       packageConcurrency;
   packagesWithIndexes = lib.imap0 (index: pkg: pkg // { __testIndex = index; }) packages;
+  taskFileStem =
+    taskName:
+    builtins.replaceStrings
+      [
+        ":"
+        "/"
+        " "
+        "."
+      ]
+      [
+        "-"
+        "-"
+        "-"
+        "_"
+      ]
+      taskName;
 
   # Do not force preserve-symlinks here. pnpm's projected workspace graph
   # relies on realpath-based resolution, and preserve-symlinks caused Vitest to
@@ -62,7 +79,9 @@ let
   # vitest `--reporter=json` SIDE-CHANNEL it injects itself (decision 0017), so the
   # human reporter output stays on the terminal unchanged. `run_package_bin` is a
   # shell function, so it is resolved to a real bin path first (experiment 0007)
-  # and otel-scrape wraps that path directly.
+  # and otel-scrape wraps that path directly. When retainVitestJson is enabled,
+  # the managed task owns the JSON output path, so otel-scrape reads but does not
+  # delete the job-local report. Its public summary remains counts-only.
   vitestExec =
     {
       name,
@@ -75,7 +94,17 @@ let
         adapter = "vitest";
         inherit name;
       }}
-      "''${_otel_instr[@]}" "$(resolve_package_bin vitest vitest)" run --testTimeout 30000 --hookTimeout 30000 ${extraArgs}
+      _vitest_collection_args=()
+      ${lib.optionalString retainVitestJson ''
+        _vitest_collection_dir="''${VITEST_COLLECTION_REPORT_DIR:-''${DEVENV_ROOT:-$PWD}/tmp/otel-scrape/summaries}"
+        mkdir -p "$_vitest_collection_dir"
+        _vitest_collection_args=(
+          --reporter=default
+          --reporter=json
+          "--outputFile.json=$_vitest_collection_dir/${taskFileStem name}.$$.vitest.json"
+        )
+      ''}
+      "''${_otel_instr[@]}" "$(resolve_package_bin vitest vitest)" run --testTimeout 30000 --hookTimeout 30000 "''${_vitest_collection_args[@]}" ${extraArgs}
     '';
   vitestWatchExec = ''
     set -euo pipefail


### PR DESCRIPTION
## Problem

Phase 1 baseline packages had registered managed test tasks and matching include patterns, but no durable proof that each baseline file contributed a collected test. A zero-test Vitest run exits successfully, and a package-wide positive count can hide an uncollected baseline file behind unrelated passing tests.

The existing migration-marker checker from #1018 had the same higher-level defect: its logic and negative probes were correct, but no task or workflow invoked it.

## Goal

Make both Effect 4 baseline checkers real CI gates and require runtime collection evidence for every mechanically discovered baseline file.

## Decisions

- Discover baseline files mechanically from baseline/cross-major `describe` blocks across package test files, matching the adjacent marker checker's semantic boundary rather than maintaining an allowlist.
- Have the managed Vitest task retain one exact, stable, job-local native JSON report per registered task whenever `retainVitestJson` is enabled. The repo root enables it; the shared module defaults to disabled.
- Generate the checker task registry directly from `packagesWithTests`. Each baseline file is assigned by registered package path, then the checker reads that task's exact report filename; it does not infer task ownership from a filename glob.
- Keep otel-scrape's public summary unchanged and counts-only. The native report remains under the ignored job-local `tmp` tree and is not uploaded as an artifact.
- Read the newest `test-<package>*.vitest.json`, map `testResults[].name` back to repository paths, and count each file's `assertionResults`.
- Fail when a baseline file is absent or has zero collected assertions, even if unrelated files in the same package collected tests.
- Append a per-file count/evidence table to `GITHUB_STEP_SUMMARY` on pass and failure. Summary writing is best-effort and cannot change gate enforcement.
- Run both checkers from the aggregate `test:run` exec after its package-task dependencies.

The Linux and macOS CI test jobs invoke `devenv tasks run test:run`; the aggregate then runs:

1. `context/effect-4/check-baseline-migration-markers.ts`
2. `context/effect-4/check-baseline-test-collection.ts`

## Verification

Static gates:

- `devenv tasks run ts:check --mode single --refresh-task-cache --show-output --no-tui` - passed
- `oxfmt --check context/effect-4/check-baseline-test-collection.ts` - passed
- `oxlint context/effect-4/check-baseline-test-collection.ts` - 0 warnings, 0 errors
- `nixfmt --check devenv.nix nix/devenv-modules/tasks/shared/test.nix` - passed
- marker checker - `PASS: 27 baseline test files contain no unmarked Effect 3 -> 4 risk signatures.`
- `devenv-modules:test` - passed

Healthy per-file fixture:

```text
PASS packages/@overeng/probe/src/runtime-baseline.test.ts: collectedTests=1 (test-probe.100.vitest.json)
PASS: 1 baseline files each contributed at least one collected test.
```

The successful run appended:

```text
| Baseline file | Collected tests | Evidence |
| --- | ---: | --- |
| packages/@overeng/probe/src/runtime-baseline.test.ts | 1 | PASS: test-probe.100.vitest.json |
```

Discriminating negative: the ordinary file still contributed one collected test, while the baseline file contributed zero:

```text
FAIL packages/@overeng/probe/src/runtime-baseline.test.ts: test-probe.100.vitest.json reports zero collected tests for this baseline file (1 tests collected across the package)
FAIL: 1/1 baseline files lack proof of collected tests.
```

The same fixture was invoked through `CI=1 devenv tasks run test:run --mode single --show-output --no-tui`; `test:run` failed.

Missing baseline entry while the ordinary file still contributed one test:

```text
FAIL packages/@overeng/probe/src/runtime-baseline.test.ts: test-probe.100.vitest.json does not contain this baseline file (1 tests collected from other files)
FAIL: 1/1 baseline files lack proof of collected tests.
```

Real managed-task canaries:

- `test:effect-schema-form` passed and retained a native report with 7 assertions.
- `test:kdl` passed and retained 7 assertions for `mod.unit.test.ts` plus 336 unrelated assertions. Exact selection reports the baseline count (`7`) from `test-kdl.vitest.json`, not `test-kdl-effect.vitest.json`.
- `test:effect-path` passed and retained a native report with 3 assertions for `baseline.unit.test.ts` and 69 for `mod.unit.test.ts`. The checker therefore proves the baseline file's count (`3`), not the package total (`72`).
- With `OTEL_SCRAPE_ENABLED=0` and a fresh report directory, a forced `test:effect-schema-form` run still retained the 7-assertion report. CI evidence generation does not depend on telemetry instrumentation.

Exact-selection and registry probes:

- A synthetic `test:probe` / `test:probe-long` prefix collision selected only `test-probe.vitest.json`.
- The generated production registry contains 33 registered package test tasks.
- All 27 baseline files map to 19 exact registered tasks.
- Exhaustive result: zero unregistered baseline files and zero package/task-name mismatches.

First real CI run (`30408452403`) proved 25/27 baseline files, then failed on two checker prefix collisions:

```text
FAIL packages/@overeng/effect-schema-form/src/mod.unit.test.tsx: test-effect-schema-form-aria.11329.vitest.json does not contain this baseline file (7 tests collected from other files)
FAIL packages/@overeng/kdl/src/mod.unit.test.ts: test-kdl-effect.12533.vitest.json does not contain this baseline file (15 tests collected from other files)
FAIL: 2/27 baseline files lack proof of collected tests.
```

The full log confirmed both correct tasks (`test:effect-schema-form` and `test:kdl`) did run. Both failures were the same glob-prefix bug, not a task naming mismatch. The registry/exact-filename design removes that class of misattribution.

That run's `devenv-perf` lane passed. The task-list probe, the most directly affected graph-loading path, measured a 61 ms current median versus 61 ms paired baseline median, with a +1 ms paired-delta median.

Second real CI run (`30409447003`) is the decisive enforcement proof:

- Linux test job `90442101886` - passed.
- macOS test job `90442101884` - passed.
- `devenv-perf` job `90442102267` - passed. The directly affected task-list probe measured a 45 ms current median versus 49 ms paired baseline median, with a -4 ms paired-delta median across 9 pairs.
- Result: all 27/27 mechanically discovered baseline files reported non-zero collected tests through their exact registered task reports on both platforms.

Per-file step-summary rendering is **NOT VERIFIED**. GitHub exposes neither `GITHUB_STEP_SUMMARY` Markdown nor rendered job summaries through REST or the Checks API, and devenv suppresses successful task stdout. This does not weaken enforcement: summary writing is caught as best-effort, and the `/dev/full` probes proved an unwritable summary preserves pass exit `0` and zero-baseline failure exit `1`.

Removed alignment-register entry:

```text
STALE: checker declaration references missing register entry "fork-defaults".
FAIL: alignment register and marker checker declarations are inconsistent.
```

## Complexity

No new dependency. The shared test module receives one opt-in flag and reporter argument array; the checker is one post-hoc script. `lib.mkForce` is required because the package aggregate module deliberately defines `test:run.exec = null`.

## Concerns

The previous telemetry-summary design could not pass in CI because those summaries are emitted only when task tracing enables otel-scrape. The retained native Vitest report removes that coupling while preserving the public counts-only boundary.

## Friction & bottlenecks

The host has been saturated during this work, so local managed checks were kept serial. CI is the authoritative exhaustive run.

## References

Refs #925.
Refs #1018.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | co3-poppy |
| `agent_session_id` | 2155cec9-fe89-499e-9a76-9959b4be572b |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.145.0 |
| `agent_runtime` | Codex CLI 0.145.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/i8y8b542cyqi385ywcjw5fvsq24f75v4-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/i81qxhzlrzcxrrdwpp6i8hagka2gby8y-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-28-effect-4-collect |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->