### PR TITLE
docs(effect4): add Schema migration recipes

### DIFF
--- a/context/effect-4/recipes/schema-codec-members.md
+++ b/context/effect-4/recipes/schema-codec-members.md
@@ -1,0 +1,139 @@
+# Pattern: schema-codec-members
+
+**Area:** Schema codecs and members **Kind:** mixed, with an `Exit` shape change **Our usage:** 783
+affected references in 159 files across about 25 packages. The removed `*Either` codec family alone
+accounts for 28 references in 11 files and 6 packages.
+
+## Shape change first: codecs return `Exit`
+
+The non-throwing v3 `*Either` adapters become v4 `*Exit` adapters. This is not merely a rename:
+callers receive `Exit`, whose success value is at `.value` and whose failure is a `Cause` at
+`.cause`. There is no `.left` or `.right`.
+
+## v3
+
+```ts
+const decoded = Schema.decodeUnknownEither(User)(input)
+const encoded = Schema.encodeEither(User)(user)
+
+if (Either.isRight(decoded)) {
+  use(decoded.right)
+}
+```
+
+## v4
+
+```ts
+import { Exit, Schema } from 'effect'
+
+const decoded = Schema.decodeUnknownExit(User)(input)
+const encoded = Schema.encodeExit(User)(user)
+
+if (Exit.isSuccess(decoded)) {
+  use(decoded.value)
+} else {
+  report(decoded.cause)
+}
+```
+
+Use the corresponding unknown-input adapters when the value is not already typed:
+
+| v3                    | v4                  |
+| --------------------- | ------------------- |
+| `decodeUnknownEither` | `decodeUnknownExit` |
+| `decodeEither`        | `decodeExit`        |
+| `encodeUnknownEither` | `encodeUnknownExit` |
+| `encodeEither`        | `encodeExit`        |
+
+## Codec and member migrations
+
+After the `Exit` call sites are structurally repaired, apply the loud member migrations:
+
+| v3                                          | v4                                    |
+| ------------------------------------------- | ------------------------------------- |
+| `Schema.parseJson()`                        | `Schema.UnknownFromJsonString`        |
+| `Schema.parseJson(S)`                       | `Schema.fromJsonString(S)`            |
+| `Schema.TaggedError`                        | `Schema.TaggedErrorClass`             |
+| `.annotations(a)` / `Schema.annotations(a)` | `.annotate(a)` / `Schema.annotate(a)` |
+| `Schema.decodeUnknown`                      | `Schema.decodeUnknownEffect`          |
+| `Schema.decode`                             | `Schema.decodeEffect`                 |
+| `Schema.encodeUnknown`                      | `Schema.encodeUnknownEffect`          |
+| `Schema.encode`                             | `Schema.encodeEffect`                 |
+| `Schema.compose(To)`                        | `Schema.decodeTo(To)`                 |
+| `Schema.OptionFromSelf(S)`                  | `Schema.Option(S)`                    |
+| `Schema.Redacted(S)`                        | `Schema.RedactedFromValue(S)`         |
+| `Schema.DateFromSelf`                       | `Schema.Date`                         |
+
+`Schema.encode` is also a surviving-name trap: it exists in v4 as a schema transformation
+constructor. Parser call sites must move to `Schema.encodeEffect`; leaving the old name can bind to
+the wrong operation instead of producing a simple missing-export error.
+
+`Redacted` is a surviving-name trap. V4 `Schema.Redacted(S)` validates values that are already
+`Redacted`; `Schema.RedactedFromValue(S)` preserves the v3 behavior of decoding a raw value and
+wrapping it.
+
+The Date pair is another surviving-name trap: v3 `DateFromSelf` becomes v4 `Date`, while v3 `Date`
+wire schemas become v4 `DateFromString`. Keep those rewrites separate and follow the
+`schema-date` recipe for the wire contract.
+
+## Affected inventory
+
+The measured codec/member heatmap is:
+
+| Package                  |       Wave | References |
+| ------------------------ | ---------: | ---------: |
+| `megarepo`               |          6 |        176 |
+| `notion-effect-schema`   |          2 |        149 |
+| `notion-datasource-sync` |          7 |         65 |
+| `restate-effect`         |          5 |         56 |
+| `utils`                  |          4 |         44 |
+| `notion-md`              |          6 |         43 |
+| `ci-tools`               |          5 |         43 |
+| `otel-contract`          |          3 |         41 |
+| `tui-react`              |          5 |         25 |
+| `effect-path`            |          2 |         25 |
+| `notion-effect-client`   |          5 |         21 |
+| `utils-dev`              |          1 |         21 |
+| `content-address`        |          2 |         18 |
+| `genie`                  |          6 |         17 |
+| `notion-cli`             |          8 |          8 |
+| `notion-react`           |          6 |          7 |
+| `npm-release`            | unassigned |          7 |
+| `effect-ai-claude-cli`   | unassigned |          6 |
+| `agent-session-ingest`   | unassigned |         26 |
+| `tui-stories`            |          7 |          4 |
+| `effect-rpc-tanstack`    | unassigned |          2 |
+| `notion-property-write`  |          3 |          2 |
+| `kdl-effect`             |          3 |          2 |
+| `kdl`                    |          2 |          1 |
+
+The heatmap counts namespace-member expressions and includes `Exit` adapters. The 783-reference
+headline also includes direct imports and type references.
+
+## Equivalence
+
+No repository migration is applied by this recipe. A slice must compare encoded bytes and normalized
+success/failure traces for every migrated codec. An `Exit` conversion is complete only after all
+callers, matchers, test helpers, and error formatters consume the new shape.
+
+Every v4 symbol in this recipe was checked against the `effect@4.0.0-beta.102` npm tarball with
+SHA-1 `f51092854960f60cbdb06bd59e788acbc8ee8492`.
+
+## Gotchas
+
+- `decodeUnknownEffect` and `encodeEffect` fail with `SchemaError`. Low-level transformation
+  callbacks fail with `SchemaIssue.Issue`; do not interchange those error types.
+- Do not infer safety from a surviving `Schema.encode` reference; its v4 meaning is unrelated to
+  running a schema encoder.
+- `fromJsonString(S)` parses the JSON string and then applies `S`.
+  `UnknownFromJsonString` stops after JSON parsing.
+- `decodeTo` names the target decoded schema. Verify transformation direction instead of mechanically
+  swapping the old `compose` call.
+- Do not add `Either` compatibility wrappers around `Exit`; that creates a migration-only dialect and
+  hides unported callers.
+
+## Codemod rule
+
+The table entries are mechanical only when the old member's role is unambiguous. The `*Either`
+family, `Redacted`, Date schemas, and custom `compose` chains require caller-aware rewrites and
+boundary fixtures.

