### PR TITLE
docs(effect4): add runtime migration recipes

### DIFF
--- a/context/effect-4/recipes/cause-extractors.md
+++ b/context/effect-4/recipes/cause-extractors.md
@@ -1,0 +1,99 @@
+# Pattern: cause-extractors
+
+**Area:** Cause inspection **Kind:** semantic **Our usage:** about 61 references span the
+repository; the measured package heatmap includes `megarepo`, `tui-react`,
+`notion-datasource-sync`, `utils`, `restate-effect`, `notion-md`, `otel-contract`,
+`notion-react`, `notion-cli`, `effect-rpc-tanstack`, and `npm-release`.
+
+## Shape changes first
+
+- A v4 `Cause<E>` is flat: `{ reasons: ReadonlyArray<Reason<E>> }`, where each reason is a `Fail`,
+  `Die`, or `Interrupt`. Code that traversed the recursive v3 tree must be rewritten around the
+  ordered `reasons` array.
+- `Cause.findDefect` returns `Result.Result<unknown, Cause<E>>`, not `Option<unknown>`.
+- Replacements for `Cause.failures` and `Cause.defects` are ordinary arrays, not `Chunk`s.
+
+## v3
+
+```ts
+const firstFailure = Cause.failureOption(cause)
+const firstDefect = Cause.dieOption(cause)
+
+const failures = Cause.failures(cause) // Chunk<E>
+const defects = Cause.defects(cause) // Chunk<unknown>
+
+const interruptedOnly = Cause.isInterruptedOnly(cause)
+const hasAnyInterrupt = Cause.isInterrupted(cause)
+```
+
+## v4
+
+```ts
+const firstFailure = Cause.findErrorOption(cause)
+
+const firstDefectResult = Cause.findDefect(cause)
+const firstDefect = Result.getSuccess(firstDefectResult) // Option<unknown>
+
+const failures = cause.reasons.filter(Cause.isFailReason).map((reason) => reason.error) // Array<E>
+const defects = cause.reasons.filter(Cause.isDieReason).map((reason) => reason.defect) // Array<unknown>
+
+const interruptedOnly = Cause.hasInterruptsOnly(cause)
+const hasAnyInterrupt = Cause.hasInterrupts(cause)
+```
+
+If the no-defect branch needs the remaining cause, keep the `Result` instead of converting it:
+
+```ts
+const defect = Cause.findDefect(cause)
+
+const rendered = Result.match(defect, {
+  onSuccess: (value) => renderDefect(value),
+  onFailure: (remainingCause) => renderCause(remainingCause),
+})
+```
+
+## Migration table
+
+| v3                        | v4                                                       | Shape                |
+| ------------------------- | -------------------------------------------------------- | -------------------- |
+| recursive `Cause` tree    | `cause.reasons`                                          | flat ordered array   |
+| `Cause.failureOption`     | `Cause.findErrorOption`                                  | `Option` retained    |
+| `Cause.dieOption`         | `Cause.findDefect`                                       | `Option` to `Result` |
+| `Cause.failures`          | filter `reasons` with `Cause.isFailReason`, map `.error` | `Chunk` to `Array`   |
+| `Cause.defects`           | filter `reasons` with `Cause.isDieReason`, map `.defect` | `Chunk` to `Array`   |
+| `Cause.isInterruptedOnly` | `Cause.hasInterruptsOnly`                                | rename               |
+| `Cause.isInterrupted`     | `Cause.hasInterrupts`                                    | rename               |
+
+## Equivalence
+
+All named v4 exports, the `Cause.reasons` representation, reason fields, and the
+`findDefect` result type were verified directly in the `effect@4.0.0-beta.102` tarball
+(SHA-1 `f51092854960f60cbdb06bd59e788acbc8ee8492`). This recipe does not replace a
+slice's differential proof.
+
+For each migrated site, compare the ordered extracted failure/defect values, interruption
+classification, empty-cause handling, and encoded output for mixed causes. A value-only assertion
+is insufficient at serialization boundaries.
+
+## Intended differences (alignment register entries)
+
+None for source inspection. The existing `rpc-failure-cause-wire-shape` entry concerns serialized
+RPC failure envelopes only. It does not cover this source migration or authorize a different
+extractor result, collection type, ordering, or traversal behavior.
+
+## Gotchas
+
+- Do not pass `Cause.findDefect(cause)` to `Option.match`; it is a `Result`. Use
+  `Result.getSuccess` only when intentionally discarding the unmatched cause.
+- Remove `Chunk.toReadonlyArray` and other `Chunk` combinators after replacing
+  `failures`/`defects`; the filtered values are already arrays.
+- Filter before reading `.error` or `.defect`. A `Reason` is a union and mixed causes are valid.
+- A flat reason scan preserves reason order, but it cannot preserve assumptions about v3
+  sequential/parallel tree topology. Any topology-sensitive formatter or serializer needs its own
+  behavioral proof.
+
+## Codemod rule
+
+Only the interruption predicates and `failureOption` rename mechanically. `dieOption`,
+`failures`, `defects`, and every direct recursive traversal require site review because their
+result or representation shape changed.

