### PR TITLE
feat(effect-path): port to Effect 4

### DIFF
--- a/context/effect-4/alignment-register.md
+++ b/context/effect-4/alignment-register.md
@@ -136,6 +136,23 @@
 - **Status:** allowlisted as a negative-control diff in
   `patterns/fork-defaults/scenario.json`.
 
+## effect-path-public-result-shape
+
+- **Difference:** Public in-memory `Sandbox.validate`, `Sandbox.resolve`, and `validatePath` results
+  follow Effect's major-version data type: v3 `Either` used `_tag: "Right" | "Left"` with
+  `right` / `left` fields, while v4 `Result` uses `_tag: "Success" | "Failure"` with
+  `success` / `failure` fields.
+- **Proposed decision:** Accept the v4 `Result` shape. These APIs deliberately expose an
+  Effect-owned type, and preserving the removed v3 `Either` shape would require a local
+  compatibility dialect.
+- **Blast radius:** `@overeng/effect-path` sandbox validation APIs and consumers that inspect the
+  returned in-memory Effect data type.
+- **Audit evidence:** Repository-wide consumer searches found no downstream call site for these
+  three APIs and no serialization, snapshot-write, cache, or persistence boundary for their result
+  objects. Package baselines normalize the branch to its success or failure value.
+- **Status:** ACCEPTED for in-memory public API only. Any future serialization site requires a
+  separate wire-format decision.
+
 ## equality-structural-default
 
 - **Difference:** v4 structurally compares plain objects, arrays, maps, sets,

--- a/packages/@overeng/effect-path/src/Sandbox.ts
+++ b/packages/@overeng/effect-path/src/Sandbox.ts
@@ -7,9 +7,7 @@
  * All operations within a sandbox are guaranteed to stay within the root directory.
  */
 
-import { FileSystem } from 'effect/FileSystem'
-import type { Path as PlatformPath } from 'effect/Path'
-import { Effect, Either } from 'effect'
+import { Effect, FileSystem, type Path as PlatformPath, Result } from 'effect'
 
 import type { AbsoluteDirPath, AbsolutePath, RelativePath } from './brands.ts'
 import { PathNotFoundError, PermissionError, TraversalError, type SandboxError } from './errors.ts'
