### PR TITLE
Fix contraction bridge ID reporting

### DIFF
--- a/context/effect-4/check-baseline-migration-markers.ts
+++ b/context/effect-4/check-baseline-migration-markers.ts
@@ -155,6 +155,7 @@ type ContractionMarker = {
   readonly file: string
   readonly kind: 'BRIDGE' | 'END' | 'TARGET' | 'TODO'
   readonly line: number
+  readonly migrationSlug: string
 }
 
 type ExpiredNoSignature = {
@@ -175,7 +176,7 @@ const liveMigrationName = ['LIVE', 'MIGRATION'].join('-')
 const todoMigrationName = ['TODO(', 'live-migration:'].join('')
 const todoMigrationPattern = ['TODO\\(', 'live-migration:'].join('')
 const blockMarkerPattern = new RegExp(
-  `${liveMigrationName}\\s+(BRIDGE|TARGET|END)(?:\\s+([a-z0-9][a-z0-9._-]*))?`,
+  `${liveMigrationName}\\s+(BRIDGE|TARGET|END)\\s+([a-z0-9][a-z0-9._-]*)(?:\\s+([a-z0-9][a-z0-9._-]*))?`,
   'gi',
 )
 const todoMarkerPattern = new RegExp(`${todoMigrationPattern}([a-z0-9][a-z0-9._-]*)?\\)`, 'gi')
@@ -279,7 +280,8 @@ const writeContractionFixture = async ({
     await Bun.write(
       resolve(fixtureRoot, 'src/survivors.ts'),
       [
-        `// ${liveMigrationName} BRIDGE fixture-bridge`,
+        `// ${liveMigrationName} BRIDGE effect-3-4 B8`,
+        `// ${liveMigrationName} BRIDGE effect-3-4`,
         `// ${todoMigrationName}fixture-todo): resolve the retained assertion`,
         '',
       ].join('\n'),
@@ -331,9 +333,10 @@ const runContractionFixtureCheck = async () => {
     const expectedDefinitionOnly =
       'PASS: contraction sweep found no live migration markers (3 permanent grammar definitions excluded).\n'
     const expectedSurvivors = [
-      'src/survivors.ts:1 DELETE BLOCK (BRIDGE) fixture-bridge',
-      'src/survivors.ts:2 RESOLVE TODO fixture-todo',
-      'FAIL: contraction blocked by 2 markers across 1 files: 1 BRIDGE blocks (1 block marker lines) to delete, 1 TODO markers to resolve; 3 permanent grammar definitions excluded.',
+      'src/survivors.ts:1 DELETE BLOCK (BRIDGE) B8',
+      'src/survivors.ts:2 DELETE BLOCK (BRIDGE) <missing-id>',
+      'src/survivors.ts:3 RESOLVE TODO fixture-todo',
+      'FAIL: contraction blocked by 3 markers across 1 files: 2 BRIDGE blocks (2 block marker lines) to delete, 1 TODO markers to resolve; 3 permanent grammar definitions excluded.',
       '',
     ].join('\n')
 
@@ -398,10 +401,11 @@ const runContractionCheck = async () => {
 
       for (const match of blockMatches) {
         markers.push({
-          bridgeId: match[2] ?? '<missing-id>',
+          bridgeId: match[3] ?? '<missing-id>',
           file,
           kind: match[1]!.toUpperCase() as 'BRIDGE' | 'END' | 'TARGET',
           line: lineIndex + 1,
+          migrationSlug: match[2]!,
         })
       }
       for (const match of todoMatches) {
@@ -410,6 +414,7 @@ const runContractionCheck = async () => {
           file,
           kind: 'TODO',
           line: lineIndex + 1,
+          migrationSlug: match[1] ?? '<missing-slug>',
         })
       }
     }

--- a/packages/@overeng/ci-tools/src/cli.contract.test.ts
+++ b/packages/@overeng/ci-tools/src/cli.contract.test.ts
@@ -11,7 +11,7 @@ const cliPath = fileURLToPath(new URL('../bin/ci-tools.ts', import.meta.url))
  * during Effect 4 repair with an alignment-register entry.
  * ANSI control bytes are normalized, so colour/styling changes are not gated by this baseline.
  */
-// LIVE-MIGRATION BRIDGE effect-3-4 — DELETE at contraction — https://github.com/overengineeringstudio/effect-utils/issues/925
+// LIVE-MIGRATION BRIDGE effect-3-4 B7 — DELETE at contraction — https://github.com/overengineeringstudio/effect-utils/issues/925
 const stripAnsi = (output: string) =>
   output.replace(
     // eslint-disable-next-line no-control-regex -- CLI contract snapshots intentionally normalize terminal control bytes.
@@ -32,7 +32,7 @@ const runCli = (...args: ReadonlyArray<string>) => {
   return {
     status: result.status,
     signal: result.signal,
-    // LIVE-MIGRATION BRIDGE effect-3-4 — DELETE at contraction — https://github.com/overengineeringstudio/effect-utils/issues/925
+    // LIVE-MIGRATION BRIDGE effect-3-4 B7 — DELETE at contraction — https://github.com/overengineeringstudio/effect-utils/issues/925
     stdout: normalizeOutput(result.stdout),
     stderr: normalizeOutput(result.stderr),
     // LIVE-MIGRATION END effect-3-4

--- a/packages/@overeng/genie/src/cli.contract.test.ts
+++ b/packages/@overeng/genie/src/cli.contract.test.ts
@@ -13,7 +13,7 @@ const cliPath = fileURLToPath(new URL('../bin/genie.tsx', import.meta.url))
  * The local-source version suffix and log timestamps are normalized, so version-string content and
  * log timing are not gated by this baseline.
  */
-// LIVE-MIGRATION BRIDGE effect-3-4 — DELETE at contraction — https://github.com/overengineeringstudio/effect-utils/issues/925
+// LIVE-MIGRATION BRIDGE effect-3-4 B7 — DELETE at contraction — https://github.com/overengineeringstudio/effect-utils/issues/925
 const stripAnsi = (output: string) =>
   output.replace(
     // eslint-disable-next-line no-control-regex -- CLI contract snapshots intentionally normalize terminal control bytes.
@@ -36,7 +36,7 @@ const runCli = (...args: ReadonlyArray<string>) => {
   return {
     status: result.status,
     signal: result.signal,
-    // LIVE-MIGRATION BRIDGE effect-3-4 — DELETE at contraction — https://github.com/overengineeringstudio/effect-utils/issues/925
+    // LIVE-MIGRATION BRIDGE effect-3-4 B7 — DELETE at contraction — https://github.com/overengineeringstudio/effect-utils/issues/925
     stdout: normalizeOutput(result.stdout),
     stderr: normalizeOutput(result.stderr),
     // LIVE-MIGRATION END effect-3-4

--- a/packages/@overeng/megarepo/src/cli.contract.test.ts
+++ b/packages/@overeng/megarepo/src/cli.contract.test.ts
@@ -22,7 +22,7 @@ afterAll(() => {
  * The local-source version suffix is normalized, so version-string content is not gated by this
  * baseline.
  */
-// LIVE-MIGRATION BRIDGE effect-3-4 — DELETE at contraction — https://github.com/overengineeringstudio/effect-utils/issues/925
+// LIVE-MIGRATION BRIDGE effect-3-4 B7 — DELETE at contraction — https://github.com/overengineeringstudio/effect-utils/issues/925
 const stripAnsi = (output: string) =>
   output.replace(
     // eslint-disable-next-line no-control-regex -- CLI contract snapshots intentionally normalize terminal control bytes.
@@ -43,7 +43,7 @@ const runCli = (...args: ReadonlyArray<string>) => {
   return {
     status: result.status,
     signal: result.signal,
-    // LIVE-MIGRATION BRIDGE effect-3-4 — DELETE at contraction — https://github.com/overengineeringstudio/effect-utils/issues/925
+    // LIVE-MIGRATION BRIDGE effect-3-4 B7 — DELETE at contraction — https://github.com/overengineeringstudio/effect-utils/issues/925
     stdout: normalizeOutput(result.stdout),
     stderr: normalizeOutput(result.stderr),
     // LIVE-MIGRATION END effect-3-4

--- a/packages/@overeng/notion-cli/src/cli.contract.test.ts
+++ b/packages/@overeng/notion-cli/src/cli.contract.test.ts
@@ -13,7 +13,7 @@ const cliPath = fileURLToPath(new URL('./cli.ts', import.meta.url))
  * The local-source version suffix and log timestamps are normalized, so version-string content and
  * log timing are not gated by this baseline.
  */
-// LIVE-MIGRATION BRIDGE effect-3-4 — DELETE at contraction — https://github.com/overengineeringstudio/effect-utils/issues/925
+// LIVE-MIGRATION BRIDGE effect-3-4 B7 — DELETE at contraction — https://github.com/overengineeringstudio/effect-utils/issues/925
 const stripAnsi = (output: string) =>
   output.replace(
     // eslint-disable-next-line no-control-regex -- CLI contract snapshots intentionally normalize terminal control bytes.
@@ -36,7 +36,7 @@ const runCli = (...args: ReadonlyArray<string>) => {
   return {
     status: result.status,
     signal: result.signal,
-    // LIVE-MIGRATION BRIDGE effect-3-4 — DELETE at contraction — https://github.com/overengineeringstudio/effect-utils/issues/925
+    // LIVE-MIGRATION BRIDGE effect-3-4 B7 — DELETE at contraction — https://github.com/overengineeringstudio/effect-utils/issues/925
     stdout: normalizeOutput(result.stdout),
     stderr: normalizeOutput(result.stderr),
     // LIVE-MIGRATION END effect-3-4

--- a/packages/@overeng/npm-release/src/cli.contract.test.ts
+++ b/packages/@overeng/npm-release/src/cli.contract.test.ts
@@ -10,7 +10,7 @@ const cliPath = fileURLToPath(new URL('./cli.ts', import.meta.url))
  * usage, and error prose are captured for review but may be re-baselined by the npm-release owner
  * during Effect 4 repair with an alignment-register entry.
  */
-// LIVE-MIGRATION BRIDGE effect-3-4 — DELETE at contraction — https://github.com/overengineeringstudio/effect-utils/issues/925
+// LIVE-MIGRATION BRIDGE effect-3-4 B7 — DELETE at contraction — https://github.com/overengineeringstudio/effect-utils/issues/925
 const normalizeLogTime = (output: string) =>
   output.replace(/^\[\d{2}:\d{2}:\d{2}\.\d{3}\]/gm, '[time]')
 // LIVE-MIGRATION END effect-3-4
@@ -24,7 +24,7 @@ const runCli = (...args: ReadonlyArray<string>) => {
   return {
     status: result.status,
     signal: result.signal,
-    // LIVE-MIGRATION BRIDGE effect-3-4 — DELETE at contraction — https://github.com/overengineeringstudio/effect-utils/issues/925
+    // LIVE-MIGRATION BRIDGE effect-3-4 B7 — DELETE at contraction — https://github.com/overengineeringstudio/effect-utils/issues/925
     stdout: normalizeLogTime(result.stdout),
     stderr: normalizeLogTime(result.stderr),
     // LIVE-MIGRATION END effect-3-4

--- a/packages/@overeng/tui-stories/test/cli.contract.test.ts
+++ b/packages/@overeng/tui-stories/test/cli.contract.test.ts
@@ -13,7 +13,7 @@ const cliPath = fileURLToPath(new URL('../bin/tui-stories.tsx', import.meta.url)
  * The local-source version suffix and log timestamps are normalized, so version-string content and
  * log timing are not gated by this baseline.
  */
-// LIVE-MIGRATION BRIDGE effect-3-4 — DELETE at contraction — https://github.com/overengineeringstudio/effect-utils/issues/925
+// LIVE-MIGRATION BRIDGE effect-3-4 B7 — DELETE at contraction — https://github.com/overengineeringstudio/effect-utils/issues/925
 const stripAnsi = (output: string) =>
   output.replace(
     // eslint-disable-next-line no-control-regex -- CLI contract snapshots intentionally normalize terminal control bytes.
@@ -36,7 +36,7 @@ const runCli = (...args: ReadonlyArray<string>) => {
   return {
     status: result.status,
     signal: result.signal,
-    // LIVE-MIGRATION BRIDGE effect-3-4 — DELETE at contraction — https://github.com/overengineeringstudio/effect-utils/issues/925
+    // LIVE-MIGRATION BRIDGE effect-3-4 B7 — DELETE at contraction — https://github.com/overengineeringstudio/effect-utils/issues/925
     stdout: normalizeOutput(result.stdout),
     stderr: normalizeOutput(result.stderr),
     // LIVE-MIGRATION END effect-3-4

--- a/pnpm-workspace.yaml.genie.ts
+++ b/pnpm-workspace.yaml.genie.ts
@@ -8,6 +8,7 @@ export default pnpmWorkspaceYaml.root({
   repoName: 'effect-utils',
   catalogVersions: catalog,
   catalogDuplicateExceptions: [
+    // LIVE-MIGRATION BRIDGE effect-3-4 B2 — DELETE at contraction — https://github.com/overengineeringstudio/effect-utils/issues/925
     {
       package: 'effect',
       versions: ['3.21.4', '4.0.0-beta.99'],
@@ -19,6 +20,7 @@ export default pnpmWorkspaceYaml.root({
         '@overeng/react-inspector tests against Effect 4 while the repository catalog remains on Effect 3; published consumers provide Effect through its peer contract',
       issue: '#937',
     },
+    // LIVE-MIGRATION END effect-3-4
     {
       package: 'string-width',
       // @opentui/core@0.4.1 (latest) pins string-width@7.2.0 exactly, so pnpm


### PR DESCRIPTION
## Problem

The contraction sweep parsed the migration slug after `LIVE-MIGRATION BRIDGE` as the bridge ID, so every Effect 3-to-4 bridge was reported as `effect-3-4`. It could not distinguish B1-B8, and the unmarked B2 exception was invisible.

## Goal

Report the optional bridge ID separately from the migration slug, surface genuinely absent IDs as `<missing-id>`, and make the main-branch B2/B7 bridge inventory mechanically identifiable.

## Decisions

- Parse block markers as `<kind> <migration-slug> [bridge-id]`, retaining the slug separately while reporting the bridge ID.
- Add `B2` to the dual-major exception and `B7` to the twelve existing CLI source bridge starts.
- Do not mark the six generated `.snap` files. They remain permanent `status`/`signal` contracts; contraction removes prose fields and migration-only normalizers, then re-baselines the same files. Epic #925 now states this explicitly.

## Verification

Red test before the parser fix:

```text
src/survivors.ts:1 DELETE BLOCK (BRIDGE) effect-3-4
src/survivors.ts:2 DELETE BLOCK (BRIDGE) effect-3-4
```

Black-box contraction probe after the fix (expected exit 1 because survivors block contraction):

```text
src/probes.ts:1 DELETE BLOCK (BRIDGE) B8
src/probes.ts:2 DELETE BLOCK (BRIDGE) <missing-id>
FAIL: contraction blocked by 2 markers across 1 files: 2 BRIDGE blocks (2 block marker lines) to delete, 0 TODO markers to resolve; 3 permanent grammar definitions excluded.
exit=1
```

Fixture and baseline-marker lane:

```text
PASS: contraction fixtures cover definition exclusions and actionable survivor reporting.
PASS: 2 noSignature production-absence justifications remain valid across 814 source files.
PASS: 27 baseline test files contain no unmarked Effect 3 -> 4 risk signatures.
```

Additional gates:

- `oxfmt` on all eight changed files: pass
- `oxlint` on all eight changed files: 0 warnings, 0 errors
- `devenv tasks run check:quick`: exit 0
- `devenv tasks run check:all`: blocked by the unrelated existing `otel:verify:setup` capture gate, which emits `{}` and exits 1; an isolated run reproduces it. No changed file touches that module.

## Complexity

No new abstraction or dependency. The marker parser gains one capture group and stores the migration slug separately.

## Concerns

The full local aggregate gate remains blocked by `otel:verify:setup`; the scoped checker, formatting, lint, typecheck, generation, and quick repository gates pass.

## Friction & bottlenecks

The full gate spent roughly 13 minutes building Nix/Weaver checks before exposing the unrelated observability verification failure.

## Follow-ups

None for this PR. The observability verification failure is outside this change.

## References

Refs #925

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | co1-flash |
| `agent_session_id` | c32fc56f-5eb9-4288-bbe7-b8ee51d6ac98 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.145.0 |
| `agent_runtime` | Codex CLI 0.145.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/v2y1w79nsgydvamlq4rmgjrs1fyxk5zb-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/jsdk9xcha1pvzq3aqcn1175178dv6vcj-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-29-effect-4-bridgefix |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@be13b6e |
</details>
<!-- agent-footer:end -->