### PR TITLE
feat(effect-4): add contraction marker sweep

### DIFF
--- a/context/effect-4/check-baseline-migration-markers.ts
+++ b/context/effect-4/check-baseline-migration-markers.ts
@@ -140,11 +140,150 @@ type Finding = {
   readonly why: string
 }
 
+type ContractionMarker = {
+  readonly bridgeId: string
+  readonly file: string
+  readonly kind: 'BRIDGE' | 'END' | 'TARGET' | 'TODO'
+  readonly line: number
+}
+
 const rootArgumentIndex = process.argv.indexOf('--root')
 const root =
   rootArgumentIndex === -1
     ? process.cwd()
     : resolve(process.argv[rootArgumentIndex + 1] ?? process.cwd())
+
+const liveMigrationName = ['LIVE', 'MIGRATION'].join('-')
+const todoMigrationName = ['TODO(', 'live-migration:'].join('')
+const todoMigrationPattern = ['TODO\\(', 'live-migration:'].join('')
+const blockMarkerPattern = new RegExp(
+  `${liveMigrationName}\\s+(BRIDGE|TARGET|END)(?:\\s+([a-z0-9][a-z0-9._-]*))?`,
+  'gi',
+)
+const todoMarkerPattern = new RegExp(`${todoMigrationPattern}([a-z0-9][a-z0-9._-]*)?\\)`, 'gi')
+
+/**
+ * Ignore only the three permanent grammar-definition sites. File plus line
+ * shape keeps the exception narrow: any executable marker elsewhere in either
+ * context file is still a contraction survivor.
+ */
+const isContractionDefinitionSite = ({
+  file,
+  sourceLine,
+}: {
+  readonly file: string
+  readonly sourceLine: string
+}) => {
+  if (
+    file === 'context/effect-4/check-baseline-migration-markers.ts' &&
+    sourceLine.trimStart().startsWith('const marker = ') === true
+  ) {
+    return true
+  }
+
+  if (file !== 'context/effect-4/baseline-operations.md') return false
+
+  return (
+    sourceLine.includes(`carry no \`${liveMigrationName} BRIDGE\` block`) ||
+    sourceLine.trimStart().startsWith(`\`${todoMigrationName}`)
+  )
+}
+
+const repositoryFiles = async () => {
+  const gitProcess = Bun.spawn(
+    ['git', '-C', root, 'ls-files', '--cached', '--others', '--exclude-standard', '-z'],
+    {
+      stderr: 'pipe',
+      stdout: 'pipe',
+    },
+  )
+  const [exitCode, stderr, stdout] = await Promise.all([
+    gitProcess.exited,
+    new Response(gitProcess.stderr).text(),
+    new Response(gitProcess.stdout).text(),
+  ])
+
+  if (exitCode !== 0) {
+    console.error(`FAIL: cannot enumerate repository files for contraction sweep: ${stderr.trim()}`)
+    process.exit(1)
+  }
+
+  return [...new Set(stdout.split('\0').filter((file) => file.length > 0))].toSorted(
+    (left, right) => left.localeCompare(right),
+  )
+}
+
+const runContractionCheck = async () => {
+  const markers: ContractionMarker[] = []
+  let definitionMarkers = 0
+  const fileEntries = await Promise.all(
+    (await repositoryFiles()).map(
+      async (file) => [file, await Bun.file(resolve(root, file)).text()] as const,
+    ),
+  )
+
+  for (const [file, source] of fileEntries) {
+    for (const [lineIndex, sourceLine] of source.split('\n').entries()) {
+      const blockMatches = [...sourceLine.matchAll(blockMarkerPattern)]
+      const todoMatches = [...sourceLine.matchAll(todoMarkerPattern)]
+
+      if (isContractionDefinitionSite({ file, sourceLine }) === true) {
+        definitionMarkers++
+        continue
+      }
+
+      for (const match of blockMatches) {
+        markers.push({
+          bridgeId: match[2] ?? '<missing-id>',
+          file,
+          kind: match[1]!.toUpperCase() as 'BRIDGE' | 'END' | 'TARGET',
+          line: lineIndex + 1,
+        })
+      }
+      for (const match of todoMatches) {
+        markers.push({
+          bridgeId: match[1] ?? '<missing-id>',
+          file,
+          kind: 'TODO',
+          line: lineIndex + 1,
+        })
+      }
+    }
+  }
+
+  markers.sort(
+    (left, right) =>
+      left.file.localeCompare(right.file) ||
+      left.line - right.line ||
+      left.kind.localeCompare(right.kind),
+  )
+
+  if (markers.length === 0) {
+    console.log(
+      `PASS: contraction sweep found no live migration markers (${definitionMarkers} permanent grammar definitions excluded).`,
+    )
+    return
+  }
+
+  for (const survivor of markers) {
+    const action = survivor.kind === 'TODO' ? 'RESOLVE TODO' : `DELETE BLOCK (${survivor.kind})`
+    console.error(`${survivor.file}:${survivor.line} ${action} ${survivor.bridgeId}`)
+  }
+
+  const fileCount = new Set(markers.map(({ file }) => file)).size
+  const bridgeBlockCount = markers.filter(({ kind }) => kind === 'BRIDGE').length
+  const blockMarkerCount = markers.filter(({ kind }) => kind !== 'TODO').length
+  const todoCount = markers.length - blockMarkerCount
+  console.error(
+    `FAIL: contraction blocked by ${markers.length} markers across ${fileCount} files: ${bridgeBlockCount} BRIDGE blocks (${blockMarkerCount} block marker lines) to delete, ${todoCount} TODO markers to resolve; ${definitionMarkers} permanent grammar definitions excluded.`,
+  )
+  process.exitCode = 1
+}
+
+if (process.argv.includes('--contraction') === true) {
+  await runContractionCheck()
+  process.exit(process.exitCode ?? 0)
+}
 
 const registerFile = 'context/effect-4/alignment-register.md'
 let registerSource: string