@@ -41,7 +39,7 @@ export interface Sandbox {
    *
    * @returns The normalized relative path, or TraversalError if it escapes
    */
-  validate(path: RelativePath): Either.Either<RelativePath, TraversalError>
+  validate(path: RelativePath): Result.Result<RelativePath, TraversalError>
 
   /**
    * Resolve a relative path to an absolute path within the sandbox.
@@ -49,7 +47,7 @@ export interface Sandbox {
    *
    * @returns The absolute path, or TraversalError if it escapes
    */
-  resolve(path: RelativePath): Either.Either<AbsolutePath, TraversalError>
+  resolve(path: RelativePath): Result.Result<AbsolutePath, TraversalError>
 
   /**
    * Check if an absolute path is contained within this sandbox.
@@ -112,13 +110,13 @@ export const sandbox = (root: AbsoluteDirPath): Sandbox => {
    * Validate that a path doesn't escape the sandbox.
    * Returns the normalized relative path.
    */
-  const validate = (path: RelativePath): Either.Either<RelativePath, TraversalError> => {
+  const validate = (path: RelativePath): Result.Result<RelativePath, TraversalError> => {
     // Normalize the path first
     const normalized = lexicalPure(path)
 
     // Reject absolute paths (POSIX semantics)
     if (normalized.startsWith('/') === true) {
-      return Either.left(
+      return Result.fail(
         new TraversalError({
           path,
           message: `Expected relative path (must not start with '/'): ${path}`,
@@ -148,7 +146,7 @@ export const sandbox = (root: AbsoluteDirPath): Sandbox => {
     }
 
     if (escapingSegments.length > 0) {
-      return Either.left(
+      return Result.fail(
         new TraversalError({
           path,
           message: `Path escapes sandbox root: ${path}`,
@@ -161,24 +159,24 @@ export const sandbox = (root: AbsoluteDirPath): Sandbox => {
 
     // Preserve trailing slash
     if (hasTrailingSlash(path) === true) {
-      return Either.right(ensureTrailingSlash(normalized) as RelativePath)
+      return Result.succeed(ensureTrailingSlash(normalized) as RelativePath)
     }
-    return Either.right(normalized as RelativePath)
+    return Result.succeed(normalized as RelativePath)
   }
 
   /**
    * Resolve a relative path to absolute within the sandbox.
    */
-  const resolve = (path: RelativePath): Either.Either<AbsolutePath, TraversalError> => {
+  const resolve = (path: RelativePath): Result.Result<AbsolutePath, TraversalError> => {
     const validatedResult = validate(path)
-    if (Either.isLeft(validatedResult) === true) {
-      return Either.left(validatedResult.left)
+    if (Result.isFailure(validatedResult) === true) {
+      return Result.fail(validatedResult.failure)
     }
 
-    const validated = validatedResult.right
+    const validated = validatedResult.success
     const relativePart = removeTrailingSlash(validated)
     if (relativePart === '.') {
-      return Either.right(ensureTrailingSlash(normalizedRoot) as AbsolutePath)
+      return Result.succeed(ensureTrailingSlash(normalizedRoot) as AbsolutePath)
     }
 
     const normalizedRelative = relativePart.replace(/^\/+/, '')
@@ -186,9 +184,9 @@ export const sandbox = (root: AbsoluteDirPath): Sandbox => {
       normalizedRoot === '/' ? `/${normalizedRelative}` : `${normalizedRoot}/${normalizedRelative}`
 
     if (hasTrailingSlash(validated) === true) {
-      return Either.right(ensureTrailingSlash(absolutePath) as AbsolutePath)
+      return Result.succeed(ensureTrailingSlash(absolutePath) as AbsolutePath)
     }
-    return Either.right(absolutePath as AbsolutePath)
+    return Result.succeed(absolutePath as AbsolutePath)
   }
 
   /**
@@ -247,32 +245,30 @@ export const sandbox = (root: AbsoluteDirPath): Sandbox => {
   const getSafeRealPath = Effect.fnUntraced(function* (path: RelativePath) {
     // First do lexical validation
     const resolveResult = resolve(path)
-    if (Either.isLeft(resolveResult) === true) {
-      return yield* resolveResult.left
+    if (Result.isFailure(resolveResult) === true) {
+      return yield* resolveResult.failure
     }
-    const resolved = resolveResult.right
+    const resolved = resolveResult.success
 
     const fs = yield* FileSystem.FileSystem
 
     // Get real path (follows symlinks)
     const realPath = yield* fs.realPath(resolved).pipe(
       Effect.mapError((error) => {
-        if (error._tag === 'SystemError') {
-          if (error.reason === 'NotFound') {
-            return new PathNotFoundError({
-              path: resolved,
-              message: `Path not found: ${resolved}`,
-              nearestExisting: undefined,
-              expectedType: 'any',
-            })
-          }
-          if (error.reason === 'PermissionDenied') {
-            return new PermissionError({
-              path: resolved,
-              message: `Permission denied: ${resolved}`,
-              operation: 'stat',
-            })
-          }
+        if (error.reason._tag === 'NotFound') {
+          return new PathNotFoundError({
+            path: resolved,
+            message: `Path not found: ${resolved}`,
+            nearestExisting: undefined,
+            expectedType: 'any',
+          })
+        }
+        if (error.reason._tag === 'PermissionDenied') {
+          return new PermissionError({
+            path: resolved,
+            message: `Permission denied: ${resolved}`,
+            operation: 'stat',
+          })
         }
         return new PathNotFoundError({
           path: resolved,
@@ -325,12 +321,12 @@ export const sandbox = (root: AbsoluteDirPath): Sandbox => {
 
     exists: Effect.fnUntraced(function* (path) {
       const resolveResult = resolve(path)
-      if (Either.isLeft(resolveResult) === true) {
-        return yield* resolveResult.left
+      if (Result.isFailure(resolveResult) === true) {
+        return yield* resolveResult.failure
       }
-      const resolved = resolveResult.right
+      const resolved = resolveResult.success
       const fs = yield* FileSystem.FileSystem
-      const exists = yield* fs.exists(resolved).pipe(Effect.orElse(() => Effect.succeed(false)))
+      const exists = yield* fs.exists(resolved).pipe(Effect.catch(() => Effect.succeed(false)))
       if (exists === false) {
         return false
       }
@@ -339,7 +335,7 @@ export const sandbox = (root: AbsoluteDirPath): Sandbox => {
         Effect.flatMap((realPath) =>
           validateRealPath({ originalPath: path, realPath }).pipe(Effect.as(true)),
         ),
-        Effect.orElse(() => Effect.succeed(false)),
+        Effect.catch(() => Effect.succeed(false)),
       )
     }),
 
@@ -363,7 +359,7 @@ export const sandbox = (root: AbsoluteDirPath): Sandbox => {
       const fs = yield* FileSystem.FileSystem
       return yield* fs.stat(safePath).pipe(
         Effect.mapError((error) => {
-          if (error._tag === 'SystemError' && error.reason === 'NotFound') {
+          if (error.reason._tag === 'NotFound') {
             return new PathNotFoundError({
               path: safePath,
               message: `Path not found: ${safePath}`,
@@ -401,7 +397,7 @@ export const withSandbox = <A, E, R>(args: {
 export const validatePath = (args: {
   readonly root: AbsoluteDirPath
   readonly path: RelativePath
-}): Either.Either<RelativePath, TraversalError> => sandbox(args.root).validate(args.path)
+}): Result.Result<RelativePath, TraversalError> => sandbox(args.root).validate(args.path)
 
 /**
  * Check if a path would stay within a directory.

--- a/packages/@overeng/effect-path/src/baseline.unit.test.ts
+++ b/packages/@overeng/effect-path/src/baseline.unit.test.ts
@@ -1,7 +1,5 @@
 import { NodeServices } from '@effect/platform-node'
-import type { Error as PlatformError } from 'effect'
-import { Effect, Either, Schema } from 'effect'
-import { FileSystem } from 'effect/FileSystem'
+import { Effect, FileSystem, type PlatformError, Result, Schema } from 'effect'
 import { describe, expect, it } from 'vitest'
 
 import {
@@ -84,18 +82,18 @@ const summarizeTraversalError = (error: TraversalError) => ({
   sandboxRoot: error.sandboxRoot,
 })
 
-const left = <A, E>(either: Either.Either<A, E>, message = 'expected failure'): E => {
-  if (Either.isRight(either) === true) {
+const left = <A, E>(either: Result.Result<A, E>, message = 'expected failure'): E => {
+  if (Result.isSuccess(either) === true) {
     throw new Error(message)
   }
-  return either.left
+  return either.failure
 }
 
 const summarizePlatformError = (error: PlatformError.PlatformError) => ({
   _tag: error._tag,
-  reason: error._tag === 'SystemError' ? error.reason : undefined,
-  module: error.module,
-  method: error.method,
+  reason: error.reason._tag,
+  module: error.reason.module,
+  method: error.reason.method,
 })
 
 type VerifiedFileBaselineError =
@@ -130,12 +128,14 @@ describe('effect-path baselines (cross-major invariant)', () => {
       Effect.gen(function* () {
         const normalizedSchema = EffectPath.schema.AbsoluteFileInfo()
         const originalSchema = EffectPath.schema.AbsoluteFileInfo({ encodeAs: 'original' })
-        const decoded = yield* Schema.decodeUnknown(normalizedSchema)('/repo//pkg/archive.tar.gz')
+        const decoded = yield* Schema.decodeUnknownEffect(normalizedSchema)(
+          '/repo//pkg/archive.tar.gz',
+        )
 
         return {
           decoded: summarizeFileInfo(decoded),
-          encodedDefault: yield* Schema.encode(normalizedSchema)(decoded),
-          encodedOriginal: yield* Schema.encode(originalSchema)(decoded),
+          encodedDefault: yield* Schema.encodeEffect(normalizedSchema)(decoded),
+          encodedOriginal: yield* Schema.encodeEffect(originalSchema)(decoded),
         }
       }),
     )
@@ -173,16 +173,16 @@ describe('effect-path baselines (cross-major invariant)', () => {
       Effect.gen(function* () {
         const absoluteFileFromRelative = yield* EffectPath.convention
           .absoluteFile('relative/file.txt')
-          .pipe(Effect.either)
+          .pipe(Effect.result)
         const relativeFileFromAbsolute = yield* EffectPath.convention
           .relativeFile('/absolute/file.txt')
-          .pipe(Effect.either)
+          .pipe(Effect.result)
         const fileFromDirectoryConvention = yield* EffectPath.convention
           .absoluteFile('/absolute/dir/')
-          .pipe(Effect.either)
+          .pipe(Effect.result)
         const invalidPath = yield* EffectPath.convention
           .relativeFile('bad\0path.txt')
-          .pipe(Effect.either)
+          .pipe(Effect.result)
 
         return [
           left(absoluteFileFromRelative),
@@ -236,9 +236,11 @@ describe('effect-path baselines (cross-major invariant)', () => {
     expect({
       joined,
       normalized,
-      allowed: Either.isRight(allowed) === true ? allowed.right : allowed.left,
+      allowed: Result.isSuccess(allowed) === true ? allowed.success : allowed.failure,
       escaped:
-        Either.isLeft(escaped) === true ? summarizeTraversalError(escaped.left) : escaped.right,
+        Result.isFailure(escaped) === true
+          ? summarizeTraversalError(escaped.failure)
+          : escaped.success,
     }).toMatchInlineSnapshot(`
       {
         "allowed": "/repo/root/index.ts",
@@ -265,13 +267,13 @@ describe('effect-path baselines (cross-major invariant)', () => {
         const root = yield* fs.makeTempDirectoryScoped()
         const missing = `${root}/missing.txt`
 
-        const enoent = left(yield* fs.stat(missing).pipe(Effect.either))
+        const enoent = left(yield* fs.stat(missing).pipe(Effect.result))
         const missingPath = left(
-          yield* EffectPath.verified.absoluteFile(missing).pipe(Effect.either),
+          yield* EffectPath.verified.absoluteFile(missing).pipe(Effect.result),
         )
         // effect-path has no public create/write API or EEXIST branch. This real failure pins the
         // platform wrapper fields only; it does not claim a package-owned EEXIST partition.
-        const eexist = left(yield* fs.makeDirectory(root).pipe(Effect.either))
+        const eexist = left(yield* fs.makeDirectory(root).pipe(Effect.result))
 
         return {
           enoent: {
@@ -285,14 +287,11 @@ describe('effect-path baselines (cross-major invariant)', () => {
       }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
     )
 
-    // TODO(live-migration:effect-3-4): v4 replaces SystemError with PlatformError (register entry
-    // platform-error-wrapper). Resolve by updating the tag while keeping this partition and these
-    // inner fields identical — a change in WHICH branch fires is a real regression, not a rename.
     expect(result).toMatchInlineSnapshot(`
       {
         "eexist": {
           "platform": {
-            "_tag": "SystemError",
+            "_tag": "PlatformError",
             "method": "makeDirectory",
             "module": "FileSystem",
             "reason": "AlreadyExists",
@@ -300,7 +299,7 @@ describe('effect-path baselines (cross-major invariant)', () => {
         },
         "enoent": {
           "platform": {
-            "_tag": "SystemError",
+            "_tag": "PlatformError",
             "method": "stat",
             "module": "FileSystem",
             "reason": "NotFound",
@@ -330,9 +329,9 @@ describe('effect-path baselines (cross-major invariant)', () => {
           yield* fs.chmod(blocked, 0o000)
 
           return yield* Effect.gen(function* () {
-            const eacces = left(yield* fs.stat(blockedFile).pipe(Effect.either))
+            const eacces = left(yield* fs.stat(blockedFile).pipe(Effect.result))
             const permission = left(
-              yield* EffectPath.verified.absoluteFile(blockedFile).pipe(Effect.either),
+              yield* EffectPath.verified.absoluteFile(blockedFile).pipe(Effect.result),
             )
 
             return {
@@ -343,13 +342,10 @@ describe('effect-path baselines (cross-major invariant)', () => {
         }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
       )
 
-      // TODO(live-migration:effect-3-4): v4 replaces SystemError with PlatformError (register entry
-      // platform-error-wrapper). Resolve by updating the tag while keeping this partition and these
-      // inner fields identical — a change in WHICH branch fires is a real regression, not a rename.
       expect(result).toMatchInlineSnapshot(`
         {
           "platform": {
-            "_tag": "SystemError",
+            "_tag": "PlatformError",
             "method": "stat",
             "module": "FileSystem",
             "reason": "PermissionDenied",

--- a/packages/@overeng/effect-path/src/convention.ts
+++ b/packages/@overeng/effect-path/src/convention.ts
@@ -8,8 +8,7 @@
  * This module provides parsing functions that use the @effect/platform Path service.
  */
 
-import { Path as PlatformPath } from 'effect/Path'
-import { Effect } from 'effect'
+import { Effect, Path as PlatformPath } from 'effect'
 
 import type {
   Abs,

--- a/packages/@overeng/effect-path/src/internal/utils.ts
+++ b/packages/@overeng/effect-path/src/internal/utils.ts
@@ -4,8 +4,7 @@
  * Uses @effect/platform's Path service for cross-platform compatibility.
  */
 
-import { Path as PlatformPath } from 'effect/Path'
-import { Effect } from 'effect'
+import { Effect, Path as PlatformPath } from 'effect'
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Platform Path Access

--- a/packages/@overeng/effect-path/src/mod.ts
+++ b/packages/@overeng/effect-path/src/mod.ts
@@ -28,7 +28,7 @@
  * const joined = EffectPath.ops.join(dir, EffectPath.unsafe.relativeFile('index.ts'))
  *
  * // Schema integration
- * const parsed = Schema.decodeUnknown(EffectPath.schema.AbsoluteFilePath)(input)
+ * const parsed = Schema.decodeUnknownEffect(EffectPath.schema.AbsoluteFilePath)(input)
  *
  * // Sandbox for secure file access
  * const sb = EffectPath.sandbox(EffectPath.unsafe.absoluteDir('/app/data/'))

--- a/packages/@overeng/effect-path/src/mod.unit.test.ts
+++ b/packages/@overeng/effect-path/src/mod.unit.test.ts
@@ -1,6 +1,5 @@
-import { FileSystem } from 'effect/FileSystem'
 import { NodeServices } from '@effect/platform-node'
-import { Effect, Either, Schema } from 'effect'
+import { Effect, FileSystem, Result, Schema } from 'effect'
 import { expect, it } from 'vitest'
 
 import { Vitest } from '@overeng/utils-dev/node-vitest'
@@ -30,8 +29,8 @@ Vitest.describe('convention parsing', () => {
       Effect.gen(function* () {
         const result = yield* EffectPath.convention
           .absoluteFile('relative/path.txt')
-          .pipe(Effect.either)
-        expect(Either.isLeft(result)).toBe(true)
+          .pipe(Effect.result)
+        expect(Result.isFailure(result)).toBe(true)
       }).pipe(Effect.provide(NodeServices.layer)),
     )
 
@@ -39,8 +38,8 @@ Vitest.describe('convention parsing', () => {
       Effect.gen(function* () {
         const result = yield* EffectPath.convention
           .absoluteFile('/path/to/dir/')
-          .pipe(Effect.either)
-        expect(Either.isLeft(result)).toBe(true)
+          .pipe(Effect.result)
+        expect(Result.isFailure(result)).toBe(true)
       }).pipe(Effect.provide(NodeServices.layer)),
     )
   })
@@ -55,8 +54,8 @@ Vitest.describe('convention parsing', () => {
 
     Vitest.it.effect('fails on file path (no trailing slash)', () =>
       Effect.gen(function* () {
-        const result = yield* EffectPath.convention.absoluteDir('/path/to/file').pipe(Effect.either)
-        expect(Either.isLeft(result)).toBe(true)
+        const result = yield* EffectPath.convention.absoluteDir('/path/to/file').pipe(Effect.result)
+        expect(Result.isFailure(result)).toBe(true)
       }).pipe(Effect.provide(NodeServices.layer)),
     )
   })
@@ -307,7 +306,7 @@ Vitest.describe('schema', () => {
   Vitest.describe('AbsoluteFilePath', () => {
     Vitest.it.effect('decodes valid absolute file path', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(EffectPath.schema.AbsoluteFilePath)(
+        const result = yield* Schema.decodeUnknownEffect(EffectPath.schema.AbsoluteFilePath)(
           '/home/user/file.txt',
         )
         expect(result).toBe('/home/user/file.txt')
@@ -316,19 +315,19 @@ Vitest.describe('schema', () => {
 
     Vitest.it.effect('rejects relative path', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(EffectPath.schema.AbsoluteFilePath)(
+        const result = yield* Schema.decodeUnknownEffect(EffectPath.schema.AbsoluteFilePath)(
           'relative/file.txt',
-        ).pipe(Effect.either)
-        expect(Either.isLeft(result)).toBe(true)
+        ).pipe(Effect.result)
+        expect(Result.isFailure(result)).toBe(true)
       }),
     )
 
     Vitest.it.effect('rejects directory path', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(EffectPath.schema.AbsoluteFilePath)(
+        const result = yield* Schema.decodeUnknownEffect(EffectPath.schema.AbsoluteFilePath)(
           '/path/to/dir/',
-        ).pipe(Effect.either)
-        expect(Either.isLeft(result)).toBe(true)
+        ).pipe(Effect.result)
+        expect(Result.isFailure(result)).toBe(true)
       }),
     )
   })
@@ -336,17 +335,19 @@ Vitest.describe('schema', () => {
   Vitest.describe('AbsoluteDirPath', () => {
     Vitest.it.effect('decodes valid absolute directory path', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(EffectPath.schema.AbsoluteDirPath)('/home/user/')
+        const result = yield* Schema.decodeUnknownEffect(EffectPath.schema.AbsoluteDirPath)(
+          '/home/user/',
+        )
         expect(result).toBe('/home/user/')
       }),
     )
 
     Vitest.it.effect('rejects file path (no trailing slash)', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(EffectPath.schema.AbsoluteDirPath)(
+        const result = yield* Schema.decodeUnknownEffect(EffectPath.schema.AbsoluteDirPath)(
           '/home/user/file.txt',
-        ).pipe(Effect.either)
-        expect(Either.isLeft(result)).toBe(true)
+        ).pipe(Effect.result)
+        expect(Result.isFailure(result)).toBe(true)
       }),
     )
   })
@@ -354,7 +355,9 @@ Vitest.describe('schema', () => {
   Vitest.describe('RelativeFilePath', () => {
     Vitest.it.effect('decodes valid relative file path', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(EffectPath.schema.RelativeFilePath)('src/mod.ts')
+        const result = yield* Schema.decodeUnknownEffect(EffectPath.schema.RelativeFilePath)(
+          'src/mod.ts',
+        )
         expect(result).toBe('src/mod.ts')
       }),
     )
@@ -363,7 +366,7 @@ Vitest.describe('schema', () => {
   Vitest.describe('RelativeDirPath', () => {
     Vitest.it.effect('decodes valid relative directory path', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(EffectPath.schema.RelativeDirPath)(
+        const result = yield* Schema.decodeUnknownEffect(EffectPath.schema.RelativeDirPath)(
           'src/components/',
         )
         expect(result).toBe('src/components/')
@@ -374,7 +377,7 @@ Vitest.describe('schema', () => {
   Vitest.describe('AbsoluteFileInfo', () => {
     Vitest.it.effect('decodes to PathInfo structure', () =>
       Effect.gen(function* () {
-        const result = yield* Schema.decodeUnknown(EffectPath.schema.AbsoluteFileInfo())(
+        const result = yield* Schema.decodeUnknownEffect(EffectPath.schema.AbsoluteFileInfo())(
           '/path/to/file.txt',
         )
         expect(result.original).toBe('/path/to/file.txt')
@@ -385,10 +388,10 @@ Vitest.describe('schema', () => {
 
     Vitest.it.effect('encodes back to normalized string by default', () =>
       Effect.gen(function* () {
-        const decoded = yield* Schema.decodeUnknown(EffectPath.schema.AbsoluteFileInfo())(
+        const decoded = yield* Schema.decodeUnknownEffect(EffectPath.schema.AbsoluteFileInfo())(
           '/path/to/file.txt',
         )
-        const encoded = yield* Schema.encode(EffectPath.schema.AbsoluteFileInfo())(decoded)
+        const encoded = yield* Schema.encodeEffect(EffectPath.schema.AbsoluteFileInfo())(decoded)
         expect(encoded).toBe('/path/to/file.txt')
       }),
     )
@@ -397,7 +400,7 @@ Vitest.describe('schema', () => {
   Vitest.describe('RelativeFileInfo', () => {
     Vitest.it.effect('uses ./ as parent for root-level relative files', () =>
       Effect.gen(function* () {
-        const decoded = yield* Schema.decodeUnknown(EffectPath.schema.RelativeFileInfo())(
+        const decoded = yield* Schema.decodeUnknownEffect(EffectPath.schema.RelativeFileInfo())(
           'file.txt',
         )
         expect(decoded.parent.normalized).toBe('./')
@@ -416,59 +419,59 @@ Vitest.describe('sandbox', () => {
   Vitest.describe('validate', () => {
     it('validates safe relative path', () => {
       const result = sandbox.validate(EffectPath.unsafe.relativeFile('file.txt'))
-      expect(Either.isRight(result)).toBe(true)
+      expect(Result.isSuccess(result)).toBe(true)
     })
 
     it('validates nested relative path', () => {
       const result = sandbox.validate(EffectPath.unsafe.relativeFile('sub/dir/file.txt'))
-      expect(Either.isRight(result)).toBe(true)
+      expect(Result.isSuccess(result)).toBe(true)
     })
 
     it('rejects path escaping with ..', () => {
       const result = sandbox.validate(EffectPath.unsafe.relativeFile('../../../etc/passwd'))
-      expect(Either.isLeft(result)).toBe(true)
-      if (Either.isLeft(result) === true) {
-        expect(result.left._tag).toBe('TraversalError')
+      expect(Result.isFailure(result)).toBe(true)
+      if (Result.isFailure(result) === true) {
+        expect(result.failure._tag).toBe('TraversalError')
       }
     })
 
     it('rejects paths that escape and then re-enter', () => {
       const result = sandbox.validate(EffectPath.unsafe.relativeFile('../safe/file.txt'))
-      expect(Either.isLeft(result)).toBe(true)
+      expect(Result.isFailure(result)).toBe(true)
     })
 
     it('rejects absolute paths passed as relative', () => {
       const result = sandbox.validate(EffectPath.unsafe.relativeFile('/etc/passwd'))
-      expect(Either.isLeft(result)).toBe(true)
+      expect(Result.isFailure(result)).toBe(true)
     })
 
     it('allows .. that stays within sandbox', () => {
       const result = sandbox.validate(EffectPath.unsafe.relativeFile('sub/../file.txt'))
-      expect(Either.isRight(result)).toBe(true)
+      expect(Result.isSuccess(result)).toBe(true)
     })
   })
 
   Vitest.describe('resolve', () => {
     it('resolves relative path to absolute', () => {
       const result = sandbox.resolve(EffectPath.unsafe.relativeFile('file.txt'))
-      expect(Either.isRight(result)).toBe(true)
-      if (Either.isRight(result) === true) {
-        expect(result.right).toBe('/home/user/file.txt')
+      expect(Result.isSuccess(result)).toBe(true)
+      if (Result.isSuccess(result) === true) {
+        expect(result.success).toBe('/home/user/file.txt')
       }
     })
 
     it('resolves nested path', () => {
       const result = sandbox.resolve(EffectPath.unsafe.relativeFile('sub/dir/file.txt'))
-      expect(Either.isRight(result)).toBe(true)
-      if (Either.isRight(result) === true) {
-        expect(result.right).toBe('/home/user/sub/dir/file.txt')
+      expect(Result.isSuccess(result)).toBe(true)
+      if (Result.isSuccess(result) === true) {
+        expect(result.success).toBe('/home/user/sub/dir/file.txt')
       }
     })
 
     it('rejects escaping path', () => {
       // Need at least 3 .. to escape /home/user/ (which is 2 levels deep)
       const result = sandbox.resolve(EffectPath.unsafe.relativeFile('../../../etc/passwd'))
-      expect(Either.isLeft(result)).toBe(true)
+      expect(Result.isFailure(result)).toBe(true)
     })
   })
 
@@ -510,7 +513,7 @@ Vitest.describe('utility functions', () => {
       const root = EffectPath.unsafe.absoluteDir('/home/user/')
       const path = EffectPath.unsafe.relativeFile('file.txt')
       const result = EffectPath.validatePath({ root, path })
-      expect(Either.isRight(result)).toBe(true)
+      expect(Result.isSuccess(result)).toBe(true)
     })
   })
 
@@ -537,8 +540,8 @@ Vitest.describe('edge cases', () => {
   Vitest.describe('path validation', () => {
     Vitest.it.effect('rejects empty path', () =>
       Effect.gen(function* () {
-        const result = yield* EffectPath.convention.absoluteFile('').pipe(Effect.either)
-        expect(Either.isLeft(result)).toBe(true)
+        const result = yield* EffectPath.convention.absoluteFile('').pipe(Effect.result)
+        expect(Result.isFailure(result)).toBe(true)
       }).pipe(Effect.provide(NodeServices.layer)),
     )
 
@@ -546,8 +549,8 @@ Vitest.describe('edge cases', () => {
       Effect.gen(function* () {
         const result = yield* EffectPath.convention
           .absoluteFile('/path/to\0file.txt')
-          .pipe(Effect.either)
-        expect(Either.isLeft(result)).toBe(true)
+          .pipe(Effect.result)
+        expect(Result.isFailure(result)).toBe(true)
       }).pipe(Effect.provide(NodeServices.layer)),
     )
   })

--- a/packages/@overeng/effect-path/src/normalize.ts
+++ b/packages/@overeng/effect-path/src/normalize.ts
@@ -7,9 +7,7 @@
  * 3. Canonical - Full resolution including symlinks (requires FileSystem)
  */
 
-import { FileSystem } from 'effect/FileSystem'
-import { Path as PlatformPath } from 'effect/Path'
-import { Effect } from 'effect'
+import { Effect, FileSystem, Path as PlatformPath } from 'effect'
 
 import type { AbsolutePath, Path, RelativePath } from './brands.ts'
 import { PathNotFoundError, SymlinkLoopError } from './errors.ts'
@@ -158,7 +156,7 @@ export const canonical = Effect.fnUntraced(function* (path: Path) {
   const realPath = yield* fs.realPath(absolutePath).pipe(
     Effect.mapError((error) => {
       // Map platform errors to our error types
-      if (error._tag === 'SystemError' && error.reason === 'NotFound') {
+      if (error.reason._tag === 'NotFound') {
         return new PathNotFoundError({
           path: absolutePath,
           message: `Path not found: ${absolutePath}`,
@@ -199,7 +197,7 @@ export const canonicalOrLexical = Effect.fnUntraced(function* (path: Path) {
 
   // Try canonical first
   const result = yield* canonical(path).pipe(
-    Effect.orElse(() =>
+    Effect.catch(() =>
       // Fall back to lexical normalization
       lexical(absolutePath),
     ),

--- a/packages/@overeng/effect-path/src/ops.ts
+++ b/packages/@overeng/effect-path/src/ops.ts
@@ -5,8 +5,7 @@
  * Uses @effect/platform's Path service for cross-platform compatibility.
  */
 
-import { Path as PlatformPath } from 'effect/Path'
-import { Effect } from 'effect'
+import { Effect, Path as PlatformPath } from 'effect'
 
 import type {
   AbsoluteDirPath,

--- a/packages/@overeng/effect-path/src/schema.ts
+++ b/packages/@overeng/effect-path/src/schema.ts
@@ -5,7 +5,7 @@
  * Supports configurable encoding (original vs normalized).
  */
 
-import { Schema } from 'effect'
+import { Schema, SchemaGetter } from 'effect'
 
 import type {
   AbsoluteDirPath as AbsoluteDirPathType,
@@ -44,19 +44,20 @@ import type {
 
 /** Validate basic path string (no null bytes, not empty, not too long) */
 const PathStringSchema = Schema.String.pipe(
-  Schema.filter((s) => !isEmpty(s), { message: () => 'Path cannot be empty' }),
-  Schema.filter((s) => !hasNullByte(s), {
-    message: () => 'Path cannot contain null bytes',
-  }),
-  Schema.filter((s) => s.length <= MAX_PATH_LENGTH, {
-    message: () => `Path exceeds maximum length of ${MAX_PATH_LENGTH} characters`,
-  }),
-  Schema.filter(
-    (s) => {
+  Schema.check(Schema.makeFilter((s) => !isEmpty(s) || 'Path cannot be empty')),
+  Schema.check(Schema.makeFilter((s) => !hasNullByte(s) || 'Path cannot contain null bytes')),
+  Schema.check(
+    Schema.makeFilter(
+      (s) =>
+        s.length <= MAX_PATH_LENGTH ||
+        `Path exceeds maximum length of ${MAX_PATH_LENGTH} characters`,
+    ),
+  ),
+  Schema.check(
+    Schema.makeFilter((s) => {
       const segments = toSegments(s)
-      return !segments.some(isWindowsReservedName)
-    },
-    { message: () => 'Path contains Windows reserved name' },
+      return !segments.some(isWindowsReservedName) || 'Path contains Windows reserved name'
+    }),
   ),
 )
 
@@ -80,51 +81,56 @@ const isAbsoluteHeuristic = (s: string): boolean => {
 
 /** Schema for AbsolutePath (absolute, could be file or dir) */
 export const AbsolutePath = PathStringSchema.pipe(
-  Schema.filter(isAbsoluteHeuristic, {
-    message: () => 'Expected absolute path (starting with / or drive letter)',
-  }),
+  Schema.check(
+    Schema.makeFilter(
+      (s) => isAbsoluteHeuristic(s) || 'Expected absolute path (starting with / or drive letter)',
+    ),
+  ),
   Schema.brand('Abs'),
-) as unknown as Schema.Schema<AbsolutePathType, string>
+) as unknown as Schema.Codec<AbsolutePathType, string>
 
 /** Schema for RelativePath (relative, could be file or dir) */
 export const RelativePath = PathStringSchema.pipe(
-  Schema.filter((s) => !isAbsoluteHeuristic(s), {
-    message: () => 'Expected relative path (not starting with / or drive letter)',
-  }),
+  Schema.check(
+    Schema.makeFilter(
+      (s) =>
+        !isAbsoluteHeuristic(s) || 'Expected relative path (not starting with / or drive letter)',
+    ),
+  ),
   Schema.brand('Rel'),
-) as unknown as Schema.Schema<RelativePathType, string>
+) as unknown as Schema.Codec<RelativePathType, string>
 
 /** Schema for AbsoluteFilePath (absolute file, no trailing slash) */
 export const AbsoluteFilePath = AbsolutePath.pipe(
-  Schema.filter((s) => !hasTrailingSlash(s), {
-    message: () => 'File path must not end with a separator',
-  }),
+  Schema.check(
+    Schema.makeFilter((s) => !hasTrailingSlash(s) || 'File path must not end with a separator'),
+  ),
   Schema.brand('File'),
-) as unknown as Schema.Schema<AbsoluteFilePathType, string>
+) as unknown as Schema.Codec<AbsoluteFilePathType, string>
 
 /** Schema for AbsoluteDirPath (absolute directory, has trailing slash) */
 export const AbsoluteDirPath = AbsolutePath.pipe(
-  Schema.filter(hasTrailingSlash, {
-    message: () => 'Directory path must end with a separator',
-  }),
+  Schema.check(
+    Schema.makeFilter((s) => hasTrailingSlash(s) || 'Directory path must end with a separator'),
+  ),
   Schema.brand('Dir'),
-) as unknown as Schema.Schema<AbsoluteDirPathType, string>
+) as unknown as Schema.Codec<AbsoluteDirPathType, string>
 
 /** Schema for RelativeFilePath (relative file, no trailing slash) */
 export const RelativeFilePath = RelativePath.pipe(
-  Schema.filter((s) => !hasTrailingSlash(s), {
-    message: () => 'File path must not end with a separator',
-  }),
+  Schema.check(
+    Schema.makeFilter((s) => !hasTrailingSlash(s) || 'File path must not end with a separator'),
+  ),
   Schema.brand('File'),
-) as unknown as Schema.Schema<RelativeFilePathType, string>
+) as unknown as Schema.Codec<RelativeFilePathType, string>
 
 /** Schema for RelativeDirPath (relative directory, has trailing slash) */
 export const RelativeDirPath = RelativePath.pipe(
-  Schema.filter(hasTrailingSlash, {
-    message: () => 'Directory path must end with a separator',
-  }),
+  Schema.check(
+    Schema.makeFilter((s) => hasTrailingSlash(s) || 'Directory path must end with a separator'),
+  ),
   Schema.brand('Dir'),
-) as unknown as Schema.Schema<RelativeDirPathType, string>
+) as unknown as Schema.Codec<RelativeDirPathType, string>
 
 // ═══════════════════════════════════════════════════════════════════════════
 // PathInfo Schemas
@@ -141,15 +147,15 @@ export interface PathInfoSchemaOptions {
  */
 export const AbsoluteFileInfo = (
   options?: PathInfoSchemaOptions,
-): Schema.Schema<AbsoluteFileInfoType, string> =>
+): Schema.Codec<AbsoluteFileInfoType, string> =>
   createPathInfoSchema<Abs, File>(
     options === undefined
       ? {
-          baseSchema: AbsoluteFilePath as Schema.Schema<AbsoluteFilePathType, string>,
+          baseSchema: AbsoluteFilePath as Schema.Codec<AbsoluteFilePathType, string>,
           isFile: true,
         }
       : {
-          baseSchema: AbsoluteFilePath as Schema.Schema<AbsoluteFilePathType, string>,
+          baseSchema: AbsoluteFilePath as Schema.Codec<AbsoluteFilePathType, string>,
           isFile: true,
           options,
         },
@@ -160,15 +166,15 @@ export const AbsoluteFileInfo = (
  */
 export const AbsoluteDirInfo = (
   options?: PathInfoSchemaOptions,
-): Schema.Schema<AbsoluteDirInfoType, string> =>
+): Schema.Codec<AbsoluteDirInfoType, string> =>
   createPathInfoSchema<Abs, Dir>(
     options === undefined
       ? {
-          baseSchema: AbsoluteDirPath as Schema.Schema<AbsoluteDirPathType, string>,
+          baseSchema: AbsoluteDirPath as Schema.Codec<AbsoluteDirPathType, string>,
           isFile: false,
         }
       : {
-          baseSchema: AbsoluteDirPath as Schema.Schema<AbsoluteDirPathType, string>,
+          baseSchema: AbsoluteDirPath as Schema.Codec<AbsoluteDirPathType, string>,
           isFile: false,
           options,
         },
@@ -179,15 +185,15 @@ export const AbsoluteDirInfo = (
  */
 export const RelativeFileInfo = (
   options?: PathInfoSchemaOptions,
-): Schema.Schema<RelativeFileInfoType, string> =>
+): Schema.Codec<RelativeFileInfoType, string> =>
   createPathInfoSchema<Rel, File>(
     options === undefined
       ? {
-          baseSchema: RelativeFilePath as Schema.Schema<RelativeFilePathType, string>,
+          baseSchema: RelativeFilePath as Schema.Codec<RelativeFilePathType, string>,
           isFile: true,
         }
       : {
-          baseSchema: RelativeFilePath as Schema.Schema<RelativeFilePathType, string>,
+          baseSchema: RelativeFilePath as Schema.Codec<RelativeFilePathType, string>,
           isFile: true,
           options,
         },
@@ -198,15 +204,15 @@ export const RelativeFileInfo = (
  */
 export const RelativeDirInfo = (
   options?: PathInfoSchemaOptions,
-): Schema.Schema<RelativeDirInfoType, string> =>
+): Schema.Codec<RelativeDirInfoType, string> =>
   createPathInfoSchema<Rel, Dir>(
     options === undefined
       ? {
-          baseSchema: RelativeDirPath as Schema.Schema<RelativeDirPathType, string>,
+          baseSchema: RelativeDirPath as Schema.Codec<RelativeDirPathType, string>,
           isFile: false,
         }
       : {
-          baseSchema: RelativeDirPath as Schema.Schema<RelativeDirPathType, string>,
+          baseSchema: RelativeDirPath as Schema.Codec<RelativeDirPathType, string>,
           isFile: false,
           options,
         },
@@ -280,15 +286,20 @@ const buildPathInfoPure = <B extends Abs | Rel, T extends File | Dir>(args: {
  * Create a schema that transforms a string into PathInfo.
  */
 const createPathInfoSchema = <B extends Abs | Rel, T extends File | Dir>(args: {
-  readonly baseSchema: Schema.Schema<string & B & T, string>
+  readonly baseSchema: Schema.Codec<string & B & T, string>
   readonly isFile: boolean
   readonly options?: PathInfoSchemaOptions
-}): Schema.Schema<PathInfo<B, T>, string> => {
+}): Schema.Codec<PathInfo<B, T>, string> => {
   const encodeAs = args.options?.encodeAs ?? 'normalized'
 
-  return Schema.transform(args.baseSchema, Schema.Unknown as Schema.Schema<PathInfo<B, T>>, {
-    strict: true,
-    decode: (s) => buildPathInfoPure<B, T>({ original: s, isFile: args.isFile }),
-    encode: (info) => (encodeAs === 'original' ? info.original : info.normalized) as string & B & T,
-  })
+  return args.baseSchema.pipe(
+    Schema.decodeTo(Schema.Unknown as Schema.Codec<PathInfo<B, T>>, {
+      decode: SchemaGetter.transform<PathInfo<B, T>, string & B & T>((s) =>
+        buildPathInfoPure<B, T>({ original: s, isFile: args.isFile }),
+      ),
+      encode: SchemaGetter.transform<string & B & T, PathInfo<B, T>>(
+        (info) => (encodeAs === 'original' ? info.original : info.normalized) as string & B & T,
+      ),
+    }),
+  )
 }

--- a/packages/@overeng/effect-path/src/symlink.ts
+++ b/packages/@overeng/effect-path/src/symlink.ts
@@ -4,10 +4,7 @@
  * Provides utilities for detecting, reading, and resolving symbolic links.
  */
 
-import type { Error as PlatformError } from 'effect'
-import { FileSystem } from 'effect/FileSystem'
-import { Path as PlatformPath } from 'effect/Path'
-import { Effect, Either } from 'effect'
+import { Effect, FileSystem, Path as PlatformPath, type PlatformError, Result } from 'effect'
 
 import type { AbsolutePath, Path } from './brands.ts'
 import { NotASymlinkError, PathNotFoundError, PermissionError, SymlinkLoopError } from './errors.ts'
@@ -30,22 +27,20 @@ const mapFsError = (args: {
   readonly error: PlatformError.PlatformError
 }): PathNotFoundError | PermissionError => {
   const { path, error } = args
-  if (error._tag === 'SystemError') {
-    if (error.reason === 'NotFound') {
-      return new PathNotFoundError({
-        path,
-        message: `Path not found: ${path}`,
-        nearestExisting: undefined,
-        expectedType: 'any',
-      })
-    }
-    if (error.reason === 'PermissionDenied') {
-      return new PermissionError({
-        path,
-        message: `Permission denied: ${path}`,
-        operation: 'stat',
-      })
-    }
+  if (error.reason._tag === 'NotFound') {
+    return new PathNotFoundError({
+      path,
+      message: `Path not found: ${path}`,
+      nearestExisting: undefined,
+      expectedType: 'any',
+    })
+  }
+  if (error.reason._tag === 'PermissionDenied') {
+    return new PermissionError({
+      path,
+      message: `Permission denied: ${path}`,
+      operation: 'stat',
+    })
   }
   return new PathNotFoundError({
     path,
@@ -70,33 +65,30 @@ export const isSymlink = Effect.fnUntraced(function* (path: AbsolutePath) {
   const handleReadLinkError = (
     error: PlatformError.PlatformError,
   ): Effect.Effect<boolean, PathNotFoundError | PermissionError, never> => {
-    if (error._tag === 'SystemError') {
-      if (error.reason === 'NotFound') {
-        return Effect.fail(
-          new PathNotFoundError({
-            path,
-            message: `Path not found: ${path}`,
-            nearestExisting: undefined,
-            expectedType: 'any',
-          }),
-        )
-      }
-      if (error.reason === 'PermissionDenied') {
-        return Effect.fail(
-          new PermissionError({
-            path,
-            message: `Permission denied: ${path}`,
-            operation: 'stat',
-          }),
-        )
-      }
+    if (error.reason._tag === 'NotFound') {
+      return Effect.fail(
+        new PathNotFoundError({
+          path,
+          message: `Path not found: ${path}`,
+          nearestExisting: undefined,
+          expectedType: 'any',
+        }),
+      )
     }
-
+    if (error.reason._tag === 'PermissionDenied') {
+      return Effect.fail(
+        new PermissionError({
+          path,
+          message: `Permission denied: ${path}`,
+          operation: 'stat',
+        }),
+      )
+    }
     // Likely not a symlink (EINVAL), treat as false.
     return Effect.succeed(false)
   }
 
-  return yield* fs.readLink(path).pipe(Effect.as(true), Effect.catchAll(handleReadLinkError))
+  return yield* fs.readLink(path).pipe(Effect.as(true), Effect.catch(handleReadLinkError))
 })
 
 /**
@@ -105,7 +97,7 @@ export const isSymlink = Effect.fnUntraced(function* (path: AbsolutePath) {
 export const isSymlinkSafe = (
   path: AbsolutePath,
 ): Effect.Effect<boolean, never, FileSystem.FileSystem> =>
-  isSymlink(path).pipe(Effect.orElse(() => Effect.succeed(false)))
+  isSymlink(path).pipe(Effect.catch(() => Effect.succeed(false)))
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Symlink Reading
@@ -119,42 +111,39 @@ export const isSymlinkSafe = (
 export const readLink = Effect.fnUntraced(function* (path: AbsolutePath) {
   const fs = yield* FileSystem.FileSystem
 
-  const targetResult = yield* fs.readLink(path).pipe(Effect.either)
-  if (Either.isRight(targetResult) === true) {
-    return targetResult.right as Path
+  const targetResult = yield* fs.readLink(path).pipe(Effect.result)
+  if (Result.isSuccess(targetResult) === true) {
+    return targetResult.success as Path
   }
 
-  const error = targetResult.left
-  if (error._tag === 'SystemError') {
-    if (error.reason === 'NotFound') {
-      return yield* new PathNotFoundError({
-        path,
-        message: `Path not found: ${path}`,
-        nearestExisting: undefined,
-        expectedType: 'any',
-      })
-    }
-    if (error.reason === 'PermissionDenied') {
-      return yield* new PermissionError({
-        path,
-        message: `Permission denied: ${path}`,
-        operation: 'stat',
-      })
-    }
+  const error = targetResult.failure
+  if (error.reason._tag === 'NotFound') {
+    return yield* new PathNotFoundError({
+      path,
+      message: `Path not found: ${path}`,
+      nearestExisting: undefined,
+      expectedType: 'any',
+    })
   }
-
+  if (error.reason._tag === 'PermissionDenied') {
+    return yield* new PermissionError({
+      path,
+      message: `Permission denied: ${path}`,
+      operation: 'stat',
+    })
+  }
   const statResult = yield* fs.stat(path).pipe(
     Effect.mapError((fsError) => mapFsError({ path, error: fsError })),
-    Effect.either,
+    Effect.result,
   )
-  if (Either.isLeft(statResult) === true) {
-    return yield* statResult.left
+  if (Result.isFailure(statResult) === true) {
+    return yield* statResult.failure
   }
 
   return yield* new NotASymlinkError({
     path,
     message: `Path is not a symbolic link: ${path}`,
-    actualType: statResult.right.type === 'Directory' ? 'directory' : 'file',
+    actualType: statResult.success.type === 'Directory' ? 'directory' : 'file',
   })
 })
 
@@ -176,22 +165,20 @@ export const resolve = Effect.fnUntraced(function* (path: AbsolutePath) {
   // Use realPath for efficient symlink resolution
   const realPath = yield* fs.realPath(path).pipe(
     Effect.mapError((error) => {
-      if (error._tag === 'SystemError') {
-        if (error.reason === 'NotFound') {
-          return new PathNotFoundError({
-            path,
-            message: `Path not found: ${path}`,
-            nearestExisting: undefined,
-            expectedType: 'any',
-          })
-        }
-        if (error.reason === 'PermissionDenied') {
-          return new PermissionError({
-            path,
-            message: `Permission denied: ${path}`,
-            operation: 'stat',
-          })
-        }
+      if (error.reason._tag === 'NotFound') {
+        return new PathNotFoundError({
+          path,
+          message: `Path not found: ${path}`,
+          nearestExisting: undefined,
+          expectedType: 'any',
+        })
+      }
+      if (error.reason._tag === 'PermissionDenied') {
+        return new PermissionError({
+          path,
+          message: `Permission denied: ${path}`,
+          operation: 'stat',
+        })
       }
       // ELOOP or other errors
       return new SymlinkLoopError({
@@ -225,13 +212,10 @@ export const chain = Effect.fnUntraced(function* (path: AbsolutePath) {
   let current = path
 
   for (let depth = 0; depth < MAX_SYMLINK_DEPTH; depth++) {
-    const targetResult = yield* fs.readLink(current).pipe(Effect.either)
-    if (Either.isLeft(targetResult) === true) {
-      const error = targetResult.left
-      if (
-        error._tag === 'SystemError' &&
-        (error.reason === 'NotFound' || error.reason === 'PermissionDenied')
-      ) {
+    const targetResult = yield* fs.readLink(current).pipe(Effect.result)
+    if (Result.isFailure(targetResult) === true) {
+      const error = targetResult.failure
+      if (error.reason._tag === 'NotFound' || error.reason._tag === 'PermissionDenied') {
         return yield* mapFsError({ path: current, error })
       }
 
@@ -239,7 +223,7 @@ export const chain = Effect.fnUntraced(function* (path: AbsolutePath) {
       return visited
     }
 
-    const target = targetResult.right
+    const target = targetResult.success
 
     // Resolve to absolute if relative
     const absoluteTarget =
@@ -279,4 +263,4 @@ export const chain = Effect.fnUntraced(function* (path: AbsolutePath) {
 export const resolveSafe = (
   path: AbsolutePath,
 ): Effect.Effect<AbsolutePath, never, FileSystem.FileSystem> =>
-  resolve(path).pipe(Effect.orElse(() => Effect.succeed(path)))
+  resolve(path).pipe(Effect.catch(() => Effect.succeed(path)))

--- a/packages/@overeng/effect-path/src/verified.ts
+++ b/packages/@overeng/effect-path/src/verified.ts
@@ -5,10 +5,7 @@
  * the actual filesystem to ensure they exist and are of the correct type.
  */
 
-import type { Error as PlatformError } from 'effect'
-import { FileSystem } from 'effect/FileSystem'
-import { Path as PlatformPath } from 'effect/Path'
-import { Effect } from 'effect'
+import { Effect, FileSystem, Path as PlatformPath, type PlatformError } from 'effect'
 
 import type {
   Abs,
@@ -106,22 +103,20 @@ const mapFsError = (args: {
   readonly error: PlatformError.PlatformError
 }): PathNotFoundError | PermissionError => {
   const { path, error } = args
-  if (error._tag === 'SystemError') {
-    if (error.reason === 'NotFound') {
-      return new PathNotFoundError({
-        path,
-        message: `Path not found: ${path}`,
-        nearestExisting: undefined,
-        expectedType: 'any',
-      })
-    }
-    if (error.reason === 'PermissionDenied') {
-      return new PermissionError({
-        path,
-        message: `Permission denied: ${path}`,
-        operation: 'stat',
-      })
-    }
+  if (error.reason._tag === 'NotFound') {
+    return new PathNotFoundError({
+      path,
+      message: `Path not found: ${path}`,
+      nearestExisting: undefined,
+      expectedType: 'any',
+    })
+  }
+  if (error.reason._tag === 'PermissionDenied') {
+    return new PermissionError({
+      path,
+      message: `Permission denied: ${path}`,
+      operation: 'stat',
+    })
   }
   // Default to not found
   return new PathNotFoundError({


### PR DESCRIPTION
## Problem

`@overeng/effect-path` still used Effect 3 result, Schema, filesystem, Path, and error APIs after the repository dependency cohort moved to `effect@4.0.0-beta.102`. The package produced 250 scoped TypeScript errors and blocked downstream collection.

## Goal

Port the package faithfully to Effect 4 while preserving its path, schema wire, sandbox, filesystem-error, and symlink behavior.

## Decisions

- Use root `FileSystem` / `Path` namespace imports, then yield `FileSystem.FileSystem` / `Path.Path`.
- Replace public Effect-owned `Either` results with Effect 4 `Result`. Repository-wide searches found no serialization or persistence consumer for these values; the accepted in-memory shape difference is recorded in the alignment register.
- Preserve the registered `PlatformError` outer-wrapper change while keeping reason, module, method, and package-owned error partitions unchanged.
- Port bidirectional path schemas to `Schema.Codec`, `Schema.check`, and `Schema.decodeTo` without changing encoded path bytes.

## Verification

- Scoped TypeScript diagnostics: `250 -> 0` under `packages/@overeng/effect-path` using the repository compiler with `DEVENV_TASK_PASSTHROUGH=1`. Referenced `utils-dev` diagnostics remain outside this slice.
- Managed committed-tree test:

  `CI=1 devenv tasks run test:effect-path --mode single --show-output --no-tui --refresh-task-cache`

  Summary metrics: `vitest.tests=74`, `vitest.failures=0`, child exit `0`. The summary reported `direct_child_only` degraded process instrumentation while retaining valid Vitest counts.
- Scoped formatter: 12 changed files passed `oxfmt --check`.
- Scoped lint: 15 source files passed `oxlint --deny-warnings` with 0 warnings and 0 errors.
- Cross-major baselines verify exact PathInfo encoded strings, parser partitions, path-operation output, and filesystem reason/module/method fields.

## Complexity

No new abstraction or dependency. This is a direct API-shape migration using the approved Effect 4 recipes.

## Concerns

Consumers compiling against the public sandbox APIs see Effect 4 `Result` tags and fields rather than Effect 3 `Either`. This is limited to in-memory Effect-owned types; no serialization site exists.

## Friction & bottlenecks

- The managed workspace TypeScript wrapper suppressed diagnostics, so scoped measurement used the documented compiler passthrough.
- The default package-test dependency batch failed on unrelated unported packages before collecting this package; `--mode single` produced the authoritative package summary.

## Follow-ups

- Repository-wide cohort integration and downstream package repair remain tracked by #925.

## References

Refs #925

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | co2-sound |
| `agent_session_id` | e0de423c-93a6-4522-b267-d42e76602dcb |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.145.0 |
| `agent_runtime` | Codex CLI 0.145.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/mnx8agbdq3wiyb6vz63lhgscgazkrn98-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/5r69m9k2llmri3na81518zx0a7y0d3cn-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-29-effect4-w9-effectpath |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@0fb7e03 |
</details>
<!-- agent-footer:end -->