--- a/context/effect-4/recipes/schema-constructor-shapes.md
+++ b/context/effect-4/recipes/schema-constructor-shapes.md
@@ -1,0 +1,168 @@
+# Pattern: schema-constructor-shapes
+
+**Area:** Schema constructors and field options **Kind:** shape change **Our usage:** 640 affected
+references in 152 files across 27 packages. `Literal` alone accounts for 195 calls in 84 files.
+
+## Shape changes first
+
+These rewrites change arguments or the resulting field representation. Do not treat them as
+find-and-replace renames.
+
+| v3                                         | v4                                                                                |
+| ------------------------------------------ | --------------------------------------------------------------------------------- |
+| `Schema.Union(A, B)`                       | `Schema.Union([A, B])`                                                            |
+| `Schema.Tuple(A, B)`                       | `Schema.Tuple([A, B])`                                                            |
+| `Schema.Literal("a", "b")`                 | `Schema.Literals(["a", "b"])`                                                     |
+| `Schema.Literal(null)`                     | `Schema.Null`                                                                     |
+| `Schema.Record({ key: K, value: V })`      | `Schema.Record(K, V)`                                                             |
+| `Schema.optionalWith(S, { as: "Option" })` | `Schema.OptionFromOptional(S)`                                                    |
+| `Schema.optionalWith(S, { default })`      | `S.pipe(Schema.withDecodingDefaultType(...), Schema.withConstructorDefault(...))` |
+
+The v4 constructors take one array or positional arguments exactly as shown. Accidentally preserving
+the v3 call shape can construct the wrong runtime AST before a slice reaches a useful type error.
+
+## v3
+
+```ts
+const Input = Schema.Struct({
+  kind: Schema.Literal('created', 'updated'),
+  payload: Schema.Union(Schema.String, Schema.Number),
+  pair: Schema.Tuple(Schema.String, Schema.Number),
+  labels: Schema.Record({ key: Schema.String, value: Schema.String }),
+  note: Schema.optionalWith(Schema.String, { as: 'Option' }),
+  retries: Schema.optionalWith(Schema.Number, { default: () => 0 }),
+})
+```
+
+## v4
+
+```ts
+import { Effect, Schema } from 'effect'
+
+const Input = Schema.Struct({
+  kind: Schema.Literals(['created', 'updated']),
+  payload: Schema.Union([Schema.String, Schema.Number]),
+  pair: Schema.Tuple([Schema.String, Schema.Number]),
+  labels: Schema.Record(Schema.String, Schema.String),
+  note: Schema.OptionFromOptional(Schema.String),
+  retries: Schema.Number.pipe(
+    Schema.withDecodingDefaultType(Effect.sync(() => 0)),
+    Schema.withConstructorDefault(Effect.sync(() => 0)),
+  ),
+})
+```
+
+## Optionality decision
+
+`optionalWith` encoded several independent choices in one options object. Preserve the old choice
+explicitly:
+
+| v3 intent                                         | v4 form                                                                  |
+| ------------------------------------------------- | ------------------------------------------------------------------------ |
+| key may be absent or `undefined`                  | `Schema.optional(S)`                                                     |
+| key may be absent, but not present as `undefined` | `Schema.optionalKey(S)`                                                  |
+| missing/`undefined` decodes to `Option.none()`    | `Schema.OptionFromOptional(S)`                                           |
+| missing exact key decodes to `Option.none()`      | `Schema.OptionFromOptionalKey(S)`                                        |
+| missing/`undefined` uses a decoded default        | `Schema.withDecodingDefaultType` plus `Schema.withConstructorDefault`    |
+| missing exact key uses a decoded default          | `Schema.withDecodingDefaultTypeKey` plus `Schema.withConstructorDefault` |
+
+The two default helpers cover different entry points and both are required for a faithful port:
+
+```ts
+const field = Schema.String.pipe(
+  Schema.withDecodingDefaultType(Effect.sync(defaultValue)),
+  Schema.withConstructorDefault(Effect.sync(defaultValue)),
+)
+```
+
+`withDecodingDefaultType` preserves `decode({})`; by itself, its field still makes `Schema.make({})`
+throw `Missing key`. `withConstructorDefault` preserves `Schema.make({})`; by itself, it does not
+apply during decoding. For nullable or combined `optionalWith` options, write an explicit
+`optional`/`optionalKey` plus `decodeTo` transformation, add the constructor default when v3 had a
+default, and prove absent, `undefined`, `null`, present, decode, and make cases separately.
+
+## Checks and refinements
+
+A v3 boolean filter becomes a v4 check. A v3 type-guard filter becomes `refine` so the narrowed type
+is preserved.
+
+```ts
+import { Option, Schema } from 'effect'
+
+const NonEmpty = Schema.String.check(
+  Schema.makeFilter((value) => value.length > 0 || 'must not be empty'),
+)
+
+const Some = Schema.Option(Schema.String).pipe(Schema.refine(Option.isSome))
+```
+
+`makeFilter` may return `undefined`/`true` for success, `false` or a string for one failure, a
+`SchemaIssue.Issue`, a `{ path, issue }` object, or an array of those issues. Do not return old
+`ParseResult` nodes from a v4 check.
+
+## Affected inventory
+
+The measured constructor/options heatmap is:
+
+| Package                   |       Wave | References |
+| ------------------------- | ---------: | ---------: |
+| `notion-effect-schema`    |          2 |        189 |
+| `megarepo`                |          6 |         77 |
+| `notion-datasource-sync`  |          7 |         71 |
+| `tui-react`               |          5 |         64 |
+| `ci-tools`                |          5 |         29 |
+| `notion-effect-client`    |          5 |         25 |
+| `pty-effect`              |          4 |         22 |
+| `agent-session-ingest`    | unassigned |         18 |
+| `effect-path`             |          2 |         17 |
+| `otel-contract`           |          3 |         14 |
+| `utils`                   |          4 |         14 |
+| `notion-cli`              |          8 |         13 |
+| `restate-effect`          |          5 |         12 |
+| `notion-md`               |          6 |         11 |
+| `effect-schema-form-aria` |          5 |          9 |
+| `react-inspector`         | unassigned |          9 |
+| `genie`                   |          6 |          8 |
+| `kdl-effect`              |          3 |          6 |
+| `utils-dev`               |          1 |          6 |
+| `notion-property-write`   |          3 |          5 |
+| `notion-react`            |          6 |          5 |
+| `effect-schema-form`      |          1 |          4 |
+| `tui-stories`             |          7 |          4 |
+| `content-address`         |          2 |          3 |
+| `kdl`                     |          2 |          3 |
+| `effect-rpc-tanstack`     | unassigned |          1 |
+| `npm-release`             | unassigned |          1 |
+
+The heatmap counts namespace-member expressions. The 640-reference headline also includes direct
+imports and type references.
+
+## Equivalence
+
+No repository migration is applied by this recipe. Each owning slice must replay the v3/v4
+differential harness and compare encoded bytes. For optional fields, the fixture matrix must include
+an absent key, an explicit `undefined`, `null` where accepted, a present value, decode, encode, and
+`Schema.make`.
+
+Every v4 symbol in this recipe was checked against the `effect@4.0.0-beta.102` npm tarball with
+SHA-1 `f51092854960f60cbdb06bd59e788acbc8ee8492`.
+
+## Gotchas
+
+- `Schema.optional` and `Schema.optionalKey` deliberately produce different TypeScript and runtime
+  shapes.
+- A v4 decoding default alone breaks v3 constructor behavior. The dual-helper form above is required
+  even when decode fixtures are already green.
+- A decoding default is also an encoding decision. Verify whether the old encoder emitted or omitted
+  the default instead of choosing `encodingStrategy` by intuition.
+- Preserve the old default callback's evaluation timing with `Effect.sync(default)`. Eagerly calling
+  it while building the schema can share mutable default values across decodes.
+- `Schema.Literal(value)` remains the v4 single-literal constructor; only multi-literal calls become
+  `Literals([...])`.
+- Preserve union member order. The v4 union tests members in array order and returns the first match.
+
+## Codemod rule
+
+The array/positional constructor rewrites are mechanical after checking arity. `optionalWith`,
+boolean filters, refinements, nullable fields, and defaults require per-site review and differential
+fixtures.

