### PR TITLE
fix(effect4): preserve HTTP header span allowlist

### DIFF
--- a/genie/external.ts
+++ b/genie/external.ts
@@ -536,9 +536,14 @@ export const createEffectUtilsRefs = (basePath: string) =>
  */
 export const utilsPatches = definePatchedDependencies({
   location: 'packages/@overeng/utils',
-  // LIVE-MIGRATION BRIDGE effect-3-4 B3 — DELETE at contraction.
-  // TODO(live-migration:effect-3-4): Re-express the removed @effect/platform header-redaction patch in Effect 4 core before merge; span attribute header cardinality is behavior.
-  patches: {},
+  patches: {
+    /* LIVE-MIGRATION BRIDGE effect-3-4 B3 — DELETE at contraction — https://github.com/Effect-TS/effect/pull/6697
+       Effect 4 beta.102 emits every redacted request/response header name as an
+       HTTP client span attribute. Preserve the v3 telemetry allowlist until
+       upstream exposes HttpClient.TracerHeaderFilter and we adopt that beta. */
+    'effect@4.0.0-beta.102': './patches/effect@4.0.0-beta.102.patch',
+    /* LIVE-MIGRATION END effect-3-4 */
+  },
 })
 
 /** Repo-local patches that should not be projected into downstream consumers. */