--- a/context/effect-4/recipes/core-error-handling.md
+++ b/context/effect-4/recipes/core-error-handling.md
@@ -1,0 +1,91 @@
+# Pattern: core-error-handling
+
+**Area:** Effect error handling and async constructors **Kind:** mixed **Our usage:** the
+`catchAll*` family has 123 sites across 47 files and 14 packages; `Effect.async` has 13 sites
+across 7 files.
+
+## Shape change first
+
+`Effect.callback` keeps the v3 `Effect.async` registration model: resume with an `Effect`, use the
+provided `AbortSignal`, and optionally return an interruption cleanup `Effect`. The v3
+`blockingOn` second argument is gone, and v4 binds its scheduler as the registration function's
+`this`. Do not silently discard `blockingOn` at a site that used it.
+
+## v3
+
+```ts
+const read = Effect.async<string, Error>((resume, signal) => {
+  const handle = startRead({
+    signal,
+    done: (value) => resume(Effect.succeed(value)),
+    failed: (error) => resume(Effect.fail(error)),
+  })
+  return Effect.sync(() => handle.cancel())
+})
+
+const recovered = program.pipe(
+  Effect.catchAll((error) => recover(error)),
+  Effect.catchAllCause((cause) => reportCause(cause)),
+  Effect.catchAllDefect((defect) => reportDefect(defect)),
+)
+```
+
+## v4
+
+```ts
+const read = Effect.callback<string, Error>((resume, signal) => {
+  const handle = startRead({
+    signal,
+    done: (value) => resume(Effect.succeed(value)),
+    failed: (error) => resume(Effect.fail(error)),
+  })
+  return Effect.sync(() => handle.cancel())
+})
+
+const recovered = program.pipe(
+  Effect.catch((error) => recover(error)),
+  Effect.catchCause((cause) => reportCause(cause)),
+  Effect.catchDefect((defect) => reportDefect(defect)),
+)
+```
+
+## Rename sheet
+
+| v3                      | v4                   | Measured exposure              |
+| ----------------------- | -------------------- | ------------------------------ |
+| `Effect.catchAll`       | `Effect.catch`       | 112 sites / 47 files / 14 pkgs |
+| `Effect.catchAllCause`  | `Effect.catchCause`  | 7 sites / 6 files / 4 pkgs     |
+| `Effect.catchAllDefect` | `Effect.catchDefect` | 4 sites / 4 files / 3 pkgs     |
+| `Effect.async`          | `Effect.callback`    | 13 sites / 7 files             |
+
+## Equivalence
+
+The v4 symbols and callback signature were verified directly in the
+`effect@4.0.0-beta.102` tarball (SHA-1
+`f51092854960f60cbdb06bd59e788acbc8ee8492`). This recipe does not replace a slice's
+differential proof.
+
+For callback sites, compare success and failure values, abort timing, registration count, and
+cleanup count under interruption. For catch sites, compare the encoded success/error output and
+confirm that `catch` still leaves defects unhandled while `catchCause` and `catchDefect` retain
+their broader boundaries.
+
+## Intended differences (alignment register entries)
+
+None. These migrations preserve the existing recovery and interruption boundaries.
+
+## Gotchas
+
+- `Effect.catch` catches typed errors, not defects. Do not broaden it to `catchCause` just because
+  a neighboring site inspects a `Cause`.
+- The callback must resume with an `Effect`, not a raw value or error.
+- Preserve interruption cleanup. Moving cleanup only onto the `AbortSignal` listener can change
+  ordering; dropping the returned cleanup effect can leak the registered resource.
+- A v3 `Effect.async` site with a `blockingOn` argument needs an explicit local rewrite; v4
+  `Effect.callback` has no corresponding argument.
+
+## Codemod rule
+
+The three `catchAll*` replacements are safe identifier rewrites. Rename `Effect.async` only after
+confirming the call has no second `blockingOn` argument, then retain the registration callback and
+cleanup effect unchanged.

