### PR TITLE
fix(devenv): refresh Node runtime for pnpm installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **devenv pnpm installs**: refresh nixpkgs so pnpm runs on Node 24.18.1,
+  avoiding the Darwin Node 24.15 teardown hang after a completed workspace
+  materialization.
+- **devenv observability verification**: validate the task trace independently
+  of unrelated setup traces captured from devenv, and keep `otel-scrape`
+  warning-clean across platform-specific backends and ambient trace links.
+
 - **@overeng/genie/package-json**: allow consumers to materialize selected
   cross-repository workspace dependencies with the `file:` protocol. This lets
   pnpm resolve singleton peers such as Effect from the consuming install graph

--- a/devenv.lock
+++ b/devenv.lock
@@ -900,11 +900,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1781895078,
-        "narHash": "sha256-TfS05Cf9v6pfhoo1ovRwdspZDqZ3TkG87FTkTFNMihk=",
+        "lastModified": 1786201459,
+        "narHash": "sha256-CiOTEjmwAmG2AWnaIno9YaCJJmpca2FXPhMAsnrolCg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5b63481602d9b0a714d5791c53bebe829d6b1a3c",
+        "rev": "8b8c811c7c2541c30382c5de7ed26be055569c60",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781895078,
-        "narHash": "sha256-TfS05Cf9v6pfhoo1ovRwdspZDqZ3TkG87FTkTFNMihk=",
+        "lastModified": 1786201459,
+        "narHash": "sha256-CiOTEjmwAmG2AWnaIno9YaCJJmpca2FXPhMAsnrolCg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5b63481602d9b0a714d5791c53bebe829d6b1a3c",
+        "rev": "8b8c811c7c2541c30382c5de7ed26be055569c60",
         "type": "github"
       },
       "original": {

--- a/nix/devenv-modules/observability.nix
+++ b/nix/devenv-modules/observability.nix
@@ -95,15 +95,16 @@ let
           ' "$summary_file" >/dev/null
 
           jq -s -e --arg task "$target_task" '
-            ([.[].trace_id] | unique | length) == 1
-            and any(.[];
+            ([.[] | select(
               .service == "devenv"
               and .name == "devenv"
               and .parent_span_id == null
-            )
+            )][0].trace_id) as $root_trace
+            | $root_trace != null
             and any(.[];
               .service == "devenv"
               and .name == $task
+              and .trace_id == $root_trace
               and .attrs["devenv.activity.kind"] == "task"
             )
           ' "$spans_file" >/dev/null

--- a/packages/@overeng/otel-scrape/src/lib.rs
+++ b/packages/@overeng/otel-scrape/src/lib.rs
@@ -16,7 +16,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 #[cfg(unix)]
 use std::os::unix::net::UnixStream;
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 use std::os::unix::process::ExitStatusExt;
 
 use serde::{Deserialize, Serialize};
@@ -481,6 +481,7 @@ struct ProcessObservation {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ProcessObservationBackend {
     DirectChild,
+    #[cfg(target_os = "linux")]
     PtraceExperimental,
     HelperStream,
 }
@@ -489,6 +490,7 @@ impl ProcessObservationBackend {
     fn as_str(self) -> &'static str {
         match self {
             Self::DirectChild => DIRECT_CHILD_BACKEND,
+            #[cfg(target_os = "linux")]
             Self::PtraceExperimental => PTRACE_EXPERIMENTAL_BACKEND,
             Self::HelperStream => HELPER_STREAM_BACKEND,
         }
@@ -3846,7 +3848,9 @@ mod tests {
                 profile_artifacts: Vec::new(),
                 trusted_otlp: false,
                 trusted_summary: false,
-                trace_url_template: None,
+                trace_url_template: std::env::var(TRACE_URL_TEMPLATE_ENV)
+                    .ok()
+                    .filter(|value| !value.is_empty()),
                 trace_link_enabled: true,
                 argv: vec!["echo".to_owned(), "hi".to_owned()],
             }))
@@ -3905,7 +3909,9 @@ mod tests {
                 }],
                 trusted_otlp: false,
                 trusted_summary: false,
-                trace_url_template: None,
+                trace_url_template: std::env::var(TRACE_URL_TEMPLATE_ENV)
+                    .ok()
+                    .filter(|value| !value.is_empty()),
                 trace_link_enabled: true,
                 argv: vec!["true".to_owned()],
             }))


### PR DESCRIPTION
## Problem

On Darwin, pnpm completed workspace materialization under Node 24.15 but left idle worker threads behind, so the install task never exited. The same workspace exits normally with the current Node 24 patch release.

## Goal

Keep the shared pnpm task on the current Node 24 release and restore deterministic task completion without forced exits or an older runtime pin.

## Decisions

- Refresh both nixpkgs lock authorities to the current `release-26.05` revision, providing Node 24.18.1.
- Keep strict Rust warnings and correct platform cfg boundaries exposed by the newer toolchain.
- Validate observability against the actual devenv root trace while allowing unrelated setup traces in the same capture.

## Verification

- `CI=1 devenv tasks run pnpm:install`
- `CI=1 devenv tasks run cargo:check --show-output`
- `CI=1 devenv tasks run devenv-modules:test --refresh-eval-cache --show-output`
- `CI=1 devenv tasks run otel:verify:setup --show-output`
- `CI=1 devenv tasks run check:quick --show-output`
- `CI=1 devenv tasks run check:all --show-output`

## Complexity

Low source complexity; the lock refresh causes a one-time Nix closure update for consumers.

## Concerns

The newer nixpkgs revision increases the first cold build cost, but avoids carrying an exact historical pin or a task-lifecycle workaround.

## Friction & bottlenecks

The original pnpm process appeared complete while remaining alive with idle Node worker threads. Strict checks also surfaced unrelated-trace and platform-cfg assumptions, which are corrected here.

## Follow-ups

None.

## References

Exact commit: `bfb0b76eb2ab9188fafd28e7a332cceef1a4d9ec`

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🐸 co2-toad |
| `agent_session_id` | c9cd4b23-e785-48b2-8c66-20e29994c01a |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.144.1 |
| `agent_runtime` | Codex CLI 0.144.1 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/9pwivx3z8bh69fjrsziw62ggmipmi35p-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/y9zyjnc2d5mkgm8p7pv5xd10prcha6z0-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | effect-utils/schickling-assistant/2026-08-08-fix-pnpm-node24-teardown |
| `machine` | mbp2025 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->