### PR TITLE
feat: harden Buck build-product contract core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- **Buck2 build-product contract**: add a pure exact validator and canonical
+  descriptor digest for the shared Buck-to-Nix product envelope. Runtime is a
+  required tagged union, invocation evidence is excluded from semantic product
+  identity, and the importer now requires an independently supplied descriptor
+  digest and rejects every runtime until its real inspector exists. This removes
+  the synthetic shell import as evidence of an admitted portable product; the
+  input-plan fixture is now labeled `buck2-package-evidence` rather than
+  masquerading as a build product.
 - **Buck2 build foundation**: add generated package-local Buck targets, an exact
   pnpm closure compiler with content/context/task identities, deterministic
   package evidence archives, a Nix-exported portable-toolchain boundary, and a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ All notable changes to this project will be documented in this file.
   digest and rejects every runtime until its real inspector exists. This removes
   the synthetic shell import as evidence of an admitted portable product; the
   input-plan fixture is now labeled `buck2-package-evidence` rather than
-  masquerading as a build product.
+  masquerading as a build product. Descriptor paths reject CR/LF bytes, fixed
+  canonical conformance vectors guard identity, and archive scanning rejects
+  non-padding bytes or concatenated archives after the first end marker.
 - **Buck2 build foundation**: add generated package-local Buck targets, an exact
   pnpm closure compiler with content/context/task identities, deterministic
   package evidence archives, a Nix-exported portable-toolchain boundary, and a

--- a/buck2/tools/package_evidence.py
+++ b/buck2/tools/package_evidence.py
@@ -181,7 +181,7 @@ def package(args: argparse.Namespace) -> None:
             "sizeBytes": len(archive_bytes),
         },
         "entrypoints": ["bin/package-evidence"],
-        "kind": "buck2-build-artifact",
+        "kind": "buck2-package-evidence",
         "name": name,
         "platform": platform,
         "provenance": {

--- a/buck2/tools/package_evidence_test.py
+++ b/buck2/tools/package_evidence_test.py
@@ -40,7 +40,7 @@ class PackageEvidenceTest(unittest.TestCase):
         ])
         return archive, descriptor
 
-    def test_is_byte_deterministic_and_matches_import_contract(self) -> None:
+    def test_is_byte_deterministic_and_has_provisional_evidence_shape(self) -> None:
         _, root = self.fixture()
         first_archive, first_descriptor = self.run_package(root, "-one")
         second_archive, second_descriptor = self.run_package(root, "-two")
@@ -48,7 +48,7 @@ class PackageEvidenceTest(unittest.TestCase):
         self.assertEqual(first_descriptor.read_bytes(), second_descriptor.read_bytes())
 
         descriptor = json.loads(first_descriptor.read_text())
-        self.assertEqual(descriptor["kind"], "buck2-build-artifact")
+        self.assertEqual(descriptor["kind"], "buck2-package-evidence")
         self.assertEqual(descriptor["artifact"]["file"], "artifact.tar")
         self.assertEqual(descriptor["artifact"]["sizeBytes"], first_archive.stat().st_size)
         self.assertEqual(descriptor["entrypoints"], ["bin/package-evidence"])

--- a/context/buck2/04-artifact-system-bridge/.experiments/2026-08-12-strict-build-product-contract-red-green.md
+++ b/context/buck2/04-artifact-system-bridge/.experiments/2026-08-12-strict-build-product-contract-red-green.md
@@ -1,0 +1,63 @@
+# Strict Build-Product Contract RED/GREEN
+
+Date: 2026-08-12
+
+## Question
+
+Can the shared Buck-to-Nix product seam reject schema drift, keep invocation
+evidence out of product identity, require an external descriptor identity, and
+remain honest before any runtime inspector exists?
+
+## Method
+
+1. Add a focused pure-Nix contract test before its implementation exists.
+2. Run the test from the exact foundation base `c31d61468` and preserve the
+   expected failure.
+3. Implement one exact validator/canonicalizer and route the importer through
+   it.
+4. Mutate the descriptor at the top level, semantic-provenance level, runtime
+   tag, and external expected-digest boundary.
+5. Exercise all four recognized runtime shapes as validation-only records.
+6. Attempt an import of a synthetically packaged shell and require rejection
+   because no runtime inspector exists.
+
+## Result
+
+The pre-implementation control failed because
+`buck2-build-product-contract.nix` did not exist. This established that the new
+test was not already passing through the permissive importer.
+
+After implementation, the focused contract test passed and printed explicit
+RED controls for:
+
+- missing and wrong independently supplied descriptor digests;
+- unknown top-level descriptor fields;
+- evidence provenance embedded in the semantic descriptor;
+- action identity embedded in semantic provenance; and
+- an unknown runtime tag.
+
+The four recognized runtime records (`interpreter`, `elf-dynamic`,
+`mach-o-dynamic`, and `self-contained`) canonicalized successfully. This proves
+only their exact schema. The bridge test then rejected the synthetic shell
+archive with `runtime inspector is not available for self-contained`; it no
+longer executes that shell as evidence of portable-product admission. Existing
+archive safety controls remained green. The separate input-plan fixture was
+relabeled `buck2-package-evidence`, so it no longer claims the strict product
+kind while remaining explicitly provisional.
+
+The canonical fixture descriptor digest was
+`sha256:920dafd10e3eb7c3d54a0ef6d80213a58ceac533019537cb9e7098177b72389d`.
+
+## Interpretation
+
+The contract is now strict enough for language adapters to target one shared
+shape without creating TypeScript or Rust importer branches. It deliberately
+provides no successful product import. The next admission slice must implement
+and independently break a real runtime inspector, beginning with the selected
+static ELF Rust product.
+
+## VRS Impact
+
+The spec now records the implemented exact schema, canonical digest algorithm,
+semantic/evidence provenance boundary, and validation-versus-admission
+distinction. Requirements and vision remain unchanged.

--- a/context/buck2/04-artifact-system-bridge/.experiments/2026-08-12-strict-build-product-contract-red-green.md
+++ b/context/buck2/04-artifact-system-bridge/.experiments/2026-08-12-strict-build-product-contract-red-green.md
@@ -36,6 +36,15 @@ RED controls for:
 - action identity embedded in semantic provenance; and
 - an unknown runtime tag.
 
+Independent review then broke two boundaries the initial proof had not fixed:
+the descriptor accepted carriage-return or newline entrypoint bytes that the
+archive scanner rejected, and GNU tar ignored bytes or another archive appended
+after its first end marker. The hardened validator rejects both path bytes. The
+scanner now reads through zero blocks and rejects appended non-padding bytes or
+concatenated archives. A fixed canonical JSON byte vector and its fixed digest
+replace the former self-comparison, while nested-field and semantic-identity
+controls prevent schema and locality drift.
+
 The four recognized runtime records (`interpreter`, `elf-dynamic`,
 `mach-o-dynamic`, and `self-contained`) canonicalized successfully. This proves
 only their exact schema. The bridge test then rejected the synthetic shell

--- a/context/buck2/04-artifact-system-bridge/spec.md
+++ b/context/buck2/04-artifact-system-bridge/spec.md
@@ -4,9 +4,11 @@ This document specifies the verified Buck-to-Nix build-product boundary and
 the handoff into Nix-managed system generations. It builds on
 [requirements.md](./requirements.md).
 
-Status: **Draft**. The generic archive and import seam and OCI protocol have
-prototype evidence. No TypeScript or Rust executable, publication flow, or
-system generation is admitted through the bridge yet.
+Status: **Draft**. The exact descriptor validator and canonical identity are
+implemented, and the generic archive/import seam plus OCI protocol have
+prototype evidence. The importer rejects every runtime because no runtime
+inspector is admitted yet. No TypeScript or Rust executable, publication flow,
+or system generation is admitted through the bridge.
 
 ## Scope
 
@@ -55,28 +57,57 @@ Nix may transform runtime representation but must not compile repository source.
 
 ## Build-Product Contract
 
-There is one logical `buck-build-product/v1` descriptor:
+There is one logical `buck-build-product/v1` descriptor. The exact common
+envelope is:
 
