### PR TITLE
Enable command tracing through the devenv observability adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- **devenv observability**: add opt-in `commandInstrumentation` composition.
+  Enabling it supplies `otel-scrape` and pins `OTEL_SCRAPE_BIN` for nested task
+  shells; the default remains task-span-only and avoids the larger command
+  observer closure.
 - **@overeng/effect-path**: add Effect 3 cross-major baselines for PathInfo schema
   encoding, convention parser failure partitions, and path operation byte output.
 - **@overeng/tui-stories**: add Effect 3 cross-major baselines for schema-encoded

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - **devenv observability**: add opt-in `commandInstrumentation` composition.
-  Enabling it supplies `otel-scrape` and pins `OTEL_SCRAPE_BIN` for nested task
-  shells; the default remains task-span-only and avoids the larger command
-  observer closure.
+  Enabling it supplies the flake-stamped `otel-scrape` build and pins
+  `OTEL_SCRAPE_BIN` for nested task shells; the default remains task-span-only
+  and avoids the larger command observer closure.
 - **@overeng/effect-path**: add Effect 3 cross-major baselines for PathInfo schema
   encoding, convention parser failure partitions, and path operation byte output.
 - **@overeng/tui-stories**: add Effect 3 cross-major baselines for schema-encoded

--- a/devenv.nix
+++ b/devenv.nix
@@ -327,6 +327,7 @@ in
     # composes with the full stack above without importing it a second time.
     (import ./nix/devenv-modules/observability.nix {
       project = "effect-utils";
+      commandInstrumentation = true;
       wireInto = [ "check:all" ];
     })
     # gh:apply-labels / gh:check-labels — reconcile .github/labels.json with live labels
@@ -491,7 +492,6 @@ in
     repoFlake.packages.${currentSystem}.notion-cli
     # Rust binaries on PATH for local smoke tests and downstream wrappers.
     repoFlake.packages.${currentSystem}.otelite
