### PR TITLE
docs(effect-4): close compiler-derived recipe gaps

### DIFF
--- a/context/effect-4/recipes/datetime-values.md
+++ b/context/effect-4/recipes/datetime-values.md
@@ -1,0 +1,39 @@
+# Pattern: datetime-values
+
+**Area:** DateTime values **Kind:** renames **Our usage:** construction and telemetry timestamp
+access in `agent-session-ingest`, `otel-contract`, and `utils`.
+
+## Migration table
+
+| v3                       | v4                           |
+| ------------------------ | ---------------------------- |
+| `DateTime.unsafeMake(x)` | `DateTime.makeUnsafe(x)`     |
+| `dateTime.epochMillis`   | `dateTime.epochMilliseconds` |
+
+These are value-level `DateTime` APIs. Schema wire codecs are covered by the separate
+`schema-date` recipe; do not confuse a value constructor rename with the surviving-name schema
+hazard.
+
+## Equivalence
+
+Both replacements are **VERIFIED** against the real `effect@3.21.4` and
+`effect@4.0.0-beta.102` tarballs. A cross-major probe constructed values from epoch zero, an ISO
+timestamp, and a native `Date`. Epoch milliseconds and formatted ISO output matched exactly for
+all inputs.
+
+## Intended differences
+
+None.
+
+## Gotchas
+
+- The `unsafe` word moved; it was not removed. `makeUnsafe` can still throw for invalid input.
+- Do not replace `unsafeMake` with safe `make` without handling its result type.
+- `Schema.DateTimeUtc` is a different migration: v3's string codec becomes
+  `Schema.DateTimeUtcFromString`, because bare v4 `Schema.DateTimeUtc` validates an existing
+  `DateTime.Utc` value.
+
+## Codemod rule
+
+Both value-level renames are mechanical. Review every `Schema.DateTime*` occurrence using the
+wire-vs-value pattern in `schema-date`.

--- a/context/effect-4/recipes/duration-input.md
+++ b/context/effect-4/recipes/duration-input.md
@@ -1,0 +1,41 @@
+# Pattern: duration-input
+
+**Area:** Duration **Kind:** renames **Our usage:** 10 workspace compiler diagnostics for
+`Duration.DurationInput` on the current flip snapshot.
+
+## Migration table
+
+| v3                       | v4                                |
+| ------------------------ | --------------------------------- |
+| `Duration.DurationInput` | `Duration.Input`                  |
+| `Duration.decode(input)` | `Duration.fromInputUnsafe(input)` |
+
+V4's `fromInputUnsafe` is the replacement for the total, typed-input v3 `decode`. Keep
+`Duration.fromInput` for unknown input that must report invalid data rather than throw.
+
+## Equivalence
+
+The aliases, signatures, and replacement are **VERIFIED** against the real `effect@3.21.4` and
+`effect@4.0.0-beta.102` tarballs. A cross-major probe compared milliseconds for the repository's
+shared input forms: number, bigint nanoseconds, seconds/nanoseconds tuple, duration string, and
+infinity. Every result matched.
+
+V4 `Input` additionally accepts duration objects and explicit infinity strings. That widening does
+not change existing v3-valid callers.
+
+## Intended differences
+
+None for existing inputs.
+
+## Gotchas
+
+- `fromInputUnsafe` is appropriate because the static `Input` type guarantees the accepted shape.
+  Do not use it at an `unknown` boundary.
+- A bigint duration input is nanoseconds in both versions, not milliseconds.
+- Do not replace a `Duration.decodeUnknown` boundary mechanically; its validation/result shape
+  needs separate handling.
+
+## Codemod rule
+
+The type and typed constructor renames are mechanical. Unknown-input parsers require per-site
+review.

--- a/context/effect-4/recipes/effect-result.md
+++ b/context/effect-4/recipes/effect-result.md
@@ -1,0 +1,85 @@
+# Pattern: effect-result
+
+**Area:** Effect error materialization / Result **Kind:** shape change **Our usage:** 131 reported
+`Effect.either` sites; the earlier full-source inventory measured 118 sites across 42 files before
+13 additional slice sites were reported.
+
+## Shape change first
+
+V3 materialized the typed error channel as `Either`. V4 materializes it as `Result`:
+
+```ts
+// v3
+const either = yield * Effect.either(program)
+
+if (Either.isRight(either)) {
+  use(either.right)
+} else {
+  recover(either.left)
+}
+```
+
+```ts
+// v4
+const result = yield * Effect.result(program)
+
+if (Result.isSuccess(result)) {
+  use(result.success)
+} else {
+  recover(result.failure)
+}
+```
+
+## Migration table
+
+| v3                      | v4                        |
+| ----------------------- | ------------------------- |
+| `Effect.either(effect)` | `Effect.result(effect)`   |
+| `Either.right(value)`   | `Result.succeed(value)`   |
+| `Either.left(error)`    | `Result.fail(error)`      |
+| `Either.isRight(value)` | `Result.isSuccess(value)` |
+| `Either.isLeft(value)`  | `Result.isFailure(value)` |
+| `either.right`          | `result.success`          |
+| `either.left`           | `result.failure`          |
+| `_tag: "Right"`         | `_tag: "Success"`         |
+| `_tag: "Left"`          | `_tag: "Failure"`         |
+| `Either.mapLeft`        | `Result.mapError`         |
+
+Do not stop after renaming `Effect.either`: every downstream guard, match arm, property access,
+constructor, serialized tag, and test expectation must move to the `Result` shape.
+
+## Equivalence
+
+The API and shape are **VERIFIED** against the real `effect@3.21.4` and
+`effect@4.0.0-beta.102` tarballs. A direct probe normalized:
+
+```text
+Effect.succeed(7) -> Success(7)
+Effect.fail("bad") -> Failure("bad")
+```
+
+Both majors produced identical normalized success values and typed failures. In both, the
+materialized effect itself cannot fail in the typed error channel.
+
+Owning slices must compare any observable encoded representation. A raw `JSON.stringify` or
+snapshot changes `_tag` and property names even when the normalized value is equivalent.
+
+## Intended differences
+
+None at internal control-flow sites. If an `Either` value crosses a wire, persistence, logging, or
+snapshot boundary, preserving or intentionally changing its bytes requires a separate alignment
+decision.
+
+## Gotchas
+
+- `Result` is not `Exit`: a `Result.Failure` contains the typed error directly, not a `Cause`.
+- Defects and interruption are not converted into `Result.Failure`; `Effect.result` materializes
+  the typed error channel, matching v3 `Effect.either`.
+- Do not leave `_tag === "Right"` checks or `.right` reads behind; they are runtime shape checks,
+  not only types.
+- Serialized `Either` and `Result` objects are not byte-identical.
+
+## Codemod rule
+
+The producer rename is mechanical only together with the complete downstream shape rewrite.
+Boundary encoders, snapshots, and pattern matches require per-site review.

