### PR TITLE
fix(utils-dev): port to Effect 4 with OTLP compatibility bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **@overeng/utils-dev**: preserve explicitly configured OTLP service identity
+  under Effect 4 when the surrounding environment also defines
+  `OTEL_SERVICE_NAME`.
+
 - **@overeng/genie/package-json**: allow consumers to materialize selected
   cross-repository workspace dependencies with the `file:` protocol. This lets
   pnpm resolve singleton peers such as Effect from the consuming install graph

--- a/context/effect-4/alignment-register.md
+++ b/context/effect-4/alignment-register.md
@@ -115,6 +115,19 @@
   `catchTag("ResponseError")` or string reason checks.
 - **Status:** two error-shape paths allowlisted; success behavior and numeric status are identical.
 
+## otlp-log-severity-text
+
+- **Bucket:** C — REAL BREAKAGE WE MUST PRESERVE OR SHIM.
+- **Difference:** Effect 4 beta.102 emits title-cased OTLP log `severityText` values such as `Info`;
+  Effect 3 emitted the conventional uppercase spelling `INFO`.
+- **Decision:** preserve the Effect 3 text through a local serialization-layer bridge until
+  [Effect-TS/effect#6749](https://github.com/Effect-TS/effect/issues/6749) is released. Do not weaken
+  log assertions or patch the Effect dependency for this normalization.
+- **Blast radius:** log filters, dashboards, alerts, and tests matching `severity_text`. The numeric
+  `severityNumber` mapping is unchanged (`Info` still maps to OTLP severity number `9`).
+- **Status:** REQUIRED COMPATIBILITY WORK; the `utils-dev` all-signals harness pins the uppercase
+  text and the bridge is contraction-marked.
+
 ## fork-defaults
 
 - **Difference:** No default startup-order difference was observed for v3

--- a/context/effect-4/recipes/tracer-span-shape.md
+++ b/context/effect-4/recipes/tracer-span-shape.md
@@ -23,6 +23,26 @@ const tracing = OtelTracer.layerWithoutOtelTracer.pipe(Layer.provideMerge(tracer
 program.pipe(Effect.provide(tracing))
 ```
 
+## OTLP exporter module move
+
+The lightweight OTLP exporter is distinct from the OpenTelemetry SDK tracer above. In v3 its
+namespaces were exported from the `@effect/opentelemetry` root:
+
+```ts
+import { OtlpSerialization, OtlpTracer } from '@effect/opentelemetry'
+```
+
+In v4 both namespaces move to the declared observability barrel:
+
+```ts
+import { OtlpSerialization, OtlpTracer } from 'effect/unstable/observability'
+```
+
+The beta.102 barrel re-exports `OtlpTracer` (`make`, `layer`, `layerFromConfig`) and
+`OtlpSerialization` (`OtlpSerialization`, `layerJson`, `layerProtobuf`) as namespaces. Preserve the
+existing exporter options and replay the owning span-shape baseline; this is not the SDK
+`OtelTracer` migration.
+
 ## Equivalence
 
 ```sh
@@ -50,12 +70,17 @@ nesting, and status under both recording and non-recording providers. Any mismat
 - Normalize nondeterministic IDs and timing, but do not normalize away span names, parent
   relationships, status, or contract attributes.
 - The module rename is `@effect/opentelemetry/Tracer` to `@effect/opentelemetry/OtelTracer`.
+- Import the OTLP exporter namespaces from the observability barrel. Do not conflate
+  `OtlpTracer` with the SDK `OtelTracer`.
 
 ## Codemod rule
 
 ```text
 import * as Tracer from "@effect/opentelemetry/Tracer"
 -> import * as OtelTracer from "@effect/opentelemetry/OtelTracer"
+
+import { OtlpSerialization, OtlpTracer } from "@effect/opentelemetry"
+-> import { OtlpSerialization, OtlpTracer } from "effect/unstable/observability"
 ```
 
 Review identifier aliases and service-layer construction after the import rewrite.

--- a/packages/@overeng/utils-dev/src/node-vitest/Vitest.ts
+++ b/packages/@overeng/utils-dev/src/node-vitest/Vitest.ts
@@ -16,13 +16,12 @@ import type { Duration } from 'effect'
 import {
   type Cause,
   Effect,
-  type FastCheck as FC,
   identity,
   Layer,
-  Predicate,
   type Schema,
   type Scope,
 } from 'effect'
+import type * as FC from 'effect/testing/FastCheck'
 import { FetchHttpClient } from 'effect/unstable/http'
 import { OtlpSerialization, OtlpTracer } from 'effect/unstable/observability'
 
@@ -119,7 +118,7 @@ export type WithTestCtxParams<ROut, E1, RIn> = {
   /** Factory to create a layer for the test. */
   makeLayer?: (testContext: Vitest.TestContext) => Layer.Layer<ROut, E1, RIn | Scope.Scope>
   /** Test timeout. @default 60_000ms in CI, 10_000ms locally */
-  timeout?: Duration.DurationInput
+  timeout?: Duration.Input
   /** Force OTEL tracing even when not in debugger. @default false */
   forceOtel?: boolean
 }
@@ -150,7 +149,7 @@ export const makeWithTestCtx: <ROut = never, E1 = never, RIn = never>(
   self: Effect.Effect<A, E, R>,
 ) => Effect.Effect<
   A,
-  E | E1 | Cause.TimeoutException,
+  E | E1 | Cause.TimeoutError,
   // Exclude dependencies provided by `withTestCtx` from the layer dependencies
   | Exclude<RIn, Scope.Scope>
   // Exclude dependencies provided by `withTestCtx` **and** dependencies produced
@@ -176,7 +175,7 @@ export const withTestCtx =
       self: Effect.Effect<A, E, R>,
     ): Effect.Effect<
       A,
-      E | E1 | Cause.TimeoutException,
+      E | E1 | Cause.TimeoutError,
       // Exclude dependencies provided internally from the provided layer's dependencies
       | Exclude<RIn, Scope.Scope>
       // Exclude dependencies provided internally **and** dependencies produced by the
@@ -242,16 +241,24 @@ const normalizePropOptions = <Arbs extends Vitest.Vitest.Arbitraries>(
     | number
     | (Vitest.TestOptions & {
         fastCheck?: FC.Parameters<{
-          [K in keyof Arbs]: Arbs[K] extends FC.Arbitrary<infer T> ? T : Schema.Schema.Type<Arbs[K]>
+          [K in keyof Arbs]: Arbs[K] extends FC.Arbitrary<infer T>
+            ? T
+            : Arbs[K] extends Schema.Schema<infer T>
+              ? T
+              : never
         }>
       }),
 ): Vitest.TestOptions & {
   fastCheck?: FC.Parameters<{
-    [K in keyof Arbs]: Arbs[K] extends FC.Arbitrary<infer T> ? T : Schema.Schema.Type<Arbs[K]>
+    [K in keyof Arbs]: Arbs[K] extends FC.Arbitrary<infer T>
+      ? T
+      : Arbs[K] extends Schema.Schema<infer T>
+        ? T
+        : never
   }>
 } => {
   // If it's a number, treat as timeout and add our default fastCheck
-  if (Predicate.isObject(propOptions) === false) {
+  if (typeof propOptions === 'number') {
     return {
       timeout: propOptions,
       fastCheck: { numRuns: 100 },
@@ -259,7 +266,7 @@ const normalizePropOptions = <Arbs extends Vitest.Vitest.Arbitraries>(
   }
 
   // If no fastCheck property, add it with our default numRuns
-  if (propOptions.fastCheck === undefined) {
+  if (propOptions.fastCheck == null) {
     return {
       ...propOptions,
       fastCheck: { numRuns: 100 },
@@ -267,7 +274,7 @@ const normalizePropOptions = <Arbs extends Vitest.Vitest.Arbitraries>(
   }
 
   // If fastCheck exists but no numRuns, add our default
-  if (propOptions.fastCheck !== undefined && propOptions.fastCheck.numRuns == null) {
+  if (propOptions.fastCheck.numRuns == null) {
     return {
       ...propOptions,
       fastCheck: {
@@ -321,7 +328,11 @@ export const asProp = <Arbs extends Vitest.Vitest.Arbitraries, A, E, R>(
     R,
     [
       {
-        [K in keyof Arbs]: Arbs[K] extends FC.Arbitrary<infer T> ? T : Schema.Schema.Type<Arbs[K]>
+        [K in keyof Arbs]: Arbs[K] extends FC.Arbitrary<infer T>
+          ? T
+          : Arbs[K] extends Schema.Schema<infer T>
+            ? T
+            : never
       },
       Vitest.TestContext,
       EnhancedTestContext,
@@ -331,7 +342,11 @@ export const asProp = <Arbs extends Vitest.Vitest.Arbitraries, A, E, R>(
     | number
     | (Vitest.TestOptions & {
         fastCheck?: FC.Parameters<{
-          [K in keyof Arbs]: Arbs[K] extends FC.Arbitrary<infer T> ? T : Schema.Schema.Type<Arbs[K]>
+          [K in keyof Arbs]: Arbs[K] extends FC.Arbitrary<infer T>
+            ? T
+            : Arbs[K] extends Schema.Schema<infer T>
+              ? T
+              : never
         }>
       }),
 ) => {

--- a/packages/@overeng/utils-dev/src/node-vitest/Vitest.ts
+++ b/packages/@overeng/utils-dev/src/node-vitest/Vitest.ts
@@ -13,7 +13,15 @@ import * as inspector from 'node:inspector'
 
 import type * as Vitest from '@effect/vitest'
 import type { Duration } from 'effect'
-import { type Cause, Effect, identity, Layer, type Schema, type Scope } from 'effect'
+import {
+  type Cause,
+  ConfigProvider,
+  Effect,
+  identity,
+  Layer,
+  type Schema,
+  type Scope,
+} from 'effect'
 import type * as FC from 'effect/testing/FastCheck'
 import { FetchHttpClient } from 'effect/unstable/http'
 import { OtlpSerialization, OtlpTracer } from 'effect/unstable/observability'
@@ -89,6 +97,19 @@ export const makeOtelVitestLayer = (
       resource: { serviceName },
       exportInterval,
     }).pipe(
+      // LIVE-MIGRATION BRIDGE effect-3-4 B9 — DELETE at contraction
+      // Effect 4 reversed OTLP resource precedence: ambient OTEL_SERVICE_NAME
+      // overrides explicitly configured service name (v3: explicit serviceName >
+      // service.name attr > OTEL_RESOURCE_ATTRIBUTES > OTEL_SERVICE_NAME).
+      // Retire when upstream restores explicit-wins precedence and we adopt that
+      // beta. Upstream issue NOT YET FILED — see context/effect-4/ findings;
+      // filing is owed.
+      Layer.provide(
+        ConfigProvider.layerAdd(ConfigProvider.fromUnknown({ OTEL_SERVICE_NAME: serviceName }), {
+          asPrimary: true,
+        }),
+      ),
+      // LIVE-MIGRATION END effect-3-4 B9
       Layer.provideMerge(FetchHttpClient.layer),
       Layer.provideMerge(OtlpSerialization.layerJson),
     )

--- a/packages/@overeng/utils-dev/src/node-vitest/Vitest.ts
+++ b/packages/@overeng/utils-dev/src/node-vitest/Vitest.ts
@@ -97,13 +97,12 @@ export const makeOtelVitestLayer = (
       resource: { serviceName },
       exportInterval,
     }).pipe(
-      // LIVE-MIGRATION BRIDGE effect-3-4 B9 — DELETE at contraction
+      // LIVE-MIGRATION BRIDGE effect-3-4 B9 — DELETE at contraction — https://github.com/Effect-TS/effect/issues/6742
       // Effect 4 reversed OTLP resource precedence: ambient OTEL_SERVICE_NAME
       // overrides explicitly configured service name (v3: explicit serviceName >
       // service.name attr > OTEL_RESOURCE_ATTRIBUTES > OTEL_SERVICE_NAME).
       // Retire when upstream restores explicit-wins precedence and we adopt that
-      // beta. Upstream issue NOT YET FILED — see context/effect-4/ findings;
-      // filing is owed.
+      // beta.
       Layer.provide(
         ConfigProvider.layerAdd(ConfigProvider.fromUnknown({ OTEL_SERVICE_NAME: serviceName }), {
           asPrimary: true,

--- a/packages/@overeng/utils-dev/src/node-vitest/Vitest.ts
+++ b/packages/@overeng/utils-dev/src/node-vitest/Vitest.ts
@@ -97,7 +97,7 @@ export const makeOtelVitestLayer = (
       resource: { serviceName },
       exportInterval,
     }).pipe(
-      // LIVE-MIGRATION BRIDGE effect-3-4 B9 — DELETE at contraction — https://github.com/Effect-TS/effect/issues/6742
+      // LIVE-MIGRATION BRIDGE effect-3-4 B9 — DELETE at contraction — https://github.com/Effect-TS/effect/issues/6746
       // Effect 4 reversed OTLP resource precedence: ambient OTEL_SERVICE_NAME
       // overrides explicitly configured service name (v3: explicit serviceName >
       // service.name attr > OTEL_RESOURCE_ATTRIBUTES > OTEL_SERVICE_NAME).

--- a/packages/@overeng/utils-dev/src/node-vitest/Vitest.ts
+++ b/packages/@overeng/utils-dev/src/node-vitest/Vitest.ts
@@ -11,7 +11,6 @@
 
 import * as inspector from 'node:inspector'
 
-import { OtlpSerialization, OtlpTracer } from '@effect/opentelemetry'
 import type * as Vitest from '@effect/vitest'
 import type { Duration } from 'effect'
 import {
@@ -25,6 +24,7 @@ import {
   type Scope,
 } from 'effect'
 import { FetchHttpClient } from 'effect/unstable/http'
+import { OtlpSerialization, OtlpTracer } from 'effect/unstable/observability'
 
 import { otlpTracesUrl } from '../otelite/otlp-url.ts'
 

--- a/packages/@overeng/utils-dev/src/node-vitest/Vitest.ts
+++ b/packages/@overeng/utils-dev/src/node-vitest/Vitest.ts
@@ -13,14 +13,7 @@ import * as inspector from 'node:inspector'
 
 import type * as Vitest from '@effect/vitest'
 import type { Duration } from 'effect'
-import {
-  type Cause,
-  Effect,
-  identity,
-  Layer,
-  type Schema,
-  type Scope,
-} from 'effect'
+import { type Cause, Effect, identity, Layer, type Schema, type Scope } from 'effect'
 import type * as FC from 'effect/testing/FastCheck'
 import { FetchHttpClient } from 'effect/unstable/http'
 import { OtlpSerialization, OtlpTracer } from 'effect/unstable/observability'
@@ -136,7 +129,7 @@ export type WithTestCtxParams<ROut, E1, RIn> = {
  *   ),
  * })
  *
- * Vitest.scopedLive('test name', (test) =>
+ * Vitest.live('test name', (test) =>
  *   Effect.gen(function* () {
  *     // test body
  *   }).pipe(withTestCtx()(test))
@@ -301,7 +294,7 @@ const normalizePropOptions = <Arbs extends Vitest.Vitest.Arbitraries>(
  * const Count = Schema.Int.pipe(Schema.between(1, 100))
  *
  * Vitest.asProp(
- *   Vitest.scopedLive,
+ *   Vitest.live,
  *   'syncs data between clients',
  *   { storageType: StorageType, count: Count },
  *   ({ storageType, count }, test, enhanced) =>

--- a/packages/@overeng/utils-dev/src/node-vitest/otel-vitest-flush.test.ts
+++ b/packages/@overeng/utils-dev/src/node-vitest/otel-vitest-flush.test.ts
@@ -54,7 +54,7 @@ describe('makeOtelVitestLayer — flush on shutdown', () => {
       const post = yield* cap.inspect({ signal: 'traces', service: SERVICE, name: SPAN })
 
       return { pre: pre.length, post: post.length }
-    }).pipe(Effect.scoped, Effect.provide(Layer.provideMerge(Otelite.Default, NodeServices.layer)))
+    }).pipe(Effect.scoped, Effect.provide(Layer.provideMerge(Otelite.layer, NodeServices.layer)))
 
     const { pre, post } = await Effect.runPromise(program)
     expect(pre).toBe(0)

--- a/packages/@overeng/utils-dev/src/otelite/Otelite.test.ts
+++ b/packages/@overeng/utils-dev/src/otelite/Otelite.test.ts
@@ -1,9 +1,9 @@
 import { access } from 'node:fs/promises'
 
-import { ChildProcess as Command } from 'effect/unstable/process'
 import { NodeServices } from '@effect/platform-node'
 import { describe, expect, it } from '@effect/vitest'
 import { Effect, Exit, Layer, Schema } from 'effect'
+import { ChildProcess as Command, ChildProcessSpawner } from 'effect/unstable/process'
 
 import { SERVICE_NAME, SPAN_NAME } from './emitter.ts'
 import {
@@ -49,7 +49,7 @@ const tracesFixture = new URL('./fixtures/traces.ndjson', import.meta.url).pathn
 const emitter = new URL('./emitter.ts', import.meta.url).pathname
 
 describe('Otelite', () => {
-  it.scoped('run() yields a decoded otelite.summary/v1 for a successful child', () =>
+  it.effect('run() yields a decoded otelite.summary/v1 for a successful child', () =>
     Effect.gen(function* () {
       const otelite = yield* Otelite
       const summary = yield* otelite.run({ command: ['true'] })
@@ -62,7 +62,7 @@ describe('Otelite', () => {
     }).pipe(Effect.provide(TestLayer)),
   )
 
-  it.scoped('a non-zero child surfaces as the tagged OteliteChildFailed error', () =>
+  it.effect('a non-zero child surfaces as the tagged OteliteChildFailed error', () =>
     Effect.gen(function* () {
       const otelite = yield* Otelite
       const exit = yield* otelite.run({ command: ['false'] }).pipe(Effect.exit)
@@ -74,7 +74,7 @@ describe('Otelite', () => {
     }).pipe(Effect.provide(TestLayer)),
   )
 
-  it.scoped('the scoped out-dir is released after the run scope closes', () =>
+  it.effect('the scoped out-dir is released after the run scope closes', () =>
     Effect.gen(function* () {
       const otelite = yield* Otelite
       // Capture the minted dir from within a child scope; the finalizer removes
@@ -147,7 +147,7 @@ describe('Otelite', () => {
   // emitter POSTs a known OTLP/JSON span to the receiver otelite injects, and we
   // assert it round-trips back out through the typed `inspect`. No fixtures —
   // the span travels the real wire.
-  it.scoped('run(emitter) captures a live OTLP span that round-trips through typed inspect', () =>
+  it.effect('run(emitter) captures a live OTLP span that round-trips through typed inspect', () =>
     Effect.gen(function* () {
       const otelite = yield* Otelite
       const summary = yield* otelite.run({ command: ['bun', emitter] })
@@ -200,7 +200,7 @@ describe('Otelite.capture', () => {
   // assert the typed row round-trips through the handle's `inspect`. The bounded
   // retry inside `inspect` absorbs any sub-ms visibility lag; running this a few
   // times exercises that it doesn't flake.
-  it.scoped('capture() serves a live receiver: a raw OTLP POST round-trips through inspect', () =>
+  it.effect('capture() serves a live receiver: a raw OTLP POST round-trips through inspect', () =>
     Effect.gen(function* () {
       const otelite = yield* Otelite
       const handle = yield* otelite.capture()
@@ -259,7 +259,8 @@ describe('Otelite.capture', () => {
       )
       expect(exists).toBe(false)
 
-      const psOut = yield* Command.string(Command.make('ps', '-eo', 'args'))
+      const executor = yield* ChildProcessSpawner.ChildProcessSpawner
+      const psOut = yield* executor.string(Command.make('ps', ['-eo', 'args']))
       const orphaned = psOut
         .split('\n')
         .some((line) => line.includes('otelite') && line.includes(outDir))

--- a/packages/@overeng/utils-dev/src/otelite/Otelite.test.ts
+++ b/packages/@overeng/utils-dev/src/otelite/Otelite.test.ts
@@ -43,7 +43,7 @@ const captureSpanPayload = (name: string, service: string) =>
   })
 
 /** Real otelite binary (from `PATH`, see README) + Node platform layer. */
-const TestLayer = Otelite.Default.pipe(Layer.provideMerge(NodeServices.layer))
+const TestLayer = Otelite.layer.pipe(Layer.provideMerge(NodeServices.layer))
 
 const tracesFixture = new URL('./fixtures/traces.ndjson', import.meta.url).pathname
 const emitter = new URL('./emitter.ts', import.meta.url).pathname

--- a/packages/@overeng/utils-dev/src/otelite/Otelite.ts
+++ b/packages/@overeng/utils-dev/src/otelite/Otelite.ts
@@ -1,6 +1,17 @@
-import { ChildProcess as Command, ChildProcessSpawner } from 'effect/unstable/process'
+import {
+  Context,
+  Deferred,
+  Effect,
+  Fiber,
+  Layer,
+  Ref,
+  Schedule,
+  Schema,
+  type Scope,
+  Stream,
+} from 'effect'
 import { FileSystem } from 'effect/FileSystem'
-import { Context, Deferred, Effect, Fiber, Layer, Ref, Schedule, Schema, type Scope, Stream } from 'effect'
+import { ChildProcess as Command, ChildProcessSpawner } from 'effect/unstable/process'
 
 import {
   cliReasonForExitCode,
@@ -149,7 +160,7 @@ const summaryKind = {
  */
 export class Otelite extends Context.Service<Otelite>()('@overeng/utils-dev/otelite/Otelite', {
   make: Effect.gen(function* () {
-    const executor = yield* ChildProcessSpawner
+    const executor = yield* ChildProcessSpawner.ChildProcessSpawner
     const fs = yield* FileSystem
 
     const binary = process.env.OTELITE_BIN ?? 'otelite'
@@ -162,12 +173,12 @@ export class Otelite extends Context.Service<Otelite>()('@overeng/utils-dev/otel
       Effect.scoped(
         Effect.gen(function* () {
           const process = yield* executor.spawn(Command.make(binary, args))
-          const collect = (stream: typeof process.stdout) =>
+          const collect = (stream: NonNullable<typeof process.stdout>) =>
             Stream.runCollect(Stream.decodeText(stream)).pipe(
               Effect.map((chunks) => Array.from(chunks).join('')),
             )
           const [exitCode, stdout, stderr] = yield* Effect.all(
-            [process.exitCode, collect(process.stdout), collect(process.stderr)],
+            [process.exitCode, collect(process.stdout!), collect(process.stderr!)],
             { concurrency: 'unbounded' },
           )
           return { exitCode, stdout, stderr }
@@ -375,7 +386,7 @@ export class Otelite extends Context.Service<Otelite>()('@overeng/utils-dev/otel
 
         // Drain the entire tagged event stream; resolve `ready` on the first line
         // (decoded as `otelite.endpoints/v1`), keep the latest line for the summary.
-        const drain = yield* process.stdout.pipe(
+        const drain = yield* process.stdout!.pipe(
           Stream.decodeText(),
           Stream.splitLines,
           Stream.filter((line) => line.trim() !== ''),
@@ -426,10 +437,10 @@ export class Otelite extends Context.Service<Otelite>()('@overeng/utils-dev/otel
             orElse: () =>
               Effect.fail(
                 new OteliteCliError({
-                exitCode: 74,
-                reason: 'io-err',
-                argv: [binary, ...flags],
-                stderr: 'otelite capture did not emit endpoints within the readiness bound',
+                  exitCode: 74,
+                  reason: 'io-err',
+                  argv: [binary, ...flags],
+                  stderr: 'otelite capture did not emit endpoints within the readiness bound',
                 }),
               ),
           }),

--- a/packages/@overeng/utils-dev/src/otelite/Otelite.ts
+++ b/packages/@overeng/utils-dev/src/otelite/Otelite.ts
@@ -1,6 +1,6 @@
-import { ChildProcess as Command, ChildProcessSpawner as CommandExecutor } from 'effect/unstable/process'
+import { ChildProcess as Command, ChildProcessSpawner } from 'effect/unstable/process'
 import { FileSystem } from 'effect/FileSystem'
-import { Deferred, Effect, Fiber, Ref, Schedule, Schema, type Scope, Stream } from 'effect'
+import { Context, Deferred, Effect, Fiber, Layer, Ref, Schedule, Schema, type Scope, Stream } from 'effect'
 
 import {
   cliReasonForExitCode,
@@ -124,8 +124,8 @@ type InspectRow<S extends Signal> = S extends 'traces'
     ? MetricRow
     : LogRow
 
-const decodeSummary = Schema.decodeUnknown(Schema.fromJsonString(Summary))
-const decodeEndpointsEvent = Schema.decodeUnknown(Schema.fromJsonString(EndpointsEvent))
+const decodeSummary = Schema.decodeUnknownEffect(Schema.fromJsonString(Summary))
+const decodeEndpointsEvent = Schema.decodeUnknownEffect(Schema.fromJsonString(EndpointsEvent))
 
 const rowSchema = { traces: SpanRow, metrics: MetricRow, logs: LogRow } as const
 const rowKind = { traces: 'span', metrics: 'metric', logs: 'log' } as const
@@ -147,11 +147,10 @@ const summaryKind = {
  * Tests normally get the nix-built binary from the devenv `PATH`; raw-shell
  * runs can set `OTELITE_BIN="$(nix build --no-link --print-out-paths .#otelite)/bin/otelite"`.
  */
-export class Otelite extends Effect.Service<Otelite>()('@overeng/utils-dev/otelite/Otelite', {
-  accessors: true,
-  effect: Effect.gen(function* () {
-    const executor = yield* CommandExecutor.CommandExecutor
-    const fs = yield* FileSystem.FileSystem
+export class Otelite extends Context.Service<Otelite>()('@overeng/utils-dev/otelite/Otelite', {
+  make: Effect.gen(function* () {
+    const executor = yield* ChildProcessSpawner
+    const fs = yield* FileSystem
 
     const binary = process.env.OTELITE_BIN ?? 'otelite'
 
@@ -162,7 +161,7 @@ export class Otelite extends Effect.Service<Otelite>()('@overeng/utils-dev/oteli
     const exec = (args: ReadonlyArray<string>) =>
       Effect.scoped(
         Effect.gen(function* () {
-          const process = yield* executor.start(Command.make(binary, ...args))
+          const process = yield* executor.spawn(Command.make(binary, args))
           const collect = (stream: typeof process.stdout) =>
             Stream.runCollect(Stream.decodeText(stream)).pipe(
               Effect.map((chunks) => Array.from(chunks).join('')),
@@ -288,14 +287,14 @@ export class Otelite extends Effect.Service<Otelite>()('@overeng/utils-dev/oteli
         const schema = summarySchema[signal]
         const kind = summaryKind[signal]
         return runCli(args, (stdout) =>
-          Schema.decodeUnknown(Schema.fromJsonString(schema))(stdout).pipe(
+          Schema.decodeUnknownEffect(Schema.fromJsonString(schema))(stdout).pipe(
             Effect.mapError((cause) => new OteliteDecodeError({ kind, raw: stdout, cause })),
           ),
         ).pipe(withOteliteInspectSummarySpan(signal))
       }
       const schema = rowSchema[signal]
       const kind = rowKind[signal]
-      const decodeRow = Schema.decodeUnknown(Schema.fromJsonString(schema))
+      const decodeRow = Schema.decodeUnknownEffect(Schema.fromJsonString(schema))
       return runCli(args, (stdout) =>
         Effect.forEach(
           stdout.split('\n').filter((line) => line.trim() !== ''),
@@ -321,7 +320,9 @@ export class Otelite extends Effect.Service<Otelite>()('@overeng/utils-dev/oteli
      * sleep. A non-empty capture returns on its first visible row; a genuinely
      * empty live capture pays the bounded budget exactly once.
      */
-    const liveRowRetry = Schedule.recurs(20).pipe(Schedule.addDelay(() => '25 millis'))
+    const liveRowRetry = Schedule.recurs(20).pipe(
+      Schedule.addDelay(() => Effect.succeed('25 millis')),
+    )
 
     /**
      * A scoped, receiver-only capture (`otelite capture`). Yields a
@@ -357,13 +358,13 @@ export class Otelite extends Effect.Service<Otelite>()('@overeng/utils-dev/oteli
         const stop = yield* Deferred.make<void>()
         const stdinStream = Stream.fromEffect(Deferred.await(stop)).pipe(Stream.drain)
 
-        const command = Command.make(binary, ...flags).pipe(
-          Command.stdin(stdinStream),
-          Command.stdout('pipe'),
-        )
-
         const process = yield* executor
-          .start(command)
+          .spawn(
+            Command.make(binary, flags, {
+              stdin: stdinStream,
+              stdout: 'pipe',
+            }),
+          )
           .pipe(
             Effect.mapError((cause) => new OteliteSpawnError({ argv: [binary, ...flags], cause })),
           )
@@ -420,15 +421,17 @@ export class Otelite extends Effect.Service<Otelite>()('@overeng/utils-dev/oteli
               ),
             ),
           ),
-          Effect.timeoutFail({
+          Effect.timeoutOrElse({
             duration: '10 seconds',
-            onTimeout: () =>
-              new OteliteCliError({
+            orElse: () =>
+              Effect.fail(
+                new OteliteCliError({
                 exitCode: 74,
                 reason: 'io-err',
                 argv: [binary, ...flags],
                 stderr: 'otelite capture did not emit endpoints within the readiness bound',
-              }),
+                }),
+              ),
           }),
         )
 
@@ -443,9 +446,9 @@ export class Otelite extends Effect.Service<Otelite>()('@overeng/utils-dev/oteli
             // Await the drained stdout, but never hang teardown: if the child is
             // wedged, fall back to a kill so the scope always closes.
             yield* Fiber.join(drain).pipe(
-              Effect.zipRight(process.exitCode),
+              Effect.andThen(process.exitCode),
               Effect.timeout('10 seconds'),
-              Effect.catchAll(() => process.kill().pipe(Effect.ignore)),
+              Effect.catch(() => process.kill().pipe(Effect.ignore)),
             )
             const line = yield* Ref.get(lastLine)
             yield* decodeSummary(line ?? '').pipe(
@@ -507,4 +510,6 @@ export class Otelite extends Effect.Service<Otelite>()('@overeng/utils-dev/oteli
 
     return { run, capture, inspect, version } as const
   }),
-}) {}
+}) {
+  static readonly layer = Layer.effect(this, this.make)
+}

--- a/packages/@overeng/utils-dev/src/otelite/diagnostics.ts
+++ b/packages/@overeng/utils-dev/src/otelite/diagnostics.ts
@@ -64,7 +64,7 @@ export const writeCaptureDiagnostics = Effect.fn('otelite.diagnostics.write', {
   includeMetrics = false,
   includeLogs = false,
 }: WriteCaptureDiagnosticsOptions) {
-  const fs = yield* FileSystem.FileSystem
+  const fs = yield* FileSystem
   yield* fs.makeDirectory(outDir, { recursive: true })
 
   const traceSummary = yield* capture.inspect({
@@ -164,4 +164,4 @@ const encodeJson =
     Schema.encodeSync(Schema.fromJsonString(schema, { space: 2 }))(value)
 
 const writeJson = ({ path, content }: { readonly path: string; readonly content: string }) =>
-  FileSystem.FileSystem.pipe(Effect.flatMap((fs) => fs.writeFileString(path, `${content}\n`)))
+  FileSystem.pipe(Effect.flatMap((fs) => fs.writeFileString(path, `${content}\n`)))

--- a/packages/@overeng/utils-dev/src/otelite/diagnostics.ts
+++ b/packages/@overeng/utils-dev/src/otelite/diagnostics.ts
@@ -1,7 +1,7 @@
 import * as NodePath from 'node:path'
 
-import { FileSystem } from 'effect/FileSystem'
 import { Effect, Schema } from 'effect'
+import { FileSystem } from 'effect/FileSystem'
 
 import type { CaptureHandle } from './Otelite.ts'
 import { LogRow, LogSummary, MetricRow, MetricSummary, SpanRow, TraceSummary } from './schema.ts'
@@ -159,9 +159,9 @@ export const writeCaptureDiagnostics = Effect.fn('otelite.diagnostics.write', {
 })
 
 const encodeJson =
-  <A, I>(schema: Schema.Schema<A, I, never>) =>
+  <A, I>(schema: Schema.Codec<A, I>) =>
   (value: A): string =>
-    Schema.encodeSync(Schema.fromJsonString(schema, { space: 2 }))(value)
+    JSON.stringify(Schema.encodeSync(schema)(value), null, 2) as string
 
 const writeJson = ({ path, content }: { readonly path: string; readonly content: string }) =>
   FileSystem.pipe(Effect.flatMap((fs) => fs.writeFileString(path, `${content}\n`)))

--- a/packages/@overeng/utils-dev/src/otelite/signal-expect.ts
+++ b/packages/@overeng/utils-dev/src/otelite/signal-expect.ts
@@ -1,4 +1,4 @@
-import { Either, Schema } from 'effect'
+import { Exit, Schema } from 'effect'
 
 import type { LogRow, MetricRow } from './schema.ts'
 
@@ -103,22 +103,22 @@ export const telemetryAttr = {
     description,
     predicate,
   }),
-  schema: <Row, A, I>(
-    schema: Schema.Schema<A, I, never>,
-    description = String(schema.ast.annotations.identifier ?? 'schema'),
+  schema: <Row, A>(
+    schema: Schema.Codec<A, unknown>,
+    description = String(schema.ast.annotations?.identifier ?? 'schema'),
   ): TelemetryAttrMatcher<Row> => ({
     _tag: 'Schema',
     description,
-    matches: (actual) => Either.isRight(Schema.decodeUnknownEither(schema)(actual)),
+    matches: (actual) => Exit.isSuccess(Schema.decodeUnknownExit(schema)(actual)),
   }),
-  json: <Row, A, I>(
-    schema: Schema.Schema<A, I, never>,
-    description = String(schema.ast.annotations.identifier ?? 'json schema'),
+  json: <Row, A>(
+    schema: Schema.Codec<A, unknown>,
+    description = String(schema.ast.annotations?.identifier ?? 'json schema'),
   ): TelemetryAttrMatcher<Row> => ({
     _tag: 'Schema',
     description,
     matches: (actual) =>
-      Either.isRight(Schema.decodeUnknownEither(Schema.fromJsonString(schema))(actual)),
+      Exit.isSuccess(Schema.decodeUnknownExit(Schema.fromJsonString(schema))(actual)),
   }),
 } as const
 

--- a/packages/@overeng/utils-dev/src/otelite/test-harness.test.ts
+++ b/packages/@overeng/utils-dev/src/otelite/test-harness.test.ts
@@ -1,7 +1,7 @@
 import { NodeServices } from '@effect/platform-node'
 import { describe, expect, it } from '@effect/vitest'
-import { FileSystem } from 'effect/FileSystem'
 import { Effect, Layer, Metric, MetricLabel, Schema } from 'effect'
+import { FileSystem } from 'effect/FileSystem'
 
 import { TraceJson, writeCaptureDiagnostics } from './diagnostics.ts'
 import {
@@ -11,7 +11,7 @@ import {
 } from './test-harness.ts'
 
 describe('OteliteTestHarness', () => {
-  it.scopedLive(
+  it.live(
     'captures in-process spans through the provided OTLP layer',
     () =>
       Effect.gen(function* () {
@@ -44,7 +44,7 @@ describe('OteliteTestHarness', () => {
     30_000,
   )
 
-  it.scopedLive(
+  it.live(
     'returns trace expectations from the ergonomic capture helper',
     () =>
       Effect.gen(function* () {
@@ -71,7 +71,7 @@ describe('OteliteTestHarness', () => {
     30_000,
   )
 
-  it.scopedLive(
+  it.live(
     'writes reusable trace diagnostics JSON from a capture',
     () =>
       Effect.gen(function* () {
@@ -109,7 +109,7 @@ describe('OteliteTestHarness', () => {
     30_000,
   )
 
-  it.scopedLive(
+  it.live(
     'restores endpoint environment after scoped use',
     () =>
       Effect.gen(function* () {
@@ -154,7 +154,7 @@ describe('OteliteTestHarness', () => {
     30_000,
   )
 
-  it.scopedLive(
+  it.live(
     'captures traces + metrics + logs in one in-process run',
     () => {
       const service = 'otelite-all-signals'

--- a/packages/@overeng/utils-dev/src/otelite/test-harness.test.ts
+++ b/packages/@overeng/utils-dev/src/otelite/test-harness.test.ts
@@ -1,6 +1,6 @@
 import { NodeServices } from '@effect/platform-node'
 import { describe, expect, it } from '@effect/vitest'
-import { Effect, Layer, Metric, MetricLabel, Schema } from 'effect'
+import { Effect, Layer, Metric, Schema } from 'effect'
 import { FileSystem } from 'effect/FileSystem'
 
 import { TraceJson, writeCaptureDiagnostics } from './diagnostics.ts'
@@ -162,11 +162,8 @@ describe('OteliteTestHarness', () => {
       const gauge = Metric.gauge('otelite_all_signals_queue_depth', { bigint: false })
 
       const workload = Effect.gen(function* () {
-        yield* Metric.increment(counter)
-        yield* Metric.set(
-          gauge.pipe(Metric.taggedWithLabels([MetricLabel.make('queue', 'primary')])),
-          7,
-        )
+        yield* Metric.update(counter, 1)
+        yield* Metric.update(gauge.pipe(Metric.withAttributes({ queue: 'primary' })), 7)
         yield* Effect.log('all-signals demo log line')
       }).pipe(Effect.withSpan(`${service}.child`, { attributes: { 'span.label': 'child' } }))
 

--- a/packages/@overeng/utils-dev/src/otelite/test-harness.test.ts
+++ b/packages/@overeng/utils-dev/src/otelite/test-harness.test.ts
@@ -40,7 +40,7 @@ describe('OteliteTestHarness', () => {
         expect(trace.expectSameTrace([{ name: root.name }, { name: child.name }])).toBe(
           child.trace_id,
         )
-      }).pipe(Effect.provide(OteliteTestHarness.Default)),
+      }).pipe(Effect.provide(OteliteTestHarness.layer)),
     30_000,
   )
 
@@ -75,7 +75,7 @@ describe('OteliteTestHarness', () => {
     'writes reusable trace diagnostics JSON from a capture',
     () =>
       Effect.gen(function* () {
-        const fs = yield* FileSystem.FileSystem
+        const fs = yield* FileSystem
         const outDir = yield* fs.makeTempDirectoryScoped()
         const harness = yield* OteliteTestHarness
         const otel = yield* harness.capture({
@@ -99,13 +99,13 @@ describe('OteliteTestHarness', () => {
           service: 'otelite-diagnostics',
         })
 
-        const traceJson = yield* Schema.decodeUnknown(Schema.fromJsonString(TraceJson))(
+        const traceJson = yield* Schema.decodeUnknownEffect(Schema.fromJsonString(TraceJson))(
           yield* fs.readFileString(files.traceJson),
         )
         expect(traceJson.schema).toBe('otelite.trace-json/v1')
         expect(traceJson.summary.span_count).toBeGreaterThanOrEqual(2)
         expect(traceJson.spans.some((span) => span.name === 'otelite-diagnostics.child')).toBe(true)
-      }).pipe(Effect.provide(Layer.mergeAll(OteliteTestHarness.Default, NodeServices.layer))),
+      }).pipe(Effect.provide(Layer.mergeAll(OteliteTestHarness.layer, NodeServices.layer))),
     30_000,
   )
 
@@ -150,7 +150,7 @@ describe('OteliteTestHarness', () => {
         expect(process.env.OTELITE_TEST_ENDPOINT).toBe(previousCustomEndpoint)
         expect(process.env.OTELITE_TEST_SERVICE).toBe(previousCustomService)
         expect(process.env.OTELITE_TEST_EXTRA).toBe(previousExtra)
-      }).pipe(Effect.provide(OteliteTestHarness.Default)),
+      }).pipe(Effect.provide(OteliteTestHarness.layer)),
     30_000,
   )
 

--- a/packages/@overeng/utils-dev/src/otelite/test-harness.ts
+++ b/packages/@overeng/utils-dev/src/otelite/test-harness.ts
@@ -148,7 +148,7 @@ const makeInProcessLayer = (
     resource: { serviceName: options.serviceName },
     exportInterval: options.exportInterval,
   }).pipe(
-    // LIVE-MIGRATION BRIDGE effect-3-4 B9 — DELETE at contraction — https://github.com/Effect-TS/effect/issues/6742
+    // LIVE-MIGRATION BRIDGE effect-3-4 B9 — DELETE at contraction — https://github.com/Effect-TS/effect/issues/6746
     // Effect 4 reversed OTLP resource precedence: ambient OTEL_SERVICE_NAME
     // overrides explicitly configured service name (v3: explicit serviceName >
     // service.name attr > OTEL_RESOURCE_ATTRIBUTES > OTEL_SERVICE_NAME).
@@ -166,14 +166,44 @@ const makeInProcessLayer = (
   )
 }
 
+// LIVE-MIGRATION BRIDGE effect-3-4 — DELETE at contraction — https://github.com/Effect-TS/effect/issues/6749
+const otlpSerializationV3SeverityText = Layer.effect(
+  OtlpSerialization.OtlpSerialization,
+  Effect.gen(function* () {
+    const serialization = yield* OtlpSerialization.OtlpSerialization
+    return {
+      ...serialization,
+      logs: (data: Parameters<typeof serialization.logs>[0]) =>
+        serialization.logs({
+          resourceLogs: data.resourceLogs.map((resourceLog) => ({
+            ...resourceLog,
+            scopeLogs: resourceLog.scopeLogs.map((scopeLog) =>
+              scopeLog.logRecords === undefined
+                ? scopeLog
+                : {
+                    ...scopeLog,
+                    logRecords: scopeLog.logRecords.map((record) =>
+                      record.severityText === undefined
+                        ? record
+                        : { ...record, severityText: record.severityText.toUpperCase() },
+                    ),
+                  },
+            ),
+          })),
+        }),
+    }
+  }),
+).pipe(Layer.provide(OtlpSerialization.layerJson))
+// LIVE-MIGRATION END effect-3-4
+
 /**
- * All-signals in-process exporter: traces + metrics + logs through ONE
- * `Otlp.layerJson`. Unlike the traces-only {@link makeInProcessLayer} (which
+ * All-signals in-process exporter: traces + metrics + logs through one combined
+ * OTLP layer with JSON serialization. Unlike the traces-only {@link makeInProcessLayer} (which
  * uses the per-signal `OtlpTracer.layer` and so must hand-append `/v1/traces`),
- * the combined `Otlp.layerJson` takes the BARE receiver base URL and appends
+ * the combined layer takes the BARE receiver base URL and appends
  * `/v1/{traces,metrics,logs}` itself — so all three signal URLs are correct and
  * the verbatim-URL footgun is gone. `Effect.log` bridges to OTLP logs because
- * `Otlp.layerJson` adds the OTLP logger by default.
+ * the combined layer adds the OTLP logger by default.
  *
  * `Layer.suspend` keeps the exporter's scope-close finalizers (the final flush
  * of every signal) tied to the layer scope — matching prod `otel.ts` and the
@@ -196,7 +226,8 @@ const makeInProcessAllSignalsLayer = (
   options: Required<Pick<OteliteTestHarnessOptions, 'serviceName' | 'exportInterval'>>,
 ): Layer.Layer<never> =>
   Layer.suspend(() =>
-    Otlp.layerJson({
+    // LIVE-MIGRATION BRIDGE effect-3-4 — DELETE at contraction — https://github.com/Effect-TS/effect/issues/6749
+    Otlp.layer({
       baseUrl: handle.endpoints.http.replace(/\/$/, ''),
       resource: { serviceName: options.serviceName },
       tracerExportInterval: options.exportInterval,
@@ -208,7 +239,9 @@ const makeInProcessAllSignalsLayer = (
       // scope-close alone).
       shutdownTimeout: 2000,
     }).pipe(
-      // LIVE-MIGRATION BRIDGE effect-3-4 B9 — DELETE at contraction — https://github.com/Effect-TS/effect/issues/6742
+      Layer.provide(otlpSerializationV3SeverityText),
+      // LIVE-MIGRATION END effect-3-4
+      // LIVE-MIGRATION BRIDGE effect-3-4 B9 — DELETE at contraction — https://github.com/Effect-TS/effect/issues/6746
       // Effect 4 reversed OTLP resource precedence: ambient OTEL_SERVICE_NAME
       // overrides explicitly configured service name (v3: explicit serviceName >
       // service.name attr > OTEL_RESOURCE_ATTRIBUTES > OTEL_SERVICE_NAME).

--- a/packages/@overeng/utils-dev/src/otelite/test-harness.ts
+++ b/packages/@overeng/utils-dev/src/otelite/test-harness.ts
@@ -1,5 +1,5 @@
 import { NodeServices } from '@effect/platform-node'
-import { Context, Effect, Layer, Semaphore, type Scope } from 'effect'
+import { ConfigProvider, Context, Effect, Layer, Semaphore, type Scope } from 'effect'
 import { FetchHttpClient } from 'effect/unstable/http'
 import { OtlpSerialization, OtlpTracer } from 'effect/unstable/observability'
 import * as Otlp from 'effect/unstable/observability/Otlp'
@@ -148,6 +148,20 @@ const makeInProcessLayer = (
     resource: { serviceName: options.serviceName },
     exportInterval: options.exportInterval,
   }).pipe(
+    // LIVE-MIGRATION BRIDGE effect-3-4 B9 — DELETE at contraction
+    // Effect 4 reversed OTLP resource precedence: ambient OTEL_SERVICE_NAME
+    // overrides explicitly configured service name (v3: explicit serviceName >
+    // service.name attr > OTEL_RESOURCE_ATTRIBUTES > OTEL_SERVICE_NAME).
+    // Retire when upstream restores explicit-wins precedence and we adopt that
+    // beta. Upstream issue NOT YET FILED — see context/effect-4/ findings;
+    // filing is owed.
+    Layer.provide(
+      ConfigProvider.layerAdd(
+        ConfigProvider.fromUnknown({ OTEL_SERVICE_NAME: options.serviceName }),
+        { asPrimary: true },
+      ),
+    ),
+    // LIVE-MIGRATION END effect-3-4 B9
     Layer.provideMerge(FetchHttpClient.layer),
     Layer.provideMerge(OtlpSerialization.layerJson),
   )
@@ -194,7 +208,23 @@ const makeInProcessAllSignalsLayer = (
       // a hung receiver fails fast in a test (was omitted before, relying on
       // scope-close alone).
       shutdownTimeout: 2000,
-    }).pipe(Layer.provide(FetchHttpClient.layer)),
+    }).pipe(
+      // LIVE-MIGRATION BRIDGE effect-3-4 B9 — DELETE at contraction
+      // Effect 4 reversed OTLP resource precedence: ambient OTEL_SERVICE_NAME
+      // overrides explicitly configured service name (v3: explicit serviceName >
+      // service.name attr > OTEL_RESOURCE_ATTRIBUTES > OTEL_SERVICE_NAME).
+      // Retire when upstream restores explicit-wins precedence and we adopt that
+      // beta. Upstream issue NOT YET FILED — see context/effect-4/ findings;
+      // filing is owed.
+      Layer.provide(
+        ConfigProvider.layerAdd(
+          ConfigProvider.fromUnknown({ OTEL_SERVICE_NAME: options.serviceName }),
+          { asPrimary: true },
+        ),
+      ),
+      // LIVE-MIGRATION END effect-3-4 B9
+      Layer.provide(FetchHttpClient.layer),
+    ),
   )
 
 /** Effect service whose `capture` boots a scoped otelite receiver and yields an {@link OteliteTestHandle}; provides its own `Otelite.layer`. */

--- a/packages/@overeng/utils-dev/src/otelite/test-harness.ts
+++ b/packages/@overeng/utils-dev/src/otelite/test-harness.ts
@@ -1,7 +1,7 @@
-import { OtlpSerialization, OtlpTracer } from '@effect/opentelemetry'
 import { NodeServices } from '@effect/platform-node'
 import { Effect, Layer, type Scope } from 'effect'
 import { FetchHttpClient } from 'effect/unstable/http'
+import { OtlpSerialization, OtlpTracer } from 'effect/unstable/observability'
 import * as Otlp from 'effect/unstable/observability/Otlp'
 
 import type { OteliteCliError, OteliteDecodeError, OteliteSpawnError } from './errors.ts'

--- a/packages/@overeng/utils-dev/src/otelite/test-harness.ts
+++ b/packages/@overeng/utils-dev/src/otelite/test-harness.ts
@@ -1,5 +1,5 @@
 import { NodeServices } from '@effect/platform-node'
-import { Effect, Layer, type Scope } from 'effect'
+import { Context, Effect, Layer, Semaphore, type Scope } from 'effect'
 import { FetchHttpClient } from 'effect/unstable/http'
 import { OtlpSerialization, OtlpTracer } from 'effect/unstable/observability'
 import * as Otlp from 'effect/unstable/observability/Otlp'
@@ -107,7 +107,7 @@ export interface OteliteTestHandle {
   ) => Effect.Effect<TraceExpect, E | OteliteSpawnError | OteliteCliError | OteliteDecodeError, R>
 }
 
-const envSemaphore = Effect.unsafeMakeSemaphore(1)
+const envSemaphore = Semaphore.makeUnsafe(1)
 
 const scopedEnv = (
   values: Readonly<Record<string, string | undefined>>,
@@ -197,12 +197,11 @@ const makeInProcessAllSignalsLayer = (
     }).pipe(Layer.provide(FetchHttpClient.layer)),
   )
 
-/** Effect service whose `capture` boots a scoped otelite receiver and yields an {@link OteliteTestHandle}; provides its own `Otelite.Default`. */
-export class OteliteTestHarness extends Effect.Service<OteliteTestHarness>()(
+/** Effect service whose `capture` boots a scoped otelite receiver and yields an {@link OteliteTestHandle}; provides its own `Otelite.layer`. */
+export class OteliteTestHarness extends Context.Service<OteliteTestHarness>()(
   '@overeng/utils-dev/otelite/OteliteTestHarness',
   {
-    accessors: true,
-    effect: Effect.gen(function* () {
+    make: Effect.gen(function* () {
       const otelite = yield* Otelite
 
       const capture = (
@@ -259,7 +258,7 @@ export class OteliteTestHarness extends Effect.Service<OteliteTestHarness>()(
                     captureHandle.endpoints.http,
                   [envOptions.serviceNameVar ?? 'OTEL_SERVICE_NAME']: options.serviceName,
                   ...envOptions.extra,
-                }).pipe(Effect.zipRight(effect)),
+                }).pipe(Effect.andThen(effect)),
               ),
             )
 
@@ -278,8 +277,8 @@ export class OteliteTestHarness extends Effect.Service<OteliteTestHarness>()(
             R
           > =>
             runInProcess(effect).pipe(
-              Effect.zipRight(flushCaptureSpans({ exportInterval })),
-              Effect.zipRight(trace(traceOptions)),
+              Effect.andThen(flushCaptureSpans({ exportInterval })),
+              Effect.andThen(trace(traceOptions)),
             )
 
           const runInProcessAllSignals = <A, E, R>(
@@ -332,8 +331,8 @@ export class OteliteTestHarness extends Effect.Service<OteliteTestHarness>()(
             R
           > =>
             withEnv(effect, envOptions).pipe(
-              Effect.zipRight(flushCaptureSpans({ exportInterval })),
-              Effect.zipRight(trace(traceOptions)),
+              Effect.andThen(flushCaptureSpans({ exportInterval })),
+              Effect.andThen(trace(traceOptions)),
             )
 
           return {
@@ -355,18 +354,24 @@ export class OteliteTestHarness extends Effect.Service<OteliteTestHarness>()(
 
       return { capture } as const
     }),
-    dependencies: [Otelite.Default.pipe(Layer.provide(NodeServices.layer))],
   },
-) {}
+) {
+  static readonly layer = Layer.effect(this, this.make).pipe(
+    Layer.provide(Otelite.layer.pipe(Layer.provide(NodeServices.layer))),
+  )
+}
 
-/** Scoped one-shot {@link OteliteTestHandle}: provides `OteliteTestHarness.Default` so callers needn't wire the layer. */
+/** Scoped one-shot {@link OteliteTestHandle}: provides `OteliteTestHarness.layer` so callers needn't wire the layer. */
 export const captureTest = (
   options: OteliteTestHarnessOptions,
 ): Effect.Effect<
   OteliteTestHandle,
   OteliteSpawnError | OteliteCliError | OteliteDecodeError,
   Scope.Scope
-> => OteliteTestHarness.capture(options).pipe(Effect.provide(OteliteTestHarness.Default))
+> =>
+  OteliteTestHarness.use((service) => service.capture(options)).pipe(
+    Effect.provide(OteliteTestHarness.layer),
+  )
 
 /** All-in-one: boot a capture, run `effect` through the in-process traces exporter, flush, and return a {@link TraceExpect}. */
 export const captureInProcessTrace = <A, E, R>(

--- a/packages/@overeng/utils-dev/src/otelite/test-harness.ts
+++ b/packages/@overeng/utils-dev/src/otelite/test-harness.ts
@@ -148,13 +148,12 @@ const makeInProcessLayer = (
     resource: { serviceName: options.serviceName },
     exportInterval: options.exportInterval,
   }).pipe(
-    // LIVE-MIGRATION BRIDGE effect-3-4 B9 — DELETE at contraction
+    // LIVE-MIGRATION BRIDGE effect-3-4 B9 — DELETE at contraction — https://github.com/Effect-TS/effect/issues/6742
     // Effect 4 reversed OTLP resource precedence: ambient OTEL_SERVICE_NAME
     // overrides explicitly configured service name (v3: explicit serviceName >
     // service.name attr > OTEL_RESOURCE_ATTRIBUTES > OTEL_SERVICE_NAME).
     // Retire when upstream restores explicit-wins precedence and we adopt that
-    // beta. Upstream issue NOT YET FILED — see context/effect-4/ findings;
-    // filing is owed.
+    // beta.
     Layer.provide(
       ConfigProvider.layerAdd(
         ConfigProvider.fromUnknown({ OTEL_SERVICE_NAME: options.serviceName }),
@@ -209,13 +208,12 @@ const makeInProcessAllSignalsLayer = (
       // scope-close alone).
       shutdownTimeout: 2000,
     }).pipe(
-      // LIVE-MIGRATION BRIDGE effect-3-4 B9 — DELETE at contraction
+      // LIVE-MIGRATION BRIDGE effect-3-4 B9 — DELETE at contraction — https://github.com/Effect-TS/effect/issues/6742
       // Effect 4 reversed OTLP resource precedence: ambient OTEL_SERVICE_NAME
       // overrides explicitly configured service name (v3: explicit serviceName >
       // service.name attr > OTEL_RESOURCE_ATTRIBUTES > OTEL_SERVICE_NAME).
       // Retire when upstream restores explicit-wins precedence and we adopt that
-      // beta. Upstream issue NOT YET FILED — see context/effect-4/ findings;
-      // filing is owed.
+      // beta.
       Layer.provide(
         ConfigProvider.layerAdd(
           ConfigProvider.fromUnknown({ OTEL_SERVICE_NAME: options.serviceName }),

--- a/packages/@overeng/utils-dev/src/otelite/trace-expect.ts
+++ b/packages/@overeng/utils-dev/src/otelite/trace-expect.ts
@@ -1,4 +1,4 @@
-import { Either, Schema } from 'effect'
+import { Exit, Schema } from 'effect'
 
 import type { SpanRow } from './schema.ts'
 
@@ -80,22 +80,22 @@ export const attr = {
     description,
     predicate,
   }),
-  schema: <A, I>(
-    schema: Schema.Schema<A, I, never>,
-    description = String(schema.ast.annotations.identifier ?? 'schema'),
+  schema: <A>(
+    schema: Schema.Codec<A, unknown>,
+    description = String(schema.ast.annotations?.identifier ?? 'schema'),
   ): AttrMatcher => ({
     _tag: 'Schema',
     description,
-    matches: (actual) => Either.isRight(Schema.decodeUnknownEither(schema)(actual)),
+    matches: (actual) => Exit.isSuccess(Schema.decodeUnknownExit(schema)(actual)),
   }),
-  json: <A, I>(
-    schema: Schema.Schema<A, I, never>,
-    description = String(schema.ast.annotations.identifier ?? 'json schema'),
+  json: <A>(
+    schema: Schema.Codec<A, unknown>,
+    description = String(schema.ast.annotations?.identifier ?? 'json schema'),
   ): AttrMatcher => ({
     _tag: 'Schema',
     description,
     matches: (actual) =>
-      Either.isRight(Schema.decodeUnknownEither(Schema.fromJsonString(schema))(actual)),
+      Exit.isSuccess(Schema.decodeUnknownExit(Schema.fromJsonString(schema))(actual)),
   }),
 } as const
 

--- a/packages/@overeng/utils-dev/src/otelite/vitest-bridge.test.ts
+++ b/packages/@overeng/utils-dev/src/otelite/vitest-bridge.test.ts
@@ -1,8 +1,8 @@
-import { OtlpSerialization, OtlpTracer } from '@effect/opentelemetry'
 import { NodeServices } from '@effect/platform-node'
 import { describe, expect, it, layer } from '@effect/vitest'
 import { Effect, Layer } from 'effect'
 import { FetchHttpClient } from 'effect/unstable/http'
+import { OtlpSerialization, OtlpTracer } from 'effect/unstable/observability'
 
 import { Otelite } from './Otelite.ts'
 import { otlpTracesUrl } from './otlp-url.ts'

--- a/packages/@overeng/utils-dev/src/otelite/vitest-bridge.test.ts
+++ b/packages/@overeng/utils-dev/src/otelite/vitest-bridge.test.ts
@@ -85,7 +85,7 @@ layer(CaptureLayer, { excludeTestServices: true })('OteliteCapture bridge', (it)
  * nothing lands. The contrasting suffixed path is the main bridge test above
  * (which DOES capture). Together they prove the suffix is load-bearing.
  */
-const BareTestLayer = Otelite.Default.pipe(Layer.provideMerge(NodeServices.layer))
+const BareTestLayer = Otelite.layer.pipe(Layer.provideMerge(NodeServices.layer))
 
 describe('OteliteCapture bridge — suffix regression', () => {
   it.scopedLive(

--- a/packages/@overeng/utils-dev/src/otelite/vitest-bridge.test.ts
+++ b/packages/@overeng/utils-dev/src/otelite/vitest-bridge.test.ts
@@ -88,7 +88,7 @@ layer(CaptureLayer, { excludeTestServices: true })('OteliteCapture bridge', (it)
 const BareTestLayer = Otelite.layer.pipe(Layer.provideMerge(NodeServices.layer))
 
 describe('OteliteCapture bridge — suffix regression', () => {
-  it.scopedLive(
+  it.live(
     'a bare (un-suffixed) exporter URL captures nothing',
     () =>
       Effect.gen(function* () {

--- a/packages/@overeng/utils-dev/src/otelite/vitest-bridge.ts
+++ b/packages/@overeng/utils-dev/src/otelite/vitest-bridge.ts
@@ -70,7 +70,7 @@ export interface OteliteCaptureLayerOptions extends CaptureOptions {
  *
  * Requires `Otelite` + a `CommandExecutor`/`FileSystem` (e.g.
  * {@link NodeServices.layer}) in context, both of which it provides internally
- * via {@link Otelite.Default} so the returned layer is self-contained.
+ * via {@link Otelite.layer} so the returned layer is self-contained.
  */
 export const makeOteliteCaptureLayer = (
   options: OteliteCaptureLayerOptions = {},
@@ -81,20 +81,20 @@ export const makeOteliteCaptureLayer = (
   const handleLayer: Layer.Layer<
     OteliteCapture,
     OteliteSpawnError | OteliteCliError | OteliteDecodeError
-  > = Layer.scoped(
+  > = Layer.effect(
     OteliteCapture,
     Effect.gen(function* () {
       const otelite = yield* Otelite
       return yield* otelite.capture(captureOptions)
     }),
-  ).pipe(Layer.provide(Otelite.Default), Layer.provide(NodeServices.layer))
+  ).pipe(Layer.provide(Otelite.layer), Layer.provide(NodeServices.layer))
 
   // Point the OTLP trace exporter at the captured receiver. Built from the
   // handle so the URL is the captured endpoint + the locked `/v1/traces` suffix.
   // Depends on `OteliteCapture`; `provideMerge(handleLayer)` below both
   // satisfies that dependency (booting the receiver ONCE — same layer reference,
   // so it is memoized within the build) and re-exports the tag to the test.
-  const exporterLayer: Layer.Layer<never, never, OteliteCapture> = Layer.unwrapEffect(
+  const exporterLayer: Layer.Layer<never, never, OteliteCapture> = Layer.unwrap(
     OteliteCapture.pipe(
       Effect.map((handle) =>
         makeOtelVitestLayer({


### PR DESCRIPTION
## Problem

`@overeng/utils-dev` is the shared test-harness dependency for many packages and still used Effect 3 APIs and OTLP behavior. Effect 4 beta.102 also changes explicit OTLP resource precedence and emits title-cased log `severityText`, breaking preserved service and log assertions.

## Goal

Port `@overeng/utils-dev` to Effect 4 beta.102 without changing its observable capture contracts, and restore a fully collected, green managed test lane.

## Decisions

- Keep B9 as a local `ConfigProvider` bridge until Effect-TS/effect#6746 is released; explicit service identity continues to win over ambient configuration.
- Normalize OTLP log `severityText` in the local JSON serialization layer until Effect-TS/effect#6749 is released. `severityNumber` remains untouched.
- Do not patch Effect or weaken the existing uppercase severity assertion. Both temporary paths are contraction-marked.

## Verification

- Fresh committed-tree managed summary: `tmp/otel-scrape/summaries/test-utils-dev.2495940.summary.json` reports `vitest.tests=31`, `vitest.failures=0`.
- Scoped pinned `effect-tsgo` for `packages/@overeng/utils-dev/tsconfig.json`: 0 errors; 32 existing `TS377098` suggestions.
- `oxfmt --check` on the touched files: pass.
- `git diff --check`: pass.
- The all-signals test verifies trace parentage, metric names/values/attributes, uppercase log severity text, and trace/log correlation through the real OTLP receiver.

## Complexity

Two temporary, grep-removable migration bridges are added. The severity bridge changes only JSON log serialization and is preferred over expanding the patched dependency surface.

## Concerns

The bridges must be removed when the Effect releases containing #6746 and #6749 are adopted. Repository-wide `check:quick` remains red on other in-flight Effect 4 slices and an existing React-hooks false positive; the scoped compiler and managed package lane above are the local proof.

## Friction & bottlenecks

The worker base required an explicit-SHA worktree and rebase before measurement. Shared host contention made broad reruns expensive, so verification stayed package-scoped and used fresh managed summaries.

## Follow-ups

- Retire B9 after adopting the Effect release containing Effect-TS/effect#6746.
- Retire the severity-text serialization bridge after adopting the Effect release containing Effect-TS/effect#6749.

## References

Refs #925
Refs #981
Effect-TS/effect#6746
Effect-TS/effect#6749

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | co1-spur |
| `agent_session_id` | 2897548b-ef37-4215-b892-fcf0b69651bb |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.145.0 |
| `agent_runtime` | Codex CLI 0.145.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/mnx8agbdq3wiyb6vz63lhgscgazkrn98-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/5r69m9k2llmri3na81518zx0a7y0d3cn-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-29-effect4-w11-utilsdev |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@0fb7e03 |
</details>
<!-- agent-footer:end -->