### PR TITLE
wip(effect4): port notion effect schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **@overeng/notion-effect-schema**: port Schema codecs, transformations, filters,
+  and error-result assertions to Effect 4 while preserving canonical wire bytes.
+
 - **@overeng/genie/package-json**: allow consumers to materialize selected
   cross-repository workspace dependencies with the `file:` protocol. This lets
   pnpm resolve singleton peers such as Effect from the consuming install graph

--- a/context/effect-4/recipes/datetime-values.md
+++ b/context/effect-4/recipes/datetime-values.md
@@ -1,0 +1,39 @@
+# Pattern: datetime-values
+
+**Area:** DateTime values **Kind:** renames **Our usage:** construction and telemetry timestamp
+access in `agent-session-ingest`, `otel-contract`, and `utils`.
+
+## Migration table
+
+| v3                       | v4                           |
+| ------------------------ | ---------------------------- |
+| `DateTime.unsafeMake(x)` | `DateTime.makeUnsafe(x)`     |
+| `dateTime.epochMillis`   | `dateTime.epochMilliseconds` |
+
+These are value-level `DateTime` APIs. Schema wire codecs are covered by the separate
+`schema-date` recipe; do not confuse a value constructor rename with the surviving-name schema
+hazard.
+
+## Equivalence
+
+Both replacements are **VERIFIED** against the real `effect@3.21.4` and
+`effect@4.0.0-beta.102` tarballs. A cross-major probe constructed values from epoch zero, an ISO
+timestamp, and a native `Date`. Epoch milliseconds and formatted ISO output matched exactly for
+all inputs.
+
+## Intended differences
+
+None.
+
+## Gotchas
+
+- The `unsafe` word moved; it was not removed. `makeUnsafe` can still throw for invalid input.
+- Do not replace `unsafeMake` with safe `make` without handling its result type.
+- `Schema.DateTimeUtc` is a different migration: v3's string codec becomes
+  `Schema.DateTimeUtcFromString`, because bare v4 `Schema.DateTimeUtc` validates an existing
+  `DateTime.Utc` value.
+
+## Codemod rule
+
+Both value-level renames are mechanical. Review every `Schema.DateTime*` occurrence using the
+wire-vs-value pattern in `schema-date`.

--- a/context/effect-4/recipes/duration-input.md
+++ b/context/effect-4/recipes/duration-input.md
@@ -1,0 +1,41 @@
+# Pattern: duration-input
+
+**Area:** Duration **Kind:** renames **Our usage:** 10 workspace compiler diagnostics for
+`Duration.DurationInput` on the current flip snapshot.
+
+## Migration table
+
+| v3                       | v4                                |
+| ------------------------ | --------------------------------- |
+| `Duration.DurationInput` | `Duration.Input`                  |
+| `Duration.decode(input)` | `Duration.fromInputUnsafe(input)` |
+
+V4's `fromInputUnsafe` is the replacement for the total, typed-input v3 `decode`. Keep
+`Duration.fromInput` for unknown input that must report invalid data rather than throw.
+
+## Equivalence
+
+The aliases, signatures, and replacement are **VERIFIED** against the real `effect@3.21.4` and
+`effect@4.0.0-beta.102` tarballs. A cross-major probe compared milliseconds for the repository's
+shared input forms: number, bigint nanoseconds, seconds/nanoseconds tuple, duration string, and
+infinity. Every result matched.
+
+V4 `Input` additionally accepts duration objects and explicit infinity strings. That widening does
+not change existing v3-valid callers.
+
+## Intended differences
+
+None for existing inputs.
+
+## Gotchas
+
+- `fromInputUnsafe` is appropriate because the static `Input` type guarantees the accepted shape.
+  Do not use it at an `unknown` boundary.
+- A bigint duration input is nanoseconds in both versions, not milliseconds.
+- Do not replace a `Duration.decodeUnknown` boundary mechanically; its validation/result shape
+  needs separate handling.
+
+## Codemod rule
+
+The type and typed constructor renames are mechanical. Unknown-input parsers require per-site
+review.

--- a/context/effect-4/recipes/effect-result.md
+++ b/context/effect-4/recipes/effect-result.md
@@ -1,0 +1,85 @@
+# Pattern: effect-result
+
+**Area:** Effect error materialization / Result **Kind:** shape change **Our usage:** 131 reported
+`Effect.either` sites; the earlier full-source inventory measured 118 sites across 42 files before
+13 additional slice sites were reported.
+
+## Shape change first
+
+V3 materialized the typed error channel as `Either`. V4 materializes it as `Result`:
+
+```ts
+// v3
+const either = yield * Effect.either(program)
+
+if (Either.isRight(either)) {
+  use(either.right)
+} else {
+  recover(either.left)
+}
+```
+
+```ts
+// v4
+const result = yield * Effect.result(program)
+
+if (Result.isSuccess(result)) {
+  use(result.success)
+} else {
+  recover(result.failure)
+}
+```
+
+## Migration table
+
+| v3                      | v4                        |
+| ----------------------- | ------------------------- |
+| `Effect.either(effect)` | `Effect.result(effect)`   |
+| `Either.right(value)`   | `Result.succeed(value)`   |
+| `Either.left(error)`    | `Result.fail(error)`      |
+| `Either.isRight(value)` | `Result.isSuccess(value)` |
+| `Either.isLeft(value)`  | `Result.isFailure(value)` |
+| `either.right`          | `result.success`          |
+| `either.left`           | `result.failure`          |
+| `_tag: "Right"`         | `_tag: "Success"`         |
+| `_tag: "Left"`          | `_tag: "Failure"`         |
+| `Either.mapLeft`        | `Result.mapError`         |
+
+Do not stop after renaming `Effect.either`: every downstream guard, match arm, property access,
+constructor, serialized tag, and test expectation must move to the `Result` shape.
+
+## Equivalence
+
+The API and shape are **VERIFIED** against the real `effect@3.21.4` and
+`effect@4.0.0-beta.102` tarballs. A direct probe normalized:
+
+```text
+Effect.succeed(7) -> Success(7)
+Effect.fail("bad") -> Failure("bad")
+```
+
+Both majors produced identical normalized success values and typed failures. In both, the
+materialized effect itself cannot fail in the typed error channel.
+
+Owning slices must compare any observable encoded representation. A raw `JSON.stringify` or
+snapshot changes `_tag` and property names even when the normalized value is equivalent.
+
+## Intended differences
+
+None at internal control-flow sites. If an `Either` value crosses a wire, persistence, logging, or
+snapshot boundary, preserving or intentionally changing its bytes requires a separate alignment
+decision.
+
+## Gotchas
+
+- `Result` is not `Exit`: a `Result.Failure` contains the typed error directly, not a `Cause`.
+- Defects and interruption are not converted into `Result.Failure`; `Effect.result` materializes
+  the typed error channel, matching v3 `Effect.either`.
+- Do not leave `_tag === "Right"` checks or `.right` reads behind; they are runtime shape checks,
+  not only types.
+- Serialized `Either` and `Result` objects are not byte-identical.
+
+## Codemod rule
+
+The producer rename is mechanical only together with the complete downstream shape rewrite.
+Boundary encoders, snapshots, and pattern matches require per-site review.

--- a/context/effect-4/recipes/effect-sequencing.md
+++ b/context/effect-4/recipes/effect-sequencing.md
@@ -1,0 +1,49 @@
+# Pattern: effect-sequencing
+
+**Area:** Effect sequencing **Kind:** rename **Our usage:** 70 workspace compiler diagnostics for
+`Effect.zipRight` on the current flip snapshot.
+
+## v3
+
+```ts
+acquire.pipe(Effect.zipRight(use))
+```
+
+## v4
+
+```ts
+acquire.pipe(Effect.andThen(use))
+```
+
+`Effect.zipRight` is absent at beta.102. `Effect.andThen` is its direct replacement when the
+right-hand operand is an `Effect`: run the left effect first, discard its success value, then run
+and return the right effect.
+
+## Equivalence
+
+The replacement is **VERIFIED** against the real `effect@3.21.4` and
+`effect@4.0.0-beta.102` tarballs. A direct cross-major probe established that both forms:
+
+- evaluated the left effect before the right effect;
+- returned the right effect's success value;
+- did not evaluate the right effect when the left effect failed.
+
+The declaration signatures also preserve the union of both error channels and both service
+requirements.
+
+## Intended differences
+
+None.
+
+## Gotchas
+
+- V4 `andThen` also accepts plain values and lazy values. Preserve an effectful right-hand operand
+  as an `Effect`; do not unwrap it into an eager computation.
+- This is sequential composition. Do not replace `zipRight` with a concurrent combinator.
+- Keep any existing `Effect.uninterruptibleMask`, scope, or transaction boundary around the whole
+  composition. Moving the boundary between the two effects changes interruption behavior.
+
+## Codemod rule
+
+`Effect.zipRight(left, right)` becomes `Effect.andThen(left, right)`, and
+`left.pipe(Effect.zipRight(right))` becomes `left.pipe(Effect.andThen(right))`.

--- a/context/effect-4/recipes/effect-timeout-custom-error.md
+++ b/context/effect-4/recipes/effect-timeout-custom-error.md
@@ -1,0 +1,59 @@
+# Pattern: effect-timeout-custom-error
+
+**Area:** Effect timeout control flow **Kind:** shape change **Our usage:** custom timeout failures
+in `megarepo`, `utils`, `utils-dev`, and `restate-effect`.
+
+## v3
+
+```ts
+program.pipe(
+  Effect.timeoutFail({
+    duration,
+    onTimeout: () => new OperationTimeout(),
+  }),
+)
+```
+
+## v4
+
+```ts
+program.pipe(
+  Effect.timeoutOrElse({
+    duration,
+    orElse: () => Effect.fail(new OperationTimeout()),
+  }),
+)
+```
+
+`timeoutFail` is absent at beta.102. `timeoutOrElse` is the replacement, but its fallback is an
+`Effect`, not a raw error value. State the `Effect.fail` explicitly; replacing the removed API with
+plain `timeout` would change the error type to `TimeoutException`.
+
+## Equivalence
+
+The replacement is **VERIFIED** against the real `effect@3.21.4` and
+`effect@4.0.0-beta.102` tarballs. A direct probe covered both branches:
+
+- an immediately successful source returned the same value and did not evaluate the timeout error;
+- a never-completing source timed out into the same normalized typed error;
+- the lazy timeout constructor ran exactly once, only on the timeout branch.
+
+Both implementations interrupt the source before producing the timeout failure.
+
+## Intended differences
+
+None.
+
+## Gotchas
+
+- Preserve laziness: `orElse: () => Effect.fail(onTimeout())`, not
+  `orElse: Effect.fail(onTimeout())`.
+- Use `Effect.fail`, not `Effect.die`, unless the v3 site used `timeoutFailCause`.
+- Keep the original duration input and custom error payload unchanged.
+- Test both branches. A timeout-only test does not prove the success path avoids constructing the
+  error.
+
+## Codemod rule
+
+The outer call shape is predictable, but the error must be lifted into `Effect.fail`. Review
+`timeoutFailCause` separately because its v3 failure is a Cause/defect boundary.

--- a/context/effect-4/recipes/inspectable-redaction.md
+++ b/context/effect-4/recipes/inspectable-redaction.md
@@ -1,0 +1,38 @@
+# Pattern: inspectable-redaction
+
+**Area:** Logging / inspection / secrets **Kind:** rename and module move **Our usage:** file logger
+JSON rendering and redaction.
+
+## Migration table
+
+| v3                      | v4                      |
+| ----------------------- | ----------------------- |
+| `Inspectable.toJSON(x)` | `Inspectable.toJson(x)` |
+| `Inspectable.redact(x)` | `Redactable.redact(x)`  |
+
+Import `Redactable` from the `effect` root for the second replacement. Redaction was moved, not
+removed; dropping the call can expose secret values in logs.
+
+## Equivalence
+
+The APIs and behavior are **VERIFIED** against the real `effect@3.21.4` and
+`effect@4.0.0-beta.102` tarballs. A cross-major probe used an object with a custom `toJSON`, a
+nested array, and a `Redacted` secret. Both `toJSON`/`toJson` and both redaction paths produced the
+same recursive JSON shape with the secret rendered as `"<redacted>"`.
+
+## Intended differences
+
+None.
+
+## Gotchas
+
+- `toJson` still invokes user-defined `toJSON()` methods; only the exported helper's capitalization
+  changed.
+- `Redactable.redact` returns `unknown`. Preserve the old boundary's validation or serialization
+  after redaction.
+- Never replace `Inspectable.redact` with identity or raw `JSON.stringify`.
+
+## Codemod rule
+
+The helper rename is mechanical. The module move additionally requires adding the `Redactable`
+root import and preserving redaction before serialization.

--- a/context/effect-4/recipes/metric-updates-attributes.md
+++ b/context/effect-4/recipes/metric-updates-attributes.md
@@ -1,0 +1,131 @@
+# Pattern: metric-updates-attributes
+
+**Area:** Metrics / telemetry **Kind:** shape change **Our usage:** about 29 affected references,
+including the schema-backed instruments in `otel-contract`, resource gauges in `utils`, and
+telemetry tests.
+
+## Shape changes first
+
+- A v4 `Metric` is no longer a callable effect. Mutations go through `Metric.update`.
+- `MetricLabel` is removed. V4 metrics use string attributes supplied as a record or
+  `ReadonlyArray<[string, string]>`.
+- Attribute names must be unique for a faithful port. V3 could retain two `MetricLabel`s with the
+  same key; v4 attributes collapse them to one key.
+- Snapshot entries changed from `{ metricKey, metricState }` to
+  `{ id, type, state, attributes }`.
+
+All mappings and observations below are **VERIFIED** against the real
+`effect@4.0.0-beta.102` tarball (SHA-1
+`f51092854960f60cbdb06bd59e788acbc8ee8492`).
+
+## v3
+
+```ts
+import { Metric, MetricLabel } from 'effect'
+
+const labels = [MetricLabel.make('route', 'alpha'), MetricLabel.make('method', 'GET')]
+
+const counter = Metric.counter('requests').pipe(Metric.taggedWithLabels(labels))
+const gauge = Metric.gauge('queue_depth')
+
+yield * Metric.increment(counter)
+yield * Metric.incrementBy(counter, 2)
+yield * Metric.set(gauge, 42)
+```
+
+## v4
+
+```ts
+import { Metric } from 'effect'
+
+const attributes: Metric.Metric.Attributes = [
+  ['route', 'alpha'],
+  ['method', 'GET'],
+]
+
+const counter = Metric.counter('requests').pipe(Metric.withAttributes(attributes))
+const gauge = Metric.gauge('queue_depth')
+
+yield * Metric.update(counter, 1)
+yield * Metric.update(counter, 2)
+yield * Metric.update(gauge, 42)
+```
+
+## Migration table
+
+| v3                                        | v4                                                                       | Shape                          |
+| ----------------------------------------- | ------------------------------------------------------------------------ | ------------------------------ |
+| `Metric.increment(metric)`                | `Metric.update(metric, 1)`                                               | named mutation to input        |
+| `Metric.incrementBy(metric, amount)`      | `Metric.update(metric, amount)`                                          | named mutation to input        |
+| `Metric.set(gauge, value)`                | `Metric.update(gauge, value)`                                            | named mutation to input        |
+| `Metric.tagged(metric, key, value)`       | `Metric.withAttributes(metric, [[key, value]])`                          | label to attribute             |
+| `Metric.taggedWithLabels(metric, labels)` | `Metric.withAttributes(metric, attributes)`                              | label objects to attribute set |
+| `MetricLabel.make(key, value)`            | `[key, value] as const`                                                  | object to tuple                |
+| `ReadonlyArray<MetricLabel.MetricLabel>`  | `Metric.Metric.Attributes` or `ReadonlyArray<readonly [string, string]>` | nominal objects to strings     |
+| `pair.metricKey.name`                     | `snapshot.id`                                                            | snapshot shape                 |
+| `pair.metricKey.tags`                     | `snapshot.attributes`                                                    | array to record                |
+| `pair.metricState`                        | `snapshot.state`                                                         | field rename                   |
+
+Use the tuple form when keys are computed. A record is convenient for known static keys:
+
+```ts
+Metric.withAttributes(metric, { route: 'alpha', method: 'GET' })
+```
+
+## Equivalence
+
+A direct cross-major probe used the real `effect@3.21.4` and
+`effect@4.0.0-beta.102` tarballs. After normalizing the snapshot shapes:
+
+- v3 `increment` followed by `incrementBy(2)` and v4 `update(1)` followed by `update(2)` both
+  produced counter value `3`;
+- a second label set produced a separate counter series with value `1` in both majors;
+- v3 `set(41)` followed by `increment` and v4 `update(41)` followed by `update(42)` both produced
+  gauge value `42`;
+- both snapshots contained exactly three series with the same unique-key label/attribute sets and
+  values.
+
+This verifies the replacement for the repository's ordinary unique-key telemetry. Each owning
+slice must still compare exported instrument name, kind, description, unit, attribute set, value,
+and series cardinality through its real telemetry exporter.
+
+## Duplicate-key trap
+
+The same probe deliberately composed two values for one key:
+
+```ts
+// v3 snapshot labels: [["key", "a"], ["key", "b"]]
+metric.pipe(Metric.tagged('key', 'a'), Metric.tagged('key', 'b'))
+
+// v4 snapshot attributes: { key: "a" }
+metric.pipe(Metric.withAttributes({ key: 'a' }), Metric.withAttributes({ key: 'b' }))
+```
+
+V4 collapses duplicate keys, and the tested composition retained the earlier value. Do not port a
+site with duplicate or potentially colliding keys until its intended cardinality and precedence
+are explicit. Schema/object-field-derived labels with unique field names can move directly to
+attributes.
+
+## Intended differences
+
+None for unique-key metrics. Counter totals, gauge values, instrument metadata, attributes, and
+series cardinality must be preserved.
+
+Duplicate-key labels have no equivalent representation in v4 attributes. No current migration
+decision authorizes silently collapsing them.
+
+## Gotchas
+
+- `Metric.update` means “apply the metric's input”, not always “replace”. It adds to counters,
+  replaces gauges, records histogram observations, and increments frequency occurrences.
+- Do not replace `incrementBy(metric, amount)` with `update(metric, 1)`.
+- Do not discard labels merely because `MetricLabel` is absent. The replacement is attributes.
+- Do not compare only an in-process value. Metrics are telemetry: verify exporter-visible metadata,
+  attributes, values, and series count.
+- Tuple attributes are converted to a string-keyed attribute set. Validate uniqueness before
+  conversion when keys are dynamic.
+
+## Codemod rule
+
+The three mutation replacements are mechanical after confirming the metric kind. Label migration
+requires changing the producer and consumer types together and reviewing duplicate-key behavior.

--- a/context/effect-4/recipes/option-nullish.md
+++ b/context/effect-4/recipes/option-nullish.md
@@ -1,0 +1,40 @@
+# Pattern: option-nullish
+
+**Area:** Option constructors **Kind:** mechanical rename **Our usage:** 19 references across 15
+files and six packages.
+
+## v3
+
+```ts
+Option.fromNullable(value)
+```
+
+## v4
+
+```ts
+Option.fromNullishOr(value)
+```
+
+This replacement is **VERIFIED** against the real `effect@4.0.0-beta.102` tarball:
+`fromNullable` is absent and `fromNullishOr` is present.
+
+## Equivalence
+
+Both constructors map `null` and `undefined` to `Option.none()` and every other value to
+`Option.some(value)`.
+
+Do not substitute the narrower `fromNullOr` or `fromUndefinedOr`:
+
+| Input       | `fromNullishOr` | `fromNullOr`      | `fromUndefinedOr` |
+| ----------- | --------------- | ----------------- | ----------------- |
+| `null`      | `None`          | `None`            | `Some(null)`      |
+| `undefined` | `None`          | `Some(undefined)` | `None`            |
+
+## Intended differences
+
+None.
+
+## Codemod rule
+
+`Option.fromNullable` mechanically becomes `Option.fromNullishOr`. Preserve any explicit fallback
+argument or surrounding `Option` combinators unchanged.

--- a/context/effect-4/recipes/predicate-object.md
+++ b/context/effect-4/recipes/predicate-object.md
@@ -1,0 +1,42 @@
+# Pattern: predicate-object
+
+**Area:** Runtime predicates **Kind:** semantic rename **Our usage:** object-or-function guards in
+shared utilities.
+
+## v3
+
+```ts
+Predicate.isObject(value)
+```
+
+## v4 replacement
+
+```ts
+Predicate.isObjectKeyword(value)
+```
+
+V4 still exports `Predicate.isObject`, but its meaning narrowed to non-null records: it rejects
+arrays and functions. Use `isObjectKeyword` to preserve v3's JavaScript `object`-keyword semantics,
+which accept non-null objects, arrays, and functions.
+
+## Equivalence
+
+The predicates are **VERIFIED** against the real `effect@3.21.4` and
+`effect@4.0.0-beta.102` tarballs. Across `null`, plain object, array, function, and string, v3
+`isObject` and v4 `isObjectKeyword` returned identical results. V4 `isObject` differed for arrays
+and functions.
+
+## Intended differences
+
+None when using `isObjectKeyword`.
+
+## Gotchas
+
+- This is a surviving-name hazard: leaving `isObject` unchanged compiles but changes behavior.
+- If a site deliberately wants record-only semantics, v4 `isObject` is appropriate, but that is a
+  behavior change requiring an explicit decision.
+
+## Codemod rule
+
+Replace v3 `Predicate.isObject` with v4 `Predicate.isObjectKeyword` unless the owning slice
+explicitly adopts record-only semantics and tests arrays and functions.

--- a/context/effect-4/recipes/root-import-renames.md
+++ b/context/effect-4/recipes/root-import-renames.md
@@ -36,15 +36,15 @@ MetricBoundaries -> Metric.boundariesFromIterable / Metric.linearBoundaries / Me
 
 These came from package moves, not from root removals:
 
-| v3 package/source | v4 package/source | Notes |
-| --- | --- | --- |
-| `@effect/cli/Args` | `effect/unstable/cli` `Argument` | Namespace renamed. |
-| `@effect/cli/Options` | `effect/unstable/cli` `Flag` | `text()` became `string()`. |
-| `@effect/cli/Command` | `effect/unstable/cli` `Command` | Do not import from root. |
-| `@effect/cli` namespace | `effect/unstable/cli` namespace | Use `Cli.Argument` / `Cli.Flag`. |
-| `@effect/platform/HttpClient*` | `effect/unstable/http` | `HttpClient`, `HttpClientRequest`, `HttpClientResponse`, `HttpClientError`, `FetchHttpClient`. |
-| `@effect/platform/Command` | `effect/unstable/process` `ChildProcess` | Existing local alias can preserve call-site name. |
-| `@effect/platform/CommandExecutor` | `effect/unstable/process` `ChildProcessSpawner` | Service type is `ChildProcessSpawner.ChildProcessSpawner`. |
+| v3 package/source                  | v4 package/source                               | Notes                                                                                          |
+| ---------------------------------- | ----------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `@effect/cli/Args`                 | `effect/unstable/cli` `Argument`                | Namespace renamed.                                                                             |
+| `@effect/cli/Options`              | `effect/unstable/cli` `Flag`                    | `text()` became `string()`.                                                                    |
+| `@effect/cli/Command`              | `effect/unstable/cli` `Command`                 | Do not import from root.                                                                       |
+| `@effect/cli` namespace            | `effect/unstable/cli` namespace                 | Use `Cli.Argument` / `Cli.Flag`.                                                               |
+| `@effect/platform/HttpClient*`     | `effect/unstable/http`                          | `HttpClient`, `HttpClientRequest`, `HttpClientResponse`, `HttpClientError`, `FetchHttpClient`. |
+| `@effect/platform/Command`         | `effect/unstable/process` `ChildProcess`        | Existing local alias can preserve call-site name.                                              |
+| `@effect/platform/CommandExecutor` | `effect/unstable/process` `ChildProcessSpawner` | Service type is `ChildProcessSpawner.ChildProcessSpawner`.                                     |
 
 `FileSystem`, `Path`, and `PlatformError` are present in beta.102 root exports. If they appear in a
 Category A provenance scan, classify them as rewrite audit hazards rather than genuine root removals.
@@ -142,25 +142,52 @@ semantics unless a separate slice records and proves a behavior change.
 
 These were verified against `effect@4.0.0-beta.102` while chasing `genie:run` module-load blockers.
 
-| v3 shape | beta.102 shape | Notes |
-| --- | --- | --- |
-| `Schema.NonEmptyTrimmedString` | `Schema.Trimmed.check(Schema.isNonEmpty())` | Value helper removed. |
-| `Schema.NonNegativeInt` | `Schema.Natural` | `Schema.Int` still exists; `Natural` is `Int >= 0`. |
-| `Schema.NonNegativeBigInt` | `Schema.BigInt.check(Schema.isGreaterThanOrEqualToBigInt(0n))` | No `NaturalBigInt` export observed. |
-| `Schema.TaggedError` | `Schema.TaggedErrorClass` | Same class-style call family. |
-| `Schema.Defect` | `Schema.Defect()` | Became a schema factory function. |
-| `Schema.parseJson(schema)` | `Schema.fromJsonString(schema)` | Zero-arg form becomes `Schema.fromJsonString(Schema.Unknown)`. Pretty-print options are not carried by this helper. |
-| `Schema.maxLength(n)` / `Schema.minLength(n)` | `Schema.check(Schema.isMaxLength(n))` / `Schema.check(Schema.isMinLength(n))` | Filters are not pipe functions by themselves. |
-| `Schema.isPattern(re)` in `.pipe(...)` | `Schema.check(Schema.isPattern(re))` | Direct `.check(Schema.isPattern(re))` is already valid. |
-| `Schema.Union(A, B)` | `Schema.Union([A, B])` | Existing array calls stay unchanged. |
-| `Schema.Tuple(A, B)` | `Schema.Tuple([A, B])` | Existing array calls stay unchanged. |
-| `Schema.fromBrand(ctor)(schema)` | `Schema.fromBrand(identifier, ctor)(schema)` | Bare constructor overload removed. |
-| `Schema.transform(from, to, options)` | `from.pipe(Schema.decodeTo(to, options))` | For effectful transforms use `SchemaTransformation.transformOrFail(...)`. |
-| `SchemaAST.getAnnotation<T>(ast, id)` | `SchemaAST.resolveAt<T>(id)(ast)` | Returns `T | undefined`, not `Option<T>`. |
-| `SchemaAST.getAnnotation<T>(id)(ast)` | `SchemaAST.resolveAt<T>(id)(ast)` | Remove `Option.isSome` / `Option.getOrUndefined` wrappers. |
-| `Context.Tag("id")<Self, Service>()` | `Context.Service<Self, Service>()("id")` | Class-style service tags. |
-| `Logger.prettyLogger()` | `Logger.consolePretty()` | Console pretty logger constructor. |
-| `Logger.replace(Logger.defaultLogger, logger)` | `Logger.layer([logger])` | To keep default plus custom logger use `Logger.layer([Logger.defaultLogger, logger])`. |
+| v3 shape                                       | beta.102 shape                                                                | Notes                                                                                                               |
+| ---------------------------------------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ---------------------------- |
+| `Schema.NonEmptyTrimmedString`                 | `Schema.Trimmed.check(Schema.isNonEmpty())`                                   | Value helper removed.                                                                                               |
+| `Schema.NonNegativeInt`                        | `Schema.Natural`                                                              | `Schema.Int` still exists; `Natural` is `Int >= 0`.                                                                 |
+| `Schema.NonNegativeBigInt`                     | `Schema.BigInt.check(Schema.isGreaterThanOrEqualToBigInt(0n))`                | No `NaturalBigInt` export observed.                                                                                 |
+| `Schema.TaggedError`                           | `Schema.TaggedErrorClass`                                                     | Same class-style call family.                                                                                       |
+| `Schema.Defect`                                | `Schema.Defect()`                                                             | Became a schema factory function.                                                                                   |
+| `Schema.parseJson(schema)`                     | `Schema.fromJsonString(schema)`                                               | Zero-arg form becomes `Schema.fromJsonString(Schema.Unknown)`. Pretty-print options are not carried by this helper. |
+| `Schema.maxLength(n)` / `Schema.minLength(n)`  | `Schema.check(Schema.isMaxLength(n))` / `Schema.check(Schema.isMinLength(n))` | Filters are not pipe functions by themselves.                                                                       |
+| `Schema.isPattern(re)` in `.pipe(...)`         | `Schema.check(Schema.isPattern(re))`                                          | Direct `.check(Schema.isPattern(re))` is already valid.                                                             |
+| `Schema.Union(A, B)`                           | `Schema.Union([A, B])`                                                        | Existing array calls stay unchanged.                                                                                |
+| `Schema.Tuple(A, B)`                           | `Schema.Tuple([A, B])`                                                        | Existing array calls stay unchanged.                                                                                |
+| `Schema.fromBrand(ctor)(schema)`               | `Schema.fromBrand(identifier, ctor)(schema)`                                  | Bare constructor overload removed.                                                                                  |
+| `Schema.transform(from, to, options)`          | `from.pipe(Schema.decodeTo(to, options))`                                     | For effectful transforms use `SchemaTransformation.transformOrFail(...)`.                                           |
+| `SchemaAST.getAnnotation<T>(ast, stringKey)`   | `SchemaAST.resolveAt<T>(stringKey)(ast)`                                      | String keys only; returns `T                                                                                        | undefined`, not `Option<T>`. |
+| `SchemaAST.getAnnotation<T>(symbolKey)(ast)`   | `SchemaAST.resolve(ast)?.[symbolKey] as T \| undefined`                       | `resolveAt` does not accept symbols.                                                                                |
+| `Context.Tag("id")<Self, Service>()`           | `Context.Service<Self, Service>()("id")`                                      | Class-style service tags.                                                                                           |
+| `Logger.prettyLogger()`                        | `Logger.consolePretty()`                                                      | Console pretty logger constructor.                                                                                  |
+| `Logger.replace(Logger.defaultLogger, logger)` | `Logger.layer([logger])`                                                      | To keep default plus custom logger use `Logger.layer([Logger.defaultLogger, logger])`.                              |
 
 Known remaining source search after this batch: `Logger.replaceScoped` in browser broadcast logging
 was not on the `genie:run` loader path and was not ported in this slice.
+
+## SchemaAST annotation-key split
+
+`SchemaAST.resolveAt` is only the replacement for **string-keyed** annotations. Beta.102 declares
+its key parameter as `string`; passing a `unique symbol` is not a valid migration.
+
+For symbol-keyed annotations, resolve the annotation object and index it with the original symbol:
+
+```ts
+const annotated = SchemaAST.resolve(schema.ast)?.[optionValueSchema] as
+  | Schema.Codec<Value>
+  | undefined
+
+if (annotated !== undefined) {
+  use(annotated)
+}
+```
+
+This is **VERIFIED** against the real beta.102 runtime: a schema annotated under a unique symbol was
+recovered by `SchemaAST.resolve(ast)?.[symbol]`, while `resolveAt(symbol.description)` returned
+`undefined`. `resolve` follows beta.102's checked-schema rule by reading the last check's
+annotations when checks are present.
+
+The cast is required because beta.102's public `Annotations.Annotations` interface has only a
+string index signature even though the runtime preserves symbol properties. Remove v3
+`Option.isSome`, `.value`, and `Option.getOrUndefined` handling; both `resolveAt` and direct symbol
+indexing use `undefined` for absence.

--- a/context/effect-4/recipes/root-import-renames.md
+++ b/context/effect-4/recipes/root-import-renames.md
@@ -173,9 +173,8 @@ its key parameter as `string`; passing a `unique symbol` is not a valid migratio
 For symbol-keyed annotations, resolve the annotation object and index it with the original symbol:
 
 ```ts
-const annotated = SchemaAST.resolve(schema.ast)?.[optionValueSchema] as
-  | Schema.Codec<Value>
-  | undefined
+const annotations = SchemaAST.resolve(schema.ast) as { readonly [key: symbol]: unknown } | undefined
+const annotated = annotations?.[optionValueSchema] as Schema.Codec<Value> | undefined
 
 if (annotated !== undefined) {
   use(annotated)
@@ -187,7 +186,8 @@ recovered by `SchemaAST.resolve(ast)?.[symbol]`, while `resolveAt(symbol.descrip
 `undefined`. `resolve` follows beta.102's checked-schema rule by reading the last check's
 annotations when checks are present.
 
-The cast is required because beta.102's public `Annotations.Annotations` interface has only a
-string index signature even though the runtime preserves symbol properties. Remove v3
+The pre-index cast is required because beta.102's public `Annotations.Annotations` interface has
+only a string index signature even though the runtime preserves symbol properties. A trailing cast
+on the indexed result is too late: TypeScript rejects the symbol indexing operation first. Remove v3
 `Option.isSome`, `.value`, and `Option.getOrUndefined` handling; both `resolveAt` and direct symbol
 indexing use `undefined` for absence.

--- a/context/effect-4/recipes/schedule-composition-metadata.md
+++ b/context/effect-4/recipes/schedule-composition-metadata.md
@@ -1,0 +1,90 @@
+# Pattern: schedule-composition-metadata
+
+**Area:** Retry/repeat scheduling **Kind:** shape change **Our usage:** `megarepo` git retries and
+retry metadata logging, plus schedule composition in Notion and release packages.
+
+## Shape changes first
+
+- V3 `Schedule.intersect(A, B)` continued only while both schedules recurred, waited for the longer
+  delay, and output `[AOutput, BOutput]`.
+- V4 `Schedule.max([A, B])` preserves the continuation and maximum-delay behavior but outputs the
+  selected `Duration`, not the tuple.
+- `Schedule.CurrentIterationMetadata` becomes `Schedule.CurrentMetadata`.
+- Metadata `recurrence` becomes `attempt`.
+- V3 `elapsed` / `elapsedSincePrevious` were `Duration`; v4 stores their millisecond values as
+  `number`.
+
+## Git retry replacement
+
+The repository's git retry does not consume the composed schedule output, so its faithful
+replacement is:
+
+```ts
+// v3
+const retry = Schedule.exponential('2 seconds').pipe(
+  Schedule.intersect(Schedule.recurs(GIT_MAX_RETRIES)),
+)
+
+// v4
+const retry = Schedule.max([Schedule.exponential('2 seconds'), Schedule.recurs(GIT_MAX_RETRIES)])
+```
+
+Metadata logging becomes:
+
+```ts
+const metadata = yield * Schedule.CurrentMetadata
+
+if (metadata.attempt > 0) {
+  yield *
+    Effect.logWarning('Retrying').pipe(
+      Effect.annotateLogs({
+        attempt: metadata.attempt,
+        elapsed: Duration.format(Duration.millis(metadata.elapsed)),
+        error: String(metadata.input),
+      }),
+    )
+}
+```
+
+## Equivalence
+
+All APIs and metadata shapes are **VERIFIED** against the real beta.102 tarball. A direct
+cross-major retry probe used exponential delay plus a three-retry cap. Both traces were:
+
+```text
+attempt 0, input absent
+attempt 1, input first failure
+attempt 2, input second failure
+attempt 3, input third failure
+success on the fourth execution
+```
+
+This establishes the replacement for the repository's output-discarding retry schedule. Owning
+slices must additionally assert their real delay sequence, retry cap, `while` classification, and
+logged metadata.
+
+## Output-shape trap
+
+`Schedule.max` is not a complete replacement when the v3 tuple output is consumed. It emits only a
+`Duration`. Such sites need an explicit `Schedule.fromStep` composition or a redesigned output
+projection, with a behavior probe. Do not cast the duration to the old tuple or silently discard an
+output used by retry logic.
+
+## Intended differences
+
+None for the git retry continuation, delay, cap, and metadata behavior. The schedule's unused output
+shape may narrow to `Duration`; consumed tuple outputs require separate adjudication.
+
+## Gotchas
+
+- `Schedule.min` has the opposite continuation/delay semantics: it continues while any schedule
+  recurs and picks the fastest delay. It is not the replacement for v3 `intersect`.
+- `metadata.elapsed` is a number of milliseconds; wrapping it with `Duration.millis` preserves
+  v3 `Duration.format` call sites.
+- Retry attempt zero has no previous failure input. Do not read/cast `metadata.input` before
+  checking `attempt > 0`.
+
+## Codemod rule
+
+Only output-discarding `intersect` sites may mechanically become `max([A, B])`. Metadata names and
+elapsed units then require the explicit rewrites above.

--- a/context/effect-4/recipes/schema-codec-type-contract.md
+++ b/context/effect-4/recipes/schema-codec-type-contract.md
@@ -5,7 +5,7 @@ references in `notion-effect-schema`
 
 ## Shape change
 
-Effect 3 used one `Schema.Schema` type for both value-only schemas and bidirectional codecs:
+Effect 3 used one `Schema.Schema` type for bidirectional codecs:
 
 ```ts
 Schema.Schema<Type, Encoded, Context>
@@ -21,11 +21,24 @@ Schema.Codec<Type, Encoded, Context, Context>
 The third and fourth parameters are decoding and encoding services respectively. Effect 3's single
 `Context` parameter applied in both directions, so it must be copied into both slots.
 
-One-parameter `Schema.Schema<Type>` references remain `Schema.Schema<Type>`.
+The rule applies at every arity. In particular, the safe-looking one-parameter form is also a real
+migration:
+
+```ts
+// Effect 3 defaults: Encoded = Type, Context = never
+Schema.Schema<Type>
+
+// Effect 4 preserves those defaults
+Schema.Codec<Type>
+```
+
+Effect 4's `Schema<Type>` is a different, weaker interface carrying only the decoded Type. It does
+not preserve Effect 3's implicit encoded type or bidirectional service contract.
 
 ## Why the alternatives are not equivalent
 
-- `Schema.Schema<Type>` drops the encoded type and both service requirements.
+- `Schema.Schema<Type>` is not the Effect 3 one-parameter contract; it drops the implicit encoded
+  type and bidirectional codec guarantee.
 - `Schema.Codec<Type, Encoded, Context, never>` narrows the encoding requirement.
 - `Schema.Codec<Type, Encoded, never, Context>` narrows the decoding requirement.
 - `Schema.ConstraintCodec` belongs to the constraint hierarchy rather than the concrete Schema
@@ -48,10 +61,11 @@ type-level mapping.
 
 - The two service slots are easy to confuse because both default to `never`.
 - A green typecheck after narrowing one slot does not prove the old public contract was preserved.
-- Do not migrate one-parameter `Schema.Schema<Type>` annotations to `Codec` without a concrete
-  encoded/service contract.
+- One-parameter references are the easiest to miss because both old and new names accept one type
+  argument while meaning different things.
 
 ## Codemod rule
 
+One-parameter `Schema.Schema<T>` references mechanically become `Schema.Codec<T>`.
 Three-parameter `Schema.Schema<T, E, R>` references mechanically become
-`Schema.Codec<T, E, R, R>`. Other arities and constraint-position types require site review.
+`Schema.Codec<T, E, R, R>`. Constraint-position types require site review.

--- a/context/effect-4/recipes/schema-codec-type-contract.md
+++ b/context/effect-4/recipes/schema-codec-type-contract.md
@@ -1,71 +1,86 @@
 # Pattern: schema-codec-type-contract
 
-**Area:** Schema type-level contracts **Kind:** shape change **Our usage:** 23 multi-parameter
-references in `notion-effect-schema`
+**Area:** Schema type-level contracts **Kind:** shape change **Our usage:** generic codec helpers
+throughout the repository, including 23 multi-parameter references in `notion-effect-schema` and
+one-parameter public return types in `otel-contract`.
 
 ## Shape change
 
-Effect 3 used one `Schema.Schema` type for bidirectional codecs:
+Effect 3 used one `Schema.Schema` type for both value-only schemas and bidirectional codecs:
 
 ```ts
 Schema.Schema<Type, Encoded, Context>
 ```
 
-Effect 4 separates the value-only interface from the bidirectional codec interface. Preserve the
-old contract as:
+Effect 4's `Schema.Schema<Type>` is a different, weaker interface that carries only the decoded
+type. The faithful replacement is `Schema.Codec` at **every arity**:
 
-```ts
-Schema.Codec<Type, Encoded, Context, Context>
-```
+| v3                       | v4                         |
+| ------------------------ | -------------------------- |
+| `Schema.Schema<T>`       | `Schema.Codec<T>`          |
+| `Schema.Schema<T, E>`    | `Schema.Codec<T, E>`       |
+| `Schema.Schema<T, E, R>` | `Schema.Codec<T, E, R, R>` |
 
-The third and fourth parameters are decoding and encoding services respectively. Effect 3's single
-`Context` parameter applied in both directions, so it must be copied into both slots.
+`Codec` defaults `E = T`, `RD = never`, and `RE = never`, exactly matching the omitted Effect 3
+parameters. For the three-parameter form, Effect 3's single `Context` applied in both directions,
+so it must be copied into v4's decoding and encoding service slots.
 
-The rule applies at every arity. In particular, the safe-looking one-parameter form is also a real
-migration:
-
-```ts
-// Effect 3 defaults: Encoded = Type, Context = never
-Schema.Schema<Type>
-
-// Effect 4 preserves those defaults
-Schema.Codec<Type>
-```
-
-Effect 4's `Schema<Type>` is a different, weaker interface carrying only the decoded Type. It does
-not preserve Effect 3's implicit encoded type or bidirectional service contract.
+All interface shapes and defaults above are **VERIFIED** against the real
+`effect@4.0.0-beta.102` tarball (SHA-1
+`f51092854960f60cbdb06bd59e788acbc8ee8492`).
 
 ## Why the alternatives are not equivalent
 
-- `Schema.Schema<Type>` is not the Effect 3 one-parameter contract; it drops the implicit encoded
-  type and bidirectional codec guarantee.
-- `Schema.Codec<Type, Encoded, Context, never>` narrows the encoding requirement.
-- `Schema.Codec<Type, Encoded, never, Context>` narrows the decoding requirement.
-- `Schema.ConstraintCodec` belongs to the constraint hierarchy rather than the concrete Schema
-  hierarchy.
+- `Schema.Schema<T>` drops the encoded type and both service requirements, even when the v3 type
+  used only one explicit parameter.
+- `Schema.Codec<T, E, R, never>` narrows the encoding requirement.
+- `Schema.Codec<T, E, never, R>` narrows the decoding requirement.
+- `Schema.ConstraintCodec` is only for APIs that read type views and do not require the full schema
+  protocol.
 - `Schema.Decoder` and `Schema.Encoder` are deliberately one-directional.
 
-Even when a current helper only exercises one direction, narrowing the other direction is a
+Even when a current helper exercises only one direction, narrowing the other direction is a
 refactor rather than a faithful port and belongs in follow-up work.
+
+## `AnyNoContext`
+
+The replacement for v3 `Schema.Schema.AnyNoContext` is:
+
+```ts
+Schema.Codec<any, any, never, never>
+```
+
+Do **not** use `Schema.Top`. `Top` erases both service slots to `unknown` and therefore admits
+codecs that require decoding or encoding services; v3 `AnyNoContext` rejected them.
+
+This bound is **VERIFIED** from both tarball declarations:
+
+```text
+v3 AnyNoContext = Schema<any, any, never>
+v4 Codec<any, any, never, never>
+v4 Top = decoded/encoded/services all unknown
+```
+
+Use `Schema.ConstraintCodec<any, any, never, never>` only when the generic utility merely reads
+type views and does not call schema methods. A direct port of a v3 `Schema` bound should retain the
+full protocol with `Codec`.
 
 ## Equivalence
 
-The `Schema`, `Codec`, `ConstraintCodec`, `Decoder`, and `Encoder` interfaces and their service
-parameters were verified against the `effect@4.0.0-beta.102` tarball. The migration preserves the
-Effect 3 type contract exactly by retaining the same service requirement for decoding and encoding.
-
-Owning slices must still replay codec behavior in both directions; this recipe only settles the
-type-level mapping.
+This recipe preserves the v3 compile-time encoded and service contracts. It does not apply a
+repository migration or establish runtime codec equivalence. Owning slices must replay decoding
+and encoding with exact encoded bytes and both service environments.
 
 ## Gotchas
 
+- The apparently safe one-parameter spelling is the easiest trap: v4 `Schema<T>` is not v3
+  `Schema<T>` with fewer visible parameters.
 - The two service slots are easy to confuse because both default to `never`.
 - A green typecheck after narrowing one slot does not prove the old public contract was preserved.
-- One-parameter references are the easiest to miss because both old and new names accept one type
-  argument while meaning different things.
+- `Top` is the existential any-schema bound, not the service-free-codec bound.
 
 ## Codemod rule
 
-One-parameter `Schema.Schema<T>` references mechanically become `Schema.Codec<T>`.
-Three-parameter `Schema.Schema<T, E, R>` references mechanically become
-`Schema.Codec<T, E, R, R>`. Constraint-position types require site review.
+All v3 `Schema.Schema<...>` type references become `Schema.Codec<...>`. Duplicate the third v3
+parameter into both v4 service slots. Replace `Schema.Schema.AnyNoContext` with
+`Schema.Codec<any, any, never, never>`.

--- a/context/effect-4/recipes/schema-codec-type-contract.md
+++ b/context/effect-4/recipes/schema-codec-type-contract.md
@@ -1,0 +1,57 @@
+# Pattern: schema-codec-type-contract
+
+**Area:** Schema type-level contracts **Kind:** shape change **Our usage:** 23 multi-parameter
+references in `notion-effect-schema`
+
+## Shape change
+
+Effect 3 used one `Schema.Schema` type for both value-only schemas and bidirectional codecs:
+
+```ts
+Schema.Schema<Type, Encoded, Context>
+```
+
+Effect 4 separates the value-only interface from the bidirectional codec interface. Preserve the
+old contract as:
+
+```ts
+Schema.Codec<Type, Encoded, Context, Context>
+```
+
+The third and fourth parameters are decoding and encoding services respectively. Effect 3's single
+`Context` parameter applied in both directions, so it must be copied into both slots.
+
+One-parameter `Schema.Schema<Type>` references remain `Schema.Schema<Type>`.
+
+## Why the alternatives are not equivalent
+
+- `Schema.Schema<Type>` drops the encoded type and both service requirements.
+- `Schema.Codec<Type, Encoded, Context, never>` narrows the encoding requirement.
+- `Schema.Codec<Type, Encoded, never, Context>` narrows the decoding requirement.
+- `Schema.ConstraintCodec` belongs to the constraint hierarchy rather than the concrete Schema
+  hierarchy.
+- `Schema.Decoder` and `Schema.Encoder` are deliberately one-directional.
+
+Even when a current helper only exercises one direction, narrowing the other direction is a
+refactor rather than a faithful port and belongs in follow-up work.
+
+## Equivalence
+
+The `Schema`, `Codec`, `ConstraintCodec`, `Decoder`, and `Encoder` interfaces and their service
+parameters were verified against the `effect@4.0.0-beta.102` tarball. The migration preserves the
+Effect 3 type contract exactly by retaining the same service requirement for decoding and encoding.
+
+Owning slices must still replay codec behavior in both directions; this recipe only settles the
+type-level mapping.
+
+## Gotchas
+
+- The two service slots are easy to confuse because both default to `never`.
+- A green typecheck after narrowing one slot does not prove the old public contract was preserved.
+- Do not migrate one-parameter `Schema.Schema<Type>` annotations to `Codec` without a concrete
+  encoded/service contract.
+
+## Codemod rule
+
+Three-parameter `Schema.Schema<T, E, R>` references mechanically become
+`Schema.Codec<T, E, R, R>`. Other arities and constraint-position types require site review.

--- a/context/effect-4/recipes/schema-date.md
+++ b/context/effect-4/recipes/schema-date.md
@@ -1,7 +1,8 @@
 # Pattern: schema-date
 
-**Area:** Schema wire format **Kind:** semantic (conditional rewrite) **Our usage:** `Schema.DateTimeUtc`,
-`Schema.DateFromSelf`, and date transforms appear in agent-session, Notion codecs, and path schemas.
+**Area:** Schema wire format **Kind:** semantic (conditional rewrite) **Our usage:**
+`Schema.DateTimeUtc`, `Schema.DateFromSelf`, and date transforms appear in agent-session, Notion
+codecs, and path schemas.
 
 ## v3
 
@@ -81,3 +82,34 @@ process, persistence, API, file, config, test fixture, or `Schema.encode*` /
 `Schema.decodeUnknown*` boundary. Do not apply this rule when callers already
 pass Date instances directly and the encoded side is not part of the observable
 contract.
+
+## DateTime follows the same surviving-name trap
+
+Effect 3 `Schema.DateTimeUtc` was a bidirectional ISO-string wire codec whose Type was
+`DateTime.Utc`. In Effect 4 the bare surviving name validates values that are already
+`DateTime.Utc`; the wire codec is:
+
+```ts
+Schema.DateTimeUtcFromString
+```
+
+At string-to-value boundaries, migrate:
+
+```ts
+Schema.DateTimeUtc
+```
+
+to:
+
+```ts
+Schema.DateTimeUtcFromString
+```
+
+The Effect 4 encoder formats the UTC value through `DateTime.formatIso`, which bottoms out in
+`Date.prototype.toISOString()`. For the repository baseline this preserves exact bytes including
+milliseconds and the `Z` suffix. Invalid strings still fail, but parse-message text may differ and
+must not be silently rebaselined at observable boundaries.
+
+The broader pattern is: when a v3 schema performed string-to-value decoding, a surviving bare v4
+identifier may have become an instance validator while a `...FromString` schema now owns the wire
+contract. Verify Type, Encoded, and exact encoded bytes rather than trusting the surviving name.

--- a/context/effect-4/recipes/schema-date.md
+++ b/context/effect-4/recipes/schema-date.md
@@ -4,6 +4,20 @@
 `Schema.DateTimeUtc`, `Schema.DateFromSelf`, and date transforms appear in agent-session, Notion
 codecs, and path schemas.
 
+## Shape change first: surviving names changed meaning
+
+Effect 4 split v3 string-to-value schemas into a bare instance validator plus a
+`...FromString` wire codec:
+
+| v3 wire schema       | v4 wire codec                  | Surviving v4 bare name                                   |
+| -------------------- | ------------------------------ | -------------------------------------------------------- |
+| `Schema.Date`        | `Schema.DateFromString`        | `Schema.Date` validates a `Date` instance                |
+| `Schema.DateTimeUtc` | `Schema.DateTimeUtcFromString` | `Schema.DateTimeUtc` validates a `DateTime.Utc` instance |
+
+This is the dangerous pattern: the old identifier survives, typechecks in some generic positions,
+and silently stops accepting or emitting the old string representation. Renames fail loudly;
+survivals require wire-boundary review.
+
 ## v3
 
 ```ts
@@ -21,6 +35,16 @@ const encode = Schema.encodeExit(DateWire)
 
 The v4 codecs return `Exit`, not `Either`; callers must handle the changed result shape.
 
+For UTC `DateTime` wire sites:
+
+```ts
+// v3
+Schema.DateTimeUtc
+
+// v4
+Schema.DateTimeUtcFromString
+```
+
 ## Equivalence
 
 Command:
@@ -33,6 +57,10 @@ Result: encoded wire strings and accept/reject outcomes are equivalent after
 using `Schema.DateFromString` on effect `4.0.0-beta.102`. The only differences
 are allowlisted parse-message text changes for invalid inputs. That allowlist is
 a harness classification, not blanket migration acceptance.
+
+`Schema.DateTimeUtcFromString` is also **VERIFIED** against beta.102. Its encode path uses
+`DateTime.formatIso`, which reaches `toDateUtc(self).toISOString()`. For the characterized value it
+emits the exact v3 bytes `"2026-05-25T10:00:00.000Z"`.
 
 ## Intended differences (alignment register entries)
 
@@ -51,6 +79,8 @@ a harness classification, not blanket migration acceptance.
 
 - This is a rename trap: `Schema.Date` still exists in v4 but means a Date
   instance schema, not the v3 ISO-string wire schema.
+- `Schema.DateTimeUtc` is the same trap for `DateTime.Utc`: the bare v4 name validates an instance;
+  use `DateTimeUtcFromString` for v3 string-to-value wire behavior.
 - In effect `4.0.0-beta.102`, `Schema.Date` rejects invalid Date instances and
   `Schema.DateFromString` decodes through that stricter Date schema. The beta.99
   mapping `Schema.DateFromString.check(Schema.isDateValid())` is stale because
@@ -82,34 +112,3 @@ process, persistence, API, file, config, test fixture, or `Schema.encode*` /
 `Schema.decodeUnknown*` boundary. Do not apply this rule when callers already
 pass Date instances directly and the encoded side is not part of the observable
 contract.
-
-## DateTime follows the same surviving-name trap
-
-Effect 3 `Schema.DateTimeUtc` was a bidirectional ISO-string wire codec whose Type was
-`DateTime.Utc`. In Effect 4 the bare surviving name validates values that are already
-`DateTime.Utc`; the wire codec is:
-
-```ts
-Schema.DateTimeUtcFromString
-```
-
-At string-to-value boundaries, migrate:
-
-```ts
-Schema.DateTimeUtc
-```
-
-to:
-
-```ts
-Schema.DateTimeUtcFromString
-```
-
-The Effect 4 encoder formats the UTC value through `DateTime.formatIso`, which bottoms out in
-`Date.prototype.toISOString()`. For the repository baseline this preserves exact bytes including
-milliseconds and the `Z` suffix. Invalid strings still fail, but parse-message text may differ and
-must not be silently rebaselined at observable boundaries.
-
-The broader pattern is: when a v3 schema performed string-to-value decoding, a surviving bare v4
-identifier may have become an instance validator while a `...FromString` schema now owns the wire
-contract. Verify Type, Encoded, and exact encoded bytes rather than trusting the surviving name.

--- a/context/effect-4/recipes/schema-json-formatting.md
+++ b/context/effect-4/recipes/schema-json-formatting.md
@@ -1,0 +1,59 @@
+# Pattern: schema-json-formatting
+
+**Area:** Schema JSON wire bytes **Kind:** semantic boundary **Our usage:** persisted configuration
+and generated JSON files that pass `{ space }` to v3 JSON codecs.
+
+## Shape change
+
+V4 has no pretty-print JSON codec. `Schema.fromJsonString(S)` accepts no formatting options, and no
+beta.102 codec replacement carries v3's `{ space }` behavior.
+
+The replacement is to encode with the schema, then stringify the encoded JSON value explicitly:
+
+```ts
+// v3
+const JsonConfig = Schema.parseJson(Config, { space: 2 })
+const content = Schema.encodeSync(JsonConfig)(value)
+
+// v4
+const encoded = Schema.encodeSync(Config)(value)
+const content = JSON.stringify(encoded, null, 2)
+```
+
+The same rule applies to v3 `Schema.fromJsonString(S, { space })` call shapes. Use
+`Schema.encodeEffect` when the surrounding path handles schema failures as an Effect.
+
+This absence and replacement are **VERIFIED** against the real
+`effect@4.0.0-beta.102` tarball.
+
+## Equivalence
+
+Formatting is behavior at persistence, CLI, snapshot, and hashing boundaries. Compare the complete
+output bytes, including indentation, property order, escaping, and final newline.
+
+`JSON.stringify(encoded, null, 2)` preserves a v3 two-space formatting request only after
+`encoded` has passed through the owning schema. Stringifying the decoded value directly can bypass
+schema transformations and emit different bytes.
+
+Preserve any existing trailing newline separately:
+
+```ts
+const content = `${JSON.stringify(encoded, null, 2)}\n`
+```
+
+## Intended differences
+
+None. File churn is not an accepted migration difference.
+
+## Gotchas
+
+- `Schema.fromJsonString(S)` remains the v4 parse/stringify codec for compact JSON, but it has no
+  pretty-print option.
+- Do not stringify the decoded application value when the schema transforms its encoded shape.
+- `space` may be a number or string in `JSON.stringify`; preserve the exact v3 setting.
+- A value-level round trip cannot prove whitespace bytes.
+
+## Codemod rule
+
+No broad codemod. Split the old combined codec operation at each formatted output boundary:
+schema-encode first, then explicit `JSON.stringify`, then preserve any newline policy.

--- a/context/effect-4/recipes/schema-struct-extension.md
+++ b/context/effect-4/recipes/schema-struct-extension.md
@@ -1,29 +1,26 @@
 # Pattern: schema-struct-extension
 
 **Area:** Schema struct composition **Kind:** shape change **Our usage:** 27 sites in
-`notion-effect-schema`
+`notion-effect-schema`.
 
 ## Shape change first
 
-Effect 4 has no standalone `Schema.extend`. There are two replacements for the repository's
-current sites, depending on whether the right-hand schema is another struct or a record index
-signature.
+Effect 4 has no standalone `Schema.extend`. There are two replacements, selected by the right-hand
+schema's shape.
 
 ### Plain field merge
 
-For two plain structs, merge their fields explicitly:
+For two plain structs:
 
 ```ts
+// v3
 Schema.extend(A, B)
-```
 
-becomes:
-
-```ts
+// v4
 Schema.Struct({ ...A.fields, ...B.fields })
 ```
 
-This is the same field merge used internally by the Effect 4 Class API's static `extend` method.
+This mirrors the field merge used internally by Effect 4's Class `static extend` implementation.
 It applies to plain `Struct` and `TaggedStruct` values; it does not require or create a Class.
 
 ### Struct plus index signature
@@ -31,46 +28,40 @@ It applies to plain `Struct` and `TaggedStruct` values; it does not require or c
 For a struct extended with a record:
 
 ```ts
-Schema.extend(BlockBase, Schema.Record(Schema.String, Schema.Unknown))
-```
+// v3
+Schema.extend(BlockBase, Schema.Record({ key: Schema.String, value: Schema.Unknown }))
 
-use:
-
-```ts
+// v4
 Schema.StructWithRest(BlockBase, [Schema.Record(Schema.String, Schema.Unknown)])
 ```
 
-`Schema.Record` returns `$Record`, not `Struct`. It has no `.fields` to spread. Treating it like a
+`Schema.Record` returns `$Record`, not `Struct`, and has no `.fields` to spread. Treating it like a
 plain struct silently drops the index signature and changes excess-property decoding.
 
 ## Not a replacement: `extendTo`
 
-Do not replace a plain merge with `Schema.extendTo`. `extendTo(fields, derive)` is a transforming
-schema operation: it computes derived fields from the original decoded input using
-`Option`-returning callbacks. It is not a struct merge.
+Do not replace a plain merge with `Schema.extendTo`. `extendTo(fields, derive)` computes derived
+fields from decoded input using `Option`-returning callbacks. It is a transforming schema
+operation, not a struct merge.
 
 ## Equivalence
 
-The two Effect 4 APIs and their implementation shapes were verified against the
-`effect@4.0.0-beta.102` tarball. The 27 `notion-effect-schema` sites were categorized as:
+Both replacements and Effect 4's own Class merge implementation are **VERIFIED** against the real
+`effect@4.0.0-beta.102` tarball.
 
-- 23 plain `Struct` plus `TaggedStruct` field merges;
-- 2 plain `Struct` plus `Struct` field merges;
-- 2 `Struct` plus `Record` index-signature extensions;
-- 0 derived-field extensions.
-
-Owning slices must replay encoded baselines. For `StructWithRest`, include an input with an
-additional property and verify that decode and encode preserve the same key and bytes.
+The measured 27 `notion-effect-schema` sites comprise 25 plain struct/tagged-struct merges and two
+struct-plus-record extensions. Owning slices must replay encoded baselines. For `StructWithRest`,
+include an additional property and verify that decode and encode preserve the same key and bytes.
 
 ## Gotchas
 
-- `Schema.Record(...).fields` is not a valid field merge; `Record` is not a `Struct`.
+- `Schema.Record(...).fields` is not a valid merge; `Record` is not a `Struct`.
 - `Schema.extendTo` can typecheck while implementing different runtime behavior.
 - Field order follows object spread order. Preserve the original left-to-right extension order.
 - When both structs define the same key, the right-hand fields continue to win.
 
 ## Codemod rule
 
-Only plain `Struct`/`TaggedStruct` pairs may use the field-spread rewrite. Every right-hand operand
-must be classified first. Record/index-signature operands require `StructWithRest`; Class and
-genuinely derived-field sites require separate adjudication.
+Only plain `Struct`/`TaggedStruct` pairs may use the field-spread rewrite. Classify every right-hand
+operand first. Record/index-signature operands require `StructWithRest`; Class and genuinely
+derived-field sites require separate adjudication.

--- a/context/effect-4/recipes/schema-struct-extension.md
+++ b/context/effect-4/recipes/schema-struct-extension.md
@@ -1,0 +1,76 @@
+# Pattern: schema-struct-extension
+
+**Area:** Schema struct composition **Kind:** shape change **Our usage:** 27 sites in
+`notion-effect-schema`
+
+## Shape change first
+
+Effect 4 has no standalone `Schema.extend`. There are two replacements for the repository's
+current sites, depending on whether the right-hand schema is another struct or a record index
+signature.
+
+### Plain field merge
+
+For two plain structs, merge their fields explicitly:
+
+```ts
+Schema.extend(A, B)
+```
+
+becomes:
+
+```ts
+Schema.Struct({ ...A.fields, ...B.fields })
+```
+
+This is the same field merge used internally by the Effect 4 Class API's static `extend` method.
+It applies to plain `Struct` and `TaggedStruct` values; it does not require or create a Class.
+
+### Struct plus index signature
+
+For a struct extended with a record:
+
+```ts
+Schema.extend(BlockBase, Schema.Record(Schema.String, Schema.Unknown))
+```
+
+use:
+
+```ts
+Schema.StructWithRest(BlockBase, [Schema.Record(Schema.String, Schema.Unknown)])
+```
+
+`Schema.Record` returns `$Record`, not `Struct`. It has no `.fields` to spread. Treating it like a
+plain struct silently drops the index signature and changes excess-property decoding.
+
+## Not a replacement: `extendTo`
+
+Do not replace a plain merge with `Schema.extendTo`. `extendTo(fields, derive)` is a transforming
+schema operation: it computes derived fields from the original decoded input using
+`Option`-returning callbacks. It is not a struct merge.
+
+## Equivalence
+
+The two Effect 4 APIs and their implementation shapes were verified against the
+`effect@4.0.0-beta.102` tarball. The 27 `notion-effect-schema` sites were categorized as:
+
+- 23 plain `Struct` plus `TaggedStruct` field merges;
+- 2 plain `Struct` plus `Struct` field merges;
+- 2 `Struct` plus `Record` index-signature extensions;
+- 0 derived-field extensions.
+
+Owning slices must replay encoded baselines. For `StructWithRest`, include an input with an
+additional property and verify that decode and encode preserve the same key and bytes.
+
+## Gotchas
+
+- `Schema.Record(...).fields` is not a valid field merge; `Record` is not a `Struct`.
+- `Schema.extendTo` can typecheck while implementing different runtime behavior.
+- Field order follows object spread order. Preserve the original left-to-right extension order.
+- When both structs define the same key, the right-hand fields continue to win.
+
+## Codemod rule
+
+Only plain `Struct`/`TaggedStruct` pairs may use the field-spread rewrite. Every right-hand operand
+must be classified first. Record/index-signature operands require `StructWithRest`; Class and
+genuinely derived-field sites require separate adjudication.

--- a/context/effect-4/recipes/schema-transformations-issues.md
+++ b/context/effect-4/recipes/schema-transformations-issues.md
@@ -48,6 +48,32 @@ const NumberFromString = Schema.String.pipe(
 The source schema is piped into `decodeTo`; the target schema is its first argument. The old `strict`
 option is not copied.
 
+### Decode-only pure transformations
+
+When an unsupported encode callback only throws, its inferred return type is `never`. Do not leave
+the transformation's encoded type to inference: state both transformation types and annotate the
+throwing callback's return type.
+
+```ts
+const DecodeOnly = Schema.String.pipe(
+  Schema.decodeTo(
+    Target,
+    SchemaTransformation.transform<TargetType, string>({
+      decode: (input) => decodeInput(input),
+      encode: (_value): string => {
+        throw new Error('This codec only supports decoding')
+      },
+    }),
+  ),
+)
+```
+
+This explicit form is **VERIFIED** to compile against the
+`effect@4.0.0-beta.102` declarations and retains the encoded `string` contract. Prefer
+`transformOrFail` with a `SchemaIssue.Forbidden` failure when the old codec represented unsupported
+encoding in the typed error channel. Whether throwing or typed failure is faithful depends on the
+v3 call site; do not change that boundary merely to satisfy inference.
+
 ## Fallible transformations and issues
 
 ### v3
@@ -118,6 +144,34 @@ Use `Schema.refine(typeGuard)` when the callback narrows the TypeScript type. `m
 a string, a `SchemaIssue.Issue`, `{ path, issue }`, or an array of issues when error structure must be
 preserved.
 
+### Filter messages are no longer lazy
+
+V3 filter/refinement annotations accepted `message: () => string`. Beta.102
+`Annotations.Filter.message` is a plain `string`; there is no lazy annotation form. This is
+**VERIFIED** from the beta.102 declaration.
+
+For the repository's closures that return a constant string, preserve the text as a constant:
+
+```ts
+// v3
+Schema.filter(predicate, { message: () => 'must be valid' })
+
+// v4
+Schema.refine(predicate, { message: 'must be valid' })
+```
+
+Do not mechanically invoke a stateful or expensive closure while constructing the schema. That
+changes evaluation from failure-time to schema-construction-time. If narrowing is not required, a
+lazy failure string can instead be produced by the check itself:
+
+```ts
+Schema.check(Schema.makeFilter((value) => predicate(value) || message()))
+```
+
+That form does not preserve a type-guard narrowing. A stateful/expensive type-guard message
+therefore needs explicit design review; beta.102 has no direct replacement that preserves both
+narrowing and lazy message evaluation.
+
 ## Affected inventory
 
 The AST audit measured 27 `ParseResult` references in 15 files and 7 packages. The namespace-member
@@ -153,12 +207,16 @@ SHA-1 `f51092854960f60cbdb06bd59e788acbc8ee8492`.
 
 - `SchemaTransformation.transform` is only for pure, infallible conversions. Returning an `Effect`
   from it creates the wrong decoded value.
+- Give decode-only pure transformations explicit `<Type, Encoded>` parameters and an encoded return
+  annotation on a throwing callback; otherwise `never` can erase the intended direction.
 - `SchemaTransformation.transformOrFail` callbacks return `Effect`; throwing bypasses the typed issue
   channel.
 - `Schema.decodeUnknownEffect` exposes `SchemaError`, while transformation callbacks operate on
   `SchemaIssue.Issue`.
 - A formatter rewrite can change user-visible text even when decoding behavior is otherwise
   equivalent.
+- V4 filter annotation messages are eager strings. Only constant closures can be collapsed without
+  a timing/value review.
 
 ## Codemod rule
 

--- a/context/effect-4/recipes/schema-transformations-issues.md
+++ b/context/effect-4/recipes/schema-transformations-issues.md
@@ -48,6 +48,37 @@ const NumberFromString = Schema.String.pipe(
 The source schema is piped into `decodeTo`; the target schema is its first argument. The old `strict`
 option is not copied.
 
+### The transformation targets `To["Encoded"]`
+
+`Schema.decodeTo(To, transformation)` requires the transformation's decoded output to be
+`To["Encoded"]`, not `To["Type"]`. The target codec then decodes that encoded representation.
+Examples such as `NumberFromString`, where the target's `Type` and `Encoded` are both `number`, do
+not exercise this distinction.
+
+For a transformed target codec, produce its encoded representation by using the target's encoder
+instead of rebuilding its decoded value:
+
+```ts
+const Users = Schema.Array(User)
+const encodeUsers = Schema.encodeSync(Users)
+
+const People = PeopleProperty.pipe(
+  Schema.decodeTo(
+    Users,
+    SchemaTransformation.transform<typeof Users.Encoded, typeof PeopleProperty.Type>({
+      decode: (property) => encodeUsers(property.people),
+      encode: (_users): typeof PeopleProperty.Type => {
+        throw new Error('This codec only supports decoding')
+      },
+    }),
+  ),
+)
+```
+
+This contract is **VERIFIED** against the beta.102 `Schema.decodeTo` declaration. For transformed
+targets, typechecking is not sufficient: replay exact encoded bytes, especially for optional fields
+whose absent representation may be omitted or encoded as `null`.
+
 ### Decode-only pure transformations
 
 When an unsupported encode callback only throws, its inferred return type is `never`. Do not leave
@@ -73,6 +104,10 @@ This explicit form is **VERIFIED** to compile against the
 `transformOrFail` with a `SchemaIssue.Forbidden` failure when the old codec represented unsupported
 encoding in the typed error channel. Whether throwing or typed failure is faithful depends on the
 v3 call site; do not change that boundary merely to satisfy inference.
+
+One-directional codecs with deliberately throwing encoders are legitimate existing contracts. A
+successful encode can be a regression when the old boundary intentionally rejected that direction;
+preserve the throw and prove only the supported direction.
 
 ## Fallible transformations and issues
 

--- a/context/effect-4/recipes/sink-reduce.md
+++ b/context/effect-4/recipes/sink-reduce.md
@@ -1,0 +1,52 @@
+# Pattern: sink-reduce
+
+**Area:** Stream sinks **Kind:** constructor rename with evaluation-shape change **Our usage:**
+constant-memory git status line counters in `megarepo`.
+
+## v3
+
+```ts
+Sink.foldLeft<number, string>(0, (count, line) => (line.trim() === '' ? count : count + 1))
+```
+
+## v4
+
+```ts
+Sink.reduce<number, string>(
+  () => 0,
+  (count, line) => (line.trim() === '' ? count : count + 1),
+)
+```
+
+V4 `Sink.reduce` is the direct pure, consume-all-input replacement. Its initial state is a
+`LazyArg`, so the seed is supplied as a function.
+
+## Equivalence
+
+The constructor signatures are **VERIFIED** against the real tarballs. A cross-major stream probe
+over empty, non-empty, and whitespace-only strings produced the same final count (`2`).
+
+Both forms consume the entire stream, update once per element, retain no leftovers, and use
+constant accumulator memory.
+
+## Seed-evaluation trap
+
+V3 receives an already-evaluated seed. V4 evaluates its seed once per sink run. For a dynamic or
+effectful-looking expression, preserve v3 timing by hoisting:
+
+```ts
+const seed = makeSeed()
+const sink = Sink.reduce(() => seed, update)
+```
+
+Writing `Sink.reduce(() => makeSeed(), update)` intentionally changes construction-time evaluation
+into per-run evaluation and may create fresh mutable state.
+
+## Intended differences
+
+None.
+
+## Codemod rule
+
+`Sink.foldLeft(seed, update)` becomes `Sink.reduce(() => seed, update)`. Hoist non-trivial seed
+expressions first when their original evaluation timing matters.

--- a/context/effect-4/recipes/stream-text-decoding.md
+++ b/context/effect-4/recipes/stream-text-decoding.md
@@ -1,0 +1,54 @@
+# Pattern: stream-text-decoding
+
+**Area:** Stream byte decoding **Kind:** call-shape change **Our usage:** git/process stdout and
+stderr decoding in `megarepo`, `utils`, `utils-dev`, and `effect-ai-claude-cli`.
+
+## v3
+
+```ts
+bytes.pipe(Stream.decodeText('utf-8'))
+```
+
+## v4
+
+```ts
+bytes.pipe(Stream.decodeText({ encoding: 'utf-8' }))
+```
+
+The encoding moved from a positional string to an options object. The no-options UTF-8 forms remain:
+
+```ts
+bytes.pipe(Stream.decodeText)
+bytes.pipe(Stream.decodeText())
+```
+
+## Equivalence
+
+The beta.102 signature and TextDecoder implementation are **VERIFIED** against the real tarball. A
+cross-major probe split the four-byte UTF-8 encoding of `😀` across two `Uint8Array` chunks. Both
+majors emitted exactly:
+
+```json
+["A", "😀B"]
+```
+
+This proves the replacement retains streaming decoder state across chunk boundaries for the tested
+UTF-8 input. Owning process/CLI slices must compare complete stdout and stderr bytes separately,
+including malformed-sequence handling where relevant.
+
+## Intended differences
+
+None.
+
+## Gotchas
+
+- Do not drop a non-default encoding while fixing the call shape.
+- Constructing a new `TextDecoder` independently for every chunk corrupts multi-byte sequences
+  split across chunks. Keep the Stream decoder.
+- Text chunk boundaries are not a stable external contract; compare concatenated bytes/text unless
+  the application explicitly consumes chunking.
+
+## Codemod rule
+
+`Stream.decodeText(encoding)` becomes `Stream.decodeText({ encoding })`. Calls that pass the stream
+as the first argument become `Stream.decodeText(stream, { encoding })`.

--- a/context/effect-4/recipes/vitest-collection.md
+++ b/context/effect-4/recipes/vitest-collection.md
@@ -58,3 +58,34 @@ effect/FastCheck -> effect/testing/FastCheck
 ```
 
 Keep runner imports from `@effect/vitest`; do not rewrite them to `effect/testing`.
+
+## Scoped test methods: one axis disappeared
+
+V3 test methods varied on two independent axes:
+
+```text
+environment: TestEnv / test clock  <->  live services / real clock
+scope:       unscoped              <->  scoped
+```
+
+Beta.102 always provides a runner-owned `Scope`, so only the environment/clock axis remains:
+
+| v3              | v4          | Clock      | Scope    |
+| --------------- | ----------- | ---------- | -------- |
+| `it.scoped`     | `it.effect` | test clock | provided |
+| `it.scopedLive` | `it.live`   | real clock | provided |
+
+This is **VERIFIED** against the installed beta.102 declarations and implementation:
+
+- `MethodsNonLive.effect` is `Tester<R | Scope.Scope>` and runs `Effect.scoped` before providing
+  `TestEnv`;
+- `Methods.live` is `Tester<Scope.Scope>` and is built with `Effect.scoped`;
+- concrete `otelite` tests call effects requiring `Scope` under `it.live`.
+
+The migration is not “remove `scoped` wherever it appears.” Preserve the clock half:
+`scoped -> live` silently swaps the test clock for real time, while `scopedLive -> effect` silently
+does the reverse. Either can compile and then change timeout, sleep, retry, or scheduling behavior.
+
+For scoped test migrations, replay resource finalizer count/order and the timing behavior exercised
+by the test. A test that merely starts successfully proves neither clock selection nor scope
+teardown.

--- a/packages/@overeng/notion-effect-schema/src/common.ts
+++ b/packages/@overeng/notion-effect-schema/src/common.ts
@@ -196,11 +196,11 @@ export const shouldNeverHappen = (msg?: string, ...args: unknown[]): never => {
 // ---------------------------------------------------------------------------
 
 const getOptionValueSchema = <TValue, TInput, TContext>(
-  schema: Schema.Schema<Option.Option<TValue>, TInput, TContext>,
-): Schema.Schema<TValue, TValue, never> => {
-  const annotated = SchemaAST.resolveAt<Schema.Schema<TValue, TValue, never>>(optionValueSchema)(
-    schema.ast,
-  )
+  schema: Schema.Codec<Option.Option<TValue>, TInput, TContext, TContext>,
+): Schema.Codec<TValue, TValue, never, never> => {
+  const annotated = SchemaAST.resolveAt<Schema.Codec<TValue, TValue, never, never>>(
+    optionValueSchema,
+  )(schema.ast)
 
   if (Option.isSome(annotated) === true) {
     return annotated.value
@@ -212,9 +212,9 @@ const getOptionValueSchema = <TValue, TInput, TContext>(
 }
 
 const getOptionNameSchema = <TName extends string, TValue, TInput, TContext>(
-  schema: Schema.Schema<TValue, TInput, TContext>,
-): Schema.Schema<TName, TName, never> => {
-  const annotated = SchemaAST.resolveAt<Schema.Schema<TName, TName, never>>(optionNameSchema)(
+  schema: Schema.Codec<TValue, TInput, TContext, TContext>,
+): Schema.Codec<TName, TName, never, never> => {
+  const annotated = SchemaAST.resolveAt<Schema.Codec<TName, TName, never, never>>(optionNameSchema)(
     schema.ast,
   )
 
@@ -229,16 +229,16 @@ const getOptionNameSchema = <TName extends string, TValue, TInput, TContext>(
 
 /** Annotates an Option schema with its inner value schema for extraction */
 export const withOptionValueSchema = <TValue, TInput, TContext>(options: {
-  schema: Schema.Schema<Option.Option<TValue>, TInput, TContext>
-  valueSchema: Schema.Schema<TValue, TValue, never>
-}): Schema.Schema<Option.Option<TValue>, TInput, TContext> =>
+  schema: Schema.Codec<Option.Option<TValue>, TInput, TContext, TContext>
+  valueSchema: Schema.Codec<TValue, TValue, never, never>
+}): Schema.Codec<Option.Option<TValue>, TInput, TContext, TContext> =>
   options.schema.annotate({ [optionValueSchema]: options.valueSchema })
 
 /** Annotates a schema with the name schema for select/status option extraction */
 export const withOptionNameSchema = <TValue, TInput, TContext, TName extends string>(options: {
-  schema: Schema.Schema<TValue, TInput, TContext>
-  nameSchema: Schema.Schema<TName, TName, never>
-}): Schema.Schema<TValue, TInput, TContext> =>
+  schema: Schema.Codec<TValue, TInput, TContext, TContext>
+  nameSchema: Schema.Codec<TName, TName, never, never>
+}): Schema.Codec<TValue, TInput, TContext, TContext> =>
   options.schema.annotate({ [optionNameSchema]: options.nameSchema })
 
 /**
@@ -253,8 +253,8 @@ export const withOptionNameSchema = <TValue, TInput, TContext, TName extends str
  * Typed options are enforced via the upstream schema. Decode-only; use write helpers for updates.
  */
 export const asName = <TName extends string, TOption extends { name: TName }, TInput, TContext>(
-  schema: Schema.Schema<Option.Option<TOption>, TInput, TContext>,
-): Schema.Schema<Option.Option<TName>, TInput, TContext> => {
+  schema: Schema.Codec<Option.Option<TOption>, TInput, TContext, TContext>,
+): Schema.Codec<Option.Option<TName>, TInput, TContext, TContext> => {
   const nameSchema = getOptionNameSchema<TName, Option.Option<TOption>, TInput, TContext>(schema)
 
   return withOptionValueSchema({
@@ -282,8 +282,8 @@ export const asName = <TName extends string, TOption extends { name: TName }, TI
  * Typed options are enforced via the upstream schema. Decode-only; use write helpers for updates.
  */
 export const asNames = <TName extends string, TOption extends { name: TName }, TInput, TContext>(
-  schema: Schema.Schema<ReadonlyArray<TOption>, TInput, TContext>,
-): Schema.Schema<ReadonlyArray<TName>, TInput, TContext> => {
+  schema: Schema.Codec<ReadonlyArray<TOption>, TInput, TContext, TContext>,
+): Schema.Codec<ReadonlyArray<TName>, TInput, TContext, TContext> => {
   const nameSchema = getOptionNameSchema<TName, ReadonlyArray<TOption>, TInput, TContext>(schema)
 
   return Schema.transform(schema, Schema.Array(nameSchema), {
@@ -302,8 +302,8 @@ export const asNames = <TName extends string, TOption extends { name: TName }, T
  * Expects a schema created by notion-effect-schema Option helpers.
  */
 export const asNullable = <TValue, TInput, TContext>(
-  schema: Schema.Schema<Option.Option<TValue>, TInput, TContext>,
-): Schema.Schema<TValue | null, TInput, TContext> => {
+  schema: Schema.Codec<Option.Option<TValue>, TInput, TContext, TContext>,
+): Schema.Codec<TValue | null, TInput, TContext, TContext> => {
   const valueSchema = getOptionValueSchema(schema)
 
   return Schema.transform(schema, Schema.NullOr(valueSchema), {
@@ -318,8 +318,8 @@ export const Required = {
   some:
     (message = 'Value is required') =>
     <TValue, TInput, TOutputContext>(
-      schema: Schema.Schema<Option.Option<TValue>, TInput, TOutputContext>,
-    ): Schema.Schema<TValue, TInput, TOutputContext> => {
+      schema: Schema.Codec<Option.Option<TValue>, TInput, TOutputContext, TOutputContext>,
+    ): Schema.Codec<TValue, TInput, TOutputContext, TOutputContext> => {
       const valueSchema = getOptionValueSchema(schema)
       return Schema.transform(
         schema.pipe(
@@ -337,12 +337,12 @@ export const Required = {
     },
   nullable:
     <TValue, TContext>(options: {
-      valueSchema: Schema.Schema<TValue, TValue, TContext>
+      valueSchema: Schema.Codec<TValue, TValue, TContext, TContext>
       message?: string
     }) =>
     <TInput, TOutputContext>(
-      schema: Schema.Schema<TValue | null, TInput, TOutputContext>,
-    ): Schema.Schema<TValue, TInput, TContext | TOutputContext> => {
+      schema: Schema.Codec<TValue | null, TInput, TOutputContext, TOutputContext>,
+    ): Schema.Codec<TValue, TInput, TContext | TOutputContext, TContext | TOutputContext> => {
       const message = options.message ?? 'Value is required'
       return Schema.transform(
         schema.pipe(

--- a/packages/@overeng/notion-effect-schema/src/common.ts
+++ b/packages/@overeng/notion-effect-schema/src/common.ts
@@ -1,4 +1,4 @@
-import { Option, Schema } from 'effect'
+import { Option, Schema, SchemaTransformation } from 'effect'
 import * as SchemaAST from 'effect/SchemaAST'
 
 import {
@@ -102,7 +102,7 @@ export type ISO8601DateTime = typeof ISO8601DateTime.Type
  *
  * @see https://developers.notion.com/reference/rich-text#the-annotation-object
  */
-export const NotionColor = Schema.Literal(...NOTION_COLORS).annotate({
+export const NotionColor = Schema.Literals(NOTION_COLORS).annotate({
   identifier: 'Notion.Color',
   title: 'Notion Color',
   description: 'Color values used for text annotations and backgrounds.',
@@ -116,7 +116,7 @@ export type NotionColor = typeof NotionColor.Type
  *
  * @see https://developers.notion.com/reference/property-value-object#select
  */
-export const SelectColor = Schema.Literal(...SELECT_COLORS).annotate({
+export const SelectColor = Schema.Literals(SELECT_COLORS).annotate({
   identifier: 'Notion.SelectColor',
   title: 'Select Color',
   description: 'Color values used for select and multi-select options.',
@@ -132,7 +132,7 @@ export type SelectColor = typeof SelectColor.Type
  *
  * @see https://developers.notion.com/reference/icon-object
  */
-export const NoticonColor = Schema.Literal(...NOTICON_COLORS).annotate({
+export const NoticonColor = Schema.Literals(NOTICON_COLORS).annotate({
   identifier: 'Notion.NoticonColor',
   title: 'Noticon Color',
   description: 'Color values used for native Notion icons (noticons).',
@@ -258,14 +258,18 @@ export const asName = <TName extends string, TOption extends { name: TName }, TI
   const nameSchema = getOptionNameSchema<TName, Option.Option<TOption>, TInput, TContext>(schema)
 
   return withOptionValueSchema({
-    schema: Schema.transform(schema, Schema.OptionFromSelf(nameSchema), {
-      strict: false,
-      decode: (opt) => Option.map(opt, (value) => value.name),
-      encode: () =>
-        shouldNeverHappen(
-          'NotionSchema.asName encode is not supported. Use the write helpers for updates.',
-        ),
-    }),
+    schema: schema.pipe(
+      Schema.decodeTo(
+        Schema.Option(nameSchema),
+        SchemaTransformation.transform({
+          decode: (opt) => Option.map(opt, (value) => value.name),
+          encode: () =>
+            shouldNeverHappen(
+              'NotionSchema.asName encode is not supported. Use the write helpers for updates.',
+            ),
+        }),
+      ),
+    ),
     valueSchema: nameSchema,
   })
 }
@@ -286,14 +290,18 @@ export const asNames = <TName extends string, TOption extends { name: TName }, T
 ): Schema.Codec<ReadonlyArray<TName>, TInput, TContext, TContext> => {
   const nameSchema = getOptionNameSchema<TName, ReadonlyArray<TOption>, TInput, TContext>(schema)
 
-  return Schema.transform(schema, Schema.Array(nameSchema), {
-    strict: false,
-    decode: (options) => options.map((option) => option.name),
-    encode: () =>
-      shouldNeverHappen(
-        'NotionSchema.asNames encode is not supported. Use the write helpers for updates.',
-      ),
-  })
+  return schema.pipe(
+    Schema.decodeTo(
+      Schema.Array(nameSchema),
+      SchemaTransformation.transform({
+        decode: (options) => options.map((option) => option.name),
+        encode: () =>
+          shouldNeverHappen(
+            'NotionSchema.asNames encode is not supported. Use the write helpers for updates.',
+          ),
+      }),
+    ),
+  )
 }
 
 /**
@@ -306,11 +314,15 @@ export const asNullable = <TValue, TInput, TContext>(
 ): Schema.Codec<TValue | null, TInput, TContext, TContext> => {
   const valueSchema = getOptionValueSchema(schema)
 
-  return Schema.transform(schema, Schema.NullOr(valueSchema), {
-    strict: false,
-    decode: (opt) => Option.getOrNull(opt),
-    encode: (value) => (value === null ? Option.none() : Option.some(value)),
-  })
+  return schema.pipe(
+    Schema.decodeTo(
+      Schema.NullOr(valueSchema),
+      SchemaTransformation.transform({
+        decode: (opt) => Option.getOrNull(opt),
+        encode: (value) => (value === null ? Option.none() : Option.some(value)),
+      }),
+    ),
+  )
 }
 
 /** Helpers for making Option/nullable values required */
@@ -321,19 +333,21 @@ export const Required = {
       schema: Schema.Codec<Option.Option<TValue>, TInput, TOutputContext, TOutputContext>,
     ): Schema.Codec<TValue, TInput, TOutputContext, TOutputContext> => {
       const valueSchema = getOptionValueSchema(schema)
-      return Schema.transform(
-        schema.pipe(
-          Schema.filter((opt): opt is Option.Some<TValue> => Option.isSome(opt), {
+      return schema
+        .pipe(
+          Schema.refine((opt): opt is Option.Some<TValue> => Option.isSome(opt), {
             message: () => message,
           }),
-        ),
-        valueSchema,
-        {
-          strict: false,
-          decode: (opt) => Option.getOrThrow(opt),
-          encode: (value) => Option.some(value),
-        },
-      )
+        )
+        .pipe(
+          Schema.decodeTo(
+            valueSchema,
+            SchemaTransformation.transform({
+              decode: (opt) => Option.getOrThrow(opt),
+              encode: (value) => Option.some(value),
+            }),
+          ),
+        )
     },
   nullable:
     <TValue, TContext>(options: {
@@ -344,18 +358,17 @@ export const Required = {
       schema: Schema.Codec<TValue | null, TInput, TOutputContext, TOutputContext>,
     ): Schema.Codec<TValue, TInput, TContext | TOutputContext, TContext | TOutputContext> => {
       const message = options.message ?? 'Value is required'
-      return Schema.transform(
-        schema.pipe(
-          Schema.filter((value): value is TValue => value !== null, {
+      return schema
+        .pipe(
+          Schema.refine((value): value is TValue => value !== null, {
             message: () => message,
           }),
-        ),
-        options.valueSchema,
-        {
-          strict: false,
-          decode: (value) => value,
-          encode: (value) => value,
-        },
-      )
+        )
+        .pipe(
+          Schema.decodeTo(
+            options.valueSchema,
+            SchemaTransformation.transform({ decode: (value) => value, encode: (value) => value }),
+          ),
+        )
     },
 } as const

--- a/packages/@overeng/notion-effect-schema/src/common.ts
+++ b/packages/@overeng/notion-effect-schema/src/common.ts
@@ -198,12 +198,15 @@ export const shouldNeverHappen = (msg?: string, ...args: unknown[]): never => {
 const getOptionValueSchema = <TValue, TInput, TContext>(
   schema: Schema.Codec<Option.Option<TValue>, TInput, TContext, TContext>,
 ): Schema.Codec<TValue, TValue, never, never> => {
-  const annotated = SchemaAST.resolveAt<Schema.Codec<TValue, TValue, never, never>>(
-    optionValueSchema,
-  )(schema.ast)
+  const annotations = SchemaAST.resolve(schema.ast) as
+    | { readonly [key: symbol]: unknown }
+    | undefined
+  const annotated = annotations?.[optionValueSchema] as
+    | Schema.Codec<TValue, TValue, never, never>
+    | undefined
 
-  if (Option.isSome(annotated) === true) {
-    return annotated.value
+  if (annotated !== undefined) {
+    return annotated
   }
 
   return shouldNeverHappen(
@@ -214,12 +217,15 @@ const getOptionValueSchema = <TValue, TInput, TContext>(
 const getOptionNameSchema = <TName extends string, TValue, TInput, TContext>(
   schema: Schema.Codec<TValue, TInput, TContext, TContext>,
 ): Schema.Codec<TName, TName, never, never> => {
-  const annotated = SchemaAST.resolveAt<Schema.Codec<TName, TName, never, never>>(optionNameSchema)(
-    schema.ast,
-  )
+  const annotations = SchemaAST.resolve(schema.ast) as
+    | { readonly [key: symbol]: unknown }
+    | undefined
+  const annotated = annotations?.[optionNameSchema] as
+    | Schema.Codec<TName, TName, never, never>
+    | undefined
 
-  if (Option.isSome(annotated) === true) {
-    return annotated.value
+  if (annotated !== undefined) {
+    return annotated
   }
 
   return shouldNeverHappen(
@@ -261,9 +267,9 @@ export const asName = <TName extends string, TOption extends { name: TName }, TI
     schema: schema.pipe(
       Schema.decodeTo(
         Schema.Option(nameSchema),
-        SchemaTransformation.transform({
+        SchemaTransformation.transform<Option.Option<TName>, Option.Option<TOption>>({
           decode: (opt) => Option.map(opt, (value) => value.name),
-          encode: () =>
+          encode: (): Option.Option<TOption> =>
             shouldNeverHappen(
               'NotionSchema.asName encode is not supported. Use the write helpers for updates.',
             ),
@@ -293,9 +299,9 @@ export const asNames = <TName extends string, TOption extends { name: TName }, T
   return schema.pipe(
     Schema.decodeTo(
       Schema.Array(nameSchema),
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<ReadonlyArray<TName>, ReadonlyArray<TOption>>({
         decode: (options) => options.map((option) => option.name),
-        encode: () =>
+        encode: (): ReadonlyArray<TOption> =>
           shouldNeverHappen(
             'NotionSchema.asNames encode is not supported. Use the write helpers for updates.',
           ),
@@ -336,15 +342,21 @@ export const Required = {
       return schema
         .pipe(
           Schema.refine((opt): opt is Option.Some<TValue> => Option.isSome(opt), {
-            message: () => message,
+            message,
           }),
         )
         .pipe(
           Schema.decodeTo(
             valueSchema,
-            SchemaTransformation.transform({
+            SchemaTransformation.transform<TValue, Option.Some<TValue>>({
               decode: (opt) => Option.getOrThrow(opt),
-              encode: (value) => Option.some(value),
+              encode: (value): Option.Some<TValue> => {
+                const option = Option.some(value)
+                if (Option.isSome(option) === true) {
+                  return option
+                }
+                return shouldNeverHappen('Option.some unexpectedly returned None.')
+              },
             }),
           ),
         )
@@ -361,13 +373,16 @@ export const Required = {
       return schema
         .pipe(
           Schema.refine((value): value is TValue => value !== null, {
-            message: () => message,
+            message,
           }),
         )
         .pipe(
           Schema.decodeTo(
             options.valueSchema,
-            SchemaTransformation.transform({ decode: (value) => value, encode: (value) => value }),
+            SchemaTransformation.transform<TValue, TValue>({
+              decode: (value) => value,
+              encode: (value) => value,
+            }),
           ),
         )
     },

--- a/packages/@overeng/notion-effect-schema/src/mod.ts
+++ b/packages/@overeng/notion-effect-schema/src/mod.ts
@@ -119,9 +119,9 @@ export type { DateValue } from './properties/date.ts'
  */
 function select(): typeof Select.asOption
 function select<TName extends string>(
-  nameSchema: Schema.Schema<TName>,
+  nameSchema: Schema.Codec<TName>,
 ): ReturnType<typeof Select.asOptionNamed<TName>>
-function select<TName extends string>(nameSchema?: Schema.Schema<TName>) {
+function select<TName extends string>(nameSchema?: Schema.Codec<TName>) {
   return nameSchema !== undefined ? Select.asOptionNamed(nameSchema) : Select.asOption
 }
 
@@ -132,9 +132,9 @@ function select<TName extends string>(nameSchema?: Schema.Schema<TName>) {
  */
 function status(): typeof Status.asOption
 function status<TName extends string>(
-  nameSchema: Schema.Schema<TName>,
+  nameSchema: Schema.Codec<TName>,
 ): ReturnType<typeof Status.asOptionNamed<TName>>
-function status<TName extends string>(nameSchema?: Schema.Schema<TName>) {
+function status<TName extends string>(nameSchema?: Schema.Codec<TName>) {
   return nameSchema !== undefined ? Status.asOptionNamed(nameSchema) : Status.asOption
 }
 
@@ -145,9 +145,9 @@ function status<TName extends string>(nameSchema?: Schema.Schema<TName>) {
  */
 function multiSelect(): typeof MultiSelect.raw
 function multiSelect<TName extends string>(
-  nameSchema: Schema.Schema<TName>,
+  nameSchema: Schema.Codec<TName>,
 ): ReturnType<typeof MultiSelect.asOptionsNamed<TName>>
-function multiSelect<TName extends string>(nameSchema?: Schema.Schema<TName>) {
+function multiSelect<TName extends string>(nameSchema?: Schema.Codec<TName>) {
   return nameSchema !== undefined ? MultiSelect.asOptionsNamed(nameSchema) : MultiSelect.raw
 }
 

--- a/packages/@overeng/notion-effect-schema/src/objects.ts
+++ b/packages/@overeng/notion-effect-schema/src/objects.ts
@@ -312,13 +312,13 @@ export const Page = Schema.Struct({
 export type Page = typeof Page.Type
 
 /** Single property item returned by `GET /v1/pages/{page_id}/properties/{property_id}` — schema mirrors the Notion API page-property item object. */
-export const PagePropertyItem = Schema.extend(
+export const PagePropertyItem = Schema.StructWithRest(
   Schema.Struct({
     object: Schema.Literal('property_item'),
     id: Schema.String,
     type: Schema.String,
   }),
-  Schema.Record(Schema.String, Schema.Unknown),
+  [Schema.Record(Schema.String, Schema.Unknown)],
 ).annotate({
   identifier: 'Notion.PagePropertyItem',
   [docsPath]: 'page-property-item',
@@ -424,10 +424,9 @@ const BlockBase = Schema.Struct({
  *
  * @see https://developers.notion.com/reference/block
  */
-export const Block = Schema.extend(
-  BlockBase,
+export const Block = Schema.StructWithRest(BlockBase, [
   Schema.Record(Schema.String, Schema.Unknown),
-).annotate({
+]).annotate({
   identifier: 'Notion.Block',
   [docsPath]: 'block',
 })

--- a/packages/@overeng/notion-effect-schema/src/objects.ts
+++ b/packages/@overeng/notion-effect-schema/src/objects.ts
@@ -449,7 +449,7 @@ const RichTextBlockCreateContent = Schema.Struct({
   rich_text: RichTextCreateArray,
 })
 
-const RichTextBlockCreateContentWithChildren: Schema.Schema<RichTextBlockCreateContentWithChildrenType> =
+const RichTextBlockCreateContentWithChildren: Schema.Codec<RichTextBlockCreateContentWithChildrenType> =
   Schema.suspend(() =>
     Schema.Struct({
       rich_text: RichTextCreateArray,
@@ -493,7 +493,7 @@ const NumberedListItemBlockCreate = Schema.Struct({
   numbered_list_item: RichTextBlockCreateContentWithChildren,
 })
 
-const ToDoBlockCreate: Schema.Schema<
+const ToDoBlockCreate: Schema.Codec<
   BlockCreatePayload<'to_do', 'to_do', ToDoBlockCreateContentType>
 > = Schema.suspend(() =>
   Schema.Struct({
@@ -593,7 +593,7 @@ type NotionBlockCreateType =
  * This is intentionally narrower than the read-side `Block` schema: create
  * payloads omit ids, timestamps, parents, and other server-populated fields.
  */
-export const NotionBlockCreate: Schema.Schema<NotionBlockCreateType> = Schema.suspend(() =>
+export const NotionBlockCreate: Schema.Codec<NotionBlockCreateType> = Schema.suspend(() =>
   Schema.Union([
     ParagraphBlockCreate,
     Heading1BlockCreate,

--- a/packages/@overeng/notion-effect-schema/src/properties.unit.test.ts
+++ b/packages/@overeng/notion-effect-schema/src/properties.unit.test.ts
@@ -34,7 +34,7 @@ Vitest.describe('Title', () => {
   Vitest.describe('NotionSchema.title', () => {
     Vitest.it.effect('decodes title property to string', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.title)(sampleTitleProperty)
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.title)(sampleTitleProperty)
         expect(result).toBe('Hello World')
       }),
     )
@@ -42,7 +42,7 @@ Vitest.describe('Title', () => {
     Vitest.it.effect('handles empty title array', () =>
       Effect.gen(function* () {
         const emptyTitle = { ...sampleTitleProperty, title: [] }
-        const result = yield* Schema.decodeUnknown(NotionSchema.title)(emptyTitle)
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.title)(emptyTitle)
         expect(result).toBe('')
       }),
     )
@@ -82,7 +82,7 @@ Vitest.describe('Title', () => {
             },
           ],
         }
-        const result = yield* Schema.decodeUnknown(NotionSchema.title)(multiSegment)
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.title)(multiSegment)
         expect(result).toBe('Hello World')
       }),
     )
@@ -91,7 +91,9 @@ Vitest.describe('Title', () => {
   Vitest.describe('NotionSchema.titleWriteFromString', () => {
     Vitest.it.effect('encodes string to title write payload', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.titleWriteFromString)('Test Title')
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.titleWriteFromString)(
+          'Test Title',
+        )
         expect(result).toEqual({
           title: [{ type: 'text', text: { content: 'Test Title' } }],
         })
@@ -101,15 +103,17 @@ Vitest.describe('Title', () => {
     Vitest.it.effect('roundtrip: encode and decode', () =>
       Effect.gen(function* () {
         const original = 'My Page Title'
-        const encoded = yield* Schema.decodeUnknown(NotionSchema.titleWriteFromString)(original)
-        const decoded = yield* Schema.encode(NotionSchema.titleWriteFromString)(encoded)
+        const encoded = yield* Schema.decodeUnknownEffect(NotionSchema.titleWriteFromString)(
+          original,
+        )
+        const decoded = yield* Schema.encodeEffect(NotionSchema.titleWriteFromString)(encoded)
         expect(decoded).toBe(original)
       }),
     )
 
     Vitest.it.effect('handles empty string', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.titleWriteFromString)('')
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.titleWriteFromString)('')
         expect(result).toEqual({
           title: [{ type: 'text', text: { content: '' } }],
         })
@@ -123,7 +127,7 @@ Vitest.describe('Title', () => {
         const payload = {
           title: [{ type: 'text' as const, text: { content: 'Test' } }],
         }
-        const result = yield* Schema.decodeUnknown(NotionSchema.titleWrite)(payload)
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.titleWrite)(payload)
         expect(result).toEqual(payload)
       }),
     )
@@ -141,7 +145,7 @@ Vitest.describe('Title', () => {
             },
           ],
         }
-        const result = yield* Schema.decodeUnknown(NotionSchema.titleWrite)(payload)
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.titleWrite)(payload)
         expect(result).toEqual(payload)
       }),
     )
@@ -177,7 +181,7 @@ Vitest.describe('RichText Property', () => {
   Vitest.describe('NotionSchema.richTextString', () => {
     Vitest.it.effect('decodes rich text property to string', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.richTextString)(
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.richTextString)(
           sampleRichTextProperty,
         )
         expect(result).toBe('Sample text')
@@ -188,7 +192,7 @@ Vitest.describe('RichText Property', () => {
   Vitest.describe('NotionSchema.richTextOption', () => {
     Vitest.it.effect('returns Some for non-empty text', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.richTextOption)(
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.richTextOption)(
           sampleRichTextProperty,
         )
         expect(Option.isSome(result)).toBe(true)
@@ -199,7 +203,7 @@ Vitest.describe('RichText Property', () => {
     Vitest.it.effect('returns None for empty text', () =>
       Effect.gen(function* () {
         const emptyProp = { ...sampleRichTextProperty, rich_text: [] }
-        const result = yield* Schema.decodeUnknown(NotionSchema.richTextOption)(emptyProp)
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.richTextOption)(emptyProp)
         expect(Option.isNone(result)).toBe(true)
       }),
     )
@@ -225,7 +229,9 @@ Vitest.describe('RichText Property', () => {
             },
           ],
         }
-        const result = yield* Schema.decodeUnknown(NotionSchema.richTextOption)(whitespaceProp)
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.richTextOption)(
+          whitespaceProp,
+        )
         expect(Option.isNone(result)).toBe(true)
       }),
     )
@@ -234,7 +240,7 @@ Vitest.describe('RichText Property', () => {
   Vitest.describe('NotionSchema.richTextWriteFromString', () => {
     Vitest.it.effect('encodes string to rich text write payload', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.richTextWriteFromString)(
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.richTextWriteFromString)(
           'Test content',
         )
         expect(result).toEqual({
@@ -246,8 +252,10 @@ Vitest.describe('RichText Property', () => {
     Vitest.it.effect('roundtrip: encode and decode', () =>
       Effect.gen(function* () {
         const original = 'Some text content'
-        const encoded = yield* Schema.decodeUnknown(NotionSchema.richTextWriteFromString)(original)
-        const decoded = yield* Schema.encode(NotionSchema.richTextWriteFromString)(encoded)
+        const encoded = yield* Schema.decodeUnknownEffect(NotionSchema.richTextWriteFromString)(
+          original,
+        )
+        const decoded = yield* Schema.encodeEffect(NotionSchema.richTextWriteFromString)(encoded)
         expect(decoded).toBe(original)
       }),
     )
@@ -256,7 +264,7 @@ Vitest.describe('RichText Property', () => {
   Vitest.describe('NotionSchema.richTextNonEmpty', () => {
     Vitest.it.effect('returns string for non-empty text', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.richTextNonEmpty)(
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.richTextNonEmpty)(
           sampleRichTextProperty,
         )
         expect(result).toBe('Sample text')
@@ -266,9 +274,9 @@ Vitest.describe('RichText Property', () => {
     Vitest.it.effect('fails for empty text', () =>
       Effect.gen(function* () {
         const emptyProp = { ...sampleRichTextProperty, rich_text: [] }
-        const result = yield* Schema.decodeUnknown(NotionSchema.richTextNonEmpty)(emptyProp).pipe(
-          Effect.either,
-        )
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.richTextNonEmpty)(
+          emptyProp,
+        ).pipe(Effect.either)
         expect(result._tag).toBe('Left')
       }),
     )
@@ -295,16 +303,16 @@ Vitest.describe('Number Property', () => {
   Vitest.describe('NotionSchema.number', () => {
     Vitest.it.effect('decodes non-null number', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.number)(sampleNumberProperty)
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.number)(sampleNumberProperty)
         expect(result).toBe(42)
       }),
     )
 
     Vitest.it.effect('fails on null number', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.number)(nullNumberProperty).pipe(
-          Effect.flip,
-        )
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.number)(
+          nullNumberProperty,
+        ).pipe(Effect.flip)
         expect(result).toBeDefined()
       }),
     )
@@ -312,7 +320,7 @@ Vitest.describe('Number Property', () => {
     Vitest.it.effect('decodes decimal numbers', () =>
       Effect.gen(function* () {
         const decimalProp = { ...sampleNumberProperty, number: 3.14 }
-        const result = yield* Schema.decodeUnknown(NotionSchema.number)(decimalProp)
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.number)(decimalProp)
         expect(result).toBe(3.14)
       }),
     )
@@ -321,7 +329,9 @@ Vitest.describe('Number Property', () => {
   Vitest.describe('NotionSchema.numberOption', () => {
     Vitest.it.effect('returns Some for non-null number', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.numberOption)(sampleNumberProperty)
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.numberOption)(
+          sampleNumberProperty,
+        )
         expect(Option.isSome(result)).toBe(true)
         expect(Option.getOrNull(result)).toBe(42)
       }),
@@ -329,7 +339,9 @@ Vitest.describe('Number Property', () => {
 
     Vitest.it.effect('returns None for null number', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.numberOption)(nullNumberProperty)
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.numberOption)(
+          nullNumberProperty,
+        )
         expect(Option.isNone(result)).toBe(true)
       }),
     )
@@ -338,14 +350,14 @@ Vitest.describe('Number Property', () => {
   Vitest.describe('NotionSchema.numberWriteFromNumber', () => {
     Vitest.it.effect('encodes number to write payload', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.numberWriteFromNumber)(100)
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.numberWriteFromNumber)(100)
         expect(result).toEqual({ number: 100 })
       }),
     )
 
     Vitest.it.effect('encodes null to write payload', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.numberWriteFromNumber)(null)
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.numberWriteFromNumber)(null)
         expect(result).toEqual({ number: null })
       }),
     )
@@ -353,8 +365,10 @@ Vitest.describe('Number Property', () => {
     Vitest.it.effect('roundtrip: encode and decode', () =>
       Effect.gen(function* () {
         const original = 99
-        const encoded = yield* Schema.decodeUnknown(NotionSchema.numberWriteFromNumber)(original)
-        const decoded = yield* Schema.encode(NotionSchema.numberWriteFromNumber)(encoded)
+        const encoded = yield* Schema.decodeUnknownEffect(NotionSchema.numberWriteFromNumber)(
+          original,
+        )
+        const decoded = yield* Schema.encodeEffect(NotionSchema.numberWriteFromNumber)(encoded)
         expect(decoded).toBe(original)
       }),
     )
@@ -381,14 +395,14 @@ Vitest.describe('Checkbox Property', () => {
   Vitest.describe('NotionSchema.checkbox', () => {
     Vitest.it.effect('decodes checked checkbox', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.checkbox)(checkedProperty)
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.checkbox)(checkedProperty)
         expect(result).toBe(true)
       }),
     )
 
     Vitest.it.effect('decodes unchecked checkbox', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.checkbox)(uncheckedProperty)
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.checkbox)(uncheckedProperty)
         expect(result).toBe(false)
       }),
     )
@@ -397,14 +411,18 @@ Vitest.describe('Checkbox Property', () => {
   Vitest.describe('NotionSchema.checkboxWriteFromBoolean', () => {
     Vitest.it.effect('encodes true to write payload', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.checkboxWriteFromBoolean)(true)
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.checkboxWriteFromBoolean)(
+          true,
+        )
         expect(result).toEqual({ checkbox: true })
       }),
     )
 
     Vitest.it.effect('encodes false to write payload', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.checkboxWriteFromBoolean)(false)
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.checkboxWriteFromBoolean)(
+          false,
+        )
         expect(result).toEqual({ checkbox: false })
       }),
     )
@@ -412,8 +430,10 @@ Vitest.describe('Checkbox Property', () => {
     Vitest.it.effect('roundtrip: encode and decode', () =>
       Effect.gen(function* () {
         const original = true
-        const encoded = yield* Schema.decodeUnknown(NotionSchema.checkboxWriteFromBoolean)(original)
-        const decoded = yield* Schema.encode(NotionSchema.checkboxWriteFromBoolean)(encoded)
+        const encoded = yield* Schema.decodeUnknownEffect(NotionSchema.checkboxWriteFromBoolean)(
+          original,
+        )
+        const decoded = yield* Schema.encodeEffect(NotionSchema.checkboxWriteFromBoolean)(encoded)
         expect(decoded).toBe(original)
       }),
     )
@@ -444,7 +464,7 @@ Vitest.describe('Select Property', () => {
   Vitest.describe('NotionSchema.select', () => {
     Vitest.it.effect('returns Some with option', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.select())(selectedProperty)
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.select())(selectedProperty)
         expect(Option.isSome(result)).toBe(true)
         expect(Option.getOrNull(result)?.name).toBe('High')
       }),
@@ -452,7 +472,7 @@ Vitest.describe('Select Property', () => {
 
     Vitest.it.effect('returns None for null select', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.select())(nullSelectProperty)
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.select())(nullSelectProperty)
         expect(Option.isNone(result)).toBe(true)
       }),
     )
@@ -463,7 +483,7 @@ Vitest.describe('Select Property', () => {
 
     Vitest.it.effect('returns Some with allowed name', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(
+        const result = yield* Schema.decodeUnknownEffect(
           NotionSchema.select(Allowed).pipe(NotionSchema.asName),
         )(selectedProperty)
         expect(Option.isSome(result)).toBe(true)
@@ -477,7 +497,7 @@ Vitest.describe('Select Property', () => {
           ...selectedProperty,
           select: { ...selectedProperty.select, name: 'Medium' },
         }
-        const result = yield* Schema.decodeUnknown(
+        const result = yield* Schema.decodeUnknownEffect(
           NotionSchema.select(Allowed).pipe(NotionSchema.asName),
         )(invalidProperty).pipe(Effect.either)
         expect(result._tag).toBe('Left')
@@ -488,7 +508,7 @@ Vitest.describe('Select Property', () => {
   Vitest.describe('NotionSchema.select(...).pipe(NotionSchema.asNullable)', () => {
     Vitest.it.effect('returns option for selected property', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(
+        const result = yield* Schema.decodeUnknownEffect(
           NotionSchema.select().pipe(NotionSchema.asNullable),
         )(selectedProperty)
         expect(result?.name).toBe('High')
@@ -497,7 +517,7 @@ Vitest.describe('Select Property', () => {
 
     Vitest.it.effect('returns null for null select', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(
+        const result = yield* Schema.decodeUnknownEffect(
           NotionSchema.select().pipe(NotionSchema.asNullable),
         )(nullSelectProperty)
         expect(result).toBeNull()
@@ -508,14 +528,14 @@ Vitest.describe('Select Property', () => {
   Vitest.describe('NotionSchema.selectWriteFromName', () => {
     Vitest.it.effect('encodes option name to write payload', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.selectWriteFromName)('Medium')
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.selectWriteFromName)('Medium')
         expect(result).toEqual({ select: { name: 'Medium' } })
       }),
     )
 
     Vitest.it.effect('encodes null to write payload', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.selectWriteFromName)(null)
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.selectWriteFromName)(null)
         expect(result).toEqual({ select: null })
       }),
     )
@@ -523,8 +543,10 @@ Vitest.describe('Select Property', () => {
     Vitest.it.effect('roundtrip: encode and decode', () =>
       Effect.gen(function* () {
         const original = 'Low'
-        const encoded = yield* Schema.decodeUnknown(NotionSchema.selectWriteFromName)(original)
-        const decoded = yield* Schema.encode(NotionSchema.selectWriteFromName)(encoded)
+        const encoded = yield* Schema.decodeUnknownEffect(NotionSchema.selectWriteFromName)(
+          original,
+        )
+        const decoded = yield* Schema.encodeEffect(NotionSchema.selectWriteFromName)(encoded)
         expect(decoded).toBe(original)
       }),
     )
@@ -554,7 +576,9 @@ Vitest.describe('MultiSelect Property', () => {
   Vitest.describe('NotionSchema.multiSelect', () => {
     Vitest.it.effect('decodes to array of options', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.multiSelect())(multiSelectProperty)
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.multiSelect())(
+          multiSelectProperty,
+        )
         expect(result).toHaveLength(2)
         expect(result[0]?.name).toBe('Tag1')
       }),
@@ -562,7 +586,7 @@ Vitest.describe('MultiSelect Property', () => {
 
     Vitest.it.effect('handles empty array', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.multiSelect())(
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.multiSelect())(
           emptyMultiSelectProperty,
         )
         expect(result).toEqual([])
@@ -575,7 +599,7 @@ Vitest.describe('MultiSelect Property', () => {
 
     Vitest.it.effect('decodes to array of allowed names', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(
+        const result = yield* Schema.decodeUnknownEffect(
           NotionSchema.multiSelect(Allowed).pipe(NotionSchema.asNames),
         )(multiSelectProperty)
         expect(result).toEqual(['Tag1', 'Tag2'])
@@ -588,7 +612,7 @@ Vitest.describe('MultiSelect Property', () => {
           ...multiSelectProperty,
           multi_select: [{ ...multiSelectProperty.multi_select[0], name: 'Tag3' }],
         }
-        const result = yield* Schema.decodeUnknown(
+        const result = yield* Schema.decodeUnknownEffect(
           NotionSchema.multiSelect(Allowed).pipe(NotionSchema.asNames),
         )(invalidProperty).pipe(Effect.either)
         expect(result._tag).toBe('Left')
@@ -599,7 +623,7 @@ Vitest.describe('MultiSelect Property', () => {
   Vitest.describe('NotionSchema.multiSelectWriteFromNames', () => {
     Vitest.it.effect('encodes names to write payload', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.multiSelectWriteFromNames)([
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.multiSelectWriteFromNames)([
           'A',
           'B',
           'C',
@@ -612,7 +636,7 @@ Vitest.describe('MultiSelect Property', () => {
 
     Vitest.it.effect('handles empty array', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.multiSelectWriteFromNames)([])
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.multiSelectWriteFromNames)([])
         expect(result).toEqual({ multi_select: [] })
       }),
     )
@@ -620,10 +644,10 @@ Vitest.describe('MultiSelect Property', () => {
     Vitest.it.effect('roundtrip: encode and decode', () =>
       Effect.gen(function* () {
         const original = ['X', 'Y', 'Z']
-        const encoded = yield* Schema.decodeUnknown(NotionSchema.multiSelectWriteFromNames)(
+        const encoded = yield* Schema.decodeUnknownEffect(NotionSchema.multiSelectWriteFromNames)(
           original,
         )
-        const decoded = yield* Schema.encode(NotionSchema.multiSelectWriteFromNames)(encoded)
+        const decoded = yield* Schema.encodeEffect(NotionSchema.multiSelectWriteFromNames)(encoded)
         expect(decoded).toEqual(original)
       }),
     )
@@ -654,7 +678,7 @@ Vitest.describe('Status Property', () => {
   Vitest.describe('NotionSchema.status', () => {
     Vitest.it.effect('returns Some with status option', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.status())(statusProperty)
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.status())(statusProperty)
         expect(Option.isSome(result)).toBe(true)
         expect(Option.getOrNull(result)?.name).toBe('In Progress')
       }),
@@ -662,7 +686,7 @@ Vitest.describe('Status Property', () => {
 
     Vitest.it.effect('returns None for null status', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.status())(nullStatusProperty)
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.status())(nullStatusProperty)
         expect(Option.isNone(result)).toBe(true)
       }),
     )
@@ -673,7 +697,7 @@ Vitest.describe('Status Property', () => {
 
     Vitest.it.effect('returns Some with allowed status name', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(
+        const result = yield* Schema.decodeUnknownEffect(
           NotionSchema.status(Allowed).pipe(NotionSchema.asName),
         )(statusProperty)
         expect(Option.isSome(result)).toBe(true)
@@ -687,7 +711,7 @@ Vitest.describe('Status Property', () => {
           ...statusProperty,
           status: { ...statusProperty.status, name: 'Done' },
         }
-        const result = yield* Schema.decodeUnknown(
+        const result = yield* Schema.decodeUnknownEffect(
           NotionSchema.status(Allowed).pipe(NotionSchema.asName),
         )(invalidProperty).pipe(Effect.either)
         expect(result._tag).toBe('Left')
@@ -698,7 +722,7 @@ Vitest.describe('Status Property', () => {
   Vitest.describe('NotionSchema.status(...).pipe(NotionSchema.asNullable)', () => {
     Vitest.it.effect('returns status option for selected status', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(
+        const result = yield* Schema.decodeUnknownEffect(
           NotionSchema.status().pipe(NotionSchema.asNullable),
         )(statusProperty)
         expect(result?.name).toBe('In Progress')
@@ -707,7 +731,7 @@ Vitest.describe('Status Property', () => {
 
     Vitest.it.effect('returns null for null status', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(
+        const result = yield* Schema.decodeUnknownEffect(
           NotionSchema.status().pipe(NotionSchema.asNullable),
         )(nullStatusProperty)
         expect(result).toBeNull()
@@ -718,7 +742,7 @@ Vitest.describe('Status Property', () => {
   Vitest.describe('NotionSchema.statusWriteFromName', () => {
     Vitest.it.effect('encodes status name to write payload', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.statusWriteFromName)('Done')
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.statusWriteFromName)('Done')
         expect(result).toEqual({ status: { name: 'Done' } })
       }),
     )
@@ -726,8 +750,10 @@ Vitest.describe('Status Property', () => {
     Vitest.it.effect('roundtrip: encode and decode', () =>
       Effect.gen(function* () {
         const original = 'Blocked'
-        const encoded = yield* Schema.decodeUnknown(NotionSchema.statusWriteFromName)(original)
-        const decoded = yield* Schema.encode(NotionSchema.statusWriteFromName)(encoded)
+        const encoded = yield* Schema.decodeUnknownEffect(NotionSchema.statusWriteFromName)(
+          original,
+        )
+        const decoded = yield* Schema.encodeEffect(NotionSchema.statusWriteFromName)(encoded)
         expect(decoded).toBe(original)
       }),
     )
@@ -782,7 +808,7 @@ Vitest.describe('Formula Property', () => {
   Vitest.describe('NotionSchema.formulaNumber', () => {
     Vitest.it.effect('decodes number formula', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.formulaNumber)(
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.formulaNumber)(
           numberFormulaProperty,
         )
         expect(result).toBe(42)
@@ -791,7 +817,7 @@ Vitest.describe('Formula Property', () => {
 
     Vitest.it.effect('fails for non-number formula', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.formulaNumber)(
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.formulaNumber)(
           stringFormulaProperty,
         ).pipe(Effect.either)
         expect(result._tag).toBe('Left')
@@ -802,7 +828,7 @@ Vitest.describe('Formula Property', () => {
   Vitest.describe('NotionSchema.formulaString', () => {
     Vitest.it.effect('decodes string formula', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.formulaString)(
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.formulaString)(
           stringFormulaProperty,
         )
         expect(result).toBe('hello')
@@ -811,7 +837,7 @@ Vitest.describe('Formula Property', () => {
 
     Vitest.it.effect('fails for non-string formula', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.formulaString)(
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.formulaString)(
           numberFormulaProperty,
         ).pipe(Effect.either)
         expect(result._tag).toBe('Left')
@@ -822,7 +848,7 @@ Vitest.describe('Formula Property', () => {
   Vitest.describe('NotionSchema.formulaBoolean', () => {
     Vitest.it.effect('decodes boolean formula', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.formulaBoolean)(
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.formulaBoolean)(
           booleanFormulaProperty,
         )
         expect(result).toBe(true)
@@ -833,7 +859,9 @@ Vitest.describe('Formula Property', () => {
   Vitest.describe('NotionSchema.formulaDate', () => {
     Vitest.it.effect('decodes date formula', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.formulaDate)(dateFormulaProperty)
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.formulaDate)(
+          dateFormulaProperty,
+        )
         expect(result.start).toBe('2024-01-15')
       }),
     )
@@ -897,14 +925,16 @@ Vitest.describe('Rollup Property', () => {
   Vitest.describe('NotionSchema.rollupNumber', () => {
     Vitest.it.effect('decodes number rollup', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.rollupNumber)(numberRollupProperty)
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.rollupNumber)(
+          numberRollupProperty,
+        )
         expect(result).toBe(7)
       }),
     )
 
     Vitest.it.effect('fails for non-number rollup', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.rollupNumber)(
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.rollupNumber)(
           stringRollupProperty,
         ).pipe(Effect.either)
         expect(result._tag).toBe('Left')
@@ -915,7 +945,9 @@ Vitest.describe('Rollup Property', () => {
   Vitest.describe('NotionSchema.rollupString', () => {
     Vitest.it.effect('decodes string rollup', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.rollupString)(stringRollupProperty)
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.rollupString)(
+          stringRollupProperty,
+        )
         expect(result).toBe('hello')
       }),
     )
@@ -924,7 +956,7 @@ Vitest.describe('Rollup Property', () => {
   Vitest.describe('NotionSchema.rollupBoolean', () => {
     Vitest.it.effect('decodes boolean rollup', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.rollupBoolean)(
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.rollupBoolean)(
           booleanRollupProperty,
         )
         expect(result).toBe(true)
@@ -935,7 +967,9 @@ Vitest.describe('Rollup Property', () => {
   Vitest.describe('NotionSchema.rollupDate', () => {
     Vitest.it.effect('decodes date rollup', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.rollupDate)(dateRollupProperty)
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.rollupDate)(
+          dateRollupProperty,
+        )
         expect(result.start).toBe('2024-01-15')
       }),
     )
@@ -944,7 +978,9 @@ Vitest.describe('Rollup Property', () => {
   Vitest.describe('NotionSchema.rollupArray', () => {
     Vitest.it.effect('decodes array rollup', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.rollupArray)(arrayRollupProperty)
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.rollupArray)(
+          arrayRollupProperty,
+        )
         expect(result).toEqual(['a', 'b'])
       }),
     )
@@ -975,7 +1011,7 @@ Vitest.describe('Date Property', () => {
   Vitest.describe('NotionSchema.dateOption', () => {
     Vitest.it.effect('returns Some with date value', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.dateOption)(dateProperty)
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.dateOption)(dateProperty)
         expect(Option.isSome(result)).toBe(true)
         const value = Option.getOrNull(result)
         expect(value?.start).toBe('2024-01-15')
@@ -984,7 +1020,7 @@ Vitest.describe('Date Property', () => {
 
     Vitest.it.effect('returns None for null date', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.dateOption)(nullDateProperty)
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.dateOption)(nullDateProperty)
         expect(Option.isNone(result)).toBe(true)
       }),
     )
@@ -995,14 +1031,16 @@ Vitest.describe('Date Property', () => {
 
     Vitest.it.effect('returns date value', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(schema)(dateProperty)
+        const result = yield* Schema.decodeUnknownEffect(schema)(dateProperty)
         expect(result.start).toBe('2024-01-15')
       }),
     )
 
     Vitest.it.effect('fails for null date', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(schema)(nullDateProperty).pipe(Effect.either)
+        const result = yield* Schema.decodeUnknownEffect(schema)(nullDateProperty).pipe(
+          Effect.either,
+        )
         expect(result._tag).toBe('Left')
       }),
     )
@@ -1011,7 +1049,7 @@ Vitest.describe('Date Property', () => {
   Vitest.describe('NotionSchema.dateDate', () => {
     Vitest.it.effect('parses start date to Date object', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.dateDate)(dateProperty)
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.dateDate)(dateProperty)
         expect(Option.isSome(result)).toBe(true)
         const date = Option.getOrNull(result)
         expect(date).toBeInstanceOf(Date)
@@ -1021,7 +1059,7 @@ Vitest.describe('Date Property', () => {
 
     Vitest.it.effect('returns None for null date', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.dateDate)(nullDateProperty)
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.dateDate)(nullDateProperty)
         expect(Option.isNone(result)).toBe(true)
       }),
     )
@@ -1030,7 +1068,9 @@ Vitest.describe('Date Property', () => {
   Vitest.describe('NotionSchema.dateWriteFromStart', () => {
     Vitest.it.effect('encodes date string to write payload', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.dateWriteFromStart)('2024-06-01')
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.dateWriteFromStart)(
+          '2024-06-01',
+        )
         expect(result).toEqual({ date: { start: '2024-06-01' } })
       }),
     )
@@ -1038,8 +1078,8 @@ Vitest.describe('Date Property', () => {
     Vitest.it.effect('roundtrip: encode and decode', () =>
       Effect.gen(function* () {
         const original = '2024-12-25'
-        const encoded = yield* Schema.decodeUnknown(NotionSchema.dateWriteFromStart)(original)
-        const decoded = yield* Schema.encode(NotionSchema.dateWriteFromStart)(encoded)
+        const encoded = yield* Schema.decodeUnknownEffect(NotionSchema.dateWriteFromStart)(original)
+        const decoded = yield* Schema.encodeEffect(NotionSchema.dateWriteFromStart)(encoded)
         expect(decoded).toBe(original)
       }),
     )
@@ -1060,14 +1100,14 @@ Vitest.describe('NotionSchema.nullable', () => {
 
   Vitest.it.effect('returns value when present', () =>
     Effect.gen(function* () {
-      const result = yield* Schema.decodeUnknown(schema)('hello')
+      const result = yield* Schema.decodeUnknownEffect(schema)('hello')
       expect(result).toBe('hello')
     }),
   )
 
   Vitest.it.effect('fails for null', () =>
     Effect.gen(function* () {
-      const result = yield* Schema.decodeUnknown(schema)(null).pipe(Effect.either)
+      const result = yield* Schema.decodeUnknownEffect(schema)(null).pipe(Effect.either)
       expect(result._tag).toBe('Left')
     }),
   )
@@ -1093,7 +1133,7 @@ Vitest.describe('URL Property', () => {
   Vitest.describe('NotionSchema.urlOption', () => {
     Vitest.it.effect('returns Some with URL', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.urlOption)(urlProperty)
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.urlOption)(urlProperty)
         expect(Option.isSome(result)).toBe(true)
         expect(Option.getOrNull(result)).toBe('https://example.com')
       }),
@@ -1101,7 +1141,7 @@ Vitest.describe('URL Property', () => {
 
     Vitest.it.effect('returns None for null URL', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.urlOption)(nullUrlProperty)
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.urlOption)(nullUrlProperty)
         expect(Option.isNone(result)).toBe(true)
       }),
     )
@@ -1110,7 +1150,7 @@ Vitest.describe('URL Property', () => {
   Vitest.describe('NotionSchema.urlWriteFromString', () => {
     Vitest.it.effect('encodes URL string to write payload', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.urlWriteFromString)(
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.urlWriteFromString)(
           'https://notion.so',
         )
         expect(result).toEqual({ url: 'https://notion.so' })
@@ -1120,8 +1160,8 @@ Vitest.describe('URL Property', () => {
     Vitest.it.effect('roundtrip: encode and decode', () =>
       Effect.gen(function* () {
         const original = 'https://github.com'
-        const encoded = yield* Schema.decodeUnknown(NotionSchema.urlWriteFromString)(original)
-        const decoded = yield* Schema.encode(NotionSchema.urlWriteFromString)(encoded)
+        const encoded = yield* Schema.decodeUnknownEffect(NotionSchema.urlWriteFromString)(original)
+        const decoded = yield* Schema.encodeEffect(NotionSchema.urlWriteFromString)(encoded)
         expect(decoded).toBe(original)
       }),
     )
@@ -1148,7 +1188,7 @@ Vitest.describe('Email Property', () => {
   Vitest.describe('NotionSchema.emailOption', () => {
     Vitest.it.effect('returns Some with email', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.emailOption)(emailProperty)
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.emailOption)(emailProperty)
         expect(Option.isSome(result)).toBe(true)
         expect(Option.getOrNull(result)).toBe('user@example.com')
       }),
@@ -1156,7 +1196,9 @@ Vitest.describe('Email Property', () => {
 
     Vitest.it.effect('returns None for null email', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.emailOption)(nullEmailProperty)
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.emailOption)(
+          nullEmailProperty,
+        )
         expect(Option.isNone(result)).toBe(true)
       }),
     )
@@ -1165,7 +1207,7 @@ Vitest.describe('Email Property', () => {
   Vitest.describe('NotionSchema.emailWriteFromString', () => {
     Vitest.it.effect('encodes email string to write payload', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.emailWriteFromString)(
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.emailWriteFromString)(
           'test@test.com',
         )
         expect(result).toEqual({ email: 'test@test.com' })
@@ -1175,8 +1217,10 @@ Vitest.describe('Email Property', () => {
     Vitest.it.effect('roundtrip: encode and decode', () =>
       Effect.gen(function* () {
         const original = 'alice@wonderland.com'
-        const encoded = yield* Schema.decodeUnknown(NotionSchema.emailWriteFromString)(original)
-        const decoded = yield* Schema.encode(NotionSchema.emailWriteFromString)(encoded)
+        const encoded = yield* Schema.decodeUnknownEffect(NotionSchema.emailWriteFromString)(
+          original,
+        )
+        const decoded = yield* Schema.encodeEffect(NotionSchema.emailWriteFromString)(encoded)
         expect(decoded).toBe(original)
       }),
     )
@@ -1203,7 +1247,9 @@ Vitest.describe('PhoneNumber Property', () => {
   Vitest.describe('NotionSchema.phoneNumberOption', () => {
     Vitest.it.effect('returns Some with phone number', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.phoneNumberOption)(phoneProperty)
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.phoneNumberOption)(
+          phoneProperty,
+        )
         expect(Option.isSome(result)).toBe(true)
         expect(Option.getOrNull(result)).toBe('+1-555-123-4567')
       }),
@@ -1211,7 +1257,7 @@ Vitest.describe('PhoneNumber Property', () => {
 
     Vitest.it.effect('returns None for null phone number', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.phoneNumberOption)(
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.phoneNumberOption)(
           nullPhoneProperty,
         )
         expect(Option.isNone(result)).toBe(true)
@@ -1222,7 +1268,7 @@ Vitest.describe('PhoneNumber Property', () => {
   Vitest.describe('NotionSchema.phoneNumberWriteFromString', () => {
     Vitest.it.effect('encodes phone string to write payload', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.phoneNumberWriteFromString)(
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.phoneNumberWriteFromString)(
           '+44-20-1234-5678',
         )
         expect(result).toEqual({ phone_number: '+44-20-1234-5678' })
@@ -1232,10 +1278,10 @@ Vitest.describe('PhoneNumber Property', () => {
     Vitest.it.effect('roundtrip: encode and decode', () =>
       Effect.gen(function* () {
         const original = '+1-800-CALL-NOW'
-        const encoded = yield* Schema.decodeUnknown(NotionSchema.phoneNumberWriteFromString)(
+        const encoded = yield* Schema.decodeUnknownEffect(NotionSchema.phoneNumberWriteFromString)(
           original,
         )
-        const decoded = yield* Schema.encode(NotionSchema.phoneNumberWriteFromString)(encoded)
+        const decoded = yield* Schema.encodeEffect(NotionSchema.phoneNumberWriteFromString)(encoded)
         expect(decoded).toBe(original)
       }),
     )
@@ -1262,7 +1308,7 @@ Vitest.describe('Relation Property', () => {
   Vitest.describe('NotionSchema.relationIds', () => {
     Vitest.it.effect('extracts page IDs', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.relationIds)(relationProperty)
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.relationIds)(relationProperty)
         expect(result).toEqual(['page-1', 'page-2'])
       }),
     )
@@ -1271,7 +1317,7 @@ Vitest.describe('Relation Property', () => {
   Vitest.describe('NotionSchema.relationSingle', () => {
     Vitest.it.effect('extracts single relation object', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.relationSingle)(
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.relationSingle)(
           singleRelationProperty,
         )
         expect(result).toEqual({ id: 'page-1' })
@@ -1280,7 +1326,7 @@ Vitest.describe('Relation Property', () => {
 
     Vitest.it.effect('fails for multiple relations', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.relationSingle)(
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.relationSingle)(
           relationProperty,
         ).pipe(Effect.either)
         expect(result._tag).toBe('Left')
@@ -1291,7 +1337,7 @@ Vitest.describe('Relation Property', () => {
   Vitest.describe('NotionSchema.relationSingleId', () => {
     Vitest.it.effect('extracts single relation ID', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.relationSingleId)(
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.relationSingleId)(
           singleRelationProperty,
         )
         expect(result).toBe('page-1')
@@ -1300,7 +1346,7 @@ Vitest.describe('Relation Property', () => {
 
     Vitest.it.effect('fails for multiple relations', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.relationSingleId)(
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.relationSingleId)(
           relationProperty,
         ).pipe(Effect.either)
         expect(result._tag).toBe('Left')
@@ -1311,7 +1357,7 @@ Vitest.describe('Relation Property', () => {
   Vitest.describe('NotionSchema.relationSingleOption', () => {
     Vitest.it.effect('returns Some for single relation', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.relationSingleOption)(
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.relationSingleOption)(
           singleRelationProperty,
         )
         expect(Option.isSome(result)).toBe(true)
@@ -1321,7 +1367,7 @@ Vitest.describe('Relation Property', () => {
 
     Vitest.it.effect('returns None for empty relation', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.relationSingleOption)({
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.relationSingleOption)({
           id: 'relation',
           type: 'relation' as const,
           relation: [],
@@ -1332,7 +1378,7 @@ Vitest.describe('Relation Property', () => {
 
     Vitest.it.effect('fails for multiple relations', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.relationSingleOption)(
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.relationSingleOption)(
           relationProperty,
         ).pipe(Effect.either)
         expect(result._tag).toBe('Left')
@@ -1343,7 +1389,7 @@ Vitest.describe('Relation Property', () => {
   Vitest.describe('NotionSchema.relationSingleIdOption', () => {
     Vitest.it.effect('returns Some for single relation', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.relationSingleIdOption)(
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.relationSingleIdOption)(
           singleRelationProperty,
         )
         expect(Option.isSome(result)).toBe(true)
@@ -1353,7 +1399,7 @@ Vitest.describe('Relation Property', () => {
 
     Vitest.it.effect('returns None for empty relation', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.relationSingleIdOption)({
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.relationSingleIdOption)({
           id: 'relation',
           type: 'relation' as const,
           relation: [],
@@ -1364,7 +1410,7 @@ Vitest.describe('Relation Property', () => {
 
     Vitest.it.effect('fails for multiple relations', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.relationSingleIdOption)(
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.relationSingleIdOption)(
           relationProperty,
         ).pipe(Effect.either)
         expect(result._tag).toBe('Left')
@@ -1375,7 +1421,7 @@ Vitest.describe('Relation Property', () => {
   Vitest.describe('NotionSchema.relationWriteFromIds', () => {
     Vitest.it.effect('encodes page IDs to write payload', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(NotionSchema.relationWriteFromIds)([
+        const result = yield* Schema.decodeUnknownEffect(NotionSchema.relationWriteFromIds)([
           'rel-1',
           'rel-2',
         ])
@@ -1388,8 +1434,10 @@ Vitest.describe('Relation Property', () => {
     Vitest.it.effect('roundtrip: encode and decode', () =>
       Effect.gen(function* () {
         const original = ['xyz-789', 'uvw-101']
-        const encoded = yield* Schema.decodeUnknown(NotionSchema.relationWriteFromIds)(original)
-        const decoded = yield* Schema.encode(NotionSchema.relationWriteFromIds)(encoded)
+        const encoded = yield* Schema.decodeUnknownEffect(NotionSchema.relationWriteFromIds)(
+          original,
+        )
+        const decoded = yield* Schema.encodeEffect(NotionSchema.relationWriteFromIds)(encoded)
         expect(decoded).toEqual(original)
       }),
     )

--- a/packages/@overeng/notion-effect-schema/src/properties.unit.test.ts
+++ b/packages/@overeng/notion-effect-schema/src/properties.unit.test.ts
@@ -4,6 +4,7 @@ import { expect } from 'vitest'
 import { Vitest } from '@overeng/utils-dev/node-vitest'
 
 import { NotionSchema } from './mod.ts'
+import { User } from './users.ts'
 
 // -----------------------------------------------------------------------------
 // Title Property Tests
@@ -276,8 +277,8 @@ Vitest.describe('RichText Property', () => {
         const emptyProp = { ...sampleRichTextProperty, rich_text: [] }
         const result = yield* Schema.decodeUnknownEffect(NotionSchema.richTextNonEmpty)(
           emptyProp,
-        ).pipe(Effect.either)
-        expect(result._tag).toBe('Left')
+        ).pipe(Effect.result)
+        expect(result._tag).toBe('Failure')
       }),
     )
   })
@@ -499,8 +500,8 @@ Vitest.describe('Select Property', () => {
         }
         const result = yield* Schema.decodeUnknownEffect(
           NotionSchema.select(Allowed).pipe(NotionSchema.asName),
-        )(invalidProperty).pipe(Effect.either)
-        expect(result._tag).toBe('Left')
+        )(invalidProperty).pipe(Effect.result)
+        expect(result._tag).toBe('Failure')
       }),
     )
   })
@@ -614,8 +615,8 @@ Vitest.describe('MultiSelect Property', () => {
         }
         const result = yield* Schema.decodeUnknownEffect(
           NotionSchema.multiSelect(Allowed).pipe(NotionSchema.asNames),
-        )(invalidProperty).pipe(Effect.either)
-        expect(result._tag).toBe('Left')
+        )(invalidProperty).pipe(Effect.result)
+        expect(result._tag).toBe('Failure')
       }),
     )
   })
@@ -713,8 +714,8 @@ Vitest.describe('Status Property', () => {
         }
         const result = yield* Schema.decodeUnknownEffect(
           NotionSchema.status(Allowed).pipe(NotionSchema.asName),
-        )(invalidProperty).pipe(Effect.either)
-        expect(result._tag).toBe('Left')
+        )(invalidProperty).pipe(Effect.result)
+        expect(result._tag).toBe('Failure')
       }),
     )
   })
@@ -819,8 +820,8 @@ Vitest.describe('Formula Property', () => {
       Effect.gen(function* () {
         const result = yield* Schema.decodeUnknownEffect(NotionSchema.formulaNumber)(
           stringFormulaProperty,
-        ).pipe(Effect.either)
-        expect(result._tag).toBe('Left')
+        ).pipe(Effect.result)
+        expect(result._tag).toBe('Failure')
       }),
     )
   })
@@ -839,8 +840,8 @@ Vitest.describe('Formula Property', () => {
       Effect.gen(function* () {
         const result = yield* Schema.decodeUnknownEffect(NotionSchema.formulaString)(
           numberFormulaProperty,
-        ).pipe(Effect.either)
-        expect(result._tag).toBe('Left')
+        ).pipe(Effect.result)
+        expect(result._tag).toBe('Failure')
       }),
     )
   })
@@ -936,8 +937,8 @@ Vitest.describe('Rollup Property', () => {
       Effect.gen(function* () {
         const result = yield* Schema.decodeUnknownEffect(NotionSchema.rollupNumber)(
           stringRollupProperty,
-        ).pipe(Effect.either)
-        expect(result._tag).toBe('Left')
+        ).pipe(Effect.result)
+        expect(result._tag).toBe('Failure')
       }),
     )
   })
@@ -1039,9 +1040,9 @@ Vitest.describe('Date Property', () => {
     Vitest.it.effect('fails for null date', () =>
       Effect.gen(function* () {
         const result = yield* Schema.decodeUnknownEffect(schema)(nullDateProperty).pipe(
-          Effect.either,
+          Effect.result,
         )
-        expect(result._tag).toBe('Left')
+        expect(result._tag).toBe('Failure')
       }),
     )
   })
@@ -1107,8 +1108,8 @@ Vitest.describe('NotionSchema.nullable', () => {
 
   Vitest.it.effect('fails for null', () =>
     Effect.gen(function* () {
-      const result = yield* Schema.decodeUnknownEffect(schema)(null).pipe(Effect.either)
-      expect(result._tag).toBe('Left')
+      const result = yield* Schema.decodeUnknownEffect(schema)(null).pipe(Effect.result)
+      expect(result._tag).toBe('Failure')
     }),
   )
 })
@@ -1289,6 +1290,46 @@ Vitest.describe('PhoneNumber Property', () => {
 })
 
 // -----------------------------------------------------------------------------
+// People Property Tests
+// -----------------------------------------------------------------------------
+
+Vitest.describe('People Property', () => {
+  const peopleProperty = {
+    id: 'people',
+    type: 'people' as const,
+    people: [
+      {
+        object: 'user' as const,
+        id: 'person-1',
+        type: 'person' as const,
+        person: {},
+      },
+      {
+        object: 'user' as const,
+        id: 'bot-1',
+        type: 'bot' as const,
+        name: 'Example Bot',
+        bot: {
+          owner: {
+            type: 'workspace' as const,
+            workspace: true as const,
+          },
+        },
+      },
+    ],
+  }
+
+  Vitest.it.effect('preserves user wire bytes while decoding raw people', () =>
+    Effect.gen(function* () {
+      const decoded = yield* Schema.decodeUnknownEffect(NotionSchema.peopleRaw)(peopleProperty)
+      const reencoded = yield* Schema.encodeEffect(Schema.Array(User))(decoded)
+
+      expect(JSON.stringify(reencoded)).toBe(JSON.stringify(peopleProperty.people))
+    }),
+  )
+})
+
+// -----------------------------------------------------------------------------
 // Relation Property Tests
 // -----------------------------------------------------------------------------
 
@@ -1328,8 +1369,8 @@ Vitest.describe('Relation Property', () => {
       Effect.gen(function* () {
         const result = yield* Schema.decodeUnknownEffect(NotionSchema.relationSingle)(
           relationProperty,
-        ).pipe(Effect.either)
-        expect(result._tag).toBe('Left')
+        ).pipe(Effect.result)
+        expect(result._tag).toBe('Failure')
       }),
     )
   })
@@ -1348,8 +1389,8 @@ Vitest.describe('Relation Property', () => {
       Effect.gen(function* () {
         const result = yield* Schema.decodeUnknownEffect(NotionSchema.relationSingleId)(
           relationProperty,
-        ).pipe(Effect.either)
-        expect(result._tag).toBe('Left')
+        ).pipe(Effect.result)
+        expect(result._tag).toBe('Failure')
       }),
     )
   })
@@ -1380,8 +1421,8 @@ Vitest.describe('Relation Property', () => {
       Effect.gen(function* () {
         const result = yield* Schema.decodeUnknownEffect(NotionSchema.relationSingleOption)(
           relationProperty,
-        ).pipe(Effect.either)
-        expect(result._tag).toBe('Left')
+        ).pipe(Effect.result)
+        expect(result._tag).toBe('Failure')
       }),
     )
   })
@@ -1412,8 +1453,8 @@ Vitest.describe('Relation Property', () => {
       Effect.gen(function* () {
         const result = yield* Schema.decodeUnknownEffect(NotionSchema.relationSingleIdOption)(
           relationProperty,
-        ).pipe(Effect.either)
-        expect(result._tag).toBe('Left')
+        ).pipe(Effect.result)
+        expect(result._tag).toBe('Failure')
       }),
     )
   })

--- a/packages/@overeng/notion-effect-schema/src/properties/audit.ts
+++ b/packages/@overeng/notion-effect-schema/src/properties/audit.ts
@@ -1,4 +1,4 @@
-import { Schema } from 'effect'
+import { Schema, SchemaTransformation } from 'effect'
 
 import { docsPath, shouldNeverHappen } from '../common.ts'
 import { PartialUser } from '../users.ts'
@@ -38,20 +38,30 @@ export const CreatedTime = {
   Property: CreatedTimeProperty,
 
   /** Transform to raw ISO string. */
-  raw: Schema.transform(CreatedTimeProperty, Schema.String, {
-    strict: false,
-    decode: (prop) => prop.created_time,
-    encode: () =>
-      shouldNeverHappen('CreatedTime.raw encode is not supported (created_time is read-only).'),
-  }),
+  raw: CreatedTimeProperty.pipe(
+    Schema.decodeTo(
+      Schema.String,
+      SchemaTransformation.transform({
+        decode: (prop) => prop.created_time,
+        encode: () =>
+          shouldNeverHappen('CreatedTime.raw encode is not supported (created_time is read-only).'),
+      }),
+    ),
+  ),
 
   /** Transform to Date object. */
-  asDate: Schema.transform(CreatedTimeProperty, Schema.DateFromSelf, {
-    strict: false,
-    decode: (prop) => new Date(prop.created_time),
-    encode: () =>
-      shouldNeverHappen('CreatedTime.asDate encode is not supported (created_time is read-only).'),
-  }),
+  asDate: CreatedTimeProperty.pipe(
+    Schema.decodeTo(
+      Schema.Date,
+      SchemaTransformation.transform({
+        decode: (prop) => new Date(prop.created_time),
+        encode: () =>
+          shouldNeverHappen(
+            'CreatedTime.asDate encode is not supported (created_time is read-only).',
+          ),
+      }),
+    ),
+  ),
 } as const
 
 // -----------------------------------------------------------------------------
@@ -88,20 +98,28 @@ export const CreatedBy = {
   Property: CreatedByProperty,
 
   /** Transform to raw PartialUser. */
-  raw: Schema.transform(CreatedByProperty, PartialUser, {
-    strict: false,
-    decode: (prop) => prop.created_by,
-    encode: () =>
-      shouldNeverHappen('CreatedBy.raw encode is not supported (created_by is read-only).'),
-  }),
+  raw: CreatedByProperty.pipe(
+    Schema.decodeTo(
+      PartialUser,
+      SchemaTransformation.transform({
+        decode: (prop) => prop.created_by,
+        encode: () =>
+          shouldNeverHappen('CreatedBy.raw encode is not supported (created_by is read-only).'),
+      }),
+    ),
+  ),
 
   /** Transform to user ID. */
-  asId: Schema.transform(CreatedByProperty, Schema.String, {
-    strict: false,
-    decode: (prop) => prop.created_by.id,
-    encode: () =>
-      shouldNeverHappen('CreatedBy.asId encode is not supported (created_by is read-only).'),
-  }),
+  asId: CreatedByProperty.pipe(
+    Schema.decodeTo(
+      Schema.String,
+      SchemaTransformation.transform({
+        decode: (prop) => prop.created_by.id,
+        encode: () =>
+          shouldNeverHappen('CreatedBy.asId encode is not supported (created_by is read-only).'),
+      }),
+    ),
+  ),
 } as const
 
 // -----------------------------------------------------------------------------
@@ -139,24 +157,32 @@ export const LastEditedTime = {
   Property: LastEditedTimeProperty,
 
   /** Transform to raw ISO string. */
-  raw: Schema.transform(LastEditedTimeProperty, Schema.String, {
-    strict: false,
-    decode: (prop) => prop.last_edited_time,
-    encode: () =>
-      shouldNeverHappen(
-        'LastEditedTime.raw encode is not supported (last_edited_time is read-only).',
-      ),
-  }),
+  raw: LastEditedTimeProperty.pipe(
+    Schema.decodeTo(
+      Schema.String,
+      SchemaTransformation.transform({
+        decode: (prop) => prop.last_edited_time,
+        encode: () =>
+          shouldNeverHappen(
+            'LastEditedTime.raw encode is not supported (last_edited_time is read-only).',
+          ),
+      }),
+    ),
+  ),
 
   /** Transform to Date object. */
-  asDate: Schema.transform(LastEditedTimeProperty, Schema.DateFromSelf, {
-    strict: false,
-    decode: (prop) => new Date(prop.last_edited_time),
-    encode: () =>
-      shouldNeverHappen(
-        'LastEditedTime.asDate encode is not supported (last_edited_time is read-only).',
-      ),
-  }),
+  asDate: LastEditedTimeProperty.pipe(
+    Schema.decodeTo(
+      Schema.Date,
+      SchemaTransformation.transform({
+        decode: (prop) => new Date(prop.last_edited_time),
+        encode: () =>
+          shouldNeverHappen(
+            'LastEditedTime.asDate encode is not supported (last_edited_time is read-only).',
+          ),
+      }),
+    ),
+  ),
 } as const
 
 // -----------------------------------------------------------------------------
@@ -193,18 +219,30 @@ export const LastEditedBy = {
   Property: LastEditedByProperty,
 
   /** Transform to raw PartialUser. */
-  raw: Schema.transform(LastEditedByProperty, PartialUser, {
-    strict: false,
-    decode: (prop) => prop.last_edited_by,
-    encode: () =>
-      shouldNeverHappen('LastEditedBy.raw encode is not supported (last_edited_by is read-only).'),
-  }),
+  raw: LastEditedByProperty.pipe(
+    Schema.decodeTo(
+      PartialUser,
+      SchemaTransformation.transform({
+        decode: (prop) => prop.last_edited_by,
+        encode: () =>
+          shouldNeverHappen(
+            'LastEditedBy.raw encode is not supported (last_edited_by is read-only).',
+          ),
+      }),
+    ),
+  ),
 
   /** Transform to user ID. */
-  asId: Schema.transform(LastEditedByProperty, Schema.String, {
-    strict: false,
-    decode: (prop) => prop.last_edited_by.id,
-    encode: () =>
-      shouldNeverHappen('LastEditedBy.asId encode is not supported (last_edited_by is read-only).'),
-  }),
+  asId: LastEditedByProperty.pipe(
+    Schema.decodeTo(
+      Schema.String,
+      SchemaTransformation.transform({
+        decode: (prop) => prop.last_edited_by.id,
+        encode: () =>
+          shouldNeverHappen(
+            'LastEditedBy.asId encode is not supported (last_edited_by is read-only).',
+          ),
+      }),
+    ),
+  ),
 } as const

--- a/packages/@overeng/notion-effect-schema/src/properties/audit.ts
+++ b/packages/@overeng/notion-effect-schema/src/properties/audit.ts
@@ -41,9 +41,9 @@ export const CreatedTime = {
   raw: CreatedTimeProperty.pipe(
     Schema.decodeTo(
       Schema.String,
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<string, CreatedTimeProperty>({
         decode: (prop) => prop.created_time,
-        encode: () =>
+        encode: (): CreatedTimeProperty =>
           shouldNeverHappen('CreatedTime.raw encode is not supported (created_time is read-only).'),
       }),
     ),
@@ -53,9 +53,9 @@ export const CreatedTime = {
   asDate: CreatedTimeProperty.pipe(
     Schema.decodeTo(
       Schema.Date,
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<Date, CreatedTimeProperty>({
         decode: (prop) => new Date(prop.created_time),
-        encode: () =>
+        encode: (): CreatedTimeProperty =>
           shouldNeverHappen(
             'CreatedTime.asDate encode is not supported (created_time is read-only).',
           ),
@@ -101,9 +101,9 @@ export const CreatedBy = {
   raw: CreatedByProperty.pipe(
     Schema.decodeTo(
       PartialUser,
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<PartialUser, CreatedByProperty>({
         decode: (prop) => prop.created_by,
-        encode: () =>
+        encode: (): CreatedByProperty =>
           shouldNeverHappen('CreatedBy.raw encode is not supported (created_by is read-only).'),
       }),
     ),
@@ -113,9 +113,9 @@ export const CreatedBy = {
   asId: CreatedByProperty.pipe(
     Schema.decodeTo(
       Schema.String,
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<string, CreatedByProperty>({
         decode: (prop) => prop.created_by.id,
-        encode: () =>
+        encode: (): CreatedByProperty =>
           shouldNeverHappen('CreatedBy.asId encode is not supported (created_by is read-only).'),
       }),
     ),
@@ -160,9 +160,9 @@ export const LastEditedTime = {
   raw: LastEditedTimeProperty.pipe(
     Schema.decodeTo(
       Schema.String,
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<string, LastEditedTimeProperty>({
         decode: (prop) => prop.last_edited_time,
-        encode: () =>
+        encode: (): LastEditedTimeProperty =>
           shouldNeverHappen(
             'LastEditedTime.raw encode is not supported (last_edited_time is read-only).',
           ),
@@ -174,9 +174,9 @@ export const LastEditedTime = {
   asDate: LastEditedTimeProperty.pipe(
     Schema.decodeTo(
       Schema.Date,
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<Date, LastEditedTimeProperty>({
         decode: (prop) => new Date(prop.last_edited_time),
-        encode: () =>
+        encode: (): LastEditedTimeProperty =>
           shouldNeverHappen(
             'LastEditedTime.asDate encode is not supported (last_edited_time is read-only).',
           ),
@@ -222,9 +222,9 @@ export const LastEditedBy = {
   raw: LastEditedByProperty.pipe(
     Schema.decodeTo(
       PartialUser,
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<PartialUser, LastEditedByProperty>({
         decode: (prop) => prop.last_edited_by,
-        encode: () =>
+        encode: (): LastEditedByProperty =>
           shouldNeverHappen(
             'LastEditedBy.raw encode is not supported (last_edited_by is read-only).',
           ),
@@ -236,9 +236,9 @@ export const LastEditedBy = {
   asId: LastEditedByProperty.pipe(
     Schema.decodeTo(
       Schema.String,
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<string, LastEditedByProperty>({
         decode: (prop) => prop.last_edited_by.id,
-        encode: () =>
+        encode: (): LastEditedByProperty =>
           shouldNeverHappen(
             'LastEditedBy.asId encode is not supported (last_edited_by is read-only).',
           ),

--- a/packages/@overeng/notion-effect-schema/src/properties/boolean.ts
+++ b/packages/@overeng/notion-effect-schema/src/properties/boolean.ts
@@ -1,4 +1,4 @@
-import { Schema } from 'effect'
+import { Schema, SchemaTransformation } from 'effect'
 
 import { docsPath, shouldNeverHappen } from '../common.ts'
 
@@ -47,11 +47,15 @@ export const CheckboxWrite = Schema.Struct({
 export type CheckboxWrite = typeof CheckboxWrite.Type
 
 /** Transform schema for converting boolean to CheckboxWrite payload */
-export const CheckboxWriteFromBoolean = Schema.transform(Schema.Boolean, CheckboxWrite, {
-  strict: false,
-  decode: (checkbox) => ({ checkbox }),
-  encode: (write) => write.checkbox,
-}).annotate({
+export const CheckboxWriteFromBoolean = Schema.Boolean.pipe(
+  Schema.decodeTo(
+    CheckboxWrite,
+    SchemaTransformation.transform({
+      decode: (checkbox) => ({ checkbox }),
+      encode: (write) => write.checkbox,
+    }),
+  ),
+).annotate({
   identifier: 'Notion.CheckboxWriteFromBoolean',
   title: 'Checkbox (Write) From Boolean',
   description: 'Transform a boolean into a checkbox write payload.',
@@ -64,24 +68,32 @@ export const Checkbox = {
   Property: CheckboxProperty,
 
   /** Transform to raw boolean. */
-  raw: Schema.transform(CheckboxProperty, Schema.Boolean, {
-    strict: false,
-    decode: (prop) => prop.checkbox,
-    encode: () =>
-      shouldNeverHappen(
-        'Checkbox.raw encode is not supported. Use CheckboxWrite / CheckboxWriteFromBoolean.',
-      ),
-  }),
+  raw: CheckboxProperty.pipe(
+    Schema.decodeTo(
+      Schema.Boolean,
+      SchemaTransformation.transform({
+        decode: (prop) => prop.checkbox,
+        encode: () =>
+          shouldNeverHappen(
+            'Checkbox.raw encode is not supported. Use CheckboxWrite / CheckboxWriteFromBoolean.',
+          ),
+      }),
+    ),
+  ),
 
   /** Alias for raw (checkbox is always boolean). */
-  asBoolean: Schema.transform(CheckboxProperty, Schema.Boolean, {
-    strict: false,
-    decode: (prop) => prop.checkbox,
-    encode: () =>
-      shouldNeverHappen(
-        'Checkbox.asBoolean encode is not supported. Use CheckboxWrite / CheckboxWriteFromBoolean.',
-      ),
-  }),
+  asBoolean: CheckboxProperty.pipe(
+    Schema.decodeTo(
+      Schema.Boolean,
+      SchemaTransformation.transform({
+        decode: (prop) => prop.checkbox,
+        encode: () =>
+          shouldNeverHappen(
+            'Checkbox.asBoolean encode is not supported. Use CheckboxWrite / CheckboxWriteFromBoolean.',
+          ),
+      }),
+    ),
+  ),
 
   Write: {
     Schema: CheckboxWrite,

--- a/packages/@overeng/notion-effect-schema/src/properties/boolean.ts
+++ b/packages/@overeng/notion-effect-schema/src/properties/boolean.ts
@@ -71,9 +71,9 @@ export const Checkbox = {
   raw: CheckboxProperty.pipe(
     Schema.decodeTo(
       Schema.Boolean,
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<boolean, CheckboxProperty>({
         decode: (prop) => prop.checkbox,
-        encode: () =>
+        encode: (): CheckboxProperty =>
           shouldNeverHappen(
             'Checkbox.raw encode is not supported. Use CheckboxWrite / CheckboxWriteFromBoolean.',
           ),
@@ -85,9 +85,9 @@ export const Checkbox = {
   asBoolean: CheckboxProperty.pipe(
     Schema.decodeTo(
       Schema.Boolean,
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<boolean, CheckboxProperty>({
         decode: (prop) => prop.checkbox,
-        encode: () =>
+        encode: (): CheckboxProperty =>
           shouldNeverHappen(
             'Checkbox.asBoolean encode is not supported. Use CheckboxWrite / CheckboxWriteFromBoolean.',
           ),

--- a/packages/@overeng/notion-effect-schema/src/properties/canonical-codec.ts
+++ b/packages/@overeng/notion-effect-schema/src/properties/canonical-codec.ts
@@ -205,12 +205,12 @@ const optionValue = (option: CanonicalOptionValue) => ({
   ...(option.color === undefined ? {} : { color: option.color }),
 })
 
-const encodeDateTimeUtc = Schema.encodeSync(Schema.DateTimeUtc)
+const encodeDateTimeUtc = Schema.encodeSync(Schema.DateTimeUtcFromString)
 
 /**
  * Encode is only ever fed values produced by decoding a write command, where
  * `date.start`/`date.end` are real `DateTime.Utc` instances — so they are
- * serialized to ISO strings via `Schema.DateTimeUtc`. The end field is omitted
+ * serialized to ISO strings via `Schema.DateTimeUtcFromString`. The end field is omitted
  * (not `null`) when absent, matching the Notion API shape.
  */
 const encodeDate = (value: Extract<CanonicalPropertyValue, { _tag: 'date' }>) => ({

--- a/packages/@overeng/notion-effect-schema/src/properties/canonical-codec.unit.test.ts
+++ b/packages/@overeng/notion-effect-schema/src/properties/canonical-codec.unit.test.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto'
 
-import { type DateTime, Effect, Exit, Option, Schema } from 'effect'
+import { Cause, type DateTime, Effect, Exit, Option, Schema } from 'effect'
 import { describe, expect, it } from 'vitest'
 
 import {
@@ -504,7 +504,7 @@ describe('canonical wire baselines (cross-major invariant)', () => {
       const exit = await Effect.runPromiseExit(encodeCanonicalPatch({ value }))
       const error =
         Exit.isFailure(exit) === true
-          ? (exit.cause as { error?: CanonicalEncodeError }).error
+          ? Option.getOrUndefined(Cause.findErrorOption(exit.cause))
           : undefined
       expect(error).toBeInstanceOf(CanonicalEncodeError)
       return JSON.stringify({
@@ -632,7 +632,7 @@ describe('canonical encode (Notion write-payload matrix)', () => {
     expect(Exit.isFailure(exit)).toBe(true)
     const error =
       Exit.isFailure(exit) === true
-        ? (exit.cause as { error?: CanonicalEncodeError }).error
+        ? Option.getOrUndefined(Cause.findErrorOption(exit.cause))
         : undefined
     expect(error).toBeInstanceOf(CanonicalEncodeError)
     expect(error?.reason).toBe('computed')
@@ -645,7 +645,7 @@ describe('canonical encode (Notion write-payload matrix)', () => {
     expect(Exit.isFailure(exit)).toBe(true)
     const error =
       Exit.isFailure(exit) === true
-        ? (exit.cause as { error?: CanonicalEncodeError }).error
+        ? Option.getOrUndefined(Cause.findErrorOption(exit.cause))
         : undefined
     expect(error).toBeInstanceOf(CanonicalEncodeError)
     expect(error?.reason).toBe('unsupported_remote_shape')
@@ -656,7 +656,7 @@ describe('canonical encode (Notion write-payload matrix)', () => {
     expect(Exit.isFailure(exit)).toBe(true)
     const error =
       Exit.isFailure(exit) === true
-        ? (exit.cause as { error?: CanonicalEncodeError }).error
+        ? Option.getOrUndefined(Cause.findErrorOption(exit.cause))
         : undefined
     expect(error?.reason).toBe('unsupported_remote_shape')
   })

--- a/packages/@overeng/notion-effect-schema/src/properties/canonical-codec.unit.test.ts
+++ b/packages/@overeng/notion-effect-schema/src/properties/canonical-codec.unit.test.ts
@@ -527,7 +527,8 @@ describe('canonical wire baselines (cross-major invariant)', () => {
   })
 })
 
-const dateTimeUtc = (iso: string): DateTime.Utc => Schema.decodeSync(Schema.DateTimeUtc)(iso)
+const dateTimeUtc = (iso: string): DateTime.Utc =>
+  Schema.decodeSync(Schema.DateTimeUtcFromString)(iso)
 
 type Opt = Extract<CanonicalPropertyValue, { _tag: 'select' }>['option'] & object
 

--- a/packages/@overeng/notion-effect-schema/src/properties/canonical.ts
+++ b/packages/@overeng/notion-effect-schema/src/properties/canonical.ts
@@ -98,8 +98,8 @@ export const CanonicalPropertyValue = Schema.Union([
     checked: Schema.Boolean,
   }),
   Schema.TaggedStruct('date', {
-    start: Schema.DateTimeUtc,
-    end: Schema.NullOr(Schema.DateTimeUtc),
+    start: Schema.DateTimeUtcFromString,
+    end: Schema.NullOr(Schema.DateTimeUtcFromString),
   }),
   Schema.TaggedStruct('select', {
     option: Schema.NullOr(CanonicalOptionValue),
@@ -135,13 +135,13 @@ export const CanonicalPropertyValue = Schema.Union([
 export type CanonicalPropertyValue = typeof CanonicalPropertyValue.Type
 
 /** Every Notion property *type* tag the API can return. */
-export const NotionPropertyType = Schema.Literal(...NOTION_PROPERTY_TYPES).annotate({
+export const NotionPropertyType = Schema.Literals(NOTION_PROPERTY_TYPES).annotate({
   identifier: 'Notion.PropertyType',
 })
 export type NotionPropertyType = typeof NotionPropertyType.Type
 
 /** How a property value may be written back to Notion. */
-export const PropertyWriteClass = Schema.Literal(...PROPERTY_WRITE_CLASSES).annotate({
+export const PropertyWriteClass = Schema.Literals(PROPERTY_WRITE_CLASSES).annotate({
   identifier: 'Notion.PropertyWriteClass',
 })
 export type PropertyWriteClass = typeof PropertyWriteClass.Type

--- a/packages/@overeng/notion-effect-schema/src/properties/computed.ts
+++ b/packages/@overeng/notion-effect-schema/src/properties/computed.ts
@@ -1,4 +1,4 @@
-import { Schema } from 'effect'
+import { Schema, SchemaTransformation } from 'effect'
 
 import { docsPath, shouldNeverHappen } from '../common.ts'
 import { DateValue } from './date.ts'
@@ -66,82 +66,87 @@ export const Formula = {
   Property: FormulaProperty,
 
   /** Transform to raw FormulaValue. */
-  raw: Schema.transform(FormulaProperty, FormulaValue, {
-    strict: false,
-    decode: (prop) => prop.formula,
-    encode: () => shouldNeverHappen('Formula.raw encode is not supported (formula is read-only).'),
-  }),
+  raw: FormulaProperty.pipe(
+    Schema.decodeTo(
+      FormulaValue,
+      SchemaTransformation.transform({
+        decode: (prop) => prop.formula,
+        encode: () =>
+          shouldNeverHappen('Formula.raw encode is not supported (formula is read-only).'),
+      }),
+    ),
+  ),
 
   /** Transform to required number (fails if not a number formula). */
-  asNumber: Schema.transform(
-    FormulaProperty.pipe(
-      Schema.filter(
-        (p): p is typeof p & { formula: { type: 'number'; number: number } } =>
-          p.formula.type === 'number' && p.formula.number !== null,
-        { message: () => 'Formula must be a non-null number' },
-      ),
+  asNumber: FormulaProperty.pipe(
+    Schema.refine(
+      (p): p is typeof p & { formula: { type: 'number'; number: number } } =>
+        p.formula.type === 'number' && p.formula.number !== null,
+      { message: () => 'Formula must be a non-null number' },
     ),
-    Schema.Number,
-    {
-      strict: false,
-      decode: (prop) => prop.formula.number,
-      encode: () =>
-        shouldNeverHappen('Formula.asNumber encode is not supported (formula is read-only).'),
-    },
+  ).pipe(
+    Schema.decodeTo(
+      Schema.Number,
+      SchemaTransformation.transform({
+        decode: (prop) => prop.formula.number,
+        encode: () =>
+          shouldNeverHappen('Formula.asNumber encode is not supported (formula is read-only).'),
+      }),
+    ),
   ),
 
   /** Transform to required string (fails if not a string formula). */
-  asString: Schema.transform(
-    FormulaProperty.pipe(
-      Schema.filter(
-        (p): p is typeof p & { formula: { type: 'string'; string: string } } =>
-          p.formula.type === 'string' && p.formula.string !== null,
-        { message: () => 'Formula must be a non-null string' },
-      ),
+  asString: FormulaProperty.pipe(
+    Schema.refine(
+      (p): p is typeof p & { formula: { type: 'string'; string: string } } =>
+        p.formula.type === 'string' && p.formula.string !== null,
+      { message: () => 'Formula must be a non-null string' },
     ),
-    Schema.String,
-    {
-      strict: false,
-      decode: (prop) => prop.formula.string,
-      encode: () =>
-        shouldNeverHappen('Formula.asString encode is not supported (formula is read-only).'),
-    },
+  ).pipe(
+    Schema.decodeTo(
+      Schema.String,
+      SchemaTransformation.transform({
+        decode: (prop) => prop.formula.string,
+        encode: () =>
+          shouldNeverHappen('Formula.asString encode is not supported (formula is read-only).'),
+      }),
+    ),
   ),
 
   /** Transform to required boolean (fails if not a boolean formula). */
-  asBoolean: Schema.transform(
-    FormulaProperty.pipe(
-      Schema.filter(
-        (p): p is typeof p & { formula: { type: 'boolean'; boolean: boolean } } =>
-          p.formula.type === 'boolean' && p.formula.boolean !== null,
-        { message: () => 'Formula must be a non-null boolean' },
-      ),
+  asBoolean: FormulaProperty.pipe(
+    Schema.refine(
+      (p): p is typeof p & { formula: { type: 'boolean'; boolean: boolean } } =>
+        p.formula.type === 'boolean' && p.formula.boolean !== null,
+      { message: () => 'Formula must be a non-null boolean' },
     ),
-    Schema.Boolean,
-    {
-      strict: false,
-      decode: (prop) => prop.formula.boolean,
-      encode: () =>
-        shouldNeverHappen('Formula.asBoolean encode is not supported (formula is read-only).'),
-    },
+  ).pipe(
+    Schema.decodeTo(
+      Schema.Boolean,
+      SchemaTransformation.transform({
+        decode: (prop) => prop.formula.boolean,
+        encode: () =>
+          shouldNeverHappen('Formula.asBoolean encode is not supported (formula is read-only).'),
+      }),
+    ),
   ),
 
   /** Transform to required date (fails if not a date formula). */
-  asDate: Schema.transform(
-    FormulaProperty.pipe(
-      Schema.filter(
-        (p): p is typeof p & { formula: { type: 'date'; date: DateValue } } =>
-          p.formula.type === 'date' && p.formula.date !== null,
-        { message: () => 'Formula must be a non-null date' },
-      ),
+  asDate: FormulaProperty.pipe(
+    Schema.refine(
+      (p): p is typeof p & { formula: { type: 'date'; date: DateValue } } =>
+        p.formula.type === 'date' && p.formula.date !== null,
+      { message: () => 'Formula must be a non-null date' },
     ),
-    DateValue,
-    {
-      strict: false,
-      decode: (prop) => prop.formula.date,
-      encode: () =>
-        shouldNeverHappen('Formula.asDate encode is not supported (formula is read-only).'),
-    },
+  ).pipe(
+    Schema.decodeTo(
+      DateValue,
+      SchemaTransformation.transform({
+        decode: (prop) => prop.formula.date,
+        encode: () =>
+          shouldNeverHappen('Formula.asDate encode is not supported (formula is read-only).'),
+      }),
+    ),
   ),
 } as const
 
@@ -188,21 +193,29 @@ export const UniqueId = {
   Property: UniqueIdProperty,
 
   /** Transform to formatted string (e.g., "TASK-42"). */
-  asString: Schema.transform(UniqueIdProperty, Schema.String, {
-    strict: false,
-    decode: (prop) => {
-      const { prefix, number } = prop.unique_id
-      return prefix !== null ? `${prefix}-${number}` : String(number)
-    },
-    encode: () =>
-      shouldNeverHappen('UniqueId.asString encode is not supported (unique_id is read-only).'),
-  }),
+  asString: UniqueIdProperty.pipe(
+    Schema.decodeTo(
+      Schema.String,
+      SchemaTransformation.transform({
+        decode: (prop) => {
+          const { prefix, number } = prop.unique_id
+          return prefix !== null ? `${prefix}-${number}` : String(number)
+        },
+        encode: () =>
+          shouldNeverHappen('UniqueId.asString encode is not supported (unique_id is read-only).'),
+      }),
+    ),
+  ),
 
   /** Transform to just the number. */
-  asNumber: Schema.transform(UniqueIdProperty, Schema.Number, {
-    strict: false,
-    decode: (prop) => prop.unique_id.number,
-    encode: () =>
-      shouldNeverHappen('UniqueId.asNumber encode is not supported (unique_id is read-only).'),
-  }),
+  asNumber: UniqueIdProperty.pipe(
+    Schema.decodeTo(
+      Schema.Number,
+      SchemaTransformation.transform({
+        decode: (prop) => prop.unique_id.number,
+        encode: () =>
+          shouldNeverHappen('UniqueId.asNumber encode is not supported (unique_id is read-only).'),
+      }),
+    ),
+  ),
 } as const

--- a/packages/@overeng/notion-effect-schema/src/properties/computed.ts
+++ b/packages/@overeng/notion-effect-schema/src/properties/computed.ts
@@ -69,9 +69,9 @@ export const Formula = {
   raw: FormulaProperty.pipe(
     Schema.decodeTo(
       FormulaValue,
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<FormulaValue, FormulaProperty>({
         decode: (prop) => prop.formula,
-        encode: () =>
+        encode: (): FormulaProperty =>
           shouldNeverHappen('Formula.raw encode is not supported (formula is read-only).'),
       }),
     ),
@@ -82,14 +82,17 @@ export const Formula = {
     Schema.refine(
       (p): p is typeof p & { formula: { type: 'number'; number: number } } =>
         p.formula.type === 'number' && p.formula.number !== null,
-      { message: () => 'Formula must be a non-null number' },
+      { message: 'Formula must be a non-null number' },
     ),
   ).pipe(
     Schema.decodeTo(
       Schema.Number,
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<
+        number,
+        FormulaProperty & { formula: { type: 'number'; number: number } }
+      >({
         decode: (prop) => prop.formula.number,
-        encode: () =>
+        encode: (): FormulaProperty & { formula: { type: 'number'; number: number } } =>
           shouldNeverHappen('Formula.asNumber encode is not supported (formula is read-only).'),
       }),
     ),
@@ -100,14 +103,17 @@ export const Formula = {
     Schema.refine(
       (p): p is typeof p & { formula: { type: 'string'; string: string } } =>
         p.formula.type === 'string' && p.formula.string !== null,
-      { message: () => 'Formula must be a non-null string' },
+      { message: 'Formula must be a non-null string' },
     ),
   ).pipe(
     Schema.decodeTo(
       Schema.String,
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<
+        string,
+        FormulaProperty & { formula: { type: 'string'; string: string } }
+      >({
         decode: (prop) => prop.formula.string,
-        encode: () =>
+        encode: (): FormulaProperty & { formula: { type: 'string'; string: string } } =>
           shouldNeverHappen('Formula.asString encode is not supported (formula is read-only).'),
       }),
     ),
@@ -118,14 +124,17 @@ export const Formula = {
     Schema.refine(
       (p): p is typeof p & { formula: { type: 'boolean'; boolean: boolean } } =>
         p.formula.type === 'boolean' && p.formula.boolean !== null,
-      { message: () => 'Formula must be a non-null boolean' },
+      { message: 'Formula must be a non-null boolean' },
     ),
   ).pipe(
     Schema.decodeTo(
       Schema.Boolean,
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<
+        boolean,
+        FormulaProperty & { formula: { type: 'boolean'; boolean: boolean } }
+      >({
         decode: (prop) => prop.formula.boolean,
-        encode: () =>
+        encode: (): FormulaProperty & { formula: { type: 'boolean'; boolean: boolean } } =>
           shouldNeverHappen('Formula.asBoolean encode is not supported (formula is read-only).'),
       }),
     ),
@@ -136,14 +145,17 @@ export const Formula = {
     Schema.refine(
       (p): p is typeof p & { formula: { type: 'date'; date: DateValue } } =>
         p.formula.type === 'date' && p.formula.date !== null,
-      { message: () => 'Formula must be a non-null date' },
+      { message: 'Formula must be a non-null date' },
     ),
   ).pipe(
     Schema.decodeTo(
       DateValue,
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<
+        DateValue,
+        FormulaProperty & { formula: { type: 'date'; date: DateValue } }
+      >({
         decode: (prop) => prop.formula.date,
-        encode: () =>
+        encode: (): FormulaProperty & { formula: { type: 'date'; date: DateValue } } =>
           shouldNeverHappen('Formula.asDate encode is not supported (formula is read-only).'),
       }),
     ),
@@ -196,12 +208,12 @@ export const UniqueId = {
   asString: UniqueIdProperty.pipe(
     Schema.decodeTo(
       Schema.String,
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<string, UniqueIdProperty>({
         decode: (prop) => {
           const { prefix, number } = prop.unique_id
           return prefix !== null ? `${prefix}-${number}` : String(number)
         },
-        encode: () =>
+        encode: (): UniqueIdProperty =>
           shouldNeverHappen('UniqueId.asString encode is not supported (unique_id is read-only).'),
       }),
     ),
@@ -211,9 +223,9 @@ export const UniqueId = {
   asNumber: UniqueIdProperty.pipe(
     Schema.decodeTo(
       Schema.Number,
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<number, UniqueIdProperty>({
         decode: (prop) => prop.unique_id.number,
-        encode: () =>
+        encode: (): UniqueIdProperty =>
           shouldNeverHappen('UniqueId.asNumber encode is not supported (unique_id is read-only).'),
       }),
     ),

--- a/packages/@overeng/notion-effect-schema/src/properties/contact.ts
+++ b/packages/@overeng/notion-effect-schema/src/properties/contact.ts
@@ -71,9 +71,9 @@ export const Url = {
   raw: UrlProperty.pipe(
     Schema.decodeTo(
       Schema.NullOr(Schema.String),
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<string | null, UrlProperty>({
         decode: (prop) => prop.url,
-        encode: () =>
+        encode: (): UrlProperty =>
           shouldNeverHappen('Url.raw encode is not supported. Use UrlWrite / UrlWriteFromString.'),
       }),
     ),
@@ -82,14 +82,14 @@ export const Url = {
   /** Transform to required string (fails if null). */
   asString: UrlProperty.pipe(
     Schema.refine((prop): prop is typeof prop & { url: string } => prop.url !== null, {
-      message: () => 'URL is required',
+      message: 'URL is required',
     }),
   ).pipe(
     Schema.decodeTo(
       Schema.String,
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<string, UrlProperty & { url: string }>({
         decode: (prop) => prop.url,
-        encode: () =>
+        encode: (): UrlProperty & { url: string } =>
           shouldNeverHappen(
             'Url.asString encode is not supported. Use UrlWrite / UrlWriteFromString.',
           ),
@@ -102,9 +102,9 @@ export const Url = {
     schema: UrlProperty.pipe(
       Schema.decodeTo(
         Schema.Option(Schema.String),
-        SchemaTransformation.transform({
+        SchemaTransformation.transform<Option.Option<string>, UrlProperty>({
           decode: (prop) => (prop.url === null ? Option.none() : Option.some(prop.url)),
-          encode: () =>
+          encode: (): UrlProperty =>
             shouldNeverHappen(
               'Url.asOption encode is not supported. Use UrlWrite / UrlWriteFromString.',
             ),
@@ -192,9 +192,9 @@ export const Email = {
   raw: EmailProperty.pipe(
     Schema.decodeTo(
       Schema.NullOr(Schema.String),
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<string | null, EmailProperty>({
         decode: (prop) => prop.email,
-        encode: () =>
+        encode: (): EmailProperty =>
           shouldNeverHappen(
             'Email.raw encode is not supported. Use EmailWrite / EmailWriteFromString.',
           ),
@@ -205,14 +205,14 @@ export const Email = {
   /** Transform to required string (fails if null). */
   asString: EmailProperty.pipe(
     Schema.refine((prop): prop is typeof prop & { email: string } => prop.email !== null, {
-      message: () => 'Email is required',
+      message: 'Email is required',
     }),
   ).pipe(
     Schema.decodeTo(
       Schema.String,
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<string, EmailProperty & { email: string }>({
         decode: (prop) => prop.email,
-        encode: () =>
+        encode: (): EmailProperty & { email: string } =>
           shouldNeverHappen(
             'Email.asString encode is not supported. Use EmailWrite / EmailWriteFromString.',
           ),
@@ -225,9 +225,9 @@ export const Email = {
     schema: EmailProperty.pipe(
       Schema.decodeTo(
         Schema.Option(Schema.String),
-        SchemaTransformation.transform({
+        SchemaTransformation.transform<Option.Option<string>, EmailProperty>({
           decode: (prop) => (prop.email === null ? Option.none() : Option.some(prop.email)),
-          encode: () =>
+          encode: (): EmailProperty =>
             shouldNeverHappen(
               'Email.asOption encode is not supported. Use EmailWrite / EmailWriteFromString.',
             ),
@@ -315,9 +315,9 @@ export const PhoneNumber = {
   raw: PhoneNumberProperty.pipe(
     Schema.decodeTo(
       Schema.NullOr(Schema.String),
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<string | null, PhoneNumberProperty>({
         decode: (prop) => prop.phone_number,
-        encode: () =>
+        encode: (): PhoneNumberProperty =>
           shouldNeverHappen(
             'PhoneNumber.raw encode is not supported. Use PhoneNumberWrite / PhoneNumberWriteFromString.',
           ),
@@ -330,15 +330,15 @@ export const PhoneNumber = {
     Schema.refine(
       (prop): prop is typeof prop & { phone_number: string } => prop.phone_number !== null,
       {
-        message: () => 'Phone number is required',
+        message: 'Phone number is required',
       },
     ),
   ).pipe(
     Schema.decodeTo(
       Schema.String,
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<string, PhoneNumberProperty & { phone_number: string }>({
         decode: (prop) => prop.phone_number,
-        encode: () =>
+        encode: (): PhoneNumberProperty & { phone_number: string } =>
           shouldNeverHappen(
             'PhoneNumber.asString encode is not supported. Use PhoneNumberWrite / PhoneNumberWriteFromString.',
           ),
@@ -351,10 +351,10 @@ export const PhoneNumber = {
     schema: PhoneNumberProperty.pipe(
       Schema.decodeTo(
         Schema.Option(Schema.String),
-        SchemaTransformation.transform({
+        SchemaTransformation.transform<Option.Option<string>, PhoneNumberProperty>({
           decode: (prop) =>
             prop.phone_number === null ? Option.none() : Option.some(prop.phone_number),
-          encode: () =>
+          encode: (): PhoneNumberProperty =>
             shouldNeverHappen(
               'PhoneNumber.asOption encode is not supported. Use PhoneNumberWrite / PhoneNumberWriteFromString.',
             ),

--- a/packages/@overeng/notion-effect-schema/src/properties/contact.ts
+++ b/packages/@overeng/notion-effect-schema/src/properties/contact.ts
@@ -1,4 +1,4 @@
-import { Option, Schema } from 'effect'
+import { Option, Schema, SchemaTransformation } from 'effect'
 
 import { docsPath, shouldNeverHappen, withOptionValueSchema } from '../common.ts'
 
@@ -48,16 +48,19 @@ export const UrlWrite = Schema.Struct({
 export type UrlWrite = typeof UrlWrite.Type
 
 /** Transforms URL string (or null) into a URL write payload */
-export const UrlWriteFromString = Schema.transform(Schema.NullOr(Schema.String), UrlWrite, {
-  strict: false,
-  decode: (url) => ({ url }),
-  encode: (write) => write.url,
-}).annotate({
-  identifier: 'Notion.UrlWriteFromString',
-  title: 'URL (Write) From String',
-  description: 'Transform a URL string (or null) into a URL write payload.',
-  [docsPath]: 'page#page-property-value',
-})
+export const UrlWriteFromString = Schema.NullOr(Schema.String)
+  .pipe(
+    Schema.decodeTo(
+      UrlWrite,
+      SchemaTransformation.transform({ decode: (url) => ({ url }), encode: (write) => write.url }),
+    ),
+  )
+  .annotate({
+    identifier: 'Notion.UrlWriteFromString',
+    title: 'URL (Write) From String',
+    description: 'Transform a URL string (or null) into a URL write payload.',
+    [docsPath]: 'page#page-property-value',
+  })
 
 /** Transforms for URL property. */
 export const Url = {
@@ -65,41 +68,49 @@ export const Url = {
   Property: UrlProperty,
 
   /** Transform to raw nullable string. */
-  raw: Schema.transform(UrlProperty, Schema.NullOr(Schema.String), {
-    strict: false,
-    decode: (prop) => prop.url,
-    encode: () =>
-      shouldNeverHappen('Url.raw encode is not supported. Use UrlWrite / UrlWriteFromString.'),
-  }),
-
-  /** Transform to required string (fails if null). */
-  asString: Schema.transform(
-    UrlProperty.pipe(
-      Schema.filter((prop): prop is typeof prop & { url: string } => prop.url !== null, {
-        message: () => 'URL is required',
+  raw: UrlProperty.pipe(
+    Schema.decodeTo(
+      Schema.NullOr(Schema.String),
+      SchemaTransformation.transform({
+        decode: (prop) => prop.url,
+        encode: () =>
+          shouldNeverHappen('Url.raw encode is not supported. Use UrlWrite / UrlWriteFromString.'),
       }),
     ),
-    Schema.String,
-    {
-      strict: false,
-      decode: (prop) => prop.url,
-      encode: () =>
-        shouldNeverHappen(
-          'Url.asString encode is not supported. Use UrlWrite / UrlWriteFromString.',
-        ),
-    },
+  ),
+
+  /** Transform to required string (fails if null). */
+  asString: UrlProperty.pipe(
+    Schema.refine((prop): prop is typeof prop & { url: string } => prop.url !== null, {
+      message: () => 'URL is required',
+    }),
+  ).pipe(
+    Schema.decodeTo(
+      Schema.String,
+      SchemaTransformation.transform({
+        decode: (prop) => prop.url,
+        encode: () =>
+          shouldNeverHappen(
+            'Url.asString encode is not supported. Use UrlWrite / UrlWriteFromString.',
+          ),
+      }),
+    ),
   ),
 
   /** Transform to Option<string>. */
   asOption: withOptionValueSchema({
-    schema: Schema.transform(UrlProperty, Schema.OptionFromSelf(Schema.String), {
-      strict: false,
-      decode: (prop) => (prop.url === null ? Option.none() : Option.some(prop.url)),
-      encode: () =>
-        shouldNeverHappen(
-          'Url.asOption encode is not supported. Use UrlWrite / UrlWriteFromString.',
-        ),
-    }),
+    schema: UrlProperty.pipe(
+      Schema.decodeTo(
+        Schema.Option(Schema.String),
+        SchemaTransformation.transform({
+          decode: (prop) => (prop.url === null ? Option.none() : Option.some(prop.url)),
+          encode: () =>
+            shouldNeverHappen(
+              'Url.asOption encode is not supported. Use UrlWrite / UrlWriteFromString.',
+            ),
+        }),
+      ),
+    ),
     valueSchema: Schema.String,
   }),
 
@@ -155,16 +166,22 @@ export const EmailWrite = Schema.Struct({
 export type EmailWrite = typeof EmailWrite.Type
 
 /** Transforms email string (or null) into an email write payload */
-export const EmailWriteFromString = Schema.transform(Schema.NullOr(Schema.String), EmailWrite, {
-  strict: false,
-  decode: (email) => ({ email }),
-  encode: (write) => write.email,
-}).annotate({
-  identifier: 'Notion.EmailWriteFromString',
-  title: 'Email (Write) From String',
-  description: 'Transform an email string (or null) into an email write payload.',
-  [docsPath]: 'page#page-property-value',
-})
+export const EmailWriteFromString = Schema.NullOr(Schema.String)
+  .pipe(
+    Schema.decodeTo(
+      EmailWrite,
+      SchemaTransformation.transform({
+        decode: (email) => ({ email }),
+        encode: (write) => write.email,
+      }),
+    ),
+  )
+  .annotate({
+    identifier: 'Notion.EmailWriteFromString',
+    title: 'Email (Write) From String',
+    description: 'Transform an email string (or null) into an email write payload.',
+    [docsPath]: 'page#page-property-value',
+  })
 
 /** Transforms for Email property. */
 export const Email = {
@@ -172,43 +189,51 @@ export const Email = {
   Property: EmailProperty,
 
   /** Transform to raw nullable string. */
-  raw: Schema.transform(EmailProperty, Schema.NullOr(Schema.String), {
-    strict: false,
-    decode: (prop) => prop.email,
-    encode: () =>
-      shouldNeverHappen(
-        'Email.raw encode is not supported. Use EmailWrite / EmailWriteFromString.',
-      ),
-  }),
-
-  /** Transform to required string (fails if null). */
-  asString: Schema.transform(
-    EmailProperty.pipe(
-      Schema.filter((prop): prop is typeof prop & { email: string } => prop.email !== null, {
-        message: () => 'Email is required',
+  raw: EmailProperty.pipe(
+    Schema.decodeTo(
+      Schema.NullOr(Schema.String),
+      SchemaTransformation.transform({
+        decode: (prop) => prop.email,
+        encode: () =>
+          shouldNeverHappen(
+            'Email.raw encode is not supported. Use EmailWrite / EmailWriteFromString.',
+          ),
       }),
     ),
-    Schema.String,
-    {
-      strict: false,
-      decode: (prop) => prop.email,
-      encode: () =>
-        shouldNeverHappen(
-          'Email.asString encode is not supported. Use EmailWrite / EmailWriteFromString.',
-        ),
-    },
+  ),
+
+  /** Transform to required string (fails if null). */
+  asString: EmailProperty.pipe(
+    Schema.refine((prop): prop is typeof prop & { email: string } => prop.email !== null, {
+      message: () => 'Email is required',
+    }),
+  ).pipe(
+    Schema.decodeTo(
+      Schema.String,
+      SchemaTransformation.transform({
+        decode: (prop) => prop.email,
+        encode: () =>
+          shouldNeverHappen(
+            'Email.asString encode is not supported. Use EmailWrite / EmailWriteFromString.',
+          ),
+      }),
+    ),
   ),
 
   /** Transform to Option<string>. */
   asOption: withOptionValueSchema({
-    schema: Schema.transform(EmailProperty, Schema.OptionFromSelf(Schema.String), {
-      strict: false,
-      decode: (prop) => (prop.email === null ? Option.none() : Option.some(prop.email)),
-      encode: () =>
-        shouldNeverHappen(
-          'Email.asOption encode is not supported. Use EmailWrite / EmailWriteFromString.',
-        ),
-    }),
+    schema: EmailProperty.pipe(
+      Schema.decodeTo(
+        Schema.Option(Schema.String),
+        SchemaTransformation.transform({
+          decode: (prop) => (prop.email === null ? Option.none() : Option.some(prop.email)),
+          encode: () =>
+            shouldNeverHappen(
+              'Email.asOption encode is not supported. Use EmailWrite / EmailWriteFromString.',
+            ),
+        }),
+      ),
+    ),
     valueSchema: Schema.String,
   }),
 
@@ -264,20 +289,22 @@ export const PhoneNumberWrite = Schema.Struct({
 export type PhoneNumberWrite = typeof PhoneNumberWrite.Type
 
 /** Transforms phone number string (or null) into a phone number write payload */
-export const PhoneNumberWriteFromString = Schema.transform(
-  Schema.NullOr(Schema.String),
-  PhoneNumberWrite,
-  {
-    strict: false,
-    decode: (phone_number) => ({ phone_number }),
-    encode: (write) => write.phone_number,
-  },
-).annotate({
-  identifier: 'Notion.PhoneNumberWriteFromString',
-  title: 'Phone Number (Write) From String',
-  description: 'Transform a phone number string (or null) into a phone number write payload.',
-  [docsPath]: 'page#page-property-value',
-})
+export const PhoneNumberWriteFromString = Schema.NullOr(Schema.String)
+  .pipe(
+    Schema.decodeTo(
+      PhoneNumberWrite,
+      SchemaTransformation.transform({
+        decode: (phone_number) => ({ phone_number }),
+        encode: (write) => write.phone_number,
+      }),
+    ),
+  )
+  .annotate({
+    identifier: 'Notion.PhoneNumberWriteFromString',
+    title: 'Phone Number (Write) From String',
+    description: 'Transform a phone number string (or null) into a phone number write payload.',
+    [docsPath]: 'page#page-property-value',
+  })
 
 /** Transforms for PhoneNumber property. */
 export const PhoneNumber = {
@@ -285,47 +312,55 @@ export const PhoneNumber = {
   Property: PhoneNumberProperty,
 
   /** Transform to raw nullable string. */
-  raw: Schema.transform(PhoneNumberProperty, Schema.NullOr(Schema.String), {
-    strict: false,
-    decode: (prop) => prop.phone_number,
-    encode: () =>
-      shouldNeverHappen(
-        'PhoneNumber.raw encode is not supported. Use PhoneNumberWrite / PhoneNumberWriteFromString.',
-      ),
-  }),
+  raw: PhoneNumberProperty.pipe(
+    Schema.decodeTo(
+      Schema.NullOr(Schema.String),
+      SchemaTransformation.transform({
+        decode: (prop) => prop.phone_number,
+        encode: () =>
+          shouldNeverHappen(
+            'PhoneNumber.raw encode is not supported. Use PhoneNumberWrite / PhoneNumberWriteFromString.',
+          ),
+      }),
+    ),
+  ),
 
   /** Transform to required string (fails if null). */
-  asString: Schema.transform(
-    PhoneNumberProperty.pipe(
-      Schema.filter(
-        (prop): prop is typeof prop & { phone_number: string } => prop.phone_number !== null,
-        {
-          message: () => 'Phone number is required',
-        },
-      ),
+  asString: PhoneNumberProperty.pipe(
+    Schema.refine(
+      (prop): prop is typeof prop & { phone_number: string } => prop.phone_number !== null,
+      {
+        message: () => 'Phone number is required',
+      },
     ),
-    Schema.String,
-    {
-      strict: false,
-      decode: (prop) => prop.phone_number,
-      encode: () =>
-        shouldNeverHappen(
-          'PhoneNumber.asString encode is not supported. Use PhoneNumberWrite / PhoneNumberWriteFromString.',
-        ),
-    },
+  ).pipe(
+    Schema.decodeTo(
+      Schema.String,
+      SchemaTransformation.transform({
+        decode: (prop) => prop.phone_number,
+        encode: () =>
+          shouldNeverHappen(
+            'PhoneNumber.asString encode is not supported. Use PhoneNumberWrite / PhoneNumberWriteFromString.',
+          ),
+      }),
+    ),
   ),
 
   /** Transform to Option<string>. */
   asOption: withOptionValueSchema({
-    schema: Schema.transform(PhoneNumberProperty, Schema.OptionFromSelf(Schema.String), {
-      strict: false,
-      decode: (prop) =>
-        prop.phone_number === null ? Option.none() : Option.some(prop.phone_number),
-      encode: () =>
-        shouldNeverHappen(
-          'PhoneNumber.asOption encode is not supported. Use PhoneNumberWrite / PhoneNumberWriteFromString.',
-        ),
-    }),
+    schema: PhoneNumberProperty.pipe(
+      Schema.decodeTo(
+        Schema.Option(Schema.String),
+        SchemaTransformation.transform({
+          decode: (prop) =>
+            prop.phone_number === null ? Option.none() : Option.some(prop.phone_number),
+          encode: () =>
+            shouldNeverHappen(
+              'PhoneNumber.asOption encode is not supported. Use PhoneNumberWrite / PhoneNumberWriteFromString.',
+            ),
+        }),
+      ),
+    ),
     valueSchema: Schema.String,
   }),
 

--- a/packages/@overeng/notion-effect-schema/src/properties/date.ts
+++ b/packages/@overeng/notion-effect-schema/src/properties/date.ts
@@ -1,4 +1,4 @@
-import { Option, Schema } from 'effect'
+import { Option, Schema, SchemaTransformation } from 'effect'
 
 import { docsPath, shouldNeverHappen, withOptionValueSchema } from '../common.ts'
 
@@ -92,17 +92,21 @@ export const DateWrite = Schema.Struct({
 export type DateWrite = typeof DateWrite.Type
 
 /** Transform schema for converting start date string to DateWrite payload */
-export const DateWriteFromStart = Schema.transform(Schema.String, DateWrite, {
-  strict: false,
-  decode: (start) => ({ date: { start } }),
-  encode: (write) => {
-    if (write.date === null) {
-      return ''
-    }
+export const DateWriteFromStart = Schema.String.pipe(
+  Schema.decodeTo(
+    DateWrite,
+    SchemaTransformation.transform({
+      decode: (start) => ({ date: { start } }),
+      encode: (write) => {
+        if (write.date === null) {
+          return ''
+        }
 
-    return write.date.start
-  },
-}).annotate({
+        return write.date.start
+      },
+    }),
+  ),
+).annotate({
   identifier: 'Notion.DateWriteFromStart',
   title: 'Date (Write) From Start',
   description: 'Transform a start date/time string into a date write payload.',
@@ -115,40 +119,52 @@ export const DateProp = {
   Property: DateProperty,
 
   /** Transform to raw nullable DateValue. */
-  raw: Schema.transform(DateProperty, Schema.NullOr(DateValue), {
-    strict: false,
-    decode: (prop) => prop.date,
-    encode: () =>
-      shouldNeverHappen(
-        'DateProp.raw encode is not supported. Use DateWrite / DateWriteFromStart.',
-      ),
-  }),
+  raw: DateProperty.pipe(
+    Schema.decodeTo(
+      Schema.NullOr(DateValue),
+      SchemaTransformation.transform({
+        decode: (prop) => prop.date,
+        encode: () =>
+          shouldNeverHappen(
+            'DateProp.raw encode is not supported. Use DateWrite / DateWriteFromStart.',
+          ),
+      }),
+    ),
+  ),
 
   /** Transform to Option<DateValue>. */
   asOption: withOptionValueSchema({
-    schema: Schema.transform(DateProperty, Schema.OptionFromSelf(DateValue), {
-      strict: false,
-      decode: (prop) => (prop.date === null ? Option.none() : Option.some(prop.date)),
-      encode: () =>
-        shouldNeverHappen(
-          'DateProp.asOption encode is not supported. Use DateWrite / DateWriteFromStart.',
-        ),
-    }),
+    schema: DateProperty.pipe(
+      Schema.decodeTo(
+        Schema.Option(DateValue),
+        SchemaTransformation.transform({
+          decode: (prop) => (prop.date === null ? Option.none() : Option.some(prop.date)),
+          encode: () =>
+            shouldNeverHappen(
+              'DateProp.asOption encode is not supported. Use DateWrite / DateWriteFromStart.',
+            ),
+        }),
+      ),
+    ),
     valueSchema: DateValue,
   }),
 
   /** Transform to Option<Date> (start date only, parsed). */
   asDate: withOptionValueSchema({
-    schema: Schema.transform(DateProperty, Schema.OptionFromSelf(Schema.DateFromSelf), {
-      strict: false,
-      decode: (prop) =>
-        prop.date === null ? Option.none() : Option.some(new Date(prop.date.start)),
-      encode: () =>
-        shouldNeverHappen(
-          'DateProp.asDate encode is not supported. Use DateWrite / DateWriteFromStart.',
-        ),
-    }),
-    valueSchema: Schema.DateFromSelf,
+    schema: DateProperty.pipe(
+      Schema.decodeTo(
+        Schema.Option(Schema.Date),
+        SchemaTransformation.transform({
+          decode: (prop) =>
+            prop.date === null ? Option.none() : Option.some(new Date(prop.date.start)),
+          encode: () =>
+            shouldNeverHappen(
+              'DateProp.asDate encode is not supported. Use DateWrite / DateWriteFromStart.',
+            ),
+        }),
+      ),
+    ),
+    valueSchema: Schema.Date,
   }),
 
   Write: {

--- a/packages/@overeng/notion-effect-schema/src/properties/date.ts
+++ b/packages/@overeng/notion-effect-schema/src/properties/date.ts
@@ -95,7 +95,7 @@ export type DateWrite = typeof DateWrite.Type
 export const DateWriteFromStart = Schema.String.pipe(
   Schema.decodeTo(
     DateWrite,
-    SchemaTransformation.transform({
+    SchemaTransformation.transform<DateWrite, string>({
       decode: (start) => ({ date: { start } }),
       encode: (write) => {
         if (write.date === null) {
@@ -122,9 +122,9 @@ export const DateProp = {
   raw: DateProperty.pipe(
     Schema.decodeTo(
       Schema.NullOr(DateValue),
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<DateValue | null, DateProperty>({
         decode: (prop) => prop.date,
-        encode: () =>
+        encode: (): DateProperty =>
           shouldNeverHappen(
             'DateProp.raw encode is not supported. Use DateWrite / DateWriteFromStart.',
           ),
@@ -137,9 +137,9 @@ export const DateProp = {
     schema: DateProperty.pipe(
       Schema.decodeTo(
         Schema.Option(DateValue),
-        SchemaTransformation.transform({
+        SchemaTransformation.transform<Option.Option<DateValue>, DateProperty>({
           decode: (prop) => (prop.date === null ? Option.none() : Option.some(prop.date)),
-          encode: () =>
+          encode: (): DateProperty =>
             shouldNeverHappen(
               'DateProp.asOption encode is not supported. Use DateWrite / DateWriteFromStart.',
             ),
@@ -154,10 +154,10 @@ export const DateProp = {
     schema: DateProperty.pipe(
       Schema.decodeTo(
         Schema.Option(Schema.Date),
-        SchemaTransformation.transform({
+        SchemaTransformation.transform<Option.Option<Date>, DateProperty>({
           decode: (prop) =>
             prop.date === null ? Option.none() : Option.some(new Date(prop.date.start)),
-          encode: () =>
+          encode: (): DateProperty =>
             shouldNeverHappen(
               'DateProp.asDate encode is not supported. Use DateWrite / DateWriteFromStart.',
             ),

--- a/packages/@overeng/notion-effect-schema/src/properties/descriptor.ts
+++ b/packages/@overeng/notion-effect-schema/src/properties/descriptor.ts
@@ -21,7 +21,7 @@ import { DataSourceId, NotionPropertyType, PropertyId, PropertyName } from './ca
 
 /** Validated `sha256:<hex64>` content-hash form shared by the descriptor identity hashes. */
 const Sha256Hash = Schema.Trimmed.check(Schema.isNonEmpty()).check(
-  Schema.check(Schema.isPattern(/^sha256:[0-9a-f]{64}$/)),
+  Schema.isPattern(/^sha256:[0-9a-f]{64}$/),
 )
 
 /**
@@ -106,12 +106,12 @@ export type PropertyDescriptors = typeof PropertyDescriptors.Type
  * fields. Use this entry point rather than a bare `Schema.decode` so callers
  * cannot accidentally accept excess (proof-shaped) keys.
  */
-export const decodePropertyDescriptor = Schema.decodeUnknown(PropertyDescriptor, {
+export const decodePropertyDescriptor = Schema.decodeUnknownEffect(PropertyDescriptor, {
   onExcessProperty: 'error',
 })
 
 /** Decode an unknown value as a {@link PropertyDescriptors} map, rejecting unknown descriptor fields. */
-export const decodePropertyDescriptors = Schema.decodeUnknown(PropertyDescriptors, {
+export const decodePropertyDescriptors = Schema.decodeUnknownEffect(PropertyDescriptors, {
   onExcessProperty: 'error',
 })
 

--- a/packages/@overeng/notion-effect-schema/src/properties/descriptor.unit.test.ts
+++ b/packages/@overeng/notion-effect-schema/src/properties/descriptor.unit.test.ts
@@ -1,4 +1,4 @@
-import { Effect, Exit, type ParseResult, Schema } from 'effect'
+import { Effect, Exit, Schema } from 'effect'
 import { describe, expect, it } from 'vitest'
 
 import { NOTION_PROPERTY_TYPES } from '@overeng/notion-core'
@@ -24,7 +24,7 @@ const validDescriptor = {
 
 const isFailure = <A>(exit: Exit.Exit<A, unknown>): boolean => Exit.isFailure(exit)
 
-const decode = <A>(effect: Effect.Effect<A, ParseResult.ParseError>): Exit.Exit<A, unknown> =>
+const decode = <A>(effect: Effect.Effect<A, Schema.SchemaError>): Exit.Exit<A, unknown> =>
   Effect.runSyncExit(effect)
 
 describe('PropertyDescriptor decoding', () => {
@@ -95,16 +95,16 @@ describe('DataSourceId brand', () => {
   })
 
   it('rejects empty / whitespace input', () => {
-    expect(isFailure(decode(Schema.decodeUnknown(DataSourceId)('')))).toBe(true)
-    expect(isFailure(decode(Schema.decodeUnknown(DataSourceId)('  ')))).toBe(true)
+    expect(isFailure(decode(Schema.decodeUnknownEffect(DataSourceId)('')))).toBe(true)
+    expect(isFailure(decode(Schema.decodeUnknownEffect(DataSourceId)('  ')))).toBe(true)
   })
 })
 
 describe('ConfigHash brand', () => {
   it('accepts a sha256 hash and rejects other shapes', () => {
     expect(Schema.decodeUnknownSync(ConfigHash)(hashOf(7))).toBe(hashOf(7))
-    expect(isFailure(decode(Schema.decodeUnknown(ConfigHash)('md5:abc')))).toBe(true)
-    expect(isFailure(decode(Schema.decodeUnknown(ConfigHash)('sha256:XYZ')))).toBe(true)
+    expect(isFailure(decode(Schema.decodeUnknownEffect(ConfigHash)('md5:abc')))).toBe(true)
+    expect(isFailure(decode(Schema.decodeUnknownEffect(ConfigHash)('sha256:XYZ')))).toBe(true)
   })
 })
 
@@ -119,7 +119,9 @@ describe('PropertyIdentityEvidenceSource', () => {
 
   it('rejects an unknown evidence source', () => {
     expect(
-      isFailure(decode(Schema.decodeUnknown(PropertyIdentityEvidenceSource)({ _tag: 'remote' }))),
+      isFailure(
+        decode(Schema.decodeUnknownEffect(PropertyIdentityEvidenceSource)({ _tag: 'remote' })),
+      ),
     ).toBe(true)
   })
 })

--- a/packages/@overeng/notion-effect-schema/src/properties/number.ts
+++ b/packages/@overeng/notion-effect-schema/src/properties/number.ts
@@ -1,4 +1,4 @@
-import { Option, Schema } from 'effect'
+import { Option, Schema, SchemaTransformation } from 'effect'
 
 import { docsPath, shouldNeverHappen, withOptionValueSchema } from '../common.ts'
 
@@ -48,16 +48,22 @@ export const NumberWrite = Schema.Struct({
 export type NumberWrite = typeof NumberWrite.Type
 
 /** Transform schema for converting number to NumberWrite payload */
-export const NumberWriteFromNumber = Schema.transform(Schema.NullOr(Schema.Number), NumberWrite, {
-  strict: false,
-  decode: (number) => ({ number }),
-  encode: (write) => write.number,
-}).annotate({
-  identifier: 'Notion.NumberWriteFromNumber',
-  title: 'Number (Write) From Number',
-  description: 'Transform a number (or null) into a number write payload.',
-  [docsPath]: 'page#page-property-value',
-})
+export const NumberWriteFromNumber = Schema.NullOr(Schema.Number)
+  .pipe(
+    Schema.decodeTo(
+      NumberWrite,
+      SchemaTransformation.transform({
+        decode: (number) => ({ number }),
+        encode: (write) => write.number,
+      }),
+    ),
+  )
+  .annotate({
+    identifier: 'Notion.NumberWriteFromNumber',
+    title: 'Number (Write) From Number',
+    description: 'Transform a number (or null) into a number write payload.',
+    [docsPath]: 'page#page-property-value',
+  })
 
 /** Transforms for Number property. */
 export const Num = {
@@ -65,44 +71,52 @@ export const Num = {
   Property: NumberProperty,
 
   /** Transform to raw nullable number. */
-  raw: Schema.transform(NumberProperty, Schema.NullOr(Schema.Number), {
-    strict: false,
-    decode: (prop) => prop.number,
-    encode: () =>
-      shouldNeverHappen(
-        'Num.raw encode is not supported. Use NumberWrite / NumberWriteFromNumber.',
-      ),
-  }),
+  raw: NumberProperty.pipe(
+    Schema.decodeTo(
+      Schema.NullOr(Schema.Number),
+      SchemaTransformation.transform({
+        decode: (prop) => prop.number,
+        encode: () =>
+          shouldNeverHappen(
+            'Num.raw encode is not supported. Use NumberWrite / NumberWriteFromNumber.',
+          ),
+      }),
+    ),
+  ),
 
   /** Transform to Option<number>. */
   asOption: withOptionValueSchema({
-    schema: Schema.transform(NumberProperty, Schema.OptionFromSelf(Schema.Number), {
-      strict: false,
-      decode: (prop) => (prop.number === null ? Option.none() : Option.some(prop.number)),
-      encode: () =>
-        shouldNeverHappen(
-          'Num.asOption encode is not supported. Use NumberWrite / NumberWriteFromNumber.',
-        ),
-    }),
+    schema: NumberProperty.pipe(
+      Schema.decodeTo(
+        Schema.Option(Schema.Number),
+        SchemaTransformation.transform({
+          decode: (prop) => (prop.number === null ? Option.none() : Option.some(prop.number)),
+          encode: () =>
+            shouldNeverHappen(
+              'Num.asOption encode is not supported. Use NumberWrite / NumberWriteFromNumber.',
+            ),
+        }),
+      ),
+    ),
     valueSchema: Schema.Number,
   }),
 
   /** Transform to required number (fails if null). */
-  asNumber: Schema.transform(
-    NumberProperty.pipe(
-      Schema.filter((p): p is typeof p & { number: number } => p.number !== null, {
-        message: () => 'Number is required',
+  asNumber: NumberProperty.pipe(
+    Schema.refine((p): p is typeof p & { number: number } => p.number !== null, {
+      message: () => 'Number is required',
+    }),
+  ).pipe(
+    Schema.decodeTo(
+      Schema.Number,
+      SchemaTransformation.transform({
+        decode: (prop) => prop.number,
+        encode: () =>
+          shouldNeverHappen(
+            'Num.asNumber encode is not supported. Use NumberWrite / NumberWriteFromNumber.',
+          ),
       }),
     ),
-    Schema.Number,
-    {
-      strict: false,
-      decode: (prop) => prop.number,
-      encode: () =>
-        shouldNeverHappen(
-          'Num.asNumber encode is not supported. Use NumberWrite / NumberWriteFromNumber.',
-        ),
-    },
   ),
 
   Write: {

--- a/packages/@overeng/notion-effect-schema/src/properties/number.ts
+++ b/packages/@overeng/notion-effect-schema/src/properties/number.ts
@@ -74,9 +74,9 @@ export const Num = {
   raw: NumberProperty.pipe(
     Schema.decodeTo(
       Schema.NullOr(Schema.Number),
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<number | null, NumberProperty>({
         decode: (prop) => prop.number,
-        encode: () =>
+        encode: (): NumberProperty =>
           shouldNeverHappen(
             'Num.raw encode is not supported. Use NumberWrite / NumberWriteFromNumber.',
           ),
@@ -89,9 +89,9 @@ export const Num = {
     schema: NumberProperty.pipe(
       Schema.decodeTo(
         Schema.Option(Schema.Number),
-        SchemaTransformation.transform({
+        SchemaTransformation.transform<Option.Option<number>, NumberProperty>({
           decode: (prop) => (prop.number === null ? Option.none() : Option.some(prop.number)),
-          encode: () =>
+          encode: (): NumberProperty =>
             shouldNeverHappen(
               'Num.asOption encode is not supported. Use NumberWrite / NumberWriteFromNumber.',
             ),
@@ -104,14 +104,14 @@ export const Num = {
   /** Transform to required number (fails if null). */
   asNumber: NumberProperty.pipe(
     Schema.refine((p): p is typeof p & { number: number } => p.number !== null, {
-      message: () => 'Number is required',
+      message: 'Number is required',
     }),
   ).pipe(
     Schema.decodeTo(
       Schema.Number,
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<number, NumberProperty & { number: number }>({
         decode: (prop) => prop.number,
-        encode: () =>
+        encode: (): NumberProperty & { number: number } =>
           shouldNeverHappen(
             'Num.asNumber encode is not supported. Use NumberWrite / NumberWriteFromNumber.',
           ),

--- a/packages/@overeng/notion-effect-schema/src/properties/reference.ts
+++ b/packages/@overeng/notion-effect-schema/src/properties/reference.ts
@@ -1,4 +1,4 @@
-import { Option, Schema } from 'effect'
+import { Option, Schema, SchemaTransformation } from 'effect'
 
 import { docsPath, NotionUUID, shouldNeverHappen } from '../common.ts'
 import {
@@ -57,18 +57,24 @@ export const PeopleWrite = Schema.Struct({
 export type PeopleWrite = typeof PeopleWrite.Type
 
 /** Transforms user IDs array into a people write payload */
-export const PeopleWriteFromIds = Schema.transform(Schema.Array(NotionUUID), PeopleWrite, {
-  strict: false,
-  decode: (ids) => ({
-    people: ids.map((id) => ({ id })),
-  }),
-  encode: (write) => write.people.map((p) => p.id),
-}).annotate({
-  identifier: 'Notion.PeopleWriteFromIds',
-  title: 'People (Write) From IDs',
-  description: 'Transform user IDs into a people write payload.',
-  [docsPath]: 'page#page-property-value',
-})
+export const PeopleWriteFromIds = Schema.Array(NotionUUID)
+  .pipe(
+    Schema.decodeTo(
+      PeopleWrite,
+      SchemaTransformation.transform({
+        decode: (ids) => ({
+          people: ids.map((id) => ({ id })),
+        }),
+        encode: (write) => write.people.map((p) => p.id),
+      }),
+    ),
+  )
+  .annotate({
+    identifier: 'Notion.PeopleWriteFromIds',
+    title: 'People (Write) From IDs',
+    description: 'Transform user IDs into a people write payload.',
+    [docsPath]: 'page#page-property-value',
+  })
 
 /** Transforms for People property. */
 export const People = {
@@ -76,24 +82,32 @@ export const People = {
   Property: PeopleProperty,
 
   /** Transform to raw array of Users. */
-  raw: Schema.transform(PeopleProperty, Schema.Array(User), {
-    strict: false,
-    decode: (prop) => prop.people,
-    encode: () =>
-      shouldNeverHappen(
-        'People.raw encode is not supported. Use PeopleWrite / PeopleWriteFromIds.',
-      ),
-  }),
+  raw: PeopleProperty.pipe(
+    Schema.decodeTo(
+      Schema.Array(User),
+      SchemaTransformation.transform({
+        decode: (prop) => prop.people,
+        encode: () =>
+          shouldNeverHappen(
+            'People.raw encode is not supported. Use PeopleWrite / PeopleWriteFromIds.',
+          ),
+      }),
+    ),
+  ),
 
   /** Transform to array of user IDs. */
-  asIds: Schema.transform(PeopleProperty, Schema.Array(Schema.String), {
-    strict: false,
-    decode: (prop) => prop.people.map((u) => u.id),
-    encode: () =>
-      shouldNeverHappen(
-        'People.asIds encode is not supported. Use PeopleWrite / PeopleWriteFromIds.',
-      ),
-  }),
+  asIds: PeopleProperty.pipe(
+    Schema.decodeTo(
+      Schema.Array(Schema.String),
+      SchemaTransformation.transform({
+        decode: (prop) => prop.people.map((u) => u.id),
+        encode: () =>
+          shouldNeverHappen(
+            'People.asIds encode is not supported. Use PeopleWrite / PeopleWriteFromIds.',
+          ),
+      }),
+    ),
+  ),
 
   Write: {
     Schema: PeopleWrite,
@@ -160,18 +174,24 @@ export const RelationWrite = Schema.Struct({
 export type RelationWrite = typeof RelationWrite.Type
 
 /** Transforms page IDs array into a relation write payload */
-export const RelationWriteFromIds = Schema.transform(Schema.Array(NotionUUID), RelationWrite, {
-  strict: false,
-  decode: (ids) => ({
-    relation: ids.map((id) => ({ id })),
-  }),
-  encode: (write) => write.relation.map((r) => r.id),
-}).annotate({
-  identifier: 'Notion.RelationWriteFromIds',
-  title: 'Relation (Write) From IDs',
-  description: 'Transform page IDs into a relation write payload.',
-  [docsPath]: 'page#page-property-value',
-})
+export const RelationWriteFromIds = Schema.Array(NotionUUID)
+  .pipe(
+    Schema.decodeTo(
+      RelationWrite,
+      SchemaTransformation.transform({
+        decode: (ids) => ({
+          relation: ids.map((id) => ({ id })),
+        }),
+        encode: (write) => write.relation.map((r) => r.id),
+      }),
+    ),
+  )
+  .annotate({
+    identifier: 'Notion.RelationWriteFromIds',
+    title: 'Relation (Write) From IDs',
+    description: 'Transform page IDs into a relation write payload.',
+    [docsPath]: 'page#page-property-value',
+  })
 
 /** Transforms for Relation property. */
 export const Relation = {
@@ -179,91 +199,93 @@ export const Relation = {
   Property: RelationProperty,
 
   /** Transform to array of page IDs. */
-  asIds: Schema.transform(RelationProperty, Schema.Array(Schema.String), {
-    strict: false,
-    decode: (prop) => prop.relation.map((r) => r.id),
-    encode: () =>
-      shouldNeverHappen(
-        'Relation.asIds encode is not supported. Use RelationWrite / RelationWriteFromIds.',
-      ),
-  }),
+  asIds: RelationProperty.pipe(
+    Schema.decodeTo(
+      Schema.Array(Schema.String),
+      SchemaTransformation.transform({
+        decode: (prop) => prop.relation.map((r) => r.id),
+        encode: () =>
+          shouldNeverHappen(
+            'Relation.asIds encode is not supported. Use RelationWrite / RelationWriteFromIds.',
+          ),
+      }),
+    ),
+  ),
 
   /** Transform to a single relation object (fails if not exactly one). */
-  asSingle: Schema.transform(
-    RelationProperty.pipe(
-      Schema.filter(
-        (p): p is typeof p & { relation: [{ id: string }] } => p.relation.length === 1,
-        {
-          message: () => 'Relation must have exactly one item',
-        },
-      ),
+  asSingle: RelationProperty.pipe(
+    Schema.refine((p): p is typeof p & { relation: [{ id: string }] } => p.relation.length === 1, {
+      message: () => 'Relation must have exactly one item',
+    }),
+  ).pipe(
+    Schema.decodeTo(
+      Schema.Struct({ id: NotionUUID }),
+      SchemaTransformation.transform({
+        decode: (prop) => prop.relation[0],
+        encode: () =>
+          shouldNeverHappen(
+            'Relation.asSingle encode is not supported. Use RelationWrite / RelationWriteFromIds.',
+          ),
+      }),
     ),
-    Schema.Struct({ id: NotionUUID }),
-    {
-      strict: false,
-      decode: (prop) => prop.relation[0],
-      encode: () =>
-        shouldNeverHappen(
-          'Relation.asSingle encode is not supported. Use RelationWrite / RelationWriteFromIds.',
-        ),
-    },
   ),
 
   /** Transform to a single related page ID (fails if not exactly one). */
-  asSingleId: Schema.transform(
-    RelationProperty.pipe(
-      Schema.filter(
-        (p): p is typeof p & { relation: [{ id: string }] } => p.relation.length === 1,
-        {
-          message: () => 'Relation must have exactly one item',
-        },
-      ),
+  asSingleId: RelationProperty.pipe(
+    Schema.refine((p): p is typeof p & { relation: [{ id: string }] } => p.relation.length === 1, {
+      message: () => 'Relation must have exactly one item',
+    }),
+  ).pipe(
+    Schema.decodeTo(
+      NotionUUID,
+      SchemaTransformation.transform({
+        decode: (prop) => prop.relation[0].id,
+        encode: () =>
+          shouldNeverHappen(
+            'Relation.asSingleId encode is not supported. Use RelationWrite / RelationWriteFromIds.',
+          ),
+      }),
     ),
-    NotionUUID,
-    {
-      strict: false,
-      decode: (prop) => prop.relation[0].id,
-      encode: () =>
-        shouldNeverHappen(
-          'Relation.asSingleId encode is not supported. Use RelationWrite / RelationWriteFromIds.',
-        ),
-    },
   ),
 
   /** Transform to an optional single relation object (allows 0 or 1 items). */
-  asSingleOption: Schema.transform(
-    RelationProperty.pipe(
-      Schema.filter((p) => p.relation.length <= 1, {
+  asSingleOption: RelationProperty.pipe(
+    Schema.check(
+      Schema.makeFilter((p) => p.relation.length <= 1, {
         message: () => 'Relation must have at most one item',
       }),
     ),
-    Schema.OptionFromSelf(Schema.Struct({ id: NotionUUID })),
-    {
-      strict: false,
-      decode: (prop) => Option.fromNullable(prop.relation[0]),
-      encode: () =>
-        shouldNeverHappen(
-          'Relation.asSingleOption encode is not supported. Use RelationWrite / RelationWriteFromIds.',
-        ),
-    },
+  ).pipe(
+    Schema.decodeTo(
+      Schema.Option(Schema.Struct({ id: NotionUUID })),
+      SchemaTransformation.transform({
+        decode: (prop) => Option.fromNullishOr(prop.relation[0]),
+        encode: () =>
+          shouldNeverHappen(
+            'Relation.asSingleOption encode is not supported. Use RelationWrite / RelationWriteFromIds.',
+          ),
+      }),
+    ),
   ),
 
   /** Transform to an optional single related page ID (allows 0 or 1 items). */
-  asSingleIdOption: Schema.transform(
-    RelationProperty.pipe(
-      Schema.filter((p) => p.relation.length <= 1, {
+  asSingleIdOption: RelationProperty.pipe(
+    Schema.check(
+      Schema.makeFilter((p) => p.relation.length <= 1, {
         message: () => 'Relation must have at most one item',
       }),
     ),
-    Schema.OptionFromSelf(NotionUUID),
-    {
-      strict: false,
-      decode: (prop) => Option.fromNullable(prop.relation[0]?.id),
-      encode: () =>
-        shouldNeverHappen(
-          'Relation.asSingleIdOption encode is not supported. Use RelationWrite / RelationWriteFromIds.',
-        ),
-    },
+  ).pipe(
+    Schema.decodeTo(
+      Schema.Option(NotionUUID),
+      SchemaTransformation.transform({
+        decode: (prop) => Option.fromNullishOr(prop.relation[0]?.id),
+        encode: () =>
+          shouldNeverHappen(
+            'Relation.asSingleIdOption encode is not supported. Use RelationWrite / RelationWriteFromIds.',
+          ),
+      }),
+    ),
   ),
 
   Write: {
@@ -376,21 +398,27 @@ export const FilesWrite = Schema.Struct({
 export type FilesWrite = typeof FilesWrite.Type
 
 /** Transforms external URLs array into a files write payload */
-export const FilesWriteFromUrls = Schema.transform(Schema.Array(Schema.String), FilesWrite, {
-  strict: false,
-  decode: (urls) => ({
-    files: urls.map((url) => ({
-      type: 'external' as const,
-      external: { url },
-    })),
-  }),
-  encode: (write) => write.files.map((f) => f.external.url),
-}).annotate({
-  identifier: 'Notion.FilesWriteFromUrls',
-  title: 'Files (Write) From URLs',
-  description: 'Transform external URLs into a files write payload.',
-  [docsPath]: 'page#page-property-value',
-})
+export const FilesWriteFromUrls = Schema.Array(Schema.String)
+  .pipe(
+    Schema.decodeTo(
+      FilesWrite,
+      SchemaTransformation.transform({
+        decode: (urls) => ({
+          files: urls.map((url) => ({
+            type: 'external' as const,
+            external: { url },
+          })),
+        }),
+        encode: (write) => write.files.map((f) => f.external.url),
+      }),
+    ),
+  )
+  .annotate({
+    identifier: 'Notion.FilesWriteFromUrls',
+    title: 'Files (Write) From URLs',
+    description: 'Transform external URLs into a files write payload.',
+    [docsPath]: 'page#page-property-value',
+  })
 
 /** Transforms for Files property. */
 export const Files = {
@@ -398,22 +426,33 @@ export const Files = {
   Property: FilesProperty,
 
   /** Transform to raw array of FileObjects. */
-  raw: Schema.transform(FilesProperty, Schema.Array(FileObject), {
-    strict: false,
-    decode: (prop) => prop.files,
-    encode: () =>
-      shouldNeverHappen('Files.raw encode is not supported. Use FilesWrite / FilesWriteFromUrls.'),
-  }),
+  raw: FilesProperty.pipe(
+    Schema.decodeTo(
+      Schema.Array(FileObject),
+      SchemaTransformation.transform({
+        decode: (prop) => prop.files,
+        encode: () =>
+          shouldNeverHappen(
+            'Files.raw encode is not supported. Use FilesWrite / FilesWriteFromUrls.',
+          ),
+      }),
+    ),
+  ),
 
   /** Transform to array of URLs. */
-  asUrls: Schema.transform(FilesProperty, Schema.Array(Schema.String), {
-    strict: false,
-    decode: (prop) => prop.files.map((f) => (f.type === 'external' ? f.external.url : f.file.url)),
-    encode: () =>
-      shouldNeverHappen(
-        'Files.asUrls encode is not supported. Use FilesWrite / FilesWriteFromUrls.',
-      ),
-  }),
+  asUrls: FilesProperty.pipe(
+    Schema.decodeTo(
+      Schema.Array(Schema.String),
+      SchemaTransformation.transform({
+        decode: (prop) =>
+          prop.files.map((f) => (f.type === 'external' ? f.external.url : f.file.url)),
+        encode: () =>
+          shouldNeverHappen(
+            'Files.asUrls encode is not supported. Use FilesWrite / FilesWriteFromUrls.',
+          ),
+      }),
+    ),
+  ),
 
   Write: {
     Schema: FilesWrite,

--- a/packages/@overeng/notion-effect-schema/src/properties/reference.ts
+++ b/packages/@overeng/notion-effect-schema/src/properties/reference.ts
@@ -35,6 +35,9 @@ export const PeopleProperty = Schema.Struct({
 
 export type PeopleProperty = typeof PeopleProperty.Type
 
+const PeopleArray = Schema.Array(User)
+const encodePeopleArray = Schema.encodeSync(PeopleArray)
+
 /**
  * People property write payload (for create/update page requests).
  * Notion expects an array of user references (by id).
@@ -61,7 +64,7 @@ export const PeopleWriteFromIds = Schema.Array(NotionUUID)
   .pipe(
     Schema.decodeTo(
       PeopleWrite,
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<PeopleWrite, ReadonlyArray<NotionUUID>>({
         decode: (ids) => ({
           people: ids.map((id) => ({ id })),
         }),
@@ -84,10 +87,10 @@ export const People = {
   /** Transform to raw array of Users. */
   raw: PeopleProperty.pipe(
     Schema.decodeTo(
-      Schema.Array(User),
-      SchemaTransformation.transform({
-        decode: (prop) => prop.people,
-        encode: () =>
+      PeopleArray,
+      SchemaTransformation.transform<typeof PeopleArray.Encoded, PeopleProperty>({
+        decode: (prop) => encodePeopleArray(prop.people),
+        encode: (): PeopleProperty =>
           shouldNeverHappen(
             'People.raw encode is not supported. Use PeopleWrite / PeopleWriteFromIds.',
           ),
@@ -99,9 +102,9 @@ export const People = {
   asIds: PeopleProperty.pipe(
     Schema.decodeTo(
       Schema.Array(Schema.String),
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<ReadonlyArray<string>, PeopleProperty>({
         decode: (prop) => prop.people.map((u) => u.id),
-        encode: () =>
+        encode: (): PeopleProperty =>
           shouldNeverHappen(
             'People.asIds encode is not supported. Use PeopleWrite / PeopleWriteFromIds.',
           ),
@@ -178,7 +181,7 @@ export const RelationWriteFromIds = Schema.Array(NotionUUID)
   .pipe(
     Schema.decodeTo(
       RelationWrite,
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<RelationWrite, ReadonlyArray<NotionUUID>>({
         decode: (ids) => ({
           relation: ids.map((id) => ({ id })),
         }),
@@ -202,9 +205,9 @@ export const Relation = {
   asIds: RelationProperty.pipe(
     Schema.decodeTo(
       Schema.Array(Schema.String),
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<ReadonlyArray<string>, RelationProperty>({
         decode: (prop) => prop.relation.map((r) => r.id),
-        encode: () =>
+        encode: (): RelationProperty =>
           shouldNeverHappen(
             'Relation.asIds encode is not supported. Use RelationWrite / RelationWriteFromIds.',
           ),
@@ -215,14 +218,17 @@ export const Relation = {
   /** Transform to a single relation object (fails if not exactly one). */
   asSingle: RelationProperty.pipe(
     Schema.refine((p): p is typeof p & { relation: [{ id: string }] } => p.relation.length === 1, {
-      message: () => 'Relation must have exactly one item',
+      message: 'Relation must have exactly one item',
     }),
   ).pipe(
     Schema.decodeTo(
       Schema.Struct({ id: NotionUUID }),
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<
+        { readonly id: NotionUUID },
+        RelationProperty & { relation: [{ id: string }] }
+      >({
         decode: (prop) => prop.relation[0],
-        encode: () =>
+        encode: (): RelationProperty & { relation: [{ id: string }] } =>
           shouldNeverHappen(
             'Relation.asSingle encode is not supported. Use RelationWrite / RelationWriteFromIds.',
           ),
@@ -233,18 +239,20 @@ export const Relation = {
   /** Transform to a single related page ID (fails if not exactly one). */
   asSingleId: RelationProperty.pipe(
     Schema.refine((p): p is typeof p & { relation: [{ id: string }] } => p.relation.length === 1, {
-      message: () => 'Relation must have exactly one item',
+      message: 'Relation must have exactly one item',
     }),
   ).pipe(
     Schema.decodeTo(
       NotionUUID,
-      SchemaTransformation.transform({
-        decode: (prop) => prop.relation[0].id,
-        encode: () =>
-          shouldNeverHappen(
-            'Relation.asSingleId encode is not supported. Use RelationWrite / RelationWriteFromIds.',
-          ),
-      }),
+      SchemaTransformation.transform<NotionUUID, RelationProperty & { relation: [{ id: string }] }>(
+        {
+          decode: (prop) => prop.relation[0].id,
+          encode: (): RelationProperty & { relation: [{ id: string }] } =>
+            shouldNeverHappen(
+              'Relation.asSingleId encode is not supported. Use RelationWrite / RelationWriteFromIds.',
+            ),
+        },
+      ),
     ),
   ),
 
@@ -252,15 +260,15 @@ export const Relation = {
   asSingleOption: RelationProperty.pipe(
     Schema.check(
       Schema.makeFilter((p) => p.relation.length <= 1, {
-        message: () => 'Relation must have at most one item',
+        message: 'Relation must have at most one item',
       }),
     ),
   ).pipe(
     Schema.decodeTo(
       Schema.Option(Schema.Struct({ id: NotionUUID })),
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<Option.Option<{ readonly id: NotionUUID }>, RelationProperty>({
         decode: (prop) => Option.fromNullishOr(prop.relation[0]),
-        encode: () =>
+        encode: (): RelationProperty =>
           shouldNeverHappen(
             'Relation.asSingleOption encode is not supported. Use RelationWrite / RelationWriteFromIds.',
           ),
@@ -272,15 +280,15 @@ export const Relation = {
   asSingleIdOption: RelationProperty.pipe(
     Schema.check(
       Schema.makeFilter((p) => p.relation.length <= 1, {
-        message: () => 'Relation must have at most one item',
+        message: 'Relation must have at most one item',
       }),
     ),
   ).pipe(
     Schema.decodeTo(
       Schema.Option(NotionUUID),
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<Option.Option<NotionUUID>, RelationProperty>({
         decode: (prop) => Option.fromNullishOr(prop.relation[0]?.id),
-        encode: () =>
+        encode: (): RelationProperty =>
           shouldNeverHappen(
             'Relation.asSingleIdOption encode is not supported. Use RelationWrite / RelationWriteFromIds.',
           ),
@@ -402,7 +410,7 @@ export const FilesWriteFromUrls = Schema.Array(Schema.String)
   .pipe(
     Schema.decodeTo(
       FilesWrite,
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<FilesWrite, ReadonlyArray<string>>({
         decode: (urls) => ({
           files: urls.map((url) => ({
             type: 'external' as const,
@@ -429,9 +437,9 @@ export const Files = {
   raw: FilesProperty.pipe(
     Schema.decodeTo(
       Schema.Array(FileObject),
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<ReadonlyArray<FileObject>, FilesProperty>({
         decode: (prop) => prop.files,
-        encode: () =>
+        encode: (): FilesProperty =>
           shouldNeverHappen(
             'Files.raw encode is not supported. Use FilesWrite / FilesWriteFromUrls.',
           ),
@@ -443,10 +451,10 @@ export const Files = {
   asUrls: FilesProperty.pipe(
     Schema.decodeTo(
       Schema.Array(Schema.String),
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<ReadonlyArray<string>, FilesProperty>({
         decode: (prop) =>
           prop.files.map((f) => (f.type === 'external' ? f.external.url : f.file.url)),
-        encode: () =>
+        encode: (): FilesProperty =>
           shouldNeverHappen(
             'Files.asUrls encode is not supported. Use FilesWrite / FilesWriteFromUrls.',
           ),

--- a/packages/@overeng/notion-effect-schema/src/properties/reference.ts
+++ b/packages/@overeng/notion-effect-schema/src/properties/reference.ts
@@ -279,14 +279,14 @@ export const Relation = {
 /**
  * External file object.
  */
-export const ExternalFile = Schema.extend(
-  ExternalFileReference,
-  Schema.Struct({
+export const ExternalFile = Schema.Struct({
+  ...ExternalFileReference.fields,
+  ...Schema.Struct({
     name: Schema.String.annotate({
       description: 'Name of the file.',
     }),
-  }),
-).annotate({
+  }).fields,
+}).annotate({
   identifier: 'Notion.ExternalFile',
   title: 'External File',
   description: 'A file hosted externally.',
@@ -298,14 +298,14 @@ export type ExternalFile = typeof ExternalFile.Type
 /**
  * Notion-hosted file object.
  */
-export const NotionFile = Schema.extend(
-  NotionFileReference,
-  Schema.Struct({
+export const NotionFile = Schema.Struct({
+  ...NotionFileReference.fields,
+  ...Schema.Struct({
     name: Schema.String.annotate({
       description: 'Name of the file.',
     }),
-  }),
-).annotate({
+  }).fields,
+}).annotate({
   identifier: 'Notion.NotionFile',
   title: 'Notion File',
   description: 'A file hosted on Notion (URL expires).',

--- a/packages/@overeng/notion-effect-schema/src/properties/rollup.ts
+++ b/packages/@overeng/notion-effect-schema/src/properties/rollup.ts
@@ -1,4 +1,4 @@
-import { Schema } from 'effect'
+import { Schema, SchemaTransformation } from 'effect'
 
 import { docsPath, shouldNeverHappen } from '../common.ts'
 import { DateValue } from './date.ts'
@@ -74,102 +74,107 @@ export const Rollup = {
   Property: RollupProperty,
 
   /** Transform to raw RollupValue. */
-  raw: Schema.transform(RollupProperty, RollupValue, {
-    strict: false,
-    decode: (prop) => prop.rollup,
-    encode: () => shouldNeverHappen('Rollup.raw encode is not supported (rollup is read-only).'),
-  }),
+  raw: RollupProperty.pipe(
+    Schema.decodeTo(
+      RollupValue,
+      SchemaTransformation.transform({
+        decode: (prop) => prop.rollup,
+        encode: () =>
+          shouldNeverHappen('Rollup.raw encode is not supported (rollup is read-only).'),
+      }),
+    ),
+  ),
 
   /** Transform to required number (fails if not a number rollup). */
-  asNumber: Schema.transform(
-    RollupProperty.pipe(
-      Schema.filter(
-        (p): p is typeof p & { rollup: { type: 'number'; number: number } } =>
-          p.rollup.type === 'number' && p.rollup.number !== null,
-        { message: () => 'Rollup must be a non-null number' },
-      ),
+  asNumber: RollupProperty.pipe(
+    Schema.refine(
+      (p): p is typeof p & { rollup: { type: 'number'; number: number } } =>
+        p.rollup.type === 'number' && p.rollup.number !== null,
+      { message: () => 'Rollup must be a non-null number' },
     ),
-    Schema.Number,
-    {
-      strict: false,
-      decode: (prop) => prop.rollup.number,
-      encode: () =>
-        shouldNeverHappen('Rollup.asNumber encode is not supported (rollup is read-only).'),
-    },
+  ).pipe(
+    Schema.decodeTo(
+      Schema.Number,
+      SchemaTransformation.transform({
+        decode: (prop) => prop.rollup.number,
+        encode: () =>
+          shouldNeverHappen('Rollup.asNumber encode is not supported (rollup is read-only).'),
+      }),
+    ),
   ),
 
   /** Transform to required string (fails if not a string rollup). */
-  asString: Schema.transform(
-    RollupProperty.pipe(
-      Schema.filter(
-        (p): p is typeof p & { rollup: { type: 'string'; string: string } } =>
-          p.rollup.type === 'string' && p.rollup.string !== null,
-        { message: () => 'Rollup must be a non-null string' },
-      ),
+  asString: RollupProperty.pipe(
+    Schema.refine(
+      (p): p is typeof p & { rollup: { type: 'string'; string: string } } =>
+        p.rollup.type === 'string' && p.rollup.string !== null,
+      { message: () => 'Rollup must be a non-null string' },
     ),
-    Schema.String,
-    {
-      strict: false,
-      decode: (prop) => prop.rollup.string,
-      encode: () =>
-        shouldNeverHappen('Rollup.asString encode is not supported (rollup is read-only).'),
-    },
+  ).pipe(
+    Schema.decodeTo(
+      Schema.String,
+      SchemaTransformation.transform({
+        decode: (prop) => prop.rollup.string,
+        encode: () =>
+          shouldNeverHappen('Rollup.asString encode is not supported (rollup is read-only).'),
+      }),
+    ),
   ),
 
   /** Transform to required boolean (fails if not a boolean rollup). */
-  asBoolean: Schema.transform(
-    RollupProperty.pipe(
-      Schema.filter(
-        (p): p is typeof p & { rollup: { type: 'boolean'; boolean: boolean } } =>
-          p.rollup.type === 'boolean' && p.rollup.boolean !== null,
-        { message: () => 'Rollup must be a non-null boolean' },
-      ),
+  asBoolean: RollupProperty.pipe(
+    Schema.refine(
+      (p): p is typeof p & { rollup: { type: 'boolean'; boolean: boolean } } =>
+        p.rollup.type === 'boolean' && p.rollup.boolean !== null,
+      { message: () => 'Rollup must be a non-null boolean' },
     ),
-    Schema.Boolean,
-    {
-      strict: false,
-      decode: (prop) => prop.rollup.boolean,
-      encode: () =>
-        shouldNeverHappen('Rollup.asBoolean encode is not supported (rollup is read-only).'),
-    },
+  ).pipe(
+    Schema.decodeTo(
+      Schema.Boolean,
+      SchemaTransformation.transform({
+        decode: (prop) => prop.rollup.boolean,
+        encode: () =>
+          shouldNeverHappen('Rollup.asBoolean encode is not supported (rollup is read-only).'),
+      }),
+    ),
   ),
 
   /** Transform to required date (fails if not a date rollup). */
-  asDate: Schema.transform(
-    RollupProperty.pipe(
-      Schema.filter(
-        (p): p is typeof p & { rollup: { type: 'date'; date: DateValue } } =>
-          p.rollup.type === 'date' && p.rollup.date !== null,
-        { message: () => 'Rollup must be a non-null date' },
-      ),
+  asDate: RollupProperty.pipe(
+    Schema.refine(
+      (p): p is typeof p & { rollup: { type: 'date'; date: DateValue } } =>
+        p.rollup.type === 'date' && p.rollup.date !== null,
+      { message: () => 'Rollup must be a non-null date' },
     ),
-    DateValue,
-    {
-      strict: false,
-      decode: (prop) => prop.rollup.date,
-      encode: () =>
-        shouldNeverHappen('Rollup.asDate encode is not supported (rollup is read-only).'),
-    },
+  ).pipe(
+    Schema.decodeTo(
+      DateValue,
+      SchemaTransformation.transform({
+        decode: (prop) => prop.rollup.date,
+        encode: () =>
+          shouldNeverHappen('Rollup.asDate encode is not supported (rollup is read-only).'),
+      }),
+    ),
   ),
 
   /** Transform to rollup array (fails if not an array rollup). */
-  asArray: Schema.transform(
-    RollupProperty.pipe(
-      Schema.filter(
-        (
-          p,
-        ): p is typeof p & {
-          rollup: { type: 'array'; array: Array<unknown> }
-        } => p.rollup.type === 'array',
-        { message: () => 'Rollup must be an array' },
-      ),
+  asArray: RollupProperty.pipe(
+    Schema.refine(
+      (
+        p,
+      ): p is typeof p & {
+        rollup: { type: 'array'; array: Array<unknown> }
+      } => p.rollup.type === 'array',
+      { message: () => 'Rollup must be an array' },
     ),
-    Schema.Array(Schema.Unknown),
-    {
-      strict: false,
-      decode: (prop) => prop.rollup.array,
-      encode: () =>
-        shouldNeverHappen('Rollup.asArray encode is not supported (rollup is read-only).'),
-    },
+  ).pipe(
+    Schema.decodeTo(
+      Schema.Array(Schema.Unknown),
+      SchemaTransformation.transform({
+        decode: (prop) => prop.rollup.array,
+        encode: () =>
+          shouldNeverHappen('Rollup.asArray encode is not supported (rollup is read-only).'),
+      }),
+    ),
   ),
 } as const

--- a/packages/@overeng/notion-effect-schema/src/properties/rollup.ts
+++ b/packages/@overeng/notion-effect-schema/src/properties/rollup.ts
@@ -77,9 +77,9 @@ export const Rollup = {
   raw: RollupProperty.pipe(
     Schema.decodeTo(
       RollupValue,
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<RollupValue, RollupProperty>({
         decode: (prop) => prop.rollup,
-        encode: () =>
+        encode: (): RollupProperty =>
           shouldNeverHappen('Rollup.raw encode is not supported (rollup is read-only).'),
       }),
     ),
@@ -90,14 +90,17 @@ export const Rollup = {
     Schema.refine(
       (p): p is typeof p & { rollup: { type: 'number'; number: number } } =>
         p.rollup.type === 'number' && p.rollup.number !== null,
-      { message: () => 'Rollup must be a non-null number' },
+      { message: 'Rollup must be a non-null number' },
     ),
   ).pipe(
     Schema.decodeTo(
       Schema.Number,
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<
+        number,
+        RollupProperty & { rollup: { type: 'number'; number: number } }
+      >({
         decode: (prop) => prop.rollup.number,
-        encode: () =>
+        encode: (): RollupProperty & { rollup: { type: 'number'; number: number } } =>
           shouldNeverHappen('Rollup.asNumber encode is not supported (rollup is read-only).'),
       }),
     ),
@@ -108,14 +111,17 @@ export const Rollup = {
     Schema.refine(
       (p): p is typeof p & { rollup: { type: 'string'; string: string } } =>
         p.rollup.type === 'string' && p.rollup.string !== null,
-      { message: () => 'Rollup must be a non-null string' },
+      { message: 'Rollup must be a non-null string' },
     ),
   ).pipe(
     Schema.decodeTo(
       Schema.String,
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<
+        string,
+        RollupProperty & { rollup: { type: 'string'; string: string } }
+      >({
         decode: (prop) => prop.rollup.string,
-        encode: () =>
+        encode: (): RollupProperty & { rollup: { type: 'string'; string: string } } =>
           shouldNeverHappen('Rollup.asString encode is not supported (rollup is read-only).'),
       }),
     ),
@@ -126,14 +132,17 @@ export const Rollup = {
     Schema.refine(
       (p): p is typeof p & { rollup: { type: 'boolean'; boolean: boolean } } =>
         p.rollup.type === 'boolean' && p.rollup.boolean !== null,
-      { message: () => 'Rollup must be a non-null boolean' },
+      { message: 'Rollup must be a non-null boolean' },
     ),
   ).pipe(
     Schema.decodeTo(
       Schema.Boolean,
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<
+        boolean,
+        RollupProperty & { rollup: { type: 'boolean'; boolean: boolean } }
+      >({
         decode: (prop) => prop.rollup.boolean,
-        encode: () =>
+        encode: (): RollupProperty & { rollup: { type: 'boolean'; boolean: boolean } } =>
           shouldNeverHappen('Rollup.asBoolean encode is not supported (rollup is read-only).'),
       }),
     ),
@@ -144,14 +153,17 @@ export const Rollup = {
     Schema.refine(
       (p): p is typeof p & { rollup: { type: 'date'; date: DateValue } } =>
         p.rollup.type === 'date' && p.rollup.date !== null,
-      { message: () => 'Rollup must be a non-null date' },
+      { message: 'Rollup must be a non-null date' },
     ),
   ).pipe(
     Schema.decodeTo(
       DateValue,
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<
+        DateValue,
+        RollupProperty & { rollup: { type: 'date'; date: DateValue } }
+      >({
         decode: (prop) => prop.rollup.date,
-        encode: () =>
+        encode: (): RollupProperty & { rollup: { type: 'date'; date: DateValue } } =>
           shouldNeverHappen('Rollup.asDate encode is not supported (rollup is read-only).'),
       }),
     ),
@@ -165,15 +177,19 @@ export const Rollup = {
       ): p is typeof p & {
         rollup: { type: 'array'; array: Array<unknown> }
       } => p.rollup.type === 'array',
-      { message: () => 'Rollup must be an array' },
+      { message: 'Rollup must be an array' },
     ),
   ).pipe(
     Schema.decodeTo(
       Schema.Array(Schema.Unknown),
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<
+        ReadonlyArray<unknown>,
+        RollupProperty & { rollup: { type: 'array'; array: Array<unknown> } }
+      >({
         decode: (prop) => prop.rollup.array,
-        encode: () =>
-          shouldNeverHappen('Rollup.asArray encode is not supported (rollup is read-only).'),
+        encode: (): RollupProperty & {
+          rollup: { type: 'array'; array: Array<unknown> }
+        } => shouldNeverHappen('Rollup.asArray encode is not supported (rollup is read-only).'),
       }),
     ),
   ),

--- a/packages/@overeng/notion-effect-schema/src/properties/select.ts
+++ b/packages/@overeng/notion-effect-schema/src/properties/select.ts
@@ -59,7 +59,7 @@ export const SelectWriteFromName = Schema.NullOr(Schema.String)
   .pipe(
     Schema.decodeTo(
       SelectWrite,
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<SelectWrite, string | null>({
         decode: (name) => ({
           select: name === null ? null : { name },
         }),
@@ -106,9 +106,9 @@ export const Select = {
   raw: SelectProperty.pipe(
     Schema.decodeTo(
       Schema.NullOr(SelectOption),
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<SelectOption | null, SelectProperty>({
         decode: (prop) => prop.select,
-        encode: () =>
+        encode: (): SelectProperty =>
           shouldNeverHappen(
             'Select.raw encode is not supported. Use SelectWrite / SelectWriteFromName.',
           ),
@@ -122,9 +122,9 @@ export const Select = {
       schema: SelectProperty.pipe(
         Schema.decodeTo(
           Schema.Option(SelectOption),
-          SchemaTransformation.transform({
+          SchemaTransformation.transform<Option.Option<SelectOption>, SelectProperty>({
             decode: (prop) => (prop.select === null ? Option.none() : Option.some(prop.select)),
-            encode: () =>
+            encode: (): SelectProperty =>
               shouldNeverHappen(
                 'Select.asOption encode is not supported. Use SelectWrite / SelectWriteFromName.',
               ),
@@ -144,7 +144,7 @@ export const Select = {
       Schema.refine(
         (p): p is typeof p & { select: typeof optionSchema.Type | null } =>
           p.select === null || isAllowedName({ nameSchema, name: p.select.name }),
-        { message: () => 'Select option must be one of the allowed options' },
+        { message: 'Select option must be one of the allowed options' },
       ),
     )
   },
@@ -160,15 +160,20 @@ export const Select = {
             (p): p is typeof p & { select: typeof optionSchema.Type | null } =>
               p.select === null || isAllowedName({ nameSchema, name: p.select.name }),
             {
-              message: () => 'Select option must be one of the allowed options',
+              message: 'Select option must be one of the allowed options',
             },
           ),
         ).pipe(
           Schema.decodeTo(
             Schema.Option(optionSchema),
-            SchemaTransformation.transform({
+            SchemaTransformation.transform<
+              Option.Option<typeof optionSchema.Type>,
+              SelectProperty & { select: typeof optionSchema.Type | null }
+            >({
               decode: (prop) => (prop.select === null ? Option.none() : Option.some(prop.select)),
-              encode: () =>
+              encode: (): SelectProperty & {
+                select: typeof optionSchema.Type | null
+              } =>
                 shouldNeverHappen(
                   'Select.asOptionNamed encode is not supported. Use SelectWrite / SelectWriteFromName.',
                 ),
@@ -189,16 +194,19 @@ export const Select = {
           (p): p is typeof p & { select: { name: TName } | null } =>
             p.select === null || isAllowedName({ nameSchema, name: p.select.name }),
           {
-            message: () => 'Select option must be one of the allowed options',
+            message: 'Select option must be one of the allowed options',
           },
         ),
       ).pipe(
         Schema.decodeTo(
           Schema.Option(nameSchema),
-          SchemaTransformation.transform({
+          SchemaTransformation.transform<
+            Option.Option<TName>,
+            SelectProperty & { select: { name: TName } | null }
+          >({
             decode: (prop) =>
               prop.select === null ? Option.none() : Option.some(prop.select.name),
-            encode: () =>
+            encode: (): SelectProperty & { select: { name: TName } | null } =>
               shouldNeverHappen(
                 'Select.asName encode is not supported. Use SelectWrite / SelectWriteFromName.',
               ),
@@ -213,9 +221,9 @@ export const Select = {
     schema: SelectProperty.pipe(
       Schema.decodeTo(
         Schema.Option(Schema.String),
-        SchemaTransformation.transform({
+        SchemaTransformation.transform<Option.Option<string>, SelectProperty>({
           decode: (prop) => (prop.select === null ? Option.none() : Option.some(prop.select.name)),
-          encode: () =>
+          encode: (): SelectProperty =>
             shouldNeverHappen(
               'Select.asString encode is not supported. Use SelectWrite / SelectWriteFromName.',
             ),
@@ -280,7 +288,7 @@ export const MultiSelectWriteFromNames = Schema.Array(Schema.String)
   .pipe(
     Schema.decodeTo(
       MultiSelectWrite,
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<MultiSelectWrite, ReadonlyArray<string>>({
         decode: (names) => ({
           multi_select: names.map((name) => ({ name })),
         }),
@@ -314,9 +322,9 @@ export const MultiSelect = {
     schema: MultiSelectProperty.pipe(
       Schema.decodeTo(
         Schema.Array(SelectOption),
-        SchemaTransformation.transform({
+        SchemaTransformation.transform<ReadonlyArray<SelectOption>, MultiSelectProperty>({
           decode: (prop) => prop.multi_select,
-          encode: () =>
+          encode: (): MultiSelectProperty =>
             shouldNeverHappen(
               'MultiSelect.raw encode is not supported. Use MultiSelectWrite / MultiSelectWriteFromNames.',
             ),
@@ -330,9 +338,9 @@ export const MultiSelect = {
   asStrings: MultiSelectProperty.pipe(
     Schema.decodeTo(
       Schema.Array(Schema.String),
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<ReadonlyArray<string>, MultiSelectProperty>({
         decode: (prop) => prop.multi_select.map((opt) => opt.name),
-        encode: () =>
+        encode: (): MultiSelectProperty =>
           shouldNeverHappen(
             'MultiSelect.asStrings encode is not supported. Use MultiSelectWrite / MultiSelectWriteFromNames.',
           ),
@@ -344,18 +352,34 @@ export const MultiSelect = {
   asNames: <TName extends string>(nameSchema: Schema.Codec<TName>) =>
     MultiSelectProperty.pipe(
       Schema.refine(
-        (p): p is typeof p & { multi_select: Array<{ name: TName }> } =>
-          p.multi_select.every((opt) => isAllowedName({ nameSchema, name: opt.name })),
+        (
+          p,
+        ): p is Omit<MultiSelectProperty, 'multi_select'> & {
+          readonly multi_select: ReadonlyArray<
+            Omit<SelectOption, 'name'> & { readonly name: TName }
+          >
+        } => p.multi_select.every((opt) => isAllowedName({ nameSchema, name: opt.name })),
         {
-          message: () => 'MultiSelect options must be one of the allowed options',
+          message: 'MultiSelect options must be one of the allowed options',
         },
       ),
     ).pipe(
       Schema.decodeTo(
         Schema.Array(nameSchema),
-        SchemaTransformation.transform({
-          decode: (prop) => prop.multi_select.map((opt) => opt.name),
-          encode: () =>
+        SchemaTransformation.transform<
+          ReadonlyArray<TName>,
+          Omit<MultiSelectProperty, 'multi_select'> & {
+            readonly multi_select: ReadonlyArray<
+              Omit<SelectOption, 'name'> & { readonly name: TName }
+            >
+          }
+        >({
+          decode: (prop) => prop.multi_select.map((option) => option.name),
+          encode: (): Omit<MultiSelectProperty, 'multi_select'> & {
+            readonly multi_select: ReadonlyArray<
+              Omit<SelectOption, 'name'> & { readonly name: TName }
+            >
+          } =>
             shouldNeverHappen(
               'MultiSelect.asNames encode is not supported. Use MultiSelectWrite / MultiSelectWriteFromNames.',
             ),
@@ -372,7 +396,7 @@ export const MultiSelect = {
         (p): p is typeof p & { multi_select: Array<typeof optionSchema.Type> } =>
           p.multi_select.every((opt) => isAllowedName({ nameSchema, name: opt.name })),
         {
-          message: () => 'MultiSelect options must be one of the allowed options',
+          message: 'MultiSelect options must be one of the allowed options',
         },
       ),
     )
@@ -391,15 +415,22 @@ export const MultiSelect = {
             multi_select: Array<typeof optionSchema.Type>
           } => p.multi_select.every((opt) => isAllowedName({ nameSchema, name: opt.name })),
           {
-            message: () => 'MultiSelect options must be one of the allowed options',
+            message: 'MultiSelect options must be one of the allowed options',
           },
         ),
       ).pipe(
         Schema.decodeTo(
           Schema.Array(optionSchema),
-          SchemaTransformation.transform({
+          SchemaTransformation.transform<
+            ReadonlyArray<typeof optionSchema.Type>,
+            MultiSelectProperty & {
+              multi_select: Array<typeof optionSchema.Type>
+            }
+          >({
             decode: (prop) => prop.multi_select,
-            encode: () =>
+            encode: (): MultiSelectProperty & {
+              multi_select: Array<typeof optionSchema.Type>
+            } =>
               shouldNeverHappen(
                 'MultiSelect.asOptionsNamed encode is not supported. Use MultiSelectWrite / MultiSelectWriteFromNames.',
               ),
@@ -465,7 +496,7 @@ export const StatusWriteFromName = Schema.NullOr(Schema.String)
   .pipe(
     Schema.decodeTo(
       StatusWrite,
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<StatusWrite, string | null>({
         decode: (name) => ({
           status: name === null ? null : { name },
         }),
@@ -499,9 +530,9 @@ export const Status = {
   raw: StatusProperty.pipe(
     Schema.decodeTo(
       Schema.NullOr(SelectOption),
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<SelectOption | null, StatusProperty>({
         decode: (prop) => prop.status,
-        encode: () =>
+        encode: (): StatusProperty =>
           shouldNeverHappen(
             'Status.raw encode is not supported. Use StatusWrite / StatusWriteFromName.',
           ),
@@ -515,9 +546,9 @@ export const Status = {
       schema: StatusProperty.pipe(
         Schema.decodeTo(
           Schema.Option(SelectOption),
-          SchemaTransformation.transform({
+          SchemaTransformation.transform<Option.Option<SelectOption>, StatusProperty>({
             decode: (prop) => (prop.status === null ? Option.none() : Option.some(prop.status)),
-            encode: () =>
+            encode: (): StatusProperty =>
               shouldNeverHappen(
                 'Status.asOption encode is not supported. Use StatusWrite / StatusWriteFromName.',
               ),
@@ -537,7 +568,7 @@ export const Status = {
       Schema.refine(
         (p): p is typeof p & { status: typeof optionSchema.Type | null } =>
           p.status === null || isAllowedName({ nameSchema, name: p.status.name }),
-        { message: () => 'Status must be one of the allowed options' },
+        { message: 'Status must be one of the allowed options' },
       ),
     )
   },
@@ -547,9 +578,9 @@ export const Status = {
     schema: StatusProperty.pipe(
       Schema.decodeTo(
         Schema.Option(Schema.String),
-        SchemaTransformation.transform({
+        SchemaTransformation.transform<Option.Option<string>, StatusProperty>({
           decode: (prop) => (prop.status === null ? Option.none() : Option.some(prop.status.name)),
-          encode: () =>
+          encode: (): StatusProperty =>
             shouldNeverHappen(
               'Status.asString encode is not supported. Use StatusWrite / StatusWriteFromName.',
             ),
@@ -569,14 +600,19 @@ export const Status = {
           Schema.refine(
             (p): p is typeof p & { status: typeof optionSchema.Type | null } =>
               p.status === null || isAllowedName({ nameSchema, name: p.status.name }),
-            { message: () => 'Status must be one of the allowed options' },
+            { message: 'Status must be one of the allowed options' },
           ),
         ).pipe(
           Schema.decodeTo(
             Schema.Option(optionSchema),
-            SchemaTransformation.transform({
+            SchemaTransformation.transform<
+              Option.Option<typeof optionSchema.Type>,
+              StatusProperty & { status: typeof optionSchema.Type | null }
+            >({
               decode: (prop) => (prop.status === null ? Option.none() : Option.some(prop.status)),
-              encode: () =>
+              encode: (): StatusProperty & {
+                status: typeof optionSchema.Type | null
+              } =>
                 shouldNeverHappen(
                   'Status.asOptionNamed encode is not supported. Use StatusWrite / StatusWriteFromName.',
                 ),
@@ -596,15 +632,18 @@ export const Status = {
         Schema.refine(
           (p): p is typeof p & { status: { name: TName } | null } =>
             p.status === null || isAllowedName({ nameSchema, name: p.status.name }),
-          { message: () => 'Status must be one of the allowed options' },
+          { message: 'Status must be one of the allowed options' },
         ),
       ).pipe(
         Schema.decodeTo(
           Schema.Option(nameSchema),
-          SchemaTransformation.transform({
+          SchemaTransformation.transform<
+            Option.Option<TName>,
+            StatusProperty & { status: { name: TName } | null }
+          >({
             decode: (prop) =>
               prop.status === null ? Option.none() : Option.some(prop.status.name),
-            encode: () =>
+            encode: (): StatusProperty & { status: { name: TName } | null } =>
               shouldNeverHappen(
                 'Status.asName encode is not supported. Use StatusWrite / StatusWriteFromName.',
               ),

--- a/packages/@overeng/notion-effect-schema/src/properties/select.ts
+++ b/packages/@overeng/notion-effect-schema/src/properties/select.ts
@@ -1,4 +1,4 @@
-import { Option, Schema } from 'effect'
+import { Option, Schema, SchemaTransformation } from 'effect'
 
 import {
   docsPath,
@@ -55,36 +55,42 @@ export const SelectWrite = Schema.Struct({
 export type SelectWrite = typeof SelectWrite.Type
 
 /** Transforms option name (or null) into a select write payload */
-export const SelectWriteFromName = Schema.transform(Schema.NullOr(Schema.String), SelectWrite, {
-  strict: false,
-  decode: (name) => ({
-    select: name === null ? null : { name },
-  }),
-  encode: (write) => {
-    if (write.select === null) {
-      return null
-    }
+export const SelectWriteFromName = Schema.NullOr(Schema.String)
+  .pipe(
+    Schema.decodeTo(
+      SelectWrite,
+      SchemaTransformation.transform({
+        decode: (name) => ({
+          select: name === null ? null : { name },
+        }),
+        encode: (write) => {
+          if (write.select === null) {
+            return null
+          }
 
-    if ('name' in write.select) {
-      return write.select.name
-    }
+          if ('name' in write.select) {
+            return write.select.name
+          }
 
-    return shouldNeverHappen('SelectWriteFromName cannot encode option referenced by id.')
-  },
-}).annotate({
-  identifier: 'Notion.SelectWriteFromName',
-  title: 'Select (Write) From Name',
-  description: 'Transform an option name (or null) into a select write payload.',
-  [docsPath]: 'page#page-property-value',
-})
+          return shouldNeverHappen('SelectWriteFromName cannot encode option referenced by id.')
+        },
+      }),
+    ),
+  )
+  .annotate({
+    identifier: 'Notion.SelectWriteFromName',
+    title: 'Select (Write) From Name',
+    description: 'Transform an option name (or null) into a select write payload.',
+    [docsPath]: 'page#page-property-value',
+  })
 
 const isAllowedName = <TName extends string>(options: {
-  nameSchema: Schema.Schema<TName>
+  nameSchema: Schema.Codec<TName>
   name: string
-}): options is { nameSchema: Schema.Schema<TName>; name: TName } =>
+}): options is { nameSchema: Schema.Codec<TName>; name: TName } =>
   Option.isSome(Schema.decodeUnknownOption(options.nameSchema)(options.name))
 
-const makeSelectOptionWithName = <TName extends string>(nameSchema: Schema.Schema<TName>) =>
+const makeSelectOptionWithName = <TName extends string>(nameSchema: Schema.Codec<TName>) =>
   Schema.Struct({
     id: NotionUUID,
     name: nameSchema,
@@ -97,37 +103,45 @@ export const Select = {
   Property: SelectProperty,
 
   /** Transform to raw nullable SelectOption. */
-  raw: Schema.transform(SelectProperty, Schema.NullOr(SelectOption), {
-    strict: false,
-    decode: (prop) => prop.select,
-    encode: () =>
-      shouldNeverHappen(
-        'Select.raw encode is not supported. Use SelectWrite / SelectWriteFromName.',
-      ),
-  }),
+  raw: SelectProperty.pipe(
+    Schema.decodeTo(
+      Schema.NullOr(SelectOption),
+      SchemaTransformation.transform({
+        decode: (prop) => prop.select,
+        encode: () =>
+          shouldNeverHappen(
+            'Select.raw encode is not supported. Use SelectWrite / SelectWriteFromName.',
+          ),
+      }),
+    ),
+  ),
 
   /** Transform to Option<SelectOption>. */
   asOption: withOptionNameSchema({
     schema: withOptionValueSchema({
-      schema: Schema.transform(SelectProperty, Schema.OptionFromSelf(SelectOption), {
-        strict: false,
-        decode: (prop) => (prop.select === null ? Option.none() : Option.some(prop.select)),
-        encode: () =>
-          shouldNeverHappen(
-            'Select.asOption encode is not supported. Use SelectWrite / SelectWriteFromName.',
-          ),
-      }),
+      schema: SelectProperty.pipe(
+        Schema.decodeTo(
+          Schema.Option(SelectOption),
+          SchemaTransformation.transform({
+            decode: (prop) => (prop.select === null ? Option.none() : Option.some(prop.select)),
+            encode: () =>
+              shouldNeverHappen(
+                'Select.asOption encode is not supported. Use SelectWrite / SelectWriteFromName.',
+              ),
+          }),
+        ),
+      ),
       valueSchema: SelectOption,
     }),
     nameSchema: Schema.String,
   }),
 
   /** Transform to SelectProperty with a typed name (fails for unknown options). */
-  asPropertyNamed: <TName extends string>(nameSchema: Schema.Schema<TName>) => {
+  asPropertyNamed: <TName extends string>(nameSchema: Schema.Codec<TName>) => {
     const optionSchema = makeSelectOptionWithName(nameSchema)
 
     return SelectProperty.pipe(
-      Schema.filter(
+      Schema.refine(
         (p): p is typeof p & { select: typeof optionSchema.Type | null } =>
           p.select === null || isAllowedName({ nameSchema, name: p.select.name }),
         { message: () => 'Select option must be one of the allowed options' },
@@ -136,30 +150,30 @@ export const Select = {
   },
 
   /** Transform to Option<SelectOption> with a typed name (fails for unknown options). */
-  asOptionNamed: <TName extends string>(nameSchema: Schema.Schema<TName>) => {
+  asOptionNamed: <TName extends string>(nameSchema: Schema.Codec<TName>) => {
     const optionSchema = makeSelectOptionWithName(nameSchema)
 
     return withOptionNameSchema({
       schema: withOptionValueSchema({
-        schema: Schema.transform(
-          SelectProperty.pipe(
-            Schema.filter(
-              (p): p is typeof p & { select: typeof optionSchema.Type | null } =>
-                p.select === null || isAllowedName({ nameSchema, name: p.select.name }),
-              {
-                message: () => 'Select option must be one of the allowed options',
-              },
-            ),
+        schema: SelectProperty.pipe(
+          Schema.refine(
+            (p): p is typeof p & { select: typeof optionSchema.Type | null } =>
+              p.select === null || isAllowedName({ nameSchema, name: p.select.name }),
+            {
+              message: () => 'Select option must be one of the allowed options',
+            },
           ),
-          Schema.OptionFromSelf(optionSchema),
-          {
-            strict: false,
-            decode: (prop) => (prop.select === null ? Option.none() : Option.some(prop.select)),
-            encode: () =>
-              shouldNeverHappen(
-                'Select.asOptionNamed encode is not supported. Use SelectWrite / SelectWriteFromName.',
-              ),
-          },
+        ).pipe(
+          Schema.decodeTo(
+            Schema.Option(optionSchema),
+            SchemaTransformation.transform({
+              decode: (prop) => (prop.select === null ? Option.none() : Option.some(prop.select)),
+              encode: () =>
+                shouldNeverHappen(
+                  'Select.asOptionNamed encode is not supported. Use SelectWrite / SelectWriteFromName.',
+                ),
+            }),
+          ),
         ),
         valueSchema: optionSchema,
       }),
@@ -168,41 +182,46 @@ export const Select = {
   },
 
   /** Transform to Option<name> with allowed options (fails for unknown options). */
-  asName: <TName extends string>(nameSchema: Schema.Schema<TName>) =>
+  asName: <TName extends string>(nameSchema: Schema.Codec<TName>) =>
     withOptionValueSchema({
-      schema: Schema.transform(
-        SelectProperty.pipe(
-          Schema.filter(
-            (p): p is typeof p & { select: { name: TName } | null } =>
-              p.select === null || isAllowedName({ nameSchema, name: p.select.name }),
-            {
-              message: () => 'Select option must be one of the allowed options',
-            },
-          ),
+      schema: SelectProperty.pipe(
+        Schema.refine(
+          (p): p is typeof p & { select: { name: TName } | null } =>
+            p.select === null || isAllowedName({ nameSchema, name: p.select.name }),
+          {
+            message: () => 'Select option must be one of the allowed options',
+          },
         ),
-        Schema.OptionFromSelf(nameSchema),
-        {
-          strict: false,
-          decode: (prop) => (prop.select === null ? Option.none() : Option.some(prop.select.name)),
-          encode: () =>
-            shouldNeverHappen(
-              'Select.asName encode is not supported. Use SelectWrite / SelectWriteFromName.',
-            ),
-        },
+      ).pipe(
+        Schema.decodeTo(
+          Schema.Option(nameSchema),
+          SchemaTransformation.transform({
+            decode: (prop) =>
+              prop.select === null ? Option.none() : Option.some(prop.select.name),
+            encode: () =>
+              shouldNeverHappen(
+                'Select.asName encode is not supported. Use SelectWrite / SelectWriteFromName.',
+              ),
+          }),
+        ),
       ),
       valueSchema: nameSchema,
     }),
 
   /** Transform to Option<string> (option name). */
   asString: withOptionValueSchema({
-    schema: Schema.transform(SelectProperty, Schema.OptionFromSelf(Schema.String), {
-      strict: false,
-      decode: (prop) => (prop.select === null ? Option.none() : Option.some(prop.select.name)),
-      encode: () =>
-        shouldNeverHappen(
-          'Select.asString encode is not supported. Use SelectWrite / SelectWriteFromName.',
-        ),
-    }),
+    schema: SelectProperty.pipe(
+      Schema.decodeTo(
+        Schema.Option(Schema.String),
+        SchemaTransformation.transform({
+          decode: (prop) => (prop.select === null ? Option.none() : Option.some(prop.select.name)),
+          encode: () =>
+            shouldNeverHappen(
+              'Select.asString encode is not supported. Use SelectWrite / SelectWriteFromName.',
+            ),
+        }),
+      ),
+    ),
     valueSchema: Schema.String,
   }),
 
@@ -257,29 +276,33 @@ export const MultiSelectWrite = Schema.Struct({
 export type MultiSelectWrite = typeof MultiSelectWrite.Type
 
 /** Transforms option names array into a multi-select write payload */
-export const MultiSelectWriteFromNames = Schema.transform(
-  Schema.Array(Schema.String),
-  MultiSelectWrite,
-  {
-    strict: false,
-    decode: (names) => ({
-      multi_select: names.map((name) => ({ name })),
-    }),
-    encode: (write) =>
-      write.multi_select.map((opt) => {
-        if ('name' in opt) {
-          return opt.name
-        }
+export const MultiSelectWriteFromNames = Schema.Array(Schema.String)
+  .pipe(
+    Schema.decodeTo(
+      MultiSelectWrite,
+      SchemaTransformation.transform({
+        decode: (names) => ({
+          multi_select: names.map((name) => ({ name })),
+        }),
+        encode: (write) =>
+          write.multi_select.map((opt) => {
+            if ('name' in opt) {
+              return opt.name
+            }
 
-        return shouldNeverHappen('MultiSelectWriteFromNames cannot encode option referenced by id.')
+            return shouldNeverHappen(
+              'MultiSelectWriteFromNames cannot encode option referenced by id.',
+            )
+          }),
       }),
-  },
-).annotate({
-  identifier: 'Notion.MultiSelectWriteFromNames',
-  title: 'Multi-Select (Write) From Names',
-  description: 'Transform option names into a multi-select write payload.',
-  [docsPath]: 'page#page-property-value',
-})
+    ),
+  )
+  .annotate({
+    identifier: 'Notion.MultiSelectWriteFromNames',
+    title: 'Multi-Select (Write) From Names',
+    description: 'Transform option names into a multi-select write payload.',
+    [docsPath]: 'page#page-property-value',
+  })
 
 /** Transforms for MultiSelect property. */
 export const MultiSelect = {
@@ -288,56 +311,64 @@ export const MultiSelect = {
 
   /** Transform to raw array of SelectOptions. */
   raw: withOptionNameSchema({
-    schema: Schema.transform(MultiSelectProperty, Schema.Array(SelectOption), {
-      strict: false,
-      decode: (prop) => prop.multi_select,
-      encode: () =>
-        shouldNeverHappen(
-          'MultiSelect.raw encode is not supported. Use MultiSelectWrite / MultiSelectWriteFromNames.',
-        ),
-    }),
+    schema: MultiSelectProperty.pipe(
+      Schema.decodeTo(
+        Schema.Array(SelectOption),
+        SchemaTransformation.transform({
+          decode: (prop) => prop.multi_select,
+          encode: () =>
+            shouldNeverHappen(
+              'MultiSelect.raw encode is not supported. Use MultiSelectWrite / MultiSelectWriteFromNames.',
+            ),
+        }),
+      ),
+    ),
     nameSchema: Schema.String,
   }),
 
   /** Transform to array of option names. */
-  asStrings: Schema.transform(MultiSelectProperty, Schema.Array(Schema.String), {
-    strict: false,
-    decode: (prop) => prop.multi_select.map((opt) => opt.name),
-    encode: () =>
-      shouldNeverHappen(
-        'MultiSelect.asStrings encode is not supported. Use MultiSelectWrite / MultiSelectWriteFromNames.',
-      ),
-  }),
-
-  /** Transform to array of option names with allowed options (fails for unknown options). */
-  asNames: <TName extends string>(nameSchema: Schema.Schema<TName>) =>
-    Schema.transform(
-      MultiSelectProperty.pipe(
-        Schema.filter(
-          (p): p is typeof p & { multi_select: Array<{ name: TName }> } =>
-            p.multi_select.every((opt) => isAllowedName({ nameSchema, name: opt.name })),
-          {
-            message: () => 'MultiSelect options must be one of the allowed options',
-          },
-        ),
-      ),
-      Schema.Array(nameSchema),
-      {
-        strict: false,
+  asStrings: MultiSelectProperty.pipe(
+    Schema.decodeTo(
+      Schema.Array(Schema.String),
+      SchemaTransformation.transform({
         decode: (prop) => prop.multi_select.map((opt) => opt.name),
         encode: () =>
           shouldNeverHappen(
-            'MultiSelect.asNames encode is not supported. Use MultiSelectWrite / MultiSelectWriteFromNames.',
+            'MultiSelect.asStrings encode is not supported. Use MultiSelectWrite / MultiSelectWriteFromNames.',
           ),
-      },
+      }),
+    ),
+  ),
+
+  /** Transform to array of option names with allowed options (fails for unknown options). */
+  asNames: <TName extends string>(nameSchema: Schema.Codec<TName>) =>
+    MultiSelectProperty.pipe(
+      Schema.refine(
+        (p): p is typeof p & { multi_select: Array<{ name: TName }> } =>
+          p.multi_select.every((opt) => isAllowedName({ nameSchema, name: opt.name })),
+        {
+          message: () => 'MultiSelect options must be one of the allowed options',
+        },
+      ),
+    ).pipe(
+      Schema.decodeTo(
+        Schema.Array(nameSchema),
+        SchemaTransformation.transform({
+          decode: (prop) => prop.multi_select.map((opt) => opt.name),
+          encode: () =>
+            shouldNeverHappen(
+              'MultiSelect.asNames encode is not supported. Use MultiSelectWrite / MultiSelectWriteFromNames.',
+            ),
+        }),
+      ),
     ),
 
   /** Transform to MultiSelectProperty with typed option names (fails for unknown options). */
-  asPropertyNamed: <TName extends string>(nameSchema: Schema.Schema<TName>) => {
+  asPropertyNamed: <TName extends string>(nameSchema: Schema.Codec<TName>) => {
     const optionSchema = makeSelectOptionWithName(nameSchema)
 
     return MultiSelectProperty.pipe(
-      Schema.filter(
+      Schema.refine(
         (p): p is typeof p & { multi_select: Array<typeof optionSchema.Type> } =>
           p.multi_select.every((opt) => isAllowedName({ nameSchema, name: opt.name })),
         {
@@ -348,32 +379,32 @@ export const MultiSelect = {
   },
 
   /** Transform to array of options with typed option names (fails for unknown options). */
-  asOptionsNamed: <TName extends string>(nameSchema: Schema.Schema<TName>) => {
+  asOptionsNamed: <TName extends string>(nameSchema: Schema.Codec<TName>) => {
     const optionSchema = makeSelectOptionWithName(nameSchema)
 
     return withOptionNameSchema({
-      schema: Schema.transform(
-        MultiSelectProperty.pipe(
-          Schema.filter(
-            (
-              p,
-            ): p is typeof p & {
-              multi_select: Array<typeof optionSchema.Type>
-            } => p.multi_select.every((opt) => isAllowedName({ nameSchema, name: opt.name })),
-            {
-              message: () => 'MultiSelect options must be one of the allowed options',
-            },
-          ),
+      schema: MultiSelectProperty.pipe(
+        Schema.refine(
+          (
+            p,
+          ): p is typeof p & {
+            multi_select: Array<typeof optionSchema.Type>
+          } => p.multi_select.every((opt) => isAllowedName({ nameSchema, name: opt.name })),
+          {
+            message: () => 'MultiSelect options must be one of the allowed options',
+          },
         ),
-        Schema.Array(optionSchema),
-        {
-          strict: false,
-          decode: (prop) => prop.multi_select,
-          encode: () =>
-            shouldNeverHappen(
-              'MultiSelect.asOptionsNamed encode is not supported. Use MultiSelectWrite / MultiSelectWriteFromNames.',
-            ),
-        },
+      ).pipe(
+        Schema.decodeTo(
+          Schema.Array(optionSchema),
+          SchemaTransformation.transform({
+            decode: (prop) => prop.multi_select,
+            encode: () =>
+              shouldNeverHappen(
+                'MultiSelect.asOptionsNamed encode is not supported. Use MultiSelectWrite / MultiSelectWriteFromNames.',
+              ),
+          }),
+        ),
       ),
       nameSchema,
     })
@@ -430,28 +461,34 @@ export const StatusWrite = Schema.Struct({
 export type StatusWrite = typeof StatusWrite.Type
 
 /** Transforms status name (or null) into a status write payload */
-export const StatusWriteFromName = Schema.transform(Schema.NullOr(Schema.String), StatusWrite, {
-  strict: false,
-  decode: (name) => ({
-    status: name === null ? null : { name },
-  }),
-  encode: (write) => {
-    if (write.status === null) {
-      return null
-    }
+export const StatusWriteFromName = Schema.NullOr(Schema.String)
+  .pipe(
+    Schema.decodeTo(
+      StatusWrite,
+      SchemaTransformation.transform({
+        decode: (name) => ({
+          status: name === null ? null : { name },
+        }),
+        encode: (write) => {
+          if (write.status === null) {
+            return null
+          }
 
-    if ('name' in write.status) {
-      return write.status.name
-    }
+          if ('name' in write.status) {
+            return write.status.name
+          }
 
-    return shouldNeverHappen('StatusWriteFromName cannot encode option referenced by id.')
-  },
-}).annotate({
-  identifier: 'Notion.StatusWriteFromName',
-  title: 'Status (Write) From Name',
-  description: 'Transform a status name (or null) into a status write payload.',
-  [docsPath]: 'page#page-property-value',
-})
+          return shouldNeverHappen('StatusWriteFromName cannot encode option referenced by id.')
+        },
+      }),
+    ),
+  )
+  .annotate({
+    identifier: 'Notion.StatusWriteFromName',
+    title: 'Status (Write) From Name',
+    description: 'Transform a status name (or null) into a status write payload.',
+    [docsPath]: 'page#page-property-value',
+  })
 
 /** Transforms for Status property. */
 export const Status = {
@@ -459,37 +496,45 @@ export const Status = {
   Property: StatusProperty,
 
   /** Transform to raw nullable SelectOption. */
-  raw: Schema.transform(StatusProperty, Schema.NullOr(SelectOption), {
-    strict: false,
-    decode: (prop) => prop.status,
-    encode: () =>
-      shouldNeverHappen(
-        'Status.raw encode is not supported. Use StatusWrite / StatusWriteFromName.',
-      ),
-  }),
+  raw: StatusProperty.pipe(
+    Schema.decodeTo(
+      Schema.NullOr(SelectOption),
+      SchemaTransformation.transform({
+        decode: (prop) => prop.status,
+        encode: () =>
+          shouldNeverHappen(
+            'Status.raw encode is not supported. Use StatusWrite / StatusWriteFromName.',
+          ),
+      }),
+    ),
+  ),
 
   /** Transform to Option<SelectOption>. */
   asOption: withOptionNameSchema({
     schema: withOptionValueSchema({
-      schema: Schema.transform(StatusProperty, Schema.OptionFromSelf(SelectOption), {
-        strict: false,
-        decode: (prop) => (prop.status === null ? Option.none() : Option.some(prop.status)),
-        encode: () =>
-          shouldNeverHappen(
-            'Status.asOption encode is not supported. Use StatusWrite / StatusWriteFromName.',
-          ),
-      }),
+      schema: StatusProperty.pipe(
+        Schema.decodeTo(
+          Schema.Option(SelectOption),
+          SchemaTransformation.transform({
+            decode: (prop) => (prop.status === null ? Option.none() : Option.some(prop.status)),
+            encode: () =>
+              shouldNeverHappen(
+                'Status.asOption encode is not supported. Use StatusWrite / StatusWriteFromName.',
+              ),
+          }),
+        ),
+      ),
       valueSchema: SelectOption,
     }),
     nameSchema: Schema.String,
   }),
 
   /** Transform to StatusProperty with a typed name (fails for unknown options). */
-  asPropertyNamed: <TName extends string>(nameSchema: Schema.Schema<TName>) => {
+  asPropertyNamed: <TName extends string>(nameSchema: Schema.Codec<TName>) => {
     const optionSchema = makeSelectOptionWithName(nameSchema)
 
     return StatusProperty.pipe(
-      Schema.filter(
+      Schema.refine(
         (p): p is typeof p & { status: typeof optionSchema.Type | null } =>
           p.status === null || isAllowedName({ nameSchema, name: p.status.name }),
         { message: () => 'Status must be one of the allowed options' },
@@ -499,40 +544,44 @@ export const Status = {
 
   /** Transform to Option<string> (status name). */
   asString: withOptionValueSchema({
-    schema: Schema.transform(StatusProperty, Schema.OptionFromSelf(Schema.String), {
-      strict: false,
-      decode: (prop) => (prop.status === null ? Option.none() : Option.some(prop.status.name)),
-      encode: () =>
-        shouldNeverHappen(
-          'Status.asString encode is not supported. Use StatusWrite / StatusWriteFromName.',
-        ),
-    }),
+    schema: StatusProperty.pipe(
+      Schema.decodeTo(
+        Schema.Option(Schema.String),
+        SchemaTransformation.transform({
+          decode: (prop) => (prop.status === null ? Option.none() : Option.some(prop.status.name)),
+          encode: () =>
+            shouldNeverHappen(
+              'Status.asString encode is not supported. Use StatusWrite / StatusWriteFromName.',
+            ),
+        }),
+      ),
+    ),
     valueSchema: Schema.String,
   }),
 
   /** Transform to Option<SelectOption> with a typed name (fails for unknown options). */
-  asOptionNamed: <TName extends string>(nameSchema: Schema.Schema<TName>) => {
+  asOptionNamed: <TName extends string>(nameSchema: Schema.Codec<TName>) => {
     const optionSchema = makeSelectOptionWithName(nameSchema)
 
     return withOptionNameSchema({
       schema: withOptionValueSchema({
-        schema: Schema.transform(
-          StatusProperty.pipe(
-            Schema.filter(
-              (p): p is typeof p & { status: typeof optionSchema.Type | null } =>
-                p.status === null || isAllowedName({ nameSchema, name: p.status.name }),
-              { message: () => 'Status must be one of the allowed options' },
-            ),
+        schema: StatusProperty.pipe(
+          Schema.refine(
+            (p): p is typeof p & { status: typeof optionSchema.Type | null } =>
+              p.status === null || isAllowedName({ nameSchema, name: p.status.name }),
+            { message: () => 'Status must be one of the allowed options' },
           ),
-          Schema.OptionFromSelf(optionSchema),
-          {
-            strict: false,
-            decode: (prop) => (prop.status === null ? Option.none() : Option.some(prop.status)),
-            encode: () =>
-              shouldNeverHappen(
-                'Status.asOptionNamed encode is not supported. Use StatusWrite / StatusWriteFromName.',
-              ),
-          },
+        ).pipe(
+          Schema.decodeTo(
+            Schema.Option(optionSchema),
+            SchemaTransformation.transform({
+              decode: (prop) => (prop.status === null ? Option.none() : Option.some(prop.status)),
+              encode: () =>
+                shouldNeverHappen(
+                  'Status.asOptionNamed encode is not supported. Use StatusWrite / StatusWriteFromName.',
+                ),
+            }),
+          ),
         ),
         valueSchema: optionSchema,
       }),
@@ -541,25 +590,26 @@ export const Status = {
   },
 
   /** Transform to Option<name> with allowed options (fails for unknown options). */
-  asName: <TName extends string>(nameSchema: Schema.Schema<TName>) =>
+  asName: <TName extends string>(nameSchema: Schema.Codec<TName>) =>
     withOptionValueSchema({
-      schema: Schema.transform(
-        StatusProperty.pipe(
-          Schema.filter(
-            (p): p is typeof p & { status: { name: TName } | null } =>
-              p.status === null || isAllowedName({ nameSchema, name: p.status.name }),
-            { message: () => 'Status must be one of the allowed options' },
-          ),
+      schema: StatusProperty.pipe(
+        Schema.refine(
+          (p): p is typeof p & { status: { name: TName } | null } =>
+            p.status === null || isAllowedName({ nameSchema, name: p.status.name }),
+          { message: () => 'Status must be one of the allowed options' },
         ),
-        Schema.OptionFromSelf(nameSchema),
-        {
-          strict: false,
-          decode: (prop) => (prop.status === null ? Option.none() : Option.some(prop.status.name)),
-          encode: () =>
-            shouldNeverHappen(
-              'Status.asName encode is not supported. Use StatusWrite / StatusWriteFromName.',
-            ),
-        },
+      ).pipe(
+        Schema.decodeTo(
+          Schema.Option(nameSchema),
+          SchemaTransformation.transform({
+            decode: (prop) =>
+              prop.status === null ? Option.none() : Option.some(prop.status.name),
+            encode: () =>
+              shouldNeverHappen(
+                'Status.asName encode is not supported. Use StatusWrite / StatusWriteFromName.',
+              ),
+          }),
+        ),
       ),
       valueSchema: nameSchema,
     }),

--- a/packages/@overeng/notion-effect-schema/src/properties/text.ts
+++ b/packages/@overeng/notion-effect-schema/src/properties/text.ts
@@ -1,4 +1,4 @@
-import { Option, Schema } from 'effect'
+import { Option, Schema, SchemaTransformation } from 'effect'
 
 import { docsPath, shouldNeverHappen, withOptionValueSchema } from '../common.ts'
 import { RichText, RichTextArray } from '../rich-text.ts'
@@ -49,13 +49,17 @@ export const TitleWrite = Schema.Struct({
 export type TitleWrite = typeof TitleWrite.Type
 
 /** Transforms plain string into a title write payload */
-export const TitleWriteFromString = Schema.transform(Schema.String, TitleWrite, {
-  strict: false,
-  decode: (str) => ({
-    title: [{ type: 'text', text: { content: str } }],
-  }),
-  encode: (write) => write.title.map((rt) => rt.text.content).join(''),
-}).annotate({
+export const TitleWriteFromString = Schema.String.pipe(
+  Schema.decodeTo(
+    TitleWrite,
+    SchemaTransformation.transform({
+      decode: (str) => ({
+        title: [{ type: 'text', text: { content: str } }],
+      }),
+      encode: (write) => write.title.map((rt) => rt.text.content).join(''),
+    }),
+  ),
+).annotate({
   identifier: 'Notion.TitleWriteFromString',
   title: 'Title (Write) From String',
   description: 'Transform a plain string into a title write payload.',
@@ -68,24 +72,32 @@ export const Title = {
   Property: TitleProperty,
 
   /** Transform to raw rich text array. */
-  raw: Schema.transform(TitleProperty, RichTextArray, {
-    strict: false,
-    decode: (prop) => prop.title,
-    encode: () =>
-      shouldNeverHappen(
-        'Title.raw encode is not supported. Use TitleWrite / TitleWriteFromString.',
-      ),
-  }),
+  raw: TitleProperty.pipe(
+    Schema.decodeTo(
+      RichTextArray,
+      SchemaTransformation.transform({
+        decode: (prop) => prop.title,
+        encode: () =>
+          shouldNeverHappen(
+            'Title.raw encode is not supported. Use TitleWrite / TitleWriteFromString.',
+          ),
+      }),
+    ),
+  ),
 
   /** Transform to plain string. */
-  asString: Schema.transform(TitleProperty, Schema.String, {
-    strict: false,
-    decode: (prop) => prop.title.map((rt) => rt.plain_text).join(''),
-    encode: () =>
-      shouldNeverHappen(
-        'Title.asString encode is not supported. Use TitleWrite / TitleWriteFromString.',
-      ),
-  }),
+  asString: TitleProperty.pipe(
+    Schema.decodeTo(
+      Schema.String,
+      SchemaTransformation.transform({
+        decode: (prop) => prop.title.map((rt) => rt.plain_text).join(''),
+        encode: () =>
+          shouldNeverHappen(
+            'Title.asString encode is not supported. Use TitleWrite / TitleWriteFromString.',
+          ),
+      }),
+    ),
+  ),
 
   Write: {
     Schema: TitleWrite,
@@ -138,13 +150,17 @@ export const RichTextWrite = Schema.Struct({
 export type RichTextWrite = typeof RichTextWrite.Type
 
 /** Transforms plain string into a rich text write payload */
-export const RichTextWriteFromString = Schema.transform(Schema.String, RichTextWrite, {
-  strict: false,
-  decode: (str) => ({
-    rich_text: [{ type: 'text', text: { content: str } }],
-  }),
-  encode: (write) => write.rich_text.map((rt) => rt.text.content).join(''),
-}).annotate({
+export const RichTextWriteFromString = Schema.String.pipe(
+  Schema.decodeTo(
+    RichTextWrite,
+    SchemaTransformation.transform({
+      decode: (str) => ({
+        rich_text: [{ type: 'text', text: { content: str } }],
+      }),
+      encode: (write) => write.rich_text.map((rt) => rt.text.content).join(''),
+    }),
+  ),
+).annotate({
   identifier: 'Notion.RichTextWriteFromString',
   title: 'Rich Text (Write) From String',
   description: 'Transform a plain string into a rich text write payload.',
@@ -157,29 +173,37 @@ export const RichTextProp = {
   Property: RichTextProperty,
 
   /** Transform to raw rich text array. */
-  raw: Schema.transform(RichTextProperty, RichTextArray, {
-    strict: false,
-    decode: (prop) => prop.rich_text,
-    encode: () =>
-      shouldNeverHappen(
-        'RichTextProp.raw encode is not supported. Use RichTextWrite / RichTextWriteFromString.',
-      ),
-  }),
+  raw: RichTextProperty.pipe(
+    Schema.decodeTo(
+      RichTextArray,
+      SchemaTransformation.transform({
+        decode: (prop) => prop.rich_text,
+        encode: () =>
+          shouldNeverHappen(
+            'RichTextProp.raw encode is not supported. Use RichTextWrite / RichTextWriteFromString.',
+          ),
+      }),
+    ),
+  ),
 
   /** Transform to plain string. */
-  asString: Schema.transform(RichTextProperty, Schema.String, {
-    strict: false,
-    decode: (prop) => prop.rich_text.map((rt) => rt.plain_text).join(''),
-    encode: () =>
-      shouldNeverHappen(
-        'RichTextProp.asString encode is not supported. Use RichTextWrite / RichTextWriteFromString.',
-      ),
-  }),
+  asString: RichTextProperty.pipe(
+    Schema.decodeTo(
+      Schema.String,
+      SchemaTransformation.transform({
+        decode: (prop) => prop.rich_text.map((rt) => rt.plain_text).join(''),
+        encode: () =>
+          shouldNeverHappen(
+            'RichTextProp.asString encode is not supported. Use RichTextWrite / RichTextWriteFromString.',
+          ),
+      }),
+    ),
+  ),
 
   /** Transform to required string (fails if empty after trim). */
-  asNonEmptyString: Schema.transform(
-    RichTextProperty.pipe(
-      Schema.filter(
+  asNonEmptyString: RichTextProperty.pipe(
+    Schema.check(
+      Schema.makeFilter(
         (p) =>
           p.rich_text
             .map((rt) => rt.plain_text)
@@ -188,30 +212,36 @@ export const RichTextProp = {
         { message: () => 'Rich text must not be empty' },
       ),
     ),
-    Schema.String,
-    {
-      strict: false,
-      decode: (prop) => prop.rich_text.map((rt) => rt.plain_text).join(''),
-      encode: () =>
-        shouldNeverHappen(
-          'RichTextProp.asNonEmptyString encode is not supported. Use RichTextWrite / RichTextWriteFromString.',
-        ),
-    },
+  ).pipe(
+    Schema.decodeTo(
+      Schema.String,
+      SchemaTransformation.transform({
+        decode: (prop) => prop.rich_text.map((rt) => rt.plain_text).join(''),
+        encode: () =>
+          shouldNeverHappen(
+            'RichTextProp.asNonEmptyString encode is not supported. Use RichTextWrite / RichTextWriteFromString.',
+          ),
+      }),
+    ),
   ),
 
   /** Transform to Option<string> (empty becomes None). */
   asOption: withOptionValueSchema({
-    schema: Schema.transform(RichTextProperty, Schema.OptionFromSelf(Schema.String), {
-      strict: false,
-      decode: (prop) => {
-        const text = prop.rich_text.map((rt) => rt.plain_text).join('')
-        return text.trim() === '' ? Option.none() : Option.some(text)
-      },
-      encode: () =>
-        shouldNeverHappen(
-          'RichTextProp.asOption encode is not supported. Use RichTextWrite / RichTextWriteFromString.',
-        ),
-    }),
+    schema: RichTextProperty.pipe(
+      Schema.decodeTo(
+        Schema.Option(Schema.String),
+        SchemaTransformation.transform({
+          decode: (prop) => {
+            const text = prop.rich_text.map((rt) => rt.plain_text).join('')
+            return text.trim() === '' ? Option.none() : Option.some(text)
+          },
+          encode: () =>
+            shouldNeverHappen(
+              'RichTextProp.asOption encode is not supported. Use RichTextWrite / RichTextWriteFromString.',
+            ),
+        }),
+      ),
+    ),
     valueSchema: Schema.String,
   }),
 

--- a/packages/@overeng/notion-effect-schema/src/properties/text.ts
+++ b/packages/@overeng/notion-effect-schema/src/properties/text.ts
@@ -52,7 +52,7 @@ export type TitleWrite = typeof TitleWrite.Type
 export const TitleWriteFromString = Schema.String.pipe(
   Schema.decodeTo(
     TitleWrite,
-    SchemaTransformation.transform({
+    SchemaTransformation.transform<TitleWrite, string>({
       decode: (str) => ({
         title: [{ type: 'text', text: { content: str } }],
       }),
@@ -75,9 +75,9 @@ export const Title = {
   raw: TitleProperty.pipe(
     Schema.decodeTo(
       RichTextArray,
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<RichTextArray, TitleProperty>({
         decode: (prop) => prop.title,
-        encode: () =>
+        encode: (): TitleProperty =>
           shouldNeverHappen(
             'Title.raw encode is not supported. Use TitleWrite / TitleWriteFromString.',
           ),
@@ -89,9 +89,9 @@ export const Title = {
   asString: TitleProperty.pipe(
     Schema.decodeTo(
       Schema.String,
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<string, TitleProperty>({
         decode: (prop) => prop.title.map((rt) => rt.plain_text).join(''),
-        encode: () =>
+        encode: (): TitleProperty =>
           shouldNeverHappen(
             'Title.asString encode is not supported. Use TitleWrite / TitleWriteFromString.',
           ),
@@ -153,7 +153,7 @@ export type RichTextWrite = typeof RichTextWrite.Type
 export const RichTextWriteFromString = Schema.String.pipe(
   Schema.decodeTo(
     RichTextWrite,
-    SchemaTransformation.transform({
+    SchemaTransformation.transform<RichTextWrite, string>({
       decode: (str) => ({
         rich_text: [{ type: 'text', text: { content: str } }],
       }),
@@ -176,9 +176,9 @@ export const RichTextProp = {
   raw: RichTextProperty.pipe(
     Schema.decodeTo(
       RichTextArray,
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<RichTextArray, RichTextProperty>({
         decode: (prop) => prop.rich_text,
-        encode: () =>
+        encode: (): RichTextProperty =>
           shouldNeverHappen(
             'RichTextProp.raw encode is not supported. Use RichTextWrite / RichTextWriteFromString.',
           ),
@@ -190,9 +190,9 @@ export const RichTextProp = {
   asString: RichTextProperty.pipe(
     Schema.decodeTo(
       Schema.String,
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<string, RichTextProperty>({
         decode: (prop) => prop.rich_text.map((rt) => rt.plain_text).join(''),
-        encode: () =>
+        encode: (): RichTextProperty =>
           shouldNeverHappen(
             'RichTextProp.asString encode is not supported. Use RichTextWrite / RichTextWriteFromString.',
           ),
@@ -209,15 +209,15 @@ export const RichTextProp = {
             .map((rt) => rt.plain_text)
             .join('')
             .trim() !== '',
-        { message: () => 'Rich text must not be empty' },
+        { message: 'Rich text must not be empty' },
       ),
     ),
   ).pipe(
     Schema.decodeTo(
       Schema.String,
-      SchemaTransformation.transform({
+      SchemaTransformation.transform<string, RichTextProperty>({
         decode: (prop) => prop.rich_text.map((rt) => rt.plain_text).join(''),
-        encode: () =>
+        encode: (): RichTextProperty =>
           shouldNeverHappen(
             'RichTextProp.asNonEmptyString encode is not supported. Use RichTextWrite / RichTextWriteFromString.',
           ),
@@ -230,12 +230,12 @@ export const RichTextProp = {
     schema: RichTextProperty.pipe(
       Schema.decodeTo(
         Schema.Option(Schema.String),
-        SchemaTransformation.transform({
+        SchemaTransformation.transform<Option.Option<string>, RichTextProperty>({
           decode: (prop) => {
             const text = prop.rich_text.map((rt) => rt.plain_text).join('')
             return text.trim() === '' ? Option.none() : Option.some(text)
           },
-          encode: () =>
+          encode: (): RichTextProperty =>
             shouldNeverHappen(
               'RichTextProp.asOption encode is not supported. Use RichTextWrite / RichTextWriteFromString.',
             ),

--- a/packages/@overeng/notion-effect-schema/src/property-schema.ts
+++ b/packages/@overeng/notion-effect-schema/src/property-schema.ts
@@ -122,10 +122,10 @@ const PropertySchemaBase = Schema.Struct({
 // -----------------------------------------------------------------------------
 
 /** Title property schema */
-export const TitlePropertySchema = Schema.extend(
-  PropertySchemaBase,
-  Schema.TaggedStruct('title', {}),
-).annotate({
+export const TitlePropertySchema = Schema.Struct({
+  ...PropertySchemaBase.fields,
+  ...Schema.TaggedStruct('title', {}).fields,
+}).annotate({
   identifier: 'Notion.TitlePropertySchema',
   [docsPath]: 'database-property#title',
 })
@@ -133,10 +133,10 @@ export const TitlePropertySchema = Schema.extend(
 export type TitlePropertySchema = typeof TitlePropertySchema.Type
 
 /** Rich text property schema */
-export const RichTextPropertySchema = Schema.extend(
-  PropertySchemaBase,
-  Schema.TaggedStruct('rich_text', {}),
-).annotate({
+export const RichTextPropertySchema = Schema.Struct({
+  ...PropertySchemaBase.fields,
+  ...Schema.TaggedStruct('rich_text', {}).fields,
+}).annotate({
   identifier: 'Notion.RichTextPropertySchema',
   [docsPath]: 'database-property#rich-text',
 })
@@ -144,14 +144,14 @@ export const RichTextPropertySchema = Schema.extend(
 export type RichTextPropertySchema = typeof RichTextPropertySchema.Type
 
 /** Number property schema */
-export const NumberPropertySchema = Schema.extend(
-  PropertySchemaBase,
-  Schema.TaggedStruct('number', {
+export const NumberPropertySchema = Schema.Struct({
+  ...PropertySchemaBase.fields,
+  ...Schema.TaggedStruct('number', {
     number: Schema.Struct({
       format: NumberFormat,
     }),
-  }),
-).annotate({
+  }).fields,
+}).annotate({
   identifier: 'Notion.NumberPropertySchema',
   [docsPath]: 'database-property#number',
 })
@@ -159,14 +159,14 @@ export const NumberPropertySchema = Schema.extend(
 export type NumberPropertySchema = typeof NumberPropertySchema.Type
 
 /** Select property schema */
-export const SelectPropertySchema = Schema.extend(
-  PropertySchemaBase,
-  Schema.TaggedStruct('select', {
+export const SelectPropertySchema = Schema.Struct({
+  ...PropertySchemaBase.fields,
+  ...Schema.TaggedStruct('select', {
     select: Schema.Struct({
       options: Schema.Array(SelectOptionConfig),
     }),
-  }),
-).annotate({
+  }).fields,
+}).annotate({
   identifier: 'Notion.SelectPropertySchema',
   [docsPath]: 'database-property#select',
 })
@@ -174,14 +174,14 @@ export const SelectPropertySchema = Schema.extend(
 export type SelectPropertySchema = typeof SelectPropertySchema.Type
 
 /** Multi-select property schema */
-export const MultiSelectPropertySchema = Schema.extend(
-  PropertySchemaBase,
-  Schema.TaggedStruct('multi_select', {
+export const MultiSelectPropertySchema = Schema.Struct({
+  ...PropertySchemaBase.fields,
+  ...Schema.TaggedStruct('multi_select', {
     multi_select: Schema.Struct({
       options: Schema.Array(SelectOptionConfig),
     }),
-  }),
-).annotate({
+  }).fields,
+}).annotate({
   identifier: 'Notion.MultiSelectPropertySchema',
   [docsPath]: 'database-property#multi-select',
 })
@@ -189,15 +189,15 @@ export const MultiSelectPropertySchema = Schema.extend(
 export type MultiSelectPropertySchema = typeof MultiSelectPropertySchema.Type
 
 /** Status property schema */
-export const StatusPropertySchema = Schema.extend(
-  PropertySchemaBase,
-  Schema.TaggedStruct('status', {
+export const StatusPropertySchema = Schema.Struct({
+  ...PropertySchemaBase.fields,
+  ...Schema.TaggedStruct('status', {
     status: Schema.Struct({
       options: Schema.Array(SelectOptionConfig),
       groups: Schema.Array(StatusGroupConfig),
     }),
-  }),
-).annotate({
+  }).fields,
+}).annotate({
   identifier: 'Notion.StatusPropertySchema',
   [docsPath]: 'database-property#status',
 })
@@ -205,10 +205,10 @@ export const StatusPropertySchema = Schema.extend(
 export type StatusPropertySchema = typeof StatusPropertySchema.Type
 
 /** Date property schema */
-export const DatePropertySchema = Schema.extend(
-  PropertySchemaBase,
-  Schema.TaggedStruct('date', {}),
-).annotate({
+export const DatePropertySchema = Schema.Struct({
+  ...PropertySchemaBase.fields,
+  ...Schema.TaggedStruct('date', {}).fields,
+}).annotate({
   identifier: 'Notion.DatePropertySchema',
   [docsPath]: 'database-property#date',
 })
@@ -216,10 +216,10 @@ export const DatePropertySchema = Schema.extend(
 export type DatePropertySchema = typeof DatePropertySchema.Type
 
 /** People property schema */
-export const PeoplePropertySchema = Schema.extend(
-  PropertySchemaBase,
-  Schema.TaggedStruct('people', {}),
-).annotate({
+export const PeoplePropertySchema = Schema.Struct({
+  ...PropertySchemaBase.fields,
+  ...Schema.TaggedStruct('people', {}).fields,
+}).annotate({
   identifier: 'Notion.PeoplePropertySchema',
   [docsPath]: 'database-property#people',
 })
@@ -227,10 +227,10 @@ export const PeoplePropertySchema = Schema.extend(
 export type PeoplePropertySchema = typeof PeoplePropertySchema.Type
 
 /** Files property schema */
-export const FilesPropertySchema = Schema.extend(
-  PropertySchemaBase,
-  Schema.TaggedStruct('files', {}),
-).annotate({
+export const FilesPropertySchema = Schema.Struct({
+  ...PropertySchemaBase.fields,
+  ...Schema.TaggedStruct('files', {}).fields,
+}).annotate({
   identifier: 'Notion.FilesPropertySchema',
   [docsPath]: 'database-property#files',
 })
@@ -238,10 +238,10 @@ export const FilesPropertySchema = Schema.extend(
 export type FilesPropertySchema = typeof FilesPropertySchema.Type
 
 /** Checkbox property schema */
-export const CheckboxPropertySchema = Schema.extend(
-  PropertySchemaBase,
-  Schema.TaggedStruct('checkbox', {}),
-).annotate({
+export const CheckboxPropertySchema = Schema.Struct({
+  ...PropertySchemaBase.fields,
+  ...Schema.TaggedStruct('checkbox', {}).fields,
+}).annotate({
   identifier: 'Notion.CheckboxPropertySchema',
   [docsPath]: 'database-property#checkbox',
 })
@@ -249,10 +249,10 @@ export const CheckboxPropertySchema = Schema.extend(
 export type CheckboxPropertySchema = typeof CheckboxPropertySchema.Type
 
 /** URL property schema */
-export const UrlPropertySchema = Schema.extend(
-  PropertySchemaBase,
-  Schema.TaggedStruct('url', {}),
-).annotate({
+export const UrlPropertySchema = Schema.Struct({
+  ...PropertySchemaBase.fields,
+  ...Schema.TaggedStruct('url', {}).fields,
+}).annotate({
   identifier: 'Notion.UrlPropertySchema',
   [docsPath]: 'database-property#url',
 })
@@ -260,10 +260,10 @@ export const UrlPropertySchema = Schema.extend(
 export type UrlPropertySchema = typeof UrlPropertySchema.Type
 
 /** Email property schema */
-export const EmailPropertySchema = Schema.extend(
-  PropertySchemaBase,
-  Schema.TaggedStruct('email', {}),
-).annotate({
+export const EmailPropertySchema = Schema.Struct({
+  ...PropertySchemaBase.fields,
+  ...Schema.TaggedStruct('email', {}).fields,
+}).annotate({
   identifier: 'Notion.EmailPropertySchema',
   [docsPath]: 'database-property#email',
 })
@@ -271,10 +271,10 @@ export const EmailPropertySchema = Schema.extend(
 export type EmailPropertySchema = typeof EmailPropertySchema.Type
 
 /** Phone number property schema */
-export const PhoneNumberPropertySchema = Schema.extend(
-  PropertySchemaBase,
-  Schema.TaggedStruct('phone_number', {}),
-).annotate({
+export const PhoneNumberPropertySchema = Schema.Struct({
+  ...PropertySchemaBase.fields,
+  ...Schema.TaggedStruct('phone_number', {}).fields,
+}).annotate({
   identifier: 'Notion.PhoneNumberPropertySchema',
   [docsPath]: 'database-property#phone-number',
 })
@@ -282,14 +282,14 @@ export const PhoneNumberPropertySchema = Schema.extend(
 export type PhoneNumberPropertySchema = typeof PhoneNumberPropertySchema.Type
 
 /** Formula property schema */
-export const FormulaPropertySchema = Schema.extend(
-  PropertySchemaBase,
-  Schema.TaggedStruct('formula', {
+export const FormulaPropertySchema = Schema.Struct({
+  ...PropertySchemaBase.fields,
+  ...Schema.TaggedStruct('formula', {
     formula: Schema.Struct({
       expression: Schema.String,
     }),
-  }),
-).annotate({
+  }).fields,
+}).annotate({
   identifier: 'Notion.FormulaPropertySchema',
   [docsPath]: 'database-property#formula',
 })
@@ -297,9 +297,9 @@ export const FormulaPropertySchema = Schema.extend(
 export type FormulaPropertySchema = typeof FormulaPropertySchema.Type
 
 /** Relation property schema */
-export const RelationPropertySchema = Schema.extend(
-  PropertySchemaBase,
-  Schema.TaggedStruct('relation', {
+export const RelationPropertySchema = Schema.Struct({
+  ...PropertySchemaBase.fields,
+  ...Schema.TaggedStruct('relation', {
     relation: Schema.Struct({
       database_id: NotionUUID,
       type: Schema.Literals(['single_property', 'dual_property']),
@@ -311,8 +311,8 @@ export const RelationPropertySchema = Schema.extend(
         }),
       ),
     }),
-  }),
-).annotate({
+  }).fields,
+}).annotate({
   identifier: 'Notion.RelationPropertySchema',
   [docsPath]: 'database-property#relation',
 })
@@ -320,9 +320,9 @@ export const RelationPropertySchema = Schema.extend(
 export type RelationPropertySchema = typeof RelationPropertySchema.Type
 
 /** Rollup property schema */
-export const RollupPropertySchema = Schema.extend(
-  PropertySchemaBase,
-  Schema.TaggedStruct('rollup', {
+export const RollupPropertySchema = Schema.Struct({
+  ...PropertySchemaBase.fields,
+  ...Schema.TaggedStruct('rollup', {
     rollup: Schema.Struct({
       relation_property_name: Schema.String,
       relation_property_id: Schema.String,
@@ -330,8 +330,8 @@ export const RollupPropertySchema = Schema.extend(
       rollup_property_id: Schema.String,
       function: RollupFunction,
     }),
-  }),
-).annotate({
+  }).fields,
+}).annotate({
   identifier: 'Notion.RollupPropertySchema',
   [docsPath]: 'database-property#rollup',
 })
@@ -339,10 +339,10 @@ export const RollupPropertySchema = Schema.extend(
 export type RollupPropertySchema = typeof RollupPropertySchema.Type
 
 /** Created time property schema (read-only) */
-export const CreatedTimePropertySchema = Schema.extend(
-  PropertySchemaBase,
-  Schema.TaggedStruct('created_time', {}),
-).annotate({
+export const CreatedTimePropertySchema = Schema.Struct({
+  ...PropertySchemaBase.fields,
+  ...Schema.TaggedStruct('created_time', {}).fields,
+}).annotate({
   identifier: 'Notion.CreatedTimePropertySchema',
   [docsPath]: 'database-property#created-time',
 })
@@ -350,10 +350,10 @@ export const CreatedTimePropertySchema = Schema.extend(
 export type CreatedTimePropertySchema = typeof CreatedTimePropertySchema.Type
 
 /** Created by property schema (read-only) */
-export const CreatedByPropertySchema = Schema.extend(
-  PropertySchemaBase,
-  Schema.TaggedStruct('created_by', {}),
-).annotate({
+export const CreatedByPropertySchema = Schema.Struct({
+  ...PropertySchemaBase.fields,
+  ...Schema.TaggedStruct('created_by', {}).fields,
+}).annotate({
   identifier: 'Notion.CreatedByPropertySchema',
   [docsPath]: 'database-property#created-by',
 })
@@ -361,10 +361,10 @@ export const CreatedByPropertySchema = Schema.extend(
 export type CreatedByPropertySchema = typeof CreatedByPropertySchema.Type
 
 /** Last edited time property schema (read-only) */
-export const LastEditedTimePropertySchema = Schema.extend(
-  PropertySchemaBase,
-  Schema.TaggedStruct('last_edited_time', {}),
-).annotate({
+export const LastEditedTimePropertySchema = Schema.Struct({
+  ...PropertySchemaBase.fields,
+  ...Schema.TaggedStruct('last_edited_time', {}).fields,
+}).annotate({
   identifier: 'Notion.LastEditedTimePropertySchema',
   [docsPath]: 'database-property#last-edited-time',
 })
@@ -372,10 +372,10 @@ export const LastEditedTimePropertySchema = Schema.extend(
 export type LastEditedTimePropertySchema = typeof LastEditedTimePropertySchema.Type
 
 /** Last edited by property schema (read-only) */
-export const LastEditedByPropertySchema = Schema.extend(
-  PropertySchemaBase,
-  Schema.TaggedStruct('last_edited_by', {}),
-).annotate({
+export const LastEditedByPropertySchema = Schema.Struct({
+  ...PropertySchemaBase.fields,
+  ...Schema.TaggedStruct('last_edited_by', {}).fields,
+}).annotate({
   identifier: 'Notion.LastEditedByPropertySchema',
   [docsPath]: 'database-property#last-edited-by',
 })
@@ -383,14 +383,14 @@ export const LastEditedByPropertySchema = Schema.extend(
 export type LastEditedByPropertySchema = typeof LastEditedByPropertySchema.Type
 
 /** Unique ID property schema (read-only) */
-export const UniqueIdPropertySchema = Schema.extend(
-  PropertySchemaBase,
-  Schema.TaggedStruct('unique_id', {
+export const UniqueIdPropertySchema = Schema.Struct({
+  ...PropertySchemaBase.fields,
+  ...Schema.TaggedStruct('unique_id', {
     unique_id: Schema.Struct({
       prefix: Schema.NullOr(Schema.String),
     }),
-  }),
-).annotate({
+  }).fields,
+}).annotate({
   identifier: 'Notion.UniqueIdPropertySchema',
   [docsPath]: 'database-property#unique-id',
 })
@@ -398,20 +398,20 @@ export const UniqueIdPropertySchema = Schema.extend(
 export type UniqueIdPropertySchema = typeof UniqueIdPropertySchema.Type
 
 /** Verification property schema */
-export const VerificationPropertySchema = Schema.extend(
-  PropertySchemaBase,
-  Schema.TaggedStruct('verification', {}),
-).annotate({
+export const VerificationPropertySchema = Schema.Struct({
+  ...PropertySchemaBase.fields,
+  ...Schema.TaggedStruct('verification', {}).fields,
+}).annotate({
   identifier: 'Notion.VerificationPropertySchema',
 })
 
 export type VerificationPropertySchema = typeof VerificationPropertySchema.Type
 
 /** Button property schema */
-export const ButtonPropertySchema = Schema.extend(
-  PropertySchemaBase,
-  Schema.TaggedStruct('button', {}),
-).annotate({
+export const ButtonPropertySchema = Schema.Struct({
+  ...PropertySchemaBase.fields,
+  ...Schema.TaggedStruct('button', {}).fields,
+}).annotate({
   identifier: 'Notion.ButtonPropertySchema',
 })
 

--- a/packages/@overeng/notion-effect-schema/src/rich-text.ts
+++ b/packages/@overeng/notion-effect-schema/src/rich-text.ts
@@ -1,4 +1,4 @@
-import { Schema } from 'effect'
+import { Schema, SchemaTransformation } from 'effect'
 
 import { docsPath, NotionColor, NotionUUID } from './common.ts'
 
@@ -402,25 +402,30 @@ export type RichTextArray = typeof RichTextArray.Type
 /**
  * Transform rich text array to plain string.
  */
-export const RichTextArrayAsString = Schema.transform(RichTextArray, Schema.String, {
-  decode: (richText) => richText.map((rt) => rt.plain_text).join(''),
-  encode: (str) => [
-    {
-      type: 'text' as const,
-      text: { content: str, link: null },
-      annotations: {
-        bold: false,
-        italic: false,
-        strikethrough: false,
-        underline: false,
-        code: false,
-        color: 'default' as const,
-      },
-      plain_text: str,
-      href: null,
-    },
-  ],
-}).annotate({
+export const RichTextArrayAsString = RichTextArray.pipe(
+  Schema.decodeTo(
+    Schema.String,
+    SchemaTransformation.transform({
+      decode: (richText) => richText.map((rt) => rt.plain_text).join(''),
+      encode: (str) => [
+        {
+          type: 'text' as const,
+          text: { content: str, link: null },
+          annotations: {
+            bold: false,
+            italic: false,
+            strikethrough: false,
+            underline: false,
+            code: false,
+            color: 'default' as const,
+          },
+          plain_text: str,
+          href: null,
+        },
+      ],
+    }),
+  ),
+).annotate({
   identifier: 'Notion.RichTextArrayAsString',
   title: 'Rich Text as String',
   description: 'Transform rich text array to/from plain string.',


### PR DESCRIPTION
## Problem

`@overeng/notion-effect-schema` is the head of the independent Notion migration branch and used Effect 3 Schema APIs throughout its public codecs and tests.

## Goal

Faithfully port the package to Effect 4 with byte-identical canonical codecs, zero package-owned actionable TypeScript diagnostics, and a green managed package test with non-zero collected tests.

## Decisions

- Replaced all v3 `Schema.Schema` type references with v4 `Schema.Codec`; one-argument defaults are also a real migration.
- Migrated 25 plain `Schema.extend` sites to field spreads and 2 index-signature sites to `StructWithRest`. `Schema.Record` is never spread.
- Applied the complete constructor/member shape sweep, including arrays for literal/union/tuple shapes, positional records, `OptionFromOptional`, effectful codec members, and `DateTimeUtcFromString`.
- Ported pure transformations with explicit `<TargetEncoded, SourceType>` contracts. Decode-only encoders retain their intentional failure behavior.
- `People.raw` now produces `Array(User).Encoded` through the target encoder before `decodeTo` decodes it. A representative optional-field payload proves the nested wire bytes are unchanged.
- Migrated symbol-keyed annotations through `SchemaAST.resolve` with the required pre-index symbol-map cast.
- Migrated 29 lazy filter messages after classifying all closures: 27 constants and 2 immutable precomputed strings; none were stateful or expensive.
- Migrated 13 `Effect.either` test sites to `Effect.result` and v4 failure tags.
- Migrated direct v3 `Cause.error` assumptions to `Cause.findErrorOption`.
- This remains a port-only change. No migration baseline marked `TODO(live-migration:effect-3-4)` was changed.

## Verification

Current checkpoint: `c3c6085cc`.

Package-scoped diagnostic:

```text
packages/@overeng/notion-effect-schema/node_modules/.bin/tsc --project packages/@overeng/notion-effect-schema/tsconfig.json --pretty false
baseline: 605 package-path diagnostics + 11 utils-dev-owned diagnostics
current:  0 actionable package-owned diagnostics
residue:  4 notion-core TS6305 project-reference diagnostics + 11 utils-dev-owned diagnostics
```

The assigned full-build inventory was 704 errors; it differs because that count came from a full project-reference build.

Committed-worktree managed test:

```text
CI=1 devenv tasks run test:notion-effect-schema --refresh-task-cache --mode single --show-output --no-tui
exit: 0
vitest.tests: 253
vitest.failures: 0
summary: tmp/otel-scrape/summaries/test-notion-effect-schema.871570.summary.json
```

The passing suite includes:

- canonical decode golden byte identity;
- canonical cross-major JSON wire baselines;
- the new `People.raw` target-encoding byte comparison, including omitted optional user fields;
- preserved failure partitions using v4 Cause extraction.

Scoped checks:

```text
oxfmt --check <16 changed files>: pass
oxlint <13 changed TypeScript files>: 0 warnings, 0 errors
git diff --check: pass
```

## Recipe corrections

- `root-import-renames.md`: a trailing cast cannot authorize unique-symbol indexing; the resolved annotations must be cast before indexing because beta.102 declares only a string index signature.
- `schema-transformations-issues.md`: `decodeTo` transforms into `To["Encoded"]`, not `To["Type"]`; trivial examples hide the distinction. The recipe now documents transformed targets, exact-byte proof, and legitimate decode-only codecs.

## External residue

- Four `TS6305` diagnostics are owned by the earlier `@overeng/notion-core` project-reference build.
- Eleven diagnostics are owned by `@overeng/utils-dev`: removed `OtlpSerialization`, `OtlpTracer`, `FastCheck`, `DurationInput`, `Cause.TimeoutException`, and related Vitest typing fallout.

No files in those packages were changed.

## Complexity

No new public abstraction. The only new internal value is the reusable `Array(User)` target codec and its encoder, required by v4's `To["Encoded"]` transformation contract.

## Concerns

The PR remains draft and blocked only on dependency-wave typecheck residue. Package behavior and its managed tests are green.

## References

Refs #925
Refs #981

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | co3-garnet |
| `agent_session_id` | 1eb740c3-a035-4282-8f52-7cf766bf9745 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.145.0 |
| `agent_runtime` | Codex CLI 0.145.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/v2y1w79nsgydvamlq4rmgjrs1fyxk5zb-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/jsdk9xcha1pvzq3aqcn1175178dv6vcj-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-29-w2-notionschema |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@be13b6e |
</details>
<!-- agent-footer:end -->