--- a/context/effect-4/recipes/effect-sequencing.md
+++ b/context/effect-4/recipes/effect-sequencing.md
@@ -1,0 +1,49 @@
+# Pattern: effect-sequencing
+
+**Area:** Effect sequencing **Kind:** rename **Our usage:** 70 workspace compiler diagnostics for
+`Effect.zipRight` on the current flip snapshot.
+
+## v3
+
+```ts
+acquire.pipe(Effect.zipRight(use))
+```
+
+## v4
+
+```ts
+acquire.pipe(Effect.andThen(use))
+```
+
+`Effect.zipRight` is absent at beta.102. `Effect.andThen` is its direct replacement when the
+right-hand operand is an `Effect`: run the left effect first, discard its success value, then run
+and return the right effect.
+
+## Equivalence
+
+The replacement is **VERIFIED** against the real `effect@3.21.4` and
+`effect@4.0.0-beta.102` tarballs. A direct cross-major probe established that both forms:
+
+- evaluated the left effect before the right effect;
+- returned the right effect's success value;
+- did not evaluate the right effect when the left effect failed.
+
+The declaration signatures also preserve the union of both error channels and both service
+requirements.
+
+## Intended differences
+
+None.
+
+## Gotchas
+
+- V4 `andThen` also accepts plain values and lazy values. Preserve an effectful right-hand operand
+  as an `Effect`; do not unwrap it into an eager computation.
+- This is sequential composition. Do not replace `zipRight` with a concurrent combinator.
+- Keep any existing `Effect.uninterruptibleMask`, scope, or transaction boundary around the whole
+  composition. Moving the boundary between the two effects changes interruption behavior.
+
+## Codemod rule
+
+`Effect.zipRight(left, right)` becomes `Effect.andThen(left, right)`, and
+`left.pipe(Effect.zipRight(right))` becomes `left.pipe(Effect.andThen(right))`.

--- a/context/effect-4/recipes/effect-timeout-custom-error.md
+++ b/context/effect-4/recipes/effect-timeout-custom-error.md
@@ -1,0 +1,59 @@
+# Pattern: effect-timeout-custom-error
+
+**Area:** Effect timeout control flow **Kind:** shape change **Our usage:** custom timeout failures
+in `megarepo`, `utils`, `utils-dev`, and `restate-effect`.
+
+## v3
+
+```ts
+program.pipe(
+  Effect.timeoutFail({
+    duration,
+    onTimeout: () => new OperationTimeout(),
+  }),
+)
+```
+
+## v4
+
+```ts
+program.pipe(
+  Effect.timeoutOrElse({
+    duration,
+    orElse: () => Effect.fail(new OperationTimeout()),
+  }),
+)
+```
+
+`timeoutFail` is absent at beta.102. `timeoutOrElse` is the replacement, but its fallback is an
+`Effect`, not a raw error value. State the `Effect.fail` explicitly; replacing the removed API with
+plain `timeout` would change the error type to `TimeoutException`.
+
+## Equivalence
+
+The replacement is **VERIFIED** against the real `effect@3.21.4` and
+`effect@4.0.0-beta.102` tarballs. A direct probe covered both branches:
+
+- an immediately successful source returned the same value and did not evaluate the timeout error;
+- a never-completing source timed out into the same normalized typed error;
+- the lazy timeout constructor ran exactly once, only on the timeout branch.
+
+Both implementations interrupt the source before producing the timeout failure.
+
+## Intended differences
+
+None.
+
+## Gotchas
+
+- Preserve laziness: `orElse: () => Effect.fail(onTimeout())`, not
+  `orElse: Effect.fail(onTimeout())`.
+- Use `Effect.fail`, not `Effect.die`, unless the v3 site used `timeoutFailCause`.
+- Keep the original duration input and custom error payload unchanged.
+- Test both branches. A timeout-only test does not prove the success path avoids constructing the
+  error.
+
+## Codemod rule
+
+The outer call shape is predictable, but the error must be lifted into `Effect.fail`. Review
+`timeoutFailCause` separately because its v3 failure is a Cause/defect boundary.

--- a/context/effect-4/recipes/inspectable-redaction.md
+++ b/context/effect-4/recipes/inspectable-redaction.md
@@ -1,0 +1,38 @@
+# Pattern: inspectable-redaction
+
+**Area:** Logging / inspection / secrets **Kind:** rename and module move **Our usage:** file logger
+JSON rendering and redaction.
+
+## Migration table
+
+| v3                      | v4                      |
+| ----------------------- | ----------------------- |
+| `Inspectable.toJSON(x)` | `Inspectable.toJson(x)` |
+| `Inspectable.redact(x)` | `Redactable.redact(x)`  |
+
+Import `Redactable` from the `effect` root for the second replacement. Redaction was moved, not
+removed; dropping the call can expose secret values in logs.
+
+## Equivalence
+
+The APIs and behavior are **VERIFIED** against the real `effect@3.21.4` and
+`effect@4.0.0-beta.102` tarballs. A cross-major probe used an object with a custom `toJSON`, a
+nested array, and a `Redacted` secret. Both `toJSON`/`toJson` and both redaction paths produced the
+same recursive JSON shape with the secret rendered as `"<redacted>"`.
+
+## Intended differences
+
+None.
+
+## Gotchas
+
+- `toJson` still invokes user-defined `toJSON()` methods; only the exported helper's capitalization
+  changed.
+- `Redactable.redact` returns `unknown`. Preserve the old boundary's validation or serialization
+  after redaction.
+- Never replace `Inspectable.redact` with identity or raw `JSON.stringify`.
+
+## Codemod rule
+
+The helper rename is mechanical. The module move additionally requires adding the `Redactable`
+root import and preserving redaction before serialization.

