### PR TITLE
Port @overeng/tui-react to Effect 4 beta.102

### DIFF
--- a/packages/@overeng/tui-react/examples/01-basic/hello-world.tsx
+++ b/packages/@overeng/tui-react/examples/01-basic/hello-world.tsx
@@ -83,10 +83,9 @@ const helloWorldCommand = Command.make(
   ({ duration, output }) => runHelloWorld(duration).pipe(Effect.provide(outputModeLayer(output))),
 )
 
-const cli = Command.run(helloWorldCommand, {
-  name: 'Hello World',
+const cli = Command.runWith(helloWorldCommand, {
   version: '1.0.0',
 })
 
 // Run with Effect CLI (handles SIGINT/SIGTERM properly)
-cli(process.argv).pipe(Effect.provide(NodeServices.layer), NodeRuntime.runMain)
+cli(process.argv.slice(2)).pipe(Effect.provide(NodeServices.layer), NodeRuntime.runMain)

--- a/packages/@overeng/tui-react/examples/02-effect-integration/counter.tsx
+++ b/packages/@overeng/tui-react/examples/02-effect-integration/counter.tsx
@@ -16,9 +16,9 @@
  *   bun examples/03-effect-integration/counter.tsx --help
  */
 
-import { Command } from 'effect/unstable/cli'
 import { NodeServices, NodeRuntime } from '@effect/platform-node'
 import { Duration, Effect } from 'effect'
+import { Command } from 'effect/unstable/cli'
 import React from 'react'
 
 import { createTuiApp, run } from '../../src/mod.tsx'
@@ -85,10 +85,9 @@ const counter = Command.make('counter', { output: outputOption }, ({ output }) =
   runCounter.pipe(Effect.provide(outputModeLayer(output))),
 )
 
-const cli = Command.run(counter, {
-  name: 'counter',
+const cli = Command.runWith(counter, {
   version: '1.0.0',
 })
 
 // Run with Effect CLI (handles SIGINT/SIGTERM properly)
-cli(process.argv).pipe(Effect.provide(NodeServices.layer), NodeRuntime.runMain)
+cli(process.argv.slice(2)).pipe(Effect.provide(NodeServices.layer), NodeRuntime.runMain)

--- a/packages/@overeng/tui-react/examples/03-cli/deploy/deploy.tsx
+++ b/packages/@overeng/tui-react/examples/03-cli/deploy/deploy.tsx
@@ -5,7 +5,7 @@
  */
 
 import { Schema } from 'effect'
-import { Duration, Effect } from 'effect'
+import { Duration, Effect, Result } from 'effect'
 import React from 'react'
 
 import type { OutputModeTag, TuiAppApi } from '../../../src/mod.tsx'
@@ -230,17 +230,17 @@ export const runDeploy = (
             },
           })
 
-          const pullResult = yield* simulatePull(service).pipe(Effect.either)
-          if (pullResult._tag === 'Left') {
+          const pullResult = yield* simulatePull(service).pipe(Effect.result)
+          if (Result.isFailure(pullResult) === true) {
             failed = true
             failedService = service
-            failedError = pullResult.left.message
-            log({ level: 'error', message: pullResult.left.message, service })
+            failedError = pullResult.failure.message
+            log({ level: 'error', message: pullResult.failure.message, service })
             results.push({
               name: service,
               result: 'failed',
               duration: Date.now() - serviceStart,
-              error: pullResult.left.message,
+              error: pullResult.failure.message,
             })
             break
           }
@@ -256,17 +256,17 @@ export const runDeploy = (
             },
           })
 
-          const startResult = yield* simulateStart(service).pipe(Effect.either)
-          if (startResult._tag === 'Left') {
+          const startResult = yield* simulateStart(service).pipe(Effect.result)
+          if (Result.isFailure(startResult) === true) {
             failed = true
             failedService = service
-            failedError = startResult.left.message
-            log({ level: 'error', message: startResult.left.message, service })
+            failedError = startResult.failure.message
+            log({ level: 'error', message: startResult.failure.message, service })
             results.push({
               name: service,
               result: 'failed',
               duration: Date.now() - serviceStart,
-              error: startResult.left.message,
+              error: startResult.failure.message,
             })
             break
           }
@@ -282,17 +282,17 @@ export const runDeploy = (
             },
           })
 
