### PR TITLE
test(effect-4): keep contraction checker exercised

### DIFF
--- a/context/effect-4/check-baseline-migration-markers.ts
+++ b/context/effect-4/check-baseline-migration-markers.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env bun
 
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
 import { resolve } from 'node:path'
 
 const marker = 'TODO(live-migration:effect-3-4)'
@@ -213,6 +215,152 @@ const repositoryFiles = async () => {
   )
 }
 
+const runProcess = async ({
+  command,
+  cwd,
+}: {
+  readonly command: readonly string[]
+  readonly cwd: string
+}) => {
+  const child = Bun.spawn(command, {
+    cwd,
+    stderr: 'pipe',
+    stdout: 'pipe',
+  })
+  const [exitCode, stderr, stdout] = await Promise.all([
+    child.exited,
+    new Response(child.stderr).text(),
+    new Response(child.stdout).text(),
+  ])
+
+  return { exitCode, stderr, stdout }
+}
+
+const writeContractionFixture = async ({
+  fixtureRoot,
+  includeSurvivors,
+}: {
+  readonly fixtureRoot: string
+  readonly includeSurvivors: boolean
+}) => {
+  const contextRoot = resolve(fixtureRoot, 'context/effect-4')
+  await mkdir(contextRoot, { recursive: true })
+  await Bun.write(
+    resolve(contextRoot, 'check-baseline-migration-markers.ts'),
+    `const marker = '${todoMigrationName}effect-3-4)'\n`,
+  )
+  await Bun.write(
+    resolve(contextRoot, 'baseline-operations.md'),
+    [
+      `Baseline files carry no \`${liveMigrationName} BRIDGE\` block after contraction.`,
+      `\`${todoMigrationName}<bridge-id>)\` identifies a migration assertion.`,
+      '',
+    ].join('\n'),
+  )
+
+  if (includeSurvivors === true) {
+    await mkdir(resolve(fixtureRoot, 'src'), { recursive: true })
+    await Bun.write(
+      resolve(fixtureRoot, 'src/survivors.ts'),
+      [
+        `// ${liveMigrationName} BRIDGE fixture-bridge`,
+        `// ${todoMigrationName}fixture-todo): resolve the retained assertion`,
+        '',
+      ].join('\n'),
+    )
+  }
+
+  const initialized = await runProcess({
+    command: ['git', 'init', '--quiet'],
+    cwd: fixtureRoot,
+  })
+  const added = await runProcess({
+    command: ['git', 'add', '--all'],
+    cwd: fixtureRoot,
+  })
+  if (initialized.exitCode !== 0 || added.exitCode !== 0) {
+    const detail = [initialized.stderr, added.stderr].join('').trim()
+    throw new Error(`cannot initialize contraction fixture repository: ${detail}`)
+  }
+}
+
+const runContractionFixtureCheck = async () => {
+  const fixtureRoot = await mkdtemp(resolve(tmpdir(), 'effect4-contraction-fixtures-'))
+  const definitionOnlyRoot = resolve(fixtureRoot, 'definition-only')
+  const survivorRoot = resolve(fixtureRoot, 'survivors')
+  let failure: string | undefined
+
+  try {
+    await Promise.all([
+      writeContractionFixture({ fixtureRoot: definitionOnlyRoot, includeSurvivors: false }),
+      writeContractionFixture({ fixtureRoot: survivorRoot, includeSurvivors: true }),
+    ])
+
+    const [definitionOnly, survivors] = await Promise.all([
+      runProcess({
+        command: [
+          process.execPath,
+          import.meta.path,
+          '--contraction',
+          '--root',
+          definitionOnlyRoot,
+        ],
+        cwd: root,
+      }),
+      runProcess({
+        command: [process.execPath, import.meta.path, '--contraction', '--root', survivorRoot],
+        cwd: root,
+      }),
+    ])
+    const expectedDefinitionOnly =
+      'PASS: contraction sweep found no live migration markers (3 permanent grammar definitions excluded).\n'
+    const expectedSurvivors = [
+      'src/survivors.ts:1 DELETE BLOCK (BRIDGE) fixture-bridge',
+      'src/survivors.ts:2 RESOLVE TODO fixture-todo',
+      'FAIL: contraction blocked by 2 markers across 1 files: 1 BRIDGE blocks (1 block marker lines) to delete, 1 TODO markers to resolve; 3 permanent grammar definitions excluded.',
+      '',
+    ].join('\n')
+
+    if (
+      definitionOnly.exitCode !== 0 ||
+      definitionOnly.stdout !== expectedDefinitionOnly ||
+      definitionOnly.stderr !== ''
+    ) {
+      failure = [
+        'FAIL: contraction definition-only fixture did not pass with the expected report.',
+        `exit: ${definitionOnly.exitCode}`,
+        `stdout: ${JSON.stringify(definitionOnly.stdout)}`,
+        `stderr: ${JSON.stringify(definitionOnly.stderr)}`,
+      ].join('\n')
+    } else if (
+      survivors.exitCode !== 1 ||
+      survivors.stdout !== '' ||
+      survivors.stderr !== expectedSurvivors
+    ) {
+      failure = [
+        'FAIL: contraction survivor fixture did not fail with the expected report.',
+        `exit: ${survivors.exitCode}`,
+        `stdout: ${JSON.stringify(survivors.stdout)}`,
+        `stderr: ${JSON.stringify(survivors.stderr)}`,
+      ].join('\n')
+    }
+  } catch (error) {
+    failure = `FAIL: contraction fixture lane could not run: ${String(error)}`
+  } finally {
+    await rm(fixtureRoot, { force: true, recursive: true })
+  }
+
+  if (failure !== undefined) {
+    console.error(failure)
+    return false
+  }
+
+  console.log(
+    'PASS: contraction fixtures cover definition exclusions and actionable survivor reporting.',
+  )
+  return true
+}
+
 const runContractionCheck = async () => {
   const markers: ContractionMarker[] = []
   let definitionMarkers = 0
@@ -284,6 +432,8 @@ if (process.argv.includes('--contraction') === true) {
   await runContractionCheck()
   process.exit(process.exitCode ?? 0)
 }
+
+if ((await runContractionFixtureCheck()) === false) process.exit(1)
 
 const registerFile = 'context/effect-4/alignment-register.md'
 let registerSource: string


### PR DESCRIPTION
## Problem

The real-repository contraction sweep must remain opt-in while 52 intentional migration markers are present, but that left the `--contraction` code path completely unexercised until the one milestone where it is needed. File enumeration, grammar exclusions, or actionable reporting could silently rot for months.

## Goal

Exercise the exact contraction subprocess path on every normal marker-checker invocation without running the permanently-red real-repository sweep.

## Decisions

- Create two temporary, self-contained Git fixture roots from controlled bytes. Neither fixture reads files from the live repository.
- Invoke this checker as a child process with `--contraction --root <fixture>`, covering Git file enumeration and the production CLI branch rather than a duplicated parser helper.
- Require the definition-only fixture to exit 0 with exactly three grammar definitions excluded.
- Require the survivor fixture to exit 1 and assert exact stdout/stderr, including `file:line`, bridge IDs, `DELETE BLOCK (BRIDGE)`, `RESOLVE TODO`, and the summary counts.
- Keep the real-repository `bun context/effect-4/check-baseline-migration-markers.ts --contraction` command opt-in for the contraction milestone.

This fixture lane becomes always-on only when #1023 merges, because #1023 is what invokes the default checker from `test:run`. Until then, the fixture mechanism exists but the normal test lane does not call it. This PR deliberately does not duplicate or overlap that `devenv.nix` wiring.

## Verification

Restored green invocation:

```text
$ bun context/effect-4/check-baseline-migration-markers.ts
PASS: contraction fixtures cover definition exclusions and actionable survivor reporting.
PASS: 27 baseline test files contain no unmarked Effect 3 -> 4 risk signatures.
```

Corrupted definition exclusion:

```text
exit status: 1
FAIL: contraction definition-only fixture did not pass with the expected report.
exit: 1
stdout: ""
stderr:
context/effect-4/check-baseline-migration-markers.ts:1 RESOLVE TODO effect-3-4
FAIL: contraction blocked by 1 markers across 1 files: 0 BRIDGE blocks (0 block marker lines) to delete, 1 TODO markers to resolve; 2 permanent grammar definitions excluded.
```

Corrupted survivor action (`DELETE BLOCK` changed to `REMOVE BLOCK`):

```text
exit status: 1
FAIL: contraction survivor fixture did not fail with the expected report.
exit: 1
stdout: ""
stderr:
src/survivors.ts:1 REMOVE BLOCK (BRIDGE) fixture-bridge
src/survivors.ts:2 RESOLVE TODO fixture-todo
FAIL: contraction blocked by 2 markers across 1 files: 1 BRIDGE blocks (1 block marker lines) to delete, 1 TODO markers to resolve; 3 permanent grammar definitions excluded.
```

Both corruptions were restored before final validation.

```text
oxfmt --check context/effect-4/check-baseline-migration-markers.ts
All matched files use the correct format.

oxlint --deny-warnings context/effect-4/check-baseline-migration-markers.ts
Found 0 warnings and 0 errors.

devenv tasks run check:quick --refresh-task-cache --show-output --no-tui
exit status: 0
```

Full aggregate gate:

```text
devenv tasks run check:all --refresh-task-cache --show-output --no-tui
✖ Running otel:verify:setup in 6.77s (failed)
✖ Running check:all in 1.19µs (dependency failed)
✖ Running tasks in 718s (failed)
exit status: 1
```

The failure was in the unrelated `otel:verify:setup` dependency; the aggregate did not run after that dependency failed. The targeted checker and fresh `check:quick` remained green.

The opt-in live sweep remains red as intended; it is not the always-on fixture lane.

## Complexity

No dependency or new module. The checker gains an embedded subprocess fixture harness so the controlled fixtures cannot drift with the live tree. Temporary roots are removed on both success and failure.

## Concerns

The normal checker now launches two short Bun subprocesses and initializes two tiny temporary Git repositories. This is deliberate coverage of the production file-enumeration boundary, not pure parser-only unit testing.

## Friction & bottlenecks

The managed task runner initially reused opaque cached task status and emitted no underlying output. A fresh task-cache run completed successfully. No persistent bottleneck was found.

## Follow-ups

- #1023 must merge for the default checker, and therefore these fixtures, to run from every `test:run` invocation.
- The real-repository contraction command remains a milestone-only manual gate until intentional migration markers are removed.

## References

Refs #925.
Refs #1023.
Refs #1024.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | co2-col |
| `agent_session_id` | fb45faad-c8dc-40a1-b763-b846910ce2f7 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.145.0 |
| `agent_runtime` | Codex CLI 0.145.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/i8y8b542cyqi385ywcjw5fvsq24f75v4-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/i81qxhzlrzcxrrdwpp6i8hagka2gby8y-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-29-effect4-contraction-fixtures |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->