--- a/context/effect-4/recipes/metric-updates-attributes.md
+++ b/context/effect-4/recipes/metric-updates-attributes.md
@@ -1,0 +1,131 @@
+# Pattern: metric-updates-attributes
+
+**Area:** Metrics / telemetry **Kind:** shape change **Our usage:** about 29 affected references,
+including the schema-backed instruments in `otel-contract`, resource gauges in `utils`, and
+telemetry tests.
+
+## Shape changes first
+
+- A v4 `Metric` is no longer a callable effect. Mutations go through `Metric.update`.
+- `MetricLabel` is removed. V4 metrics use string attributes supplied as a record or
+  `ReadonlyArray<[string, string]>`.
+- Attribute names must be unique for a faithful port. V3 could retain two `MetricLabel`s with the
+  same key; v4 attributes collapse them to one key.
+- Snapshot entries changed from `{ metricKey, metricState }` to
+  `{ id, type, state, attributes }`.
+
+All mappings and observations below are **VERIFIED** against the real
+`effect@4.0.0-beta.102` tarball (SHA-1
+`f51092854960f60cbdb06bd59e788acbc8ee8492`).
+
+## v3
+
+```ts
+import { Metric, MetricLabel } from 'effect'
+
+const labels = [MetricLabel.make('route', 'alpha'), MetricLabel.make('method', 'GET')]
+
+const counter = Metric.counter('requests').pipe(Metric.taggedWithLabels(labels))
+const gauge = Metric.gauge('queue_depth')
+
+yield * Metric.increment(counter)
+yield * Metric.incrementBy(counter, 2)
+yield * Metric.set(gauge, 42)
+```
+
+## v4
+
+```ts
+import { Metric } from 'effect'
+
+const attributes: Metric.Metric.Attributes = [
+  ['route', 'alpha'],
+  ['method', 'GET'],
+]
+
+const counter = Metric.counter('requests').pipe(Metric.withAttributes(attributes))
+const gauge = Metric.gauge('queue_depth')
+
+yield * Metric.update(counter, 1)
+yield * Metric.update(counter, 2)
+yield * Metric.update(gauge, 42)
+```
+
+## Migration table
+
+| v3                                        | v4                                                                       | Shape                          |
+| ----------------------------------------- | ------------------------------------------------------------------------ | ------------------------------ |
+| `Metric.increment(metric)`                | `Metric.update(metric, 1)`                                               | named mutation to input        |
+| `Metric.incrementBy(metric, amount)`      | `Metric.update(metric, amount)`                                          | named mutation to input        |
+| `Metric.set(gauge, value)`                | `Metric.update(gauge, value)`                                            | named mutation to input        |
+| `Metric.tagged(metric, key, value)`       | `Metric.withAttributes(metric, [[key, value]])`                          | label to attribute             |
+| `Metric.taggedWithLabels(metric, labels)` | `Metric.withAttributes(metric, attributes)`                              | label objects to attribute set |
+| `MetricLabel.make(key, value)`            | `[key, value] as const`                                                  | object to tuple                |
+| `ReadonlyArray<MetricLabel.MetricLabel>`  | `Metric.Metric.Attributes` or `ReadonlyArray<readonly [string, string]>` | nominal objects to strings     |
+| `pair.metricKey.name`                     | `snapshot.id`                                                            | snapshot shape                 |
+| `pair.metricKey.tags`                     | `snapshot.attributes`                                                    | array to record                |
+| `pair.metricState`                        | `snapshot.state`                                                         | field rename                   |
+
+Use the tuple form when keys are computed. A record is convenient for known static keys:
+
+```ts
+Metric.withAttributes(metric, { route: 'alpha', method: 'GET' })
+```
+
+## Equivalence
+
+A direct cross-major probe used the real `effect@3.21.4` and
+`effect@4.0.0-beta.102` tarballs. After normalizing the snapshot shapes:
+
+- v3 `increment` followed by `incrementBy(2)` and v4 `update(1)` followed by `update(2)` both
+  produced counter value `3`;
+- a second label set produced a separate counter series with value `1` in both majors;
+- v3 `set(41)` followed by `increment` and v4 `update(41)` followed by `update(42)` both produced
+  gauge value `42`;
+- both snapshots contained exactly three series with the same unique-key label/attribute sets and
+  values.
+
+This verifies the replacement for the repository's ordinary unique-key telemetry. Each owning
+slice must still compare exported instrument name, kind, description, unit, attribute set, value,
+and series cardinality through its real telemetry exporter.
+
+## Duplicate-key trap
+
+The same probe deliberately composed two values for one key:
+
+```ts
+// v3 snapshot labels: [["key", "a"], ["key", "b"]]
+metric.pipe(Metric.tagged('key', 'a'), Metric.tagged('key', 'b'))
+
+// v4 snapshot attributes: { key: "a" }
+metric.pipe(Metric.withAttributes({ key: 'a' }), Metric.withAttributes({ key: 'b' }))
+```
+
+V4 collapses duplicate keys, and the tested composition retained the earlier value. Do not port a
+site with duplicate or potentially colliding keys until its intended cardinality and precedence
+are explicit. Schema/object-field-derived labels with unique field names can move directly to
+attributes.
+
+## Intended differences
+
+None for unique-key metrics. Counter totals, gauge values, instrument metadata, attributes, and
+series cardinality must be preserved.
+
+Duplicate-key labels have no equivalent representation in v4 attributes. No current migration
+decision authorizes silently collapsing them.
+
+## Gotchas
+
+- `Metric.update` means “apply the metric's input”, not always “replace”. It adds to counters,
+  replaces gauges, records histogram observations, and increments frequency occurrences.
+- Do not replace `incrementBy(metric, amount)` with `update(metric, 1)`.
+- Do not discard labels merely because `MetricLabel` is absent. The replacement is attributes.
+- Do not compare only an in-process value. Metrics are telemetry: verify exporter-visible metadata,
+  attributes, values, and series count.
+- Tuple attributes are converted to a string-keyed attribute set. Validate uniqueness before
+  conversion when keys are dynamic.
+
+## Codemod rule
+
+The three mutation replacements are mechanical after confirming the metric kind. Label migration
+requires changing the producer and consumer types together and reviewing duplicate-key behavior.

--- a/context/effect-4/recipes/option-nullish.md
+++ b/context/effect-4/recipes/option-nullish.md
@@ -1,0 +1,40 @@
+# Pattern: option-nullish
+
+**Area:** Option constructors **Kind:** mechanical rename **Our usage:** 19 references across 15
+files and six packages.
+
+## v3
+
+```ts
+Option.fromNullable(value)
+```
+
+## v4
+
+```ts
+Option.fromNullishOr(value)
+```
+
+This replacement is **VERIFIED** against the real `effect@4.0.0-beta.102` tarball:
+`fromNullable` is absent and `fromNullishOr` is present.
+
+## Equivalence
+
+Both constructors map `null` and `undefined` to `Option.none()` and every other value to
+`Option.some(value)`.
+
+Do not substitute the narrower `fromNullOr` or `fromUndefinedOr`:
+
+| Input       | `fromNullishOr` | `fromNullOr`      | `fromUndefinedOr` |
+| ----------- | --------------- | ----------------- | ----------------- |
+| `null`      | `None`          | `None`            | `Some(null)`      |
+| `undefined` | `None`          | `Some(undefined)` | `None`            |
+
+## Intended differences
+
+None.
+
+## Codemod rule
+
+`Option.fromNullable` mechanically becomes `Option.fromNullishOr`. Preserve any explicit fallback
+argument or surrounding `Option` combinators unchanged.

--- a/context/effect-4/recipes/predicate-object.md
+++ b/context/effect-4/recipes/predicate-object.md
@@ -1,0 +1,42 @@
+# Pattern: predicate-object
+
+**Area:** Runtime predicates **Kind:** semantic rename **Our usage:** object-or-function guards in
+shared utilities.
+
+## v3
+
+```ts
+Predicate.isObject(value)
+```
+
+## v4 replacement
+
+```ts
+Predicate.isObjectKeyword(value)
+```
+
+V4 still exports `Predicate.isObject`, but its meaning narrowed to non-null records: it rejects
+arrays and functions. Use `isObjectKeyword` to preserve v3's JavaScript `object`-keyword semantics,
+which accept non-null objects, arrays, and functions.
+
+## Equivalence
+
+The predicates are **VERIFIED** against the real `effect@3.21.4` and
+`effect@4.0.0-beta.102` tarballs. Across `null`, plain object, array, function, and string, v3
+`isObject` and v4 `isObjectKeyword` returned identical results. V4 `isObject` differed for arrays
+and functions.
+
+## Intended differences
+
+None when using `isObjectKeyword`.
+
+## Gotchas
+
+- This is a surviving-name hazard: leaving `isObject` unchanged compiles but changes behavior.
+- If a site deliberately wants record-only semantics, v4 `isObject` is appropriate, but that is a
+  behavior change requiring an explicit decision.
+
+## Codemod rule
+
+Replace v3 `Predicate.isObject` with v4 `Predicate.isObjectKeyword` unless the owning slice
+explicitly adopts record-only semantics and tests arrays and functions.

--- a/context/effect-4/recipes/root-import-renames.md
+++ b/context/effect-4/recipes/root-import-renames.md
@@ -36,15 +36,15 @@ MetricBoundaries -> Metric.boundariesFromIterable / Metric.linearBoundaries / Me
 
 These came from package moves, not from root removals:
 