-    repoFlake.packages.${currentSystem}.otel-scrape
     cliBuildStamp.package
     ciToolsSourceCli
     (mkSourceCli {

--- a/devenv.nix
+++ b/devenv.nix
@@ -328,6 +328,7 @@ in
     (import ./nix/devenv-modules/observability.nix {
       project = "effect-utils";
       commandInstrumentation = true;
+      otelScrapePackage = repoFlake.packages.${currentSystem}.otel-scrape;
       wireInto = [ "check:all" ];
     })
     # gh:apply-labels / gh:check-labels — reconcile .github/labels.json with live labels

--- a/flake.nix
+++ b/flake.nix
@@ -250,7 +250,20 @@
       devenvModules = {
         # Lightweight native-devenv + effect-utils capture, optionally composed
         # with the full Collector/Tempo/Grafana stack.
-        observability = import ./nix/devenv-modules/observability.nix;
+        observability =
+          args:
+          { pkgs, ... }@moduleArgs:
+          (import ./nix/devenv-modules/observability.nix (
+            args
+            // {
+              # Preserve the source-revision stamp carried by the flake package.
+              # A direct build.nix import would compile `0.0.0+unknown`, and that
+              # compile-time identity intentionally wins over runtime stamps.
+              otelScrapePackage =
+                args.otelScrapePackage or self.packages.${pkgs.stdenv.hostPlatform.system}.otel-scrape;
+            }
+          ))
+            moduleArgs;
         # OpenTelemetry observability stack (Collector + Tempo + Grafana)
         otel = import ./nix/devenv-modules/otel.nix;
         # Shared task modules (parameterized) - meant for reuse in other repos

--- a/nix/devenv-modules/observability.nix
+++ b/nix/devenv-modules/observability.nix
@@ -10,6 +10,7 @@
   project,
   backend ? "ambient",
   commandInstrumentation ? false,
+  otelScrapePackage ? null,
   profile ? {
     name = "setup";
     task = "setup:strict";
@@ -43,10 +44,12 @@ let
   otelSpan = import ./otel/otel-span.nix { inherit pkgs; };
   otelite = import (../../packages + "/@overeng/otelite/nix/build.nix") { inherit pkgs; };
   otelScrape =
-    if commandInstrumentation then
-      import (../../packages + "/@overeng/otel-scrape/nix/build.nix") { inherit pkgs; }
+    if !commandInstrumentation then
+      null
+    else if otelScrapePackage != null then
+      otelScrapePackage
     else
-      null;
+      throw "effect-utils observability: commandInstrumentation requires the flake-stamped otelScrapePackage";
 
   capture =
     if profile == null then

--- a/nix/devenv-modules/observability.nix
+++ b/nix/devenv-modules/observability.nix
@@ -9,6 +9,7 @@
 {
   project,
   backend ? "ambient",
+  commandInstrumentation ? false,
   profile ? {
     name = "setup";
     task = "setup:strict";
@@ -41,6 +42,11 @@ let
   # the profile/verify surface after this producer can be retired.
   otelSpan = import ./otel/otel-span.nix { inherit pkgs; };
   otelite = import (../../packages + "/@overeng/otelite/nix/build.nix") { inherit pkgs; };
+  otelScrape =
+    if commandInstrumentation then
+      import (../../packages + "/@overeng/otel-scrape/nix/build.nix") { inherit pkgs; }
+    else
+      null;
 
   capture =
     if profile == null then
@@ -191,10 +197,17 @@ in
     # Devenv task execution may reconstruct PATH independently of the capture
     # process, so task wrappers resolve the module-owned bridge explicitly.
     OTEL_SPAN_BIN = "${otelSpan}/bin/otel-span";
+  }
+  // lib.optionalAttrs commandInstrumentation {
+    # Command instrumentation is explicit because otel-scrape is materially
+    # larger than the task-span bridge. Pin its path for nested task shells,
+    # which must not depend on the parent shell's reconstructed PATH.
+    OTEL_SCRAPE_BIN = "${otelScrape}/bin/otel-scrape";
   };
   packages = [
     otelSpan
     otelite
-  ];
+  ]
+  ++ lib.optional commandInstrumentation otelScrape;
   tasks = profileTasks // wiredTasks;
 }

--- a/nix/devenv-modules/tasks/README.md
+++ b/nix/devenv-modules/tasks/README.md
@@ -32,6 +32,8 @@ imports = [
     backend = "auto";
     # Optional: gate an existing aggregate task on the hermetic shape check.
     wireInto = [ "check:all" ];
+    # Optional: provide otel-scrape to trace.instr command wrappers.
+    commandInstrumentation = true;
   })
 ];
 ```
@@ -43,7 +45,10 @@ do not depend on ambient `PATH`; capture tasks also prefer otelite's
 invocation-scoped HTTP endpoint over a repository's ambient collector endpoint.
 The module intentionally avoids the full local observability stack. Override
 `profile` to capture a different task graph, or set `profile = null` when only
-the packages and project attribution are needed.
+the packages and project attribution are needed. Command instrumentation is
+also opt-in: `commandInstrumentation = true` adds `otel-scrape` and pins
+`OTEL_SCRAPE_BIN` for nested task shells. Leaving it disabled avoids adding the
+command observer to consumers that only need task spans and hermetic capture.
 
 ### Characteristics:
 

--- a/nix/devenv-modules/tasks/shared/tests/observability-command-instrumentation.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/observability-command-instrumentation.test.sh
@@ -74,10 +74,13 @@ disabled_supplies_scrape="$(nix eval --impure --json --expr "
   || fail "disabled module should not add otel-scrape to packages"
 
 otel_span_bin="$(module_attr true OTEL_SPAN_BIN)"
-otel_scrape_bin="$(module_attr true OTEL_SCRAPE_BIN)"
+module_otel_scrape_bin="$(module_attr true OTEL_SCRAPE_BIN)"
+otel_scrape_bin="$(nix build --no-link --print-out-paths "git+file://$ROOT#otel-scrape")/bin/otel-scrape"
 otelite_bin="$(nix build --no-link --print-out-paths "$ROOT#otelite")/bin/otelite"
 
 [ -x "$otel_span_bin" ] || fail "enabled module should provide executable otel-span"
+[ "$module_otel_scrape_bin" = "$otel_scrape_bin" ] \
+  || fail "enabled module should select the flake-built otel-scrape package"
 [ -x "$otel_scrape_bin" ] || fail "enabled module should provide executable otel-scrape"
 [ -x "$otelite_bin" ] || fail "otelite should be executable"
 

--- a/nix/devenv-modules/tasks/shared/tests/observability-command-instrumentation.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/observability-command-instrumentation.test.sh
@@ -19,9 +19,9 @@ module_attr() {
   local attr="$2"
   nix eval --impure --raw --expr "
     let
-      flake = builtins.getFlake (toString $ROOT);
+      flake = builtins.getFlake (\"git+file://\" + toString $ROOT);
       pkgs = import flake.inputs.nixpkgs { system = builtins.currentSystem; };
-      module = (import $ROOT/nix/devenv-modules/observability.nix {
+      module = (flake.devenvModules.observability {
         project = \"module-smoke\";
         profile = null;
         commandInstrumentation = $enabled;
@@ -41,9 +41,9 @@ mkdir -p "$tmpdir/bin"
 
 disabled_has_scrape="$(nix eval --impure --json --expr "
   let
-    flake = builtins.getFlake (toString $ROOT);
+    flake = builtins.getFlake (\"git+file://\" + toString $ROOT);
     pkgs = import flake.inputs.nixpkgs { system = builtins.currentSystem; };
-    module = (import $ROOT/nix/devenv-modules/observability.nix {
+    module = (flake.devenvModules.observability {
       project = \"module-smoke\";
       profile = null;
       commandInstrumentation = false;
@@ -58,7 +58,7 @@ disabled_has_scrape="$(nix eval --impure --json --expr "
 
 disabled_supplies_scrape="$(nix eval --impure --json --expr "
   let
-    flake = builtins.getFlake (toString $ROOT);
+    flake = builtins.getFlake (\"git+file://\" + toString $ROOT);
     pkgs = import flake.inputs.nixpkgs { system = builtins.currentSystem; };
     module = (import $ROOT/nix/devenv-modules/observability.nix {
       project = \"module-smoke\";
@@ -81,9 +81,23 @@ otelite_bin="$(nix build --no-link --print-out-paths "$ROOT#otelite")/bin/otelit
 [ -x "$otel_scrape_bin" ] || fail "enabled module should provide executable otel-scrape"
 [ -x "$otelite_bin" ] || fail "otelite should be executable"
 
+otel_scrape_version="$("$otel_scrape_bin" --version 2>/dev/null)"
+case "$otel_scrape_version" in
+  "otel-scrape 0.0.0+"*)
+    ;;
+  *)
+    fail "module-provided otel-scrape should carry a build-correlated machine version"
+    ;;
+esac
+case "$otel_scrape_version" in
+  *"+unknown"* | *"+dev"*)
+    fail "module-provided otel-scrape should preserve the flake source stamp"
+    ;;
+esac
+
 nix eval --impure --raw --expr "
   let
-    flake = builtins.getFlake (toString $ROOT);
+    flake = builtins.getFlake (\"git+file://\" + toString $ROOT);
     pkgs = import flake.inputs.nixpkgs { system = builtins.currentSystem; };
     trace = import $ROOT/nix/devenv-modules/tasks/lib/trace.nix { lib = pkgs.lib; };
   in trace.exec \"test:command-instrumentation\" ''

--- a/nix/devenv-modules/tasks/shared/tests/observability-command-instrumentation.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/observability-command-instrumentation.test.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Proves that the observability module's opt-in command instrumentation supplies
+# the real otel-scrape binary and that trace.instr composes it beneath a task
+# span. Expensive devenv evaluation is replaced only by a basename-preserving
+# command stub; otelite, otel-span, and otel-scrape are all real.
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$TESTS_DIR/../../../../.." && pwd)"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+module_attr() {
+  local enabled="$1"
+  local attr="$2"
+  nix eval --impure --raw --expr "
+    let
+      flake = builtins.getFlake (toString $ROOT);
+      pkgs = import flake.inputs.nixpkgs { system = builtins.currentSystem; };
+      module = (import $ROOT/nix/devenv-modules/observability.nix {
+        project = \"module-smoke\";
+        profile = null;
+        commandInstrumentation = $enabled;
+      }) {
+        inherit pkgs;
+        lib = pkgs.lib;
+      };
+    in module.env.$attr
+  "
+}
+
+echo "Running observability command-instrumentation test..."
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+mkdir -p "$tmpdir/bin"
+
+disabled_has_scrape="$(nix eval --impure --json --expr "
+  let
+    flake = builtins.getFlake (toString $ROOT);
+    pkgs = import flake.inputs.nixpkgs { system = builtins.currentSystem; };
+    module = (import $ROOT/nix/devenv-modules/observability.nix {
+      project = \"module-smoke\";
+      profile = null;
+      commandInstrumentation = false;
+    }) {
+      inherit pkgs;
+      lib = pkgs.lib;
+    };
+  in builtins.hasAttr \"OTEL_SCRAPE_BIN\" module.env
+")"
+[ "$disabled_has_scrape" = "false" ] \
+  || fail "disabled module should not expose OTEL_SCRAPE_BIN"
+
+disabled_supplies_scrape="$(nix eval --impure --json --expr "
+  let
+    flake = builtins.getFlake (toString $ROOT);
+    pkgs = import flake.inputs.nixpkgs { system = builtins.currentSystem; };
+    module = (import $ROOT/nix/devenv-modules/observability.nix {
+      project = \"module-smoke\";
+      profile = null;
+      commandInstrumentation = false;
+    }) {
+      inherit pkgs;
+      lib = pkgs.lib;
+    };
+  in builtins.any (package: (package.meta.mainProgram or null) == \"otel-scrape\") module.packages
+")"
+[ "$disabled_supplies_scrape" = "false" ] \
+  || fail "disabled module should not add otel-scrape to packages"
+
+otel_span_bin="$(module_attr true OTEL_SPAN_BIN)"
+otel_scrape_bin="$(module_attr true OTEL_SCRAPE_BIN)"
+otelite_bin="$(nix build --no-link --print-out-paths "$ROOT#otelite")/bin/otelite"
+
+[ -x "$otel_span_bin" ] || fail "enabled module should provide executable otel-span"
+[ -x "$otel_scrape_bin" ] || fail "enabled module should provide executable otel-scrape"
+[ -x "$otelite_bin" ] || fail "otelite should be executable"
+
+nix eval --impure --raw --expr "
+  let
+    flake = builtins.getFlake (toString $ROOT);
+    pkgs = import flake.inputs.nixpkgs { system = builtins.currentSystem; };
+    trace = import $ROOT/nix/devenv-modules/tasks/lib/trace.nix { lib = pkgs.lib; };
+  in trace.exec \"test:command-instrumentation\" ''
+    \${trace.instr {
+      adapter = \"none\";
+      name = \"devenv:build:test-output\";
+    }}
+    \"''\${_otel_instr[@]}\" devenv build outputs.example
+  ''
+" > "$tmpdir/task-exec.sh"
+chmod +x "$tmpdir/task-exec.sh"
+
+cat > "$tmpdir/bin/devenv" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+[ "$#" -eq 2 ] && [ "$1" = build ] && [ "$2" = outputs.example ]
+EOF
+chmod +x "$tmpdir/bin/devenv"
+
+capture="$tmpdir/capture"
+env -u TRACEPARENT -u OTEL_TASK_TRACEPARENT -u OTEL_SHELL_ENTRY_NS \
+  PATH="$tmpdir/bin:$PATH" \
+  DEVENV_ROOT="$tmpdir/workspace" \
+  OTEL_DEVENV_PROJECT="module-smoke" \
+  OTEL_SPAN_BIN="$otel_span_bin" \
+  OTEL_SCRAPE_BIN="$otel_scrape_bin" \
+  "$otelite_bin" run --out "$capture" --protocol http/json -- bash "$tmpdir/task-exec.sh" \
+  > "$tmpdir/summary.json"
+
+"$otelite_bin" inspect "$capture" --signal traces > "$tmpdir/spans.ndjson"
+
+jq -e '
+  .child.exit_code == 0
+  and .counts.rejected == 0
+  and .counts.spans == 2
+' "$tmpdir/summary.json" >/dev/null \
+  || fail "capture should contain exactly the accepted task and command spans"
+
+task_span="$(jq -r 'select(.name == "devenv.task.exec") | .span_id' "$tmpdir/spans.ndjson")"
+[ -n "$task_span" ] || fail "missing devenv.task.exec task span"
+
+jq -s -e --arg task "$task_span" '
+  ([.[].trace_id] | unique | length) == 1
+  and any(.[];
+    .service == "effect-utils-devenv"
+    and .name == "devenv.task.exec"
+    and .attrs["task.name"] == "test:command-instrumentation"
+    and .attrs["devenv.project.name"] == "module-smoke"
+  )
+  and any(.[];
+    .service == "effect-utils-devenv"
+    and .name == "devenv"
+    and .attrs["otel_scrape.span.origin"] == "otel-scrape"
+    and .parent_span_id == $task
+  )
+' "$tmpdir/spans.ndjson" >/dev/null \
+  || fail "real devenv command span should be a direct child of the task span"
+
+echo "observability command-instrumentation test passed"


### PR DESCRIPTION
## Problem

Reusable `trace.instr` wrappers only activate when `otel-scrape` is available.
The observability module supplied the task-span bridge and hermetic capture, but
left every consumer to add `otel-scrape` and preserve its path independently.
That made command-level visibility easy to configure syntactically while
remaining inactive at runtime.

## Goal

Let repositories explicitly opt into command instrumentation through the
existing observability composition point, without adding `otel-scrape` to every
consumer's default closure and without losing the binary's source-build identity.

## Decisions

- Add `commandInstrumentation = true` to the existing
  `devenvModules.observability` adapter.
- When enabled, supply `otel-scrape` and set an absolute `OTEL_SCRAPE_BIN` for
  nested task shells whose `PATH` may be reconstructed by devenv.
- Inject the flake-built package through the exported module so its compile-time
  source-revision stamp is preserved; direct source imports must supply that
  package explicitly instead of silently building `0.0.0+unknown`.
- Keep the option disabled by default, preserving the lighter task-span-only
  closure.
- Keep the existing observability adapter as the sole capture/lifecycle owner.
  This is intentionally orthogonal to #886 and does not introduce another
  backend or service lifecycle.

## Verification

- `bash nix/devenv-modules/tasks/shared/tests/observability-command-instrumentation.test.sh`
  - disabled module has neither `OTEL_SCRAPE_BIN` nor an `otel-scrape` package
  - enabled module resolves real `otel-span` and `otel-scrape` executables
  - module-provided `otel-scrape --version` is build-correlated and is neither
    `+unknown` nor `+dev`
  - real otelite capture contains exactly one task span and one otel-scrape-owned
    `devenv` command child in a single trace
- `bash nix/devenv-modules/tasks/shared/tests/otel-instr-gating.test.sh`
- `devenv tasks run lint:nix:format lint:nix:deadcode --mode single --no-tui`

All three commands pass at `3e6d977a8`.

## Complexity

The module adds one boolean branch and the flake export injects one existing,
stamped package. Disabled consumers do not evaluate or add the command observer
derivation; enabled consumers receive one package and one absolute-path
environment variable.

## Concerns

#886 reorganizes the observability VRS and may create documentation conflicts if
it lands first. The runtime ownership model is aligned: this PR extends the
existing adapter rather than creating another lifecycle.

## Friction & bottlenecks

The aggregate module test lane previously reached an unrelated
projected-install failure in `deploy-task-e2e.test.sh`. The focused
real-binary/otelite proof and affected Nix lint lanes pass independently.

## Follow-ups

- Downstream repositories can remove hand-written `otel-scrape` packaging when
  they enable `commandInstrumentation`.

## References

- overengineeringstudio/effect-utils#886
- livestorejs/livestore#1402

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | dev3.livestore-issue-1402-performance-rca |
| `agent_session_id` | dev3.livestore-issue-1402-performance-rca |
| `agent_tool` | Codex |
| `agent_tool_version` | 0.145.0 |
| `agent_runtime` | Codex 0.145.0 |
| `agent_model` | gpt-5.6-sol |
| `runtime_profile` | /home/schickling/.local/state/agent-session-recovery/2026-07-29-pty-st2-cutover/runtime-profile/profile-without-null-opencode.json |
| `skills_manifest` | /nix/store/kx5j47nghj1yps2v693ryb6wnf1c2xhb-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | livestore/schickling/2026-07-27-1402 |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@16a22c6 |
</details>
<!-- agent-footer:end -->