--- a/context/effect-4/recipes/schema-transformations-issues.md
+++ b/context/effect-4/recipes/schema-transformations-issues.md
@@ -1,0 +1,166 @@
+# Pattern: schema-transformations-issues
+
+**Area:** Schema transformations and parse issues **Kind:** shape change **Our usage:** 27
+`ParseResult` references in 15 files across 7 packages, plus transformation and filter callbacks
+inside the 640-reference Schema constructor/options surface.
+
+## Shape change first
+
+V3 fallible transformation callbacks returned `ParseResult` effects and received the transformation
+AST as a callback argument. V4 separates the concerns:
+
+- `Schema.decodeTo` connects the encoded/source schema to the decoded/target schema.
+- `SchemaTransformation.transform` describes a pure bidirectional conversion.
+- `SchemaTransformation.transformOrFail` describes an effectful conversion whose failure is a
+  `SchemaIssue.Issue`.
+- `SchemaIssue` replaces the old parse-issue constructors and formatters.
+
+All three modules are exported from the `effect` root at `4.0.0-beta.102`.
+
+## Pure transformations
+
+### v3
+
+```ts
+const NumberFromString = Schema.transform(Schema.String, Schema.Number, {
+  strict: true,
+  decode: Number,
+  encode: String,
+})
+```
+
+### v4
+
+```ts
+import { Schema, SchemaTransformation } from 'effect'
+
+const NumberFromString = Schema.String.pipe(
+  Schema.decodeTo(
+    Schema.Number,
+    SchemaTransformation.transform({
+      decode: Number,
+      encode: String,
+    }),
+  ),
+)
+```
+
+The source schema is piped into `decodeTo`; the target schema is its first argument. The old `strict`
+option is not copied.
+
+## Fallible transformations and issues
+
+### v3
+
+```ts
+const Parsed = Schema.transformOrFail(Schema.String, Schema.Unknown, {
+  strict: true,
+  decode: (text, _options, ast) =>
+    ParseResult.try({
+      try: () => parse(text),
+      catch: (cause) => new ParseResult.Type(ast, text, String(cause)),
+    }),
+  encode: (value) => ParseResult.succeed(format(value)),
+})
+```
+
+### v4
+
+```ts
+import { Effect, Option, Schema, SchemaIssue, SchemaTransformation } from 'effect'
+
+const Parsed = Schema.String.pipe(
+  Schema.decodeTo(
+    Schema.Unknown,
+    SchemaTransformation.transformOrFail({
+      decode: (text) =>
+        Effect.try({
+          try: () => parse(text),
+          catch: (cause) =>
+            new SchemaIssue.InvalidValue(Option.some(text), {
+              message: String(cause),
+            }),
+        }),
+      encode: (value) => Effect.succeed(format(value)),
+    }),
+  ),
+)
+```
+
+The v4 callback failure must be an `Issue`, not `SchemaError` and not an old `ParseResult.ParseError`.
+When the offending value is known, pass `Option.some(value)`; use `Option.none()` only when it is
+genuinely absent.
+
+## Issue migration
+
+| v3 callback form                                   | v4 callback form                                                 |
+| -------------------------------------------------- | ---------------------------------------------------------------- |
+| `ParseResult.succeed(value)`                       | `Effect.succeed(value)`                                          |
+| `ParseResult.fail(issue)`                          | `Effect.fail(issue)`                                             |
+| `ParseResult.try({ try, catch })`                  | `Effect.try({ try, catch })`, with `catch` returning an `Issue`  |
+| `new ParseResult.Type(ast, actual, message)`       | `new SchemaIssue.InvalidValue(Option.some(actual), { message })` |
+| `new ParseResult.Forbidden(ast, actual, message)`  | `new SchemaIssue.Forbidden(Option.some(actual), { message })`    |
+| `ParseResult.TreeFormatter.formatIssueSync(issue)` | `SchemaIssue.makeFormatterDefault()(issue)`                      |
+
+Do not preserve the old `ast` parameter by manufacturing an AST. `InvalidValue` and `Forbidden`
+carry the actual value and annotations directly. Use richer `SchemaIssue` nodes only when their
+structure is observable and verified by the slice.
+
+## Filters and refinements
+
+A validation-only callback does not need a transformation:
+
+```ts
+const Positive = Schema.Number.check(Schema.makeFilter((value) => value > 0 || 'must be positive'))
+```
+
+Use `Schema.refine(typeGuard)` when the callback narrows the TypeScript type. `makeFilter` can return
+a string, a `SchemaIssue.Issue`, `{ path, issue }`, or an array of issues when error structure must be
+preserved.
+
+## Affected inventory
+
+The AST audit measured 27 `ParseResult` references in 15 files and 7 packages. The namespace-member
+heatmap identifies the densest callback owners as:
+
+| Package          | Wave | Namespace-member references |
+| ---------------- | ---: | --------------------------: |
+| `kdl-effect`     |    3 |                           6 |
+| `otel-contract`  |    3 |                           5 |
+| `restate-effect` |    5 |                           3 |
+
+Direct imports and type-only references account for the remainder of the headline inventory. Pure
+`transform`, `transformOrFail`, boolean-filter, and refinement sites are also represented in the
+broader 640-reference Schema constructor/options inventory.
+
+## Equivalence
+
+No repository migration is applied by this recipe. Each slice must compare:
+
+1. decoded values;
+2. exact encoded bytes;
+3. success versus failure;
+4. issue path and message at observable boundaries; and
+5. whether a supposedly synchronous codec still requires an effectful adapter.
+
+Do not silently rebaseline parse messages. If v4 formatting differs, preserve or normalize the
+boundary text, or record an explicit alignment decision.
+
+Every v4 symbol in this recipe was checked against the `effect@4.0.0-beta.102` npm tarball with
+SHA-1 `f51092854960f60cbdb06bd59e788acbc8ee8492`.
+
+## Gotchas
+
+- `SchemaTransformation.transform` is only for pure, infallible conversions. Returning an `Effect`
+  from it creates the wrong decoded value.
+- `SchemaTransformation.transformOrFail` callbacks return `Effect`; throwing bypasses the typed issue
+  channel.
+- `Schema.decodeUnknownEffect` exposes `SchemaError`, while transformation callbacks operate on
+  `SchemaIssue.Issue`.
+- A formatter rewrite can change user-visible text even when decoding behavior is otherwise
+  equivalent.
+
+## Codemod rule
+
+None. The outer `transform*` syntax is predictable, but callback failure construction, formatting,
+and observable issue paths require per-site review.


