### PR TITLE
build: prototype Rust musl platform boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ All notable changes to this project will be documented in this file.
   probe that produces and inspects a self-contained static PIE. Bind the probe
   to an exact Buck execution constraint and one Nix-authored toolchain config
   so platform claims cannot silently fall back or drift from tool identities.
+  Use nixpkgs' version-matched prebuilt musl Rust toolchain instead of rebuilding
+  the target standard library from source in each uncached CI environment.
 - **genie/ci-workflow**: allow CI consumers to select the devenv lock file used
   by the pinned-devenv preparation and Nix-store validation steps.
 - **@overeng/effect-path**: add Effect 3 cross-major baselines for PathInfo schema

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ All notable changes to this project will be documented in this file.
   pins, sealed admission bundles, independent durability and restore proof,
   zero-network activation, conservative collection, separate reuse planes, and
   an admitted on-demand Prelude CPython action-toolchain bootstrap boundary.
+- **Buck2 Rust platform prototype**: add explicit x86_64 Linux glibc-dynamic and
+  musl-static target boundaries plus a local-only, Nix-store Rust toolchain
+  probe that produces and inspects a self-contained static PIE.
 - **genie/ci-workflow**: allow CI consumers to select the devenv lock file used
   by the pinned-devenv preparation and Nix-store validation steps.
 - **@overeng/effect-path**: add Effect 3 cross-major baselines for PathInfo schema

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,8 @@ All notable changes to this project will be documented in this file.
   to an exact Buck execution constraint and one Nix-authored toolchain config
   so platform claims cannot silently fall back or drift from tool identities.
   Use nixpkgs' version-matched prebuilt musl Rust toolchain instead of rebuilding
-  the target standard library from source in each uncached CI environment.
+  the target standard library from source in each uncached CI environment, and
+  retain a task-scoped GC root until all Buck invocations finish.
 - **genie/ci-workflow**: allow CI consumers to select the devenv lock file used
   by the pinned-devenv preparation and Nix-store validation steps.
 - **@overeng/effect-path**: add Effect 3 cross-major baselines for PathInfo schema

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,9 @@ All notable changes to this project will be documented in this file.
   an admitted on-demand Prelude CPython action-toolchain bootstrap boundary.
 - **Buck2 Rust platform prototype**: add explicit x86_64 Linux glibc-dynamic and
   musl-static target boundaries plus a local-only, Nix-store Rust toolchain
-  probe that produces and inspects a self-contained static PIE.
+  probe that produces and inspects a self-contained static PIE. Bind the probe
+  to an exact Buck execution constraint and one Nix-authored toolchain config
+  so platform claims cannot silently fall back or drift from tool identities.
 - **genie/ci-workflow**: allow CI consumers to select the devenv lock file used
   by the pinned-devenv preparation and Nix-store validation steps.
 - **@overeng/effect-path**: add Effect 3 cross-major baselines for PathInfo schema

--- a/buck2/platforms/BUCK
+++ b/buck2/platforms/BUCK
@@ -1,0 +1,50 @@
+load("@prelude//platforms:defs.bzl", "execution_platform")
+
+constraint_setting(
+    name = "runtime_linkage",
+    visibility = ["PUBLIC"],
+)
+
+constraint_value(
+    name = "dynamic",
+    constraint_setting = ":runtime_linkage",
+    visibility = ["PUBLIC"],
+)
+
+constraint_value(
+    name = "static",
+    constraint_setting = ":runtime_linkage",
+    visibility = ["PUBLIC"],
+)
+
+platform(
+    name = "target_x86_64_linux_glibc_dynamic",
+    constraint_values = [
+        "prelude//abi/constraints:gnu",
+        "prelude//cpu/constraints:x86_64",
+        "prelude//os/constraints:linux",
+        ":dynamic",
+    ],
+    visibility = ["PUBLIC"],
+)
+
+platform(
+    name = "target_x86_64_linux_musl_static",
+    constraint_values = [
+        "prelude//abi/constraints:musl",
+        "prelude//cpu/constraints:x86_64",
+        "prelude//os/constraints:linux",
+        ":static",
+    ],
+    visibility = ["PUBLIC"],
+)
+
+# Current delivery is an exact Nix store path and therefore local-only. The
+# compiler executes for the host platform even when it emits a musl target.
+execution_platform(
+    name = "exec_x86_64_linux_local_store",
+    cpu_configuration = "prelude//cpu:x86_64",
+    os_configuration = "prelude//os:linux",
+    use_windows_path_separators = False,
+    visibility = ["PUBLIC"],
+)

