### PR TITLE
Port @overeng/utils to Effect 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **@overeng/utils**: preserve the non-recursive `FileSystem.watch` default on
+  Effect 4 beta.102 while retaining explicit recursive watches.
+
 - **@overeng/genie/package-json**: allow consumers to materialize selected
   cross-repository workspace dependencies with the `file:` protocol. This lets
   pnpm resolve singleton peers such as Effect from the consuming install graph

--- a/genie/external.ts
+++ b/genie/external.ts
@@ -536,10 +536,16 @@ export const createEffectUtilsRefs = (basePath: string) =>
 export const utilsPatches = definePatchedDependencies({
   location: 'packages/@overeng/utils',
   patches: {
+    /* LIVE-MIGRATION BRIDGE effect-3-4 — DELETE at contraction — https://github.com/Effect-TS/effect/pull/6705
+       beta.102 made FileSystem.watch recursive unconditionally. Restore the
+       upstream non-recursive default and explicit recursive option until the
+       cohort advances to a release containing PR #6705. */
+    '@effect/platform-node-shared@4.0.0-beta.102':
+      './patches/@effect__platform-node-shared@4.0.0-beta.102.patch',
     /* LIVE-MIGRATION BRIDGE effect-3-4 B3 — DELETE at contraction — https://github.com/Effect-TS/effect/pull/6697
-       Effect 4 beta.102 emits every redacted request/response header name as an
-       HTTP client span attribute. Preserve the v3 telemetry allowlist until
-       upstream exposes HttpClient.TracerHeaderFilter and we adopt that beta. */
+       The Effect patch carries both the FileSystem.watch type surface from
+       PR #6705 and the v3 HTTP telemetry allowlist until upstream exposes
+       HttpClient.TracerHeaderFilter and we adopt that beta. */
     'effect@4.0.0-beta.102': './patches/effect@4.0.0-beta.102.patch',
     /* LIVE-MIGRATION END effect-3-4 */
   },

--- a/packages/@overeng/utils/package.json
+++ b/packages/@overeng/utils/package.json
@@ -84,6 +84,7 @@
   },
   "pnpm": {
     "patchedDependencies": {
+      "@effect/platform-node-shared@4.0.0-beta.102": "patches/@effect__platform-node-shared@4.0.0-beta.102.patch",
       "effect@4.0.0-beta.102": "patches/effect@4.0.0-beta.102.patch"
     }
   },

--- a/packages/@overeng/utils/patches/@effect__platform-node-shared@4.0.0-beta.102.patch
+++ b/packages/@overeng/utils/patches/@effect__platform-node-shared@4.0.0-beta.102.patch
@@ -1,0 +1,86 @@
+diff --git a/dist/NodeFileSystem.js b/dist/NodeFileSystem.js
+index f2230ae56a9161e2d45d3cf9f2c0a79d8d08a61c..d347332d8e5fa852d8127fe4707212e37a79f792 100644
+--- a/dist/NodeFileSystem.js
++++ b/dist/NodeFileSystem.js
+@@ -335,9 +335,9 @@ const utimes = /*#__PURE__*/(() => {
+   return (path, atime, mtime) => nodeUtimes(path, atime, mtime);
+ })();
+ // == watch
+-const watchNode = path => Stream.callback(queue => Effect.acquireRelease(Effect.sync(() => {
++const watchNode = (path, options) => Stream.callback(queue => Effect.acquireRelease(Effect.sync(() => {
+   const watcher = NFS.watch(path, {
+-    recursive: true
++    recursive: options?.recursive ?? false
+   }, (event, path) => {
+     if (!path) return;
+     switch (event) {
+@@ -379,7 +379,7 @@ const watchNode = path => Stream.callback(queue => Effect.acquireRelease(Effect.
+   });
+   return watcher;
+ }), watcher => Effect.sync(() => watcher.close())));
+-const watch = (backend, path) => stat(path).pipe(Effect.map(stat => backend.pipe(Option.flatMap(_ => _.register(path, stat)), Option.getOrElse(() => watchNode(path)))), Stream.unwrap);
++const watch = (backend, path, options) => stat(path).pipe(Effect.map(stat => backend.pipe(Option.flatMap(_ => _.register(path, stat, options)), Option.getOrElse(() => watchNode(path, options)))), Stream.unwrap);
+ // == writeFile
+ const writeFile = (path, data, options) => Effect.callback((resume, signal) => {
+   try {
+@@ -422,8 +422,8 @@ const makeFileSystem = /*#__PURE__*/Effect.map(/*#__PURE__*/Effect.serviceOption
+   symlink,
+   truncate,
+   utimes,
+-  watch(path) {
+-    return watch(backend, path);
++  watch(path, options) {
++    return watch(backend, path, options);
+   },
+   writeFile
+ }));
+diff --git a/src/NodeFileSystem.ts b/src/NodeFileSystem.ts
+index fe7dd6314935ac8969f6e3b8ae4c2c6d3b229655..c9a7ecb4fa1a791faf43cd4ed2c1a13bf057b65c 100644
+--- a/src/NodeFileSystem.ts
++++ b/src/NodeFileSystem.ts
+@@ -550,12 +550,12 @@ const utimes = (() => {
+ 
+ // == watch
+ 
+-const watchNode = (path: string) =>
++const watchNode = (path: string, options?: FileSystem.WatchOptions) =>
+   Stream.callback<FileSystem.WatchEvent, Error.PlatformError>((queue) =>
+     Effect.acquireRelease(
+       Effect.sync(() => {
+         const watcher = NFS.watch(path, {
+-          recursive: true
++          recursive: options?.recursive ?? false
+         }, (event, path) => {
+           if (!path) return
+           switch (event) {
+@@ -595,12 +595,16 @@ const watchNode = (path: string) =>
+     )
+   )
+ 
+-const watch = (backend: Option.Option<FileSystem.WatchBackend["Service"]>, path: string) =>
++const watch = (
++  backend: Option.Option<FileSystem.WatchBackend["Service"]>,
++  path: string,
++  options?: FileSystem.WatchOptions
++) =>
+   stat(path).pipe(
+     Effect.map((stat) =>
+       backend.pipe(
+-        Option.flatMap((_) => _.register(path, stat)),
+-        Option.getOrElse(() => watchNode(path))
++        Option.flatMap((_) => _.register(path, stat, options)),
++        Option.getOrElse(() => watchNode(path, options))
+       )
+     ),
+     Stream.unwrap
+@@ -652,8 +656,8 @@ const makeFileSystem = Effect.map(Effect.serviceOption(FileSystem.WatchBackend),
+     symlink,
+     truncate,
+     utimes,
+-    watch(path) {
+-      return watch(backend, path)
++    watch(path, options) {
++      return watch(backend, path, options)
+     },
+     writeFile
+   }))

--- a/packages/@overeng/utils/patches/@effect__platform-node-shared@4.0.0-beta.102.patch
+++ b/packages/@overeng/utils/patches/@effect__platform-node-shared@4.0.0-beta.102.patch
@@ -2,10 +2,11 @@ diff --git a/dist/NodeFileSystem.js b/dist/NodeFileSystem.js
 index f2230ae56a9161e2d45d3cf9f2c0a79d8d08a61c..d347332d8e5fa852d8127fe4707212e37a79f792 100644
 --- a/dist/NodeFileSystem.js
 +++ b/dist/NodeFileSystem.js
-@@ -335,9 +335,9 @@ const utimes = /*#__PURE__*/(() => {
+@@ -335,9 +335,10 @@ const utimes = /*#__PURE__*/(() => {
    return (path, atime, mtime) => nodeUtimes(path, atime, mtime);
  })();
  // == watch
++// LIVE-MIGRATION BRIDGE effect-3-4 - DELETE at contraction - https://github.com/Effect-TS/effect/pull/6705
 -const watchNode = path => Stream.callback(queue => Effect.acquireRelease(Effect.sync(() => {
 +const watchNode = (path, options) => Stream.callback(queue => Effect.acquireRelease(Effect.sync(() => {
    const watcher = NFS.watch(path, {
@@ -14,7 +15,7 @@ index f2230ae56a9161e2d45d3cf9f2c0a79d8d08a61c..d347332d8e5fa852d8127fe4707212e3
    }, (event, path) => {
      if (!path) return;
      switch (event) {
-@@ -379,7 +379,7 @@ const watchNode = path => Stream.callback(queue => Effect.acquireRelease(Effect.
+@@ -379,7 +380,7 @@ const watchNode = path => Stream.callback(queue => Effect.acquireRelease(Effect.
    });
    return watcher;
  }), watcher => Effect.sync(() => watcher.close())));
@@ -23,7 +24,7 @@ index f2230ae56a9161e2d45d3cf9f2c0a79d8d08a61c..d347332d8e5fa852d8127fe4707212e3
  // == writeFile
  const writeFile = (path, data, options) => Effect.callback((resume, signal) => {
    try {
-@@ -422,8 +422,8 @@ const makeFileSystem = /*#__PURE__*/Effect.map(/*#__PURE__*/Effect.serviceOption
+@@ -422,8 +423,9 @@ const makeFileSystem = /*#__PURE__*/Effect.map(/*#__PURE__*/Effect.serviceOption
    symlink,
    truncate,
    utimes,
@@ -32,16 +33,18 @@ index f2230ae56a9161e2d45d3cf9f2c0a79d8d08a61c..d347332d8e5fa852d8127fe4707212e3
 +  watch(path, options) {
 +    return watch(backend, path, options);
    },
++  // LIVE-MIGRATION END effect-3-4
    writeFile
  }));
 diff --git a/src/NodeFileSystem.ts b/src/NodeFileSystem.ts
 index fe7dd6314935ac8969f6e3b8ae4c2c6d3b229655..c9a7ecb4fa1a791faf43cd4ed2c1a13bf057b65c 100644
 --- a/src/NodeFileSystem.ts
 +++ b/src/NodeFileSystem.ts
-@@ -550,12 +550,12 @@ const utimes = (() => {
+@@ -550,12 +550,13 @@ const utimes = (() => {
  
  // == watch
  
++// LIVE-MIGRATION BRIDGE effect-3-4 - DELETE at contraction - https://github.com/Effect-TS/effect/pull/6705
 -const watchNode = (path: string) =>
 +const watchNode = (path: string, options?: FileSystem.WatchOptions) =>
    Stream.callback<FileSystem.WatchEvent, Error.PlatformError>((queue) =>
@@ -53,7 +56,7 @@ index fe7dd6314935ac8969f6e3b8ae4c2c6d3b229655..c9a7ecb4fa1a791faf43cd4ed2c1a13b
          }, (event, path) => {
            if (!path) return
            switch (event) {
-@@ -595,12 +595,16 @@ const watchNode = (path: string) =>
+@@ -595,12 +596,16 @@ const watchNode = (path: string) =>
      )
    )
  
@@ -73,7 +76,7 @@ index fe7dd6314935ac8969f6e3b8ae4c2c6d3b229655..c9a7ecb4fa1a791faf43cd4ed2c1a13b
        )
      ),
      Stream.unwrap
-@@ -652,8 +656,8 @@ const makeFileSystem = Effect.map(Effect.serviceOption(FileSystem.WatchBackend),
+@@ -652,8 +657,9 @@ const makeFileSystem = Effect.map(Effect.serviceOption(FileSystem.WatchBackend),
      symlink,
      truncate,
      utimes,
@@ -82,5 +85,6 @@ index fe7dd6314935ac8969f6e3b8ae4c2c6d3b229655..c9a7ecb4fa1a791faf43cd4ed2c1a13b
 +    watch(path, options) {
 +      return watch(backend, path, options)
      },
++    // LIVE-MIGRATION END effect-3-4
      writeFile
    }))

--- a/packages/@overeng/utils/patches/effect@4.0.0-beta.102.patch
+++ b/packages/@overeng/utils/patches/effect@4.0.0-beta.102.patch
@@ -2,10 +2,11 @@ diff --git a/dist/FileSystem.d.ts b/dist/FileSystem.d.ts
 index 3d4e8aa70ef1691fdf2694101a55273e4ecbbd09..373bfd538305292a2108b8ae0a7e9db0ab36792b 100644
 --- a/dist/FileSystem.d.ts
 +++ b/dist/FileSystem.d.ts
-@@ -254,9 +254,15 @@ export interface FileSystem {
-      */
-     readonly utimes: (path: string, atime: Date | number, mtime: Date | number) => Effect.Effect<void, PlatformError>;
-     /**
+@@ -254,9 +254,16 @@ export interface FileSystem {
+     */
+    readonly utimes: (path: string, atime: Date | number, mtime: Date | number) => Effect.Effect<void, PlatformError>;
++    // LIVE-MIGRATION BRIDGE effect-3-4 - DELETE at contraction - https://github.com/Effect-TS/effect/pull/6705
+    /**
 -     * Watch a directory or file for changes
 +     * Watch a directory or file for changes.
 +     *
@@ -20,7 +21,7 @@ index 3d4e8aa70ef1691fdf2694101a55273e4ecbbd09..373bfd538305292a2108b8ae0a7e9db0
      /**
       * Write data to a file at `path`.
       */
-@@ -969,6 +975,18 @@ export declare const FileDescriptor: Brand.Constructor<File.Descriptor>;
+@@ -969,6 +976,18 @@ export declare const FileDescriptor: Brand.Constructor<File.Descriptor>;
   * @since 4.0.0
   */
  export type SeekMode = "start" | "current";
@@ -39,13 +40,14 @@ index 3d4e8aa70ef1691fdf2694101a55273e4ecbbd09..373bfd538305292a2108b8ae0a7e9db0
  /**
   * Represents file system events emitted when watching files or directories.
   *
-@@ -1041,7 +1059,7 @@ export declare namespace WatchEvent {
+@@ -1041,7 +1060,8 @@ export declare namespace WatchEvent {
      }
  }
  declare const WatchBackend_base: Context.ServiceClass<WatchBackend, "effect/platform/FileSystem/WatchBackend", {
 -    readonly register: (path: string, stat: File.Info) => Option.Option<Stream.Stream<WatchEvent, PlatformError>>;
 +    readonly register: (path: string, stat: File.Info, options?: WatchOptions) => Option.Option<Stream.Stream<WatchEvent, PlatformError>>;
  }>;
++// LIVE-MIGRATION END effect-3-4
  /**
   * Service key for file system watch backend implementations.
 diff --git a/dist/unstable/http/HttpClient.js b/dist/unstable/http/HttpClient.js
@@ -87,9 +89,10 @@ diff --git a/src/FileSystem.ts b/src/FileSystem.ts
 index beadaa7a2f7a1179c23d39e79924a31ac7db62d0..517499c22dccd9fec83f91ae085f53af5aaeb0d5 100644
 --- a/src/FileSystem.ts
 +++ b/src/FileSystem.ts
-@@ -341,9 +341,15 @@ export interface FileSystem {
+@@ -341,9 +341,16 @@ export interface FileSystem {
      mtime: Date | number
    ) => Effect.Effect<void, PlatformError>
++  // LIVE-MIGRATION BRIDGE effect-3-4 - DELETE at contraction - https://github.com/Effect-TS/effect/pull/6705
    /**
 -   * Watch a directory or file for changes
 +   * Watch a directory or file for changes.
@@ -105,7 +108,7 @@ index beadaa7a2f7a1179c23d39e79924a31ac7db62d0..517499c22dccd9fec83f91ae085f53af
    /**
     * Write data to a file at `path`.
     */
-@@ -1287,6 +1293,19 @@ export const FileDescriptor = Brand.nominal<File.Descriptor>()
+@@ -1287,6 +1294,19 @@ export const FileDescriptor = Brand.nominal<File.Descriptor>()
   */
  export type SeekMode = "start" | "current"
 
@@ -125,7 +128,7 @@ index beadaa7a2f7a1179c23d39e79924a31ac7db62d0..517499c22dccd9fec83f91ae085f53af
  /**
   * Represents file system events emitted when watching files or directories.
   *
-@@ -1403,5 +1422,9 @@ export declare namespace WatchEvent {
+@@ -1403,5 +1423,10 @@ export declare namespace WatchEvent {
   * @since 4.0.0
   */
  export class WatchBackend extends Context.Service<WatchBackend, {
@@ -136,6 +139,7 @@ index beadaa7a2f7a1179c23d39e79924a31ac7db62d0..517499c22dccd9fec83f91ae085f53af
 +    options?: WatchOptions
 +  ) => Option.Option<Stream.Stream<WatchEvent, PlatformError>>
  }>()("effect/platform/FileSystem/WatchBackend") {}
++// LIVE-MIGRATION END effect-3-4
 diff --git a/src/unstable/http/HttpClient.ts b/src/unstable/http/HttpClient.ts
 index 3f45ece547db0ace00bd43b2e402651dd26a55fe..e016152314ad6e07c51f0f75d1ca3879eeca9a1a 100644
 --- a/src/unstable/http/HttpClient.ts

--- a/packages/@overeng/utils/patches/effect@4.0.0-beta.102.patch
+++ b/packages/@overeng/utils/patches/effect@4.0.0-beta.102.patch
@@ -1,8 +1,59 @@
+diff --git a/dist/FileSystem.d.ts b/dist/FileSystem.d.ts
+index 3d4e8aa70ef1691fdf2694101a55273e4ecbbd09..373bfd538305292a2108b8ae0a7e9db0ab36792b 100644
+--- a/dist/FileSystem.d.ts
++++ b/dist/FileSystem.d.ts
+@@ -254,9 +254,15 @@ export interface FileSystem {
+      */
+     readonly utimes: (path: string, atime: Date | number, mtime: Date | number) => Effect.Effect<void, PlatformError>;
+     /**
+-     * Watch a directory or file for changes
++     * Watch a directory or file for changes.
++     *
++     * **Details**
++     *
++     * By default, only changes to the direct children of the directory are
++     * reported. Set the `recursive` option to `true` to watch for changes in
++     * subdirectories as well.
+      */
+-    readonly watch: (path: string) => Stream.Stream<WatchEvent, PlatformError>;
++    readonly watch: (path: string, options?: WatchOptions) => Stream.Stream<WatchEvent, PlatformError>;
+     /**
+      * Write data to a file at `path`.
+      */
+@@ -969,6 +975,18 @@ export declare const FileDescriptor: Brand.Constructor<File.Descriptor>;
+  * @since 4.0.0
+  */
+ export type SeekMode = "start" | "current";
++/**
++ * Options for watching files or directories.
++ *
++ * @category models
++ * @since 4.0.0
++ */
++export interface WatchOptions {
++    /**
++     * When `true`, changes in subdirectories are also reported.
++     */
++    readonly recursive?: boolean | undefined;
++}
+ /**
+  * Represents file system events emitted when watching files or directories.
+  *
+@@ -1041,7 +1059,7 @@ export declare namespace WatchEvent {
+     }
+ }
+ declare const WatchBackend_base: Context.ServiceClass<WatchBackend, "effect/platform/FileSystem/WatchBackend", {
+-    readonly register: (path: string, stat: File.Info) => Option.Option<Stream.Stream<WatchEvent, PlatformError>>;
++    readonly register: (path: string, stat: File.Info, options?: WatchOptions) => Option.Option<Stream.Stream<WatchEvent, PlatformError>>;
+ }>;
+ /**
+  * Service key for file system watch backend implementations.
 diff --git a/dist/unstable/http/HttpClient.js b/dist/unstable/http/HttpClient.js
-index 6dc8ad5..28aa227 100644
+index 6dc8ad5206294330605e191c1a803fb04a9bf13a..54f763605668c277354e8e4bf453e875b9d974ca 100644
 --- a/dist/unstable/http/HttpClient.js
 +++ b/dist/unstable/http/HttpClient.js
-@@ -25,4 +25,8 @@ import * as HttpMethod from "./HttpMethod.js";
+@@ -24,6 +24,10 @@ import * as HttpIncomingMessage from "./HttpIncomingMessage.js";
+ import * as HttpMethod from "./HttpMethod.js";
  import * as TraceContext from "./HttpTraceContext.js";
  import * as Url from "./Url.js";
 +// LIVE-MIGRATION BRIDGE effect-3-4 B3 - DELETE at contraction - https://github.com/Effect-TS/effect/pull/6697
@@ -11,6 +62,7 @@ index 6dc8ad5..28aa227 100644
 +// LIVE-MIGRATION END effect-3-4
  const TypeId = "~effect/http/HttpClient";
  /**
+  * Returns `true` if the provided value is an `HttpClient`.
 @@ -262,6 +266,9 @@ export const make = f => makeWith(effect => Effect.flatMap(effect, request => Ef
      const redactedHeaderNames = fiber.getRef(Headers.CurrentRedactedNames);
      const redactedHeaders = Headers.redact(request.headers, redactedHeaderNames);
@@ -31,8 +83,61 @@ index 6dc8ad5..28aa227 100644
            span.attribute(`http.response.header.${name}`, String(redactedHeaders[name]));
          }
          if (scopedController) return Effect.succeed(response);
+diff --git a/src/FileSystem.ts b/src/FileSystem.ts
+index beadaa7a2f7a1179c23d39e79924a31ac7db62d0..517499c22dccd9fec83f91ae085f53af5aaeb0d5 100644
+--- a/src/FileSystem.ts
++++ b/src/FileSystem.ts
+@@ -341,9 +341,15 @@ export interface FileSystem {
+     mtime: Date | number
+   ) => Effect.Effect<void, PlatformError>
+   /**
+-   * Watch a directory or file for changes
++   * Watch a directory or file for changes.
++   *
++   * **Details**
++   *
++   * By default, only changes to the direct children of the directory are
++   * reported. Set the `recursive` option to `true` to watch for changes in
++   * subdirectories as well.
+    */
+-  readonly watch: (path: string) => Stream.Stream<WatchEvent, PlatformError>
++  readonly watch: (path: string, options?: WatchOptions) => Stream.Stream<WatchEvent, PlatformError>
+   /**
+    * Write data to a file at `path`.
+    */
+@@ -1287,6 +1293,19 @@ export const FileDescriptor = Brand.nominal<File.Descriptor>()
+  */
+ export type SeekMode = "start" | "current"
+
++/**
++ * Options for watching files or directories.
++ *
++ * @category models
++ * @since 4.0.0
++ */
++export interface WatchOptions {
++  /**
++   * When `true`, changes in subdirectories are also reported.
++   */
++  readonly recursive?: boolean | undefined
++}
++
+ /**
+  * Represents file system events emitted when watching files or directories.
+  *
+@@ -1403,5 +1422,9 @@ export declare namespace WatchEvent {
+  * @since 4.0.0
+  */
+ export class WatchBackend extends Context.Service<WatchBackend, {
+-  readonly register: (path: string, stat: File.Info) => Option.Option<Stream.Stream<WatchEvent, PlatformError>>
++  readonly register: (
++    path: string,
++    stat: File.Info,
++    options?: WatchOptions
++  ) => Option.Option<Stream.Stream<WatchEvent, PlatformError>>
+ }>()("effect/platform/FileSystem/WatchBackend") {}
 diff --git a/src/unstable/http/HttpClient.ts b/src/unstable/http/HttpClient.ts
-index 3f45ece..e016152 100644
+index 3f45ece547db0ace00bd43b2e402651dd26a55fe..e016152314ad6e07c51f0f75d1ca3879eeca9a1a 100644
 --- a/src/unstable/http/HttpClient.ts
 +++ b/src/unstable/http/HttpClient.ts
 @@ -42,6 +42,19 @@ import * as HttpMethod from "./HttpMethod.ts"

--- a/packages/@overeng/utils/src/browser/BroadcastLogger.ts
+++ b/packages/@overeng/utils/src/browser/BroadcastLogger.ts
@@ -98,7 +98,7 @@ const trustOtelContract = <A, E, R>(
   effect.pipe(Effect.catchTag('OtelAttrEncodeError', (error) => Effect.die(error)))
 
 const trustedWith =
-  <S extends Schema.Codec<unknown, unknown, never, never>>({
+  <S extends Schema.Codec<any, any, never, never>>({
     operation,
     attributes,
   }: {

--- a/packages/@overeng/utils/src/browser/BroadcastLogger.ts
+++ b/packages/@overeng/utils/src/browser/BroadcastLogger.ts
@@ -98,7 +98,7 @@ const trustOtelContract = <A, E, R>(
   effect.pipe(Effect.catchTag('OtelAttrEncodeError', (error) => Effect.die(error)))
 
 const trustedWith =
-  <S extends Schema.Schema.AnyNoContext>({
+  <S extends Schema.Codec<unknown, unknown, never, never>>({
     operation,
     attributes,
   }: {
@@ -302,7 +302,7 @@ export interface LogBridgeOptions {
 export const makeLogBridgeLive = (
   options?: LogBridgeOptions,
 ): Layer.Layer<never, never, Scope.Scope> =>
-  Layer.scopedDiscard(
+  Layer.effectDiscard(
     logStream.pipe(
       Stream.filter((entry) => {
         if (options?.sources !== undefined && options.sources.length > 0) {
@@ -315,16 +315,16 @@ export const makeLogBridgeLive = (
 
         return Effect.logWithLevel(
           entry.level === 'FATAL'
-            ? LogLevel.Fatal
+            ? 'Fatal'
             : entry.level === 'ERROR'
-              ? LogLevel.Error
+              ? 'Error'
               : entry.level === 'WARNING'
-                ? LogLevel.Warning
+                ? 'Warn'
                 : entry.level === 'DEBUG'
-                  ? LogLevel.Debug
+                  ? 'Debug'
                   : entry.level === 'TRACE'
                     ? LogLevel.Trace
-                    : LogLevel.Info,
+                    : 'Info',
           msg,
         ).pipe(
           Effect.annotateLogs({

--- a/packages/@overeng/utils/src/browser/BroadcastLogger.ts
+++ b/packages/@overeng/utils/src/browser/BroadcastLogger.ts
@@ -69,7 +69,7 @@
  *
  * @module
  */
-import { Cause, Effect, HashMap, Layer, Logger, LogLevel, Schema, Scope, Stream } from 'effect'
+import { Cause, Effect, Layer, Logger, Queue, References, Schema, Scope, Stream } from 'effect'
 
 import {
   OtelAttr,
@@ -98,7 +98,7 @@ const trustOtelContract = <A, E, R>(
   effect.pipe(Effect.catchTag('OtelAttrEncodeError', (error) => Effect.die(error)))
 
 const trustedWith =
-  <S extends Schema.Codec<any, any, never, never>>({
+  <S extends Schema.Codec<any, any, any, any>>({
     operation,
     attributes,
   }: {
@@ -168,18 +168,20 @@ const makeBroadcastLoggerFromChannel = ({
   channel,
   source,
 }: MakeBroadcastLoggerFromChannelOptions) =>
-  Logger.make<unknown, void>(({ annotations, cause, date, fiberId, logLevel, message, spans }) => {
+  Logger.make<unknown, void>(({ cause, date, fiber, logLevel, message }) => {
+    const annotations = fiber.getRef(References.CurrentLogAnnotations)
+    const spans = fiber.getRef(References.CurrentLogSpans)
     const entry = new BroadcastLogEntry({
       _tag: 'BroadcastLogEntry',
       timestamp: date.getTime(),
-      level: logLevel.label,
+      level: logLevel.toUpperCase(),
       message: (Array.isArray(message) === true ? message : [message]).map(sanitizeForBroadcast),
-      fiberId: formatFiberId(fiberId),
-      spans: [...spans].map((span) => span.label),
+      fiberId: formatFiberId(fiber.id),
+      spans: spans.map(([label]) => label),
       annotations: Object.fromEntries(
-        HashMap.toEntries(annotations).map(([k, v]) => [k, sanitizeForBroadcast(v)]),
+        Object.entries(annotations).map(([key, value]) => [key, sanitizeForBroadcast(value)]),
       ),
-      cause: Cause.isEmpty(cause) === true ? undefined : Cause.pretty(cause),
+      cause: cause.reasons.length === 0 ? undefined : Cause.pretty(cause),
       source,
     })
 
@@ -205,13 +207,12 @@ export const makeBroadcastLogger = (source?: string) => {
  * @param source - Optional identifier for the log source (e.g., worker name)
  */
 export const BroadcastLoggerLive = (source?: string) =>
-  Logger.replaceScoped(
-    Logger.defaultLogger,
+  Logger.layer([
     Effect.acquireRelease(
       Effect.sync(() => new BroadcastChannel(BROADCAST_CHANNEL_NAME)),
       (channel) => Effect.sync(() => channel.close()),
     ).pipe(Effect.map((channel) => makeBroadcastLoggerFromChannel({ channel, source }))),
-  )
+  ])
 
 /**
  * Stream of broadcast log entries from all sources.
@@ -235,8 +236,8 @@ export const BroadcastLoggerLive = (source?: string) =>
  * )
  * ```
  */
-export const logStream: Stream.Stream<BroadcastLogEntry, never, Scope.Scope> =
-  Stream.asyncScoped<BroadcastLogEntry>((emit) =>
+export const logStream: Stream.Stream<BroadcastLogEntry> = Stream.callback<BroadcastLogEntry>(
+  (queue) =>
     Effect.gen(function* () {
       const channel = new BroadcastChannel(BROADCAST_CHANNEL_NAME)
       const scope = yield* Effect.scope
@@ -244,7 +245,7 @@ export const logStream: Stream.Stream<BroadcastLogEntry, never, Scope.Scope> =
       const handler = (event: MessageEvent<unknown>) => {
         const decoded = decodeBroadcastLogEntry(event.data)
         if (decoded._tag === 'Some') {
-          emit.single(decoded.value)
+          Queue.offerUnsafe(queue, decoded.value)
         }
       }
 
@@ -263,7 +264,7 @@ export const logStream: Stream.Stream<BroadcastLogEntry, never, Scope.Scope> =
         attributes: { label: 'setup' },
       }),
     ),
-  )
+)
 
 /** Options for creating a log bridge layer. */
 export interface LogBridgeOptions {
@@ -299,9 +300,7 @@ export interface LogBridgeOptions {
  * timestamp=2024-01-15T10:30:45.789Z level=INFO fiber=#0 message="Syncing records" broadcastSource=sync-worker broadcastFiberId=#5 broadcastSpans="sync-operation"
  * ```
  */
-export const makeLogBridgeLive = (
-  options?: LogBridgeOptions,
-): Layer.Layer<never, never, Scope.Scope> =>
+export const makeLogBridgeLive = (options?: LogBridgeOptions): Layer.Layer<never, never> =>
   Layer.effectDiscard(
     logStream.pipe(
       Stream.filter((entry) => {
@@ -323,10 +322,9 @@ export const makeLogBridgeLive = (
                 : entry.level === 'DEBUG'
                   ? 'Debug'
                   : entry.level === 'TRACE'
-                    ? LogLevel.Trace
+                    ? 'Trace'
                     : 'Info',
-          msg,
-        ).pipe(
+        )(msg).pipe(
           Effect.annotateLogs({
             broadcastSource: entry.source ?? 'unknown',
             broadcastFiberId: entry.fiberId,

--- a/packages/@overeng/utils/src/browser/web-lock.ts
+++ b/packages/@overeng/utils/src/browser/web-lock.ts
@@ -7,7 +7,7 @@
  */
 
 import type { Exit } from 'effect'
-import { Deferred, Effect, Runtime, Schema } from 'effect'
+import { Deferred, Effect, Schema } from 'effect'
 
 /**
  * Error thrown when Web Locks API is not supported.
@@ -49,7 +49,7 @@ export const withLock =
         >
       }
 
-      const runtime = yield* Effect.runtime<Ctx>()
+      const context = yield* Effect.context<Ctx>()
 
       const exit = yield* Effect.tryPromise<Exit.Exit<A, E> | undefined, E | E2>({
         try: async (signal) => {
@@ -64,7 +64,7 @@ export const withLock =
             async (lock: Lock | null) => {
               if (lock === null) {
                 if (onTaken !== undefined) {
-                  const onTakenExit = await Runtime.runPromiseExit(runtime)(onTaken)
+                  const onTakenExit = await Effect.runPromiseExitWith(context)(onTaken)
                   if (onTakenExit._tag === 'Failure') {
                     return onTakenExit as unknown as Exit.Exit<A, E>
                   }
@@ -72,7 +72,7 @@ export const withLock =
                 return undefined
               }
 
-              return await Runtime.runPromiseExit(runtime)(eff)
+              return await Effect.runPromiseExitWith(context)(eff)
             },
           )
 
@@ -104,7 +104,7 @@ export const waitForDeferredLock = (opts: {
       return Effect.fail(WebLockNotSupportedError.notAvailable)
     }
 
-    return Effect.async<void>((cb, signal) => {
+    return Effect.callback<void>((cb, signal) => {
       if (signal.aborted === true) return
 
       navigator.locks
@@ -141,7 +141,7 @@ export const tryGetDeferredLock = (opts: {
       return Effect.fail(WebLockNotSupportedError.notAvailable)
     }
 
-    return Effect.async<boolean>((cb, signal) => {
+    return Effect.callback<boolean>((cb, signal) => {
       navigator.locks.request(
         lockName,
         { mode: 'exclusive', ifAvailable: true },
@@ -171,7 +171,7 @@ export const stealDeferredLock = (opts: {
       return Effect.fail(WebLockNotSupportedError.notAvailable)
     }
 
-    return Effect.async<boolean>((cb, signal) => {
+    return Effect.callback<boolean>((cb, signal) => {
       navigator.locks.request(lockName, { mode: 'exclusive', steal: true }, (lock: Lock | null) => {
         cb(Effect.succeed(lock !== null))
 
@@ -198,7 +198,7 @@ export const waitForLock = (lockName: string): Effect.Effect<void, WebLockNotSup
       return Effect.fail(WebLockNotSupportedError.notAvailable)
     }
 
-    return Effect.async<void>((cb, signal) => {
+    return Effect.callback<void>((cb, signal) => {
       if (signal.aborted === true) return
 
       navigator.locks.request(
@@ -226,7 +226,7 @@ export const getLockAndWaitForSteal = (
       return Effect.fail(WebLockNotSupportedError.notAvailable)
     }
 
-    return Effect.async<void>((cb, signal) => {
+    return Effect.callback<void>((cb, signal) => {
       if (signal.aborted === true) return
 
       navigator.locks

--- a/packages/@overeng/utils/src/isomorphic/ScopeDebugger.ts
+++ b/packages/@overeng/utils/src/isomorphic/ScopeDebugger.ts
@@ -28,7 +28,7 @@ export interface FinalizerExecutionInfo extends FinalizerInfo {
  * FiberRef to track whether scope debugging is enabled for the current fiber.
  * When enabled, `addTracedFinalizer` will log registration and execution.
  */
-export const ScopeDebugEnabled = Context.Reference<boolean>()('ScopeDebugEnabled', {
+export const ScopeDebugEnabled = Context.Reference('ScopeDebugEnabled', {
   defaultValue: () => false,
 })
 
@@ -44,7 +44,7 @@ export const ScopeDebugEnabled = Context.Reference<boolean>()('ScopeDebugEnabled
  * ```
  */
 export const withScopeDebug = <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
-  Effect.locally(effect, ScopeDebugEnabled, true)
+  Effect.provideService(effect, ScopeDebugEnabled, true)
 
 /**
  * Adds a finalizer with debug tracing.

--- a/packages/@overeng/utils/src/isomorphic/ScopeDebugger.unit.test.ts
+++ b/packages/@overeng/utils/src/isomorphic/ScopeDebugger.unit.test.ts
@@ -1,4 +1,4 @@
-import { Chunk, Effect, Exit, Layer, Logger, Ref } from 'effect'
+import { Chunk, Effect, Exit, Layer, Logger, Ref, References } from 'effect'
 import { expect } from 'vitest'
 
 import { Vitest } from '@overeng/utils-dev/node-vitest'
@@ -17,7 +17,10 @@ const makeTestLogger = Effect.fnUntraced(function* () {
 
   const getLogs = Ref.get(logs).pipe(Effect.map(Chunk.toArray))
 
-  const loggerLayer = Layer.merge(Logger.layer([logger]), Logger.minimumLogLevel('All'))
+  const loggerLayer = Layer.merge(
+    Logger.layer([logger]),
+    Layer.succeed(References.MinimumLogLevel, 'All'),
+  )
 
   return { logger, getLogs, loggerLayer } as const
 })

--- a/packages/@overeng/utils/src/isomorphic/ScopeDebugger.unit.test.ts
+++ b/packages/@overeng/utils/src/isomorphic/ScopeDebugger.unit.test.ts
@@ -1,4 +1,4 @@
-import { Chunk, Effect, Exit, Layer, Logger, LogLevel, Ref, Runtime } from 'effect'
+import { Chunk, Effect, Exit, Layer, Logger, Ref } from 'effect'
 import { expect } from 'vitest'
 
 import { Vitest } from '@overeng/utils-dev/node-vitest'
@@ -8,16 +8,16 @@ import { addTracedFinalizer, withScopeDebug, withTracedScope } from './ScopeDebu
 /** Test logger that captures log messages at all levels */
 const makeTestLogger = Effect.fnUntraced(function* () {
   const logs = yield* Ref.make<Chunk.Chunk<string>>(Chunk.empty())
-  const runtime = yield* Effect.runtime<never>()
+  const context = yield* Effect.context<never>()
 
   const logger = Logger.make<unknown, void>(({ message }) => {
     const msg = Array.isArray(message) === true ? message.join(' ') : String(message)
-    Runtime.runSync(runtime)(Ref.update(logs, Chunk.append(msg)))
+    Effect.runSyncWith(context)(Ref.update(logs, Chunk.append(msg)))
   })
 
   const getLogs = Ref.get(logs).pipe(Effect.map(Chunk.toArray))
 
-  const loggerLayer = Layer.merge(Logger.layer([logger]), Logger.minimumLogLevel(LogLevel.All))
+  const loggerLayer = Layer.merge(Logger.layer([logger]), Logger.minimumLogLevel('All'))
 
   return { logger, getLogs, loggerLayer } as const
 })

--- a/packages/@overeng/utils/src/isomorphic/lineage/mod.ts
+++ b/packages/@overeng/utils/src/isomorphic/lineage/mod.ts
@@ -161,7 +161,7 @@ const unwrapAst = (ast: SchemaAST.AST): SchemaAST.AST => {
  * than throwing — the inspector must never crash on bad annotations.
  */
 const readAnnotation = <A>(args: {
-  schema: Schema.Codec<unknown, unknown, never, never>
+  schema: Schema.Codec<any, any, never, never>
   id: symbol
   decoder: Schema.Codec<A>
 }): A | undefined => {
@@ -185,24 +185,24 @@ const readAnnotation = <A>(args: {
 
 /** Read the `Lineage` annotation from a schema, if present. */
 export const getLineage = (
-  schema: Schema.Codec<unknown, unknown, never, never>,
+  schema: Schema.Codec<any, any, never, never>,
 ): Lineage | undefined => readAnnotation({ schema, id: LineageAnnotationId, decoder: Lineage })
 
 /** Read the `Authority` annotation from a schema, if present. */
 export const getAuthority = (
-  schema: Schema.Codec<unknown, unknown, never, never>,
+  schema: Schema.Codec<any, any, never, never>,
 ): Authority | undefined =>
   readAnnotation({ schema, id: AuthorityAnnotationId, decoder: Authority })
 
 /** Read the `Freshness` annotation from a schema, if present. */
 export const getFreshness = (
-  schema: Schema.Codec<unknown, unknown, never, never>,
+  schema: Schema.Codec<any, any, never, never>,
 ): Freshness | undefined =>
   readAnnotation({ schema, id: FreshnessAnnotationId, decoder: Freshness })
 
 /** Read the `Reference` annotation from a schema, if present. */
 export const getReference = (
-  schema: Schema.Codec<unknown, unknown, never, never>,
+  schema: Schema.Codec<any, any, never, never>,
 ): Reference | undefined =>
   readAnnotation({ schema, id: ReferenceAnnotationId, decoder: Reference })
 
@@ -241,12 +241,12 @@ const coerceDerivationKind = (
 
 const annotate =
   <V>(args: { id: symbol; value: V }) =>
-  <S extends Schema.Codec<unknown, unknown, never, never>>(schema: S): S =>
+  <S extends Schema.Codec<any, any, never, never>>(schema: S): S =>
     schema.annotate({ [args.id]: args.value }) as S
 
 const lineageAnnotation =
   (value: Lineage) =>
-  <S extends Schema.Codec<unknown, unknown, never, never>>(schema: S): S =>
+  <S extends Schema.Codec<any, any, never, never>>(schema: S): S =>
     annotate({ id: LineageAnnotationId, value })(schema)
 
 /** Mark a field as the authoritative source of truth. */

--- a/packages/@overeng/utils/src/isomorphic/lineage/mod.ts
+++ b/packages/@overeng/utils/src/isomorphic/lineage/mod.ts
@@ -125,19 +125,14 @@ export const ReferenceAnnotationId = Symbol.for('effect/annotation/Reference')
  * outer or inner layer are discoverable.
  */
 const isNullishAst = (ast: SchemaAST.AST): boolean => {
-  if (ast._tag === 'UndefinedKeyword' || ast._tag === 'VoidKeyword') return true
-  return ast._tag === 'Literal' && ast.literal === null
+  return ast._tag === 'Null' || ast._tag === 'Undefined' || ast._tag === 'Void'
 }
 
 const unwrapAst = (ast: SchemaAST.AST): SchemaAST.AST => {
   switch (ast._tag) {
-    case 'Transformation':
-      return unwrapAst(ast.to)
-    case 'Refinement':
-      return unwrapAst(ast.from)
     case 'Suspend':
       try {
-        return unwrapAst(ast.f())
+        return unwrapAst(ast.thunk())
       } catch {
         return ast
       }
@@ -167,14 +162,17 @@ const readAnnotation = <A>(args: {
 }): A | undefined => {
   const { schema, id, decoder } = args
   const decode = Schema.decodeUnknownOption(decoder)
-  const raw = schema.ast.annotations[id]
+  // `SchemaAST.resolve` gives check annotations precedence in v4. For a
+  // checked primitive that would hide annotations already attached to the
+  // schema itself, so inspect the node's own annotations first.
+  const raw = (schema.ast.annotations as unknown as Record<symbol, unknown> | undefined)?.[id]
   if (raw !== undefined) {
     const decoded = decode(raw)
     if (Option.isSome(decoded) === true) return decoded.value
   }
   const unwrapped = unwrapAst(schema.ast)
   if (unwrapped !== schema.ast) {
-    const innerRaw = unwrapped.annotations[id]
+    const innerRaw = (unwrapped.annotations as unknown as Record<symbol, unknown> | undefined)?.[id]
     if (innerRaw !== undefined) {
       const decoded = decode(innerRaw)
       if (Option.isSome(decoded) === true) return decoded.value
@@ -184,26 +182,19 @@ const readAnnotation = <A>(args: {
 }
 
 /** Read the `Lineage` annotation from a schema, if present. */
-export const getLineage = (
-  schema: Schema.Codec<any, any, never, never>,
-): Lineage | undefined => readAnnotation({ schema, id: LineageAnnotationId, decoder: Lineage })
+export const getLineage = (schema: Schema.Codec<any, any, never, never>): Lineage | undefined =>
+  readAnnotation({ schema, id: LineageAnnotationId, decoder: Lineage })
 
 /** Read the `Authority` annotation from a schema, if present. */
-export const getAuthority = (
-  schema: Schema.Codec<any, any, never, never>,
-): Authority | undefined =>
+export const getAuthority = (schema: Schema.Codec<any, any, never, never>): Authority | undefined =>
   readAnnotation({ schema, id: AuthorityAnnotationId, decoder: Authority })
 
 /** Read the `Freshness` annotation from a schema, if present. */
-export const getFreshness = (
-  schema: Schema.Codec<any, any, never, never>,
-): Freshness | undefined =>
+export const getFreshness = (schema: Schema.Codec<any, any, never, never>): Freshness | undefined =>
   readAnnotation({ schema, id: FreshnessAnnotationId, decoder: Freshness })
 
 /** Read the `Reference` annotation from a schema, if present. */
-export const getReference = (
-  schema: Schema.Codec<any, any, never, never>,
-): Reference | undefined =>
+export const getReference = (schema: Schema.Codec<any, any, never, never>): Reference | undefined =>
   readAnnotation({ schema, id: ReferenceAnnotationId, decoder: Reference })
 
 /* --------------------------------------------------------------------------

--- a/packages/@overeng/utils/src/isomorphic/lineage/mod.ts
+++ b/packages/@overeng/utils/src/isomorphic/lineage/mod.ts
@@ -161,9 +161,9 @@ const unwrapAst = (ast: SchemaAST.AST): SchemaAST.AST => {
  * than throwing — the inspector must never crash on bad annotations.
  */
 const readAnnotation = <A>(args: {
-  schema: Schema.Schema.AnyNoContext
+  schema: Schema.Codec<unknown, unknown, never, never>
   id: symbol
-  decoder: Schema.Schema<A>
+  decoder: Schema.Codec<A>
 }): A | undefined => {
   const { schema, id, decoder } = args
   const decode = Schema.decodeUnknownOption(decoder)
@@ -184,19 +184,26 @@ const readAnnotation = <A>(args: {
 }
 
 /** Read the `Lineage` annotation from a schema, if present. */
-export const getLineage = (schema: Schema.Schema.AnyNoContext): Lineage | undefined =>
-  readAnnotation({ schema, id: LineageAnnotationId, decoder: Lineage })
+export const getLineage = (
+  schema: Schema.Codec<unknown, unknown, never, never>,
+): Lineage | undefined => readAnnotation({ schema, id: LineageAnnotationId, decoder: Lineage })
 
 /** Read the `Authority` annotation from a schema, if present. */
-export const getAuthority = (schema: Schema.Schema.AnyNoContext): Authority | undefined =>
+export const getAuthority = (
+  schema: Schema.Codec<unknown, unknown, never, never>,
+): Authority | undefined =>
   readAnnotation({ schema, id: AuthorityAnnotationId, decoder: Authority })
 
 /** Read the `Freshness` annotation from a schema, if present. */
-export const getFreshness = (schema: Schema.Schema.AnyNoContext): Freshness | undefined =>
+export const getFreshness = (
+  schema: Schema.Codec<unknown, unknown, never, never>,
+): Freshness | undefined =>
   readAnnotation({ schema, id: FreshnessAnnotationId, decoder: Freshness })
 
 /** Read the `Reference` annotation from a schema, if present. */
-export const getReference = (schema: Schema.Schema.AnyNoContext): Reference | undefined =>
+export const getReference = (
+  schema: Schema.Codec<unknown, unknown, never, never>,
+): Reference | undefined =>
   readAnnotation({ schema, id: ReferenceAnnotationId, decoder: Reference })
 
 /* --------------------------------------------------------------------------
@@ -234,12 +241,12 @@ const coerceDerivationKind = (
 
 const annotate =
   <V>(args: { id: symbol; value: V }) =>
-  <S extends Schema.Schema.AnyNoContext>(schema: S): S =>
+  <S extends Schema.Codec<unknown, unknown, never, never>>(schema: S): S =>
     schema.annotate({ [args.id]: args.value }) as S
 
 const lineageAnnotation =
   (value: Lineage) =>
-  <S extends Schema.Schema.AnyNoContext>(schema: S): S =>
+  <S extends Schema.Codec<unknown, unknown, never, never>>(schema: S): S =>
     annotate({ id: LineageAnnotationId, value })(schema)
 
 /** Mark a field as the authoritative source of truth. */

--- a/packages/@overeng/utils/src/isomorphic/lineage/mod.unit.test.ts
+++ b/packages/@overeng/utils/src/isomorphic/lineage/mod.unit.test.ts
@@ -100,7 +100,7 @@ describe('Lineage annotations: round-trip', () => {
   it('reads annotations through Refinement wrappers', () => {
     const inner = Schema.Number.pipe(sourceOfTruth())
     /* Refinement wrapper around an inner-annotated schema. */
-    const wrapped = inner.pipe(Schema.positive())
+    const wrapped = inner.pipe(Schema.check(Schema.isGreaterThan(0)))
     expect(getLineage(wrapped)).toEqual({ _tag: 'SourceOfTruth' })
   })
 })

--- a/packages/@overeng/utils/src/isomorphic/timestamp.ts
+++ b/packages/@overeng/utils/src/isomorphic/timestamp.ts
@@ -1,4 +1,4 @@
-import { Brand, Schema } from 'effect'
+import { Brand, Schema, SchemaTransformation } from 'effect'
 
 /** Unix timestamp integer in milliseconds since epoch */
 export type Timestamp = Brand.Branded<number, 'Timestamp'>
@@ -18,7 +18,15 @@ export const timestamp = (value: number | string | Date): Timestamp => {
 export const timestampSchema = Schema.fromBrand(
   'Timestamp',
   Brand.nominal<Timestamp>(),
-)(Schema.Number).pipe(Schema.decodeTo(Schema.Number, { decode: (_) => _, encode: timestamp }))
+)(Schema.Number).pipe(
+  Schema.decodeTo(
+    Schema.Number,
+    SchemaTransformation.transform<number, Timestamp>({
+      decode: (value) => value,
+      encode: timestamp,
+    }),
+  ),
+)
 
 /** Returns the current time as a Timestamp */
 export const timestampNow = (): Timestamp => Math.round(Date.now()) as Timestamp

--- a/packages/@overeng/utils/src/node/ActiveHandlesDebugger.ts
+++ b/packages/@overeng/utils/src/node/ActiveHandlesDebugger.ts
@@ -4,7 +4,7 @@
  * Node.js processes stay alive while there are active handles (timers, sockets, etc.)
  * or pending requests. This module provides Effect-native APIs to inspect these.
  */
-import { type Duration, Effect, Runtime, Schedule, Schema, Stream } from 'effect'
+import { type Duration, Effect, Schedule, Schema, Stream } from 'effect'
 
 import {
   OtelAttr,
@@ -41,7 +41,7 @@ const trustOtelContract = <A, E, R>(
   effect.pipe(Effect.catchTag('OtelAttrEncodeError', (error) => Effect.die(error)))
 
 const trustedWith =
-  <S extends Schema.Schema.AnyNoContext>({
+  <S extends Schema.Codec<unknown, unknown, never, never>>({
     operation,
     attributes,
   }: {
@@ -152,7 +152,7 @@ export const logActiveHandles = Effect.gen(function* () {
  * ```
  */
 export const monitorActiveHandles = Effect.fn('ActiveHandlesDebugger.monitorActiveHandles')(
-  function* (interval: Duration.DurationInput) {
+  function* (interval: Duration.Input) {
     let lastTotal = -1
 
     const _ = yield* Stream.fromSchedule(Schedule.spaced(interval)).pipe(
@@ -189,11 +189,11 @@ export const monitorActiveHandles = Effect.fn('ActiveHandlesDebugger.monitorActi
 export const withActiveHandlesDumpOnSigint = Effect.fn(
   'ActiveHandlesDebugger.withActiveHandlesDumpOnSigint',
 )(function* <A, E, R>(effect: Effect.Effect<A, E, R>) {
-  const runtime = yield* Effect.runtime<R>()
+  const context = yield* Effect.context<R>()
 
   const handler = () => {
     try {
-      Runtime.runSync(runtime)(logActiveHandles.pipe(Effect.ignore))
+      Effect.runSyncWith(context)(logActiveHandles.pipe(Effect.ignore))
     } finally {
       process.off('SIGINT', handler)
       process.kill(process.pid, 'SIGINT')

--- a/packages/@overeng/utils/src/node/ActiveHandlesDebugger.ts
+++ b/packages/@overeng/utils/src/node/ActiveHandlesDebugger.ts
@@ -41,7 +41,7 @@ const trustOtelContract = <A, E, R>(
   effect.pipe(Effect.catchTag('OtelAttrEncodeError', (error) => Effect.die(error)))
 
 const trustedWith =
-  <S extends Schema.Codec<any, any, never, never>>({
+  <S extends Schema.Codec<any, any, any, any>>({
     operation,
     attributes,
   }: {

--- a/packages/@overeng/utils/src/node/ActiveHandlesDebugger.ts
+++ b/packages/@overeng/utils/src/node/ActiveHandlesDebugger.ts
@@ -41,7 +41,7 @@ const trustOtelContract = <A, E, R>(
   effect.pipe(Effect.catchTag('OtelAttrEncodeError', (error) => Effect.die(error)))
 
 const trustedWith =
-  <S extends Schema.Codec<unknown, unknown, never, never>>({
+  <S extends Schema.Codec<any, any, never, never>>({
     operation,
     attributes,
   }: {

--- a/packages/@overeng/utils/src/node/ActiveHandlesDebugger.unit.test.ts
+++ b/packages/@overeng/utils/src/node/ActiveHandlesDebugger.unit.test.ts
@@ -1,4 +1,4 @@
-import { Chunk, Duration, Effect, Layer, Logger, LogLevel, Ref, Runtime } from 'effect'
+import { Chunk, Duration, Effect, Layer, Logger, Ref } from 'effect'
 import { expect } from 'vitest'
 
 import { Vitest } from '@overeng/utils-dev/node-vitest'
@@ -13,16 +13,16 @@ import {
 /** Test logger that captures log messages at all levels */
 const makeTestLogger = Effect.fnUntraced(function* () {
   const logs = yield* Ref.make<Chunk.Chunk<string>>(Chunk.empty())
-  const runtime = yield* Effect.runtime<never>()
+  const context = yield* Effect.context<never>()
 
   const logger = Logger.make<unknown, void>(({ message }) => {
     const msg = Array.isArray(message) === true ? message.join(' ') : String(message)
-    Runtime.runSync(runtime)(Ref.update(logs, Chunk.append(msg)))
+    Effect.runSyncWith(context)(Ref.update(logs, Chunk.append(msg)))
   })
 
   const getLogs = Ref.get(logs).pipe(Effect.map(Chunk.toArray))
 
-  const loggerLayer = Layer.merge(Logger.layer([logger]), Logger.minimumLogLevel(LogLevel.All))
+  const loggerLayer = Layer.merge(Logger.layer([logger]), Logger.minimumLogLevel('All'))
 
   return { getLogs, loggerLayer } as const
 })

--- a/packages/@overeng/utils/src/node/ActiveHandlesDebugger.unit.test.ts
+++ b/packages/@overeng/utils/src/node/ActiveHandlesDebugger.unit.test.ts
@@ -1,4 +1,4 @@
-import { Chunk, Duration, Effect, Layer, Logger, Ref } from 'effect'
+import { Chunk, Duration, Effect, Layer, Logger, Ref, References } from 'effect'
 import { expect } from 'vitest'
 
 import { Vitest } from '@overeng/utils-dev/node-vitest'
@@ -22,7 +22,10 @@ const makeTestLogger = Effect.fnUntraced(function* () {
 
   const getLogs = Ref.get(logs).pipe(Effect.map(Chunk.toArray))
 
-  const loggerLayer = Layer.merge(Logger.layer([logger]), Logger.minimumLogLevel('All'))
+  const loggerLayer = Layer.merge(
+    Logger.layer([logger]),
+    Layer.succeed(References.MinimumLogLevel, 'All'),
+  )
 
   return { getLogs, loggerLayer } as const
 })

--- a/packages/@overeng/utils/src/node/FileLogger.ts
+++ b/packages/@overeng/utils/src/node/FileLogger.ts
@@ -46,7 +46,7 @@ export interface MakeFileLoggerOptions {
 
 /** Creates a Layer that replaces the default logger with a pretty-printed file logger */
 export const makeFileLogger = ({ logFilePath, threadName, colors }: MakeFileLoggerOptions) =>
-  Layer.unwrapScoped(
+  Layer.unwrap(
     Effect.gen(function* () {
       yield* Effect.sync(() => fs.mkdirSync(path.dirname(logFilePath), { recursive: true }))
 

--- a/packages/@overeng/utils/src/node/FileLogger.ts
+++ b/packages/@overeng/utils/src/node/FileLogger.ts
@@ -2,7 +2,16 @@ import * as fs from 'node:fs'
 import path from 'node:path'
 import util from 'node:util'
 
-import { Cause, Effect, HashMap, Inspectable, Layer, Logger, type LogLevel } from 'effect'
+import {
+  Cause,
+  Effect,
+  HashMap,
+  Inspectable,
+  Layer,
+  Logger,
+  type LogLevel,
+  Redactable,
+} from 'effect'
 import * as EffectArray from 'effect/Array'
 
 const formatFiberId = (fiberId: unknown): string =>
@@ -115,7 +124,7 @@ export const structuredMessage = (input: unknown): unknown => {
       return String(input)
     }
     default: {
-      return Inspectable.toJSON(input)
+      return Inspectable.toJson(input)
     }
   }
 }
@@ -214,7 +223,7 @@ export const prettyLoggerTty = (options: {
               }),
             )
           } else {
-            logIndented(Inspectable.redact(msg))
+            logIndented(Redactable.redact(msg))
           }
         }
       }
@@ -229,7 +238,7 @@ export const prettyLoggerTty = (options: {
                   compact: false,
                   breakLength: 120,
                 })
-              : Inspectable.redact(value)
+              : Redactable.redact(value)
           logIndented(color(`${key}:`, colors.bold, colors.white), formattedValue)
         }
       }

--- a/packages/@overeng/utils/src/node/FileLogger.ts
+++ b/packages/@overeng/utils/src/node/FileLogger.ts
@@ -5,11 +5,11 @@ import util from 'node:util'
 import {
   Cause,
   Effect,
-  HashMap,
   Inspectable,
   Layer,
   Logger,
   type LogLevel,
+  References,
   Redactable,
 } from 'effect'
 import * as EffectArray from 'effect/Array'
@@ -97,15 +97,15 @@ const colors = {
   bgBrightRed: '101',
 } as const
 
-const logLevelColors: Record<LogLevel.LogLevel['_tag'], readonly string[]> = {
-  None: [],
+const logLevelColors: Record<LogLevel.LogLevel, readonly string[]> = {
   All: [],
-  Trace: [colors.gray],
-  Debug: [colors.blue],
-  Info: [colors.green],
-  Warning: [colors.yellow],
-  Error: [colors.red],
   Fatal: [colors.bgBrightRed, colors.black],
+  Error: [colors.red],
+  Warn: [colors.yellow],
+  Info: [colors.green],
+  Debug: [colors.blue],
+  Trace: [colors.gray],
+  None: [],
 }
 
 /** Formats date as HH:MM:SS.mmm (24-hour local time with milliseconds) */
@@ -166,84 +166,84 @@ export const prettyLoggerTty = (options: {
   readonly onLog?: (str: string) => void
 }) => {
   const color = options.colors === true ? withColor : withColorNoop
-  return Logger.make<unknown, string>(
-    ({ annotations, cause, date, fiberId, logLevel, message: message_, spans }) => {
-      let str = ''
+  return Logger.make<unknown, string>(({ cause, date, fiber, logLevel, message: message_ }) => {
+    const annotations = fiber.getRef(References.CurrentLogAnnotations)
+    const spans = fiber.getRef(References.CurrentLogSpans)
+    let str = ''
 
-      const log = (...inputs: any[]) => {
-        str += `${consoleLogToString(...inputs)}\n`
-        options.onLog?.(str)
+    const log = (...inputs: any[]) => {
+      str += `${consoleLogToString(...inputs)}\n`
+      options.onLog?.(str)
+    }
+
+    const logIndented = (...inputs: any[]) => {
+      str += `${consoleLogToString(...inputs).replace(/^/gm, '  ')}\n`
+      options.onLog?.(str)
+    }
+
+    const message = EffectArray.ensure(message_)
+
+    let firstLine =
+      color(`[${options.formatDate(date)}]`, colors.white) +
+      ` ${color(logLevel.toUpperCase(), ...logLevelColors[logLevel])}` +
+      ` (${formatFiberId(fiber.id)})`
+
+    if (spans.length > 0) {
+      const now = date.getTime()
+      for (const [label, timestamp] of spans) {
+        firstLine += ` ${label} (${now - timestamp}ms)`
       }
+    }
 
-      const logIndented = (...inputs: any[]) => {
-        str += `${consoleLogToString(...inputs).replace(/^/gm, '  ')}\n`
-        options.onLog?.(str)
+    firstLine += ':'
+    let messageIndex = 0
+    if (message.length > 0) {
+      const firstMaybeString = structuredMessage(message[0])
+      if (typeof firstMaybeString === 'string') {
+        firstLine += ` ${color(firstMaybeString, colors.bold, colors.cyan)}`
+        messageIndex++
       }
+    }
 
-      const message = EffectArray.ensure(message_)
+    log(firstLine)
 
-      let firstLine =
-        color(`[${options.formatDate(date)}]`, colors.white) +
-        ` ${color(logLevel.label, ...logLevelColors[logLevel._tag])}` +
-        ` (${formatFiberId(fiberId)})`
+    if (cause.reasons.length > 0) {
+      logIndented(Cause.pretty(cause))
+    }
 
-      if (spans.length > 0) {
-        const now = date.getTime()
-        for (const [label, timestamp] of spans) {
-          firstLine += ` ${label} (${now - timestamp}ms)`
+    if (messageIndex < message.length) {
+      for (; messageIndex < message.length; messageIndex++) {
+        const msg = message[messageIndex]
+        if (typeof msg === 'object' && msg !== null) {
+          logIndented(
+            util.inspect(structuredMessage(msg), {
+              depth: 3,
+              colors: false,
+              compact: false,
+              breakLength: 120,
+            }),
+          )
+        } else {
+          logIndented(Redactable.redact(msg))
         }
       }
+    }
 
-      firstLine += ':'
-      let messageIndex = 0
-      if (message.length > 0) {
-        const firstMaybeString = structuredMessage(message[0])
-        if (typeof firstMaybeString === 'string') {
-          firstLine += ` ${color(firstMaybeString, colors.bold, colors.cyan)}`
-          messageIndex++
-        }
-      }
-
-      log(firstLine)
-
-      if (Cause.isEmpty(cause) === false) {
-        logIndented(Cause.pretty(cause, { renderErrorCause: true }))
-      }
-
-      if (messageIndex < message.length) {
-        for (; messageIndex < message.length; messageIndex++) {
-          const msg = message[messageIndex]
-          if (typeof msg === 'object' && msg !== null) {
-            logIndented(
-              util.inspect(structuredMessage(msg), {
+    if (Object.keys(annotations).length > 0) {
+      for (const [key, value] of Object.entries(annotations)) {
+        const formattedValue =
+          typeof value === 'object' && value !== null
+            ? util.inspect(structuredMessage(value), {
                 depth: 3,
                 colors: false,
                 compact: false,
                 breakLength: 120,
-              }),
-            )
-          } else {
-            logIndented(Redactable.redact(msg))
-          }
-        }
+              })
+            : Redactable.redact(value)
+        logIndented(color(`${key}:`, colors.bold, colors.white), formattedValue)
       }
+    }
 
-      if (HashMap.size(annotations) > 0) {
-        for (const [key, value] of annotations) {
-          const formattedValue =
-            typeof value === 'object' && value !== null
-              ? util.inspect(structuredMessage(value), {
-                  depth: 3,
-                  colors: false,
-                  compact: false,
-                  breakLength: 120,
-                })
-              : Redactable.redact(value)
-          logIndented(color(`${key}:`, colors.bold, colors.white), formattedValue)
-        }
-      }
-
-      return str
-    },
-  )
+    return str
+  })
 }

--- a/packages/@overeng/utils/src/node/cmd.ts
+++ b/packages/@overeng/utils/src/node/cmd.ts
@@ -46,7 +46,7 @@ const trustOtelContract = <A, E, R>(
   effect.pipe(Effect.catchTag('OtelAttrEncodeError', (error) => Effect.die(error)))
 
 const trustedWith =
-  <S extends Schema.Schema.AnyNoContext>({
+  <S extends Schema.Codec<unknown, unknown, never, never>>({
     operation,
     attributes,
   }: {
@@ -93,7 +93,7 @@ export const cmd: (
         /** Optional number of archived logs to retain; defaults to 50 */
         logRetention?: number
         /** Grace period before escalating from SIGTERM to SIGKILL on cleanup. Defaults to 5 seconds. */
-        killTimeout?: Duration.DurationInput
+        killTimeout?: Duration.Input
       }
     | undefined,
 ) => Effect.Effect<
@@ -443,7 +443,7 @@ type TRunBaseArgs = {
   readonly stdoutMode: 'inherit' | 'pipe'
   readonly stderrMode: 'inherit' | 'pipe'
   readonly useShell: boolean
-  readonly killTimeout: Duration.DurationInput | undefined
+  readonly killTimeout: Duration.Input | undefined
 }
 
 const runWithoutLogging = ({
@@ -505,7 +505,7 @@ const runWithLogging = ({
         Effect.sync(() => {
           const formatted = prettyLogger.log({
             fiberId: undefined,
-            logLevel: channel === 'stdout' ? LogLevel.Info : LogLevel.Warning,
+            logLevel: channel === 'stdout' ? 'Info' : 'Warn',
             message: [`[${channel}]${content.length > 0 ? ` ${content}` : ''}`],
             cause: Cause.empty,
             spans: [],
@@ -594,7 +594,7 @@ const runWithLogging = ({
   )
 
 /** Default grace period before escalating from SIGTERM to SIGKILL */
-const DEFAULT_KILL_TIMEOUT: Duration.DurationInput = '5 seconds'
+const DEFAULT_KILL_TIMEOUT: Duration.Input = '5 seconds'
 
 /**
  * Send a signal to a process group (or individual process as fallback).
@@ -638,7 +638,7 @@ const sendSignalToProcessGroup = (opts: {
  */
 const killProcessGroup = Effect.fn('cmd/killProcessGroup')(function* (opts: {
   proc: Process
-  timeout?: Duration.DurationInput
+  timeout?: Duration.Input
 }) {
   const { proc } = opts
   const timeout = opts.timeout ?? DEFAULT_KILL_TIMEOUT

--- a/packages/@overeng/utils/src/node/cmd.ts
+++ b/packages/@overeng/utils/src/node/cmd.ts
@@ -1,17 +1,7 @@
 import fs from 'node:fs'
 
 import type { Scope } from 'effect'
-import {
-  Cause,
-  type Duration,
-  Effect,
-  Fiber,
-  HashMap,
-  LogLevel,
-  Option,
-  Schema,
-  Stream,
-} from 'effect'
+import { Cause, type Duration, Effect, Fiber, Option, Schema, Stream } from 'effect'
 import type { PlatformError } from 'effect/PlatformError'
 import { ChildProcess, ChildProcessSpawner } from 'effect/unstable/process'
 
@@ -42,7 +32,7 @@ const trustOtelContract = <A, E, R>(
   effect.pipe(Effect.catchTag('OtelAttrEncodeError', (error) => Effect.die(error)))
 
 const trustedWith =
-  <S extends Schema.Codec<any, any, never, never>>({
+  <S extends Schema.Codec<any, any, any, any>>({
     operation,
     attributes,
   }: {
@@ -308,6 +298,7 @@ export const cmdText: (
   const child = ChildProcess.make(command, args, {
     cwd,
     env: options?.env ?? {},
+    extendEnv: true,
     shell: options?.runInShell === true,
     stderr: options?.stderr ?? 'inherit',
   })
@@ -509,18 +500,18 @@ const runWithLogging = ({
       })
 
       const appendLog = ({ channel, content }: { channel: 'stdout' | 'stderr'; content: string }) =>
-        Effect.sync(() => {
-          const formatted = prettyLogger.log({
-            fiberId: undefined,
-            logLevel: channel === 'stdout' ? 'Info' : 'Warn',
-            message: [`[${channel}]${content.length > 0 ? ` ${content}` : ''}`],
-            cause: Cause.empty,
-            spans: [],
-            annotations: HashMap.empty(),
-            date: new Date(),
-          })
-          fs.writeSync(logFile, formatted)
-        })
+        Effect.withFiber((fiber) =>
+          Effect.sync(() => {
+            const formatted = prettyLogger.log({
+              fiber,
+              logLevel: channel === 'stdout' ? 'Info' : 'Warn',
+              message: [`[${channel}]${content.length > 0 ? ` ${content}` : ''}`],
+              cause: Cause.empty,
+              date: new Date(),
+            })
+            fs.writeSync(logFile, formatted)
+          }),
+        )
 
       const command = buildCommand({
         input: commandInput,
@@ -677,16 +668,16 @@ const buildCommand = (opts: {
   if (Array.isArray(input) === true) {
     const [command, ...args] = input
     if (command === undefined) throw new Error('Command cannot be empty')
-    return ChildProcess.make(command, args, { ...options, shell: useShell })
+    return ChildProcess.make(command, args, { extendEnv: true, ...options, shell: useShell })
   }
 
   if (useShell === true) {
-    return ChildProcess.make(input, [], { ...options, shell: true })
+    return ChildProcess.make(input, [], { extendEnv: true, ...options, shell: true })
   }
 
   const [command, ...args] = input.split(' ')
   if (command === undefined) throw new Error('Command cannot be empty')
-  return ChildProcess.make(command, args, { ...options, shell: false })
+  return ChildProcess.make(command, args, { extendEnv: true, ...options, shell: false })
 }
 
 type TLineTerminator = 'newline' | 'carriage-return' | 'none'

--- a/packages/@overeng/utils/src/node/cmd.ts
+++ b/packages/@overeng/utils/src/node/cmd.ts
@@ -3,21 +3,17 @@ import fs from 'node:fs'
 import type { Scope } from 'effect'
 import {
   Cause,
-  Chunk,
   type Duration,
   Effect,
   Fiber,
   HashMap,
-  identity,
   LogLevel,
   Option,
   Schema,
   Stream,
 } from 'effect'
-import type { PlatformError } from 'effect/Error'
-import { ChildProcess as Command } from 'effect/unstable/process'
-import type * as CommandExecutor from 'effect/unstable/process/CommandExecutor'
-import type { Process } from 'effect/unstable/process/CommandExecutor'
+import type { PlatformError } from 'effect/PlatformError'
+import { ChildProcess, ChildProcessSpawner } from 'effect/unstable/process'
 
 import { type OtelAttrEncodeError, type OtelOperationDefinition } from '@overeng/otel-contract'
 
@@ -32,7 +28,7 @@ import * as FileLogger from './FileLogger.ts'
 import { CurrentWorkingDirectory } from './workspace.ts'
 
 // Branded zero value so we can compare exit codes without touching internals.
-const SUCCESS_EXIT_CODE: CommandExecutor.ExitCode = 0 as CommandExecutor.ExitCode
+const SUCCESS_EXIT_CODE = ChildProcessSpawner.ExitCode(0)
 
 // Runtime spans DERIVED from the registered seam contract (`./cmd.contract.ts`, namespace `cmd`),
 // the single SSOT for the Weaver registry projection AND these runtime encoders (SC-R13/R14).
@@ -46,7 +42,7 @@ const trustOtelContract = <A, E, R>(
   effect.pipe(Effect.catchTag('OtelAttrEncodeError', (error) => Effect.die(error)))
 
 const trustedWith =
-  <S extends Schema.Codec<unknown, unknown, never, never>>({
+  <S extends Schema.Codec<any, any, never, never>>({
     operation,
     attributes,
   }: {
@@ -97,9 +93,9 @@ export const cmd: (
       }
     | undefined,
 ) => Effect.Effect<
-  CommandExecutor.ExitCode,
+  ChildProcessSpawner.ExitCode,
   PlatformError | CmdError,
-  CommandExecutor.CommandExecutor | CurrentWorkingDirectory
+  ChildProcessSpawner.ChildProcessSpawner | CurrentWorkingDirectory
 > = Effect.fn('cmd')(function* (commandInput, options) {
   const cwd = yield* CurrentWorkingDirectory
 
@@ -209,9 +205,9 @@ export const cmdStart: (
       }
     | undefined,
 ) => Effect.Effect<
-  CommandExecutor.Process,
+  ChildProcessSpawner.ChildProcessHandle,
   PlatformError,
-  CommandExecutor.CommandExecutor | CurrentWorkingDirectory | Scope.Scope
+  ChildProcessSpawner.ChildProcessSpawner | CurrentWorkingDirectory | Scope.Scope
 > = Effect.fn('cmdStart')(function* (commandInput, options) {
   const cwd = yield* CurrentWorkingDirectory
 
@@ -249,15 +245,17 @@ export const cmdStart: (
     shell: useShell,
   })
 
-  return yield* buildCommand({ input: normalizedInput, useShell }).pipe(
-    Command.stdin('inherit'),
-    Command.stdout(options?.stdout ?? 'inherit'),
-    Command.stderr(options?.stderr ?? 'inherit'),
-    Command.workingDirectory(cwd),
-    useShell === true ? Command.runInShell(true) : identity,
-    Command.env(options?.env ?? {}),
-    Command.start,
-  )
+  return yield* buildCommand({
+    input: normalizedInput,
+    useShell,
+    options: {
+      stdin: 'inherit',
+      stdout: options?.stdout ?? 'inherit',
+      stderr: options?.stderr ?? 'inherit',
+      cwd,
+      env: options?.env ?? {},
+    },
+  })
 })
 
 /**
@@ -279,7 +277,7 @@ export const cmdText: (
 ) => Effect.Effect<
   string,
   PlatformError,
-  CommandExecutor.CommandExecutor | CurrentWorkingDirectory
+  ChildProcessSpawner.ChildProcessSpawner | CurrentWorkingDirectory
 > = Effect.fn('cmdText')(function* (commandInput, options) {
   const cwd = yield* CurrentWorkingDirectory
   const [command, ...args] =
@@ -306,14 +304,15 @@ export const cmdText: (
     shell: options?.runInShell === true,
   })
 
-  return yield* Command.make(command, ...args).pipe(
-    // inherit = Stream stderr to process.stderr, pipe = Stream stderr to process.stdout
-    Command.stderr(options?.stderr ?? 'inherit'),
-    Command.workingDirectory(cwd),
-    options?.runInShell === true ? Command.runInShell(true) : identity,
-    Command.env(options?.env ?? {}),
-    Command.string,
-  )
+  const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
+  const child = ChildProcess.make(command, args, {
+    cwd,
+    env: options?.env ?? {},
+    shell: options?.runInShell === true,
+    stderr: options?.stderr ?? 'inherit',
+  })
+  // inherit = Stream stderr to process.stderr, pipe = include stderr in the collected string
+  return yield* spawner.string(child, { includeStderr: options?.stderr === 'pipe' })
 })
 
 /** Result of collecting stdout/stderr from a command. */
@@ -343,7 +342,7 @@ export const cmdCollect = <R = never>(opts: {
 }): Effect.Effect<
   CmdCollectResult,
   PlatformError,
-  CommandExecutor.CommandExecutor | CurrentWorkingDirectory | R
+  ChildProcessSpawner.ChildProcessSpawner | CurrentWorkingDirectory | R
 > =>
   Effect.gen(function* () {
     const cwd = opts.workingDirectory ?? (yield* CurrentWorkingDirectory)
@@ -364,38 +363,39 @@ export const cmdCollect = <R = never>(opts: {
 
     yield* Effect.logDebug(`Collecting '${debugStr}' in '${cwd}'`)
 
-    const builtCmd = buildCommand({ input: normalizedInput, useShell }).pipe(
-      Command.stdout('pipe'),
-      Command.stderr('pipe'),
-      Command.workingDirectory(cwd),
-      useShell === true ? Command.runInShell(true) : identity,
-      Command.env(opts.env ?? {}),
-    )
+    const builtCmd = buildCommand({
+      input: normalizedInput,
+      useShell,
+      options: {
+        stdout: 'pipe',
+        stderr: 'pipe',
+        cwd,
+        env: opts.env ?? {},
+      },
+    })
 
     const { onOutput } = opts
 
     return yield* Effect.scoped(
-      Command.start(builtCmd).pipe(
+      builtCmd.pipe(
         Effect.flatMap((proc) =>
           Effect.all(
             {
               stdout: proc.stdout.pipe(
-                Stream.decodeText('utf8'),
+                Stream.decodeText({ encoding: 'utf8' }),
                 Stream.splitLines,
                 Stream.tap((line) =>
                   onOutput !== undefined ? onOutput('stdout', line) : Effect.void,
                 ),
                 Stream.runCollect,
-                Effect.map(Chunk.toReadonlyArray),
               ),
               stderr: proc.stderr.pipe(
-                Stream.decodeText('utf8'),
+                Stream.decodeText({ encoding: 'utf8' }),
                 Stream.splitLines,
                 Stream.tap((line) =>
                   onOutput !== undefined ? onOutput('stderr', line) : Effect.void,
                 ),
                 Stream.runCollect,
-                Effect.map(Chunk.toReadonlyArray),
               ),
               exitCode: proc.exitCode,
             },
@@ -454,15 +454,22 @@ const runWithoutLogging = ({
   stderrMode,
   useShell,
 }: TRunBaseArgs) =>
-  buildCommand({ input: commandInput, useShell }).pipe(
-    Command.stdin('inherit'),
-    Command.stdout(stdoutMode),
-    Command.stderr(stderrMode),
-    Command.workingDirectory(cwd),
-    useShell === true ? Command.runInShell(true) : identity,
-    Command.env(env),
-    Command.exitCode,
-  )
+  Effect.gen(function* () {
+    const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
+    return yield* spawner.exitCode(
+      buildCommand({
+        input: commandInput,
+        useShell,
+        options: {
+          stdin: 'inherit',
+          stdout: stdoutMode,
+          stderr: stderrMode,
+          cwd,
+          env,
+        },
+      }),
+    )
+  })
 
 type TRunWithLoggingArgs = TRunBaseArgs & {
   readonly logPath: string
@@ -515,17 +522,20 @@ const runWithLogging = ({
           fs.writeSync(logFile, formatted)
         })
 
-      const command = buildCommand({ input: commandInput, useShell }).pipe(
-        Command.stdin('inherit'),
-        Command.stdout('pipe'),
-        Command.stderr('pipe'),
-        Command.workingDirectory(cwd),
-        useShell === true ? Command.runInShell(true) : identity,
-        Command.env(envWithColor),
-      )
+      const command = buildCommand({
+        input: commandInput,
+        useShell,
+        options: {
+          stdin: 'inherit',
+          stdout: 'pipe',
+          stderr: 'pipe',
+          cwd,
+          env: envWithColor,
+        },
+      })
 
       // Acquire/start the command and make sure we kill the process group on interruption.
-      const runningProcess = yield* Effect.acquireRelease(command.pipe(Command.start), (proc) =>
+      const runningProcess = yield* Effect.acquireRelease(command, (proc) =>
         proc.isRunning.pipe(
           Effect.flatMap((running) =>
             running === true
@@ -551,13 +561,13 @@ const runWithLogging = ({
       })
 
       const stdoutFiber = yield* runningProcess.stdout.pipe(
-        Stream.decodeText('utf8'),
+        Stream.decodeText({ encoding: 'utf8' }),
         Stream.runForEach((chunk) => stdoutHandler.onChunk(chunk)),
         Effect.forkScoped,
       )
 
       const stderrFiber = yield* runningProcess.stderr.pipe(
-        Stream.decodeText('utf8'),
+        Stream.decodeText({ encoding: 'utf8' }),
         Stream.runForEach((chunk) => stderrHandler.onChunk(chunk)),
         Effect.forkScoped,
       )
@@ -601,7 +611,7 @@ const DEFAULT_KILL_TIMEOUT: Duration.Input = '5 seconds'
  * On Unix, uses negative PID to signal the entire group.
  */
 const sendSignalToProcessGroup = (opts: {
-  proc: Process
+  proc: ChildProcessSpawner.ChildProcessHandle
   signal: NodeJS.Signals
 }): Effect.Effect<void> => {
   const { proc, signal } = opts
@@ -615,7 +625,7 @@ const sendSignalToProcessGroup = (opts: {
         const errno = e as NodeJS.ErrnoException
         return new ProcessSignalError({
           cause: e,
-          code: Option.fromNullable(errno.code),
+          code: Option.fromNullishOr(errno.code),
         })
       },
     }).pipe(
@@ -623,13 +633,13 @@ const sendSignalToProcessGroup = (opts: {
         // ESRCH = no such process (already dead) - that's fine
         if (Option.getOrUndefined(e.code) === 'ESRCH') return Effect.void
         // Other errors: fall back to individual kill (ignore errors)
-        return proc.kill(signal).pipe(Effect.ignore)
+        return proc.kill({ killSignal: signal }).pipe(Effect.ignore)
       }),
     )
   }
 
   // Windows: just use individual kill (taskkill /T would need shell)
-  return proc.kill(signal).pipe(Effect.ignore)
+  return proc.kill({ killSignal: signal }).pipe(Effect.ignore)
 }
 
 /**
@@ -637,40 +647,46 @@ const sendSignalToProcessGroup = (opts: {
  * Sends SIGTERM first, waits for graceful exit, then SIGKILL if needed.
  */
 const killProcessGroup = Effect.fn('cmd/killProcessGroup')(function* (opts: {
-  proc: Process
+  proc: ChildProcessSpawner.ChildProcessHandle
   timeout?: Duration.Input
 }) {
-  const { proc } = opts
-  const timeout = opts.timeout ?? DEFAULT_KILL_TIMEOUT
+  yield* Effect.gen(function* () {
+    const { proc } = opts
+    const timeout = opts.timeout ?? DEFAULT_KILL_TIMEOUT
 
-  // Send SIGTERM first
-  yield* sendSignalToProcessGroup({ proc, signal: 'SIGTERM' })
+    // Send SIGTERM first
+    yield* sendSignalToProcessGroup({ proc, signal: 'SIGTERM' })
 
-  // Wait for process to exit gracefully (with timeout)
-  const exited = yield* proc.exitCode.pipe(Effect.timeout(timeout), Effect.option)
+    // Wait for process to exit gracefully (with timeout)
+    const exited = yield* proc.exitCode.pipe(Effect.timeout(timeout), Effect.option)
 
-  // If still running after timeout, escalate to SIGKILL
-  if (Option.isNone(exited) === true) {
-    yield* Effect.logDebug(`Process ${proc.pid} didn't exit gracefully, sending SIGKILL`)
-    yield* sendSignalToProcessGroup({ proc, signal: 'SIGKILL' })
-  }
-}, Effect.ignore)
+    // If still running after timeout, escalate to SIGKILL
+    if (Option.isNone(exited) === true) {
+      yield* Effect.logDebug(`Process ${proc.pid} didn't exit gracefully, sending SIGKILL`)
+      yield* sendSignalToProcessGroup({ proc, signal: 'SIGKILL' })
+    }
+  }).pipe(Effect.ignore)
+})
 
-const buildCommand = (opts: { input: string | string[]; useShell: boolean }) => {
-  const { input, useShell } = opts
+const buildCommand = (opts: {
+  input: string | string[]
+  useShell: boolean
+  options?: ChildProcess.CommandOptions
+}) => {
+  const { input, options, useShell } = opts
   if (Array.isArray(input) === true) {
     const [command, ...args] = input
     if (command === undefined) throw new Error('Command cannot be empty')
-    return Command.make(command, ...args)
+    return ChildProcess.make(command, args, { ...options, shell: useShell })
   }
 
   if (useShell === true) {
-    return Command.make(input)
+    return ChildProcess.make(input, [], { ...options, shell: true })
   }
 
   const [command, ...args] = input.split(' ')
   if (command === undefined) throw new Error('Command cannot be empty')
-  return Command.make(command, ...args)
+  return ChildProcess.make(command, args, { ...options, shell: false })
 }
 
 type TLineTerminator = 'newline' | 'carriage-return' | 'none'

--- a/packages/@overeng/utils/src/node/cmd.unit.test.ts
+++ b/packages/@overeng/utils/src/node/cmd.unit.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 import { NodeServices } from '@effect/platform-node'
-import * as CommandExecutor from 'effect/unstable/process/CommandExecutor'
+import { ChildProcessSpawner } from 'effect/unstable/process'
 import { Effect, Layer } from 'effect'
 import { expect } from 'vitest'
 
@@ -22,7 +22,7 @@ Vitest.describe('cmd helper', () => {
     Effect.fnUntraced(
       function* () {
         const exit = yield* cmd('printf ok')
-        expect(exit).toBe(CommandExecutor.ExitCode(0))
+        expect(exit).toBe(ChildProcessSpawner.ExitCode(0))
       },
       Effect.provide(TestLayer),
       Effect.scoped,
@@ -34,7 +34,7 @@ Vitest.describe('cmd helper', () => {
     Effect.fnUntraced(
       function* () {
         const exit = yield* cmd(['printf', 'ok'])
-        expect(exit).toBe(CommandExecutor.ExitCode(0))
+        expect(exit).toBe(ChildProcessSpawner.ExitCode(0))
       },
       Effect.provide(TestLayer),
       Effect.scoped,
@@ -51,7 +51,7 @@ Vitest.describe('cmd helper', () => {
 
         // first run
         const exit1 = yield* cmd('printf first', { logDir: logsDir })
-        expect(exit1).toBe(CommandExecutor.ExitCode(0))
+        expect(exit1).toBe(ChildProcessSpawner.ExitCode(0))
         const current = path.join(logsDir, 'dev.log')
         expect(fs.existsSync(current)).toBe(true)
         const firstLog = fs.readFileSync(current, 'utf8')
@@ -65,7 +65,7 @@ Vitest.describe('cmd helper', () => {
 
         // second run — archives previous
         const exit2 = yield* cmd('printf second', { logDir: logsDir })
-        expect(exit2).toBe(CommandExecutor.ExitCode(0))
+        expect(exit2).toBe(ChildProcessSpawner.ExitCode(0))
         const archiveDir = path.join(logsDir, 'archive')
         const archives = fs.readdirSync(archiveDir).filter((file) => file.endsWith('.log'))
         expect(archives.length).toBe(1)
@@ -114,7 +114,7 @@ Vitest.describe('cmd helper', () => {
         const exit = yield* cmd(['bun', '-e', "console.log('out'); console.error('err')"], {
           logDir: logsDir,
         })
-        expect(exit).toBe(CommandExecutor.ExitCode(0))
+        expect(exit).toBe(ChildProcessSpawner.ExitCode(0))
 
         const current = path.join(logsDir, 'dev.log')
         const logContent = fs.readFileSync(current, 'utf8')

--- a/packages/@overeng/utils/src/node/file-system-backing.unit.test.ts
+++ b/packages/@overeng/utils/src/node/file-system-backing.unit.test.ts
@@ -64,7 +64,7 @@ const makeNodeFsLayer = (): Layer.Layer<FileSystem.FileSystem | Path.Path> => {
     writeFile: () => Effect.void,
     writeFileString: (filePath: string, content: string) =>
       Effect.sync(() => fs.writeFileSync(filePath, content)),
-  } as FileSystem.FileSystem
+  } as unknown as FileSystem.FileSystem
 
   const nodePath = {
     [Path.TypeId]: Path.TypeId,
@@ -976,7 +976,7 @@ Vitest.describe('FileSystemBacking', () => {
         const watchFiber = yield* fsService
           .watch(watchDir)
           .pipe(Stream.runForEach(recordEvent), Effect.forkChild)
-        yield* Effect.yieldNow()
+        yield* Effect.yieldNow
 
         const writeDirectFileUntilObserved = (fileName: string, content: string) =>
           Effect.gen(function* () {
@@ -987,7 +987,7 @@ Vitest.describe('FileSystemBacking', () => {
                 path.join(watchDir, fileName),
                 `${content}-${attempt}`,
               )
-              yield* Effect.yieldNow()
+              yield* Effect.yieldNow
             }
 
             return yield* Fiber.join(eventFiber)

--- a/packages/@overeng/utils/src/node/file-system-backing.unit.test.ts
+++ b/packages/@overeng/utils/src/node/file-system-backing.unit.test.ts
@@ -3,9 +3,9 @@ import * as os from 'node:os'
 import * as path from 'node:path'
 
 import { NodeServices } from '@effect/platform-node'
+import { Context, Data, Deferred, Duration, Effect, Fiber, Layer, Schema, Stream } from 'effect'
 import * as FileSystem from 'effect/FileSystem'
 import * as Path from 'effect/Path'
-import { Context, Data, Deferred, Duration, Effect, Fiber, Layer, Schema, Stream } from 'effect'
 import { expect } from 'vitest'
 
 import { DistributedSemaphoreBacking } from '@overeng/effect-distributed-lock'
@@ -595,13 +595,13 @@ Vitest.describe('FileSystemBacking', () => {
           expect(entries).toEqual(['holder-a.lock', 'holder-b.lock'])
 
           // Verify lock file content
-          const holderAContent = yield* Schema.decodeUnknown(
+          const holderAContent = yield* Schema.decodeUnknownEffect(
             Schema.fromJsonString(LockFileContent),
           )(fs.readFileSync(`${keyDir}/holder-a.lock`, 'utf-8'))
           expect(holderAContent.permits).toBe(2)
           expect(typeof holderAContent.expiresAt).toBe('number')
 
-          const holderBContent = yield* Schema.decodeUnknown(
+          const holderBContent = yield* Schema.decodeUnknownEffect(
             Schema.fromJsonString(LockFileContent),
           )(fs.readFileSync(`${keyDir}/holder-b.lock`, 'utf-8'))
           expect(holderBContent.permits).toBe(1)
@@ -830,7 +830,9 @@ Vitest.describe('FileSystemBacking', () => {
         const now = Date.now()
 
         yield* fsService.makeDirectory(keyDir, { recursive: true })
-        const expiredLockContent = yield* Schema.encode(Schema.fromJsonString(LockFileContent))({
+        const expiredLockContent = yield* Schema.encodeEffect(
+          Schema.fromJsonString(LockFileContent),
+        )({
           permits: 2,
           expiresAt: now - 60_000,
         })
@@ -838,7 +840,9 @@ Vitest.describe('FileSystemBacking', () => {
           `${keyDir}/${encodeURIComponent('holder-expired')}.lock`,
           expiredLockContent,
         )
-        const activeLockContent = yield* Schema.encode(Schema.fromJsonString(LockFileContent))({
+        const activeLockContent = yield* Schema.encodeEffect(
+          Schema.fromJsonString(LockFileContent),
+        )({
           permits: 3,
           expiresAt: now + 60_000,
         })
@@ -926,7 +930,7 @@ Vitest.describe('FileSystemBacking', () => {
         const awaitObservedPath = (
           fileName: string,
         ): Effect.Effect<FileSystem.WatchEvent, WatchEventTimeout> =>
-          Effect.async<FileSystem.WatchEvent, WatchEventTimeout>((resume) => {
+          Effect.callback<FileSystem.WatchEvent, WatchEventTimeout>((resume) => {
             const waiter: WatchWaiter = {
               fileName,
               resume,
@@ -971,12 +975,12 @@ Vitest.describe('FileSystemBacking', () => {
 
         const watchFiber = yield* fsService
           .watch(watchDir)
-          .pipe(Stream.runForEach(recordEvent), Effect.fork)
+          .pipe(Stream.runForEach(recordEvent), Effect.forkChild)
         yield* Effect.yieldNow()
 
         const writeDirectFileUntilObserved = (fileName: string, content: string) =>
           Effect.gen(function* () {
-            const eventFiber = yield* awaitObservedPath(fileName).pipe(Effect.fork)
+            const eventFiber = yield* awaitObservedPath(fileName).pipe(Effect.forkChild)
 
             for (const attempt of [1, 2, 3, 4, 5]) {
               yield* fsService.writeFileString(

--- a/packages/@overeng/utils/src/node/file-system-backing.unit.test.ts
+++ b/packages/@overeng/utils/src/node/file-system-backing.unit.test.ts
@@ -128,7 +128,7 @@ Vitest.describe('FileSystemBacking', () => {
           release: (releaseKey: string, releaseHolderId: string, permits: number) =>
             Effect.sync(() => {
               events.push('release')
-            }).pipe(Effect.zipRight(baseBacking.release(releaseKey, releaseHolderId, permits))),
+            }).pipe(Effect.andThen(baseBacking.release(releaseKey, releaseHolderId, permits))),
           refresh: (
             refreshKey: string,
             refreshHolderId: string,
@@ -680,11 +680,11 @@ Vitest.describe('FileSystemBacking', () => {
           options,
           key: 'test-key',
           targetHolderId: 'nonexistent',
-        }).pipe(Effect.either)
+        }).pipe(Effect.result)
 
-        expect(result._tag).toBe('Left')
-        if (result._tag === 'Left') {
-          expect(result.left._tag).toBe('HolderNotFoundError')
+        expect(result._tag).toBe('Failure')
+        if (result._tag === 'Failure') {
+          expect(result.failure._tag).toBe('HolderNotFoundError')
         }
       }).pipe(Effect.provide(TestLayer), Effect.scoped),
     )

--- a/packages/@overeng/utils/src/node/otel-attrs.unit.test.ts
+++ b/packages/@overeng/utils/src/node/otel-attrs.unit.test.ts
@@ -22,12 +22,12 @@ describe('OtelAttrs', () => {
       count: Schema.Natural.pipe(OtelAttr.key({ key: 'op.count' })),
       cacheHit: Schema.Boolean.pipe(OtelAttr.key({ key: 'op.cache_hit' })),
       maybeShard: Schema.OptionFromNullOr(Schema.String).pipe(OtelAttr.key({ key: 'op.shard' })),
-      at: Schema.DateTimeUtc.pipe(OtelAttr.key({ key: 'op.at' })),
+      at: Schema.DateTimeUtcFromString.pipe(OtelAttr.key({ key: 'op.at' })),
       latency: Schema.DurationFromMillis.pipe(OtelAttr.key({ key: 'op.latency_ms' })),
       tags: Schema.Array(Schema.String).pipe(OtelAttr.key({ key: 'op.tags', encode: 'json' })),
     })
     const attrs = await Effect.runPromise(OtelAttrs.define(Attrs))
-    const at = DateTime.unsafeMake('2026-06-11T10:00:00.000Z')
+    const at = DateTime.makeUnsafe('2026-06-11T10:00:00.000Z')
 
     await expect(
       Effect.runPromise(
@@ -75,7 +75,7 @@ describe('OtelAttrs', () => {
   it('rejects unsafe schemas unless policy is explicit', async () => {
     await expect(
       Effect.runPromise(
-        Effect.either(
+        Effect.result(
           OtelAttrs.define(
             Schema.Struct({
               nested: Schema.Struct({ id: Schema.String }).pipe(OtelAttr.key({ key: 'nested' })),
@@ -84,13 +84,13 @@ describe('OtelAttrs', () => {
         ),
       ),
     ).resolves.toMatchObject({
-      _tag: 'Left',
-      left: expect.any(OtelAttrPlanError),
+      _tag: 'Failure',
+      failure: expect.any(OtelAttrPlanError),
     })
 
     await expect(
       Effect.runPromise(
-        Effect.either(
+        Effect.result(
           OtelAttrs.define(
             Schema.Struct({
               secret: Schema.RedactedFromValue(Schema.String).pipe(OtelAttr.key({ key: 'secret' })),
@@ -99,13 +99,13 @@ describe('OtelAttrs', () => {
         ),
       ),
     ).resolves.toMatchObject({
-      _tag: 'Left',
-      left: expect.any(OtelAttrPlanError),
+      _tag: 'Failure',
+      failure: expect.any(OtelAttrPlanError),
     })
 
     await expect(
       Effect.runPromise(
-        Effect.either(
+        Effect.result(
           OtelAttrs.define(
             Schema.Struct({
               tags: Schema.Array(Schema.String).pipe(OtelAttr.key({ key: 'tags' })),
@@ -114,8 +114,8 @@ describe('OtelAttrs', () => {
         ),
       ),
     ).resolves.toMatchObject({
-      _tag: 'Left',
-      left: expect.any(OtelAttrPlanError),
+      _tag: 'Failure',
+      failure: expect.any(OtelAttrPlanError),
     })
   })
 
@@ -146,7 +146,7 @@ describe('OtelAttrs', () => {
   it('only allows redacted-safe policies for redacted values', async () => {
     await expect(
       Effect.runPromise(
-        Effect.either(
+        Effect.result(
           OtelAttrs.define(
             Schema.Struct({
               secret: Schema.RedactedFromValue(Schema.String).pipe(
@@ -157,8 +157,8 @@ describe('OtelAttrs', () => {
         ),
       ),
     ).resolves.toMatchObject({
-      _tag: 'Left',
-      left: expect.any(OtelAttrPlanError),
+      _tag: 'Failure',
+      failure: expect.any(OtelAttrPlanError),
     })
 
     const attrs = await Effect.runPromise(
@@ -183,10 +183,10 @@ describe('OtelAttrs', () => {
     const attrs = await Effect.runPromise(OtelAttrs.define(Attrs))
 
     await expect(
-      Effect.runPromise(Effect.either(attrs.encode({ count: Number.NaN }))),
+      Effect.runPromise(Effect.result(attrs.encode({ count: Number.NaN }))),
     ).resolves.toMatchObject({
-      _tag: 'Left',
-      left: expect.any(OtelAttrEncodeError),
+      _tag: 'Failure',
+      failure: expect.any(OtelAttrEncodeError),
     })
   })
 
@@ -243,14 +243,14 @@ describe('OtelAttrs', () => {
     ]
     const results = await Promise.all(
       invalidInputs.map((invalid) =>
-        Effect.runPromise(Effect.either(attrs.encode(invalid as never))),
+        Effect.runPromise(Effect.result(attrs.encode(invalid as never))),
       ),
     )
 
     for (const result of results) {
       expect(result).toMatchObject({
-        _tag: 'Left',
-        left: expect.any(OtelAttrEncodeError),
+        _tag: 'Failure',
+        failure: expect.any(OtelAttrEncodeError),
       })
     }
   })
@@ -361,7 +361,7 @@ describe('OtelSpan', () => {
 
     await expect(
       Effect.runPromise(
-        Effect.either(
+        Effect.result(
           OtelSpan.with({
             span,
             attributes: {},
@@ -370,8 +370,8 @@ describe('OtelSpan', () => {
         ),
       ),
     ).resolves.toMatchObject({
-      _tag: 'Left',
-      left: expect.any(OtelAttrEncodeError),
+      _tag: 'Failure',
+      failure: expect.any(OtelAttrEncodeError),
     })
   })
 })

--- a/packages/@overeng/utils/src/node/otel-attrs.unit.test.ts
+++ b/packages/@overeng/utils/src/node/otel-attrs.unit.test.ts
@@ -93,7 +93,7 @@ describe('OtelAttrs', () => {
         Effect.either(
           OtelAttrs.define(
             Schema.Struct({
-              secret: Schema.Redacted(Schema.String).pipe(OtelAttr.key({ key: 'secret' })),
+              secret: Schema.RedactedFromValue(Schema.String).pipe(OtelAttr.key({ key: 'secret' })),
             }),
           ),
         ),
@@ -121,7 +121,7 @@ describe('OtelAttrs', () => {
 
   it('allows explicit redacted and json policies', async () => {
     const Attrs = Schema.Struct({
-      secret: Schema.Redacted(Schema.String).pipe(
+      secret: Schema.RedactedFromValue(Schema.String).pipe(
         OtelAttr.key({ key: 'secret', encode: 'redacted' }),
       ),
       nested: Schema.Struct({ id: Schema.String }).pipe(
@@ -149,7 +149,7 @@ describe('OtelAttrs', () => {
         Effect.either(
           OtelAttrs.define(
             Schema.Struct({
-              secret: Schema.Redacted(Schema.String).pipe(
+              secret: Schema.RedactedFromValue(Schema.String).pipe(
                 OtelAttr.key({ key: 'secret', encode: 'json' }),
               ),
             }),
@@ -164,7 +164,7 @@ describe('OtelAttrs', () => {
     const attrs = await Effect.runPromise(
       OtelAttrs.define(
         Schema.Struct({
-          secret: Schema.Redacted(Schema.String).pipe(
+          secret: Schema.RedactedFromValue(Schema.String).pipe(
             OtelAttr.key({ key: 'secret', encode: 'drop' }),
           ),
         }),
@@ -198,7 +198,7 @@ describe('OtelAttrs', () => {
       asString: Schema.Natural.pipe(OtelAttr.key({ key: 'string', encode: 'string' })),
       asNumber: Schema.Natural.pipe(OtelAttr.key({ key: 'number', encode: 'number' })),
       asBoolean: Schema.Boolean.pipe(OtelAttr.key({ key: 'boolean', encode: 'boolean' })),
-      secret: Schema.Redacted(Schema.String).pipe(
+      secret: Schema.RedactedFromValue(Schema.String).pipe(
         OtelAttr.key({ key: 'secret', encode: 'redacted' }),
       ),
     })

--- a/packages/@overeng/utils/src/node/otel-attrs.unit.test.ts
+++ b/packages/@overeng/utils/src/node/otel-attrs.unit.test.ts
@@ -15,7 +15,7 @@ describe('OtelAttrs', () => {
   it('derives primitive, literal, uuid, option, date, duration, and explicit array attributes', async () => {
     const Attrs = Schema.Struct({
       label: Schema.Trimmed.check(Schema.isNonEmpty()).pipe(OtelAttr.spanLabel()),
-      requestId: Schema.UUID.pipe(OtelAttr.key({ key: 'request.id' })),
+      requestId: Schema.String.check(Schema.isUUID()).pipe(OtelAttr.key({ key: 'request.id' })),
       outcome: Schema.Literals(['approved', 'denied', 'timeout']).pipe(
         OtelAttr.key({ key: 'op.outcome' }),
       ),

--- a/packages/@overeng/utils/src/node/otel-identity.test.ts
+++ b/packages/@overeng/utils/src/node/otel-identity.test.ts
@@ -74,7 +74,7 @@ const resourceAttrsBySignal = (
     const out: Record<string, Record<string, string>> = {}
     // @effect-diagnostics-next-line schemaSyncInEffect:off -- reads the tool's own capture ndjson in a controlled test env; a malformed line is a scaffolding bug, so a thrown defect is correct (this helper is annotated `Effect<..., never, FileSystem>`).
     const parseLine = Schema.decodeSync(
-      Schema.fromJsonString(Schema.Record(Schema.String, Schema.Array(Schema.Object))),
+      Schema.fromJsonString(Schema.Record(Schema.String, Schema.Array(Schema.Unknown))),
     )
     for (const [signal, resourceKey] of files) {
       const raw = yield* fs

--- a/packages/@overeng/utils/src/node/otel-identity.test.ts
+++ b/packages/@overeng/utils/src/node/otel-identity.test.ts
@@ -29,7 +29,7 @@ const identity = Schema.decodeSync(ServiceIdentity)({
 /** A workload that emits all three signals (span + counter + log) with no sleeps. */
 const workload = Effect.gen(function* () {
   yield* Effect.annotateCurrentSpan('span.label', 'identity-root')
-  yield* Metric.increment(Metric.counter('identity_requests_total'))
+  yield* Metric.update(Metric.counter('identity_requests_total'), 1)
   yield* Effect.log('identity demo log line')
 }).pipe(Effect.withSpan('identity-root', { root: true }))
 
@@ -125,7 +125,7 @@ Vitest.describe('makeOtelCliLayer — typed ServiceIdentity', () => {
         // explicit identity.
         yield* Effect.scoped(
           scopedEnv({ OTEL_RESOURCE_ATTRIBUTES: undefined, OTEL_SERVICE_NAME: undefined }).pipe(
-            Effect.zipRight(runWorkload(cap.endpoints.http)),
+            Effect.andThen(runWorkload(cap.endpoints.http)),
           ),
         )
 
@@ -160,7 +160,7 @@ Vitest.describe('makeOtelCliLayer — typed ServiceIdentity', () => {
             OTEL_RESOURCE_ATTRIBUTES:
               'deployment.environment=ci-test,service.namespace=env-namespace',
             OTEL_SERVICE_NAME: undefined,
-          }).pipe(Effect.zipRight(runWorkload(cap.endpoints.http))),
+          }).pipe(Effect.andThen(runWorkload(cap.endpoints.http))),
         )
 
         const spans = yield* cap.inspect({ signal: 'traces', service: identity.name })

--- a/packages/@overeng/utils/src/node/otel-telemetry.test.ts
+++ b/packages/@overeng/utils/src/node/otel-telemetry.test.ts
@@ -36,8 +36,8 @@ const workload = Effect.gen(function* () {
   yield* Effect.annotateCurrentSpan('span.label', 'parent')
   yield* Effect.gen(function* () {
     yield* Effect.annotateCurrentSpan('span.label', 'child')
-    yield* Metric.increment(Metric.counter('telemetry_requests_total'))
-    yield* Metric.set(Metric.gauge('telemetry_queue_depth', { bigint: false }), 7)
+    yield* Metric.update(Metric.counter('telemetry_requests_total'), 1)
+    yield* Metric.update(Metric.gauge('telemetry_queue_depth', { bigint: false }), 7)
     yield* Effect.log('telemetry demo log line')
   }).pipe(Effect.withSpan('telemetry-child'))
 }).pipe(Effect.withSpan('telemetry-parent', { root: true }))

--- a/packages/@overeng/utils/src/node/otel.ts
+++ b/packages/@overeng/utils/src/node/otel.ts
@@ -461,12 +461,11 @@ export interface SampleResourceOptions {
  *    {@link OtelConfig} marker), so when no endpoint is configured the fiber is
  *    never forked — "zero overhead when unset" means not paying the periodic cost,
  *    not merely a metric going nowhere.
- * 2. **Ticks on real wall time.** `Effect.withClock(Clock.make())` overrides the
- *    contextual (possibly test/fixed) decision clock that `Schedule.spaced`
- *    resolves through — placed BEFORE `forkScoped` so it wraps the forked fiber,
- *    not the fork action. `provideService` does NOT work for `Clock` (it is a
- *    default service read via `clockWith`, not from `R`). Without this, a
- *    zero-sleep decision clock turns the sampler into a hot loop.
+   * 2. **Ticks on real wall time.** The live `Clock.Clock.defaultValue()` overrides
+   *    the contextual (possibly test/fixed) decision clock that `Schedule.spaced`
+   *    resolves through — placed BEFORE `forkScoped` so it wraps the forked fiber,
+   *    not the fork action. Without this, a zero-sleep decision clock turns the
+   *    sampler into a hot loop.
  *
  * @example
  * ```typescript
@@ -483,9 +482,9 @@ export const sampleResource = (
     sample.pipe(
       Effect.repeat(Schedule.spaced(interval)),
       // Decouple from any ambient (test/fixed) decision clock — this sampler is
-      // infrastructure and must tick on real wall time. `withClock` is placed
+      // infrastructure and must tick on real wall time. Provisioning is placed
       // BEFORE `forkScoped` so it wraps the forked fiber, not the fork action.
-      Effect.withClock(Clock.make()),
+      Effect.provideService(Clock.Clock, Clock.Clock.defaultValue()),
       Effect.forkScoped,
       Effect.asVoid,
     ),

--- a/packages/@overeng/utils/src/node/otel.ts
+++ b/packages/@overeng/utils/src/node/otel.ts
@@ -12,7 +12,6 @@
  * @module
  */
 
-import type { MetricLabel } from 'effect'
 import {
   Clock,
   Config,
@@ -250,7 +249,7 @@ export const makeOtelCliLayer = (config: OtelCliLayerConfig): Layer.Layer<OtelCo
     const resolved =
       explicitEndpoint !== undefined
         ? explicitEndpoint
-        : Option.fromNullable(process.env[endpointEnvVar])
+        : Option.fromNullishOr(process.env[endpointEnvVar])
 
     // Always provide the resolved config so command code can gate optional
     // telemetry work on the same signal the exporter is built from.
@@ -507,7 +506,7 @@ export interface SampleGaugeOptions {
    * Optional labels applied to the gauge so a sweep yields one comparable series
    * per operating point (via `taggedWithLabels`, not the banned `Metric.tagged`).
    */
-  readonly labels?: ReadonlyArray<MetricLabel.MetricLabel>
+  readonly labels?: Metric.Metric.Attributes
   /** @default 250ms */
   readonly interval?: Duration.Duration
 }
@@ -521,9 +520,9 @@ export const sampleGauge = (
   options: SampleGaugeOptions,
 ): Effect.Effect<void, never, OtelConfig | Scope.Scope> => {
   const { gauge, read, labels, interval } = options
-  const target = labels === undefined ? gauge : gauge.pipe(Metric.taggedWithLabels(labels))
+  const target = labels === undefined ? gauge : gauge.pipe(Metric.withAttributes(labels))
   return sampleResource({
-    sample: Effect.sync(read).pipe(Effect.flatMap((value) => Metric.set(target, value))),
+    sample: Effect.sync(read).pipe(Effect.flatMap((value) => Metric.update(target, value))),
     ...(interval === undefined ? {} : { interval }),
   })
 }

--- a/packages/@overeng/utils/src/node/otel.ts
+++ b/packages/@overeng/utils/src/node/otel.ts
@@ -436,7 +436,7 @@ export const telemetryEnabled: Effect.Effect<boolean> = Effect.serviceOption(Ote
  */
 export const whenTelemetryEnabled = <A, E, R>(
   effect: Effect.Effect<A, E, R>,
-): Effect.Effect<void, E, R> => Effect.whenEffect(effect, telemetryEnabled).pipe(Effect.asVoid)
+): Effect.Effect<void, E, R> => effect.pipe(Effect.when(telemetryEnabled), Effect.asVoid)
 
 /** Inputs to {@link sampleResource}: the per-tick `sample` effect and its real-wall-time `interval`. */
 export interface SampleResourceOptions {
@@ -461,11 +461,11 @@ export interface SampleResourceOptions {
  *    {@link OtelConfig} marker), so when no endpoint is configured the fiber is
  *    never forked — "zero overhead when unset" means not paying the periodic cost,
  *    not merely a metric going nowhere.
-   * 2. **Ticks on real wall time.** The live `Clock.Clock.defaultValue()` overrides
-   *    the contextual (possibly test/fixed) decision clock that `Schedule.spaced`
-   *    resolves through — placed BEFORE `forkScoped` so it wraps the forked fiber,
-   *    not the fork action. Without this, a zero-sleep decision clock turns the
-   *    sampler into a hot loop.
+ * 2. **Ticks on real wall time.** The live `Clock.Clock.defaultValue()` overrides
+ *    the contextual (possibly test/fixed) decision clock that `Schedule.spaced`
+ *    resolves through — placed BEFORE `forkScoped` so it wraps the forked fiber,
+ *    not the fork action. Without this, a zero-sleep decision clock turns the
+ *    sampler into a hot loop.
  *
  * @example
  * ```typescript
@@ -498,7 +498,7 @@ export interface SampleGaugeOptions {
    * constructor and `Metric.set` are NOT in the raw-OTEL banned set, unlike
    * `Metric.counter`/`histogram`/`update`/`increment*`).
    */
-  readonly gauge: Metric.Metric.Gauge<number>
+  readonly gauge: Metric.Gauge<number>
   /** Reads the current value on each tick (e.g. `() => process.memoryUsage().rss`). */
   readonly read: () => number
   /**
@@ -521,6 +521,7 @@ export const sampleGauge = (
   const { gauge, read, labels, interval } = options
   const target = labels === undefined ? gauge : gauge.pipe(Metric.withAttributes(labels))
   return sampleResource({
+    // oxlint-disable-next-line overeng/no-raw-otel-primitives -- this schema-first utility is the package's deliberate boundary that encapsulates the raw gauge update for consumers.
     sample: Effect.sync(read).pipe(Effect.flatMap((value) => Metric.update(target, value))),
     ...(interval === undefined ? {} : { interval }),
   })

--- a/packages/@overeng/utils/src/node/playwright/op.ts
+++ b/packages/@overeng/utils/src/node/playwright/op.ts
@@ -50,7 +50,7 @@ const trustOtelContract = <A, E, R>(
   effect.pipe(Effect.catchTag('OtelAttrEncodeError', (error) => Effect.die(error)))
 
 const trustedWith =
-  <S extends Schema.Codec<any, any, never, never>>({
+  <S extends Schema.Codec<any, any, any, any>>({
     operation,
     attributes,
   }: {

--- a/packages/@overeng/utils/src/node/playwright/op.ts
+++ b/packages/@overeng/utils/src/node/playwright/op.ts
@@ -50,7 +50,7 @@ const trustOtelContract = <A, E, R>(
   effect.pipe(Effect.catchTag('OtelAttrEncodeError', (error) => Effect.die(error)))
 
 const trustedWith =
-  <S extends Schema.Codec<unknown, unknown, never, never>>({
+  <S extends Schema.Codec<any, any, never, never>>({
     operation,
     attributes,
   }: {

--- a/packages/@overeng/utils/src/node/playwright/op.ts
+++ b/packages/@overeng/utils/src/node/playwright/op.ts
@@ -50,7 +50,7 @@ const trustOtelContract = <A, E, R>(
   effect.pipe(Effect.catchTag('OtelAttrEncodeError', (error) => Effect.die(error)))
 
 const trustedWith =
-  <S extends Schema.Schema.AnyNoContext>({
+  <S extends Schema.Codec<unknown, unknown, never, never>>({
     operation,
     attributes,
   }: {

--- a/packages/@overeng/utils/src/node/playwright/otel.ts
+++ b/packages/@overeng/utils/src/node/playwright/otel.ts
@@ -47,7 +47,7 @@ export const currentParentSpanContextJson: Effect.Effect<string | undefined, nev
     if (span._tag === 'None') return undefined
 
     const ctx = span.value.spanContext()
-    return yield* Schema.encode(Schema.fromJsonString(ParentSpanContextSchema))({
+    return yield* Schema.encodeEffect(Schema.fromJsonString(ParentSpanContextSchema))({
       traceId: ctx.traceId,
       spanId: ctx.spanId,
     }).pipe(Effect.orDie)
@@ -70,9 +70,9 @@ export const parentSpanFromEnv: (
     const raw = process.env[envVar]
     if (raw === undefined) return undefined
 
-    const ctx = yield* Schema.decode(Schema.fromJsonString(ParentSpanContextSchema))(raw).pipe(
-      Effect.orDie,
-    )
+    const ctx = yield* Schema.decodeEffect(Schema.fromJsonString(ParentSpanContextSchema))(
+      raw,
+    ).pipe(Effect.orDie)
     return Tracer.makeExternalSpan({
       traceId: ctx.traceId,
       spanId: ctx.spanId,
@@ -140,7 +140,7 @@ export const makeOtelPlaywrightLayer = (
     shutdownTimeout = 2000,
   } = config
 
-  return Layer.unwrapEffect(
+  return Layer.unwrap(
     Effect.gen(function* () {
       const endpoint = process.env[endpointEnvVar]
       yield* Effect.logDebug('[pw.otel] Building OTEL layer', {

--- a/packages/@overeng/utils/src/node/playwright/otel.ts
+++ b/packages/@overeng/utils/src/node/playwright/otel.ts
@@ -12,9 +12,10 @@
  * @module
  */
 
-import { OtlpSerialization, OtlpTracer, Tracer } from '@effect/opentelemetry'
-import { Effect, Layer, Schema } from 'effect'
+import { OtelTracer } from '@effect/opentelemetry'
+import { Effect, Layer, Schema, Tracer } from 'effect'
 import { FetchHttpClient } from 'effect/unstable/http'
+import { OtlpSerialization, OtlpTracer } from 'effect/unstable/observability'
 
 /**
  * Minimal parent span context needed to join an existing trace across process boundaries.
@@ -43,7 +44,7 @@ export const PW_SPAN_CONTEXT_ENV_VAR = 'PW_SPAN_CONTEXT_JSON'
  */
 export const currentParentSpanContextJson: Effect.Effect<string | undefined, never, never> =
   Effect.gen(function* () {
-    const span = yield* Tracer.currentOtelSpan.pipe(Effect.option)
+    const span = yield* OtelTracer.currentOtelSpan.pipe(Effect.option)
     if (span._tag === 'None') return undefined
 
     const ctx = span.value.spanContext()
@@ -63,7 +64,7 @@ export const currentParentSpanContextJson: Effect.Effect<string | undefined, nev
  */
 export const parentSpanFromEnv: (
   envVar?: string,
-) => Effect.Effect<ReturnType<typeof Tracer.makeExternalSpan> | undefined> = Effect.fn(
+) => Effect.Effect<ReturnType<typeof Tracer.externalSpan> | undefined> = Effect.fn(
   'pw.otel.parentSpanFromEnv',
 )((envVar = PW_SPAN_CONTEXT_ENV_VAR) =>
   Effect.gen(function* () {
@@ -73,7 +74,7 @@ export const parentSpanFromEnv: (
     const ctx = yield* Schema.decodeEffect(Schema.fromJsonString(ParentSpanContextSchema))(
       raw,
     ).pipe(Effect.orDie)
-    return Tracer.makeExternalSpan({
+    return Tracer.externalSpan({
       traceId: ctx.traceId,
       spanId: ctx.spanId,
     })
@@ -129,9 +130,7 @@ export interface OtelPlaywrightLayerConfig {
  * })
  * ```
  */
-export const makeOtelPlaywrightLayer = (
-  config: OtelPlaywrightLayerConfig = {},
-): Layer.Layer<never> => {
+export const makeOtelPlaywrightLayer = (config: OtelPlaywrightLayerConfig = {}) => {
   const {
     serviceName = 'playwright',
     endpointEnvVar = 'OTEL_EXPORTER_OTLP_ENDPOINT',

--- a/packages/@overeng/utils/src/node/playwright/otel.unit.test.ts
+++ b/packages/@overeng/utils/src/node/playwright/otel.unit.test.ts
@@ -48,8 +48,8 @@ Vitest.describe('playwright/otel', () => {
 
         const result = yield* Schema.decodeUnknownEffect(ParentSpanContextSchema)(
           invalidContext,
-        ).pipe(Effect.either)
-        expect(result._tag).toBe('Left')
+        ).pipe(Effect.result)
+        expect(result._tag).toBe('Failure')
       }),
     )
 
@@ -62,8 +62,8 @@ Vitest.describe('playwright/otel', () => {
 
         const result = yield* Schema.decodeUnknownEffect(ParentSpanContextSchema)(
           invalidContext,
-        ).pipe(Effect.either)
-        expect(result._tag).toBe('Left')
+        ).pipe(Effect.result)
+        expect(result._tag).toBe('Failure')
       }),
     )
   })

--- a/packages/@overeng/utils/src/node/playwright/otel.unit.test.ts
+++ b/packages/@overeng/utils/src/node/playwright/otel.unit.test.ts
@@ -21,7 +21,7 @@ Vitest.describe('playwright/otel', () => {
           spanId: 'b7ad6b7169203331',
         }
 
-        const result = yield* Schema.decodeUnknown(ParentSpanContextSchema)(validContext)
+        const result = yield* Schema.decodeUnknownEffect(ParentSpanContextSchema)(validContext)
         expect(result).toEqual(validContext)
       }),
     )
@@ -34,7 +34,7 @@ Vitest.describe('playwright/otel', () => {
           spanId: 'any-span-id',
         }
 
-        const result = yield* Schema.decodeUnknown(ParentSpanContextSchema)(context)
+        const result = yield* Schema.decodeUnknownEffect(ParentSpanContextSchema)(context)
         expect(result).toEqual(context)
       }),
     )
@@ -46,9 +46,9 @@ Vitest.describe('playwright/otel', () => {
           spanId: 'b7ad6b7169203331',
         }
 
-        const result = yield* Schema.decodeUnknown(ParentSpanContextSchema)(invalidContext).pipe(
-          Effect.either,
-        )
+        const result = yield* Schema.decodeUnknownEffect(ParentSpanContextSchema)(
+          invalidContext,
+        ).pipe(Effect.either)
         expect(result._tag).toBe('Left')
       }),
     )
@@ -60,9 +60,9 @@ Vitest.describe('playwright/otel', () => {
           traceId: '0af7651916cd43dd8448eb211c80319c',
         }
 
-        const result = yield* Schema.decodeUnknown(ParentSpanContextSchema)(invalidContext).pipe(
-          Effect.either,
-        )
+        const result = yield* Schema.decodeUnknownEffect(ParentSpanContextSchema)(
+          invalidContext,
+        ).pipe(Effect.either)
         expect(result._tag).toBe('Left')
       }),
     )
@@ -103,7 +103,9 @@ Vitest.describe('playwright/otel', () => {
     Vitest.it.effect(
       'returns ExternalSpan for valid JSON',
       Effect.fnUntraced(function* () {
-        const validContext = yield* Schema.encode(Schema.fromJsonString(ParentSpanContextSchema))({
+        const validContext = yield* Schema.encodeEffect(
+          Schema.fromJsonString(ParentSpanContextSchema),
+        )({
           traceId: '0af7651916cd43dd8448eb211c80319c',
           spanId: 'b7ad6b7169203331',
         })
@@ -121,7 +123,9 @@ Vitest.describe('playwright/otel', () => {
     Vitest.it.effect(
       'returns ExternalSpan for valid JSON from custom env var',
       Effect.fnUntraced(function* () {
-        const validContext = yield* Schema.encode(Schema.fromJsonString(ParentSpanContextSchema))({
+        const validContext = yield* Schema.encodeEffect(
+          Schema.fromJsonString(ParentSpanContextSchema),
+        )({
           traceId: 'custom-trace-id',
           spanId: 'custom-span-id',
         })
@@ -151,7 +155,7 @@ Vitest.describe('playwright/otel', () => {
     Vitest.it.effect(
       'dies on malformed context (missing traceId)',
       Effect.fnUntraced(function* () {
-        const malformedContext = yield* Schema.encode(
+        const malformedContext = yield* Schema.encodeEffect(
           Schema.fromJsonString(Schema.Struct({ spanId: Schema.String })),
         )({ spanId: 'b7ad6b7169203331' })
         process.env[PW_SPAN_CONTEXT_ENV_VAR] = malformedContext
@@ -166,7 +170,7 @@ Vitest.describe('playwright/otel', () => {
     Vitest.it.effect(
       'dies on malformed context (missing spanId)',
       Effect.fnUntraced(function* () {
-        const malformedContext = yield* Schema.encode(
+        const malformedContext = yield* Schema.encodeEffect(
           Schema.fromJsonString(Schema.Struct({ traceId: Schema.String })),
         )({ traceId: '0af7651916cd43dd8448eb211c80319c' })
         process.env[PW_SPAN_CONTEXT_ENV_VAR] = malformedContext
@@ -211,7 +215,7 @@ Vitest.describe('playwright/otel', () => {
       'uses custom parent span env var',
       Effect.fnUntraced(function* () {
         delete process.env.OTEL_EXPORTER_OTLP_ENDPOINT
-        const customParentSpan = yield* Schema.encode(
+        const customParentSpan = yield* Schema.encodeEffect(
           Schema.fromJsonString(ParentSpanContextSchema),
         )({
           traceId: '0af7651916cd43dd8448eb211c80319c',

--- a/packages/@overeng/utils/src/node/playwright/page.ts
+++ b/packages/@overeng/utils/src/node/playwright/page.ts
@@ -48,7 +48,7 @@ const trustOtelContract = <A, E, R>(
   effect.pipe(Effect.catchTag('OtelAttrEncodeError', (error) => Effect.die(error)))
 
 const trustedWith =
-  <S extends Schema.Schema.AnyNoContext>({
+  <S extends Schema.Codec<unknown, unknown, never, never>>({
     operation,
     attributes,
   }: {

--- a/packages/@overeng/utils/src/node/playwright/page.ts
+++ b/packages/@overeng/utils/src/node/playwright/page.ts
@@ -48,7 +48,7 @@ const trustOtelContract = <A, E, R>(
   effect.pipe(Effect.catchTag('OtelAttrEncodeError', (error) => Effect.die(error)))
 
 const trustedWith =
-  <S extends Schema.Codec<unknown, unknown, never, never>>({
+  <S extends Schema.Codec<any, any, never, never>>({
     operation,
     attributes,
   }: {

--- a/packages/@overeng/utils/src/node/playwright/page.ts
+++ b/packages/@overeng/utils/src/node/playwright/page.ts
@@ -48,7 +48,7 @@ const trustOtelContract = <A, E, R>(
   effect.pipe(Effect.catchTag('OtelAttrEncodeError', (error) => Effect.die(error)))
 
 const trustedWith =
-  <S extends Schema.Codec<any, any, never, never>>({
+  <S extends Schema.Codec<any, any, any, any>>({
     operation,
     attributes,
   }: {

--- a/packages/@overeng/utils/src/node/playwright/step.ts
+++ b/packages/@overeng/utils/src/node/playwright/step.ts
@@ -42,7 +42,7 @@ const trustOtelContract = <A, E, R>(
   effect.pipe(Effect.catchTag('OtelAttrEncodeError', (error) => Effect.die(error)))
 
 const trustedWith =
-  <S extends Schema.Schema.AnyNoContext>({
+  <S extends Schema.Codec<unknown, unknown, never, never>>({
     operation,
     attributes,
   }: {
@@ -78,7 +78,7 @@ export const step: {
   2,
   <A, E, R>(self: Effect.Effect<A, E, R>, name: string): Effect.Effect<A, E, R> =>
     Effect.gen(function* () {
-      const runtime = yield* Effect.runtime<R>()
+      const context = yield* Effect.context<R>()
       const parentSpan = yield* Effect.currentSpan.pipe(Effect.option)
 
       const run =
@@ -95,10 +95,10 @@ export const step: {
         }),
       )
 
-      return yield* Effect.async<A, E>((resume) => {
+      return yield* Effect.callback<A, E>((resume) => {
         void test
           .step(name, async () => {
-            const exit = await Effect.runPromiseExit(traced.pipe(Effect.provide(runtime)))
+            const exit = await Effect.runPromiseExitWith(context)(traced)
             resume(
               Exit.matchEffect(exit, {
                 onFailure: (cause) => Effect.failCause(cause),

--- a/packages/@overeng/utils/src/node/playwright/step.ts
+++ b/packages/@overeng/utils/src/node/playwright/step.ts
@@ -42,7 +42,7 @@ const trustOtelContract = <A, E, R>(
   effect.pipe(Effect.catchTag('OtelAttrEncodeError', (error) => Effect.die(error)))
 
 const trustedWith =
-  <S extends Schema.Codec<any, any, never, never>>({
+  <S extends Schema.Codec<any, any, any, any>>({
     operation,
     attributes,
   }: {
@@ -100,7 +100,7 @@ export const step: {
           .step(name, async () => {
             const exit = await Effect.runPromiseExitWith(context)(traced)
             resume(
-              Exit.matchEffect(exit, {
+              Exit.match(exit, {
                 onFailure: (cause) => Effect.failCause(cause),
                 onSuccess: (value) => Effect.succeed(value),
               }),

--- a/packages/@overeng/utils/src/node/playwright/step.ts
+++ b/packages/@overeng/utils/src/node/playwright/step.ts
@@ -42,7 +42,7 @@ const trustOtelContract = <A, E, R>(
   effect.pipe(Effect.catchTag('OtelAttrEncodeError', (error) => Effect.die(error)))
 
 const trustedWith =
-  <S extends Schema.Codec<unknown, unknown, never, never>>({
+  <S extends Schema.Codec<any, any, never, never>>({
     operation,
     attributes,
   }: {

--- a/packages/@overeng/utils/src/node/playwright/test.ts
+++ b/packages/@overeng/utils/src/node/playwright/test.ts
@@ -10,7 +10,7 @@
 import { NodeServices } from '@effect/platform-node'
 import type { BrowserContext, Page } from '@playwright/test'
 import { test } from '@playwright/test'
-import { ConfigProvider, Effect, Layer, Logger, LogLevel, type Config } from 'effect'
+import { ConfigProvider, Effect, Layer, Logger, type Config } from 'effect'
 import { FetchHttpClient } from 'effect/unstable/http'
 
 import { OtelPlaywrightLive } from './otel.ts'
@@ -23,7 +23,7 @@ const testEnvConfigProvider = ConfigProvider.fromEnv({
 })
 
 /** Layer that installs the Playwright test config provider. */
-export const TestEnvConfigLive = testEnvConfigProvider.pipe(Layer.setConfigProvider)
+export const TestEnvConfigLive = ConfigProvider.layer(testEnvConfigProvider)
 
 /**
  * Load a config schema from process.env in Playwright tests.
@@ -118,7 +118,7 @@ export const makeWithTestCtx =
  * - `OtelPlaywrightLive` (tracing, when OTEL endpoint is configured)
  * - `NodeServices.layer` (filesystem, path, etc.)
  * - `FetchHttpClient.layer`
- * - `Logger.minimumLogLevel(LogLevel.Debug)` (debug logs enabled by default)
+ * - `Logger.minimumLogLevel('Debug')` (debug logs enabled by default)
  *
  * @example
  * ```typescript
@@ -188,11 +188,8 @@ const runWithTestCtx = <ROut, E1, A, E, R>(
   const loggerLayer =
     debugLogs === true
       ? usePrettyLogger === true
-        ? Layer.mergeAll(
-            Logger.minimumLogLevel(LogLevel.Debug),
-            Logger.layer([Logger.consolePretty()]),
-          )
-        : Logger.minimumLogLevel(LogLevel.Debug)
+        ? Layer.mergeAll(Logger.minimumLogLevel('Debug'), Logger.layer([Logger.consolePretty()]))
+        : Logger.minimumLogLevel('Debug')
       : Layer.empty
 
   const combinedLayer = Layer.mergeAll(

--- a/packages/@overeng/utils/src/node/playwright/test.ts
+++ b/packages/@overeng/utils/src/node/playwright/test.ts
@@ -10,17 +10,14 @@
 import { NodeServices } from '@effect/platform-node'
 import type { BrowserContext, Page } from '@playwright/test'
 import { test } from '@playwright/test'
-import { ConfigProvider, Effect, Layer, Logger, type Config } from 'effect'
+import { ConfigProvider, Effect, Layer, Logger, References, type Config } from 'effect'
 import { FetchHttpClient } from 'effect/unstable/http'
 
 import { OtelPlaywrightLive } from './otel.ts'
 import { PwBrowserContext, PwPage } from './tags.ts'
 
 /** Config provider for Playwright tests (constant-case environment variables). */
-const testEnvConfigProvider = ConfigProvider.fromEnv({
-  pathDelim: '_',
-  seqDelim: ',',
-})
+const testEnvConfigProvider = ConfigProvider.fromEnv().pipe(ConfigProvider.constantCase)
 
 /** Layer that installs the Playwright test config provider. */
 export const TestEnvConfigLive = ConfigProvider.layer(testEnvConfigProvider)
@@ -29,7 +26,7 @@ export const TestEnvConfigLive = ConfigProvider.layer(testEnvConfigProvider)
  * Load a config schema from process.env in Playwright tests.
  */
 export const loadEnvConfig = Effect.fn('pw.loadEnvConfig')(<TA>(config: Config.Config<TA>) =>
-  testEnvConfigProvider.load(config),
+  config.parse(testEnvConfigProvider),
 )
 
 /** Playwright test fixtures passed to each test function. */
@@ -188,8 +185,11 @@ const runWithTestCtx = <ROut, E1, A, E, R>(
   const loggerLayer =
     debugLogs === true
       ? usePrettyLogger === true
-        ? Layer.mergeAll(Logger.minimumLogLevel('Debug'), Logger.layer([Logger.consolePretty()]))
-        : Logger.minimumLogLevel('Debug')
+        ? Layer.mergeAll(
+            Layer.succeed(References.MinimumLogLevel, 'Debug'),
+            Logger.layer([Logger.consolePretty()]),
+          )
+        : Layer.succeed(References.MinimumLogLevel, 'Debug')
       : Layer.empty
 
   const combinedLayer = Layer.mergeAll(

--- a/packages/@overeng/utils/src/node/playwright/wait.ts
+++ b/packages/@overeng/utils/src/node/playwright/wait.ts
@@ -37,7 +37,7 @@ const trustOtelContract = <A, E, R>(
   effect.pipe(Effect.catchTag('OtelAttrEncodeError', (error) => Effect.die(error)))
 
 const trustedWith =
-  <S extends Schema.Schema.AnyNoContext>({
+  <S extends Schema.Codec<unknown, unknown, never, never>>({
     operation,
     attributes,
   }: {
@@ -76,9 +76,9 @@ export const until = <TResult, TError, TContext>(args: {
   /** Effect to evaluate; should succeed when ready and fail with a retryable error when not ready. */
   check: Effect.Effect<TResult, TError, TContext>
   /** Delay between retry attempts. */
-  pollInterval: Duration.DurationInput
+  pollInterval: Duration.Input
   /** Maximum time to wait before failing with `PwWaitTimeoutError`. */
-  timeout: Duration.DurationInput
+  timeout: Duration.Input
   /** Predicate that decides whether to retry for a given error value. */
   while: (error: TError) => boolean
 }): Effect.Effect<TResult, TError | PwWaitTimeoutError, TContext> => {

--- a/packages/@overeng/utils/src/node/playwright/wait.ts
+++ b/packages/@overeng/utils/src/node/playwright/wait.ts
@@ -37,7 +37,7 @@ const trustOtelContract = <A, E, R>(
   effect.pipe(Effect.catchTag('OtelAttrEncodeError', (error) => Effect.die(error)))
 
 const trustedWith =
-  <S extends Schema.Codec<any, any, never, never>>({
+  <S extends Schema.Codec<any, any, any, any>>({
     operation,
     attributes,
   }: {

--- a/packages/@overeng/utils/src/node/playwright/wait.ts
+++ b/packages/@overeng/utils/src/node/playwright/wait.ts
@@ -37,7 +37,7 @@ const trustOtelContract = <A, E, R>(
   effect.pipe(Effect.catchTag('OtelAttrEncodeError', (error) => Effect.die(error)))
 
 const trustedWith =
-  <S extends Schema.Codec<unknown, unknown, never, never>>({
+  <S extends Schema.Codec<any, any, never, never>>({
     operation,
     attributes,
   }: {
@@ -104,9 +104,9 @@ export const until = <TResult, TError, TContext>(args: {
 
     return yield* checkWithTelemetry.pipe(
       Effect.retry({ schedule: Schedule.spaced(pollInterval), while: while_ }),
-      Effect.timeoutFail({
+      Effect.timeoutOrElse({
         duration: timeout,
-        onTimeout: () => new PwWaitTimeoutError({ label, timeout: String(timeout) }),
+        orElse: () => Effect.fail(new PwWaitTimeoutError({ label, timeout: String(timeout) })),
       }),
     )
   }).pipe(

--- a/pnpm-install-contract.json
+++ b/pnpm-install-contract.json
@@ -139,6 +139,7 @@
       "packages/@overeng/utils-dev"
     ],
     "patchedDependencies": {
+      "@effect/platform-node-shared@4.0.0-beta.102": "packages/@overeng/utils/patches/@effect__platform-node-shared@4.0.0-beta.102.patch",
       "@myobie/pty@0.10.0": "packages/@overeng/utils/patches/@myobie__pty@0.10.0.patch",
       "effect@4.0.0-beta.102": "packages/@overeng/utils/patches/effect@4.0.0-beta.102.patch"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,8 +8,9 @@ settings:
 packageExtensionsChecksum: sha256-4HimX0luQTvo3jbLtYHagQKuv0eSu+BxzCFfrE1bdnM=
 
 patchedDependencies:
+  '@effect/platform-node-shared@4.0.0-beta.102': 419554c5ddc5465204857c3b8b621b712f310661e68b65bbe99cc63e411b3144
   '@myobie/pty@0.10.0': e6d9b2f6990efbb98235e6e4018e3e9bb5ac94bc54ea6764364857206b6b95a5
-  effect@4.0.0-beta.102: 0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f
+  effect@4.0.0-beta.102: 5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a
 
 importers:
 
@@ -19,10 +20,10 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(ioredis@5.11.1)
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(ioredis@5.11.1)
       effect:
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+        version: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
     devDependencies:
       '@types/node':
         specifier: 26.0.0
@@ -32,7 +33,7 @@ importers:
     dependencies:
       '@effect/atom-react':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(react@19.2.7)(scheduler@0.27.0)
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(react@19.2.7)(scheduler@0.27.0)
       '@opentui/core':
         specifier: 0.4.1
         version: 0.4.1(typescript@6.0.3)(web-tree-sitter@0.25.10)
@@ -41,7 +42,7 @@ importers:
         version: 0.4.1(react-devtools-core@7.0.1)(react@19.2.7)(typescript@6.0.3)(web-tree-sitter@0.25.10)(ws@8.21.0)
       effect:
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+        version: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
       react:
         specifier: 19.2.7
         version: 19.2.7
@@ -57,19 +58,19 @@ importers:
     devDependencies:
       '@effect/platform-node':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(ioredis@5.11.1)
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(ioredis@5.11.1)
       '@effect/vitest':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
       '@overeng/utils-dev':
         specifier: workspace:^
-        version: file:packages/@overeng/utils-dev(fafa27166f9fea900351b0e7d1b455e5)
+        version: file:packages/@overeng/utils-dev(b414451f6003434e75c51b43b369120d)
       '@types/node':
         specifier: 26.0.0
         version: 26.0.0
       effect:
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+        version: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -81,7 +82,7 @@ importers:
     dependencies:
       '@effect/opentelemetry':
         specifier: ^4.0.0-beta.102
-        version: 4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))
+        version: 4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))
       '@overeng/otel-contract':
         specifier: workspace:^
         version: link:../otel-contract
@@ -94,10 +95,10 @@ importers:
     devDependencies:
       '@effect/platform-node':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(ioredis@5.11.1)
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(ioredis@5.11.1)
       '@effect/vitest':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
       '@overeng/utils-dev':
         specifier: workspace:^
         version: link:../utils-dev
@@ -109,7 +110,7 @@ importers:
         version: 26.0.0
       effect:
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+        version: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -124,14 +125,14 @@ importers:
         version: 2.2.0
       effect:
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+        version: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
     devDependencies:
       '@effect/vitest':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
       '@overeng/utils-dev':
         specifier: workspace:^
-        version: file:packages/@overeng/utils-dev(fafa27166f9fea900351b0e7d1b455e5)
+        version: file:packages/@overeng/utils-dev(b414451f6003434e75c51b43b369120d)
       '@types/node':
         specifier: 26.0.0
         version: 26.0.0
@@ -146,13 +147,13 @@ importers:
     devDependencies:
       '@effect/vitest':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
       '@overeng/utils-dev':
         specifier: workspace:^
-        version: file:packages/@overeng/utils-dev(fafa27166f9fea900351b0e7d1b455e5)
+        version: file:packages/@overeng/utils-dev(b414451f6003434e75c51b43b369120d)
       effect:
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+        version: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -167,16 +168,16 @@ importers:
     devDependencies:
       '@effect/vitest':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
       '@overeng/utils-dev':
         specifier: workspace:^
-        version: file:packages/@overeng/utils-dev(fafa27166f9fea900351b0e7d1b455e5)
+        version: file:packages/@overeng/utils-dev(b414451f6003434e75c51b43b369120d)
       '@types/node':
         specifier: 26.0.0
         version: 26.0.0
       effect:
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+        version: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -188,19 +189,19 @@ importers:
     devDependencies:
       '@effect/platform-node':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(ioredis@5.11.1)
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(ioredis@5.11.1)
       '@effect/vitest':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
       '@overeng/utils-dev':
         specifier: workspace:^
-        version: file:packages/@overeng/utils-dev(fafa27166f9fea900351b0e7d1b455e5)
+        version: file:packages/@overeng/utils-dev(b414451f6003434e75c51b43b369120d)
       '@types/node':
         specifier: 26.0.0
         version: 26.0.0
       effect:
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+        version: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -216,7 +217,7 @@ importers:
     devDependencies:
       '@overeng/utils':
         specifier: workspace:^
-        version: file:packages/@overeng/utils(@effect/opentelemetry@4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.43.0)(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(ioredis@5.11.1))(@playwright/test@1.61.0)(@types/node@26.0.0)(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+        version: file:packages/@overeng/utils(@effect/opentelemetry@4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.43.0)(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(ioredis@5.11.1))(@playwright/test@1.61.0)(@types/node@26.0.0)(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
       '@storybook/react':
         specifier: 10.4.6
         version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(typescript@6.0.3)
@@ -234,7 +235,7 @@ importers:
         version: 6.0.2(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
       effect:
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+        version: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
       react:
         specifier: 19.2.7
         version: 19.2.7
@@ -261,10 +262,10 @@ importers:
     devDependencies:
       '@effect/platform-node':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(ioredis@5.11.1)
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(ioredis@5.11.1)
       '@overeng/utils':
         specifier: workspace:^
-        version: file:packages/@overeng/utils(@effect/opentelemetry@4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.43.0)(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(ioredis@5.11.1))(@playwright/test@1.61.0)(@types/node@26.0.0)(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+        version: file:packages/@overeng/utils(@effect/opentelemetry@4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.43.0)(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(ioredis@5.11.1))(@playwright/test@1.61.0)(@types/node@26.0.0)(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
       '@tanstack/react-router':
         specifier: 1.170.16
         version: 1.170.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -276,7 +277,7 @@ importers:
         version: 19.2.17
       effect:
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+        version: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
       react:
         specifier: 19.2.7
         version: 19.2.7
@@ -303,7 +304,7 @@ importers:
         version: 1.168.26(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
       effect:
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+        version: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
       react:
         specifier: 19.2.7
         version: 19.2.7
@@ -313,7 +314,7 @@ importers:
     devDependencies:
       '@overeng/utils':
         specifier: workspace:^
-        version: file:packages/@overeng/utils(@effect/opentelemetry@4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.43.0)(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(ioredis@5.11.1))(@playwright/test@1.61.0)(@types/node@26.0.0)(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+        version: file:packages/@overeng/utils(@effect/opentelemetry@4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.43.0)(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(ioredis@5.11.1))(@playwright/test@1.61.0)(@types/node@26.0.0)(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
       '@playwright/test':
         specifier: 1.61.0
         version: 1.61.0
@@ -349,7 +350,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       effect:
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+        version: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
       react:
         specifier: 19.2.7
         version: 19.2.7
@@ -371,7 +372,7 @@ importers:
     devDependencies:
       '@overeng/utils':
         specifier: workspace:^
-        version: file:packages/@overeng/utils(@effect/opentelemetry@4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.43.0)(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(ioredis@5.11.1))(@playwright/test@1.61.0)(@types/node@26.0.0)(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+        version: file:packages/@overeng/utils(@effect/opentelemetry@4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.43.0)(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(ioredis@5.11.1))(@playwright/test@1.61.0)(@types/node@26.0.0)(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
       '@storybook/react':
         specifier: 10.4.6
         version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(typescript@6.0.3)
@@ -392,7 +393,7 @@ importers:
         version: 6.0.2(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
       effect:
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+        version: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
       react:
         specifier: 19.2.7
         version: 19.2.7
@@ -422,16 +423,16 @@ importers:
     dependencies:
       '@effect/atom-react':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(react@19.2.7)(scheduler@0.27.0)
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(react@19.2.7)(scheduler@0.27.0)
       '@effect/opentelemetry':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.43.0)(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))
+        version: 4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.43.0)(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))
       '@effect/platform-node':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(ioredis@5.11.1)
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(ioredis@5.11.1)
       '@effect/vitest':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
       '@opentui/core':
         specifier: 0.4.1
         version: 0.4.1(typescript@6.0.3)(web-tree-sitter@0.25.10)
@@ -455,7 +456,7 @@ importers:
         version: 0.33.0(@types/react@19.2.17)
       effect:
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+        version: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
       react:
         specifier: 19.2.7
         version: 19.2.7
@@ -480,13 +481,13 @@ importers:
         version: link:../tui-core
       '@overeng/tui-react':
         specifier: workspace:^
-        version: file:packages/@overeng/tui-react(3be8b8040347bbbbcb942f74e7efaa77)
+        version: file:packages/@overeng/tui-react(00fcce63f18b4f4e097ef8cebd0327be)
       '@overeng/utils':
         specifier: workspace:^
-        version: file:packages/@overeng/utils(@effect/opentelemetry@4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.43.0)(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(ioredis@5.11.1))(@playwright/test@1.61.0)(@types/node@26.0.0)(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+        version: file:packages/@overeng/utils(@effect/opentelemetry@4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.43.0)(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(ioredis@5.11.1))(@playwright/test@1.61.0)(@types/node@26.0.0)(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
       '@overeng/utils-dev':
         specifier: workspace:^
-        version: file:packages/@overeng/utils-dev(fafa27166f9fea900351b0e7d1b455e5)
+        version: file:packages/@overeng/utils-dev(b414451f6003434e75c51b43b369120d)
       '@storybook/react-vite':
         specifier: 10.4.6
         version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
@@ -507,16 +508,16 @@ importers:
     devDependencies:
       '@effect/vitest':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
       '@overeng/utils-dev':
         specifier: workspace:^
-        version: file:packages/@overeng/utils-dev(fafa27166f9fea900351b0e7d1b455e5)
+        version: file:packages/@overeng/utils-dev(b414451f6003434e75c51b43b369120d)
       '@types/node':
         specifier: 26.0.0
         version: 26.0.0
       effect:
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+        version: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -532,16 +533,16 @@ importers:
     devDependencies:
       '@effect/vitest':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
       '@overeng/utils-dev':
         specifier: workspace:^
-        version: file:packages/@overeng/utils-dev(fafa27166f9fea900351b0e7d1b455e5)
+        version: file:packages/@overeng/utils-dev(b414451f6003434e75c51b43b369120d)
       '@types/node':
         specifier: 26.0.0
         version: 26.0.0
       effect:
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+        version: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -553,16 +554,16 @@ importers:
     dependencies:
       '@effect/atom-react':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(react@19.2.7)(scheduler@0.27.0)
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(react@19.2.7)(scheduler@0.27.0)
       '@effect/opentelemetry':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))
+        version: 4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))
       '@effect/platform-node':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(ioredis@5.11.1)
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(ioredis@5.11.1)
       '@effect/vitest':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
       '@opentui/core':
         specifier: 0.4.1
         version: 0.4.1(typescript@6.0.3)(web-tree-sitter@0.25.10)
@@ -583,7 +584,7 @@ importers:
         version: link:../otel-contract
       '@overeng/tui-react':
         specifier: workspace:^
-        version: link:../tui-react
+        version: file:packages/@overeng/tui-react(00fcce63f18b4f4e097ef8cebd0327be)
       '@overeng/utils':
         specifier: workspace:^
         version: link:../utils
@@ -601,7 +602,7 @@ importers:
         version: 0.33.0(@types/react@19.2.17)
       effect:
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+        version: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
       react:
         specifier: 19.2.7
         version: 19.2.7
@@ -656,16 +657,16 @@ importers:
     dependencies:
       '@effect/atom-react':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(react@19.2.7)(scheduler@0.27.0)
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(react@19.2.7)(scheduler@0.27.0)
       '@effect/opentelemetry':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))
+        version: 4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))
       '@effect/platform-node':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(ioredis@5.11.1)
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(ioredis@5.11.1)
       '@effect/vitest':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
       '@opentui/core':
         specifier: 0.4.1
         version: 0.4.1(typescript@6.0.3)(web-tree-sitter@0.25.10)
@@ -680,7 +681,7 @@ importers:
         version: link:../notion-datasource-sync
       '@overeng/notion-effect-client':
         specifier: workspace:^
-        version: link:../notion-effect-client
+        version: file:packages/@overeng/notion-effect-client(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.43.0)(@types/node@26.0.0)(happy-dom@20.10.6)(ioredis@5.11.1)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
       '@overeng/notion-effect-schema':
         specifier: workspace:^
         version: link:../notion-effect-schema
@@ -695,7 +696,7 @@ importers:
         version: link:../tui-core
       '@overeng/tui-react':
         specifier: workspace:^
-        version: link:../tui-react
+        version: file:packages/@overeng/tui-react(00fcce63f18b4f4e097ef8cebd0327be)
       '@overeng/utils':
         specifier: workspace:^
         version: link:../utils
@@ -713,7 +714,7 @@ importers:
         version: 0.33.0(@types/react@19.2.17)
       effect:
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+        version: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
       react:
         specifier: 19.2.7
         version: 19.2.7
@@ -756,13 +757,13 @@ importers:
     devDependencies:
       '@overeng/utils-dev':
         specifier: workspace:^
-        version: file:packages/@overeng/utils-dev(fafa27166f9fea900351b0e7d1b455e5)
+        version: file:packages/@overeng/utils-dev(b414451f6003434e75c51b43b369120d)
       '@types/node':
         specifier: 26.0.0
         version: 26.0.0
       effect:
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+        version: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -780,7 +781,7 @@ importers:
         version: link:../notion-core
       '@overeng/notion-effect-client':
         specifier: workspace:^
-        version: link:../notion-effect-client
+        version: file:packages/@overeng/notion-effect-client(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.43.0)(@types/node@26.0.0)(happy-dom@20.10.6)(ioredis@5.11.1)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
       '@overeng/notion-effect-schema':
         specifier: workspace:^
         version: link:../notion-effect-schema
@@ -795,7 +796,7 @@ importers:
         version: link:../otel-contract
       '@overeng/tui-react':
         specifier: workspace:^
-        version: link:../tui-react
+        version: file:packages/@overeng/tui-react(00fcce63f18b4f4e097ef8cebd0327be)
       '@overeng/utils':
         specifier: workspace:^
         version: link:../utils
@@ -808,16 +809,16 @@ importers:
     devDependencies:
       '@effect/atom-react':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(react@19.2.7)(scheduler@0.27.0)
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(react@19.2.7)(scheduler@0.27.0)
       '@effect/opentelemetry':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))
+        version: 4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))
       '@effect/platform-node':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(ioredis@5.11.1)
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(ioredis@5.11.1)
       '@effect/vitest':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
       '@opentui/core':
         specifier: 0.4.1
         version: 0.4.1(typescript@6.0.3)(web-tree-sitter@0.25.10)
@@ -841,7 +842,7 @@ importers:
         version: 0.33.0(@types/react@19.2.17)
       effect:
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+        version: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
       react-dom:
         specifier: 19.2.7
         version: 19.2.7(react@19.2.7)
@@ -859,13 +860,13 @@ importers:
     dependencies:
       '@effect/opentelemetry':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))
+        version: 4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))
       '@effect/platform-node':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(ioredis@5.11.1)
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(ioredis@5.11.1)
       '@effect/vitest':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
       '@overeng/content-address':
         specifier: workspace:^
         version: link:../content-address
@@ -886,7 +887,7 @@ importers:
         version: 1.61.0
       effect:
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+        version: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
       mdast-util-gfm-strikethrough:
         specifier: 2.0.0
         version: 2.0.0
@@ -939,16 +940,16 @@ importers:
     devDependencies:
       '@effect/vitest':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
       '@overeng/utils-dev':
         specifier: workspace:^
-        version: file:packages/@overeng/utils-dev(fafa27166f9fea900351b0e7d1b455e5)
+        version: file:packages/@overeng/utils-dev(b414451f6003434e75c51b43b369120d)
       '@types/node':
         specifier: 26.0.0
         version: 26.0.0
       effect:
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+        version: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -966,7 +967,7 @@ importers:
         version: link:../notion-core
       '@overeng/notion-effect-client':
         specifier: workspace:^
-        version: link:../notion-effect-client
+        version: file:packages/@overeng/notion-effect-client(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.43.0)(@types/node@26.0.0)(happy-dom@20.10.6)(ioredis@5.11.1)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
       '@overeng/notion-effect-schema':
         specifier: workspace:^
         version: link:../notion-effect-schema
@@ -982,16 +983,16 @@ importers:
     devDependencies:
       '@effect/opentelemetry':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))
+        version: 4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))
       '@effect/platform-node':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(ioredis@5.11.1)
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(ioredis@5.11.1)
       '@effect/vitest':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
       '@overeng/tui-react':
         specifier: workspace:^
-        version: file:packages/@overeng/tui-react(d3c0a82ae4c3820b85cb46e13b611cfc)
+        version: file:packages/@overeng/tui-react(c5ba86b835922a6dc1ed1f643b739be0)
       '@overeng/utils-dev':
         specifier: workspace:^
         version: link:../utils-dev
@@ -1018,7 +1019,7 @@ importers:
         version: 6.0.2(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
       effect:
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+        version: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
       react:
         specifier: 19.2.7
         version: 19.2.7
@@ -1049,16 +1050,16 @@ importers:
     devDependencies:
       '@effect/vitest':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
       '@overeng/utils-dev':
         specifier: workspace:^
-        version: file:packages/@overeng/utils-dev(fafa27166f9fea900351b0e7d1b455e5)
+        version: file:packages/@overeng/utils-dev(b414451f6003434e75c51b43b369120d)
       '@types/node':
         specifier: 26.0.0
         version: 26.0.0
       effect:
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+        version: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -1070,16 +1071,16 @@ importers:
     dependencies:
       '@effect/opentelemetry':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))
+        version: 4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))
       '@effect/platform-node':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(ioredis@5.11.1)
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(ioredis@5.11.1)
       '@effect/vitest':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
       '@overeng/notion-effect-client':
         specifier: workspace:^
-        version: link:../notion-effect-client
+        version: file:packages/@overeng/notion-effect-client(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.43.0)(@types/node@26.0.0)(happy-dom@20.10.6)(ioredis@5.11.1)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
       '@overeng/notion-effect-schema':
         specifier: workspace:^
         version: link:../notion-effect-schema
@@ -1091,7 +1092,7 @@ importers:
         version: 1.61.0
       effect:
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+        version: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
       vitest:
         specifier: 4.1.9
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
@@ -1155,13 +1156,13 @@ importers:
     devDependencies:
       '@effect/platform-node':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(ioredis@5.11.1)
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(ioredis@5.11.1)
       '@types/node':
         specifier: 26.0.0
         version: 26.0.0
       effect:
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+        version: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -1177,13 +1178,13 @@ importers:
     devDependencies:
       '@overeng/utils-dev':
         specifier: workspace:^
-        version: file:packages/@overeng/utils-dev(fafa27166f9fea900351b0e7d1b455e5)
+        version: file:packages/@overeng/utils-dev(b414451f6003434e75c51b43b369120d)
       '@types/node':
         specifier: 26.0.0
         version: 26.0.0
       effect:
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+        version: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -1229,16 +1230,16 @@ importers:
     devDependencies:
       '@effect/vitest':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
       '@overeng/utils-dev':
         specifier: workspace:^
-        version: file:packages/@overeng/utils-dev(fafa27166f9fea900351b0e7d1b455e5)
+        version: file:packages/@overeng/utils-dev(b414451f6003434e75c51b43b369120d)
       '@types/node':
         specifier: 26.0.0
         version: 26.0.0
       effect:
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+        version: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -1278,7 +1279,7 @@ importers:
         version: 6.0.2(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
       effect:
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+        version: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
       happy-dom:
         specifier: 20.10.6
         version: 20.10.6
@@ -1305,7 +1306,7 @@ importers:
     dependencies:
       '@effect/platform-node':
         specifier: ^4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(ioredis@5.11.1)
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(ioredis@5.11.1)
       '@overeng/otel-contract':
         specifier: workspace:^
         version: link:../otel-contract
@@ -1321,10 +1322,10 @@ importers:
     devDependencies:
       '@effect/opentelemetry':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))
+        version: 4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))
       '@effect/vitest':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
       '@opentelemetry/api':
         specifier: 1.9.1
         version: 1.9.1
@@ -1363,7 +1364,7 @@ importers:
         version: 26.0.0
       effect:
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+        version: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -1387,13 +1388,13 @@ importers:
     dependencies:
       '@effect/opentelemetry':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))
+        version: 4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))
       '@effect/platform-node':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(ioredis@5.11.1)
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(ioredis@5.11.1)
       '@effect/vitest':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
       '@overeng/tui-core':
         specifier: workspace:^
         version: link:../tui-core
@@ -1420,7 +1421,7 @@ importers:
         version: 6.0.0
       effect:
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+        version: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
       string-width:
         specifier: 8.2.1
         version: 8.2.1
@@ -1433,7 +1434,7 @@ importers:
     devDependencies:
       '@effect/atom-react':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(react@19.2.7)(scheduler@0.27.0)
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(react@19.2.7)(scheduler@0.27.0)
       '@opentui/core':
         specifier: 0.4.1
         version: 0.4.1(typescript@6.0.3)(web-tree-sitter@0.25.10)
@@ -1484,16 +1485,16 @@ importers:
     dependencies:
       '@effect/atom-react':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(react@19.2.7)(scheduler@0.27.0)
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(react@19.2.7)(scheduler@0.27.0)
       '@effect/opentelemetry':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))
+        version: 4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))
       '@effect/platform-node':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(ioredis@5.11.1)
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(ioredis@5.11.1)
       '@effect/vitest':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
       '@opentui/core':
         specifier: 0.4.1
         version: 0.4.1(typescript@6.0.3)(web-tree-sitter@0.25.10)
@@ -1505,7 +1506,7 @@ importers:
         version: link:../tui-core
       '@overeng/tui-react':
         specifier: workspace:^
-        version: link:../tui-react
+        version: file:packages/@overeng/tui-react(00fcce63f18b4f4e097ef8cebd0327be)
       '@overeng/utils':
         specifier: workspace:^
         version: link:../utils
@@ -1523,7 +1524,7 @@ importers:
         version: 0.33.0(@types/react@19.2.17)
       effect:
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+        version: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
       react:
         specifier: 19.2.7
         version: 19.2.7
@@ -1563,13 +1564,13 @@ importers:
     dependencies:
       '@effect/opentelemetry':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))
+        version: 4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))
       '@effect/platform-node':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(ioredis@5.11.1)
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(ioredis@5.11.1)
       '@effect/vitest':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
       '@noble/hashes':
         specifier: 2.2.0
         version: 2.2.0
@@ -1584,7 +1585,7 @@ importers:
         version: link:../otel-contract
       effect:
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+        version: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
       vitest:
         specifier: 4.1.9
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
@@ -1636,19 +1637,19 @@ importers:
     devDependencies:
       '@effect/opentelemetry':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))
+        version: 4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))
       '@effect/platform-node':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(ioredis@5.11.1)
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(ioredis@5.11.1)
       '@effect/vitest':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
+        version: 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
       '@types/node':
         specifier: 26.0.0
         version: 26.0.0
       effect:
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+        version: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -2262,6 +2263,17 @@ packages:
 
   '@overeng/effect-distributed-lock@file:packages/@overeng/effect-distributed-lock':
     resolution: {directory: packages/@overeng/effect-distributed-lock, type: directory}
+    peerDependencies:
+      effect: ^4.0.0-beta.102
+
+  '@overeng/notion-core@file:packages/@overeng/notion-core':
+    resolution: {directory: packages/@overeng/notion-core, type: directory}
+
+  '@overeng/notion-effect-client@file:packages/@overeng/notion-effect-client':
+    resolution: {directory: packages/@overeng/notion-effect-client, type: directory}
+
+  '@overeng/notion-effect-schema@file:packages/@overeng/notion-effect-schema':
+    resolution: {directory: packages/@overeng/notion-effect-schema, type: directory}
     peerDependencies:
       effect: ^4.0.0-beta.102
 
@@ -4947,16 +4959,16 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@effect/atom-react@4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(react@19.2.7)(scheduler@0.27.0)':
+  '@effect/atom-react@4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(react@19.2.7)(scheduler@0.27.0)':
     dependencies:
-      effect: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+      effect: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
       react: 19.2.7
       scheduler: 0.27.0
 
-  '@effect/opentelemetry@4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))':
+  '@effect/opentelemetry@4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))':
     dependencies:
       '@opentelemetry/semantic-conventions': 1.41.1
-      effect: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+      effect: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.219.0
@@ -4967,10 +4979,10 @@ snapshots:
       '@opentelemetry/sdk-trace-node': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-web': 2.8.0(@opentelemetry/api@1.9.1)
 
-  '@effect/opentelemetry@4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.43.0)(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))':
+  '@effect/opentelemetry@4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.43.0)(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))':
     dependencies:
       '@opentelemetry/semantic-conventions': 1.43.0
-      effect: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+      effect: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.219.0
@@ -4981,19 +4993,19 @@ snapshots:
       '@opentelemetry/sdk-trace-node': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-web': 2.8.0(@opentelemetry/api@1.9.1)
 
-  '@effect/platform-node-shared@4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))':
+  '@effect/platform-node-shared@4.0.0-beta.102(patch_hash=419554c5ddc5465204857c3b8b621b712f310661e68b65bbe99cc63e411b3144)(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))':
     dependencies:
       '@types/ws': 8.18.1
-      effect: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+      effect: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
       ws: 8.21.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(ioredis@5.11.1)':
+  '@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(ioredis@5.11.1)':
     dependencies:
-      '@effect/platform-node-shared': 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))
-      effect: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+      '@effect/platform-node-shared': 4.0.0-beta.102(patch_hash=419554c5ddc5465204857c3b8b621b712f310661e68b65bbe99cc63e411b3144)(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))
+      effect: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
       ioredis: 5.11.1
       mime: 4.1.0
       undici: 8.9.0
@@ -5001,9 +5013,9 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@effect/vitest@4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))':
+  '@effect/vitest@4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))':
     dependencies:
-      effect: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+      effect: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
       vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
 
   '@emnapi/core@1.10.0':
@@ -5408,29 +5420,86 @@ snapshots:
   '@overeng/content-address@file:packages/@overeng/content-address':
     dependencies:
       '@noble/hashes': 2.2.0
-      effect: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+      effect: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
 
-  '@overeng/effect-distributed-lock@file:packages/@overeng/effect-distributed-lock(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))':
+  '@overeng/effect-distributed-lock@file:packages/@overeng/effect-distributed-lock(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))':
     dependencies:
-      effect: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+      effect: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
 
-  '@overeng/otel-contract@file:packages/@overeng/otel-contract(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))':
+  '@overeng/notion-core@file:packages/@overeng/notion-core': {}
+
+  '@overeng/notion-effect-client@file:packages/@overeng/notion-effect-client(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.43.0)(@types/node@26.0.0)(happy-dom@20.10.6)(ioredis@5.11.1)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))':
+    dependencies:
+      '@effect/opentelemetry': 4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.43.0)(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))
+      '@effect/platform-node': 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(ioredis@5.11.1)
+      '@effect/vitest': 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
+      '@overeng/content-address': file:packages/@overeng/content-address
+      '@overeng/notion-core': file:packages/@overeng/notion-core
+      '@overeng/notion-effect-schema': file:packages/@overeng/notion-effect-schema(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))
+      '@overeng/otel-contract': file:packages/@overeng/otel-contract(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))
+      '@overeng/utils': file:packages/@overeng/utils(@effect/opentelemetry@4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(ioredis@5.11.1))(@playwright/test@1.61.0)(@types/node@26.0.0)(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+      '@playwright/test': 1.61.0
+      effect: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-task-list-item: 2.1.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@opentelemetry/api'
+      - '@opentelemetry/api-logs'
+      - '@opentelemetry/resources'
+      - '@opentelemetry/sdk-logs'
+      - '@opentelemetry/sdk-metrics'
+      - '@opentelemetry/sdk-trace-base'
+      - '@opentelemetry/sdk-trace-node'
+      - '@opentelemetry/sdk-trace-web'
+      - '@opentelemetry/semantic-conventions'
+      - '@types/node'
+      - '@vitest/browser-playwright'
+      - '@vitest/browser-preview'
+      - '@vitest/browser-webdriverio'
+      - '@vitest/coverage-istanbul'
+      - '@vitest/coverage-v8'
+      - '@vitest/ui'
+      - bufferutil
+      - happy-dom
+      - ioredis
+      - jsdom
+      - msw
+      - supports-color
+      - utf-8-validate
+      - vite
+
+  '@overeng/notion-effect-schema@file:packages/@overeng/notion-effect-schema(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))':
+    dependencies:
+      '@overeng/notion-core': file:packages/@overeng/notion-core
+      effect: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
+
+  '@overeng/otel-contract@file:packages/@overeng/otel-contract(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))':
     dependencies:
       '@overeng/content-address': file:packages/@overeng/content-address
-      effect: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+      effect: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
 
   '@overeng/tui-core@file:packages/@overeng/tui-core': {}
 
-  '@overeng/tui-react@file:packages/@overeng/tui-react(3be8b8040347bbbbcb942f74e7efaa77)':
+  '@overeng/tui-react@file:packages/@overeng/tui-react(00fcce63f18b4f4e097ef8cebd0327be)':
     dependencies:
-      '@effect/atom-react': 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(react@19.2.7)(scheduler@0.27.0)
-      '@effect/opentelemetry': 4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.43.0)(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))
-      '@effect/platform-node': 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(ioredis@5.11.1)
-      '@effect/vitest': 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
+      '@effect/atom-react': 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(react@19.2.7)(scheduler@0.27.0)
+      '@effect/opentelemetry': 4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.43.0)(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))
+      '@effect/platform-node': 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(ioredis@5.11.1)
+      '@effect/vitest': 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
       '@opentui/core': 0.4.1(typescript@6.0.3)(web-tree-sitter@0.25.10)
       '@opentui/react': 0.4.1(react-devtools-core@7.0.1)(react@19.2.7)(typescript@6.0.3)(web-tree-sitter@0.25.10)(ws@8.21.0)
       '@overeng/tui-core': file:packages/@overeng/tui-core
-      '@overeng/utils': file:packages/@overeng/utils(@effect/opentelemetry@4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.43.0)(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(ioredis@5.11.1))(@playwright/test@1.61.0)(@types/node@26.0.0)(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+      '@overeng/utils': file:packages/@overeng/utils(@effect/opentelemetry@4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.43.0)(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(ioredis@5.11.1))(@playwright/test@1.61.0)(@types/node@26.0.0)(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
       '@playwright/test': 1.61.0
       '@storybook/react': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(typescript@6.0.3)
       '@types/react': 19.2.17
@@ -5440,7 +5509,7 @@ snapshots:
       '@xterm/headless': 6.0.0
       '@xterm/xterm': 6.0.0
       cli-truncate: 6.0.0
-      effect: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+      effect: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       react-reconciler: 0.33.0(react@19.2.7)
@@ -5470,16 +5539,16 @@ snapshots:
       - msw
       - vite
 
-  '@overeng/tui-react@file:packages/@overeng/tui-react(d3c0a82ae4c3820b85cb46e13b611cfc)':
+  '@overeng/tui-react@file:packages/@overeng/tui-react(c5ba86b835922a6dc1ed1f643b739be0)':
     dependencies:
-      '@effect/atom-react': 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(react@19.2.7)(scheduler@0.27.0)
-      '@effect/opentelemetry': 4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))
-      '@effect/platform-node': 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(ioredis@5.11.1)
-      '@effect/vitest': 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
+      '@effect/atom-react': 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(react@19.2.7)(scheduler@0.27.0)
+      '@effect/opentelemetry': 4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.43.0)(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))
+      '@effect/platform-node': 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(ioredis@5.11.1)
+      '@effect/vitest': 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
       '@opentui/core': 0.4.1(typescript@6.0.3)(web-tree-sitter@0.25.10)
       '@opentui/react': 0.4.1(react-devtools-core@7.0.1)(react@19.2.7)(typescript@6.0.3)(web-tree-sitter@0.25.10)(ws@8.21.1)
       '@overeng/tui-core': file:packages/@overeng/tui-core
-      '@overeng/utils': file:packages/@overeng/utils(@effect/opentelemetry@4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(ioredis@5.11.1))(@playwright/test@1.61.0)(@types/node@26.0.0)(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+      '@overeng/utils': file:packages/@overeng/utils(@effect/opentelemetry@4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(ioredis@5.11.1))(@playwright/test@1.61.0)(@types/node@26.0.0)(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
       '@playwright/test': 1.61.0
       '@storybook/react': 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(typescript@6.0.3)
       '@types/react': 19.2.17
@@ -5489,7 +5558,7 @@ snapshots:
       '@xterm/headless': 6.0.0
       '@xterm/xterm': 6.0.0
       cli-truncate: 6.0.0
-      effect: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+      effect: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       react-reconciler: 0.33.0(react@19.2.7)
@@ -5519,25 +5588,25 @@ snapshots:
       - msw
       - vite
 
-  '@overeng/utils-dev@file:packages/@overeng/utils-dev(fafa27166f9fea900351b0e7d1b455e5)':
+  '@overeng/utils-dev@file:packages/@overeng/utils-dev(b414451f6003434e75c51b43b369120d)':
     dependencies:
-      '@effect/opentelemetry': 4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.43.0)(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))
-      '@effect/platform-node': 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(ioredis@5.11.1)
-      '@effect/vitest': 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
-      effect: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+      '@effect/opentelemetry': 4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.43.0)(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))
+      '@effect/platform-node': 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(ioredis@5.11.1)
+      '@effect/vitest': 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
+      effect: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
       vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
 
-  ? '@overeng/utils@file:packages/@overeng/utils(@effect/opentelemetry@4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(ioredis@5.11.1))(@playwright/test@1.61.0)(@types/node@26.0.0)(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))'
+  ? '@overeng/utils@file:packages/@overeng/utils(@effect/opentelemetry@4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(ioredis@5.11.1))(@playwright/test@1.61.0)(@types/node@26.0.0)(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))'
   : dependencies:
-      '@effect/opentelemetry': 4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))
-      '@effect/platform-node': 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(ioredis@5.11.1)
-      '@effect/vitest': 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
+      '@effect/opentelemetry': 4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))
+      '@effect/platform-node': 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(ioredis@5.11.1)
+      '@effect/vitest': 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
       '@noble/hashes': 2.2.0
       '@opentelemetry/api': 1.9.1
-      '@overeng/effect-distributed-lock': file:packages/@overeng/effect-distributed-lock(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))
-      '@overeng/otel-contract': file:packages/@overeng/otel-contract(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))
+      '@overeng/effect-distributed-lock': file:packages/@overeng/effect-distributed-lock(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))
+      '@overeng/otel-contract': file:packages/@overeng/otel-contract(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))
       '@playwright/test': 1.61.0
-      effect: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+      effect: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
       vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@edge-runtime/vm'
@@ -5553,17 +5622,17 @@ snapshots:
       - msw
       - vite
 
-  ? '@overeng/utils@file:packages/@overeng/utils(@effect/opentelemetry@4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.43.0)(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(ioredis@5.11.1))(@playwright/test@1.61.0)(@types/node@26.0.0)(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))'
+  ? '@overeng/utils@file:packages/@overeng/utils(@effect/opentelemetry@4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.43.0)(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)))(@effect/platform-node@4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(ioredis@5.11.1))(@playwright/test@1.61.0)(@types/node@26.0.0)(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))'
   : dependencies:
-      '@effect/opentelemetry': 4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.43.0)(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))
-      '@effect/platform-node': 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(ioredis@5.11.1)
-      '@effect/vitest': 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
+      '@effect/opentelemetry': 4.0.0-beta.102(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.43.0)(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))
+      '@effect/platform-node': 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(ioredis@5.11.1)
+      '@effect/vitest': 4.0.0-beta.102(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))
       '@noble/hashes': 2.2.0
       '@opentelemetry/api': 1.9.1
-      '@overeng/effect-distributed-lock': file:packages/@overeng/effect-distributed-lock(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))
-      '@overeng/otel-contract': file:packages/@overeng/otel-contract(effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f))
+      '@overeng/effect-distributed-lock': file:packages/@overeng/effect-distributed-lock(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))
+      '@overeng/otel-contract': file:packages/@overeng/otel-contract(effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a))
       '@playwright/test': 1.61.0
-      effect: 4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f)
+      effect: 4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a)
       vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@edge-runtime/vm'
@@ -6664,7 +6733,7 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
-  effect@4.0.0-beta.102(patch_hash=0e466320200ea28a3acd29dbedb9e0d8be0ce5659bfac9e4a17a96ad6235e63f):
+  effect@4.0.0-beta.102(patch_hash=5b75ab22f047286a8d69ecf7f46470a080d6201a84bed44b2532f1f38926fb8a):
     dependencies:
       '@standard-schema/spec': 1.1.0
       fast-check: 4.9.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -40,6 +40,7 @@ packages:
   - packages/@overeng/utils-dev
 
 patchedDependencies:
+  '@effect/platform-node-shared@4.0.0-beta.102': packages/@overeng/utils/patches/@effect__platform-node-shared@4.0.0-beta.102.patch
   '@myobie/pty@0.10.0': packages/@overeng/utils/patches/@myobie__pty@0.10.0.patch
   effect@4.0.0-beta.102: packages/@overeng/utils/patches/effect@4.0.0-beta.102.patch
 


### PR DESCRIPTION
## Problem

`@overeng/utils` is still on Effect 3 API shapes after the repository cohort moved to `effect@4.0.0-beta.102`.

## Goal

Port `@overeng/utils` faithfully to the verified Effect 4 recipes, including the temporary non-recursive `FileSystem.watch` compatibility shim.

## Decisions

- Applied only mappings covered by the checked-in beta.102 recipes.
- Preserved all migration characterization baselines and their intentional failure markers.
- Stopped at recipe gaps instead of introducing package-local migration dialects.

## Verification

- Initial package compiler census: 335 `@overeng/utils` error lines.
- After the 43-recipe, child-process, watcher, schema, and clock sweep: 80 error lines.
- Command: `DEVENV_TASK_PASSTHROUGH=1 /nix/store/n9dn050479c55i4zhrmlil6a67nay5fp-tsgo/bin/tsgo --build packages/@overeng/utils/tsconfig.json --pretty false --force`
- Managed `test:utils` is blocked before Vitest collection by the shared
  `oxc-config-pnpm-deps` FOD hash invalidated by the required watcher patches.
  No `vitest.tests` / `vitest.failures` summary exists yet.

## Complexity

No new abstraction has been added.

## Concerns

The checked-in recipe catalog does not yet cover several beta.102 APIs used by this package, including logger construction/input shape, lineage AST traversal, environment config loading, and some OpenTelemetry moves.

The watcher patch changes the shared pnpm closure. The managed lane currently
reports specified `sha256-UY6mLb26sY3NWsB1Sg4HgQOrrNufBvmiZpsm5ABY048=` and
got `sha256-Mfv1pAWgM3T7mlWkjgT7gGqiJoXPeCCMkrHs8PmKAG0=`; this slice did not
hand-edit the FOD hash.

## Friction & bottlenecks

- The bootstrap base advanced during the slice from 28 to 43 recipe files; the branch was rebased and the added recipes were applied.
- Initial host load averages were 48.70 / 105.49 / 97.58.

## Follow-ups

- Obtain or add the missing approved recipes before completing the port.
- Backport the post-beta.102 recursive watch control as a marked migration bridge.

## References

- Refs #925
- Elective refactors remain out of scope under #981.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | co2-nebula |
| `agent_session_id` | 88a1c861-9727-4fa6-95d1-3aacf25bce71 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.145.0 |
| `agent_runtime` | Codex CLI 0.145.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/xlzszm8nx5v5spwmhb20x5ng68wmfz3l-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/jbv137fkdbd5kj3q62makn63glkhccpr-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-29-w4-utils-effect4 |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@973b4e1 |
</details>
<!-- agent-footer:end -->