### PR DESCRIPTION
## Problem

Effect 4 changes several Schema call shapes and runtime result shapes. Without a verified shared recipe, package slices can preserve different semantics for optional defaults, codecs, and transformation failures.

## Goal

Add three self-contained Effect 3 to 4 migration recipes for Schema constructors, codecs, and transformations/issues. This PR documents the migration only; it does not apply it to packages.

## Decisions

- Lead with runtime shape changes before loud renames.
- Preserve both decode and `Schema.make` behavior for v3 optional defaults by composing decoding and constructor defaults.
- Treat surviving names such as `Schema.encode` and `Schema.Redacted` as semantic traps.
- Describe v4 transformation failures in terms of `SchemaIssue.Issue`, not legacy `ParseResult` nodes.
- Include measured package inventories so slice owners can locate the affected waves.

## Verification

- Checked every named v4 symbol against the packed `effect@4.0.0-beta.102` package (`f51092854960f60cbdb06bd59e788acbc8ee8492`).
- Runtime probes passed for constructor arrays, optional/default decode and construction, pure/fallible transformations, and `Exit` success/failure shape.
- `oxfmt --check` passed for all three recipes.
- `oxlint --deny-warnings` passed with 0 warnings and 0 errors (Markdown is not an oxlint input type).
- `devenv tasks run check:quick --no-tui` exited 0.
- `git diff --check` passed.
- `check:all` reached an unrelated `otel:verify:setup` timeout during the active host/Nix GC load; the aggregate reported dependency failure before remaining independent tasks drained.

## Complexity

Documentation-only: 3 new recipe files, 473 lines. No production code, generated files, dependencies, or repository migrations change.

## Concerns

The full aggregate gate was not green because the observability setup timed out under host load. The task-specific formatter, linter, repository quick check, symbol audit, and runtime probes are green.

## Friction & bottlenecks

The full gate continued running independent Rust/test batches after its required observability dependency had already failed, adding several minutes without changing the aggregate result.

## Follow-ups

Package slice owners should apply these recipes with their package-specific differential fixtures and encoded-byte/error-boundary checks.

## References

Related to #925.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | co2-agate |
| `agent_session_id` | f50dca57-c1e3-439e-8f0c-8a127af72a28 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.145.0 |
| `agent_runtime` | Codex CLI 0.145.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/v2g542rika3abxn98x5yimz431j5br13-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/3aq75z8arl44fsvn49i2k4yqlzb1kcwb-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-29-effect-4-schema-recipes |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->