### PR DESCRIPTION
## Problem

The documented contraction grep can never return zero because it matches three permanent grammar-definition sites: two documentation examples and the marker checker constant. That leaves contraction dependent on manual exceptions.

## Goal

Give the marker checker an owned `--contraction` mode that fails on every actionable live marker while narrowly excluding only the three permanent definition sites.

## Decisions

- Enumerate tracked and non-ignored repository files through Git, matching the scope of a repository sweep without traversing generated dependency trees.
- Exclude only exact file-plus-line shapes for the checker constant and two `baseline-operations.md` grammar examples. No directory is blanket-excluded.
- Report BRIDGE/TARGET/END lines as `DELETE BLOCK` and TODO markers as `RESOLVE TODO`, always with file, line, and bridge ID.
- Recognize missing bridge IDs as `<missing-id>` survivors rather than silently ignoring malformed markers.
- Keep default marker-scanning behavior unchanged. Contraction is intentionally opt-in because 50 markers exist by design before the one-time contraction event; an always-on permanently red gate would be disabled rather than respected.

## Verification

Run the contraction sweep from the repository root:

```bash
bun context/effect-4/check-baseline-migration-markers.ts --contraction
```

Live-tree failure probe:

```text
packages/@overeng/ci-tools/src/cli.contract.test.ts:14 DELETE BLOCK (BRIDGE) effect-3-4
packages/@overeng/notion-effect-schema/src/properties/canonical-codec.unit.test.ts:403 RESOLVE TODO effect-3-4
...
FAIL: contraction blocked by 50 markers across 17 files: 12 BRIDGE blocks (24 block marker lines) to delete, 26 TODO markers to resolve; 3 permanent grammar definitions excluded.
exit status: 1
```

Definition-sites-only scratch-tree probe:

```text
PASS: contraction sweep found no live migration markers (3 permanent grammar definitions excluded).
exit status: 0
```

Normal mode and quality gates:

```text
bun context/effect-4/check-baseline-migration-markers.ts
PASS: 27 baseline test files contain no unmarked Effect 3 -> 4 risk signatures.

devenv tasks run lint:check:oxlint --mode single --show-output --no-tui
exit status: 0

devenv tasks run --no-tui check:quick
exit status: 0
```

`oxfmt` is clean and direct `oxlint --deny-warnings` reports 0 warnings/errors. The managed lint task additionally caught and verified the explicit comparator required by type-aware lint.

## Complexity

No new module or dependency. The checker gains an opt-in repository enumeration and marker classifier. Git is already required by the repository workflow and gives the contraction sweep the same tracked/non-ignored boundary expected from the documented grep.

## Concerns

A PASS means only that live marker syntax is absent. It does **not** prove contraction is complete or correct: BRIDGE code must be deleted deliberately, while TODO assertions must remain and be resolved correctly. Bulk-deleting marked assertions could make this sweep green while destroying the behavioral gates it was meant to protect.

The three exclusions intentionally depend on exact file and line shapes; edits to the grammar definitions may cause the contraction sweep to fail until the exclusion is consciously updated. That is preferable to a broad path exception.

## Friction & bottlenecks

The managed lint task initially surfaced its type-aware diagnostic only through the OTEL summary filename hash and rule metadata. Host saturation delayed the isolated rerun, but no retries were launched.

## Follow-ups

The separate collect lane owns `devenv.nix` integration for the existing default checker invocation; this PR does not overlap that wiring.

## References

Refs #925.
Follows #1018.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | co2-col |
| `agent_session_id` | fb45faad-c8dc-40a1-b763-b846910ce2f7 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.145.0 |
| `agent_runtime` | Codex CLI 0.145.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/i8y8b542cyqi385ywcjw5fvsq24f75v4-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/i81qxhzlrzcxrrdwpp6i8hagka2gby8y-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-29-effect4-contraction-gate |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->