-| v3 package/source | v4 package/source | Notes |
-| --- | --- | --- |
-| `@effect/cli/Args` | `effect/unstable/cli` `Argument` | Namespace renamed. |
-| `@effect/cli/Options` | `effect/unstable/cli` `Flag` | `text()` became `string()`. |
-| `@effect/cli/Command` | `effect/unstable/cli` `Command` | Do not import from root. |
-| `@effect/cli` namespace | `effect/unstable/cli` namespace | Use `Cli.Argument` / `Cli.Flag`. |
-| `@effect/platform/HttpClient*` | `effect/unstable/http` | `HttpClient`, `HttpClientRequest`, `HttpClientResponse`, `HttpClientError`, `FetchHttpClient`. |
-| `@effect/platform/Command` | `effect/unstable/process` `ChildProcess` | Existing local alias can preserve call-site name. |
-| `@effect/platform/CommandExecutor` | `effect/unstable/process` `ChildProcessSpawner` | Service type is `ChildProcessSpawner.ChildProcessSpawner`. |
+| v3 package/source                  | v4 package/source                               | Notes                                                                                          |
+| ---------------------------------- | ----------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `@effect/cli/Args`                 | `effect/unstable/cli` `Argument`                | Namespace renamed.                                                                             |
+| `@effect/cli/Options`              | `effect/unstable/cli` `Flag`                    | `text()` became `string()`.                                                                    |
+| `@effect/cli/Command`              | `effect/unstable/cli` `Command`                 | Do not import from root.                                                                       |
+| `@effect/cli` namespace            | `effect/unstable/cli` namespace                 | Use `Cli.Argument` / `Cli.Flag`.                                                               |
+| `@effect/platform/HttpClient*`     | `effect/unstable/http`                          | `HttpClient`, `HttpClientRequest`, `HttpClientResponse`, `HttpClientError`, `FetchHttpClient`. |
+| `@effect/platform/Command`         | `effect/unstable/process` `ChildProcess`        | Existing local alias can preserve call-site name.                                              |
+| `@effect/platform/CommandExecutor` | `effect/unstable/process` `ChildProcessSpawner` | Service type is `ChildProcessSpawner.ChildProcessSpawner`.                                     |
 
 `FileSystem`, `Path`, and `PlatformError` are present in beta.102 root exports. If they appear in a
 Category A provenance scan, classify them as rewrite audit hazards rather than genuine root removals.
@@ -142,25 +142,52 @@ semantics unless a separate slice records and proves a behavior change.
 
 These were verified against `effect@4.0.0-beta.102` while chasing `genie:run` module-load blockers.
 
-| v3 shape | beta.102 shape | Notes |
-| --- | --- | --- |
-| `Schema.NonEmptyTrimmedString` | `Schema.Trimmed.check(Schema.isNonEmpty())` | Value helper removed. |
-| `Schema.NonNegativeInt` | `Schema.Natural` | `Schema.Int` still exists; `Natural` is `Int >= 0`. |
-| `Schema.NonNegativeBigInt` | `Schema.BigInt.check(Schema.isGreaterThanOrEqualToBigInt(0n))` | No `NaturalBigInt` export observed. |
-| `Schema.TaggedError` | `Schema.TaggedErrorClass` | Same class-style call family. |
-| `Schema.Defect` | `Schema.Defect()` | Became a schema factory function. |
-| `Schema.parseJson(schema)` | `Schema.fromJsonString(schema)` | Zero-arg form becomes `Schema.fromJsonString(Schema.Unknown)`. Pretty-print options are not carried by this helper. |
-| `Schema.maxLength(n)` / `Schema.minLength(n)` | `Schema.check(Schema.isMaxLength(n))` / `Schema.check(Schema.isMinLength(n))` | Filters are not pipe functions by themselves. |
-| `Schema.isPattern(re)` in `.pipe(...)` | `Schema.check(Schema.isPattern(re))` | Direct `.check(Schema.isPattern(re))` is already valid. |
-| `Schema.Union(A, B)` | `Schema.Union([A, B])` | Existing array calls stay unchanged. |
-| `Schema.Tuple(A, B)` | `Schema.Tuple([A, B])` | Existing array calls stay unchanged. |
-| `Schema.fromBrand(ctor)(schema)` | `Schema.fromBrand(identifier, ctor)(schema)` | Bare constructor overload removed. |
-| `Schema.transform(from, to, options)` | `from.pipe(Schema.decodeTo(to, options))` | For effectful transforms use `SchemaTransformation.transformOrFail(...)`. |
-| `SchemaAST.getAnnotation<T>(ast, id)` | `SchemaAST.resolveAt<T>(id)(ast)` | Returns `T | undefined`, not `Option<T>`. |
-| `SchemaAST.getAnnotation<T>(id)(ast)` | `SchemaAST.resolveAt<T>(id)(ast)` | Remove `Option.isSome` / `Option.getOrUndefined` wrappers. |
-| `Context.Tag("id")<Self, Service>()` | `Context.Service<Self, Service>()("id")` | Class-style service tags. |
-| `Logger.prettyLogger()` | `Logger.consolePretty()` | Console pretty logger constructor. |
-| `Logger.replace(Logger.defaultLogger, logger)` | `Logger.layer([logger])` | To keep default plus custom logger use `Logger.layer([Logger.defaultLogger, logger])`. |
+| v3 shape                                       | beta.102 shape                                                                | Notes                                                                                                               |
+| ---------------------------------------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ---------------------------- |
+| `Schema.NonEmptyTrimmedString`                 | `Schema.Trimmed.check(Schema.isNonEmpty())`                                   | Value helper removed.                                                                                               |
+| `Schema.NonNegativeInt`                        | `Schema.Natural`                                                              | `Schema.Int` still exists; `Natural` is `Int >= 0`.                                                                 |
+| `Schema.NonNegativeBigInt`                     | `Schema.BigInt.check(Schema.isGreaterThanOrEqualToBigInt(0n))`                | No `NaturalBigInt` export observed.                                                                                 |
+| `Schema.TaggedError`                           | `Schema.TaggedErrorClass`                                                     | Same class-style call family.                                                                                       |
+| `Schema.Defect`                                | `Schema.Defect()`                                                             | Became a schema factory function.                                                                                   |
+| `Schema.parseJson(schema)`                     | `Schema.fromJsonString(schema)`                                               | Zero-arg form becomes `Schema.fromJsonString(Schema.Unknown)`. Pretty-print options are not carried by this helper. |
+| `Schema.maxLength(n)` / `Schema.minLength(n)`  | `Schema.check(Schema.isMaxLength(n))` / `Schema.check(Schema.isMinLength(n))` | Filters are not pipe functions by themselves.                                                                       |
+| `Schema.isPattern(re)` in `.pipe(...)`         | `Schema.check(Schema.isPattern(re))`                                          | Direct `.check(Schema.isPattern(re))` is already valid.                                                             |
+| `Schema.Union(A, B)`                           | `Schema.Union([A, B])`                                                        | Existing array calls stay unchanged.                                                                                |
+| `Schema.Tuple(A, B)`                           | `Schema.Tuple([A, B])`                                                        | Existing array calls stay unchanged.                                                                                |
+| `Schema.fromBrand(ctor)(schema)`               | `Schema.fromBrand(identifier, ctor)(schema)`                                  | Bare constructor overload removed.                                                                                  |
+| `Schema.transform(from, to, options)`          | `from.pipe(Schema.decodeTo(to, options))`                                     | For effectful transforms use `SchemaTransformation.transformOrFail(...)`.                                           |
+| `SchemaAST.getAnnotation<T>(ast, stringKey)`   | `SchemaAST.resolveAt<T>(stringKey)(ast)`                                      | String keys only; returns `T                                                                                        | undefined`, not `Option<T>`. |
+| `SchemaAST.getAnnotation<T>(symbolKey)(ast)`   | `SchemaAST.resolve(ast)?.[symbolKey] as T \| undefined`                       | `resolveAt` does not accept symbols.                                                                                |
+| `Context.Tag("id")<Self, Service>()`           | `Context.Service<Self, Service>()("id")`                                      | Class-style service tags.                                                                                           |
+| `Logger.prettyLogger()`                        | `Logger.consolePretty()`                                                      | Console pretty logger constructor.                                                                                  |
+| `Logger.replace(Logger.defaultLogger, logger)` | `Logger.layer([logger])`                                                      | To keep default plus custom logger use `Logger.layer([Logger.defaultLogger, logger])`.                              |
 
 Known remaining source search after this batch: `Logger.replaceScoped` in browser broadcast logging
 was not on the `genie:run` loader path and was not ported in this slice.
