### PR TITLE
test(effect-4): expire absence-based noSignatures

### DIFF
--- a/context/effect-4/check-baseline-migration-markers.ts
+++ b/context/effect-4/check-baseline-migration-markers.ts
@@ -548,13 +548,111 @@ const isProductionSource = (file: string) => {
 
 /**
  * Preserve offsets while excluding prose that can name an API without using
- * it. Template literals are excluded in full; production API calls belong in
- * executable expressions rather than fixture-like string bytes.
+ * it. Template text is masked while interpolation expressions remain
+ * executable and searchable.
  */
-const maskCommentsAndStrings = (source: string) =>
-  source.replace(/(["'`])(?:\\[\s\S]|(?!\1)[^\\])*\1|\/\*[\s\S]*?(?:\*\/|$)|\/\/[^\n]*/g, (text) =>
-    text.replace(/[^\n]/g, ' '),
-  )
+const maskCommentsAndStrings = (source: string) => {
+  const masked = source.split('')
+  const templateBraceDepth: number[] = []
+  let escaped = false
+  let mode: 'blockComment' | 'code' | 'doubleQuote' | 'lineComment' | 'singleQuote' | 'template' =
+    'code'
+
+  const mask = (index: number) => {
+    if (masked[index] !== '\n') masked[index] = ' '
+  }
+
+  for (let index = 0; index < source.length; index++) {
+    const character = source[index]
+    const next = source[index + 1]
+
+    if (mode === 'lineComment') {
+      mask(index)
+      if (character === '\n') mode = 'code'
+      continue
+    }
+    if (mode === 'blockComment') {
+      mask(index)
+      if (character === '*' && next === '/') {
+        mask(index + 1)
+        mode = 'code'
+        index++
+      }
+      continue
+    }
+    if (mode === 'singleQuote' || mode === 'doubleQuote') {
+      mask(index)
+      if (escaped === true) {
+        escaped = false
+      } else if (character === '\\') {
+        escaped = true
+      } else if (
+        (mode === 'singleQuote' && character === "'") ||
+        (mode === 'doubleQuote' && character === '"')
+      ) {
+        mode = 'code'
+      }
+      continue
+    }
+    if (mode === 'template') {
+      mask(index)
+      if (escaped === true) {
+        escaped = false
+      } else if (character === '\\') {
+        escaped = true
+      } else if (character === '`') {
+        mode = 'code'
+      } else if (character === '$' && next === '{') {
+        mask(index + 1)
+        templateBraceDepth.push(0)
+        mode = 'code'
+        index++
+      }
+      continue
+    }
+    if (character === '/' && next === '/') {
+      mask(index)
+      mask(index + 1)
+      mode = 'lineComment'
+      index++
+      continue
+    }
+    if (character === '/' && next === '*') {
+      mask(index)
+      mask(index + 1)
+      mode = 'blockComment'
+      index++
+      continue
+    }
+    if (character === "'" || character === '"') {
+      mask(index)
+      escaped = false
+      mode = character === "'" ? 'singleQuote' : 'doubleQuote'
+      continue
+    }
+    if (character === '`') {
+      mask(index)
+      escaped = false
+      mode = 'template'
+      continue
+    }
+    if (templateBraceDepth.length > 0 && character === '{') {
+      const depthIndex = templateBraceDepth.length - 1
+      templateBraceDepth[depthIndex] = templateBraceDepth[depthIndex]! + 1
+    } else if (templateBraceDepth.length > 0 && character === '}') {
+      const depthIndex = templateBraceDepth.length - 1
+      if (templateBraceDepth[depthIndex] === 0) {
+        mask(index)
+        templateBraceDepth.pop()
+        mode = 'template'
+      } else {
+        templateBraceDepth[depthIndex] = templateBraceDepth[depthIndex]! - 1
+      }
+    }
+  }
+
+  return masked.join('')
+}
 
 const runProductionAbsenceChecks = async () => {
   const productionFiles = (await repositoryFiles()).filter(isProductionSource)

--- a/context/effect-4/check-baseline-migration-markers.ts
+++ b/context/effect-4/check-baseline-migration-markers.ts
@@ -117,12 +117,20 @@ const noSignatures = [
   {
     registerEntry: 'equality-structural-default',
     noSignature:
-      'Structural equality depends on runtime value types, and the register audit found no production Effect equality site.',
+      'Structural equality depends on runtime value types; production sources are asserted to contain no Equal.equals call.',
+    productionAbsence: {
+      regex: /\bEqual\s*\.\s*equals\s*\(/g,
+      site: 'Equal.equals(...)',
+    },
   },
   {
     registerEntry: 'effect-never-idle-timer',
     noSignature:
-      'Process liveness is a runtime side effect; Effect.never is also used as unrelated test-only suspension control, with no production liveness site.',
+      'Process liveness is a runtime side effect; production sources are asserted to contain no Effect.never site.',
+    productionAbsence: {
+      regex: /\bEffect\s*\.\s*never\b/g,
+      site: 'Effect.never',
+    },
   },
 ] as const
 
@@ -147,6 +155,14 @@ type ContractionMarker = {
   readonly file: string
   readonly kind: 'BRIDGE' | 'END' | 'TARGET' | 'TODO'
   readonly line: number
+}
+
+type ExpiredNoSignature = {
+  readonly column: number
+  readonly file: string
+  readonly line: number
+  readonly registerEntry: string
+  readonly site: string
 }
 
 const rootArgumentIndex = process.argv.indexOf('--root')
@@ -206,7 +222,7 @@ const repositoryFiles = async () => {
   ])
 
   if (exitCode !== 0) {
-    console.error(`FAIL: cannot enumerate repository files for contraction sweep: ${stderr.trim()}`)
+    console.error(`FAIL: cannot enumerate repository files: ${stderr.trim()}`)
     process.exit(1)
   }
 
@@ -498,6 +514,101 @@ const lineAndColumnAt = ({
     line: lines.length,
   }
 }
+
+const productionAbsenceAssertions = noSignatures.flatMap((declaration) =>
+  'productionAbsence' in declaration
+    ? [
+        {
+          ...declaration.productionAbsence,
+          registerEntry: declaration.registerEntry,
+        },
+      ]
+    : [],
+)
+
+const isProductionSource = (file: string) => {
+  if (file.startsWith('packages/') === false || /\.(?:[cm]?[jt]sx?)$/.test(file) === false) {
+    return false
+  }
+
+  if (
+    /(?:^|\/)(?:__tests__|e2e|examples?|fixtures?|mocks?|stories?|test|tests|testing)(?:\/|$)/i.test(
+      file,
+    ) === true
+  ) {
+    return false
+  }
+
+  const fileName = file.slice(file.lastIndexOf('/') + 1)
+  return (
+    /(?:^|[.-])(?:e2e|fixture|mock|spec|stories|test)(?:[.-]|$)/i.test(fileName) === false &&
+    fileName.includes('.genie.') === false
+  )
+}
+
+/**
+ * Preserve offsets while excluding prose that can name an API without using
+ * it. Template literals are excluded in full; production API calls belong in
+ * executable expressions rather than fixture-like string bytes.
+ */
+const maskCommentsAndStrings = (source: string) =>
+  source.replace(/(["'`])(?:\\[\s\S]|(?!\1)[^\\])*\1|\/\*[\s\S]*?(?:\*\/|$)|\/\/[^\n]*/g, (text) =>
+    text.replace(/[^\n]/g, ' '),
+  )
+
+const runProductionAbsenceChecks = async () => {
+  const productionFiles = (await repositoryFiles()).filter(isProductionSource)
+  const productionEntries = await Promise.all(
+    productionFiles.map(
+      async (file) => [file, await Bun.file(resolve(root, file)).text()] as const,
+    ),
+  )
+  const expired: ExpiredNoSignature[] = []
+
+  for (const [file, source] of productionEntries) {
+    const executableSource = maskCommentsAndStrings(source)
+
+    for (const assertion of productionAbsenceAssertions) {
+      for (const match of executableSource.matchAll(assertion.regex)) {
+        expired.push({
+          ...lineAndColumnAt({ source, offset: match.index }),
+          file,
+          registerEntry: assertion.registerEntry,
+          site: assertion.site,
+        })
+      }
+    }
+  }
+
+  expired.sort(
+    (left, right) =>
+      left.file.localeCompare(right.file) ||
+      left.line - right.line ||
+      left.column - right.column ||
+      left.registerEntry.localeCompare(right.registerEntry),
+  )
+
+  if (expired.length === 0) {
+    console.log(
+      `PASS: ${productionAbsenceAssertions.length} noSignature production-absence justifications remain valid across ${productionFiles.length} source files.`,
+    )
+    return
+  }
+
+  for (const finding of expired) {
+    console.error(
+      `${finding.file}:${finding.line}:${finding.column} EXPIRED noSignature "${finding.registerEntry}": found production site ${finding.site}; this entry needs a real risk signature.`,
+    )
+  }
+  const expiredEntries = new Set(expired.map(({ registerEntry }) => registerEntry)).size
+  const expiredFiles = new Set(expired.map(({ file }) => file)).size
+  console.error(
+    `FAIL: ${expiredEntries} noSignature production-absence justifications expired at ${expired.length} sites across ${expiredFiles} source files.`,
+  )
+  process.exit(1)
+}
+
+await runProductionAbsenceChecks()
 
 const findMatchingDelimiter = ({
   source,


### PR DESCRIPTION
## Problem

Two `noSignature` declarations were justified by point-in-time absence claims: no production `Equal.equals(...)` call and no production `Effect.never` site. Those comments could silently become false when production code changed, leaving the migration risk unguarded.

## Goal

Make both absence-based justifications self-invalidating while leaving the three intrinsic `noSignature` reasons unchanged.

## Decisions

- Attach a production-absence pattern directly to each expiring `noSignature` declaration, keeping the assertion coupled to the register entry it justifies.
- Scan tracked and unignored TypeScript-family sources under `packages/`.
- Exclude test, spec, e2e, example, story, fixture, mock, testing, and `.genie` paths so deliberate baselines and support code cannot cry wolf.
- Mask comments and literal template text while preserving offsets and executable template interpolation expressions, so prose that names an API is not mistaken for a site.
- Fail with file, line, column, register entry, matched API, and an explicit instruction that the entry needs a real risk signature.

## Verification

Restored tree:

```text
$ bun context/effect-4/check-baseline-migration-markers.ts
PASS: contraction fixtures cover definition exclusions and actionable survivor reporting.
PASS: 2 noSignature production-absence justifications remain valid across 814 source files.
PASS: 27 baseline test files contain no unmarked Effect 3 -> 4 risk signatures.
```

A temporary production module contained API text in template prose and a line comment, plus both executable sites inside template interpolation expressions. Only the interpolation expressions fired:

```text
exit status: 1
stdout:
PASS: contraction fixtures cover definition exclusions and actionable survivor reporting.
stderr:
packages/@overeng/utils/src/expiring-nosignature-probe.ts:6:33 EXPIRED noSignature "equality-structural-default": found production site Equal.equals(...); this entry needs a real risk signature.
packages/@overeng/utils/src/expiring-nosignature-probe.ts:7:33 EXPIRED noSignature "effect-never-idle-timer": found production site Effect.never; this entry needs a real risk signature.
FAIL: 2 noSignature production-absence justifications expired at 2 sites across 1 source files.
```

The probe was removed, then the restored checker passed. Existing test-only `Effect.never` uses also remain excluded by the live production classifier.

```text
oxfmt --check context/effect-4/check-baseline-migration-markers.ts
All matched files use the correct format.

oxlint --deny-warnings context/effect-4/check-baseline-migration-markers.ts
Found 0 warnings and 0 errors.

devenv tasks run check:quick --refresh-task-cache --show-output --no-tui
exit status: 0
```

Full aggregate:

```text
devenv tasks run check:all --refresh-task-cache --show-output --no-tui
✖ Running otel:verify:setup in 4.28s (failed)
✖ Running check:all in 802ns (dependency failed)
✖ Running tasks in 376s (failed)
exit status: 1
```

The unrelated `otel:verify:setup` failure matches the prior main-based run; `check:all` itself was skipped after that dependency failed. Both Rust suites and the targeted/quick gates passed.

## Complexity

No dependency or new module. The offset-preserving lexer distinguishes comments and literal text from executable code, including nested template interpolation expressions; that complexity prevents prose false positives without hiding executable sites.

## Concerns

The guard intentionally recognizes the repository's canonical qualified forms, `Equal.equals(...)` and `Effect.never`. A future aliased import would require extending the assertion rather than being inferred as the same spelling.

## Friction & bottlenecks

The repository-wide full gate spent 376 seconds running independent dependencies after the known OTel setup failure. No task-specific bottleneck was found.

## Follow-ups

None.

## References

Refs #925.
Refs #1018.
Refs #1023.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | co2-col |
| `agent_session_id` | fb45faad-c8dc-40a1-b763-b846910ce2f7 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.145.0 |
| `agent_runtime` | Codex CLI 0.145.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/i8y8b542cyqi385ywcjw5fvsq24f75v4-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/i81qxhzlrzcxrrdwpp6i8hagka2gby8y-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-29-effect4-expiring-nosignatures |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->