### PR TITLE
docs: fix Effect 4 schema date codec names

### DIFF
--- a/context/effect-4/recipes/schema-date.md
+++ b/context/effect-4/recipes/schema-date.md
@@ -14,9 +14,11 @@ const encode = Schema.encodeEither(Schema.Date)
 
 ```ts
 const DateWire = Schema.DateFromString
-const decode = Schema.decodeUnknownEither(DateWire)
-const encode = Schema.encodeEither(DateWire)
+const decode = Schema.decodeUnknownExit(DateWire)
+const encode = Schema.encodeExit(DateWire)
 ```
+
+The v4 codecs return `Exit`, not `Either`; callers must handle the changed result shape.
 
 ## Equivalence
 


### PR DESCRIPTION
## Problem

The Effect 4 date migration recipe uses `Schema.decodeUnknownEither` and `Schema.encodeEither` in its beta.102 example. Neither API exists in `effect@4.0.0-beta.102`, so following the documented recipe fails immediately.

## Goal

Make the recipe executable against beta.102 and state the result-shape change readers must handle.

## Decisions

Use the beta.102 APIs `Schema.decodeUnknownExit` and `Schema.encodeExit`. Keep the correction deliberately narrow and call out that v4 returns `Exit`, not `Either`.

## Verification

- `DEVENV_TASK_PASSTHROUGH=1 devenv shell -- oxfmt --check context/effect-4/recipes/schema-date.md`
  - Passed: all matched files use the correct format.
- `DEVENV_TASK_PASSTHROUGH=1 devenv shell -- oxlint context/effect-4/recipes/schema-date.md`
  - Passed: 0 warnings and 0 errors.
- Verified the old exports are absent and the replacement exports are present in the real `effect@4.0.0-beta.102` package.
- `git diff --check` passed.
- `devenv tasks run check:all --no-tui` was attempted. It failed outside this documentation change when Nix captured the worktree while an `otelite/target` Rust object disappeared; dependent test tasks were cancelled.

## Complexity

No new complexity; this is a two-name documentation correction plus one result-shape note.

## Concerns

None introduced. Slice owners must still adapt from `Either` matching to `Exit` matching, which the recipe now states explicitly.

## Friction & bottlenecks

The all-repository gate raced with concurrent Rust output under `packages/@overeng/otelite/target`, causing Nix path capture to reference a removed object file. Scoped formatting and lint checks were unaffected.

## Follow-ups

None for this correction.

## References

Refs #925

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | co2-gust |
| `agent_session_id` | 0d2214de-8432-4906-ab76-b81c802cab5c |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.145.0 |
| `agent_runtime` | Codex CLI 0.145.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/i8y8b542cyqi385ywcjw5fvsq24f75v4-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/i81qxhzlrzcxrrdwpp6i8hagka2gby8y-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-29-fix-effect4-schema-date-recipe |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->