+
+## SchemaAST annotation-key split
+
+`SchemaAST.resolveAt` is only the replacement for **string-keyed** annotations. Beta.102 declares
+its key parameter as `string`; passing a `unique symbol` is not a valid migration.
+
+For symbol-keyed annotations, resolve the annotation object and index it with the original symbol:
+
+```ts
+const annotated = SchemaAST.resolve(schema.ast)?.[optionValueSchema] as
+  | Schema.Codec<Value>
+  | undefined
+
+if (annotated !== undefined) {
+  use(annotated)
+}
+```
+
+This is **VERIFIED** against the real beta.102 runtime: a schema annotated under a unique symbol was
+recovered by `SchemaAST.resolve(ast)?.[symbol]`, while `resolveAt(symbol.description)` returned
+`undefined`. `resolve` follows beta.102's checked-schema rule by reading the last check's
+annotations when checks are present.
+
+The cast is required because beta.102's public `Annotations.Annotations` interface has only a
+string index signature even though the runtime preserves symbol properties. Remove v3
+`Option.isSome`, `.value`, and `Option.getOrUndefined` handling; both `resolveAt` and direct symbol
+indexing use `undefined` for absence.

--- a/context/effect-4/recipes/schedule-composition-metadata.md
+++ b/context/effect-4/recipes/schedule-composition-metadata.md
@@ -1,0 +1,90 @@
+# Pattern: schedule-composition-metadata
+
+**Area:** Retry/repeat scheduling **Kind:** shape change **Our usage:** `megarepo` git retries and
+retry metadata logging, plus schedule composition in Notion and release packages.
+
+## Shape changes first
+
+- V3 `Schedule.intersect(A, B)` continued only while both schedules recurred, waited for the longer
+  delay, and output `[AOutput, BOutput]`.
+- V4 `Schedule.max([A, B])` preserves the continuation and maximum-delay behavior but outputs the
+  selected `Duration`, not the tuple.
+- `Schedule.CurrentIterationMetadata` becomes `Schedule.CurrentMetadata`.
+- Metadata `recurrence` becomes `attempt`.
+- V3 `elapsed` / `elapsedSincePrevious` were `Duration`; v4 stores their millisecond values as
+  `number`.
+
+## Git retry replacement
+
+The repository's git retry does not consume the composed schedule output, so its faithful
+replacement is:
+
+```ts
+// v3
+const retry = Schedule.exponential('2 seconds').pipe(
+  Schedule.intersect(Schedule.recurs(GIT_MAX_RETRIES)),
+)
+
+// v4
+const retry = Schedule.max([Schedule.exponential('2 seconds'), Schedule.recurs(GIT_MAX_RETRIES)])
+```
+
+Metadata logging becomes:
+
+```ts
+const metadata = yield * Schedule.CurrentMetadata
+
+if (metadata.attempt > 0) {
+  yield *
+    Effect.logWarning('Retrying').pipe(
+      Effect.annotateLogs({
+        attempt: metadata.attempt,
+        elapsed: Duration.format(Duration.millis(metadata.elapsed)),
+        error: String(metadata.input),
+      }),
+    )
+}
+```
+
+## Equivalence
+
+All APIs and metadata shapes are **VERIFIED** against the real beta.102 tarball. A direct
+cross-major retry probe used exponential delay plus a three-retry cap. Both traces were:
+
+```text
+attempt 0, input absent
+attempt 1, input first failure
+attempt 2, input second failure
+attempt 3, input third failure
+success on the fourth execution
+```
+
+This establishes the replacement for the repository's output-discarding retry schedule. Owning
+slices must additionally assert their real delay sequence, retry cap, `while` classification, and
+logged metadata.
+
+## Output-shape trap
+
+`Schedule.max` is not a complete replacement when the v3 tuple output is consumed. It emits only a
+`Duration`. Such sites need an explicit `Schedule.fromStep` composition or a redesigned output
+projection, with a behavior probe. Do not cast the duration to the old tuple or silently discard an
+output used by retry logic.
+
+## Intended differences
+
+None for the git retry continuation, delay, cap, and metadata behavior. The schedule's unused output
+shape may narrow to `Duration`; consumed tuple outputs require separate adjudication.
+
+## Gotchas
+
+- `Schedule.min` has the opposite continuation/delay semantics: it continues while any schedule
+  recurs and picks the fastest delay. It is not the replacement for v3 `intersect`.
+- `metadata.elapsed` is a number of milliseconds; wrapping it with `Duration.millis` preserves
+  v3 `Duration.format` call sites.
+- Retry attempt zero has no previous failure input. Do not read/cast `metadata.input` before
+  checking `attempt > 0`.
+
+## Codemod rule
+
+Only output-discarding `intersect` sites may mechanically become `max([A, B])`. Metadata names and
+elapsed units then require the explicit rewrites above.

--- a/context/effect-4/recipes/schema-codec-type-contract.md
+++ b/context/effect-4/recipes/schema-codec-type-contract.md
@@ -1,0 +1,86 @@
+# Pattern: schema-codec-type-contract
+
+**Area:** Schema type-level contracts **Kind:** shape change **Our usage:** generic codec helpers
+throughout the repository, including 23 multi-parameter references in `notion-effect-schema` and
+one-parameter public return types in `otel-contract`.
+
+## Shape change
+
+Effect 3 used one `Schema.Schema` type for both value-only schemas and bidirectional codecs:
+
+```ts
+Schema.Schema<Type, Encoded, Context>
+```
+
+Effect 4's `Schema.Schema<Type>` is a different, weaker interface that carries only the decoded
+type. The faithful replacement is `Schema.Codec` at **every arity**:
+
+| v3                       | v4                         |
+| ------------------------ | -------------------------- |
+| `Schema.Schema<T>`       | `Schema.Codec<T>`          |
+| `Schema.Schema<T, E>`    | `Schema.Codec<T, E>`       |
+| `Schema.Schema<T, E, R>` | `Schema.Codec<T, E, R, R>` |
+
+`Codec` defaults `E = T`, `RD = never`, and `RE = never`, exactly matching the omitted Effect 3
+parameters. For the three-parameter form, Effect 3's single `Context` applied in both directions,
+so it must be copied into v4's decoding and encoding service slots.
+
+All interface shapes and defaults above are **VERIFIED** against the real
+`effect@4.0.0-beta.102` tarball (SHA-1
+`f51092854960f60cbdb06bd59e788acbc8ee8492`).
+
+## Why the alternatives are not equivalent
+
+- `Schema.Schema<T>` drops the encoded type and both service requirements, even when the v3 type
+  used only one explicit parameter.
+- `Schema.Codec<T, E, R, never>` narrows the encoding requirement.
+- `Schema.Codec<T, E, never, R>` narrows the decoding requirement.
+- `Schema.ConstraintCodec` is only for APIs that read type views and do not require the full schema
+  protocol.
+- `Schema.Decoder` and `Schema.Encoder` are deliberately one-directional.
+
+Even when a current helper exercises only one direction, narrowing the other direction is a
+refactor rather than a faithful port and belongs in follow-up work.
+
+## `AnyNoContext`
+
+The replacement for v3 `Schema.Schema.AnyNoContext` is:
+
+```ts
+Schema.Codec<any, any, never, never>
+```
+
+Do **not** use `Schema.Top`. `Top` erases both service slots to `unknown` and therefore admits
+codecs that require decoding or encoding services; v3 `AnyNoContext` rejected them.
+
+This bound is **VERIFIED** from both tarball declarations:
+
+```text
+v3 AnyNoContext = Schema<any, any, never>
+v4 Codec<any, any, never, never>
+v4 Top = decoded/encoded/services all unknown
+```
+
+Use `Schema.ConstraintCodec<any, any, never, never>` only when the generic utility merely reads
+type views and does not call schema methods. A direct port of a v3 `Schema` bound should retain the
+full protocol with `Codec`.
+
+## Equivalence
+
+This recipe preserves the v3 compile-time encoded and service contracts. It does not apply a
+repository migration or establish runtime codec equivalence. Owning slices must replay decoding
+and encoding with exact encoded bytes and both service environments.
+
+## Gotchas
+
+- The apparently safe one-parameter spelling is the easiest trap: v4 `Schema<T>` is not v3
+  `Schema<T>` with fewer visible parameters.
+- The two service slots are easy to confuse because both default to `never`.
+- A green typecheck after narrowing one slot does not prove the old public contract was preserved.
+- `Top` is the existential any-schema bound, not the service-free-codec bound.
+
+## Codemod rule
+
+All v3 `Schema.Schema<...>` type references become `Schema.Codec<...>`. Duplicate the third v3
+parameter into both v4 service slots. Replace `Schema.Schema.AnyNoContext` with
+`Schema.Codec<any, any, never, never>`.