--- a/packages/@overeng/utils/patches/effect@4.0.0-beta.102.patch
+++ b/packages/@overeng/utils/patches/effect@4.0.0-beta.102.patch
@@ -1,0 +1,77 @@
+diff --git a/dist/unstable/http/HttpClient.js b/dist/unstable/http/HttpClient.js
+index 6dc8ad5..28aa227 100644
+--- a/dist/unstable/http/HttpClient.js
++++ b/dist/unstable/http/HttpClient.js
+@@ -25,4 +25,8 @@ import * as HttpMethod from "./HttpMethod.js";
+ import * as TraceContext from "./HttpTraceContext.js";
+ import * as Url from "./Url.js";
++// LIVE-MIGRATION BRIDGE effect-3-4 B3 - DELETE at contraction - https://github.com/Effect-TS/effect/pull/6697
++// Preserve effect-utils v3 HTTP client span-attribute allowlist until upstream TracerHeaderFilter is adopted.
++const HTTP_HEADER_ATTR_ALLOWLIST = new Set(["content-type", "content-length", "date", "x-request-id", "x-notion-request-id", "retry-after", "x-ratelimit-remaining"]);
++// LIVE-MIGRATION END effect-3-4
+ const TypeId = "~effect/http/HttpClient";
+ /**
+@@ -262,6 +266,9 @@ export const make = f => makeWith(effect => Effect.flatMap(effect, request => Ef
+     const redactedHeaderNames = fiber.getRef(Headers.CurrentRedactedNames);
+     const redactedHeaders = Headers.redact(request.headers, redactedHeaderNames);
+     for (const name in redactedHeaders) {
++      // LIVE-MIGRATION BRIDGE effect-3-4 B3 - DELETE at contraction - https://github.com/Effect-TS/effect/pull/6697
++      if (HTTP_HEADER_ATTR_ALLOWLIST.has(name.toLowerCase()) === false) continue;
++      // LIVE-MIGRATION END effect-3-4
+       span.attribute(`http.request.header.${name}`, String(redactedHeaders[name]));
+     }
+     request = fiber.getRef(TracerPropagationEnabled) ? HttpClientRequest.setHeaders(request, TraceContext.toHeaders(span)) : request;
+@@ -272,6 +279,9 @@ export const make = f => makeWith(effect => Effect.flatMap(effect, request => Ef
+         span.attribute("http.response.status_code", response.status);
+         const redactedHeaders = Headers.redact(response.headers, redactedHeaderNames);
+         for (const name in redactedHeaders) {
++          // LIVE-MIGRATION BRIDGE effect-3-4 B3 - DELETE at contraction - https://github.com/Effect-TS/effect/pull/6697
++          if (HTTP_HEADER_ATTR_ALLOWLIST.has(name.toLowerCase()) === false) continue;
++          // LIVE-MIGRATION END effect-3-4
+           span.attribute(`http.response.header.${name}`, String(redactedHeaders[name]));
+         }
+         if (scopedController) return Effect.succeed(response);
+diff --git a/src/unstable/http/HttpClient.ts b/src/unstable/http/HttpClient.ts
+index 3f45ece..e016152 100644
+--- a/src/unstable/http/HttpClient.ts
++++ b/src/unstable/http/HttpClient.ts
+@@ -42,6 +42,19 @@ import * as HttpMethod from "./HttpMethod.ts"
+ import * as TraceContext from "./HttpTraceContext.ts"
+ import * as Url from "./Url.ts"
+ 
++// LIVE-MIGRATION BRIDGE effect-3-4 B3 - DELETE at contraction - https://github.com/Effect-TS/effect/pull/6697
++// Preserve effect-utils v3 HTTP client span-attribute allowlist until upstream TracerHeaderFilter is adopted.
++const HTTP_HEADER_ATTR_ALLOWLIST = new Set([
++  "content-type",
++  "content-length",
++  "date",
++  "x-request-id",
++  "x-notion-request-id",
++  "retry-after",
++  "x-ratelimit-remaining"
++])
++// LIVE-MIGRATION END effect-3-4
++
+ const TypeId = "~effect/http/HttpClient"
+ 
+ /**
+@@ -841,6 +854,9 @@ export const make = (
+             const redactedHeaderNames = fiber.getRef(Headers.CurrentRedactedNames)
+             const redactedHeaders = Headers.redact(request.headers, redactedHeaderNames)
+             for (const name in redactedHeaders) {
++              // LIVE-MIGRATION BRIDGE effect-3-4 B3 - DELETE at contraction - https://github.com/Effect-TS/effect/pull/6697
++              if (HTTP_HEADER_ATTR_ALLOWLIST.has(name.toLowerCase()) === false) continue
++              // LIVE-MIGRATION END effect-3-4
+               span.attribute(`http.request.header.${name}`, String(redactedHeaders[name]))
+             }
+             request = fiber.getRef(TracerPropagationEnabled)
+@@ -854,6 +870,9 @@ export const make = (
+                     span.attribute("http.response.status_code", response.status)
+                     const redactedHeaders = Headers.redact(response.headers, redactedHeaderNames)
+                     for (const name in redactedHeaders) {
++                      // LIVE-MIGRATION BRIDGE effect-3-4 B3 - DELETE at contraction - https://github.com/Effect-TS/effect/pull/6697
++                      if (HTTP_HEADER_ATTR_ALLOWLIST.has(name.toLowerCase()) === false) continue
++                      // LIVE-MIGRATION END effect-3-4
+                       span.attribute(`http.response.header.${name}`, String(redactedHeaders[name]))
+                     }
+ 


### PR DESCRIPTION
# Summary

- Adds a temporary Effect 4 beta.102 package patch preserving the existing v3 HTTP client span-attribute header allowlist.
- Wires the patch through `utilsPatches` with `LIVE-MIGRATION BRIDGE effect-3-4 B3` markers and effect#6697 as the deletion trigger.
- Keeps omission semantics: non-allowlisted request and response headers are not emitted as span attributes at all.

# B3 handoff

CurrentRedactedNames verdict: refuted for this blocker. I captured real v4 beta.102 spans and observed that `Headers.CurrentRedactedNames` only changes attribute values to `<redacted>`; it does not suppress span attribute keys. The span still included `http.request.header.authorization`, `http.response.header.set-cookie`, and other non-allowlisted header names. Wire headers were unaffected except normal trace propagation, so this is specifically a span-attribute-path refutation, not a wire redaction result.

Exact v3 behavior to preserve:

```text
allowlisted header names:
- content-type
- content-length
- date
- x-request-id
- x-notion-request-id
- retry-after
- x-ratelimit-remaining

semantics:
- omit all non-allowlisted HTTP header span attributes
- omission, not redaction
- apply to both request and response header loops
```

Precise v4 patch sites identified in `effect@4.0.0-beta.102`:

```text
src/unstable/http/HttpClient.ts:841-857
  request header loop and response header loop

dist/unstable/http/HttpClient.js
  matching emitted JS loops
```

Why the utils wrapper was rejected: wrapping `HttpClient` at the effect-utils boundary is too late and too narrow. The core v4 client writes header span attributes inside `HttpClient.make` before a downstream wrapper can reliably prevent the behavior for all clients, and it would miss direct Effect HTTP client usage. The regression is in the core span emission path, so the bridge patch stays at the core emission sites until upstream provides the filter hook.

# Proof

Patch application proof:

```text
patch --dry-run -p1 -d <exact effect@4.0.0-beta.102 package> < packages/@overeng/utils/patches/effect@4.0.0-beta.102.patch
checking file dist/unstable/http/HttpClient.js
checking file src/unstable/http/HttpClient.ts
```

Differential proof did run. Captured v3 patched span header attrs and v4 patched span header attrs for the same request/response, sorted them with `jq -S`, and diffed the sets. The diff was empty.

Observed identical header span attribute map:

```json
{
  "http.request.header.content-type": "application/json",
  "http.request.header.x-request-id": "request-123",
  "http.response.header.content-type": "text/plain",
  "http.response.header.date": "Tue, 28 Jul 2026 10:00:00 GMT"
}
```

The same probe input included `authorization`, `x-noise`, `set-cookie`, and `x-response-noise`; those were absent from the patched v4 span attributes.

# effect#6697 ownership

#6697 is ours: `Effect-TS/effect#6697` was opened by `schickling-assistant` from fork branch `schickling-assistant/2026-07-28-httpclient-header-filter` into `Effect-TS/effect:main`. It is open and not draft.

# Generated files

This PR intentionally carries no generated projections. It changes only the source of truth (`genie/external.ts`) and the patch file. Regeneration is deferred to the flip because this branch currently has a bootstrap deadlock: the Genie entrypoint imports `effect/unstable/cli`, but the installed generated dependency graph still resolves Genie against Effect 3. The flip owns the dependency graph update/install first, then regeneration.

# Stack / base

PR #1025 is retargeted to the live flip branch behind #1019: `schickling-assistant/2026-07-28-effect-4-flip-c945bbfe4`. It no longer targets the stale safety branch `schickling-assistant/effect-4-flip-wip`.

The branch was force-pushed as a single clean B3 commit on top of #1019. Current head: `f7430217d1ad920129655162b724a08965a3d0ad`.

Current compare against #1019 is exactly:

```text
genie/external.ts
packages/@overeng/utils/patches/effect@4.0.0-beta.102.patch
```

# G2 watch-membership baseline

This PR does not change `packages/@overeng/utils/src/node/file-system-backing.unit.test.ts` relative to #1019 (`git diff --exit-code origin/schickling-assistant/2026-07-28-effect-4-flip-c945bbfe4 -- packages/@overeng/utils/src/node/file-system-backing.unit.test.ts` exits 0). The G2 assertion remains the flip branch's assertion: direct child observed, nested child not observed, with the TODO noting that the nested assertion is expected to fail at beta.102.

I attempted the focused G2 test locally, but it did not reach the assertion. Vite failed during suite import on `./unstable/process/Command` not being exported from the installed `effect` package, so there is no local G2 pass/fail signal from that command.

# Validation caveats

- `git diff --check` passed after retargeting.
- Exact beta.102 patch dry-run passed after retargeting.
- Differential span proof passed before retargeting; the B3 patch content is unchanged.
- Full `check:quick` was not rerun locally in this follow-up.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | co1-brass |
| `agent_session_id` | b32fce31-1c07-43d6-8fca-3bc0bc5b9bac |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.145.0 |
| `agent_runtime` | Codex CLI 0.145.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/i8y8b542cyqi385ywcjw5fvsq24f75v4-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/i81qxhzlrzcxrrdwpp6i8hagka2gby8y-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-29-effect-4-b3-header-span-probe |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->