--- a/context/effect-4/recipes/layer-clock-providers.md
+++ b/context/effect-4/recipes/layer-clock-providers.md
@@ -1,0 +1,196 @@
+# Pattern: layer-clock-providers
+
+**Area:** Layer, Clock, Random, and ConfigProvider construction **Kind:** semantic **Our usage:**
+Layer has 31 affected sites across 23 files and 8 packages; Clock has 13 sites across 6 files and
+3 packages; `ConfigProvider.fromMap` has 5 sites across 3 files. The measured Layer/Clock package
+heatmap includes `megarepo`, `tui-react`, `notion-datasource-sync`, `utils`, `restate-effect`,
+`notion-md`, `notion-effect-client`, `utils-dev`, and `effect-distributed-lock`.
+
+## Shape changes first
+
+- v4 has no separate scoped Layer constructors. `Layer.effect` and `Layer.effectDiscard` own the
+  layer scope and exclude `Scope.Scope` from their requirements.
+- `Layer.map` is removed. Transform a produced `Context` with `Layer.flatMap`, then lift the
+  replacement `Context` with `Layer.succeedContext`.
+- Clock, Random, and ConfigProvider are `Context.Reference`s. Their old `Layer.set*` constructors
+  become ordinary Reference layers.
+- `Clock.make` is removed. The live implementation is the default value of the `Clock.Clock`
+  Reference, and custom implementations use renamed unsafe methods.
+- `ConfigProvider.fromUnknown` walks an object hierarchy. It does not split delimiters embedded
+  in object keys as v3 `fromMap` did.
+
+## Layer constructors
+
+### v3
+
+```ts
+const serviceLayer = Layer.scoped(Service, acquireService)
+const startupLayer = Layer.scopedDiscard(startup)
+
+const selected = Layer.unwrapEffect(selectLayer)
+const selectedScoped = Layer.unwrapScoped(selectLayerScoped)
+
+const projected = Layer.map(sourceLayer, (context) => projectContext(context))
+```
+
+### v4
+
+```ts
+const serviceLayer = Layer.effect(Service, acquireService)
+const startupLayer = Layer.effectDiscard(startup)
+
+const selected = Layer.unwrap(selectLayer)
+const selectedScoped = Layer.unwrap(selectLayerScoped)
+
+const projected = sourceLayer.pipe(
+  Layer.flatMap((context) => Layer.succeedContext(projectContext(context))),
+)
+```
+
+| v3                            | v4 restructuring                                                                 |
+| ----------------------------- | -------------------------------------------------------------------------------- |
+| `Layer.scoped`                | `Layer.effect`                                                                   |
+| `Layer.scopedDiscard`         | `Layer.effectDiscard`                                                            |
+| `Layer.unwrapEffect`          | `Layer.unwrap`                                                                   |
+| `Layer.unwrapScoped`          | `Layer.unwrap`                                                                   |
+| `Layer.map(layer, transform)` | `layer.pipe(Layer.flatMap(context => Layer.succeedContext(transform(context))))` |
+
+## Reference layers
+
+### v3
+
+```ts
+const runtimeOverrides = Layer.mergeAll(
+  Layer.setClock(customClock),
+  Layer.setRandom(customRandom),
+  Layer.setConfigProvider(configProvider),
+)
+```
+
+### v4
+
+```ts
+const runtimeOverrides = Layer.mergeAll(
+  Layer.succeed(Clock.Clock, customClock),
+  Layer.succeed(Random.Random, customRandom),
+  ConfigProvider.layer(configProvider),
+)
+```
+
+The v4 Random service shape is the primitive generator, not the v3 effectful facade:
+
+```ts
+const deterministicRandom = Layer.succeed(Random.Random, {
+  nextIntUnsafe: () => 4,
+  nextDoubleUnsafe: () => 0.25,
+})
+```
+
+Callers continue to use effectful operations such as `Random.next`, `Random.nextInt`, and
+`Random.shuffle`; those operations derive from the two Reference methods.
+
+## Custom Clock
+
+### v3
+
+```ts
+const liveClock = Clock.make()
+
+const fixedClock: Clock.Clock = {
+  [Clock.ClockTypeId]: Clock.ClockTypeId,
+  unsafeCurrentTimeMillis: () => nowMillis,
+  currentTimeMillis: Effect.succeed(nowMillis),
+  unsafeCurrentTimeNanos: () => BigInt(nowMillis) * 1_000_000n,
+  currentTimeNanos: Effect.succeed(BigInt(nowMillis) * 1_000_000n),
+  sleep: (duration) => liveClock.sleep(duration),
+}
+```
+
+### v4
+
+```ts
+const liveClock = Clock.Clock.defaultValue()
+
+const fixedClock: Clock.Clock = {
+  currentTimeMillisUnsafe: () => nowMillis,
+  currentTimeMillis: Effect.succeed(nowMillis),
+  currentTimeNanosUnsafe: () => BigInt(nowMillis) * 1_000_000n,
+  currentTimeNanos: Effect.succeed(BigInt(nowMillis) * 1_000_000n),
+  sleep: (duration) => liveClock.sleep(duration),
+}
+
+const fixedClockLayer = Layer.succeed(Clock.Clock, fixedClock)
+```
+
+`Clock.ClockTypeId` and its brand are gone. The unsafe names move the `Unsafe` suffix to the end:
+`unsafeCurrentTimeMillis` becomes `currentTimeMillisUnsafe`, and
+`unsafeCurrentTimeNanos` becomes `currentTimeNanosUnsafe`.
+
+## ConfigProvider
+
+For the repository's flat, already-complete keys, construct the object explicitly and install it
+with the provider's layer:
+
+```ts
+const provider = ConfigProvider.fromUnknown({
+  RESTATE_ADMIN_URL: 'http://admin.local:9070',
+  RESTATE_ADMIN_KEY: 'k3y',
+})
+
+const configLayer = ConfigProvider.layer(provider)
+```
+
+When a v3 map encoded path segments with `pathDelim`, expand those keys into the matching object
+hierarchy before calling `fromUnknown`:
+
+```ts
+// v3: fromMap(new Map([["database_host", "localhost"]]), { pathDelim: "_" })
+const provider = ConfigProvider.fromUnknown({
+  database: {
+    host: 'localhost',
+  },
+})
+```
+
+Do not migrate that example to `{ database_host: "localhost" }`: a config lookup for
+`["database", "host"]` would miss at runtime.
+
+## Equivalence
+
+All v4 constructors, Reference shapes, Clock method names, and ConfigProvider behavior named here
+were verified directly in the `effect@4.0.0-beta.102` tarball (SHA-1
+`f51092854960f60cbdb06bd59e788acbc8ee8492`). The legacy constructors were also confirmed absent.
+This recipe does not replace a slice's differential proof.
+
+For Layer sites, compare acquisition/finalization counts and order, output services, and failures
+under interruption. For Clock/Random sites, compare every consumed value and sleep behavior. For
+ConfigProvider sites, probe flat keys, nested paths, missing keys, and empty strings used by that
+slice.
+
+## Intended differences (alignment register entries)
+
+None for these constructor forms. The layer-memoization recipe separately governs v4's sharing
+change; this recipe does not alter that decision. Neither that recipe nor `services-context`
+documents the constructor replacements covered here.
+
+## Gotchas
+
+- Do not replace `Layer.map` with `Layer.flatMap((context) => projectContext(context))` directly:
+  `flatMap` must return a `Layer`, so lift the projected `Context` with `Layer.succeedContext`.
+- Preserve scoped acquisition and finalization when renaming `scoped`/`scopedDiscard`. Green
+  construction alone does not prove finalizers still run.
+- Do not implement a custom Clock by spreading `Clock.Clock.defaultValue()`: its unsafe and
+  `sleep` methods live on the prototype. Delegate explicitly or retain the prototype.
+- Do not implement custom Clock `sleep` as `Effect.sleep(duration)` while that same Clock is
+  installed; it resolves the installed Clock again. Delegate to a captured live Clock.
+- A v3 custom Random object cannot be installed unchanged. Implement the v4 Reference's
+  `nextIntUnsafe` and `nextDoubleUnsafe` primitives and prove the derived sequence used by the
+  slice.
+- `ConfigProvider.fromUnknown` treats empty strings as missing unless
+  `{ preserveEmptyStrings: true }` is passed.
+
+## Codemod rule
+
+The scoped/unwrap names can be rewritten mechanically only after their effect types still include
+the intended scope. `Layer.map`, every Reference layer, custom Clock/Random implementations, and
+delimited `fromMap` inputs require site review and differential proof.