-```text
-buck-build-product/v1
-  schema and semantic contract
-  payload digest, size, and normalized format
-  declared entrypoints
-  target platform and runtime ABI
-  result-affecting provenance
+```json
+{
+  "schema": "buck-build-product/v1",
+  "name": "otel-scrape",
+  "platform": {
+    "os": "linux",
+    "architecture": "x86_64",
+    "abi": "musl"
+  },
+  "payload": {
+    "file": "artifact.tar",
+    "format": "tar",
+    "digest": {
+      "algorithm": "sha256",
+      "sri": "sha256-..."
+    },
+    "sizeBytes": 123
+  },
+  "entrypoints": ["bin/otel-scrape"],
+  "runtime": {
+    "kind": "self-contained",
+    "inspectionContract": "elf-static/v1"
+  },
+  "semanticProvenance": {
+    "target": "//packages/@overeng/otel-scrape:product",
+    "recipe": "otel-scrape/v1",
+    "toolchain": "rust-linux-musl/v1"
+  }
+}
 ```
+
+All listed records are exact: missing and unknown fields fail. The canonical
+descriptor bytes are UTF-8 `builtins.toJSON` output with no trailing newline;
+their external identity is `sha256:<lowercase-hex>`. Payload identity remains
+the SHA-256 SRI digest of `artifact.tar` and is therefore distinct from
+descriptor identity.
 
 The descriptor carries a required runtime tagged union. Runtime behavior is a
 product property rather than a source-language property:
 
 ```text
 RuntimeContract =