--- a/context/effect-4/recipes/schema-date.md
+++ b/context/effect-4/recipes/schema-date.md
@@ -1,7 +1,22 @@
 # Pattern: schema-date
 
-**Area:** Schema wire format **Kind:** semantic (conditional rewrite) **Our usage:** `Schema.DateTimeUtc`,
-`Schema.DateFromSelf`, and date transforms appear in agent-session, Notion codecs, and path schemas.
+**Area:** Schema wire format **Kind:** semantic (conditional rewrite) **Our usage:**
+`Schema.DateTimeUtc`, `Schema.DateFromSelf`, and date transforms appear in agent-session, Notion
+codecs, and path schemas.
+
+## Shape change first: surviving names changed meaning
+
+Effect 4 split v3 string-to-value schemas into a bare instance validator plus a
+`...FromString` wire codec:
+
+| v3 wire schema       | v4 wire codec                  | Surviving v4 bare name                                   |
+| -------------------- | ------------------------------ | -------------------------------------------------------- |
+| `Schema.Date`        | `Schema.DateFromString`        | `Schema.Date` validates a `Date` instance                |
+| `Schema.DateTimeUtc` | `Schema.DateTimeUtcFromString` | `Schema.DateTimeUtc` validates a `DateTime.Utc` instance |
+
+This is the dangerous pattern: the old identifier survives, typechecks in some generic positions,
+and silently stops accepting or emitting the old string representation. Renames fail loudly;
+survivals require wire-boundary review.
 
 ## v3
 
@@ -20,6 +35,16 @@ const encode = Schema.encodeExit(DateWire)
 
 The v4 codecs return `Exit`, not `Either`; callers must handle the changed result shape.
 
+For UTC `DateTime` wire sites:
+
+```ts
+// v3
+Schema.DateTimeUtc
+
+// v4
+Schema.DateTimeUtcFromString
+```
+
 ## Equivalence
 
 Command:
@@ -32,6 +57,10 @@ Result: encoded wire strings and accept/reject outcomes are equivalent after
 using `Schema.DateFromString` on effect `4.0.0-beta.102`. The only differences
 are allowlisted parse-message text changes for invalid inputs. That allowlist is
 a harness classification, not blanket migration acceptance.
+
+`Schema.DateTimeUtcFromString` is also **VERIFIED** against beta.102. Its encode path uses
+`DateTime.formatIso`, which reaches `toDateUtc(self).toISOString()`. For the characterized value it
+emits the exact v3 bytes `"2026-05-25T10:00:00.000Z"`.
 
 ## Intended differences (alignment register entries)
 
@@ -50,6 +79,8 @@ a harness classification, not blanket migration acceptance.
 
 - This is a rename trap: `Schema.Date` still exists in v4 but means a Date
   instance schema, not the v3 ISO-string wire schema.
+- `Schema.DateTimeUtc` is the same trap for `DateTime.Utc`: the bare v4 name validates an instance;
+  use `DateTimeUtcFromString` for v3 string-to-value wire behavior.
 - In effect `4.0.0-beta.102`, `Schema.Date` rejects invalid Date instances and
   `Schema.DateFromString` decodes through that stricter Date schema. The beta.99
   mapping `Schema.DateFromString.check(Schema.isDateValid())` is stale because

--- a/context/effect-4/recipes/schema-json-formatting.md
+++ b/context/effect-4/recipes/schema-json-formatting.md
@@ -1,0 +1,59 @@
+# Pattern: schema-json-formatting
+
+**Area:** Schema JSON wire bytes **Kind:** semantic boundary **Our usage:** persisted configuration
+and generated JSON files that pass `{ space }` to v3 JSON codecs.
+
+## Shape change
+
+V4 has no pretty-print JSON codec. `Schema.fromJsonString(S)` accepts no formatting options, and no
+beta.102 codec replacement carries v3's `{ space }` behavior.
+
+The replacement is to encode with the schema, then stringify the encoded JSON value explicitly:
+
+```ts
+// v3
+const JsonConfig = Schema.parseJson(Config, { space: 2 })
+const content = Schema.encodeSync(JsonConfig)(value)
+
+// v4
+const encoded = Schema.encodeSync(Config)(value)
+const content = JSON.stringify(encoded, null, 2)
+```
+
+The same rule applies to v3 `Schema.fromJsonString(S, { space })` call shapes. Use
+`Schema.encodeEffect` when the surrounding path handles schema failures as an Effect.
+
+This absence and replacement are **VERIFIED** against the real
+`effect@4.0.0-beta.102` tarball.
+
+## Equivalence
+
+Formatting is behavior at persistence, CLI, snapshot, and hashing boundaries. Compare the complete
+output bytes, including indentation, property order, escaping, and final newline.
+
+`JSON.stringify(encoded, null, 2)` preserves a v3 two-space formatting request only after
+`encoded` has passed through the owning schema. Stringifying the decoded value directly can bypass
+schema transformations and emit different bytes.
+
+Preserve any existing trailing newline separately:
+
+```ts
+const content = `${JSON.stringify(encoded, null, 2)}\n`
+```
+
+## Intended differences
+
+None. File churn is not an accepted migration difference.
+
+## Gotchas
+
+- `Schema.fromJsonString(S)` remains the v4 parse/stringify codec for compact JSON, but it has no
+  pretty-print option.
+- Do not stringify the decoded application value when the schema transforms its encoded shape.
+- `space` may be a number or string in `JSON.stringify`; preserve the exact v3 setting.
+- A value-level round trip cannot prove whitespace bytes.
+
+## Codemod rule
+
+No broad codemod. Split the old combined codec operation at each formatted output boundary:
+schema-encode first, then explicit `JSON.stringify`, then preserve any newline policy.