--- a/buck2/platforms/BUCK
+++ b/buck2/platforms/BUCK
@@ -1,4 +1,4 @@
-load("@prelude//platforms:defs.bzl", "execution_platform")
+load(":local_execution.bzl", "local_execution_platform")
 
 constraint_setting(
     name = "runtime_linkage",
@@ -8,6 +8,19 @@ constraint_setting(
 constraint_value(
     name = "dynamic",
     constraint_setting = ":runtime_linkage",
+    visibility = ["PUBLIC"],
+)
+
+# This is an execution identity, not merely a locality hint. Actions requiring
+# it cannot silently fall back to Prelude's host-derived default platform.
+constraint_setting(
+    name = "execution_identity",
+    visibility = ["PUBLIC"],
+)
+
+constraint_value(
+    name = "x86_64_linux_local_store_execution",
+    constraint_setting = ":execution_identity",
     visibility = ["PUBLIC"],
 )
 
@@ -39,12 +52,21 @@ platform(
     visibility = ["PUBLIC"],
 )
 
-# Current delivery is an exact Nix store path and therefore local-only. The
-# compiler executes for the host platform even when it emits a musl target.
-execution_platform(
+# Current delivery is an exact Nix store path and therefore local-only. Keep a
+# distinct configuration target so execution compatibility can require this
+# exact identity instead of trusting descriptive provider metadata.
+platform(
+    name = "exec_x86_64_linux_local_store_configuration",
+    constraint_values = [
+        "prelude//cpu/constraints:x86_64",
+        "prelude//os/constraints:linux",
+        ":x86_64_linux_local_store_execution",
+    ],
+)
+
+local_execution_platform(
     name = "exec_x86_64_linux_local_store",
-    cpu_configuration = "prelude//cpu:x86_64",
-    os_configuration = "prelude//os:linux",
+    platform = ":exec_x86_64_linux_local_store_configuration",
     use_windows_path_separators = False,
     visibility = ["PUBLIC"],
 )

--- a/buck2/platforms/local_execution.bzl
+++ b/buck2/platforms/local_execution.bzl
@@ -1,0 +1,35 @@
+"""Fail-closed local execution-platform registration."""
+
+load("@prelude//cfg/exec_platform:marker.bzl", "get_exec_platform_marker")
+
+def _local_execution_platform_impl(ctx):
+    configured = ctx.attrs.platform[PlatformInfo]
+    name = ctx.label.raw_target()
+    execution = ExecutionPlatformInfo(
+        label = name,
+        configuration = configured.configuration,
+        executor_config = CommandExecutorConfig(
+            local_enabled = True,
+            remote_enabled = False,
+            use_windows_path_separators = ctx.attrs.use_windows_path_separators,
+        ),
+    )
+    return [
+        DefaultInfo(),
+        execution,
+        ExecutionPlatformRegistrationInfo(
+            platforms = [execution],
+            # No unspecified fallback: incompatible actions fail during
+            # execution-platform resolution rather than running on the host.
+            fallback = "error",
+            exec_marker_constraint = get_exec_platform_marker(),
+        ),
+    ]
+
+local_execution_platform = rule(
+    impl = _local_execution_platform_impl,
+    attrs = {
+        "platform": attrs.dep(providers = [PlatformInfo]),
+        "use_windows_path_separators": attrs.bool(),
+    },
+)

--- a/buck2/rust/BUCK
+++ b/buck2/rust/BUCK
@@ -4,9 +4,13 @@ load(":local_store.bzl", "rust_local_store_toolchain", "rust_static_binary")
 # paths with --config; they are command-line inputs to the local-only action.
 rust_local_store_toolchain(
     name = "x86_64_linux_musl_toolchain",
+    contract = read_config("rust_toolchain", "contract", ""),
+    execution_platform = read_config("rust_toolchain", "execution_platform", ""),
     linker = read_config("rust_toolchain", "linker", ""),
     rustc = read_config("rust_toolchain", "rustc", ""),
-    target_triple = "x86_64-unknown-linux-musl",
+    target_platform = read_config("rust_toolchain", "target_platform", ""),
+    target_triple = read_config("rust_toolchain", "target_triple", ""),
+    toolchain_identity = read_config("rust_toolchain", "toolchain_identity", ""),
 )
 
 rust_static_binary(
@@ -14,6 +18,9 @@ rust_static_binary(
     binary_name = "static-hello",
     crate_name = "static_hello",
     src = "static_hello.rs",
+    exec_compatible_with = [
+        "//buck2/platforms:x86_64_linux_local_store_execution",
+    ],
     target_compatible_with = [
         "prelude//abi/constraints:musl",
         "prelude//cpu/constraints:x86_64",

--- a/buck2/rust/BUCK
+++ b/buck2/rust/BUCK
@@ -1,0 +1,25 @@
+load(":local_store.bzl", "rust_local_store_toolchain", "rust_static_binary")
+
+# Nix owns these values. The invoking Nix/devenv launcher supplies exact store
+# paths with --config; they are command-line inputs to the local-only action.
+rust_local_store_toolchain(
+    name = "x86_64_linux_musl_toolchain",
+    linker = read_config("rust_toolchain", "linker", ""),
+    rustc = read_config("rust_toolchain", "rustc", ""),
+    target_triple = "x86_64-unknown-linux-musl",
+)
+
+rust_static_binary(
+    name = "static_hello",
+    binary_name = "static-hello",
+    crate_name = "static_hello",
+    src = "static_hello.rs",
+    target_compatible_with = [
+        "prelude//abi/constraints:musl",
+        "prelude//cpu/constraints:x86_64",
+        "prelude//os/constraints:linux",
+        "//buck2/platforms:static",
+    ],
+    toolchain = ":x86_64_linux_musl_toolchain",
+    visibility = ["PUBLIC"],
+)

--- a/buck2/rust/local_store.bzl
+++ b/buck2/rust/local_store.bzl
@@ -1,0 +1,76 @@
+"""Exact Nix-store Rust tools for local-only target probes."""
+
+RustLocalStoreToolchainInfo = provider(fields = [
+    "execution_platform",
+    "linker",
+    "rustc",
+    "target_triple",
+])
+
+def _require_nix_store_executable(value, name):
+    if not value.startswith("/nix/store/") or "/bin/" not in value:
+        fail("{} must be an absolute Nix store executable".format(name))
+
+def _rust_local_store_toolchain_impl(ctx):
+    _require_nix_store_executable(ctx.attrs.rustc, "rustc")
+    _require_nix_store_executable(ctx.attrs.linker, "linker")
+    if ctx.attrs.target_triple != "x86_64-unknown-linux-musl":
+        fail("the prototype admits only x86_64-unknown-linux-musl")
+    return [
+        DefaultInfo(),
+        RustLocalStoreToolchainInfo(
+            execution_platform = "x86_64-linux-local-store",
+            linker = ctx.attrs.linker,
+            rustc = ctx.attrs.rustc,
+            target_triple = ctx.attrs.target_triple,
+        ),
+    ]
+
+rust_local_store_toolchain = rule(
+    impl = _rust_local_store_toolchain_impl,
+    attrs = {
+        "linker": attrs.string(),
+        "rustc": attrs.string(),
+        "target_triple": attrs.string(),
+    },
+)
+
+def _rust_static_binary_impl(ctx):
+    toolchain = ctx.attrs.toolchain[RustLocalStoreToolchainInfo]
+    out = ctx.actions.declare_output(ctx.attrs.binary_name)
+    ctx.actions.run(
+        [
+            toolchain.rustc,
+            ctx.attrs.src,
+            "--crate-name",
+            ctx.attrs.crate_name,
+            "--edition=2024",
+            "--target",
+            toolchain.target_triple,
+            "-C",
+            "linker=" + toolchain.linker,
+            "-C",
+            "target-feature=+crt-static",
+            "-C",
+            "opt-level=2",
+            "-C",
+            "strip=symbols",
+            "-o",
+            out.as_output(),
+        ],
+        category = "rust_compile",
+        env = {"PATH": "/nonexistent"},
+        identifier = toolchain.target_triple,
+        local_only = True,
+    )
+    return [DefaultInfo(default_output = out), RunInfo(args = cmd_args(out))]
+
+rust_static_binary = rule(
+    impl = _rust_static_binary_impl,
+    attrs = {
+        "binary_name": attrs.string(),
+        "crate_name": attrs.string(),
+        "src": attrs.source(),
+        "toolchain": attrs.exec_dep(providers = [RustLocalStoreToolchainInfo]),
+    },
+)

--- a/buck2/rust/local_store.bzl
+++ b/buck2/rust/local_store.bzl
@@ -1,37 +1,63 @@
 """Exact Nix-store Rust tools for local-only target probes."""
 
 RustLocalStoreToolchainInfo = provider(fields = [
+    "contract",
     "execution_platform",
     "linker",
     "rustc",
+    "target_platform",
     "target_triple",
+    "toolchain_identity",
 ])
+
+_CONTRACT = "effect-utils/rust-local-store-toolchain/v1"
+_EXECUTION_PLATFORM = "//buck2/platforms:exec_x86_64_linux_local_store"
+_TARGET_PLATFORM = "//buck2/platforms:target_x86_64_linux_musl_static"
+_TARGET_TRIPLE = "x86_64-unknown-linux-musl"
 
 def _require_nix_store_executable(value, name):
     if not value.startswith("/nix/store/") or "/bin/" not in value:
         fail("{} must be an absolute Nix store executable".format(name))
 
+def _require_toolchain_identity(value):
+    if len(value) != 71 or not value.startswith("sha256:"):
+        fail("toolchain_identity must be a Nix-authored sha256 identity")
+
 def _rust_local_store_toolchain_impl(ctx):
     _require_nix_store_executable(ctx.attrs.rustc, "rustc")
     _require_nix_store_executable(ctx.attrs.linker, "linker")
-    if ctx.attrs.target_triple != "x86_64-unknown-linux-musl":
-        fail("the prototype admits only x86_64-unknown-linux-musl")
+    _require_toolchain_identity(ctx.attrs.toolchain_identity)
+    if ctx.attrs.contract != _CONTRACT:
+        fail("unsupported Rust toolchain contract: {}".format(ctx.attrs.contract))
+    if ctx.attrs.execution_platform != _EXECUTION_PLATFORM:
+        fail("Rust toolchain execution platform mismatch: {}".format(ctx.attrs.execution_platform))
+    if ctx.attrs.target_platform != _TARGET_PLATFORM:
+        fail("Rust toolchain target platform mismatch: {}".format(ctx.attrs.target_platform))
+    if ctx.attrs.target_triple != _TARGET_TRIPLE:
+        fail("the prototype admits only {}".format(_TARGET_TRIPLE))
     return [
         DefaultInfo(),
         RustLocalStoreToolchainInfo(
-            execution_platform = "x86_64-linux-local-store",
+            contract = ctx.attrs.contract,
+            execution_platform = ctx.attrs.execution_platform,
             linker = ctx.attrs.linker,
             rustc = ctx.attrs.rustc,
+            target_platform = ctx.attrs.target_platform,
             target_triple = ctx.attrs.target_triple,
+            toolchain_identity = ctx.attrs.toolchain_identity,
         ),
     ]
 
 rust_local_store_toolchain = rule(
     impl = _rust_local_store_toolchain_impl,
     attrs = {
+        "contract": attrs.string(),
+        "execution_platform": attrs.string(),
         "linker": attrs.string(),
         "rustc": attrs.string(),
+        "target_platform": attrs.string(),
         "target_triple": attrs.string(),
+        "toolchain_identity": attrs.string(),
     },
 )
 
@@ -60,7 +86,7 @@ def _rust_static_binary_impl(ctx):
         ],
         category = "rust_compile",
         env = {"PATH": "/nonexistent"},
-        identifier = toolchain.target_triple,
+        identifier = "{}-{}".format(toolchain.target_triple, toolchain.toolchain_identity[7:19]),
         local_only = True,
     )
     return [DefaultInfo(default_output = out), RunInfo(args = cmd_args(out))]

--- a/buck2/rust/static_hello.rs
+++ b/buck2/rust/static_hello.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("buck2-rust-musl-ok");
+}

--- a/context/buck2/02-execution-platforms/.experiments/2026-08-12-rust-musl-platform-prototype.md
+++ b/context/buck2/02-execution-platforms/.experiments/2026-08-12-rust-musl-platform-prototype.md
@@ -21,7 +21,10 @@ prebuilt musl Rust bootstrap archive supplies `rustc` and its target standard
 library without rebuilding them from source on an uncached runner. Nix supplies
 the exact tool store paths, semantic platform claims, and their joined identity
 through one immutable Buck configuration. The action ran with
-`PATH=/nonexistent`.
+`PATH=/nonexistent`. The task retains a temporary Nix out-link for that config
+through all three Buck invocations, so concurrent garbage collection cannot
+invalidate the config or its transitive compiler and linker closure. Its
+signal-safe cleanup removes the root after Buck has stopped.
 
 The probe compiled one dependency-free Rust program. Controls inspected ELF
 headers and strings, executed the binary with an empty environment, selected

--- a/context/buck2/02-execution-platforms/.experiments/2026-08-12-rust-musl-platform-prototype.md
+++ b/context/buck2/02-execution-platforms/.experiments/2026-08-12-rust-musl-platform-prototype.md
@@ -15,9 +15,10 @@ self-contained ELF without ambient `PATH`?
 ## Method
 
 The prototype introduced distinct glibc-dynamic and musl-static target labels,
-plus an x86_64 Linux local-store execution label. Nix's flake-pinned
-`pkgsCross.musl64` supplied exact `rustc` and linker store paths to a local-only
-Buck action through configuration. The action ran with `PATH=/nonexistent`.
+plus an x86_64 Linux local-store execution constraint and platform. Nix's
+flake-pinned `pkgsCross.musl64` supplies exact `rustc` and linker store paths,
+the semantic platform claims, and their joined identity through one immutable
+Buck configuration. The action ran with `PATH=/nonexistent`.
 
 The probe compiled one dependency-free Rust program. Controls inspected ELF
 headers and strings, executed the binary with an empty environment, selected
@@ -33,6 +34,8 @@ Remote execution and remote caches remained disabled.
 | Source mtime only               | 0.044 s; zero actions                                    |
 | Relevant source content         | 0.579 s; one local action                                |
 | glibc target for musl-only rule | rejected during analysis; musl constraint unsatisfied    |
+| Prelude default exec platform   | rejected; exact local-store exec constraint unsatisfied  |
+| Mismatched Nix target metadata  | rejected during toolchain analysis                       |
 | Output                          | 488,064-byte x86-64 static PIE                           |
 | Runtime dependencies            | no `PT_INTERP`, no `DT_NEEDED`, `ldd`: statically linked |
 | Nix-store leakage               | no `/nix/store` string in the output                     |
@@ -55,11 +58,14 @@ flake-pinned Nix cross-toolchain
   -> self-contained musl target product
 ```
 
-The store paths participate in the action command and therefore its identity,
-but the current prototype supplies them as invocation configuration. Production
-integration still needs one Nix/devenv-owned launcher projection that emits the
-complete toolchain descriptor and arguments atomically. Buck actions must not
-invoke Nix, and committed BUCK files must not pin ephemeral store paths.
+The store paths participate in the action command and therefore its identity.
+The Nix/devenv-owned projection emits those paths, the contract version,
+execution platform, target platform, target triple, and their SHA-256 identity
+atomically. Buck validates the semantic fields and separately requires the
+selected execution and target constraints. `buck2:rust-musl:check` keeps the two
+negative controls and real compile probe executable on x86_64 Linux. Buck
+actions do not invoke Nix, and committed BUCK files do not pin ephemeral store
+paths.
 
 The target needs both ABI and linkage constraints. A `musl` constraint alone
 does not establish static linkage. `static` versus `dynamic` is therefore an

--- a/context/buck2/02-execution-platforms/.experiments/2026-08-12-rust-musl-platform-prototype.md
+++ b/context/buck2/02-execution-platforms/.experiments/2026-08-12-rust-musl-platform-prototype.md
@@ -1,0 +1,84 @@
+# Rust musl Platform Prototype
+
+## Status
+
+Completed on 2026-08-12 for `x86_64-linux`. This is platform and tool-delivery
+evidence, not admission of `otel-scrape`, Cargo/Reindeer, remote execution, or
+another architecture.
+
+## Question
+
+Can a Buck action consume a repository-pinned Nix Rust cross-toolchain while
+separating its execution platform from a static-musl target and producing a
+self-contained ELF without ambient `PATH`?
+
+## Method
+
+The prototype introduced distinct glibc-dynamic and musl-static target labels,
+plus an x86_64 Linux local-store execution label. Nix's flake-pinned
+`pkgsCross.musl64` supplied exact `rustc` and linker store paths to a local-only
+Buck action through configuration. The action ran with `PATH=/nonexistent`.
+
+The probe compiled one dependency-free Rust program. Controls inspected ELF
+headers and strings, executed the binary with an empty environment, selected
+the wrong glibc target, changed only source mtime, and changed source content.
+Remote execution and remote caches remained disabled.
+
+## Result
+
+| Control                         | Result                                                   |
+| ------------------------------- | -------------------------------------------------------- |
+| First fresh-daemon build        | 0.900 s; one local action                                |
+| Warm build                      | 0.142 s; zero actions                                    |
+| Source mtime only               | 0.044 s; zero actions                                    |
+| Relevant source content         | 0.579 s; one local action                                |
+| glibc target for musl-only rule | rejected during analysis; musl constraint unsatisfied    |
+| Output                          | 488,064-byte x86-64 static PIE                           |
+| Runtime dependencies            | no `PT_INTERP`, no `DT_NEEDED`, `ldd`: statically linked |
+| Nix-store leakage               | no `/nix/store` string in the output                     |
+| Empty-environment execution     | printed `buck2-rust-musl-ok`                             |
+
+The measured output SHA-256 was
+`502b79c30d8c92cb5cb6b970a5e4ef47fa8c852ef8f03afe88e366d1d2a2a098`.
+The exact digest is evidence for this build, not a committed product pin.
+
+## Design Findings
+
+The existing portable-tool archive is not the right compiler delivery
+mechanism: a Rust compiler is a large Nix closure that legitimately retains
+store references. The smaller boundary is:
+
+```text
+flake-pinned Nix cross-toolchain
+  -> exact local-store execution-tool identities
+  -> Buck compile/link action
+  -> self-contained musl target product
+```
+
+The store paths participate in the action command and therefore its identity,
+but the current prototype supplies them as invocation configuration. Production
+integration still needs one Nix/devenv-owned launcher projection that emits the
+complete toolchain descriptor and arguments atomically. Buck actions must not
+invoke Nix, and committed BUCK files must not pin ephemeral store paths.
+
+The target needs both ABI and linkage constraints. A `musl` constraint alone
+does not establish static linkage. `static` versus `dynamic` is therefore an
+independent target-platform dimension.
+
+## No-Verdict Boundaries
+
+- No aarch64 or Darwin compiler/product ran; cross-architecture support remains
+  no-verdict.
+- No remote worker consumed the Nix toolchain; delivery remains local-only.
+- The probe has no third-party dependencies, proc macros, build scripts, Cargo
+  profile semantics, or Reindeer graph.
+- `env -i` plus ELF inspection proves absence of declared runtime dependencies,
+  but this run did not execute inside a separate filesystem namespace.
+- Independent rebuild reproducibility was not measured.
+
+## VRS Impact
+
+Confirms the existing one-way Nix-to-Buck local-store contract, independent
+target/execution platforms, fail-closed compatibility, and a static-musl first
+Rust product direction. Refines the platform vocabulary with an independent
+runtime-linkage dimension. It does not change requirements or admit a product.

--- a/context/buck2/02-execution-platforms/.experiments/2026-08-12-rust-musl-platform-prototype.md
+++ b/context/buck2/02-execution-platforms/.experiments/2026-08-12-rust-musl-platform-prototype.md
@@ -16,9 +16,12 @@ self-contained ELF without ambient `PATH`?
 
 The prototype introduced distinct glibc-dynamic and musl-static target labels,
 plus an x86_64 Linux local-store execution constraint and platform. Nix's
-flake-pinned `pkgsCross.musl64` supplies exact `rustc` and linker store paths,
-the semantic platform claims, and their joined identity through one immutable
-Buck configuration. The action ran with `PATH=/nonexistent`.
+flake-pinned `pkgsCross.musl64` supplies the linker, while nixpkgs' matching
+prebuilt musl Rust bootstrap archive supplies `rustc` and its target standard
+library without rebuilding them from source on an uncached runner. Nix supplies
+the exact tool store paths, semantic platform claims, and their joined identity
+through one immutable Buck configuration. The action ran with
+`PATH=/nonexistent`.
 
 The probe compiled one dependency-free Rust program. Controls inspected ELF
 headers and strings, executed the binary with an empty environment, selected
@@ -52,7 +55,7 @@ mechanism: a Rust compiler is a large Nix closure that legitimately retains
 store references. The smaller boundary is:
 
 ```text
-flake-pinned Nix cross-toolchain
+flake-pinned Nix prebuilt musl rustc plus cross linker
   -> exact local-store execution-tool identities
   -> Buck compile/link action
   -> self-contained musl target product

--- a/context/buck2/04-artifact-system-bridge/.experiments/2026-08-12-uniform-language-bridge-prototypes.md
+++ b/context/buck2/04-artifact-system-bridge/.experiments/2026-08-12-uniform-language-bridge-prototypes.md
@@ -32,18 +32,19 @@ hardening and real-product gates required before authority transfer.
 
 ## Current Reality
 
-| Surface                                              | Result |
-| ---------------------------------------------------- | -----: |
-| Generated package-local BUCK files                   |      1 |
-| Real TypeScript compile/test/executable Buck targets |      0 |
-| Real Rust Buck targets                               |      0 |
-| TypeScript Nix source builders                       |      7 |
-| Rust Nix source builders                             |      2 |
-| Production/system artifact-import consumers          |      0 |
+| Surface                                              |                              Result |
+| ---------------------------------------------------- | ----------------------------------: |
+| Generated package-local BUCK files                   |                                   1 |
+| Real TypeScript compile/test/executable Buck targets |                                   0 |
+| Real Rust Buck targets                               | 1 platform probe; 0 product targets |
+| TypeScript Nix source builders                       |                                   7 |
+| Rust Nix source builders                             |                                   2 |
+| Production/system artifact-import consumers          |                                   0 |
 
 The existing `tui-core` target packages a non-authoritative TypeScript input
-plan. The existing bridge imports a synthetic portable fixture. These are
-working prototypes, not production TS/Rust convergence.
+plan. The Rust target is a dependency-free static-musl platform probe, not a
+Cargo/Reindeer product. The existing bridge imports a synthetic portable
+fixture. These are working prototypes, not production TS/Rust convergence.
 
 ## TypeScript Closure Controls
 
@@ -73,9 +74,10 @@ control proves packager hermeticity, not TypeScript compiler hermeticity.
 | Nix-built Rust binary                    | 1.34 MB; store-bound; 49.35 MB runtime closure     |
 | Preserved Buck Rust binary               | 2.10 MB; no store bytes; local CLI behavior passed |
 | Preserved Buck Rust ABI                  | Dynamic glibc through 2.39; not fleet-portable     |
-| Static-musl Rust product                 | No-verdict; toolchain/build blocked by disk freeze |
+| Static-musl Rust hello probe             | 488 KB static PIE; no loader, Nix refs, or deps    |
 
-The preserved real Buck descriptor also does not satisfy the current importer's
+The static probe proves the target/toolchain boundary, not the shared product
+descriptor or importer. The preserved real Buck descriptor also does not satisfy the current importer's
 provenance shape, so a genuine Rust product round trip is unproved. Two equal
 preserved archives may be cache copies and do not prove independent rebuild
 reproducibility.

--- a/devenv.nix
+++ b/devenv.nix
@@ -886,8 +886,13 @@ in
       set -euo pipefail
       isolation="rust-musl-check-$$-$RANDOM"
       stderr_file="$(${pkgs.coreutils}/bin/mktemp "''${TMPDIR:-/tmp}/buck2-rust-musl-check.XXXXXX")"
+      toolchain_root_dir=""
       cleanup() {
         ${pkgs.buck2}/bin/buck2 --isolation-dir "$isolation" kill >/dev/null 2>&1 || true
+        if [ -n "$toolchain_root_dir" ]; then
+          ${pkgs.coreutils}/bin/rm -f "$toolchain_root_dir/toolchain"
+          ${pkgs.coreutils}/bin/rmdir "$toolchain_root_dir" 2>/dev/null || true
+        fi
         ${pkgs.coreutils}/bin/rm -f "$stderr_file"
       }
       trap cleanup EXIT
@@ -895,11 +900,24 @@ in
       trap 'exit 143' TERM
 
       # Keep the large cross-toolchain out of the default devenv closure. This
-      # explicit task boundary realizes it only when the Rust probe is run.
+      # explicit task boundary realizes it only when the Rust probe is run. The
+      # temporary out-link roots the config and its transitive toolchain closure
+      # until every Buck invocation has finished, including under concurrent GC.
+      toolchain_root_dir="$(${pkgs.coreutils}/bin/mktemp -d "''${TMPDIR:-/tmp}/buck2-rust-musl-root.XXXXXX")"
       toolchain_config="$(${pkgs.nix}/bin/nix build \
-        --no-link \
+        --out-link "$toolchain_root_dir/toolchain" \
         --print-out-paths \
         .#buck2-rust-musl-toolchain-config)"
+
+      buck2_with_toolchain_root() {
+        if [ ! -L "$toolchain_root_dir/toolchain" ] || \
+          [ "$(${pkgs.coreutils}/bin/readlink -f "$toolchain_root_dir/toolchain")" != "$toolchain_config" ] || \
+          [ ! -e "$toolchain_config" ]; then
+          echo "buck2:rust-musl:check: toolchain GC root disappeared before Buck completed" >&2
+          return 1
+        fi
+        ${pkgs.buck2}/bin/buck2 "$@"
+      }
 
       common=(
         --isolation-dir "$isolation"
@@ -911,7 +929,7 @@ in
         --no-remote-cache
       )
 
-      if ${pkgs.buck2}/bin/buck2 "''${common[@]}" \
+      if buck2_with_toolchain_root "''${common[@]}" \
         --config build.execution_platforms=prelude//platforms:default \
         >/dev/null 2>"$stderr_file"; then
         echo "buck2:rust-musl:check: default execution platform unexpectedly admitted" >&2
@@ -922,7 +940,7 @@ in
         exit 1
       }
 
-      if ${pkgs.buck2}/bin/buck2 "''${common[@]}" \
+      if buck2_with_toolchain_root "''${common[@]}" \
         --config rust_toolchain.target_platform=//buck2/platforms:target_x86_64_linux_glibc_dynamic \
         >/dev/null 2>"$stderr_file"; then
         echo "buck2:rust-musl:check: mismatched Nix toolchain metadata unexpectedly admitted" >&2
@@ -933,7 +951,7 @@ in
         exit 1
       }
 
-      ${pkgs.buck2}/bin/buck2 "''${common[@]}"
+      buck2_with_toolchain_root "''${common[@]}"
       identity="$(${pkgs.gawk}/bin/awk '$1 == "toolchain_identity" { print $3 }' "$toolchain_config")"
       echo "buck2:rust-musl:check: PASS identity=$identity"
     '';

--- a/devenv.nix
+++ b/devenv.nix
@@ -113,7 +113,6 @@ let
       portable_toolchain_fixture = ${buck2Stage0.portableToolchainFixture}/bin/buck2-portable-toolchain-fixture
   '';
   buck2Stage0Args = "--config-file ${buck2Stage0Config}";
-
   # CLI packages built with Nix (for hash management)
   nixCliPackages = [
     {
@@ -855,6 +854,7 @@ in
       trap cleanup EXIT
       trap 'exit 130' INT
       trap 'exit 143' TERM
+
       if ${pkgs.buck2}/bin/buck2 \
         --isolation-dir "$isolation" \
         build --config-file ${buck2Stage0Config} --fake-arch aarch64 \
@@ -880,6 +880,65 @@ in
     '';
   };
 
+  tasks."buck2:rust-musl:check" = lib.mkIf (currentSystem == "x86_64-linux") {
+    description = "Prove the Nix-authored Rust toolchain, target, and execution-platform contract";
+    exec = trace.exec "buck2:rust-musl:check" ''
+      set -euo pipefail
+      isolation="rust-musl-check-$$-$RANDOM"
+      stderr_file="$(${pkgs.coreutils}/bin/mktemp "''${TMPDIR:-/tmp}/buck2-rust-musl-check.XXXXXX")"
+      cleanup() {
+        ${pkgs.buck2}/bin/buck2 --isolation-dir "$isolation" kill >/dev/null 2>&1 || true
+        ${pkgs.coreutils}/bin/rm -f "$stderr_file"
+      }
+      trap cleanup EXIT
+      trap 'exit 130' INT
+      trap 'exit 143' TERM
+
+      # Keep the large cross-toolchain out of the default devenv closure. This
+      # explicit task boundary realizes it only when the Rust probe is run.
+      toolchain_config="$(${pkgs.nix}/bin/nix build \
+        --no-link \
+        --print-out-paths \
+        .#buck2-rust-musl-toolchain-config)"
+
+      common=(
+        --isolation-dir "$isolation"
+        build
+        --config-file "$toolchain_config"
+        --target-platforms //buck2/platforms:target_x86_64_linux_musl_static
+        //buck2/rust:static_hello
+        --local-only
+        --no-remote-cache
+      )
+
+      if ${pkgs.buck2}/bin/buck2 "''${common[@]}" \
+        --config build.execution_platforms=prelude//platforms:default \
+        >/dev/null 2>"$stderr_file"; then
+        echo "buck2:rust-musl:check: default execution platform unexpectedly admitted" >&2
+        exit 1
+      fi
+      ${pkgs.gnugrep}/bin/grep -F "No compatible execution platform" "$stderr_file" >/dev/null || {
+        echo "buck2:rust-musl:check: missing execution-platform rejection" >&2
+        exit 1
+      }
+
+      if ${pkgs.buck2}/bin/buck2 "''${common[@]}" \
+        --config rust_toolchain.target_platform=//buck2/platforms:target_x86_64_linux_glibc_dynamic \
+        >/dev/null 2>"$stderr_file"; then
+        echo "buck2:rust-musl:check: mismatched Nix toolchain metadata unexpectedly admitted" >&2
+        exit 1
+      fi
+      ${pkgs.gnugrep}/bin/grep -F "Rust toolchain target platform mismatch" "$stderr_file" >/dev/null || {
+        echo "buck2:rust-musl:check: missing toolchain-metadata rejection" >&2
+        exit 1
+      }
+
+      ${pkgs.buck2}/bin/buck2 "''${common[@]}"
+      identity="$(${pkgs.gawk}/bin/awk '$1 == "toolchain_identity" { print $3 }' "$toolchain_config")"
+      echo "buck2:rust-musl:check: PASS identity=$identity"
+    '';
+  };
+
   tasks."buck2:check" = {
     description = "Run Buck2 foundation, invalidation, platform, Nix bridge, and benchmark gates";
     after = [
@@ -891,6 +950,9 @@ in
       "buck2:benchmark:check"
       "buck2:invalidation:e2e"
       "buck2:platform:check"
+    ]
+    ++ lib.optionals (currentSystem == "x86_64-linux") [
+      "buck2:rust-musl:check"
     ];
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -74,6 +74,20 @@
           };
         };
         buck2-stage0-tools = import ./nix/buck2-stage0-tools.nix { inherit pkgs; };
+        buck2-rust-musl-toolchain-config =
+          if system == "x86_64-linux" then
+            let
+              cross = pkgs.pkgsCross.musl64;
+            in
+            (
+              import ./nix/workspace-tools/lib/buck2-rust-local-toolchain-config.nix { inherit pkgs; }
+              {
+                rustc = "${cross.rustc}/bin/rustc";
+                linker = "${cross.stdenv.cc}/bin/${cross.stdenv.cc.targetPrefix}cc";
+              }
+            ).config
+          else
+            null;
         cliPackages = {
           genie = import (rootPath + "/packages/@overeng/genie/nix/build.nix") {
             inherit
@@ -231,6 +245,9 @@
               inherit pkgs oxlintNpm;
             };
             node-pty-native = nodePtyNative;
+          }
+          // pkgs.lib.optionalAttrs (system == "x86_64-linux") {
+            inherit buck2-rust-musl-toolchain-config;
           };
         # Direnv helper for comparing expected CLI outputs to PATH entries.
         cliOutPaths = {

--- a/flake.nix
+++ b/flake.nix
@@ -78,14 +78,19 @@
           if system == "x86_64-linux" then
             let
               cross = pkgs.pkgsCross.musl64;
+              rustVersionParts = pkgs.lib.versions.splitVersion cross.rustc.version;
+              rustPackageSet =
+                cross.${"rust_${builtins.elemAt rustVersionParts 0}_${builtins.elemAt rustVersionParts 1}"};
             in
-            (
-              import ./nix/workspace-tools/lib/buck2-rust-local-toolchain-config.nix { inherit pkgs; }
-              {
-                rustc = "${cross.rustc}/bin/rustc";
-                linker = "${cross.stdenv.cc}/bin/${cross.stdenv.cc.targetPrefix}cc";
-              }
-            ).config
+            (import ./nix/workspace-tools/lib/buck2-rust-local-toolchain-config.nix { inherit pkgs; } {
+              # `cross.rustc` builds the target standard library from the
+              # Rust source tree.  This probe needs the same pinned compiler
+              # and musl stdlib, but not a source-built compiler toolchain.
+              # nixpkgs' matching bootstrap archive supplies both as a
+              # substitutable binary while the cross linker remains Nix-owned.
+              rustc = "${rustPackageSet.packages.prebuilt.rustc}/bin/rustc";
+              linker = "${cross.stdenv.cc}/bin/${cross.stdenv.cc.targetPrefix}cc";
+            }).config
           else
             null;
         cliPackages = {

--- a/nix/workspace-tools/lib/buck2-rust-local-toolchain-config.nix
+++ b/nix/workspace-tools/lib/buck2-rust-local-toolchain-config.nix
@@ -1,0 +1,44 @@
+{ pkgs }:
+
+{
+  rustc,
+  linker,
+  targetTriple ? "x86_64-unknown-linux-musl",
+}:
+
+let
+  contract = "effect-utils/rust-local-store-toolchain/v1";
+  executionPlatform = "//buck2/platforms:exec_x86_64_linux_local_store";
+  targetPlatform = "//buck2/platforms:target_x86_64_linux_musl_static";
+  identity = builtins.hashString "sha256" (
+    builtins.toJSON {
+      inherit
+        contract
+        executionPlatform
+        linker
+        rustc
+        targetPlatform
+        targetTriple
+        ;
+    }
+  );
+in
+{
+  inherit identity;
+
+  # One immutable file carries paths and semantic claims together. Buck still
+  # enforces its configured target/execution constraints independently.
+  config = pkgs.writeText "buck2-rust-local-toolchain.conf" ''
+    [build]
+      execution_platforms = ${executionPlatform}
+
+    [rust_toolchain]
+      contract = ${contract}
+      execution_platform = ${executionPlatform}
+      linker = ${linker}
+      rustc = ${rustc}
+      target_platform = ${targetPlatform}
+      target_triple = ${targetTriple}
+      toolchain_identity = sha256:${identity}
+  '';
+}


### PR DESCRIPTION
Stacks directly on #1073. Supports #1052.

## Scope

This prototype separates the Rust target platform from the execution platform:

- explicit `x86_64-linux-glibc-dynamic` and `x86_64-linux-musl-static` target boundaries;
- an independent runtime-linkage constraint (`static` versus `dynamic`);
- one local-only `x86_64-linux-local-store` execution platform;
- exact Nix-store `rustc` and linker paths supplied as Buck configuration inputs;
- one dependency-free Rust action producing a self-contained musl static PIE.

Nix remains the compiler/linker recipe and pin authority. Buck owns the repository-local action and output. The action never invokes Nix and runs with `PATH=/nonexistent`.

## Evidence

| Control | Result |
| --- | --- |
| Fresh-daemon build | 0.900 s; one local action |
| Warm build | 0.142 s; zero actions |
| Source mtime only | 0.044 s; zero actions |
| Relevant source change | 0.579 s; one local action |
| glibc target selected for musl rule | rejected during analysis |
| Missing Nix tool configuration | rejected during analysis |
| Output | 488,064-byte x86-64 static PIE |
| Runtime inspection | no `PT_INTERP`, no `DT_NEEDED`, `ldd`: statically linked |
| Nix leakage | no `/nix/store` string in product |
| Sterile execution | succeeds under `env -i` |

Observed product SHA-256: `502b79c30d8c92cb5cb6b970a5e4ef47fa8c852ef8f03afe88e366d1d2a2a098`. This is evidence for the measured build, not a production pin.

The existing Buck foundation tests also pass: 3 targets, 18 assertions.

## Boundary

This admits only the platform/tool-delivery direction for a minimal probe. It does **not** admit:

- `otel-scrape` or another production product;
- Cargo/Reindeer dependencies, proc macros, or build scripts;
- aarch64 Linux or either Darwin architecture;
- remote execution or remote-cache-safe tool delivery;
- independent rebuild reproducibility;
- the shared product descriptor/importer contract;
- a production Nix/devenv toolchain projection.

The compiler is intentionally not packed through the portable-tool archive: its legitimate Nix-store closure is large. The production follow-up is one Nix/devenv-owned projection that supplies the complete descriptor and Buck configuration atomically. BUCK files must not contain ephemeral store paths.


## Exact-head status

Native stack #1074, position 6 of 12; exact base #1066 at `2aafc7ba1208483e7c063c14bcb77f23b77428e2`.
The current head is `09f1a094aaefa262449796a4cb4ae3d291933fef`;
its stable patch ID matches the previously reviewed prototype commit.

Focused verification on the current head is green with remote execution/cache
disabled:

- one local compile action produced the same
  `502b79c30d8c92cb5cb6b970a5e4ef47fa8c852ef8f03afe88e366d1d2a2a098`
  output;
- `file`, `ldd`, and ELF inspection confirm a stripped x86-64 static PIE with no
  `PT_INTERP` or `DT_NEEDED`;
- the product contains no `/nix/store` string and runs under `env -i`;
- selecting the glibc-dynamic target fails analysis because the musl constraint
  is unsatisfied;
- a second build is warm and executes zero actions.

Fresh CI is running on this exact head. Promotion remains subject to that
current-head CI result; prior CI at the superseded head is historical evidence
only.

## Current stack identity

- Native stack: #1074, position 6 of 12
- Exact base: `4844ffaeb348045f65819e841648a22e4d9daf35`
- Exact head: `acfd863a37cb8ebb1865b79e50b03f8fd0a9ada1`
- All actionable review threads resolved; fresh exact-head CI is the remaining merge gate.