-  | Interpreter { runtimeId, runtimeContract, program }
-  | ElfDynamic { machine, loaderClass, neededLibraries,
-                 symbolVersionFloors, runpathPolicy }
-  | MachODynamic { architecture, minimumOs, dylibs,
-                   installNamePolicy, rpathPolicy, signingPolicy }
-  | SelfContained { inspectionContract }
+  | interpreter { runtimeId, runtimeContract, program }
+  | elf-dynamic { machine, loaderClass, neededLibraries,
+                  symbolVersionFloors, runpathPolicy }
+  | mach-o-dynamic { architecture, minimumOs, dylibs,
+                     installNamePolicy, rpathPolicy, signingPolicy }
+  | self-contained { inspectionContract }
 ```
 
 The shared importer has no TypeScript or Rust branches. It strictly validates
@@ -91,11 +122,14 @@ rejects digest or size mismatch, unknown fields, duplicate or escaping paths,
 file/ancestor collisions, unsupported node types, undeclared entrypoints,
 trailing data, and platform or ABI mismatch.
 
-Semantic provenance that changes the declared product contract or bytes enters
-descriptor identity. Implementation provenance such as helper language,
-checkout location, native Buck invocation/action identity, or generator binary
-identity belongs in the evidence envelope. It must not perturb product identity
-when the normalized payload and semantic contract are equal.
+Semantic provenance is the exact `target`, `recipe`, and `toolchain` contract
+that changes the declared product meaning and therefore enters descriptor
+identity. Implementation provenance such as helper language, checkout
+location, source revision used only for attribution, native Buck
+invocation/action identity, or generator binary identity belongs in the
+evidence envelope. Evidence fields are unknown descriptor fields and fail exact
+validation. Evidence must not perturb product identity when the normalized
+payload and semantic contract are equal.
 
 ## Verified Import
 
@@ -121,8 +155,10 @@ Import is fail closed:
 7. Emit an evidence record through the evidence subsystem and expose only the
    verified realized output to system composition.
 
-The caller supplies the digest of the canonical descriptor bytes independently
-of the descriptor. Unknown fields and runtime variants fail strict decoding.
+The caller supplies the `sha256:<lowercase-hex>` digest of the canonical
+descriptor bytes independently of the descriptor. Unknown fields and runtime
+variants fail strict decoding. A recognized runtime tag is still not import
+admission: the importer fails until the selected runtime inspector exists.
 `portable` is not a synonym for a script or source archive: an interpreter-based
 product names the exact runtime contract that Nix supplies and wraps.
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -758,7 +758,7 @@ in
   };
 
   tasks."buck2:e2e:tui-core" = {
-    description = "Generate, build, observe, and Nix-import the tui-core Buck input-plan artifact";
+    description = "Generate, build, and observe the provisional tui-core Buck input-plan evidence";
     after = [ "genie:run" ];
     exec = trace.exec "buck2:e2e:tui-core" ''
       set -euo pipefail
@@ -766,16 +766,16 @@ in
       export AWK_BIN=${pkgs.gawk}/bin/awk
       export JQ_BIN=${pkgs.jq}/bin/jq
       export NIX_BIN=${pkgs.nix}/bin/nix
-      export NIX_STORE_BIN=${pkgs.nix}/bin/nix-store
       exec ${pkgs.bash}/bin/bash scripts/buck2-package-e2e.sh \
         "$root" ${buck2Task} //packages/@overeng/tui-core:typescript_input_plan
     '';
   };
 
   tasks."buck2:nix-bridge:check" = {
-    description = "Prove portable Nix tool export and digest/platform-verified Buck artifact import";
+    description = "Check the strict build-product contract, Nix tool export, and fail-closed artifact importer";
     exec = trace.exec "buck2:nix-bridge:check" ''
       set -euo pipefail
+      ${pkgs.bash}/bin/bash nix/workspace-tools/lib/tests/buck2-build-product-contract.sh "$PWD"
       exec ${pkgs.bash}/bin/bash nix/workspace-tools/lib/tests/buck2-bridge.sh "$PWD"
     '';
   };

--- a/nix/workspace-tools/README.md
+++ b/nix/workspace-tools/README.md
@@ -6,6 +6,10 @@ pure and designed to work in both megarepo workspaces and standalone repos.
 ## Layout
 
 - `lib/`
+  - `buck2-build-product-contract.nix` — pure exact validation and canonical
+    identity for the shared Buck-to-Nix product descriptor.
+  - `buck2-artifact-import.nix` — fail-closed product import entry point; each
+    runtime remains rejected until its inspector is implemented.
   - `mk-bun-cli.nix` — Bun binary builder (deterministic, local file deps).
   - `mk-pnpm-cli.nix` — pnpm + bun compile builder for workspace CLIs.
   - `mk-pnpm-deps.nix` — FOD helper for preparing relocatable pnpm install trees that downstream builds restore without rerunning `pnpm install`.

--- a/nix/workspace-tools/lib/buck2-artifact-import.nix
+++ b/nix/workspace-tools/lib/buck2-artifact-import.nix
@@ -1,189 +1,38 @@
-# Verify and import a published Buck2 artifact into a normal Nix store output.
-# The descriptor is an evaluated, reviewed input; Nix never invokes Buck2 or a
-# mutable checkout while composing the result. Provenance fields provide
-# attributable lineage, not authenticity: callers must obtain the descriptor
-# through a trusted source or verify a signature before evaluation.
+# Verify and import a published Buck2 build product into the Nix store.
+#
+# This entry point intentionally rejects every runtime until a runtime-specific
+# inspector exists. Shape validation is not runtime proof, and the former
+# synthetic shell fixture must not make this bridge look admitted.
 { pkgs }:
 
 let
   lib = pkgs.lib;
-  scan = import ./buck2-artifact-scan.nix { inherit pkgs; };
-  validName = value: builtins.isString value && builtins.match "[A-Za-z0-9._+-]+" value != null;
-  safeRelativePath =
-    value:
-    let
-      components = lib.splitString "/" value;
-    in
-    builtins.isString value
-    && value != ""
-    && !(lib.hasPrefix "/" value)
-    && !(lib.hasInfix "\\" value)
-    && builtins.match ".*[[:cntrl:]].*" value == null
-    && lib.all (component: component != "" && component != "." && component != "..") components;
-  hasOnlyFields =
-    allowed: value:
-    builtins.isAttrs value && lib.all (field: lib.elem field allowed) (builtins.attrNames value);
+  contract = import ./buck2-build-product-contract.nix;
 in
 {
   descriptor,
+  expectedDescriptorDigest,
+  expectedPlatform,
   url ? null,
   artifact ? null,
-  expectedPlatform ? pkgs.stdenv.hostPlatform.system,
 }:
 
-assert lib.assertMsg (builtins.isAttrs descriptor)
-  "buck2-artifact-import: descriptor must be an attribute set";
-assert lib.assertMsg (hasOnlyFields [
-  "artifact"
-  "entrypoints"
-  "kind"
-  "name"
-  "platform"
-  "provenance"
-  "schemaVersion"
-] descriptor) "buck2-artifact-import: descriptor contains unknown fields";
+let
+  checkedDescriptor = contract.verifyDescriptor {
+    inherit descriptor expectedDescriptorDigest;
+  };
+  checkedPlatform = checkedDescriptor.platform;
+  runtimeKind = checkedDescriptor.runtime.kind;
+in
+assert lib.assertMsg (builtins.isAttrs expectedPlatform)
+  "buck2-artifact-import: expectedPlatform must be an exact platform attribute set";
 assert lib.assertMsg (
-  (descriptor.schemaVersion or null) == 1
-) "buck2-artifact-import: unsupported descriptor schemaVersion";
+  checkedPlatform == expectedPlatform
+) "buck2-artifact-import: platform mismatch";
 assert lib.assertMsg (
-  (descriptor.kind or null) == "buck2-build-artifact"
-) "buck2-artifact-import: unsupported descriptor kind";
-assert lib.assertMsg (validName (
-  descriptor.name or null
-)) "buck2-artifact-import: descriptor name is invalid";
-assert lib.assertMsg (validName (
-  descriptor.platform or null
-)) "buck2-artifact-import: descriptor platform is invalid";
-assert lib.assertMsg (descriptor.platform == expectedPlatform)
-  "buck2-artifact-import: platform mismatch: expected ${expectedPlatform}, got ${
-    descriptor.platform or "<missing>"
-  }";
-assert lib.assertMsg (
-  descriptor ? artifact
-  && hasOnlyFields [ "digest" "file" "format" "sizeBytes" "url" ] descriptor.artifact
-  && (descriptor.artifact.format or null) == "tar"
-  && (descriptor.artifact.file or null) == "artifact.tar"
-  && descriptor.artifact ? digest
-  && hasOnlyFields [ "algorithm" "sri" ] descriptor.artifact.digest
-  && (descriptor.artifact.digest.algorithm or null) == "sha256"
-  && builtins.isString (descriptor.artifact.digest.sri or null)
-  && builtins.match "sha256-[A-Za-z0-9+/]+={0,2}" descriptor.artifact.digest.sri != null
-  && builtins.isInt (descriptor.artifact.sizeBytes or null)
-  && descriptor.artifact.sizeBytes > 0
-) "buck2-artifact-import: descriptor artifact/digest shape is invalid";
-assert lib.assertMsg (
-  descriptor ? entrypoints && builtins.isList descriptor.entrypoints && descriptor.entrypoints != [ ]
-) "buck2-artifact-import: descriptor entrypoints must be a non-empty list";
-assert lib.assertMsg (lib.all safeRelativePath descriptor.entrypoints)
-  "buck2-artifact-import: descriptor entrypoints must be canonical safe relative paths";
-assert lib.assertMsg (
-  builtins.length descriptor.entrypoints == builtins.length (lib.unique descriptor.entrypoints)
-) "buck2-artifact-import: descriptor entrypoints must be unique";
-assert lib.assertMsg (
-  descriptor ? provenance
-  && hasOnlyFields [ "actionDigest" "producer" "sourceRevision" "target" ] descriptor.provenance
-  && builtins.isString (descriptor.provenance.producer or null)
-  && descriptor.provenance.producer != ""
-  && builtins.isString (descriptor.provenance.target or null)
-  && descriptor.provenance.target != ""
-  && builtins.isString (descriptor.provenance.sourceRevision or null)
-  && descriptor.provenance.sourceRevision != ""
-  && builtins.isString (descriptor.provenance.actionDigest or null)
-  && descriptor.provenance.actionDigest != ""
-) "buck2-artifact-import: descriptor provenance is incomplete";
-assert lib.assertMsg (
-  !((url != null || descriptor.artifact ? url) && artifact != null)
+  !(url != null && artifact != null)
 ) "buck2-artifact-import: choose either a published URL or a declared artifact path";
 assert lib.assertMsg (
-  url != null || descriptor.artifact ? url || artifact != null
+  url != null || artifact != null
 ) "buck2-artifact-import: a published URL or declared artifact path is required";
-
-let
-  effectiveUrl = if url != null then url else descriptor.artifact.url;
-  descriptorFile = pkgs.writeText "${descriptor.name}-buck2-artifact-descriptor.json" (
-    builtins.toJSON descriptor
-  );
-  archive =
-    if artifact != null then
-      pkgs.runCommand "${descriptor.name}-${descriptor.platform}-buck2-artifact.tar"
-        {
-          outputHashMode = "flat";
-          outputHashAlgo = "sha256";
-          outputHash = descriptor.artifact.digest.sri;
-        }
-        ''
-          cp ${lib.escapeShellArg (toString artifact)} "$out"
-        ''
-    else
-      pkgs.fetchurl {
-        name = "${descriptor.name}-${descriptor.platform}-buck2-artifact.tar";
-        url = effectiveUrl;
-        hash = descriptor.artifact.digest.sri;
-      };
-in
-pkgs.runCommand "${descriptor.name}-${descriptor.platform}-buck2-import"
-  {
-    nativeBuildInputs = [
-      pkgs.jq
-      pkgs.openssl
-    ];
-    allowedReferences = [ ];
-    passthru = {
-      buck2ArtifactDescriptor = descriptor;
-      inherit archive;
-    };
-    meta.platforms = [ descriptor.platform ];
-  }
-  ''
-    set -euo pipefail
-
-    expected_digest=${lib.escapeShellArg descriptor.artifact.digest.sri}
-    actual_digest="sha256-$(${pkgs.openssl}/bin/openssl dgst -sha256 -binary ${archive} \
-      | ${pkgs.openssl}/bin/openssl base64 -A)"
-    [ "$actual_digest" = "$expected_digest" ] || {
-      echo "buck2-artifact-import: digest mismatch after fixed-output fetch" >&2
-      exit 1
-    }
-    expected_size=${toString descriptor.artifact.sizeBytes}
-    actual_size="$(${pkgs.coreutils}/bin/stat --format=%s ${archive})"
-    [ "$actual_size" = "$expected_size" ] || {
-      echo "buck2-artifact-import: size mismatch: expected $expected_size bytes, got $actual_size" >&2
-      exit 1
-    }
-
-    ${scan} archive ${archive}
-    mkdir -p "$out"
-    ${pkgs.gnutar}/bin/tar \
-      --extract \
-      --file ${archive} \
-      --directory "$out" \
-      --no-same-owner \
-      --no-same-permissions \
-      --delay-directory-restore
-
-    ${scan} tree "$out"
-
-    if [ -L "$out/share" ] \
-      || [ -e "$out/share/buck2-artifact" ] \
-      || [ -L "$out/share/buck2-artifact" ]; then
-      echo "buck2-artifact-import: artifact occupies reserved importer metadata path" >&2
-      exit 1
-    fi
-
-    while IFS= read -r entrypoint; do
-      case "$entrypoint" in
-        /*|../*|*/../*|*/..) echo "buck2-artifact-import: unsafe entrypoint: $entrypoint" >&2; exit 1 ;;
-      esac
-      [ -f "$out/$entrypoint" ] && [ -x "$out/$entrypoint" ] || {
-        echo "buck2-artifact-import: missing executable entrypoint: $entrypoint" >&2
-        exit 1
-      }
-    done < <(${pkgs.jq}/bin/jq -r '.entrypoints[]' ${descriptorFile})
-
-    chmod u+w "$out" "$out/share" 2>/dev/null || true
-    mkdir -p "$out/share/buck2-artifact"
-    cp ${descriptorFile} "$out/share/buck2-artifact/descriptor.json"
-    chmod 0444 "$out/share/buck2-artifact/descriptor.json"
-    ${pkgs.findutils}/bin/find "$out" -type d -exec chmod 0555 {} +
-    ${scan} tree "$out"
-  ''
+throw "buck2-artifact-import: runtime inspector is not available for ${runtimeKind}"

--- a/nix/workspace-tools/lib/buck2-artifact-scan.nix
+++ b/nix/workspace-tools/lib/buck2-artifact-scan.nix
@@ -75,6 +75,20 @@ pkgs.writeShellScript "buck2-artifact-scan" ''
     local archive="$1"
     [ -f "$archive" ] || fail "archive does not exist: $archive"
 
+    # GNU tar normally stops at the first end-of-archive marker. Validate the
+    # complete byte stream as well, otherwise appended bytes or a concatenated
+    # second archive would be outside every member/path/resource check below.
+    local archive_size canonical_listing complete_listing
+    archive_size="$(${pkgs.coreutils}/bin/stat --format=%s "$archive")"
+    [ $((archive_size % 512)) -eq 0 ] \
+      || fail "archive contains trailing data after end-of-archive marker"
+    canonical_listing="$(${pkgs.gnutar}/bin/tar --list --file "$archive")" \
+      || fail "archive member listing failed"
+    complete_listing="$(${pkgs.gnutar}/bin/tar --ignore-zeros --list --file "$archive" 2>/dev/null)" \
+      || fail "archive contains trailing data after end-of-archive marker"
+    [ "$canonical_listing" = "$complete_listing" ] \
+      || fail "archive contains trailing data after end-of-archive marker"
+
     # These are deliberately limits on the declared, extracted byte count,
     # rather than on the compact archive. That rejects sparse-file and archive
     # bomb inputs before extraction while leaving ample room for toolchains.

--- a/nix/workspace-tools/lib/buck2-build-product-contract.nix
+++ b/nix/workspace-tools/lib/buck2-build-product-contract.nix
@@ -44,6 +44,7 @@ let
     nonEmptyString value
     && builtins.substring 0 1 value != "/"
     && builtins.match ".*\\\\.*" value == null
+    && builtins.match "[^\n\r]*" value != null
     && builtins.all (component: component != "" && component != "." && component != "..") (
       builtins.filter builtins.isString (builtins.split "/" value)
     );

--- a/nix/workspace-tools/lib/buck2-build-product-contract.nix
+++ b/nix/workspace-tools/lib/buck2-build-product-contract.nix
@@ -1,0 +1,218 @@
+# Pure, exact validation and canonicalization for buck-build-product/v1.
+# Runtime inspection and artifact realization deliberately live outside this
+# module: accepting a descriptor shape is not proof that its runtime is usable.
+let
+  fail = message: throw "buck2-build-product-contract: ${message}";
+  ensure = condition: message: if condition then true else fail message;
+  force = checks: value: builtins.deepSeq checks value;
+  nonEmptyString = value: builtins.isString value && value != "";
+
+  exactAttrs =
+    path: expected: value:
+    if !builtins.isAttrs value then
+      fail "${path} must be an attribute set"
+    else
+      let
+        actual = builtins.attrNames value;
+        unknown = builtins.filter (name: !(builtins.elem name expected)) actual;
+        missing = builtins.filter (name: !(builtins.elem name actual)) expected;
+      in
+      if unknown != [ ] then
+        fail "${path} has unknown fields: ${builtins.concatStringsSep ", " unknown}"
+      else if missing != [ ] then
+        fail "${path} is missing fields: ${builtins.concatStringsSep ", " missing}"
+      else
+        value;
+
+  unique =
+    values:
+    if values == [ ] then
+      true
+    else
+      !(builtins.elem (builtins.head values) (builtins.tail values)) && unique (builtins.tail values);
+
+  validateStringList =
+    path: values:
+    force [
+      (ensure (builtins.isList values) "${path} must be a list")
+      (ensure (builtins.all nonEmptyString values) "${path} entries must be non-empty strings")
+      (ensure (unique values) "${path} entries must be unique")
+    ] values;
+
+  safePath =
+    value:
+    nonEmptyString value
+    && builtins.substring 0 1 value != "/"
+    && builtins.match ".*\\\\.*" value == null
+    && builtins.all (component: component != "" && component != "." && component != "..") (
+      builtins.filter builtins.isString (builtins.split "/" value)
+    );
+
+  validateRuntime =
+    runtime:
+    if !builtins.isAttrs runtime then
+      fail "descriptor.runtime must be an attribute set"
+    else if !(runtime ? kind) then
+      fail "descriptor.runtime is missing fields: kind"
+    else if !nonEmptyString runtime.kind then
+      fail "descriptor.runtime.kind must be a non-empty string"
+    else
+      let
+        kind = runtime.kind;
+      in
+      if kind == "interpreter" then
+        let
+          value = exactAttrs "descriptor.runtime" [
+            "kind"
+            "program"
+            "runtimeContract"
+            "runtimeId"
+          ] runtime;
+        in
+        force [
+          (ensure (nonEmptyString value.runtimeId) "descriptor.runtime.runtimeId must be a non-empty string")
+          (ensure (nonEmptyString value.runtimeContract) "descriptor.runtime.runtimeContract must be a non-empty string")
+          (ensure (safePath value.program) "descriptor.runtime.program must be a safe relative path")
+        ] value
+      else if kind == "elf-dynamic" then
+        let
+          value = exactAttrs "descriptor.runtime" [
+            "kind"
+            "loaderClass"
+            "machine"
+            "neededLibraries"
+            "runpathPolicy"
+            "symbolVersionFloors"
+          ] runtime;
+        in
+        force [
+          (ensure (nonEmptyString value.machine) "descriptor.runtime.machine must be a non-empty string")
+          (ensure (nonEmptyString value.loaderClass) "descriptor.runtime.loaderClass must be a non-empty string")
+          (validateStringList "descriptor.runtime.neededLibraries" value.neededLibraries)
+          (validateStringList "descriptor.runtime.symbolVersionFloors" value.symbolVersionFloors)
+          (ensure (nonEmptyString value.runpathPolicy) "descriptor.runtime.runpathPolicy must be a non-empty string")
+        ] value
+      else if kind == "mach-o-dynamic" then
+        let
+          value = exactAttrs "descriptor.runtime" [
+            "architecture"
+            "dylibs"
+            "installNamePolicy"
+            "kind"
+            "minimumOs"
+            "rpathPolicy"
+            "signingPolicy"
+          ] runtime;
+        in
+        force [
+          (ensure (nonEmptyString value.architecture) "descriptor.runtime.architecture must be a non-empty string")
+          (ensure (nonEmptyString value.minimumOs) "descriptor.runtime.minimumOs must be a non-empty string")
+          (validateStringList "descriptor.runtime.dylibs" value.dylibs)
+          (ensure (nonEmptyString value.installNamePolicy) "descriptor.runtime.installNamePolicy must be a non-empty string")
+          (ensure (nonEmptyString value.rpathPolicy) "descriptor.runtime.rpathPolicy must be a non-empty string")
+          (ensure (nonEmptyString value.signingPolicy) "descriptor.runtime.signingPolicy must be a non-empty string")
+        ] value
+      else if kind == "self-contained" then
+        let
+          value = exactAttrs "descriptor.runtime" [
+            "inspectionContract"
+            "kind"
+          ] runtime;
+        in
+        force [
+          (ensure (nonEmptyString value.inspectionContract) "descriptor.runtime.inspectionContract must be a non-empty string")
+        ] value
+      else
+        fail "unsupported runtime kind: ${toString kind}";
+
+  validateDescriptor =
+    descriptor:
+    let
+      value = exactAttrs "descriptor" [
+        "entrypoints"
+        "name"
+        "payload"
+        "platform"
+        "runtime"
+        "schema"
+        "semanticProvenance"
+      ] descriptor;
+      platform = exactAttrs "descriptor.platform" [
+        "abi"
+        "architecture"
+        "os"
+      ] value.platform;
+      payload = exactAttrs "descriptor.payload" [
+        "digest"
+        "file"
+        "format"
+        "sizeBytes"
+      ] value.payload;
+      digest = exactAttrs "descriptor.payload.digest" [
+        "algorithm"
+        "sri"
+      ] payload.digest;
+      semanticProvenance = exactAttrs "descriptor.semanticProvenance" [
+        "recipe"
+        "target"
+        "toolchain"
+      ] value.semanticProvenance;
+      entrypoints = validateStringList "descriptor.entrypoints" value.entrypoints;
+      runtime = validateRuntime value.runtime;
+    in
+    force [
+      (ensure (value.schema == "buck-build-product/v1") "unsupported descriptor schema")
+      (ensure (
+        nonEmptyString value.name && builtins.match "[A-Za-z0-9._+-]+" value.name != null
+      ) "descriptor.name is invalid")
+      (ensure (nonEmptyString platform.os) "descriptor.platform.os must be a non-empty string")
+      (ensure (nonEmptyString platform.architecture) "descriptor.platform.architecture must be a non-empty string")
+      (ensure (nonEmptyString platform.abi) "descriptor.platform.abi must be a non-empty string")
+      (ensure (payload.file == "artifact.tar") "descriptor.payload.file must be artifact.tar")
+      (ensure (payload.format == "tar") "descriptor.payload.format must be tar")
+      (ensure (digest.algorithm == "sha256") "descriptor.payload.digest.algorithm must be sha256")
+      (ensure (
+        nonEmptyString digest.sri && builtins.match "sha256-[A-Za-z0-9+/]{43}=" digest.sri != null
+      ) "descriptor.payload.digest.sri must be a sha256 SRI digest")
+      (ensure (
+        builtins.isInt payload.sizeBytes && payload.sizeBytes > 0
+      ) "descriptor.payload.sizeBytes must be a positive integer")
+      (ensure (entrypoints != [ ]) "descriptor.entrypoints must not be empty")
+      (ensure (builtins.all safePath entrypoints) "descriptor.entrypoints must be safe relative paths")
+      (ensure (
+        runtime.kind != "interpreter" || builtins.elem runtime.program entrypoints
+      ) "descriptor.runtime.program must name a declared entrypoint")
+      (ensure (nonEmptyString semanticProvenance.target) "descriptor.semanticProvenance.target must be a non-empty string")
+      (ensure (nonEmptyString semanticProvenance.recipe) "descriptor.semanticProvenance.recipe must be a non-empty string")
+      (ensure (nonEmptyString semanticProvenance.toolchain) "descriptor.semanticProvenance.toolchain must be a non-empty string")
+    ] value;
+
+  canonicalDescriptorJson = descriptor: builtins.toJSON (validateDescriptor descriptor);
+  descriptorDigest =
+    descriptor: "sha256:${builtins.hashString "sha256" (canonicalDescriptorJson descriptor)}";
+in
+{
+  inherit
+    canonicalDescriptorJson
+    descriptorDigest
+    validateDescriptor
+    validateRuntime
+    ;
+
+  verifyDescriptor =
+    { descriptor, expectedDescriptorDigest }:
+    let
+      expectedCheck = ensure (
+        nonEmptyString expectedDescriptorDigest
+        && builtins.match "sha256:[0-9a-f]{64}" expectedDescriptorDigest != null
+      ) "expectedDescriptorDigest must be a sha256 digest";
+      actual = descriptorDigest descriptor;
+      digestCheck = ensure (
+        actual == expectedDescriptorDigest
+      ) "descriptor digest mismatch: expected ${expectedDescriptorDigest}, got ${actual}";
+    in
+    force [
+      expectedCheck
+      digestCheck
+    ] (validateDescriptor descriptor);
+}

--- a/nix/workspace-tools/lib/tests/buck2-bridge.nix
+++ b/nix/workspace-tools/lib/tests/buck2-bridge.nix
@@ -86,14 +86,16 @@ in
   mkImport =
     {
       descriptor,
+      expectedDescriptorDigest,
+      expectedPlatform,
       url ? null,
       artifact ? null,
-      expectedPlatform ? pkgs.stdenv.hostPlatform.system,
     }:
     importArtifact {
       inherit
         artifact
         descriptor
+        expectedDescriptorDigest
         expectedPlatform
         url
         ;

--- a/nix/workspace-tools/lib/tests/buck2-bridge.sh
+++ b/nix/workspace-tools/lib/tests/buck2-bridge.sh
@@ -8,13 +8,18 @@ common_let='repo = builtins.toPath (builtins.getEnv "BUCK2_BRIDGE_REPO");
   flake = builtins.getFlake (toString repo);
   pkgs = import flake.inputs.nixpkgs { system = builtins.currentSystem; };
   test = import (repo + "/nix/workspace-tools/lib/tests/buck2-bridge.nix") { inherit pkgs; };
-  asBuckDescriptor = original: (builtins.removeAttrs original [ "normalization" ]) // {
-    kind = "buck2-build-artifact";
-    provenance = {
-      producer = "buck2-test-fixture";
-      target = "//fixtures:portable-tool";
-      sourceRevision = "0123456789abcdef0123456789abcdef01234567";
-      actionDigest = original.artifact.digest.sri;
+  contract = import (repo + "/nix/workspace-tools/lib/buck2-build-product-contract.nix");
+  mkStrictDescriptor = { original, entrypoints }: {
+    schema = "buck-build-product/v1";
+    name = "fixture-tool";
+    platform = { os = "linux"; architecture = "x86_64"; abi = "musl"; };
+    payload = original.artifact;
+    inherit entrypoints;
+    runtime = { kind = "self-contained"; inspectionContract = "elf-static/v1"; };
+    semanticProvenance = {
+      target = "//fixtures:tool";
+      recipe = "fixture-tool/v1";
+      toolchain = "rust-linux-musl/v1";
     };
   };'
 base_expr="let
@@ -86,27 +91,43 @@ actual_digest="$(nix hash file --type sha256 --sri "$archive")"
 [ "$declared_digest" = "$actual_digest" ]
 
 export BUCK2_BRIDGE_EXPORT_OUT="$export_out"
-import_expr="let
+unsupported_runtime_expr="let
   $common_let
   exported = builtins.storePath (builtins.getEnv \"BUCK2_BRIDGE_EXPORT_OUT\");
-    descriptor = asBuckDescriptor (builtins.fromJSON (builtins.readFile (exported + \"/descriptor.json\")));
+    original = builtins.fromJSON (builtins.readFile (exported + \"/descriptor.json\"));
+    descriptor = mkStrictDescriptor {
+      inherit original;
+      entrypoints = [ \"bin/fixture-tool\" ];
+    };
   in test.mkImport {
     inherit descriptor;
+    expectedDescriptorDigest = contract.descriptorDigest descriptor;
+    expectedPlatform = descriptor.platform;
     artifact = exported + \"/artifact.tar\";
   }"
-import_out="$(build_expr "$import_expr")"
+expect_build_failure \
+  "unsupported build-product runtime" \
+  "runtime inspector is not available for self-contained" \
+  "$unsupported_runtime_expr"
 
-[ "$(env -i PATH=/nonexistent "$import_out/bin/fixture-tool")" = "buck2-bridge-ok" ]
-[ -f "$import_out/share/buck2-artifact/descriptor.json" ]
-jq -e '
-  .kind == "buck2-build-artifact" and
-  .provenance.target == "//fixtures:portable-tool"
-' "$import_out/share/buck2-artifact/descriptor.json" >/dev/null
-if grep -a -R -F '/nix/store/' "$import_out" >/dev/null; then
-  echo "buck2-bridge-test: imported artifact contains a Nix store reference" >&2
-  exit 1
-fi
-[ -z "$(nix-store --query --references "$import_out")" ]
+duplicate_import_entrypoint_expr="let
+  $common_let
+  exported = builtins.storePath (builtins.getEnv \"BUCK2_BRIDGE_EXPORT_OUT\");
+    original = builtins.fromJSON (builtins.readFile (exported + \"/descriptor.json\"));
+    descriptor = mkStrictDescriptor {
+      inherit original;
+      entrypoints = [ \"bin/fixture-tool\" \"bin/fixture-tool\" ];
+    };
+  in test.mkImport {
+    inherit descriptor;
+    expectedDescriptorDigest = \"sha256:0000000000000000000000000000000000000000000000000000000000000000\";
+    expectedPlatform = descriptor.platform;
+    artifact = exported + \"/artifact.tar\";
+  }"
+expect_build_failure \
+  "duplicate import entrypoint" \
+  "descriptor.entrypoints entries must be unique" \
+  "$duplicate_import_entrypoint_expr"
 
 expect_build_failure \
   "store-reference export" \
@@ -142,128 +163,6 @@ expect_build_failure \
   "duplicate entrypoint export" \
   "entrypoints must be unique" \
   "($base_expr).duplicateEntrypointExport"
-
-wrong_digest_expr="let
-  $common_let
-  exported = builtins.storePath (builtins.getEnv \"BUCK2_BRIDGE_EXPORT_OUT\");
-    original = asBuckDescriptor (builtins.fromJSON (builtins.readFile (exported + \"/descriptor.json\")));
-    descriptor = original // {
-      artifact = original.artifact // {
-        digest = original.artifact.digest // {
-          sri = \"sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\";
-        };
-      };
-    };
-  in test.mkImport {
-    inherit descriptor;
-    artifact = exported + \"/artifact.tar\";
-  }"
-expect_build_failure "wrong digest import" "hash mismatch" "$wrong_digest_expr"
-
-wrong_size_expr="let
-  $common_let
-  exported = builtins.storePath (builtins.getEnv \"BUCK2_BRIDGE_EXPORT_OUT\");
-    original = asBuckDescriptor (builtins.fromJSON (builtins.readFile (exported + \"/descriptor.json\")));
-    descriptor = original // {
-      artifact = original.artifact // { sizeBytes = original.artifact.sizeBytes + 1; };
-    };
-  in test.mkImport {
-    inherit descriptor;
-    artifact = exported + \"/artifact.tar\";
-  }"
-expect_build_failure "wrong size import" "size mismatch" "$wrong_size_expr"
-
-unknown_descriptor_field_expr="let
-  $common_let
-  exported = builtins.storePath (builtins.getEnv \"BUCK2_BRIDGE_EXPORT_OUT\");
-  descriptor = (asBuckDescriptor (builtins.fromJSON (builtins.readFile (exported + \"/descriptor.json\"))) // {
-    unexpected = true;
-  });
-  in test.mkImport {
-    inherit descriptor;
-    artifact = exported + \"/artifact.tar\";
-  }"
-expect_build_failure \
-  "unknown descriptor field" \
-  "descriptor contains unknown fields" \
-  "$unknown_descriptor_field_expr"
-
-duplicate_import_entrypoint_expr="let
-  $common_let
-  exported = builtins.storePath (builtins.getEnv \"BUCK2_BRIDGE_EXPORT_OUT\");
-  original = asBuckDescriptor (builtins.fromJSON (builtins.readFile (exported + \"/descriptor.json\")));
-  descriptor = original // { entrypoints = [ \"bin/fixture-tool\" \"bin/fixture-tool\" ]; };
-  in test.mkImport {
-    inherit descriptor;
-    artifact = exported + \"/artifact.tar\";
-  }"
-expect_build_failure \
-  "duplicate import entrypoint" \
-  "descriptor entrypoints must be unique" \
-  "$duplicate_import_entrypoint_expr"
-
-control_character_import_entrypoint_expr="let
-  $common_let
-  exported = builtins.storePath (builtins.getEnv \"BUCK2_BRIDGE_EXPORT_OUT\");
-  original = asBuckDescriptor (builtins.fromJSON (builtins.readFile (exported + \"/descriptor.json\")));
-  descriptor = original // { entrypoints = [ \"bin/fixture-tool\\nbin/fixture-tool\" ]; };
-  in test.mkImport {
-    inherit descriptor;
-    artifact = exported + \"/artifact.tar\";
-  }"
-expect_build_failure \
-  "control-character import entrypoint" \
-  "descriptor entrypoints must be canonical safe relative paths" \
-  "$control_character_import_entrypoint_expr"
-
-reserved_metadata_out="$(build_expr "($base_expr).reservedMetadataExport")"
-export BUCK2_BRIDGE_RESERVED_METADATA_OUT="$reserved_metadata_out"
-reserved_metadata_expr="let
-  $common_let
-  exported = builtins.storePath (builtins.getEnv \"BUCK2_BRIDGE_RESERVED_METADATA_OUT\");
-  descriptor = asBuckDescriptor (builtins.fromJSON (builtins.readFile (exported + \"/descriptor.json\")));
-  in test.mkImport {
-    inherit descriptor;
-    artifact = exported + \"/artifact.tar\";
-  }"
-expect_build_failure \
-  "reserved importer metadata path" \
-  "artifact occupies reserved importer metadata path" \
-  "$reserved_metadata_expr"
-
-for entrypoint_case in \
-  "repeated-separator|bin//fixture-tool" \
-  "dot-component|bin/./fixture-tool" \
-  'backslash|bin\fixture-tool'
-do
-  entrypoint_label="${entrypoint_case%%|*}"
-  entrypoint_value="${entrypoint_case#*|}"
-  export BUCK2_BRIDGE_ENTRYPOINT="$entrypoint_value"
-  non_canonical_import_entrypoint_expr="let
-    $common_let
-    exported = builtins.storePath (builtins.getEnv \"BUCK2_BRIDGE_EXPORT_OUT\");
-    original = asBuckDescriptor (builtins.fromJSON (builtins.readFile (exported + \"/descriptor.json\")));
-    descriptor = original // { entrypoints = [ (builtins.getEnv \"BUCK2_BRIDGE_ENTRYPOINT\") ]; };
-    in test.mkImport {
-      inherit descriptor;
-      artifact = exported + \"/artifact.tar\";
-    }"
-  expect_build_failure \
-    "$entrypoint_label import entrypoint" \
-    "descriptor entrypoints must be canonical safe relative paths" \
-    "$non_canonical_import_entrypoint_expr"
-done
-
-wrong_platform_expr="let
-  $common_let
-  exported = builtins.storePath (builtins.getEnv \"BUCK2_BRIDGE_EXPORT_OUT\");
-    original = asBuckDescriptor (builtins.fromJSON (builtins.readFile (exported + \"/descriptor.json\")));
-    descriptor = original // { platform = \"definitely-not-${system:-current}-platform\"; };
-  in test.mkImport {
-    inherit descriptor;
-    artifact = exported + \"/artifact.tar\";
-  }"
-expect_build_failure "wrong platform import" "platform mismatch" "$wrong_platform_expr"
 
 scan_expr="let
   $common_let
@@ -332,17 +231,6 @@ expect_command_failure \
   "$scan_out" archive "$duplicate_root.tar"
 rm -rf "$duplicate_root" "$duplicate_root.tar"
 
-trailing_root="$(mktemp -d)"
-printf '%s\n' canonical >"$trailing_root/file"
-tar --create --file "$trailing_root.tar" --directory "$trailing_root" file
-printf 'x' >>"$trailing_root.tar"
-dd if=/dev/zero bs=511 count=1 status=none >>"$trailing_root.tar"
-expect_command_failure \
-  "non-zero bytes after archive end marker" \
-  "non-zero data after archive end marker" \
-  "$scan_out" archive "$trailing_root.tar"
-rm -rf "$trailing_root" "$trailing_root.tar"
-
 backslash_root="$(mktemp -d)"
 mkdir -p "$backslash_root/share"
 tar --create --file "$backslash_root.tar" --directory "$backslash_root" \
@@ -386,4 +274,4 @@ expect_command_failure \
   "$scan_out" archive "$aggregate_root.tar"
 rm -rf "$aggregate_root" "$aggregate_root.tar"
 
-echo "buck2-bridge-test: PASS export=$export_out import=$import_out"
+echo "buck2-bridge-test: PASS export=$export_out importer=fail-closed"

--- a/nix/workspace-tools/lib/tests/buck2-bridge.sh
+++ b/nix/workspace-tools/lib/tests/buck2-bridge.sh
@@ -274,4 +274,26 @@ expect_command_failure \
   "$scan_out" archive "$aggregate_root.tar"
 rm -rf "$aggregate_root" "$aggregate_root.tar"
 
+trailing_root="$(mktemp -d)"
+printf '%s\n' payload >"$trailing_root/file"
+tar --create --file "$trailing_root.tar" --directory "$trailing_root" file
+printf '%s' trailing-bytes >>"$trailing_root.tar"
+expect_command_failure \
+  "trailing archive bytes" \
+  "archive contains trailing data after end-of-archive marker" \
+  "$scan_out" archive "$trailing_root.tar"
+rm -rf "$trailing_root" "$trailing_root.tar"
+
+concatenated_root="$(mktemp -d)"
+printf '%s\n' first >"$concatenated_root/first"
+printf '%s\n' second >"$concatenated_root/second"
+tar --create --file "$concatenated_root.tar" --directory "$concatenated_root" first
+tar --create --file "$concatenated_root-second.tar" --directory "$concatenated_root" second
+${CAT_BIN:-cat} "$concatenated_root-second.tar" >>"$concatenated_root.tar"
+expect_command_failure \
+  "concatenated archive" \
+  "archive contains trailing data after end-of-archive marker" \
+  "$scan_out" archive "$concatenated_root.tar"
+rm -rf "$concatenated_root" "$concatenated_root.tar" "$concatenated_root-second.tar"
+
 echo "buck2-bridge-test: PASS export=$export_out importer=fail-closed"

--- a/nix/workspace-tools/lib/tests/buck2-build-product-contract.sh
+++ b/nix/workspace-tools/lib/tests/buck2-build-product-contract.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd -P)}"
+export BUCK2_BRIDGE_REPO="$repo_root"
+
+contract_expr='repo = builtins.toPath (builtins.getEnv "BUCK2_BRIDGE_REPO");
+  contract = import (repo + "/nix/workspace-tools/lib/buck2-build-product-contract.nix");
+  valid = {
+    schema = "buck-build-product/v1";
+    name = "fixture-tool";
+    platform = {
+      os = "linux";
+      architecture = "x86_64";
+      abi = "musl";
+    };
+    payload = {
+      file = "artifact.tar";
+      format = "tar";
+      digest = {
+        algorithm = "sha256";
+        sri = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+      };
+      sizeBytes = 123;
+    };
+    entrypoints = [ "bin/fixture-tool" ];
+    runtime = {
+      kind = "self-contained";
+      inspectionContract = "elf-static/v1";
+    };
+    semanticProvenance = {
+      target = "//fixtures:tool";
+      recipe = "fixture-tool/v1";
+      toolchain = "rust-linux-musl/v1";
+    };
+  };'
+
+eval_raw() {
+  nix eval --impure --raw --expr "let $contract_expr in $1"
+}
+
+expect_eval_failure() {
+  local label="$1"
+  local expected="$2"
+  local expression="$3"
+  local log
+  log="$(mktemp)"
+  if eval_raw "$expression" >"$log" 2>&1; then
+    echo "buck2-build-product-contract-test: expected $label to fail" >&2
+    rm -f "$log"
+    exit 1
+  fi
+  if ! grep -F "$expected" "$log" >/dev/null; then
+    echo "buck2-build-product-contract-test: $label failed without expected diagnostic: $expected" >&2
+    sed -n '1,160p' "$log" >&2
+    rm -f "$log"
+    exit 1
+  fi
+  rm -f "$log"
+  echo "buck2-build-product-contract-test: RED $label"
+}
+
+canonical="$(eval_raw 'contract.canonicalDescriptorJson valid')"
+[ "$canonical" = "$(eval_raw 'contract.canonicalDescriptorJson valid')" ]
+
+descriptor_digest="$(eval_raw 'contract.descriptorDigest valid')"
+[[ "$descriptor_digest" =~ ^sha256:[0-9a-f]{64}$ ]] || {
+  echo "buck2-build-product-contract-test: invalid descriptor digest: $descriptor_digest" >&2
+  exit 1
+}
+
+verified="$(eval_raw 'contract.canonicalDescriptorJson (contract.verifyDescriptor {
+  descriptor = valid;
+  expectedDescriptorDigest = contract.descriptorDigest valid;
+})')"
+[ "$verified" = "$canonical" ]
+
+expect_eval_failure \
+  "missing independent descriptor digest" \
+  "expectedDescriptorDigest must be a sha256 digest" \
+  'contract.canonicalDescriptorJson (contract.verifyDescriptor {
+    descriptor = valid;
+    expectedDescriptorDigest = "";
+  })'
+
+expect_eval_failure \
+  "wrong independent descriptor digest" \
+  "descriptor digest mismatch" \
+  'contract.canonicalDescriptorJson (contract.verifyDescriptor {
+    descriptor = valid;
+    expectedDescriptorDigest = "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+  })'
+
+expect_eval_failure \
+  "unknown descriptor field" \
+  "descriptor has unknown fields: surprise" \
+  'contract.canonicalDescriptorJson (valid // { surprise = true; })'
+
+expect_eval_failure \
+  "evidence provenance in semantic descriptor" \
+  "descriptor has unknown fields: evidenceProvenance" \
+  'contract.canonicalDescriptorJson (valid // {
+    evidenceProvenance = { invocationId = "invocation-1"; };
+  })'
+
+expect_eval_failure \
+  "action identity in semantic provenance" \
+  "descriptor.semanticProvenance has unknown fields: actionDigest" \
+  'contract.canonicalDescriptorJson (valid // {
+    semanticProvenance = valid.semanticProvenance // { actionDigest = "action-1"; };
+  })'
+
+expect_eval_failure \
+  "unknown runtime variant" \
+  "unsupported runtime kind: wasm-magic" \
+  'contract.canonicalDescriptorJson (valid // {
+    runtime = { kind = "wasm-magic"; };
+  })'
+
+expect_eval_failure \
+  "unknown runtime field" \
+  "descriptor.runtime has unknown fields: assumedPortable" \
+  'contract.canonicalDescriptorJson (valid // {
+    runtime = valid.runtime // { assumedPortable = true; };
+  })'
+
+expect_eval_failure \
+  "duplicate entrypoint" \
+  "descriptor.entrypoints entries must be unique" \
+  'contract.canonicalDescriptorJson (valid // {
+    entrypoints = [ "bin/fixture-tool" "bin/fixture-tool" ];
+  })'
+
+for variant in interpreter elf-dynamic mach-o-dynamic self-contained; do
+  case "$variant" in
+    interpreter)
+      runtime='{ kind = "interpreter"; runtimeId = "bun"; runtimeContract = "bun-1.2/v1"; program = "bin/fixture-tool"; }'
+      ;;
+    elf-dynamic)
+      runtime='{ kind = "elf-dynamic"; machine = "x86_64"; loaderClass = "glibc"; neededLibraries = [ "libc.so.6" ]; symbolVersionFloors = [ "GLIBC_2.39" ]; runpathPolicy = "nix-realized/v1"; }'
+      ;;
+    mach-o-dynamic)
+      runtime='{ kind = "mach-o-dynamic"; architecture = "arm64"; minimumOs = "14.0"; dylibs = [ "/usr/lib/libSystem.B.dylib" ]; installNamePolicy = "system-only/v1"; rpathPolicy = "none/v1"; signingPolicy = "adhoc/v1"; }'
+      ;;
+    self-contained)
+      runtime='{ kind = "self-contained"; inspectionContract = "elf-static/v1"; }'
+      ;;
+  esac
+  eval_raw "contract.descriptorDigest (valid // { runtime = $runtime; })" >/dev/null
+done
+
+echo "buck2-build-product-contract-test: PASS digest=$descriptor_digest"

--- a/nix/workspace-tools/lib/tests/buck2-build-product-contract.sh
+++ b/nix/workspace-tools/lib/tests/buck2-build-product-contract.sh
@@ -62,10 +62,15 @@ expect_eval_failure() {
 
 canonical="$(eval_raw 'contract.canonicalDescriptorJson valid')"
 [ "$canonical" = "$(eval_raw 'contract.canonicalDescriptorJson valid')" ]
+expected_canonical='{"entrypoints":["bin/fixture-tool"],"name":"fixture-tool","payload":{"digest":{"algorithm":"sha256","sri":"sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="},"file":"artifact.tar","format":"tar","sizeBytes":123},"platform":{"abi":"musl","architecture":"x86_64","os":"linux"},"runtime":{"inspectionContract":"elf-static/v1","kind":"self-contained"},"schema":"buck-build-product/v1","semanticProvenance":{"recipe":"fixture-tool/v1","target":"//fixtures:tool","toolchain":"rust-linux-musl/v1"}}'
+[ "$canonical" = "$expected_canonical" ] || {
+  echo "buck2-build-product-contract-test: canonical descriptor bytes changed" >&2
+  exit 1
+}
 
 descriptor_digest="$(eval_raw 'contract.descriptorDigest valid')"
-[[ "$descriptor_digest" =~ ^sha256:[0-9a-f]{64}$ ]] || {
-  echo "buck2-build-product-contract-test: invalid descriptor digest: $descriptor_digest" >&2
+[ "$descriptor_digest" = "sha256:920dafd10e3eb7c3d54a0ef6d80213a58ceac533019537cb9e7098177b72389d" ] || {
+  echo "buck2-build-product-contract-test: canonical descriptor digest changed: $descriptor_digest" >&2
   exit 1
 }
 
@@ -97,6 +102,29 @@ expect_eval_failure \
   'contract.canonicalDescriptorJson (valid // { surprise = true; })'
 
 expect_eval_failure \
+  "unknown nested payload field" \
+  "descriptor.payload has unknown fields: surprise" \
+  'contract.canonicalDescriptorJson (valid // {
+    payload = valid.payload // { surprise = true; };
+  })'
+
+expect_eval_failure \
+  "unknown nested digest field" \
+  "descriptor.payload.digest has unknown fields: surprise" \
+  'contract.canonicalDescriptorJson (valid // {
+    payload = valid.payload // {
+      digest = valid.payload.digest // { surprise = true; };
+    };
+  })'
+
+expect_eval_failure \
+  "unknown nested platform field" \
+  "descriptor.platform has unknown fields: surprise" \
+  'contract.canonicalDescriptorJson (valid // {
+    platform = valid.platform // { surprise = true; };
+  })'
+
+expect_eval_failure \
   "evidence provenance in semantic descriptor" \
   "descriptor has unknown fields: evidenceProvenance" \
   'contract.canonicalDescriptorJson (valid // {
@@ -123,6 +151,28 @@ expect_eval_failure \
   'contract.canonicalDescriptorJson (valid // {
     runtime = valid.runtime // { assumedPortable = true; };
   })'
+
+expect_eval_failure \
+  "newline entrypoint" \
+  "descriptor.entrypoints must be safe relative paths" \
+  'contract.canonicalDescriptorJson (valid // {
+    entrypoints = [ "bin/fixture\nunsafe" ];
+  })'
+
+expect_eval_failure \
+  "carriage-return entrypoint" \
+  "descriptor.entrypoints must be safe relative paths" \
+  'contract.canonicalDescriptorJson (valid // {
+    entrypoints = [ "bin/fixture\runsafe" ];
+  })'
+
+semantic_change_digest="$(eval_raw 'contract.descriptorDigest (valid // {
+  semanticProvenance = valid.semanticProvenance // { recipe = "fixture-tool/v2"; };
+})')"
+[ "$semantic_change_digest" != "$descriptor_digest" ] || {
+  echo "buck2-build-product-contract-test: semantic provenance did not change descriptor identity" >&2
+  exit 1
+}
 
 expect_eval_failure \
   "duplicate entrypoint" \

--- a/scripts/buck2-package-e2e.sh
+++ b/scripts/buck2-package-e2e.sh
@@ -7,7 +7,6 @@ target="${3:?usage: buck2-package-e2e.sh REPO_ROOT LAUNCHER TARGET}"
 evidence_dir="$repo_root/tmp/buck2-evidence"
 awk_bin="${AWK_BIN:-awk}"
 nix_bin="${NIX_BIN:-nix}"
-nix_store_bin="${NIX_STORE_BIN:-nix-store}"
 jq_bin="${JQ_BIN:-jq}"
 run_id="package-e2e-$$-$RANDOM"
 receipt="$evidence_dir/$run_id/receipt.json"
@@ -60,31 +59,20 @@ descriptor="$(printf '%s\n' "$build_output" | "$awk_bin" -v label="$output_label
   exit 1
 }
 
-export BUCK2_E2E_REPO="$repo_root"
-# A sandboxed Nix build cannot read Buck's mutable output tree directly. Admit
-# the two immutable files to the local store first, then make the importer
-# independently verify the descriptor's digest, size, platform, and archive.
-export BUCK2_E2E_ARTIFACT="$($nix_bin store add --mode flat --name artifact.tar "$artifact")"
-export BUCK2_E2E_DESCRIPTOR="$($nix_bin store add --mode flat --name descriptor.json "$descriptor")"
-imported="$("$nix_bin" build --impure --no-link --print-out-paths --expr '
-  let
-    repo = builtins.toPath (builtins.getEnv "BUCK2_E2E_REPO");
-    flake = builtins.getFlake (toString repo);
-    pkgs = import flake.inputs.nixpkgs { system = builtins.currentSystem; };
-    importArtifact = import (repo + "/nix/workspace-tools/lib/buck2-artifact-import.nix") { inherit pkgs; };
-    artifact = builtins.storePath (builtins.getEnv "BUCK2_E2E_ARTIFACT");
-    descriptorPath = builtins.storePath (builtins.getEnv "BUCK2_E2E_DESCRIPTOR");
-    descriptor = builtins.fromJSON (builtins.readFile descriptorPath);
-  in importArtifact {
-    inherit descriptor;
-    inherit artifact;
-  }
-')"
-
-env -i PATH=/nonexistent "$imported/bin/package-evidence" >/dev/null
-[ -z "$("$nix_store_bin" --query --references "$imported")" ] || {
-  echo "buck2-package-e2e: imported artifact retained Nix references" >&2
+# This output is an input-plan evidence fixture, not an admitted build product.
+# Verify its own provisional package-evidence shape and payload identity without
+# routing it through the strict product importer.
+"$jq_bin" -e '
+  .schemaVersion == 1 and
+  .kind == "buck2-package-evidence" and
+  .provenance.producer == "effect-utils/buck2/package-evidence@1" and
+  .entrypoints == ["bin/package-evidence"]
+' "$descriptor" >/dev/null
+declared_digest="$("$jq_bin" -r '.artifact.digest.sri' "$descriptor")"
+actual_digest="$("$nix_bin" hash file --type sha256 --sri "$artifact")"
+[ "$declared_digest" = "$actual_digest" ] || {
+  echo "buck2-package-e2e: package evidence payload digest mismatch" >&2
   exit 1
 }
 
-echo "buck2-package-e2e: PASS target=$target imported=$imported"
+echo "buck2-package-e2e: PASS target=$target admission=not-attempted"


### PR DESCRIPTION
## Problem

The Buck-to-Nix seam accepted a permissive synthetic descriptor and executed a shell fixture as if that proved portable-product admission. This blurred package evidence, semantic product identity, invocation evidence, and runtime compatibility.

## Scope

This PR establishes the strict, language-neutral contract core. It does not complete product admission or close #1061.

## Decisions

- Use one exact `buck-build-product/v1` envelope with canonical JSON identity.
- Require an independently supplied expected descriptor digest.
- Model runtime as an exact tagged union: interpreter, ELF dynamic, Mach-O dynamic, or self-contained.
- Keep target, recipe, and toolchain in semantic provenance; reject invocation/action evidence from descriptor identity.
- Recognizing a runtime schema does not admit it. The importer rejects every runtime until its inspector exists.
- Relabel provisional TypeScript input-plan output as `buck2-package-evidence` and stop importing it as a product.
- Reject CR/LF entrypoint bytes and archive data appended after the first end marker, including concatenated archives.

No runtime or product is admitted by this PR. Archive/export controls are scanner proof, not product-import admission.

## Verification

Exact base: `94ecb2ce9128f76d9d4cb63872b493cc501169d5` (#1070)

Exact head: `aa32cbd4732b977714aa7b16b82b8a9b30145310`

Verified on the exact head:

- In native stack #1074, replayed only #1069's two semantic commits onto #1070 in the native review chain; the second review-fix patch is byte-equivalent under `git range-diff`.
- Preserved the terminal authorized foundation scanner bounds, structural evidence checks, launcher/receipt hardening, reserved-metadata fixture, control-character export rejection, and duplicate-entrypoint controls. Duplicate entrypoints are independently rejected at producer export, strict contract canonicalization, and importer invocation. The fail-closed importer remains deliberately stricter: no payload reaches runtime-specific extraction until an inspector is admitted.
- Independent RED/GREEN review broke and then closed CR/LF path acceptance and trailing/concatenated tar acceptance.
- Fixed canonical JSON bytes and fixed descriptor digest `sha256:920dafd10e3eb7c3d54a0ef6d80213a58ceac533019537cb9e7098177b72389d` form the conformance vector.
- Nested payload, digest, platform, runtime, and semantic identity negative controls pass.
- `nix/workspace-tools/lib/tests/buck2-build-product-contract.sh "$PWD"`
- `nix/workspace-tools/lib/tests/buck2-bridge.sh "$PWD"`
- `python3 -m unittest buck2.tools.package_evidence_test`
- `bash -n` for the changed bridge/product shell gates.
- `nixfmt --check` for changed Nix files.
- `oxfmt --check` for changed Markdown files.
- `git diff --check` against the exact base.

Fresh exact-head CI remains the broad merge gate.

## Remaining #1061 work

- Remove or rename every remaining prototype `actionDigest` use outside this strict descriptor core.
- Implement genuine independently pinned payload/platform/runtime expectation checks at the successful importer seam.
- Restore payload, size, platform mismatch and archive controls as real import-admission tests once the first runtime inspector exists.
- Add non-Nix producer conformance before TypeScript or Rust descriptor generation is admitted.

## Complexity

This adds one pure Nix validator/canonicalizer and removes more permissive importer logic than it adds. Runtime-specific complexity remains outside the common contract.

## Compatibility

This is an intentional hard cut. There are no production consumers, so no compatibility decoder is retained. Newline-bearing descriptor paths and non-canonical trailing tar data are now rejected.

## References

Refs #1061

Native stack #1074, position 3 of 12; stacked directly on #1070.

## Current stack identity

- Native stack: #1074, position 3 of 12
- Exact base: `94ecb2ce9128f76d9d4cb63872b493cc501169d5`
- Exact head: `aa32cbd4732b977714aa7b16b82b8a9b30145310`
- All actionable review threads resolved; fresh exact-head CI is the remaining merge gate.