--- a/context/effect-4/recipes/schema-struct-extension.md
+++ b/context/effect-4/recipes/schema-struct-extension.md
@@ -1,0 +1,67 @@
+# Pattern: schema-struct-extension
+
+**Area:** Schema struct composition **Kind:** shape change **Our usage:** 27 sites in
+`notion-effect-schema`.
+
+## Shape change first
+
+Effect 4 has no standalone `Schema.extend`. There are two replacements, selected by the right-hand
+schema's shape.
+
+### Plain field merge
+
+For two plain structs:
+
+```ts
+// v3
+Schema.extend(A, B)
+
+// v4
+Schema.Struct({ ...A.fields, ...B.fields })
+```
+
+This mirrors the field merge used internally by Effect 4's Class `static extend` implementation.
+It applies to plain `Struct` and `TaggedStruct` values; it does not require or create a Class.
+
+### Struct plus index signature
+
+For a struct extended with a record:
+
+```ts
+// v3
+Schema.extend(BlockBase, Schema.Record({ key: Schema.String, value: Schema.Unknown }))
+
+// v4
+Schema.StructWithRest(BlockBase, [Schema.Record(Schema.String, Schema.Unknown)])
+```
+
+`Schema.Record` returns `$Record`, not `Struct`, and has no `.fields` to spread. Treating it like a
+plain struct silently drops the index signature and changes excess-property decoding.
+
+## Not a replacement: `extendTo`
+
+Do not replace a plain merge with `Schema.extendTo`. `extendTo(fields, derive)` computes derived
+fields from decoded input using `Option`-returning callbacks. It is a transforming schema
+operation, not a struct merge.
+
+## Equivalence
+
+Both replacements and Effect 4's own Class merge implementation are **VERIFIED** against the real
+`effect@4.0.0-beta.102` tarball.
+
+The measured 27 `notion-effect-schema` sites comprise 25 plain struct/tagged-struct merges and two
+struct-plus-record extensions. Owning slices must replay encoded baselines. For `StructWithRest`,
+include an additional property and verify that decode and encode preserve the same key and bytes.
+
+## Gotchas
+
+- `Schema.Record(...).fields` is not a valid merge; `Record` is not a `Struct`.
+- `Schema.extendTo` can typecheck while implementing different runtime behavior.
+- Field order follows object spread order. Preserve the original left-to-right extension order.
+- When both structs define the same key, the right-hand fields continue to win.
+
+## Codemod rule
+
+Only plain `Struct`/`TaggedStruct` pairs may use the field-spread rewrite. Classify every right-hand
+operand first. Record/index-signature operands require `StructWithRest`; Class and genuinely
+derived-field sites require separate adjudication.