### PR DESCRIPTION
## Problem

Phase 4 package slices repeatedly encounter Effect error handling, Cause inspection, and Layer/Clock/provider constructors. The existing recipe catalog did not define canonical Effect 4 forms for these APIs, including runtime-significant result, collection, context, and Reference shape changes.

## Goal

Give every slice owner one durable, beta-pinned migration recipe for each of:

- core error handling and callback construction
- flat Cause extraction
- Layer, Clock, Random, and ConfigProvider construction

## Decisions

- Lead each recipe with runtime shape changes; loud renames follow in tables.
- Verify every named v4 symbol and removed v3 export against the published `effect@4.0.0-beta.102` tarball.
- Keep source inspection distinct from the existing RPC Cause wire-shape entry.
- Document required per-slice differential proofs without applying any migration.

## Verification

- Tarball: `effect@4.0.0-beta.102`, SHA-1 `f51092854960f60cbdb06bd59e788acbc8ee8492`.
- Export/absence probe: `beta.102 recipe symbol check: PASS`.
- Runtime shape probe: `{"failures":["typed"],"defects":["defect"],"projected":2,"clockValue":123,"randomValue":0.25,"host":"localhost","status":"PASS"}`.
- `oxfmt --write <three recipe files>`: completed.
- `oxlint <three recipe files>`: 0 warnings, 0 errors.
- `devenv tasks run lint:check --no-tui`: passed.
- `devenv tasks run check:quick --no-tui`: passed.
- `devenv tasks run check:all --no-tui`: attempted twice; the unrelated `otel:verify:setup` task failed during an announced Nix store GC. Flake evaluation passed in both attempts.

## Complexity

No runtime or dependency complexity. This adds three documentation-only recipes.

## Concerns

API existence and representative runtime shapes are proven here; each package slice must still run its own byte-level differential baseline before accepting a migration.

## Friction & bottlenecks

- Friction: the full gate's OTel setup failed while a Nix store GC was active.
- Bottlenecks: none attributable to this change.

## Follow-ups

None in this PR. Applying these recipes is intentionally owned by the package slices.

## References

Refs #925

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | co3-bee |
| `agent_session_id` | fbde4fb5-5d17-4ccc-b8ec-31712199f508 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.145.0 |
| `agent_runtime` | Codex CLI 0.145.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/v2g542rika3abxn98x5yimz431j5br13-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/3aq75z8arl44fsvn49i2k4yqlzb1kcwb-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-29-effect4-rec-runtime |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->