-          const healthResult = yield* simulateHealthcheck(service).pipe(Effect.either)
-          if (healthResult._tag === 'Left') {
+          const healthResult = yield* simulateHealthcheck(service).pipe(Effect.result)
+          if (Result.isFailure(healthResult) === true) {
             failed = true
             failedService = service
-            failedError = healthResult.left.message
-            log({ level: 'error', message: healthResult.left.message, service })
+            failedError = healthResult.failure.message
+            log({ level: 'error', message: healthResult.failure.message, service })
             results.push({
               name: service,
               result: 'failed',
               duration: Date.now() - serviceStart,
-              error: healthResult.left.message,
+              error: healthResult.failure.message,
             })
             break
           }

--- a/packages/@overeng/tui-react/examples/03-cli/deploy/main.ts
+++ b/packages/@overeng/tui-react/examples/03-cli/deploy/main.ts
@@ -103,10 +103,9 @@ const deploy = Command.make(
 // CLI Runner
 // =============================================================================
 
-const cli = Command.run(deploy, {
-  name: 'deploy',
+const cli = Command.runWith(deploy, {
   version: '1.0.0',
 })
 
 // Run with Effect CLI (handles SIGINT/SIGTERM properly)
-cli(process.argv).pipe(Effect.provide(NodeServices.layer), NodeRuntime.runMain)
+cli(process.argv.slice(2)).pipe(Effect.provide(NodeServices.layer), NodeRuntime.runMain)

--- a/packages/@overeng/tui-react/examples/04-stress-tests/rapid-updates.tsx
+++ b/packages/@overeng/tui-react/examples/04-stress-tests/rapid-updates.tsx
@@ -64,7 +64,7 @@ const runStressTest = (durationMs: number) => {
     (tui) =>
       Effect.gen(function* () {
         // Run the animation loop
-        const animationFiber = yield* Effect.fork(
+        const animationFiber = yield* Effect.forkChild(
           Effect.gen(function* () {
             while (tui.getState()._tag === 'Running') {
               tui.dispatch({ _tag: 'Tick' })
@@ -102,10 +102,9 @@ const stressTestCommand = Command.make(
     runStressTest(duration * 1000).pipe(Effect.provide(outputModeLayer(output))),
 )
 
-const cli = Command.run(stressTestCommand, {
-  name: 'Rapid Updates Stress Test',
+const cli = Command.runWith(stressTestCommand, {
   version: '1.0.0',
 })
 
 // Run with Effect CLI (handles SIGINT/SIGTERM properly)
-cli(process.argv).pipe(Effect.provide(NodeServices.layer), NodeRuntime.runMain)
+cli(process.argv.slice(2)).pipe(Effect.provide(NodeServices.layer), NodeRuntime.runMain)

--- a/packages/@overeng/tui-react/examples/05-advanced/bouncing-windows.tsx
+++ b/packages/@overeng/tui-react/examples/05-advanced/bouncing-windows.tsx
@@ -96,7 +96,7 @@ const runBouncingWindows = ({
         process.stdout.on('resize', resizeHandler)
 
         // Animation loop
-        const animationFiber = yield* Effect.fork(
+        const animationFiber = yield* Effect.forkChild(
           Effect.gen(function* () {
             while (tui.getState()._tag === 'Running') {
               tui.dispatch({ _tag: 'Tick' })
@@ -138,10 +138,9 @@ const bouncingWindowsCommand = Command.make(
     ),
 )
 
-const cli = Command.run(bouncingWindowsCommand, {
-  name: 'Bouncing Windows Demo',
+const cli = Command.runWith(bouncingWindowsCommand, {
   version: '1.0.0',
 })
 
 // Run with Effect CLI (handles SIGINT/SIGTERM properly)
-cli(process.argv).pipe(Effect.provide(NodeServices.layer), NodeRuntime.runMain)
+cli(process.argv.slice(2)).pipe(Effect.provide(NodeServices.layer), NodeRuntime.runMain)

--- a/packages/@overeng/tui-react/examples/06-log-capture/log-capture.tsx
+++ b/packages/@overeng/tui-react/examples/06-log-capture/log-capture.tsx
@@ -10,9 +10,9 @@
  *   bun examples/06-log-capture/log-capture.tsx --output json
  */
 
-import { Command } from 'effect/unstable/cli'
 import { NodeServices, NodeRuntime } from '@effect/platform-node'
 import { Duration, Effect } from 'effect'
+import { Command } from 'effect/unstable/cli'
 import React from 'react'
 
 import { createTuiApp, run } from '../../src/mod.tsx'
@@ -70,9 +70,8 @@ const logCaptureCmd = Command.make('log-capture', { output: outputOption }, ({ o
   runTaskRunner.pipe(Effect.provide(outputModeLayer(output))),
 )
 
-const cli = Command.run(logCaptureCmd, {
-  name: 'log-capture',
+const cli = Command.runWith(logCaptureCmd, {
   version: '1.0.0',
 })
 
-cli(process.argv).pipe(Effect.provide(NodeServices.layer), NodeRuntime.runMain)
+cli(process.argv.slice(2)).pipe(Effect.provide(NodeServices.layer), NodeRuntime.runMain)

--- a/packages/@overeng/tui-react/src/effect/LogCapture.ts
+++ b/packages/@overeng/tui-react/src/effect/LogCapture.ts
@@ -31,7 +31,7 @@
  */
 
 import type { Layer, Scope } from 'effect'
-import { Effect, Fiber, Inspectable, Logger, Stream, SubscriptionRef } from 'effect'
+import { Effect, Fiber, Inspectable, Logger, References, Stream, SubscriptionRef } from 'effect'
 import React, { createContext, type ReactNode } from 'react'
 
 import { useContext, useSyncExternalStore } from './hooks.tsx'
@@ -131,7 +131,9 @@ export const useCapturedLogs = (): readonly TuiLogEntry[] => {
   const subscribeActive = (onStoreChange: () => void): (() => void) => {
     if (handle === null) return () => {}
     const fiber = Effect.runFork(
-      handle.logsRef.changes.pipe(Stream.runForEach(() => Effect.sync(() => onStoreChange()))),
+      SubscriptionRef.changes(handle.logsRef).pipe(
+        Stream.runForEach(() => Effect.sync(() => onStoreChange())),
+      ),
     )
     return () => {
       void Effect.runFork(Fiber.interrupt(fiber))
@@ -186,21 +188,21 @@ export const createLogCapture = (options?: {
     }
 
     // Create Effect Logger that captures instead of printing
-    const capturingLogger = Logger.make<unknown, void>(
-      ({ logLevel, message, date, fiberId, annotations, spans }) => {
-        const spanLabel = spans._tag === 'Cons' ? spans.head.label : undefined
-        const entry: TuiLogEntry = {
-          id: ++logCaptureEntryId,
-          level: logLevel.label,
-          message: String(message),
-          timestamp: date,
-          fiberId: formatFiberId(fiberId),
-          annotations: Object.fromEntries(annotations),
-          ...(spanLabel !== undefined ? { span: spanLabel } : {}),
-        }
-        appendLogSync(entry)
-      },
-    )
+    const capturingLogger = Logger.make<unknown, void>(({ logLevel, message, date, fiber }) => {
+      const annotations = fiber.getRef(References.CurrentLogAnnotations)
+      const spans = fiber.getRef(References.CurrentLogSpans)
+      const spanLabel = spans[0]?.[0]
+      const entry: TuiLogEntry = {
+        id: ++logCaptureEntryId,
+        level: logLevel.toUpperCase(),
+        message: String(message),
+        timestamp: date,
+        fiberId: formatFiberId(fiber.id),
+        annotations: { ...annotations },
+        ...(spanLabel !== undefined ? { span: spanLabel } : {}),
+      }
+      appendLogSync(entry)
+    })
 
     const loggerLayer = Logger.layer([capturingLogger])
 

--- a/packages/@overeng/tui-react/src/effect/OpenTuiRenderer.ts
+++ b/packages/@overeng/tui-react/src/effect/OpenTuiRenderer.ts
@@ -35,7 +35,7 @@
 import type { CliRenderer, CliRendererConfig, KeyEvent } from '@opentui/core'
 import type { Root } from '@opentui/react'
 import type { Scope, SubscriptionRef } from 'effect'
-import { Effect, PubSub, Runtime } from 'effect'
+import { Effect, PubSub } from 'effect'
 import type { FC } from 'react'
 
 import type { InputEvent } from './events.ts'
@@ -242,7 +242,7 @@ export const useOpenTuiRenderer = <S>(
     // Import React for createElement
     const React = yield* Effect.promise(() => import('react'))
 
-    const runtime = yield* Effect.runtime<never>()
+    const context = yield* Effect.context<never>()
 
     // Create wrapper component that bridges events
     const WrapperComponent: FC = () => {
@@ -251,7 +251,7 @@ export const useOpenTuiRenderer = <S>(
         (key) => {
           if (eventPubSub !== undefined) {
             const event = bridgeKeyEvent(key)
-            void Runtime.runFork(runtime)(PubSub.publish(eventPubSub, event))
+            void Effect.runForkWith(context)(PubSub.publish(eventPubSub, event))
           }
         },
         { release: false },
@@ -261,7 +261,7 @@ export const useOpenTuiRenderer = <S>(
       reactLib.useOnResize((width, height) => {
         if (eventPubSub !== undefined) {
           const event = bridgeResizeEvent({ width, height })
-          void Runtime.runFork(runtime)(PubSub.publish(eventPubSub, event))
+          void Effect.runForkWith(context)(PubSub.publish(eventPubSub, event))
         }
       })
 

--- a/packages/@overeng/tui-react/src/effect/TerminalInput.ts
+++ b/packages/@overeng/tui-react/src/effect/TerminalInput.ts
@@ -26,7 +26,7 @@
 
 import type { Readable } from 'node:stream'
 
-import { Effect, PubSub, Runtime, Stream } from 'effect'
+import { Effect, PubSub, Stream } from 'effect'
 
 import { type KeyEvent, keyEvent, resizeEvent, type InputEvent } from './events.ts'
 
@@ -507,7 +507,7 @@ export const createTerminalInput = Effect.fn('TerminalInput.create')(function* (
 
   // Create event PubSub
   const pubsub = yield* PubSub.unbounded<InputEvent>()
-  const runtime = yield* Effect.runtime<never>()
+  const context = yield* Effect.context<never>()
 
   // Track if raw mode was set
   let didEnableRawMode = false
@@ -562,7 +562,7 @@ export const createTerminalInput = Effect.fn('TerminalInput.create')(function* (
         for (const event of events) {
           // Publish events synchronously and let the consuming Effect decide
           // whether Ctrl+C should interrupt the current fiber.
-          void Runtime.runFork(runtime)(PubSub.publish(pubsub, event))
+          void Effect.runForkWith(context)(PubSub.publish(pubsub, event))
         }
       }
 
@@ -578,7 +578,7 @@ export const createTerminalInput = Effect.fn('TerminalInput.create')(function* (
         resizeHandler = () => {
           const cols = output.columns ?? 80
           const rows = output.rows ?? 24
-          void Runtime.runFork(runtime)(PubSub.publish(pubsub, resizeEvent({ cols, rows })))
+          void Effect.runForkWith(context)(PubSub.publish(pubsub, resizeEvent({ cols, rows })))
         }
 
         process.on('SIGWINCH', resizeHandler)
@@ -654,7 +654,7 @@ export const createTerminalResize = Effect.fn('TerminalResize.create')(function*
 ) {
   // Create PubSub for resize events
   const pubsub = yield* PubSub.unbounded<{ cols: number; rows: number }>()
-  const runtime = yield* Effect.runtime<never>()
+  const context = yield* Effect.context<never>()
 
   // Get dimensions helper
   const getDimensions = (): { cols: number; rows: number } => ({
@@ -666,7 +666,7 @@ export const createTerminalResize = Effect.fn('TerminalResize.create')(function*
     // Set up resize handler
     const resizeHandler = () => {
       const dims = getDimensions()
-      void Runtime.runFork(runtime)(PubSub.publish(pubsub, dims))
+      void Effect.runForkWith(context)(PubSub.publish(pubsub, dims))
     }
 
     yield* Effect.acquireRelease(

--- a/packages/@overeng/tui-react/src/effect/TuiApp.tsx
+++ b/packages/@overeng/tui-react/src/effect/TuiApp.tsx
@@ -307,8 +307,8 @@ const hasInterruptedVariant = <A,>(schema: Schema.ConstraintCodec<A>): boolean =
 
   // Check each variant in the union
   return ast.types.some((type) => {
-    // We're looking for a TypeLiteral with a _tag property set to 'Interrupted'
-    if (type._tag !== 'TypeLiteral') {
+    // We're looking for an Objects node with a _tag property set to 'Interrupted'
+    if (type._tag !== 'Objects') {
       return false
     }
 
@@ -389,15 +389,13 @@ export const createTuiApp = <S, A>(config: TuiAppConfig<S, A>): TuiApp<S, A> => 
     get.set(stateAtom, newState)
   })
 
-  // Create a registry for this app
-  const registry = AtomRegistry.make()
-
   // Check once if schema has Interrupted variant
   const interruptedAction = createInterruptedAction(config.actionSchema)
   const run_ = (
     view?: ReactElement,
   ): Effect.Effect<TuiAppApi<S, A>, never, Scope.Scope | OutputModeTag> =>
     Effect.gen(function* () {
+      const registry = AtomRegistry.make()
       const mode = yield* OutputModeTag
       const { stateSchema } = config
 
@@ -879,57 +877,18 @@ export interface RunResultOptions<O> {
 
 /** Check if schema resolves to a plain string type */
 const isStringSchema = (schema: Schema.ConstraintCodec<unknown>): boolean =>
-  schema.ast._tag === 'StringKeyword'
+  schema.ast._tag === 'String'
 
 /**
  * Build an Effect `Console` service bound to a single Node `WriteStream`.
  *
  * Used by `runResult` to route handler-emitted `Effect.Console.log`/`.info`/
  * `.warn`/… to stderr so they don't contaminate the stdout result channel.
- * Wraps Node's built-in `console.Console` (which already understands the full
- * Console surface) and promotes each method into an `Effect`.
+ * Wraps Node's built-in `console.Console`, which implements the full Effect 4
+ * Console service surface.
  */
-const consoleOnStream = (stream: NodeJS.WriteStream): Console.Console => {
-  const raw = new NodeConsole({ stdout: stream, stderr: stream })
-  // Brand the object with the Console `TypeId` so `Console.setConsole`
-  // accepts it. The symbol is keyed as `effect/Console` via `Symbol.for`.
-  const TypeId = Symbol.for('effect/Console')
-  const service = {
-    [TypeId]: TypeId,
-    assert: (condition: boolean, ...args: ReadonlyArray<any>) =>
-      Effect.sync(() => raw.assert(condition, ...args)),
-    clear: Effect.sync(() => raw.clear()),
-    count: (label?: string) => Effect.sync(() => raw.count(label)),
-    countReset: (label?: string) => Effect.sync(() => raw.countReset(label)),
-    debug: (...args: ReadonlyArray<any>) => Effect.sync(() => raw.debug(...args)),
-    // oxlint-disable-next-line overeng/named-args -- matches effect Console.Console interface
-    dir: (item: any, options?: any) => Effect.sync(() => raw.dir(item, options)),
-    dirxml: (...args: ReadonlyArray<any>) => Effect.sync(() => raw.dirxml(...args)),
-    error: (...args: ReadonlyArray<any>) => Effect.sync(() => raw.error(...args)),
-    group: (options?: { label?: string; collapsed?: boolean }) =>
-      Effect.sync(() =>
-        options?.collapsed === true
-          ? raw.groupCollapsed(options?.label)
-          : raw.group(options?.label),
-      ),
-    groupEnd: Effect.sync(() => raw.groupEnd()),
-    info: (...args: ReadonlyArray<any>) => Effect.sync(() => raw.info(...args)),
-    log: (...args: ReadonlyArray<any>) => Effect.sync(() => raw.log(...args)),
-    // oxlint-disable-next-line overeng/named-args -- matches effect Console.Console interface
-    table: (tabularData: any, properties?: ReadonlyArray<string>) =>
-      Effect.sync(() =>
-        raw.table(tabularData, properties === undefined ? undefined : [...properties]),
-      ),
-    time: (label?: string) => Effect.sync(() => raw.time(label)),
-    timeEnd: (label?: string) => Effect.sync(() => raw.timeEnd(label)),
-    timeLog: (label?: string, ...args: ReadonlyArray<any>) =>
-      Effect.sync(() => raw.timeLog(label, ...args)),
-    trace: (...args: ReadonlyArray<any>) => Effect.sync(() => raw.trace(...args)),
-    warn: (...args: ReadonlyArray<any>) => Effect.sync(() => raw.warn(...args)),
-    unsafe: raw,
-  }
-  return service as unknown as Console.Console
-}
+const consoleOnStream = (stream: NodeJS.WriteStream): Console.Console =>
+  new NodeConsole({ stdout: stream, stderr: stream }) as unknown as Console.Console
 
 /** Write a value to stdout using the appropriate format for its schema type.
  *  Strings are written raw (no JSON encoding). Structured types are JSON-encoded.
@@ -997,7 +956,7 @@ const runResultImpl = <S, A, O, E, R>(
     const stderrSideChannelLayer = Layer.mergeAll(
       Layer.succeed(ViewOutputStreamTag, process.stderr),
       Logger.layer([Logger.consolePretty().pipe(Logger.withConsoleError)]),
-      Console.setConsole(consoleOnStream(process.stderr)),
+      Layer.succeed(Console.Console, consoleOnStream(process.stderr)),
     )
 
     const innerEffect =

--- a/packages/@overeng/tui-react/src/effect/TuiLogger.ts
+++ b/packages/@overeng/tui-react/src/effect/TuiLogger.ts
@@ -36,6 +36,7 @@ import {
   Layer,
   Logger,
   LogLevel,
+  References,
   Stream,
   SubscriptionRef,
   Fiber,
@@ -83,7 +84,7 @@ export interface TuiLoggerOptions {
   /**
    * Minimum log level to capture.
    * Logs below this level are not captured.
-   * @default LogLevel.All
+   * @default "All"
    */
   minLevel?: LogLevel.LogLevel
 
@@ -147,7 +148,7 @@ export const createTuiLogger = (
   options: TuiLoggerOptions = {},
 ): Effect.Effect<TuiLoggerResult, never, Scope.Scope> =>
   Effect.gen(function* () {
-    const { maxEntries = 100, minLevel = LogLevel.All, logToConsole = true } = options
+    const { maxEntries = 100, minLevel = 'All', logToConsole = true } = options
 
     // Create the logs SubscriptionRef
     const logsRef = yield* SubscriptionRef.make<readonly TuiLogEntry[]>([])
@@ -160,35 +161,38 @@ export const createTuiLogger = (
         return newLogs.length > maxEntries ? newLogs.slice(-maxEntries) : newLogs
       })
     // Create the TUI logger
-    const tuiLogger = Logger.make<unknown, void>(
-      ({ logLevel, message, date, fiberId, annotations, spans }) => {
-        // Check minimum level
-        if (LogLevel.greaterThanEqual(logLevel, minLevel) === true) {
-          const spanLabel = spans._tag === 'Cons' ? spans.head.label : undefined
-          const entry: TuiLogEntry = {
-            id: ++logEntryId,
-            level: logLevel.label,
-            message: String(message),
-            timestamp: date,
-            fiberId: formatFiberId(fiberId),
-            annotations: Object.fromEntries(annotations),
-            ...(spanLabel !== undefined ? { span: spanLabel } : {}),
-          }
-
-          // Fire and forget - we don't want logging to block
-          void Effect.runFork(appendLog(entry))
+    const tuiLogger = Logger.make<unknown, void>(({ logLevel, message, date, fiber }) => {
+      // Check minimum level
+      if (LogLevel.isGreaterThanOrEqualTo(logLevel, minLevel) === true) {
+        const annotations = fiber.getRef(References.CurrentLogAnnotations)
+        const spans = fiber.getRef(References.CurrentLogSpans)
+        const spanLabel = spans[0]?.[0]
+        const entry: TuiLogEntry = {
+          id: ++logEntryId,
+          level: logLevel.toUpperCase(),
+          message: String(message),
+          timestamp: date,
+          fiberId: formatFiberId(fiber.id),
+          annotations: { ...annotations },
+          ...(spanLabel !== undefined ? { span: spanLabel } : {}),
         }
-      },
-    )
+
+        // Fire and forget - we don't want logging to block
+        void Effect.runFork(appendLog(entry))
+      }
+    })
 
     // Create the layer - either TUI only or combined with console
     const layer =
       logToConsole === true
         ? Layer.merge(
             Logger.layer([Logger.defaultLogger, tuiLogger]),
-            Logger.minimumLogLevel(minLevel),
+            Layer.succeed(References.MinimumLogLevel, minLevel),
           )
-        : Layer.merge(Logger.layer([tuiLogger]), Logger.minimumLogLevel(minLevel))
+        : Layer.merge(
+            Logger.layer([tuiLogger]),
+            Layer.succeed(References.MinimumLogLevel, minLevel),
+          )
 
     // Clear function
     const clear = SubscriptionRef.set(logsRef, [])
@@ -246,7 +250,7 @@ export const useTuiLogs = (
   // Subscribe to changes
   const subscribe = (onStoreChange: () => void): (() => void) => {
     const fiber = Effect.runFork(
-      logsRef.changes.pipe(
+      SubscriptionRef.changes(logsRef).pipe(
         Stream.runForEach(() =>
           Effect.sync(() => {
             onStoreChange()

--- a/packages/@overeng/tui-react/src/effect/cli.tsx
+++ b/packages/@overeng/tui-react/src/effect/cli.tsx
@@ -6,7 +6,7 @@
  *
  * @example
  * ```typescript
- * import { Command, Options } from "@effect/cli"
+ * import { Command, Flag as Options } from "effect/unstable/cli"
  * import { Effect } from "effect"
  * import { outputOption, outputModeLayer } from "@overeng/tui-react"
  *
@@ -224,8 +224,8 @@ export interface RunTuiMainOptions {
    * @example Suppress errors already represented in JSON output:
    * ```typescript
    * formatError: (cause) =>
-   *   Cause.failures(cause).pipe(chunk =>
-   *     [...chunk].some(e => e._tag === 'SyncFailedError')
+   *   cause.reasons.some(
+   *     reason => Cause.isFailReason(reason) && reason.error._tag === 'SyncFailedError'
    *   ) ? Option.none()
    *     : defaultFormatError(cause)
    * ```
@@ -235,16 +235,16 @@ export interface RunTuiMainOptions {
 
 /** Verbose error formatter — full stack traces via `Cause.pretty`. This is the default. */
 export const defaultFormatError = (cause: Cause.Cause<unknown>): Option.Option<string> =>
-  Option.some(Cause.pretty(cause, { renderErrorCause: true }))
+  Option.some(Cause.pretty(cause))
 
 /** Compact error formatter — just error messages, no stack traces. For machine/agent output. */
 export const compactFormatError = (cause: Cause.Cause<unknown>): Option.Option<string> => {
   const messages: string[] = []
-  for (const failure of Cause.failures(cause)) {
-    messages.push(failure instanceof Error ? failure.message : String(failure))
+  for (const reason of cause.reasons.filter(Cause.isFailReason)) {
+    messages.push(reason.error instanceof Error ? reason.error.message : String(reason.error))
   }
-  for (const defect of Cause.defects(cause)) {
-    messages.push(defect instanceof Error ? defect.message : String(defect))
+  for (const reason of cause.reasons.filter(Cause.isDieReason)) {
+    messages.push(reason.defect instanceof Error ? reason.defect.message : String(reason.defect))
   }
   return messages.length > 0 ? Option.some(messages.join('\n')) : Option.none()
 }
@@ -262,7 +262,7 @@ export interface TuiRuntime {
 
 /**
  * Custom finalization so a signal-interrupted CLI (Ctrl-C) exits 130 — the shell
- * convention — instead of the default teardown's hardcoded 0. The `catchAllCause`
+ * convention — instead of the default teardown's hardcoded 0. The `catchCause`
  * in {@link runTuiMainImpl} catches the interrupt, suppresses the stack, sets
  * `process.exitCode = 130`, and completes the fiber as a Success, so the
  * interrupt surfaces here only via `process.exitCode` — which we honor instead
@@ -291,7 +291,7 @@ const tuiTeardown = <E, A>(exit: Exit.Exit<E, A>, onExit: (code: number) => void
  * @example
  * ```typescript
  * // Pipeable usage (recommended):
- * Cli.Command.run(myCommand, { name: 'my-cli', version })(process.argv).pipe(
+ * Cli.Command.runWith(myCommand, { version })(process.argv.slice(2)).pipe(
  *   Effect.scoped,
  *   Effect.provide(baseLayer),
  *   runTuiMain(NodeRuntime)
@@ -307,7 +307,7 @@ const tuiTeardown = <E, A>(exit: Exit.Exit<E, A>, onExit: (code: number) => void
  * @example
  * ```typescript
  * // With compact errors (for agent-friendly CLIs):
- * Cli.Command.run(myCommand, { name: 'my-cli', version })(process.argv).pipe(
+ * Cli.Command.runWith(myCommand, { version })(process.argv.slice(2)).pipe(
  *   Effect.scoped,
  *   Effect.provide(baseLayer),
  *   runTuiMain(NodeRuntime, { formatError: compactFormatError })

--- a/packages/@overeng/tui-react/src/effect/events.ts
+++ b/packages/@overeng/tui-react/src/effect/events.ts
@@ -114,7 +114,7 @@ export type KeyEvent = Schema.Schema.Type<typeof KeyEvent>
 /**
  * Encoded type for KeyEvent (for JSON)
  */
-export type KeyEventEncoded = Schema.Schema.Encoded<typeof KeyEvent>
+export type KeyEventEncoded = Schema.Codec.Encoded<typeof KeyEvent>
 
 // =============================================================================
 // Resize Event
@@ -154,7 +154,7 @@ export type ResizeEvent = Schema.Schema.Type<typeof ResizeEvent>
 /**
  * Encoded type for ResizeEvent (for JSON)
  */
-export type ResizeEventEncoded = Schema.Schema.Encoded<typeof ResizeEvent>
+export type ResizeEventEncoded = Schema.Codec.Encoded<typeof ResizeEvent>
 
 // =============================================================================
 // Focus Event
@@ -187,7 +187,7 @@ export type FocusEvent = Schema.Schema.Type<typeof FocusEvent>
 /**
  * Encoded type for FocusEvent (for JSON)
  */
-export type FocusEventEncoded = Schema.Schema.Encoded<typeof FocusEvent>
+export type FocusEventEncoded = Schema.Codec.Encoded<typeof FocusEvent>
 
 // =============================================================================
 // Mouse Event (for future use)
@@ -274,7 +274,7 @@ export type MouseEvent = Schema.Schema.Type<typeof MouseEvent>
 /**
  * Encoded type for MouseEvent (for JSON)
  */
-export type MouseEventEncoded = Schema.Schema.Encoded<typeof MouseEvent>
+export type MouseEventEncoded = Schema.Codec.Encoded<typeof MouseEvent>
 
 // =============================================================================
 // Input Event Union
@@ -312,7 +312,7 @@ export type InputEvent = Schema.Schema.Type<typeof InputEvent>
 /**
  * Encoded type for InputEvent (for JSON)
  */
-export type InputEventEncoded = Schema.Schema.Encoded<typeof InputEvent>
+export type InputEventEncoded = Schema.Codec.Encoded<typeof InputEvent>
 
 // =============================================================================
 // Helper Functions

--- a/packages/@overeng/tui-react/src/effect/opentui/hooks.tsx
+++ b/packages/@overeng/tui-react/src/effect/opentui/hooks.tsx
@@ -59,7 +59,7 @@ export const useOState = <S,>(ref: SubscriptionRef.SubscriptionRef<S>): S => {
   useEffect(() => {
     // Subscribe to changes
     const fiber = Effect.runFork(
-      ref.changes.pipe(Stream.runForEach((s) => Effect.sync(() => setState(s)))),
+      SubscriptionRef.changes(ref).pipe(Stream.runForEach((s) => Effect.sync(() => setState(s)))),
     )
 
     return () => {

--- a/packages/@overeng/tui-react/src/effect/testing.tsx
+++ b/packages/@overeng/tui-react/src/effect/testing.tsx
@@ -20,7 +20,7 @@
  */
 
 import type { Scope } from 'effect'
-import { Effect, type Exit, Layer, PubSub, Runtime, Schema, Stream } from 'effect'
+import { Console, Effect, Exit, Layer, PubSub, Schema, Stream } from 'effect'
 import { Atom, AtomRegistry } from 'effect/unstable/reactivity'
 
 import {
@@ -53,7 +53,7 @@ export interface RunTestCommandOptions<S, Args> {
   /** Output mode preset to use */
   mode: TestModePreset
   /** Schema for parsing and validating JSON output */
-  schema: Schema.Schema<S>
+  schema: Schema.ConstraintCodec<S>
 }
 
 /**
@@ -108,7 +108,10 @@ export const modeFromTag = (preset: TestModePreset): OutputMode => {
  * Create a layer for a specific output mode.
  */
 export const testModeLayer = (preset: TestModePreset): Layer.Layer<OutputModeTag> =>
-  Layer.succeed(OutputModeTag, modeFromTag(preset))
+  Layer.mergeAll(
+    Layer.succeed(OutputModeTag, modeFromTag(preset)),
+    Layer.succeed(Console.Console, globalThis.console),
+  )
 
 /**
  * Run a command function with test utilities.
@@ -155,8 +158,8 @@ export const runTestCommand = async <S, Args, E>({
   const jsonSchema = Schema.fromJsonString(options.schema)
   const parsedStates = jsonOutput
     .map((line) => {
-      const result = Schema.decodeUnknownEither(jsonSchema)(line)
-      return result._tag === 'Right' ? result.right : null
+      const result = Schema.decodeUnknownExit(jsonSchema)(line)
+      return Exit.isSuccess(result) === true ? result.value : null
     })
     .filter((s): s is S => s !== null)
 
@@ -217,7 +220,7 @@ export const createTestTuiState = <S, A>(
     const registry = AtomRegistry.make()
 
     const actionPubSub = yield* PubSub.unbounded<A>()
-    const runtime = yield* Effect.runtime<never>()
+    const context = yield* Effect.context<never>()
 
     // Create sync dispatch function that captures states and actions directly
     const dispatch = (action: A): void => {
@@ -229,7 +232,7 @@ export const createTestTuiState = <S, A>(
       // Capture the action
       actions.push(action)
       // Also publish to PubSub for the actions stream
-      void Runtime.runFork(runtime)(PubSub.publish(actionPubSub, action))
+      void Effect.runForkWith(context)(PubSub.publish(actionPubSub, action))
     }
 
     const api: TuiAppApi<S, A> = {
@@ -312,7 +315,7 @@ export const assertJsonMatchesSchema = <S, I>({
   schema,
 }: {
   jsonString: string
-  schema: Schema.Schema<S, I>
+  schema: Schema.ConstraintCodec<S, I>
 }): S => {
   return Schema.decodeSync(Schema.fromJsonString(schema))(jsonString)
 }

--- a/packages/@overeng/tui-react/src/storybook/TuiStoryPreview.tsx
+++ b/packages/@overeng/tui-react/src/storybook/TuiStoryPreview.tsx
@@ -37,11 +37,11 @@
 // oxlint-disable-next-line typescript-eslint(triple-slash-reference) -- intentional: an ambient-only .d.ts cannot be an ES import
 /// <reference path="./asset-modules.d.ts" />
 
-import { Atom, AtomRegistry } from 'effect/unstable/reactivity'
 import { FitAddon } from '@xterm/addon-fit'
 import { WebglAddon } from '@xterm/addon-webgl'
 import { Terminal } from '@xterm/xterm'
 import { Schema } from 'effect'
+import { Atom, AtomRegistry } from 'effect/unstable/reactivity'
 // oxlint-disable-next-line eslint-plugin-import(no-unassigned-import) -- deliberate bundler stylesheet
 import '@xterm/xterm/css/xterm.css'
 import React, { useEffect, useRef, useState, useCallback, useMemo } from 'react'
@@ -82,8 +82,8 @@ export interface TuiStoryPreviewProps<S, A> {
   /** A TuiApp instance (or any object with a compatible config) */
   app: {
     config: {
-      stateSchema: Schema.Schema<S>
-      actionSchema: Schema.Schema<A>
+      stateSchema: Schema.ConstraintCodec<S>
+      actionSchema: Schema.ConstraintCodec<A>
       initial: S
       reducer: (args: { state: S; action: A }) => S
     }

--- a/packages/@overeng/tui-react/test/unit/LogCapture.test.tsx
+++ b/packages/@overeng/tui-react/test/unit/LogCapture.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import { it } from '@effect/vitest'
-import { Chunk, Effect, Fiber, Stream } from 'effect'
+import { Effect, Fiber, Stream, SubscriptionRef } from 'effect'
 import { describe, expect, beforeEach, afterEach } from 'vitest'
 
 import { createLogCapture } from '../../src/effect/LogCapture.ts'
@@ -20,11 +20,11 @@ const awaitLogs = (
   handle: LogCaptureHandle,
   predicate: (logs: readonly TuiLogEntry[]) => boolean,
 ): Effect.Effect<readonly TuiLogEntry[]> =>
-  handle.logsRef.changes.pipe(
+  SubscriptionRef.changes(handle.logsRef).pipe(
     Stream.filter(predicate),
     Stream.take(1),
     Stream.runCollect,
-    Effect.map((chunk) => Chunk.unsafeGet(chunk, 0)),
+    Effect.map((items) => items[0]!),
   )
 
 // =============================================================================
@@ -59,7 +59,7 @@ describe('createLogCapture', () => {
     Effect.gen(function* () {
       const { handle, loggerLayer } = yield* createLogCapture()
 
-      const fiber = yield* Effect.fork(awaitLogs(handle, (logs) => logs.length >= 1))
+      const fiber = yield* Effect.forkChild(awaitLogs(handle, (logs) => logs.length >= 1))
 
       yield* Effect.log('hello from effect').pipe(Effect.provide(loggerLayer))
 
@@ -74,7 +74,7 @@ describe('createLogCapture', () => {
     Effect.gen(function* () {
       const { handle } = yield* createLogCapture()
 
-      const fiber = yield* Effect.fork(
+      const fiber = yield* Effect.forkChild(
         awaitLogs(handle, (logs) => logs.some((l) => l.message === 'hello from console')),
       )
 
@@ -89,7 +89,7 @@ describe('createLogCapture', () => {
     Effect.gen(function* () {
       const { handle } = yield* createLogCapture()
 
-      const fiber = yield* Effect.fork(
+      const fiber = yield* Effect.forkChild(
         awaitLogs(handle, (logs) => logs.some((l) => l.message === 'error message')),
       )
 
@@ -106,7 +106,7 @@ describe('createLogCapture', () => {
     Effect.gen(function* () {
       const { handle } = yield* createLogCapture()
 
-      const fiber = yield* Effect.fork(
+      const fiber = yield* Effect.forkChild(
         awaitLogs(handle, (logs) => logs.some((l) => l.message === 'warning message')),
       )
 
@@ -123,7 +123,7 @@ describe('createLogCapture', () => {
     Effect.gen(function* () {
       const { handle } = yield* createLogCapture()
 
-      const fiber = yield* Effect.fork(
+      const fiber = yield* Effect.forkChild(
         awaitLogs(
           handle,
           (logs) =>
@@ -160,7 +160,7 @@ describe('createLogCapture', () => {
     Effect.gen(function* () {
       const { handle } = yield* createLogCapture({ maxEntries: 3 })
 
-      const fiber = yield* Effect.fork(
+      const fiber = yield* Effect.forkChild(
         awaitLogs(handle, (logs) => logs.some((l) => l.message === 'five')),
       )
 
@@ -191,7 +191,7 @@ describe('createLogCapture', () => {
         capturedConsoleLog(...args)
       }
 
-      const fiber = yield* Effect.fork(
+      const fiber = yield* Effect.forkChild(
         awaitLogs(handle, (logs) => logs.some((l) => l.message === 'should not print')),
       )
 
@@ -199,7 +199,7 @@ describe('createLogCapture', () => {
       yield* Fiber.join(fiber)
     }).pipe(
       Effect.scoped,
-      Effect.andThen(() => {
+      Effect.map(() => {
         // The Effect.log message should not appear as direct stdout output
         expect(printed.filter((p) => p.includes('should not print'))).toHaveLength(0)
       }),
@@ -247,7 +247,7 @@ describe('log capture integration', () => {
     }).pipe(
       Effect.scoped,
       Effect.provide(testModeLayer('json')),
-      Effect.andThen(() => {
+      Effect.map(() => {
         // JSON mode should still output to console.log (our captured output)
         expect(capturedOutput).toHaveLength(1)
         const state = JSON.parse(capturedOutput[0]!)

--- a/packages/@overeng/tui-react/test/unit/TuiApp.test.tsx
+++ b/packages/@overeng/tui-react/test/unit/TuiApp.test.tsx
@@ -10,7 +10,7 @@ import { describe, expect, beforeEach, afterEach, test } from 'vitest'
 import { testModeLayer } from '../../src/effect/testing.tsx'
 import { createTuiApp, run, runResult, useTuiAtomValue, Box, Text } from '../../src/mod.tsx'
 
-const decodeJson = <A, I>(schema: Schema.Schema<A, I, never>, json: string): A =>
+const decodeJson = <A, I>(schema: Schema.ConstraintCodec<A, I>, json: string): A =>
   Schema.decodeSync(Schema.fromJsonString(schema))(json)
 
 // =============================================================================
@@ -132,7 +132,7 @@ describe('createTuiApp', () => {
       }).pipe(
         Effect.scoped,
         Effect.provide(testModeLayer('json')),
-        Effect.andThen(() => {
+        Effect.map(() => {
           expect(capturedOutput).toHaveLength(1)
           const state = decodeJson(CounterState, capturedOutput[0]!)
           expect(state).toEqual({ count: 2 })
@@ -147,7 +147,7 @@ describe('createTuiApp', () => {
       }).pipe(
         Effect.scoped,
         Effect.provide(testModeLayer('json')),
-        Effect.andThen(() => {
+        Effect.map(() => {
           expect(capturedOutput).toHaveLength(1)
           const state = decodeJson(CounterState, capturedOutput[0]!)
           expect(state).toEqual({ count: 100 })
@@ -168,7 +168,7 @@ describe('createTuiApp', () => {
       }).pipe(
         Effect.scoped,
         Effect.provide(testModeLayer('ndjson')),
-        Effect.andThen(() => {
+        Effect.map(() => {
           // Initial snapshot + one line per state change. No trailing envelope.
           expect(capturedOutput.length).toBeGreaterThanOrEqual(2)
 
@@ -222,7 +222,7 @@ describe('createTuiApp', () => {
       }).pipe(
         Effect.scoped,
         Effect.provide(testModeLayer('ndjson')),
-        Effect.andThen(() => {
+        Effect.map(() => {
           // Line 1: initial full state snapshot
           const initialState = decodeJson(CounterState, capturedOutput[0]!)
           expect(initialState).toEqual({ count: 0 })
@@ -260,7 +260,7 @@ describe('createTuiApp', () => {
       }).pipe(
         Effect.scoped,
         Effect.provide(testModeLayer('ndjson')),
-        Effect.andThen(() => {
+        Effect.map(() => {
           // Only initial state snapshot — no intermediate events, no envelope.
           expect(capturedOutput).toHaveLength(1)
           expect(decodeJson(CounterState, capturedOutput[0]!)).toEqual({ count: 0 })
@@ -294,7 +294,7 @@ describe('createTuiApp', () => {
       }).pipe(
         Effect.scoped,
         Effect.provide(testModeLayer('ndjson')),
-        Effect.andThen(() => {
+        Effect.map(() => {
           // Initial + 2 events from 1 action. No trailing envelope.
           expect(capturedOutput).toHaveLength(3)
           expect(decodeJson(CounterEvent, capturedOutput[1]!)).toEqual({
@@ -408,7 +408,7 @@ describe('createTuiApp', () => {
 
         expect(Exit.isFailure(exit)).toBe(true)
         if (Exit.isFailure(exit) === true) {
-          expect(Cause.isInterruptedOnly(exit.cause)).toBe(true)
+          expect(Cause.hasInterruptsOnly(exit.cause)).toBe(true)
         }
         expect(reducedStatuses).toContain('running')
         expect(reducedStatuses).toContain('interrupted')
@@ -486,7 +486,7 @@ describe('Issue #129: typed errors do not mask final state', () => {
       }),
     ).pipe(
       Effect.provide(testModeLayer('json')),
-      Effect.catchAllCause((cause) =>
+      Effect.catchCause((cause) =>
         Effect.sync(() => {
           // Flat contract: stdout gets the final raw state, no envelope.
           // Exit code signals failure; the error details live in `cause` and
@@ -497,7 +497,7 @@ describe('Issue #129: typed errors do not mask final state', () => {
           expect(state._tag).toBeUndefined()
 
           // Typed error still propagates via the Effect channel.
-          const failures = [...Cause.failures(cause)]
+          const failures = cause.reasons.filter(Cause.isFailReason).map((reason) => reason.error)
           expect(failures.some((e) => e instanceof GenerationFailed)).toBe(true)
         }),
       ),
@@ -517,7 +517,7 @@ describe('Issue #129: typed errors do not mask final state', () => {
       }),
     ).pipe(
       Effect.provide(testModeLayer('ndjson')),
-      Effect.catchAllCause((cause) =>
+      Effect.catchCause((cause) =>
         Effect.sync(() => {
           // Every state change before the error is on stdout as raw JSON.
           // No trailing Failure envelope — exit code + stderr carry error info.
@@ -526,7 +526,7 @@ describe('Issue #129: typed errors do not mask final state', () => {
           expect(states.every((s) => s._tag !== 'Failure')).toBe(true)
 
           // Typed error still propagates via the Effect channel.
-          const failures = [...Cause.failures(cause)]
+          const failures = cause.reasons.filter(Cause.isFailReason).map((reason) => reason.error)
           expect(failures.some((e) => e instanceof GenerationFailed)).toBe(true)
         }),
       ),
@@ -598,7 +598,7 @@ describe('run (standalone dual API)', () => {
   it.effect('typed errors are propagated via Effect channel', () =>
     run(CounterApp, () => new TestError({ message: 'test error' })).pipe(
       Effect.provide(testModeLayer('log')),
-      Effect.catchAll((error) =>
+      Effect.catch((error) =>
         Effect.sync(() => {
           expect(error).toBeInstanceOf(TestError)
           expect(error.message).toBe('test error')
@@ -623,7 +623,7 @@ describe('run (standalone dual API)', () => {
       }),
     ).pipe(
       Effect.provide(testModeLayer('json')),
-      Effect.andThen(() => {
+      Effect.map(() => {
         expect(capturedOutput).toHaveLength(1)
         const state = JSON.parse(capturedOutput[0]!)
         expect(state).toEqual({ count: 77 })
@@ -694,7 +694,7 @@ describe('runResult', () => {
         { result: Schema.String },
       ).pipe(
         Effect.provide(testModeLayer('json')),
-        Effect.andThen((result) => {
+        Effect.map((result) => {
           expect(result).toBe('my-secret-value')
           const stdout = capturedStdout.join('')
           expect(stdout).toBe('my-secret-value\n')
@@ -714,7 +714,7 @@ describe('runResult', () => {
         { result: Schema.String },
       ).pipe(
         Effect.provide(testModeLayer('json')),
-        Effect.andThen(() => {
+        Effect.map(() => {
           const allOutput = capturedStdout.join('') + capturedConsole.join('')
           expect(allOutput).not.toContain('Success')
           expect(allOutput).not.toContain('Failure')
@@ -734,7 +734,7 @@ describe('runResult', () => {
         { result: Schema.String, view: <CounterView /> },
       ).pipe(
         Effect.provide(testModeLayer('log')),
-        Effect.andThen((result) => {
+        Effect.map((result) => {
           expect(result).toBe('the-secret')
           // stdout is byte-for-byte the result (plus a trailing newline).
           const stdout = capturedStdout.join('')
@@ -759,7 +759,7 @@ describe('runResult', () => {
         { result: Schema.String, view: <CounterView /> },
       ).pipe(
         Effect.provide(testModeLayer('tty')),
-        Effect.andThen((result) => {
+        Effect.map((result) => {
           expect(result).toBe('tty-secret')
           const stdout = capturedStdout.join('')
           expect(stdout).toBe('tty-secret\n')
@@ -786,7 +786,7 @@ describe('runResult', () => {
         { result: ResultSchema },
       ).pipe(
         Effect.provide(testModeLayer('json')),
-        Effect.andThen((result) => {
+        Effect.map((result) => {
           expect(result).toEqual({ items: ['a', 'b', 'c'], total: 3 })
           // `runResult` writes structured results directly via process.stdout
           // (not Effect.Console) so handler-emitted logs can be routed to
@@ -814,7 +814,7 @@ describe('runResult', () => {
         { result: Schema.String, view: <CounterView /> },
       ).pipe(
         Effect.provide(testModeLayer('log')),
-        Effect.andThen((result) => {
+        Effect.map((result) => {
           expect(result).toBe('the-clean-payload')
           // stdout must be byte-clean: only the result + trailing newline.
           const stdout = capturedStdout.join('')
@@ -833,7 +833,7 @@ describe('runResult', () => {
       () =>
         runResult(CounterApp, () => Effect.succeed('value'), { result: Schema.String }).pipe(
           Effect.provide(testModeLayer('ndjson')),
-          Effect.catchAllDefect((defect) =>
+          Effect.catchDefect((defect) =>
             Effect.sync(() => {
               expect(defect).toBeInstanceOf(Error)
               expect((defect as Error).message).toContain('runResult does not support ndjson')
@@ -853,7 +853,7 @@ describe('runResult', () => {
         result: Schema.String,
       }).pipe(
         Effect.provide(testModeLayer('json')),
-        Effect.catchAll((error) =>
+        Effect.catch((error) =>
           Effect.sync(() => {
             expect(error).toBeInstanceOf(ReadError)
             expect(error.message).toBe('access denied')

--- a/packages/@overeng/tui-react/test/unit/exit-rendering.test.tsx
+++ b/packages/@overeng/tui-react/test/unit/exit-rendering.test.tsx
@@ -10,7 +10,7 @@
  */
 
 import { it } from '@effect/vitest'
-import { Effect, Schema } from 'effect'
+import { Effect, Fiber, Schema } from 'effect'
 import React from 'react'
 import { describe, test, expect, beforeEach, afterEach } from 'vitest'
 
@@ -38,9 +38,9 @@ const TestActionWithInterrupt = Schema.Union([
 type TestActionWithInterrupt = Schema.Schema.Type<typeof TestActionWithInterrupt>
 
 // Action schema WITHOUT Interrupted variant
-const TestActionNoInterrupt = Schema.Union(
+const TestActionNoInterrupt = Schema.Union([
   Schema.TaggedStruct('SetValue', { value: Schema.String }),
-)
+])
 
 type TestActionNoInterrupt = Schema.Schema.Type<typeof TestActionNoInterrupt>
 
@@ -91,7 +91,7 @@ const AppNoInterrupt = createTuiApp({
 })
 
 const WireState = Schema.TaggedStruct('WireState', {
-  phase: Schema.Literal('idle', 'done'),
+  phase: Schema.Literals(['idle', 'done']),
   text: Schema.String,
   nullable: Schema.NullOr(Schema.String),
   note: Schema.optional(Schema.String),
@@ -105,18 +105,18 @@ const WireState = Schema.TaggedStruct('WireState', {
 
 type WireState = typeof WireState.Type
 
-const WireAction = Schema.Union(Schema.TaggedStruct('SetWireState', { next: WireState }))
+const WireAction = Schema.Union([Schema.TaggedStruct('SetWireState', { next: WireState })])
 type WireAction = typeof WireAction.Type
 
 const WireEvent = Schema.TaggedStruct('WireEvent', {
-  from: Schema.Literal('idle', 'done'),
-  to: Schema.Literal('idle', 'done'),
+  from: Schema.Literals(['idle', 'done']),
+  to: Schema.Literals(['idle', 'done']),
   text: Schema.String,
 })
 
 const FailurePartitionWire = Schema.fromJsonString(
   Schema.Struct({
-    _tag: Schema.Literal('Failure', 'Success'),
+    _tag: Schema.Literals(['Failure', 'Success']),
     cause: Schema.NullOr(Schema.String),
   }),
 )
@@ -330,7 +330,7 @@ describe('Interrupt Handling', () => {
       }).pipe(
         Effect.scoped,
         Effect.provide(testModeLayer('log')),
-        Effect.andThen(() => {
+        Effect.map(() => {
           // After scope closes, Interrupted should have been dispatched
           // The finalizer dispatches Interrupted, so the last state should have interrupted: true
           // Note: We need to check the final state after the effect completes
@@ -352,7 +352,7 @@ describe('Interrupt Handling', () => {
       }).pipe(
         Effect.scoped,
         Effect.provide(testModeLayer('log')),
-        Effect.andThen(() => {
+        Effect.map(() => {
           // Should not have interrupted state since schema doesn't have Interrupted
           expect(states.every((s) => s.interrupted === false)).toBe(true)
         }),
@@ -425,7 +425,7 @@ describe('Final state output', () => {
     }).pipe(
       Effect.scoped,
       Effect.provide(testModeLayer('json')),
-      Effect.andThen(() => {
+      Effect.map(() => {
         expect(capturedOutput).toHaveLength(1)
         const state = JSON.parse(capturedOutput[0]!)
         // Flat contract: stdout is raw state, no envelope.
@@ -444,8 +444,8 @@ describe('Final state output', () => {
     }).pipe(
       Effect.scoped,
       Effect.provide(testModeLayer('json')),
-      Effect.catchAllDefect((defect) => Effect.succeed({ caught: defect })),
-      Effect.andThen((result) => {
+      Effect.catchDefect((defect) => Effect.succeed({ caught: defect })),
+      Effect.map((result) => {
         expect(result).toHaveProperty('caught')
         // State captured at time of failure is still emitted (no envelope).
         expect(capturedOutput).toHaveLength(1)
@@ -472,15 +472,15 @@ describe('Final state output', () => {
       const fiber = yield* Effect.gen(function* () {
         const tui = yield* InterruptTestApp.run()
         tui.dispatch({ _tag: 'SetValue', value: 'before interrupt' })
-        yield* Effect.yieldNow()
+        yield* Effect.yieldNow
         return yield* Effect.never
-      }).pipe(Effect.scoped, Effect.provide(testModeLayer('json')), Effect.fork)
+      }).pipe(Effect.scoped, Effect.provide(testModeLayer('json')), Effect.forkChild)
 
       yield* Effect.sleep('50 millis')
-      yield* fiber.interruptAsFork(fiber.id())
-      const _ = yield* fiber.await
+      yield* Fiber.interruptAs(fiber, fiber.id)
+      const _ = yield* Fiber.await(fiber)
     }).pipe(
-      Effect.andThen(() => {
+      Effect.map(() => {
         // Interrupt still emits the final state (no envelope). The interrupt
         // signal itself rides the Effect channel, not stdout.
         expect(capturedOutput).toHaveLength(1)
@@ -517,7 +517,7 @@ describe('tui-react JSON/NDJSON wire baselines (cross-major invariant)', () => {
     }).pipe(
       Effect.scoped,
       Effect.provide(testModeLayer('json')),
-      Effect.andThen(() => {
+      Effect.map(() => {
         expect(capturedOutput).toMatchInlineSnapshot(`
           [
             "{"_tag":"WireState","phase":"done","text":"Line 1\\r\\nLine 2 世界 NaN 2026-02-31","nullable":null,"note":"","items":[{"id":"α","value":""},{"id":"big","value":"9007199254740991"}]}",
@@ -536,7 +536,7 @@ describe('tui-react JSON/NDJSON wire baselines (cross-major invariant)', () => {
     }).pipe(
       Effect.scoped,
       Effect.provide(testModeLayer('ndjson')),
-      Effect.andThen(() => {
+      Effect.map(() => {
         expect(capturedOutput.join('\n')).toMatchInlineSnapshot(`
           "{"_tag":"WireState","phase":"idle","text":"","nullable":null,"items":[]}
           {"_tag":"WireState","phase":"done","text":"Line 1\\r\\nLine 2 世界 NaN 2026-02-31","nullable":null,"note":"","items":[{"id":"α","value":""},{"id":"big","value":"9007199254740991"}]}"
@@ -554,7 +554,7 @@ describe('tui-react JSON/NDJSON wire baselines (cross-major invariant)', () => {
     }).pipe(
       Effect.scoped,
       Effect.provide(testModeLayer('ndjson')),
-      Effect.andThen(() => {
+      Effect.map(() => {
         expect(capturedOutput.join('\n')).toMatchInlineSnapshot(`
           "{"_tag":"WireState","phase":"idle","text":"","nullable":null,"items":[]}
           {"_tag":"WireEvent","from":"idle","to":"done","text":"Line 1\\r\\nLine 2 世界 NaN 2026-02-31"}"
@@ -575,7 +575,7 @@ describe('tui-react JSON/NDJSON wire baselines (cross-major invariant)', () => {
         const tui = yield* InvalidApp.run()
         tui.dispatch({ next: { ...finalWireState, text: null } })
       }).pipe(Effect.scoped, Effect.provide(testModeLayer('json')), Effect.exit)
-      const failureBytes = yield* Schema.encode(FailurePartitionWire)({
+      const failureBytes = yield* Schema.encodeEffect(FailurePartitionWire)({
         _tag: exit._tag,
         cause:
           exit._tag === 'Failure' && exit.cause !== undefined

--- a/packages/@overeng/tui-react/test/unit/exit-rendering.test.tsx
+++ b/packages/@overeng/tui-react/test/unit/exit-rendering.test.tsx
@@ -583,10 +583,10 @@ describe('tui-react JSON/NDJSON wire baselines (cross-major invariant)', () => {
             : null,
       })
 
-      // TODO(live-migration:effect-3-4): Effect 4 may print help on stdout here (effect#6313); apply #980 rather than accepting bytes on the machine stream.
+      // TODO(live-migration:effect-3-4): Effect 4's formatter-derived SchemaError prose differs from the v3 ParseError tree; tracked by #978. Both majors produce a defect here because the encode failure passes through Effect.orDie.
       expect(capturedOutput).toMatchInlineSnapshot(`[]`)
       expect(failureBytes).toMatchInlineSnapshot(
-        `"{"_tag":"Failure","cause":"ParseError: (parseJson <-> { readonly _tag: \\"WireState\\"; readonly phase: \\"idle\\" | \\"done\\"; readonly text: string; readonly nullable: string | null; readonly note?: string | undefined; readonly items: ReadonlyArray<{ readonly id: string; readonly value: string }> })\\n└─ Type side transformation failure\\n   └─ { readonly _tag: \\"WireState\\"; readonly phase: \\"idle\\" | \\"done\\"; readonly text: string; readonly nullable: string | null; readonly note?: string | undefined; readonly items: ReadonlyArray<{ readonly id: string; readonly value: string }> }\\n      └─ [\\"text\\"]\\n         └─ Expected string, actual null"}"`,
+        `"{"_tag":"Failure","cause":"Cause([Die(SchemaError(Expected string, got null\\n  at [\\"text\\"]))])"}"`,
       )
     }),
   )

--- a/packages/@overeng/tui-react/test/unit/terminal-input.test.ts
+++ b/packages/@overeng/tui-react/test/unit/terminal-input.test.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'node:events'
 import type { Readable } from 'node:stream'
 
-import { Cause, Effect, Exit, Stream } from 'effect'
+import { Cause, Effect, Exit, Fiber, Stream } from 'effect'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { createTerminalInput } from '../../src/effect/TerminalInput.ts'
@@ -47,16 +47,16 @@ describe('createTerminalInput', () => {
 
               return Effect.void
             }),
-            Effect.fork,
+            Effect.forkChild,
           )
 
-          yield* Effect.yieldNow()
+          yield* Effect.yieldNow
           input.emitData(Buffer.from([0x03]))
 
-          const fiberExit = yield* fiber.await
+          const fiberExit = yield* Fiber.await(fiber)
           expect(Exit.isFailure(fiberExit)).toBe(true)
           if (Exit.isFailure(fiberExit) === true) {
-            expect(Cause.isInterruptedOnly(fiberExit.cause)).toBe(true)
+            expect(Cause.hasInterruptsOnly(fiberExit.cause)).toBe(true)
           }
         }),
       ),

--- a/packages/@overeng/tui-react/test/unit/useTuiState.test.tsx
+++ b/packages/@overeng/tui-react/test/unit/useTuiState.test.tsx
@@ -134,7 +134,7 @@ describe('createTuiApp', () => {
       }).pipe(
         Effect.scoped,
         Effect.provide(testModeLayer('json')),
-        Effect.andThen(() => {
+        Effect.map(() => {
           expect(capturedOutput).toHaveLength(1)
           const parsed = JSON.parse(capturedOutput[0]!)
           expect(parsed).toEqual({ _tag: 'Complete', total: 10 })
@@ -146,7 +146,7 @@ describe('createTuiApp', () => {
       TestApp.run().pipe(
         Effect.scoped,
         Effect.provide(testModeLayer('json')),
-        Effect.andThen(() => {
+        Effect.map(() => {
           expect(capturedOutput).toHaveLength(1)
           const parsed = JSON.parse(capturedOutput[0]!)
           expect(parsed).toEqual({ _tag: 'Idle' })
@@ -167,7 +167,7 @@ describe('createTuiApp', () => {
       }).pipe(
         Effect.scoped,
         Effect.provide(testModeLayer('ndjson')),
-        Effect.andThen(() => {
+        Effect.map(() => {
           // Initial snapshot + one line per state change. No trailing envelope.
           expect(capturedOutput.length).toBeGreaterThanOrEqual(2)
 
@@ -194,7 +194,7 @@ describe('createTuiApp', () => {
       }).pipe(
         Effect.scoped,
         Effect.provide(testModeLayer('log')),
-        Effect.andThen(() => {
+        Effect.map(() => {
           expect(capturedOutput).toHaveLength(0)
         }),
       ),
@@ -218,7 +218,7 @@ describe('createTuiApp', () => {
       }).pipe(
         Effect.scoped,
         Effect.provide(testModeLayer('log')),
-        Effect.andThen(() => {
+        Effect.map(() => {
           expect(states).toEqual([{ _tag: 'Idle' }, { _tag: 'Running', count: 0 }])
         }),
       )


### PR DESCRIPTION
## Problem

`@overeng/tui-react` had 307 package-local TypeScript errors after the Effect 4 beta.102 cohort flip.

## Goal

Port the package and its tests faithfully to Effect 4 beta.102 while preserving its public behavior.

## Decisions

- Applied the package-local Effect 4 migration recipes for Schema, runtime capture, CLI, Cause, fibers, subscriptions, logging, Console, and AST APIs.
- Create a fresh `AtomRegistry` for every app run to preserve run isolation.
- Read Effect 4 logger fiber references while preserving the uppercase public log-level contract.
- Bind Effect 4 Console references in test helpers to preserve output capture and stderr routing.
- Updated the schema-error snapshot only after a direct Effect 3.21.4 runtime probe confirmed that `Effect.orDie` turns the encoding failure into a defect in both majors; only the rendered prose changed. The remaining compatibility concern is tracked by #978.

## Verification

- Scoped TypeScript: 307 errors to 0 package-local errors.
- Scoped formatting and lint: clean across all 22 changed files.
- Managed package tests: 232 tests passed, 0 failed; 107 suites passed; 24 snapshots matched.
- Test telemetry exported successfully; the task summary was degraded only to direct-child telemetry.
- `check:quick` remains red on both this branch and the exact untouched base with the same existing errors in other migration slices, including `tui-stories`.

## Complexity

No new dependencies, generated-file changes, or module-boundary changes.

## Concerns

The repository-wide gate remains unavailable while other Effect 4 migration slices are unported. This slice adds no package-local TypeScript, lint, formatting, or test failures.

## Friction & bottlenecks

The default package test task pulled unrelated batch dependencies; single-task mode provided the scoped package signal.

## Follow-ups

- #978 owns the framework error-prose compatibility concern.

## References

Refs #925
Refs #978

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | co1-peach |
| `agent_session_id` | ae337dfa-9265-4e41-8d1a-561250b455a3 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.145.0 |
| `agent_runtime` | Codex CLI 0.145.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/mnx8agbdq3wiyb6vz63lhgscgazkrn98-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/5r69m9k2llmri3na81518zx0a7y0d3cn-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-07-29-2026-07-29-effect4-w5-tuireact |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@0fb7e03 |
</details>
<!-- agent-footer:end -->