--- a/context/effect-4/recipes/schema-transformations-issues.md
+++ b/context/effect-4/recipes/schema-transformations-issues.md
@@ -48,6 +48,32 @@ const NumberFromString = Schema.String.pipe(
 The source schema is piped into `decodeTo`; the target schema is its first argument. The old `strict`
 option is not copied.
 
+### Decode-only pure transformations
+
+When an unsupported encode callback only throws, its inferred return type is `never`. Do not leave
+the transformation's encoded type to inference: state both transformation types and annotate the
+throwing callback's return type.
+
+```ts
+const DecodeOnly = Schema.String.pipe(
+  Schema.decodeTo(
+    Target,
+    SchemaTransformation.transform<TargetType, string>({
+      decode: (input) => decodeInput(input),
+      encode: (_value): string => {
+        throw new Error('This codec only supports decoding')
+      },
+    }),
+  ),
+)
+```
+
+This explicit form is **VERIFIED** to compile against the
+`effect@4.0.0-beta.102` declarations and retains the encoded `string` contract. Prefer
+`transformOrFail` with a `SchemaIssue.Forbidden` failure when the old codec represented unsupported
+encoding in the typed error channel. Whether throwing or typed failure is faithful depends on the
+v3 call site; do not change that boundary merely to satisfy inference.
+
 ## Fallible transformations and issues
 
 ### v3
@@ -118,6 +144,34 @@ Use `Schema.refine(typeGuard)` when the callback narrows the TypeScript type. `m
 a string, a `SchemaIssue.Issue`, `{ path, issue }`, or an array of issues when error structure must be
 preserved.
 
+### Filter messages are no longer lazy
+
+V3 filter/refinement annotations accepted `message: () => string`. Beta.102
+`Annotations.Filter.message` is a plain `string`; there is no lazy annotation form. This is
+**VERIFIED** from the beta.102 declaration.
+
+For the repository's closures that return a constant string, preserve the text as a constant:
+
+```ts
+// v3
+Schema.filter(predicate, { message: () => 'must be valid' })
+
+// v4
+Schema.refine(predicate, { message: 'must be valid' })
+```
+
+Do not mechanically invoke a stateful or expensive closure while constructing the schema. That
+changes evaluation from failure-time to schema-construction-time. If narrowing is not required, a
+lazy failure string can instead be produced by the check itself:
+
+```ts
+Schema.check(Schema.makeFilter((value) => predicate(value) || message()))
+```
+
+That form does not preserve a type-guard narrowing. A stateful/expensive type-guard message
+therefore needs explicit design review; beta.102 has no direct replacement that preserves both
+narrowing and lazy message evaluation.
+
 ## Affected inventory
 
 The AST audit measured 27 `ParseResult` references in 15 files and 7 packages. The namespace-member
@@ -153,12 +207,16 @@ SHA-1 `f51092854960f60cbdb06bd59e788acbc8ee8492`.
 
 - `SchemaTransformation.transform` is only for pure, infallible conversions. Returning an `Effect`
   from it creates the wrong decoded value.
+- Give decode-only pure transformations explicit `<Type, Encoded>` parameters and an encoded return
+  annotation on a throwing callback; otherwise `never` can erase the intended direction.
 - `SchemaTransformation.transformOrFail` callbacks return `Effect`; throwing bypasses the typed issue
   channel.
 - `Schema.decodeUnknownEffect` exposes `SchemaError`, while transformation callbacks operate on
   `SchemaIssue.Issue`.
 - A formatter rewrite can change user-visible text even when decoding behavior is otherwise
   equivalent.
+- V4 filter annotation messages are eager strings. Only constant closures can be collapsed without
+  a timing/value review.
 
 ## Codemod rule
 

--- a/context/effect-4/recipes/sink-reduce.md
+++ b/context/effect-4/recipes/sink-reduce.md
@@ -1,0 +1,52 @@
+# Pattern: sink-reduce
+
+**Area:** Stream sinks **Kind:** constructor rename with evaluation-shape change **Our usage:**
+constant-memory git status line counters in `megarepo`.
+
+## v3
+
+```ts
+Sink.foldLeft<number, string>(0, (count, line) => (line.trim() === '' ? count : count + 1))
+```
+
+## v4
+
+```ts
+Sink.reduce<number, string>(
+  () => 0,
+  (count, line) => (line.trim() === '' ? count : count + 1),
+)
+```
+
+V4 `Sink.reduce` is the direct pure, consume-all-input replacement. Its initial state is a
+`LazyArg`, so the seed is supplied as a function.
+
+## Equivalence
+
+The constructor signatures are **VERIFIED** against the real tarballs. A cross-major stream probe
+over empty, non-empty, and whitespace-only strings produced the same final count (`2`).
+
+Both forms consume the entire stream, update once per element, retain no leftovers, and use
+constant accumulator memory.
+
+## Seed-evaluation trap
+
+V3 receives an already-evaluated seed. V4 evaluates its seed once per sink run. For a dynamic or
+effectful-looking expression, preserve v3 timing by hoisting:
+
+```ts
+const seed = makeSeed()
+const sink = Sink.reduce(() => seed, update)
+```
+
+Writing `Sink.reduce(() => makeSeed(), update)` intentionally changes construction-time evaluation
+into per-run evaluation and may create fresh mutable state.
+
+## Intended differences
+
+None.
+
+## Codemod rule
+
+`Sink.foldLeft(seed, update)` becomes `Sink.reduce(() => seed, update)`. Hoist non-trivial seed
+expressions first when their original evaluation timing matters.

--- a/context/effect-4/recipes/stream-text-decoding.md
+++ b/context/effect-4/recipes/stream-text-decoding.md
@@ -1,0 +1,54 @@
+# Pattern: stream-text-decoding
+
+**Area:** Stream byte decoding **Kind:** call-shape change **Our usage:** git/process stdout and
+stderr decoding in `megarepo`, `utils`, `utils-dev`, and `effect-ai-claude-cli`.
+
+## v3
+
+```ts
+bytes.pipe(Stream.decodeText('utf-8'))
+```
+
+## v4
+
+```ts
+bytes.pipe(Stream.decodeText({ encoding: 'utf-8' }))
+```
+
+The encoding moved from a positional string to an options object. The no-options UTF-8 forms remain:
+
+```ts
+bytes.pipe(Stream.decodeText)
+bytes.pipe(Stream.decodeText())
+```
+
+## Equivalence
+
+The beta.102 signature and TextDecoder implementation are **VERIFIED** against the real tarball. A
+cross-major probe split the four-byte UTF-8 encoding of `😀` across two `Uint8Array` chunks. Both
+majors emitted exactly:
+
+```json
+["A", "😀B"]
+```
+
+This proves the replacement retains streaming decoder state across chunk boundaries for the tested
+UTF-8 input. Owning process/CLI slices must compare complete stdout and stderr bytes separately,
+including malformed-sequence handling where relevant.
+
+## Intended differences
+
+None.
+
+## Gotchas
+
+- Do not drop a non-default encoding while fixing the call shape.
+- Constructing a new `TextDecoder` independently for every chunk corrupts multi-byte sequences
+  split across chunks. Keep the Stream decoder.
+- Text chunk boundaries are not a stable external contract; compare concatenated bytes/text unless
+  the application explicitly consumes chunking.
+
+## Codemod rule
+
+`Stream.decodeText(encoding)` becomes `Stream.decodeText({ encoding })`. Calls that pass the stream
+as the first argument become `Stream.decodeText(stream, { encoding })`.

--- a/context/effect-4/recipes/vitest-collection.md
+++ b/context/effect-4/recipes/vitest-collection.md
@@ -58,3 +58,34 @@ effect/FastCheck -> effect/testing/FastCheck
 ```
 
 Keep runner imports from `@effect/vitest`; do not rewrite them to `effect/testing`.
+
+## Scoped test methods: one axis disappeared
+
+V3 test methods varied on two independent axes:
+
+```text
+environment: TestEnv / test clock  <->  live services / real clock
+scope:       unscoped              <->  scoped
+```
+
+Beta.102 always provides a runner-owned `Scope`, so only the environment/clock axis remains:
+
+| v3              | v4          | Clock      | Scope    |
+| --------------- | ----------- | ---------- | -------- |
+| `it.scoped`     | `it.effect` | test clock | provided |
+| `it.scopedLive` | `it.live`   | real clock | provided |
+
+This is **VERIFIED** against the installed beta.102 declarations and implementation:
+
+- `MethodsNonLive.effect` is `Tester<R | Scope.Scope>` and runs `Effect.scoped` before providing
+  `TestEnv`;
+- `Methods.live` is `Tester<Scope.Scope>` and is built with `Effect.scoped`;
+- concrete `otelite` tests call effects requiring `Scope` under `it.live`.
+
+The migration is not “remove `scoped` wherever it appears.” Preserve the clock half:
+`scoped -> live` silently swaps the test clock for real time, while `scopedLive -> effect` silently
+does the reverse. Either can compile and then change timeout, sleep, retry, or scheduling behavior.
+
+For scoped test migrations, replay resource finalizer count/order and the timing behavior exercised
+by the test. A test that merely starts successfully proves neither clock selection nor scope
+teardown.


### PR DESCRIPTION
## Problem

The Effect 4 recipe catalog was derived from documented upstream changes and omitted compiler-visible long-tail mappings. Several Phase 4 slices stopped on missing recipes, while three existing recipes described forms that do not apply to real source call shapes.

## Goal

Give migration slices verified replacements for the highest-impact clusters in the flip branch's 6,345 real workspace TypeScript diagnostics, including telemetry-preserving Metric guidance and corrected Schema contracts.

## Decisions

- Treat metrics as observable telemetry: preserve values, attributes, and series cardinality, and call out duplicate-key behavior explicitly.
- Preserve v3 schema codec contracts at every generic arity; v4 `Schema<T>` is not the replacement for v3 `Schema<T>`.
- Split safe renames from runtime shape changes and state the replacement for every removed API.
- Record surviving Date, DateTime, and Predicate identifiers as behavior hazards where v4 silently changed their meanings.
- Preserve Vitest's clock axis: `scoped -> effect`, `scopedLive -> live`, with `Scope` supplied by both v4 forms.
- Preserve retry continuation, delay, cap, and metadata while explicitly rejecting `Schedule.max` as a universal tuple-output replacement.

## Compiler-derived clusters

The strict direct build captured 6,941 total diagnostics: exactly 6,345 from workspace `packages/`, plus 541 installed-copy duplicates and 55 other-path diagnostics. The highest named workspace gaps include `FileSystem` (268), `decodeUnknown` (204), `AnyNoContext` (128), `either` (113), `catchAll` (101), `transform` (88), `zipRight` (70), `filter` (42), and `scopedLive` (30).

This PR adds or corrects recipes for the newly adjudicated clusters:

- Metric mutations, attributes, snapshots, and duplicate-key cardinality
- `Effect.either -> Effect.result`
- `Effect.zipRight -> Effect.andThen`
- `Effect.timeoutFail -> Effect.timeoutOrElse(... Effect.fail(...))`
- Schedule intersection and current metadata
- `Sink.foldLeft -> Sink.reduce`
- Stream text-decoder option shape
- `Option.fromNullable -> Option.fromNullishOr`
- schema codec types, `AnyNoContext`, JSON formatting, struct extension, transformations, annotation symbols, filter messages, and Date/DateTime wire codecs
- Vitest scoped/live collection behavior
- Duration, DateTime value, Inspectable/Redactable, and Predicate surviving-name mappings

The remaining dominant names are covered by the pre-existing flip recipes or are downstream type fallout that owning migration slices must resolve with package-level behavior baselines.

## Verification

- Checked every target API against the real `effect@4.0.0-beta.102` npm tarball (SHA-1 `f51092854960f60cbdb06bd59e788acbc8ee8492`).
- Ran cross-major probes against `effect@3.21.4` and beta.102 for Metric values/cardinality, Effect result materialization and sequencing, custom timeout laziness, schedule retry metadata, sink reduction, split UTF-8 stream decoding, Duration inputs, DateTime values, Inspectable redaction, and Predicate object semantics.
- Verified unique-symbol annotations through the beta.102 runtime and compiled the explicit one-direction transformation form against its declarations.
- `oxfmt --check context/effect-4/recipes/*.md` - passed, 43 files.
- `oxlint context/effect-4/recipes/*.md --deny-warnings` - passed, 0 warnings/errors.
- `git diff --check` - passed.

The repository-wide `ts:check` and `check:all` remain intentionally red on the migration flip branch. `check:all` reproduced the disclosed unrelated `otel:verify:setup` failure and expected unmigrated Effect 4 failures; this PR documents their migration clusters and does not apply source migrations.

## Complexity

No runtime or dependency complexity. This adds durable per-pattern migration guidance only.

## Concerns

- Duplicate metric attribute keys cannot preserve v3's two-label representation.
- `Schedule.max` changes an `intersect` schedule's output shape even where retry timing is equivalent.
- Beta.102 has no lazy annotation message that also preserves type-guard narrowing.
- V4 `Predicate.isObject` still exists but no longer accepts arrays and functions; the preserving replacement is `isObjectKeyword`.

## Friction & bottlenecks

The managed type-check view suppresses the intentionally red diagnostics. The guarded compiler had to be run directly with `DEVENV_TASK_PASSTHROUGH=1` to obtain and reconcile the 6,345-error workspace corpus.

## Follow-ups

Owning slices still need their package-level differential baselines. This PR deliberately does not apply migrations.

## References

Refs #925

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | co2-bison |
| `agent_session_id` | bb44ea3d-d2eb-441a-b347-1fa92755da82 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.145.0 |
| `agent_runtime` | Codex CLI 0.145.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/v2y1w79nsgydvamlq4rmgjrs1fyxk5zb-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/jsdk9xcha1pvzq3aqcn1175178dv6vcj-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-29-effect-4-recipe2 |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@be13b6e |
</details>
<!-- agent-footer:end -->