### PR TITLE
fix(buck2): close foundation review and runtime-admission gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file.
 
 - Fix lazy Buck stage-0 recovery to snapshot only its fingerprinted source inputs, keep unrelated Cargo product manifests out of tool derivations, and retain the observability gate when shell-entry setup is disabled.
 
+- Harden Buck foundation review contracts by recording explicit revision and execution-platform receipt identity, redacting password aliases, validating schema-v3 provenance, preserving mutation-free observability checks, narrowing generated-file markings, and leasing in-flight publications against future collection.
+- Preserve pre-identity Buck receipt and dry-run compatibility while hardening dynamic ELF metadata boundaries, inspector failures, and artifact-seam mutation proofs.
+- Parse dynamic ELF dependency delimiters and version-need sections structurally, including non-numeric symbol versions without admitting local definition noise.
+- Preserve fixed-marker PT_INTERP paths and complete whitespace-bearing version-need names when inspecting dynamic ELF artifacts.
+
 - **Buck2/devenv fast path**: make shell activation independent of Buck and
   repository setup, expose the pinned Buck client through a source-mode local
   launcher, lazily resolve stage-0 tools only for consuming tasks, and classify

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Preserve pre-identity Buck receipt and dry-run compatibility while hardening dynamic ELF metadata boundaries, inspector failures, and artifact-seam mutation proofs.
 - Parse dynamic ELF dependency delimiters and version-need sections structurally, including non-numeric symbol versions without admitting local definition noise.
 - Preserve fixed-marker PT_INTERP paths and complete whitespace-bearing version-need names when inspecting dynamic ELF artifacts.
+- Bind Buck comparison receipts to the same repository revision and execution platform, preserve delimiter-like ELF version names, and keep the Rust toolchain flake call aligned with its minimal config API.
 
 - **Buck2/devenv fast path**: make shell activation independent of Buck and
   repository setup, expose the pinned Buck client through a source-mode local

--- a/buck2/rust/BUCK
+++ b/buck2/rust/BUCK
@@ -6,10 +6,12 @@ rust_local_store_toolchain(
     name = "x86_64_linux_musl_toolchain",
     contract = read_config("rust_toolchain", "contract", ""),
     execution_platform = read_config("rust_toolchain", "execution_platform", ""),
+    identity_verifier = read_config("rust_toolchain", "identity_verifier", ""),
     linker = read_config("rust_toolchain", "linker", ""),
     rustc = read_config("rust_toolchain", "rustc", ""),
     target_platform = read_config("rust_toolchain", "target_platform", ""),
     target_triple = read_config("rust_toolchain", "target_triple", ""),
+    toolchain_identity_material = read_config("rust_toolchain", "toolchain_identity_material", ""),
     toolchain_identity = read_config("rust_toolchain", "toolchain_identity", ""),
 )
 

--- a/buck2/rust/local_store.bzl
+++ b/buck2/rust/local_store.bzl
@@ -3,11 +3,13 @@
 RustLocalStoreToolchainInfo = provider(fields = [
     "contract",
     "execution_platform",
+    "identity_verifier",
     "linker",
     "rustc",
     "target_platform",
     "target_triple",
     "toolchain_identity",
+    "toolchain_identity_material",
 ])
 
 _CONTRACT = "effect-utils/rust-local-store-toolchain/v1"
@@ -23,10 +25,24 @@ def _require_toolchain_identity(value):
     if len(value) != 71 or not value.startswith("sha256:"):
         fail("toolchain_identity must be a Nix-authored sha256 identity")
 
+def _identity_material(ctx):
+    return ";".join([
+        "contract=" + ctx.attrs.contract,
+        "execution_platform=" + ctx.attrs.execution_platform,
+        "identity_verifier=" + ctx.attrs.identity_verifier,
+        "linker=" + ctx.attrs.linker,
+        "rustc=" + ctx.attrs.rustc,
+        "target_platform=" + ctx.attrs.target_platform,
+        "target_triple=" + ctx.attrs.target_triple,
+    ])
+
 def _rust_local_store_toolchain_impl(ctx):
     _require_nix_store_executable(ctx.attrs.rustc, "rustc")
     _require_nix_store_executable(ctx.attrs.linker, "linker")
+    _require_nix_store_executable(ctx.attrs.identity_verifier, "identity_verifier")
     _require_toolchain_identity(ctx.attrs.toolchain_identity)
+    if ctx.attrs.toolchain_identity_material != _identity_material(ctx):
+        fail("Rust toolchain identity material does not match the configured fields")
     if ctx.attrs.contract != _CONTRACT:
         fail("unsupported Rust toolchain contract: {}".format(ctx.attrs.contract))
     if ctx.attrs.execution_platform != _EXECUTION_PLATFORM:
@@ -40,11 +56,13 @@ def _rust_local_store_toolchain_impl(ctx):
         RustLocalStoreToolchainInfo(
             contract = ctx.attrs.contract,
             execution_platform = ctx.attrs.execution_platform,
+            identity_verifier = ctx.attrs.identity_verifier,
             linker = ctx.attrs.linker,
             rustc = ctx.attrs.rustc,
             target_platform = ctx.attrs.target_platform,
             target_triple = ctx.attrs.target_triple,
             toolchain_identity = ctx.attrs.toolchain_identity,
+            toolchain_identity_material = ctx.attrs.toolchain_identity_material,
         ),
     ]
 
@@ -53,11 +71,13 @@ rust_local_store_toolchain = rule(
     attrs = {
         "contract": attrs.string(),
         "execution_platform": attrs.string(),
+        "identity_verifier": attrs.string(),
         "linker": attrs.string(),
         "rustc": attrs.string(),
         "target_platform": attrs.string(),
         "target_triple": attrs.string(),
         "toolchain_identity": attrs.string(),
+        "toolchain_identity_material": attrs.string(),
     },
 )
 
@@ -66,6 +86,9 @@ def _rust_static_binary_impl(ctx):
     out = ctx.actions.declare_output(ctx.attrs.binary_name)
     ctx.actions.run(
         [
+            toolchain.identity_verifier,
+            toolchain.toolchain_identity_material,
+            toolchain.toolchain_identity,
             toolchain.rustc,
             ctx.attrs.src,
             "--crate-name",

--- a/buck2/toolchains/BUCK
+++ b/buck2/toolchains/BUCK
@@ -15,6 +15,7 @@ portable_toolchain(
     descriptor_sha256_by_platform = {
         "aarch64-darwin": "2d3d9a4016ba9d2030b79507a6f291e6e217a79dc88551c54391409331c07779",
         "aarch64-linux": "bd3345101be98fec5153fc58377413133a7f0c58f402010a3c7c751f493574a5",
+        "x86_64-darwin": "c06f03188b6a97d872f372f068072cb5dabc0a1fa03a031b34a681a946acd3b9",
         "x86_64-linux": "d8092ec6f82b460b8d19d5f02e504bfd718191851fa33a15b53118f1f34b0244",
     },
     entrypoint = "bin/fixture-tool",

--- a/context/buck2/04-artifact-system-bridge/requirements.md
+++ b/context/buck2/04-artifact-system-bridge/requirements.md
@@ -81,6 +81,11 @@ identity, build on the
 - **BUCK.BRIDGE-R13 Post-relocation proof:** When Nix injects a loader, search
   path, wrapper, or signing state, it must re-inspect the realized output and
   record the transformation separately from the normalized Buck2 payload.
+- **BUCK.BRIDGE-R23 Exact dynamic ELF observation:** A dynamic ELF import must
+  compare every declared entrypoint's ELF class, normalized machine, absolute
+  interpreter, complete sorted `DT_NEEDED` set, and complete sorted required
+  symbol-version set against its exact descriptor. It must reject any RPATH or
+  RUNPATH and any payload byte containing a Nix store reference.
 
 ### Must support declarative system realization
 
@@ -119,5 +124,6 @@ identity, build on the
   network access.
 - **BUCK.BRIDGE-R22 Conservative collection:** Published graphs and admission
   bundles must remain undeletable until collection derives a complete live set
-  from reviewed pins and retained rollback states, previews the sweep, preserves
+  from reviewed pins, retained rollback states, and active publication or
+  staging leases acquired before the first upload, previews the sweep, preserves
   a restorable snapshot, and proves restoration after collection.

--- a/context/buck2/04-artifact-system-bridge/spec.md
+++ b/context/buck2/04-artifact-system-bridge/spec.md
@@ -6,9 +6,10 @@ the handoff into Nix-managed system generations. It builds on
 
 Status: **Draft**. The exact descriptor validator and canonical identity are
 implemented, and the generic archive/import seam plus OCI protocol have
-prototype evidence. The importer rejects every runtime because no runtime
-inspector is admitted yet. No TypeScript or Rust executable, publication flow,
-or system generation is admitted through the bridge.
+prototype evidence. The importer admits the exact observation-only
+`elf-dynamic/v1` runtime inspector on the supported Linux/glibc tuples and
+rejects every other runtime. No TypeScript or Rust executable, publication
+flow, or system generation is admitted through the bridge.
 
 ## Scope
 
@@ -24,12 +25,12 @@ fleet configuration, credentials, evidence verdicts, or admission records.
 
 ## Requirement Trace
 
-| Section                | Requirements        |
-| ---------------------- | ------------------- |
-| Authorities and flow   | BUCK.BRIDGE-R01-R04 |
-| Build-product contract | BUCK.BRIDGE-R05-R13 |
-| System handoff         | BUCK.BRIDGE-R14-R16 |
-| Publication boundary   | BUCK.BRIDGE-R17-R22 |
+| Section                | Requirements                         |
+| ---------------------- | ------------------------------------ |
+| Authorities and flow   | BUCK.BRIDGE-R01-R04                  |
+| Build-product contract | BUCK.BRIDGE-R05-R13, BUCK.BRIDGE-R23 |
+| System handoff         | BUCK.BRIDGE-R14-R16                  |
+| Publication boundary   | BUCK.BRIDGE-R17-R22                  |
 
 ## Authorities and Flow
 
@@ -103,8 +104,8 @@ product property rather than a source-language property:
 ```text
 RuntimeContract =
   | interpreter { runtimeId, runtimeContract, program }
-  | elf-dynamic { machine, loaderClass, neededLibraries,
-                  symbolVersionFloors, runpathPolicy }
+  | elf-dynamic { inspectionContract, elfClass, machine, interpreter,
+                  neededLibraries, symbolVersionFloors, rpathPolicy }
   | mach-o-dynamic { architecture, minimumOs, dylibs,
                      installNamePolicy, rpathPolicy, signingPolicy }
   | self-contained { inspectionContract }
@@ -169,6 +170,22 @@ normalizes install names and runtime paths, applies declared signing policy,
 then rechecks architecture, minimum OS, dependencies, runtime paths, and
 signature state. Portable artifacts remain unmodified and contain no
 undeclared host or Nix-store dependencies.
+
+The first admitted runtime inspector is `elf-dynamic/v1`. It is
+observation-only: after payload identity verification, complete archive
+pre-scan, extraction, and tree scanning, it checks every declared entrypoint as
+a regular executable. ELF class is `ELF32` or `ELF64`; machine names normalize
+only explicitly supported GNU `readelf` values to descriptor names;
+interpreter equality is byte-exact; `DT_NEEDED` and required symbol versions
+are compared as complete C-locale sorted unique sets; and any RPATH or RUNPATH
+fails. The common contract also binds the runtime machine to the declared
+platform architecture, admits this runtime only on Linux/glibc, and maps each
+supported architecture to its exact glibc interpreter so an artifact cannot
+self-describe a contradictory platform and runtime. The inspector does not
+inject a loader, run the program, or infer host compatibility.
+Hostile-environment execution belongs to the subsequent Nix
+runtime realization and admission proof, because running a normalized dynamic
+payload directly would otherwise make the verifier host an undeclared input.
 
 ## OCI Publication Boundary
 
@@ -275,7 +292,10 @@ configuration and never enter public product identity.
 
 Deletion and registry garbage collection remain disabled initially. Later
 collection derives its live set from reviewed Nix pins, retained system
-generations, and their complete sealed bundles; emits a dry-run plan; snapshots
+generations, active publication and staging leases, and their complete sealed
+bundles. A publisher acquires its lease before uploading the first object and
+releases it only after the reviewed pin advances or the publication is
+explicitly abandoned. Collection then emits a dry-run plan; snapshots
 the candidate sweep; deletes only unreachable objects; and proves restore from
 that snapshot before collection is admitted. A replica is not a backup.
 

--- a/flake.nix
+++ b/flake.nix
@@ -83,13 +83,16 @@
                 cross.${"rust_${builtins.elemAt rustVersionParts 0}_${builtins.elemAt rustVersionParts 1}"};
             in
             (import ./nix/workspace-tools/lib/buck2-rust-local-toolchain-config.nix { inherit pkgs; } {
-              # `cross.rustc` builds the target standard library from the
-              # Rust source tree.  This probe needs the same pinned compiler
-              # and musl stdlib, but not a source-built compiler toolchain.
-              # nixpkgs' matching bootstrap archive supplies both as a
-              # substitutable binary while the cross linker remains Nix-owned.
+              clippyDriver = "${pkgs.clippy}/bin/clippy-driver";
+              # The matching prebuilt archive supplies rustc, rustdoc, and
+              # the musl standard library without rebuilding Rust/LLVM.
               rustc = "${rustPackageSet.packages.prebuilt.rustc}/bin/rustc";
+              rustdoc = "${rustPackageSet.packages.prebuilt.rustc}/bin/rustdoc";
               linker = "${cross.stdenv.cc}/bin/${cross.stdenv.cc.targetPrefix}cc";
+              cxx = "${cross.stdenv.cc}/bin/${cross.stdenv.cc.targetPrefix}c++";
+              binutils = cross.binutils;
+              python = "${pkgs.python3}/bin/python3";
+              toolPath = "${pkgs.bash}/bin:${pkgs.coreutils}/bin";
             }).config
           else
             null;
@@ -217,6 +220,7 @@
             inherit otelite otel-scrape buck2-launcher;
             buck2-closure-tool = buck2-stage0-tools.closure-tool;
             buck2-package-evidence = buck2-stage0-tools.package-evidence;
+            buck2-typescript-product = buck2-stage0-tools.typescript-product;
             buck2-portable-toolchain = buck2-stage0-tools.portable-toolchain;
             buck2-portable-toolchain-fixture = buck2-stage0-tools.portable-toolchain-fixture;
             cli-build-stamp = cliBuildStamp.package;

--- a/flake.nix
+++ b/flake.nix
@@ -83,16 +83,10 @@
                 cross.${"rust_${builtins.elemAt rustVersionParts 0}_${builtins.elemAt rustVersionParts 1}"};
             in
             (import ./nix/workspace-tools/lib/buck2-rust-local-toolchain-config.nix { inherit pkgs; } {
-              clippyDriver = "${pkgs.clippy}/bin/clippy-driver";
-              # The matching prebuilt archive supplies rustc, rustdoc, and
-              # the musl standard library without rebuilding Rust/LLVM.
+              # The matching prebuilt archive supplies rustc and the musl
+              # standard library without rebuilding Rust/LLVM.
               rustc = "${rustPackageSet.packages.prebuilt.rustc}/bin/rustc";
-              rustdoc = "${rustPackageSet.packages.prebuilt.rustc}/bin/rustdoc";
               linker = "${cross.stdenv.cc}/bin/${cross.stdenv.cc.targetPrefix}cc";
-              cxx = "${cross.stdenv.cc}/bin/${cross.stdenv.cc.targetPrefix}c++";
-              binutils = cross.binutils;
-              python = "${pkgs.python3}/bin/python3";
-              toolPath = "${pkgs.bash}/bin:${pkgs.coreutils}/bin";
             }).config
           else
             null;

--- a/nix/workspace-tools/README.md
+++ b/nix/workspace-tools/README.md
@@ -8,8 +8,11 @@ pure and designed to work in both megarepo workspaces and standalone repos.
 - `lib/`
   - `buck2-build-product-contract.nix` — pure exact validation and canonical
     identity for the shared Buck-to-Nix product descriptor.
-  - `buck2-artifact-import.nix` — fail-closed product import entry point; each
-    runtime remains rejected until its inspector is implemented.
+  - `buck2-artifact-import.nix` — fail-closed product import entry point; the
+    exact `elf-dynamic/v1` inspector is admitted and other runtimes remain
+    rejected until their inspectors exist.
+  - `buck2-runtime-inspect-elf-dynamic.nix` — observation-only ELF class,
+    machine, interpreter, dependency, and runtime-path verification.
   - `mk-bun-cli.nix` — Bun binary builder (deterministic, local file deps).
   - `mk-pnpm-cli.nix` — pnpm + bun compile builder for workspace CLIs.
   - `mk-pnpm-deps.nix` — FOD helper for preparing relocatable pnpm install trees that downstream builds restore without rerunning `pnpm install`.

--- a/nix/workspace-tools/lib/buck2-artifact-import.nix
+++ b/nix/workspace-tools/lib/buck2-artifact-import.nix
@@ -1,13 +1,14 @@
 # Verify and import a published Buck2 build product into the Nix store.
 #
-# This entry point intentionally rejects every runtime until a runtime-specific
-# inspector exists. Shape validation is not runtime proof, and the former
-# synthetic shell fixture must not make this bridge look admitted.
+# Shape validation is not runtime proof. Each accepted tagged runtime dispatches
+# to an exact inspector; all other runtime kinds remain fail closed.
 { pkgs }:
 
 let
   lib = pkgs.lib;
   contract = import ./buck2-build-product-contract.nix;
+  scan = import ./buck2-artifact-scan.nix { inherit pkgs; };
+  inspectElfDynamic = import ./buck2-runtime-inspect-elf-dynamic.nix { inherit pkgs; };
 in
 {
   descriptor,
@@ -23,6 +24,15 @@ let
   };
   checkedPlatform = checkedDescriptor.platform;
   runtimeKind = checkedDescriptor.runtime.kind;
+  payload = checkedDescriptor.payload;
+  fetchedArtifact =
+    if url == null then artifact else pkgs.fetchurl {
+      inherit url;
+      hash = payload.digest.sri;
+    };
+  descriptorFile = pkgs.writeText "${checkedDescriptor.name}-buck-build-product.json" (
+    contract.canonicalDescriptorJson checkedDescriptor
+  );
 in
 assert lib.assertMsg (builtins.isAttrs expectedPlatform)
   "buck2-artifact-import: expectedPlatform must be an exact platform attribute set";
@@ -35,4 +45,42 @@ assert lib.assertMsg (
 assert lib.assertMsg (
   url != null || artifact != null
 ) "buck2-artifact-import: a published URL or declared artifact path is required";
-throw "buck2-artifact-import: runtime inspector is not available for ${runtimeKind}"
+if runtimeKind != "elf-dynamic" then
+  throw "buck2-artifact-import: runtime inspector is not available for ${runtimeKind}"
+else
+  pkgs.runCommand "${checkedDescriptor.name}-buck2-import"
+    {
+      nativeBuildInputs = [ pkgs.openssl ];
+      allowedReferences = [ ];
+      passthru = {
+        descriptorDigest = expectedDescriptorDigest;
+        inherit checkedDescriptor;
+      };
+    }
+    ''
+      set -euo pipefail
+      archive=${lib.escapeShellArg (toString fetchedArtifact)}
+      actual_size="$(${pkgs.coreutils}/bin/stat --format=%s "$archive")"
+      [ "$actual_size" = ${lib.escapeShellArg (toString payload.sizeBytes)} ] || {
+        echo "buck2-artifact-import: payload size mismatch: expected ${toString payload.sizeBytes}, got $actual_size" >&2
+        exit 1
+      }
+      actual_digest="sha256-$(${pkgs.openssl}/bin/openssl dgst -sha256 -binary "$archive" \
+        | ${pkgs.openssl}/bin/openssl base64 -A)"
+      [ "$actual_digest" = ${lib.escapeShellArg payload.digest.sri} ] || {
+        echo "buck2-artifact-import: payload digest mismatch" >&2
+        exit 1
+      }
+
+      ${scan} archive "$archive"
+      mkdir -p "$out"
+      ${pkgs.gnutar}/bin/tar --extract --file "$archive" --directory "$out" \
+        --no-same-owner --no-same-permissions
+      ${scan} tree "$out"
+      ${inspectElfDynamic} ${descriptorFile} "$out"
+
+      ${pkgs.findutils}/bin/find "$out" -type d -exec chmod 0555 {} +
+      while IFS= read -r -d "" file; do
+        if [ -x "$file" ]; then chmod 0555 "$file"; else chmod 0444 "$file"; fi
+      done < <(${pkgs.findutils}/bin/find "$out" -type f -print0)
+    ''

--- a/nix/workspace-tools/lib/buck2-artifact-import.nix
+++ b/nix/workspace-tools/lib/buck2-artifact-import.nix
@@ -26,10 +26,13 @@ let
   runtimeKind = checkedDescriptor.runtime.kind;
   payload = checkedDescriptor.payload;
   fetchedArtifact =
-    if url == null then artifact else pkgs.fetchurl {
-      inherit url;
-      hash = payload.digest.sri;
-    };
+    if url == null then
+      artifact
+    else
+      pkgs.fetchurl {
+        inherit url;
+        hash = payload.digest.sri;
+      };
   descriptorFile = pkgs.writeText "${checkedDescriptor.name}-buck-build-product.json" (
     contract.canonicalDescriptorJson checkedDescriptor
   );

--- a/nix/workspace-tools/lib/buck2-artifact-scan.nix
+++ b/nix/workspace-tools/lib/buck2-artifact-scan.nix
@@ -63,9 +63,15 @@ pkgs.writeShellScript "buck2-artifact-scan" ''
       fi
     done < <(${pkgs.findutils}/bin/find "$root" -mindepth 1 -print0)
 
-    local leaked
-    leaked="$(${pkgs.gnugrep}/bin/grep -a -R -l -F -- '${builtins.storeDir}/' "$root" \
-      | ${pkgs.coreutils}/bin/head -n 1 || true)"
+    local leaked grep_status
+    if leaked="$(${pkgs.gnugrep}/bin/grep -a -R -l -F -- '${builtins.storeDir}/' "$root")"; then
+      leaked="''${leaked%%$'\n'*}"
+    else
+      grep_status=$?
+      [ "$grep_status" -eq 1 ] \
+        || fail "failed to scan tree for forbidden Nix store references"
+      leaked=""
+    fi
     if [ -n "$leaked" ]; then
       fail "forbidden Nix store reference in ''${leaked#"$root"/}"
     fi

--- a/nix/workspace-tools/lib/buck2-build-product-contract.nix
+++ b/nix/workspace-tools/lib/buck2-build-product-contract.nix
@@ -39,12 +39,21 @@ let
       (ensure (unique values) "${path} entries must be unique")
     ] values;
 
+  validateStructuredStringList =
+    path: values:
+    force [
+      (validateStringList path values)
+      (ensure (builtins.all (
+        value: builtins.match ".*[[:cntrl:]].*" value == null
+      ) values) "${path} entries must not contain control characters")
+    ] values;
+
   safePath =
     value:
     nonEmptyString value
     && builtins.substring 0 1 value != "/"
     && builtins.match ".*\\\\.*" value == null
-    && builtins.match "[^\n\r]*" value != null
+    && builtins.match ".*[[:cntrl:]].*" value == null
     && builtins.all (component: component != "" && component != "." && component != "..") (
       builtins.filter builtins.isString (builtins.split "/" value)
     );
@@ -78,20 +87,37 @@ let
       else if kind == "elf-dynamic" then
         let
           value = exactAttrs "descriptor.runtime" [
+            "elfClass"
+            "inspectionContract"
+            "interpreter"
             "kind"
-            "loaderClass"
             "machine"
             "neededLibraries"
-            "runpathPolicy"
+            "rpathPolicy"
             "symbolVersionFloors"
           ] runtime;
         in
         force [
+          (ensure (
+            value.inspectionContract == "elf-dynamic/v1"
+          ) "descriptor.runtime.inspectionContract must be elf-dynamic/v1")
+          (ensure (builtins.elem value.elfClass [
+            "ELF32"
+            "ELF64"
+          ]) "descriptor.runtime.elfClass must be ELF32 or ELF64")
           (ensure (nonEmptyString value.machine) "descriptor.runtime.machine must be a non-empty string")
-          (ensure (nonEmptyString value.loaderClass) "descriptor.runtime.loaderClass must be a non-empty string")
-          (validateStringList "descriptor.runtime.neededLibraries" value.neededLibraries)
-          (validateStringList "descriptor.runtime.symbolVersionFloors" value.symbolVersionFloors)
-          (ensure (nonEmptyString value.runpathPolicy) "descriptor.runtime.runpathPolicy must be a non-empty string")
+          (ensure (
+            nonEmptyString value.interpreter && builtins.substring 0 1 value.interpreter == "/"
+          ) "descriptor.runtime.interpreter must be an absolute path")
+          (validateStructuredStringList "descriptor.runtime.neededLibraries" value.neededLibraries)
+          (ensure (
+            value.neededLibraries == builtins.sort builtins.lessThan value.neededLibraries
+          ) "descriptor.runtime.neededLibraries must be sorted")
+          (validateStructuredStringList "descriptor.runtime.symbolVersionFloors" value.symbolVersionFloors)
+          (ensure (
+            value.symbolVersionFloors == builtins.sort builtins.lessThan value.symbolVersionFloors
+          ) "descriptor.runtime.symbolVersionFloors must be sorted")
+          (ensure (value.rpathPolicy == "empty/v1") "descriptor.runtime.rpathPolicy must be empty/v1")
         ] value
       else if kind == "mach-o-dynamic" then
         let
@@ -160,6 +186,34 @@ let
       ] value.semanticProvenance;
       entrypoints = validateStringList "descriptor.entrypoints" value.entrypoints;
       runtime = validateRuntime value.runtime;
+      glibcInterpreterByArchitecture = {
+        x86_64 = "/lib64/ld-linux-x86-64.so.2";
+        aarch64 = "/lib/ld-linux-aarch64.so.1";
+      };
+      expectedGlibcInterpreter = glibcInterpreterByArchitecture.${platform.architecture} or null;
+      runtimePlatformChecks =
+        if runtime.kind == "elf-dynamic" then
+          [
+            (ensure (
+              platform.os == "linux"
+            ) "descriptor.runtime elf-dynamic requires descriptor.platform.os = linux")
+            (ensure (
+              platform.abi == "glibc"
+            ) "descriptor.runtime elf-dynamic/v1 currently requires descriptor.platform.abi = glibc")
+            (ensure (
+              runtime.machine == platform.architecture
+            ) "descriptor.runtime.machine must match descriptor.platform.architecture")
+            (ensure (builtins.elem platform.architecture [
+              "x86_64"
+              "aarch64"
+            ]) "descriptor.runtime elf-dynamic architecture is unsupported")
+            (ensure (runtime.elfClass == "ELF64") "descriptor.runtime elf-dynamic architecture requires ELF64")
+            (ensure (
+              expectedGlibcInterpreter != null && runtime.interpreter == expectedGlibcInterpreter
+            ) "descriptor.runtime.interpreter does not prove the declared glibc architecture")
+          ]
+        else
+          [ ];
     in
     force [
       (ensure (value.schema == "buck-build-product/v1") "unsupported descriptor schema")
@@ -173,7 +227,12 @@ let
       (ensure (payload.format == "tar") "descriptor.payload.format must be tar")
       (ensure (digest.algorithm == "sha256") "descriptor.payload.digest.algorithm must be sha256")
       (ensure (
-        nonEmptyString digest.sri && builtins.match "sha256-[A-Za-z0-9+/]{43}=" digest.sri != null
+        nonEmptyString digest.sri
+        # SHA-256 is exactly 32 bytes. Canonical RFC 4648 base64 therefore has
+        # 42 unrestricted digits, one digit whose low four bits are zero, and
+        # exactly one padding byte. This rejects alternate encodings that
+        # decode to the same digest.
+        && builtins.match "sha256-[A-Za-z0-9+/]{42}[AEIMQUYcgkosw048]=" digest.sri != null
       ) "descriptor.payload.digest.sri must be a sha256 SRI digest")
       (ensure (
         builtins.isInt payload.sizeBytes && payload.sizeBytes > 0
@@ -186,6 +245,7 @@ let
       (ensure (nonEmptyString semanticProvenance.target) "descriptor.semanticProvenance.target must be a non-empty string")
       (ensure (nonEmptyString semanticProvenance.recipe) "descriptor.semanticProvenance.recipe must be a non-empty string")
       (ensure (nonEmptyString semanticProvenance.toolchain) "descriptor.semanticProvenance.toolchain must be a non-empty string")
+      runtimePlatformChecks
     ] value;
 
   canonicalDescriptorJson = descriptor: builtins.toJSON (validateDescriptor descriptor);

--- a/nix/workspace-tools/lib/buck2-runtime-inspect-elf-dynamic.nix
+++ b/nix/workspace-tools/lib/buck2-runtime-inspect-elf-dynamic.nix
@@ -1,0 +1,127 @@
+# Inspect an extracted buck-build-product/v1 elf-dynamic payload without
+# rewriting it. The descriptor is a claim; readelf output is the observation.
+{
+  pkgs,
+  readelf ? "${pkgs.binutils}/bin/readelf",
+}:
+
+pkgs.writeShellScript "buck2-runtime-inspect-elf-dynamic" ''
+  set -euo pipefail
+  export LC_ALL=C
+
+  fail() {
+    echo "buck2-runtime-inspect-elf-dynamic: FATAL - $*" >&2
+    exit 1
+  }
+
+  [ "$#" -eq 2 ] || fail "usage: $0 DESCRIPTOR_JSON EXTRACTED_ROOT"
+  descriptor="$1"
+  root="$2"
+  [ -f "$descriptor" ] || fail "descriptor does not exist"
+  [ -d "$root" ] || fail "extracted root does not exist"
+
+  [ "$(${pkgs.jq}/bin/jq -r '.runtime.kind' "$descriptor")" = elf-dynamic ] \
+    || fail "descriptor runtime kind must be elf-dynamic"
+  [ "$(${pkgs.jq}/bin/jq -r '.runtime.inspectionContract' "$descriptor")" = elf-dynamic/v1 ] \
+    || fail "unsupported inspection contract"
+
+  inspect_entrypoint() {
+    local relative="$1"
+    local executable="$root/$relative"
+    [ -f "$executable" ] && [ ! -L "$executable" ] \
+      || fail "entrypoint must be a regular non-symlink file: $relative"
+    [ -x "$executable" ] || fail "entrypoint is not executable: $relative"
+
+    local actual_class expected_class
+    actual_class="$(${readelf} --file-header "$executable" \
+      | ${pkgs.gawk}/bin/awk -F: '$1 ~ /^[[:space:]]*Class$/ { sub(/^[[:space:]]+/, "", $2); print $2 }')"
+    expected_class="$(${pkgs.jq}/bin/jq -r '.runtime.elfClass' "$descriptor")"
+    [ "$actual_class" = "$expected_class" ] \
+      || fail "ELF class mismatch for $relative: expected $expected_class, got $actual_class"
+
+    local raw_machine actual_machine actual_interpreter
+    raw_machine="$(${readelf} --file-header "$executable" \
+      | ${pkgs.gawk}/bin/awk -F: '$1 ~ /^[[:space:]]*Machine$/ { sub(/^[[:space:]]+/, "", $2); print $2 }')"
+    case "$raw_machine" in
+      "Advanced Micro Devices X86-64") actual_machine=x86_64 ;;
+      "AArch64") actual_machine=aarch64 ;;
+      *) fail "unsupported ELF machine for $relative: $raw_machine" ;;
+    esac
+    if ! actual_interpreter="$(${readelf} --program-headers "$executable" \
+      | ${pkgs.gawk}/bin/awk '
+          BEGIN { matches = 0 }
+          /Requesting program interpreter:/ {
+            marker = "[Requesting program interpreter: "
+            start = index($0, marker)
+            if (start == 0) exit 2
+            matches++
+            if (matches != 1) exit 2
+            value = substr($0, start + length(marker))
+            if (substr(value, length(value), 1) != "]") exit 2
+            value = substr(value, 1, length(value) - 1)
+            if (value == "" || value ~ /[[:cntrl:]]/) exit 2
+            print value
+          }
+          END { if (matches != 1) exit 2 }')"; then
+      fail "malformed ELF program interpreter observation: $relative"
+    fi
+    [ -n "$actual_interpreter" ] || fail "entrypoint has no ELF program interpreter: $relative"
+
+    local expected_machine expected_interpreter
+    expected_machine="$(${pkgs.jq}/bin/jq -r '.runtime.machine' "$descriptor")"
+    expected_interpreter="$(${pkgs.jq}/bin/jq -r '.runtime.interpreter' "$descriptor")"
+    [ "$actual_machine" = "$expected_machine" ] \
+      || fail "ELF machine mismatch for $relative: expected $expected_machine, got $actual_machine"
+    [ "$actual_interpreter" = "$expected_interpreter" ] \
+      || fail "ELF interpreter mismatch for $relative: expected $expected_interpreter, got $actual_interpreter"
+
+    if ${readelf} --dynamic "$executable" \
+      | ${pkgs.gnugrep}/bin/grep -Eq '\((RPATH|RUNPATH)\)'; then
+      fail "RPATH/RUNPATH must be absent: $relative"
+    fi
+
+    local actual_needed expected_needed
+    actual_needed="$(${readelf} --dynamic "$executable" \
+      | ${pkgs.gawk}/bin/awk '
+          /\(NEEDED\)/ {
+            marker = "Shared library: ["
+            start = index($0, marker)
+            if (start == 0) exit 2
+            value = substr($0, start + length(marker))
+            if (substr(value, length(value), 1) != "]") exit 2
+            print substr(value, 1, length(value) - 1)
+          }' \
+      | ${pkgs.coreutils}/bin/sort -u)"
+    expected_needed="$(${pkgs.jq}/bin/jq -r '.runtime.neededLibraries[]' "$descriptor")"
+    [ "$actual_needed" = "$expected_needed" ] \
+      || fail "DT_NEEDED mismatch for $relative: expected [$(${pkgs.coreutils}/bin/tr '\n' ' ' <<<"$expected_needed")], got [$(${pkgs.coreutils}/bin/tr '\n' ' ' <<<"$actual_needed")]"
+
+    local version_info actual_symbol_versions expected_symbol_versions
+    if ! version_info="$(${readelf} --version-info "$executable")"; then
+      fail "readelf --version-info failed for $relative"
+    fi
+    actual_symbol_versions="$(printf '%s\n' "$version_info" \
+      | ${pkgs.gawk}/bin/awk '
+          /^[[:space:]]*Version needs section / { in_needs = 1; next }
+          /^[[:space:]]*Version (symbols|definition) section / { in_needs = 0 }
+          in_needs {
+            name_marker = "Name: "
+            flags_marker = "  Flags: "
+            name_start = index($0, name_marker)
+            if (name_start > 0) {
+              value = substr($0, name_start + length(name_marker))
+              flags_start = index(value, flags_marker)
+              if (flags_start == 0) exit 2
+              print substr(value, 1, flags_start - 1)
+            }
+          }' \
+      | ${pkgs.coreutils}/bin/sort -u)"
+    expected_symbol_versions="$(${pkgs.jq}/bin/jq -r '.runtime.symbolVersionFloors[]' "$descriptor")"
+    [ "$actual_symbol_versions" = "$expected_symbol_versions" ] \
+      || fail "symbol-version mismatch for $relative: expected [$(${pkgs.coreutils}/bin/tr '\n' ' ' <<<"$expected_symbol_versions")], got [$(${pkgs.coreutils}/bin/tr '\n' ' ' <<<"$actual_symbol_versions")]"
+  }
+
+  while IFS= read -r entrypoint; do
+    inspect_entrypoint "$entrypoint"
+  done < <(${pkgs.jq}/bin/jq -r '.entrypoints[]' "$descriptor")
+''

--- a/nix/workspace-tools/lib/buck2-runtime-inspect-elf-dynamic.nix
+++ b/nix/workspace-tools/lib/buck2-runtime-inspect-elf-dynamic.nix
@@ -110,7 +110,14 @@ pkgs.writeShellScript "buck2-runtime-inspect-elf-dynamic" ''
             name_start = index($0, name_marker)
             if (name_start > 0) {
               value = substr($0, name_start + length(name_marker))
-              flags_start = index(value, flags_marker)
+              # A version name may contain the delimiter text. The GNU readelf
+              # flags field is the final delimiter on the record.
+              flags_start = 0
+              search_start = 1
+              while ((relative_start = index(substr(value, search_start), flags_marker)) > 0) {
+                flags_start = search_start + relative_start - 1
+                search_start = flags_start + length(flags_marker)
+              }
               if (flags_start == 0) exit 2
               print substr(value, 1, flags_start - 1)
             }

--- a/nix/workspace-tools/lib/buck2-rust-local-toolchain-config.nix
+++ b/nix/workspace-tools/lib/buck2-rust-local-toolchain-config.nix
@@ -10,18 +10,34 @@ let
   contract = "effect-utils/rust-local-store-toolchain/v1";
   executionPlatform = "//buck2/platforms:exec_x86_64_linux_local_store";
   targetPlatform = "//buck2/platforms:target_x86_64_linux_musl_static";
-  identity = builtins.hashString "sha256" (
-    builtins.toJSON {
-      inherit
-        contract
-        executionPlatform
-        linker
-        rustc
-        targetPlatform
-        targetTriple
-        ;
+  identityVerifier = pkgs.writeShellScript "buck2-rust-toolchain-identity-verify" ''
+    set -euo pipefail
+    [ "$#" -ge 3 ] || {
+      echo "buck2-rust-toolchain-identity-verify: expected MATERIAL ID COMMAND..." >&2
+      exit 64
     }
-  );
+    material="$1"
+    expected="$2"
+    shift 2
+    actual="sha256:$(printf '%s' "$material" | ${pkgs.coreutils}/bin/sha256sum | ${pkgs.gawk}/bin/awk '{ print $1 }')"
+    [ "$actual" = "$expected" ] || {
+      echo "buck2-rust-toolchain-identity-verify: toolchain identity digest mismatch" >&2
+      exit 1
+    }
+    exec "$@"
+  '';
+  # This ordered material is both hashed by Nix and reassembled by Buck from
+  # the supplied fields. A stale/mixed config cannot retain the old identity.
+  identityMaterial = builtins.concatStringsSep ";" [
+    "contract=${contract}"
+    "execution_platform=${executionPlatform}"
+    "identity_verifier=${identityVerifier}"
+    "linker=${linker}"
+    "rustc=${rustc}"
+    "target_platform=${targetPlatform}"
+    "target_triple=${targetTriple}"
+  ];
+  identity = builtins.hashString "sha256" identityMaterial;
 in
 {
   inherit identity;
@@ -35,10 +51,12 @@ in
     [rust_toolchain]
       contract = ${contract}
       execution_platform = ${executionPlatform}
+      identity_verifier = ${identityVerifier}
       linker = ${linker}
       rustc = ${rustc}
       target_platform = ${targetPlatform}
       target_triple = ${targetTriple}
+      toolchain_identity_material = ${identityMaterial}
       toolchain_identity = sha256:${identity}
   '';
 }

--- a/nix/workspace-tools/lib/tests/buck2-bridge.nix
+++ b/nix/workspace-tools/lib/tests/buck2-bridge.nix
@@ -61,7 +61,7 @@ let
         export LC_ALL=C
         mkdir -p payload/bin "$out"
         printf '%s\n' 'int fixture_symbol(void) { return 0; }' > library.c
-        printf '%s\n' 'FOO { global: fixture_symbol; };' > library.map
+        printf '%s\n' 'F123456789O { global: fixture_symbol; };' > library.map
         cc -shared -Wl,--version-script=library.map \
           -Wl,-soname,'libfixture[bracket].so' -o 'libfixture[bracket].so' library.c
         printf '%s\n' \
@@ -73,7 +73,7 @@ let
         # ELF string-table names may contain whitespace even though the linker
         # version-script grammar cannot spell it. Preserve the byte width while
         # making the observed version need distinguishable from field splitting.
-        sed -i 's/FOO/F O/g' payload/bin/fixture-tool
+        sed -i 's/F123456789O/F  Flags: O/g' payload/bin/fixture-tool
         # Replacing the wrapper-injected store RPATH before removing it ensures
         # those bytes are absent rather than merely unreachable dynamic data.
         patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 --set-rpath /unused payload/bin/fixture-tool
@@ -104,7 +104,12 @@ let
                 name_start = index($0, name_marker)
                 if (name_start > 0) {
                   value = substr($0, name_start + length(name_marker))
-                  flags_start = index(value, flags_marker)
+              flags_start = 0
+              search_start = 1
+              while ((relative_start = index(substr(value, search_start), flags_marker)) > 0) {
+                flags_start = search_start + relative_start - 1
+                search_start = flags_start + length(flags_marker)
+              }
                   if (flags_start == 0) exit 2
                   print substr(value, 1, flags_start - 1)
                 }

--- a/nix/workspace-tools/lib/tests/buck2-bridge.nix
+++ b/nix/workspace-tools/lib/tests/buck2-bridge.nix
@@ -104,12 +104,12 @@ let
                 name_start = index($0, name_marker)
                 if (name_start > 0) {
                   value = substr($0, name_start + length(name_marker))
-              flags_start = 0
-              search_start = 1
-              while ((relative_start = index(substr(value, search_start), flags_marker)) > 0) {
-                flags_start = search_start + relative_start - 1
-                search_start = flags_start + length(flags_marker)
-              }
+                  flags_start = 0
+                  search_start = 1
+                  while ((relative_start = index(substr(value, search_start), flags_marker)) > 0) {
+                    flags_start = search_start + relative_start - 1
+                    search_start = flags_start + length(flags_marker)
+                  }
                   if (flags_start == 0) exit 2
                   print substr(value, 1, flags_start - 1)
                 }

--- a/nix/workspace-tools/lib/tests/buck2-bridge.nix
+++ b/nix/workspace-tools/lib/tests/buck2-bridge.nix
@@ -45,6 +45,122 @@ let
         chmod 0444 "$out/share/buck2-artifact/descriptor.json"
       '';
 
+  dynamicExport =
+    pkgs.runCommand "buck2-bridge-dynamic-export"
+      {
+        nativeBuildInputs = [
+          pkgs.binutils
+          pkgs.jq
+          pkgs.openssl
+          pkgs.patchelf
+          pkgs.stdenv.cc
+        ];
+      }
+      ''
+        set -euo pipefail
+        export LC_ALL=C
+        mkdir -p payload/bin "$out"
+        printf '%s\n' 'int fixture_symbol(void) { return 0; }' > library.c
+        printf '%s\n' 'FOO { global: fixture_symbol; };' > library.map
+        cc -shared -Wl,--version-script=library.map \
+          -Wl,-soname,'libfixture[bracket].so' -o 'libfixture[bracket].so' library.c
+        printf '%s\n' \
+          'extern int fixture_symbol(void);' \
+          'int main(void) { return fixture_symbol(); }' > fixture.c
+        printf '%s\n' 'LOCAL_DEFINITION { global: main; };' > executable.map
+        cc -Wl,--version-script=executable.map -o payload/bin/fixture-tool \
+          fixture.c './libfixture[bracket].so'
+        # ELF string-table names may contain whitespace even though the linker
+        # version-script grammar cannot spell it. Preserve the byte width while
+        # making the observed version need distinguishable from field splitting.
+        sed -i 's/FOO/F O/g' payload/bin/fixture-tool
+        # Replacing the wrapper-injected store RPATH before removing it ensures
+        # those bytes are absent rather than merely unreachable dynamic data.
+        patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 --set-rpath /unused payload/bin/fixture-tool
+        patchelf --remove-rpath payload/bin/fixture-tool
+        chmod 0555 payload/bin/fixture-tool
+        tar --create --format=gnu --sort=name --mtime='@1' --owner=0 --group=0 \
+          --numeric-owner --file "$out/artifact.tar" --directory payload .
+        digest="sha256-$(openssl dgst -sha256 -binary "$out/artifact.tar" | openssl base64 -A)"
+        size="$(stat --format=%s "$out/artifact.tar")"
+        needed="$(readelf --dynamic payload/bin/fixture-tool \
+          | awk '
+              /\(NEEDED\)/ {
+                marker = "Shared library: ["
+                start = index($0, marker)
+                if (start == 0) exit 2
+                value = substr($0, start + length(marker))
+                if (substr(value, length(value), 1) != "]") exit 2
+                print substr(value, 1, length(value) - 1)
+              }' \
+          | sort -u | jq --raw-input --slurp 'split("\n") | map(select(length > 0))')"
+        versions="$(readelf --version-info payload/bin/fixture-tool \
+          | awk '
+              /^[[:space:]]*Version needs section / { in_needs = 1; next }
+              /^[[:space:]]*Version (symbols|definition) section / { in_needs = 0 }
+              in_needs {
+                name_marker = "Name: "
+                flags_marker = "  Flags: "
+                name_start = index($0, name_marker)
+                if (name_start > 0) {
+                  value = substr($0, name_start + length(name_marker))
+                  flags_start = index(value, flags_marker)
+                  if (flags_start == 0) exit 2
+                  print substr(value, 1, flags_start - 1)
+                }
+              }' \
+          | sort -u \
+          | jq --raw-input --slurp 'split("\n") | map(select(length > 0))')"
+        jq --null-input --sort-keys \
+          --arg digest "$digest" --argjson size "$size" \
+          --argjson needed "$needed" --argjson versions "$versions" \
+          '{
+            schema: "buck-build-product/v1",
+            name: "fixture-tool",
+            platform: { os: "linux", architecture: "x86_64", abi: "glibc" },
+            payload: {
+              file: "artifact.tar", format: "tar",
+              digest: { algorithm: "sha256", sri: $digest }, sizeBytes: $size
+            },
+            entrypoints: ["bin/fixture-tool"],
+            runtime: {
+              kind: "elf-dynamic", inspectionContract: "elf-dynamic/v1",
+              elfClass: "ELF64", machine: "x86_64",
+              interpreter: "/lib64/ld-linux-x86-64.so.2",
+              neededLibraries: $needed, symbolVersionFloors: $versions,
+              rpathPolicy: "empty/v1"
+            },
+            semanticProvenance: {
+              target: "//fixtures:dynamic-tool", recipe: "fixture-dynamic/v1",
+              toolchain: "cc-linux-glibc/v1"
+            }
+          }' > "$out/descriptor.json"
+      '';
+
+  failingVersionReadelf = pkgs.writeShellScript "failing-version-readelf" ''
+    if [ "''${1-}" = --version-info ]; then
+      exit 9
+    fi
+    exec ${pkgs.binutils}/bin/readelf "$@"
+  '';
+
+  emptyVersionReadelf = pkgs.writeShellScript "empty-version-readelf" ''
+    if [ "''${1-}" = --version-info ]; then
+      exit 0
+    fi
+    exec ${pkgs.binutils}/bin/readelf "$@"
+  '';
+
+  multilineInterpreterReadelf = pkgs.writeShellScript "multiline-interpreter-readelf" ''
+    if [ "''${1-}" = --program-headers ]; then
+      printf '%s\n' \
+        '      [Requesting program interpreter: /lib64/ld-linux-x86-64.so.2' \
+        'injected-control-data]'
+      exit 0
+    fi
+    exec ${pkgs.binutils}/bin/readelf "$@"
+  '';
+
   mkExport =
     src:
     exportToolchain {
@@ -61,9 +177,105 @@ let
       inherit provenance;
       entrypoints = [ entrypoint ];
     };
+
+  mkElfProduct =
+    {
+      name,
+      cc,
+      static ? false,
+    }:
+    pkgs.runCommand name
+      {
+        nativeBuildInputs = [
+          cc
+          pkgs.gnutar
+          pkgs.jq
+          pkgs.openssl
+        ];
+        allowedReferences = [ ];
+      }
+      ''
+        mkdir -p payload/bin "$out"
+        printf '%s\n' 'int main(void) { return 0; }' > fixture.c
+        $CC ${
+          if static then
+            "-static"
+          else
+            "-Wl,--dynamic-linker=/lib64/ld-linux-x86-64.so.2 -Wl,--disable-new-dtags"
+        } fixture.c -o payload/bin/fixture-tool
+        tar --create --format=gnu --sort=name --mtime=@1 --owner=0 --group=0 --numeric-owner \
+          --file "$out/artifact.tar" --directory payload .
+        digest="sha256-$(openssl dgst -sha256 -binary "$out/artifact.tar" | openssl base64 -A)"
+        size="$(stat --format=%s "$out/artifact.tar")"
+        jq -cn --arg digest "$digest" --argjson size "$size" '{
+          entrypoints: ["bin/fixture-tool"],
+          name: "fixture-tool",
+          payload: { digest: { algorithm: "sha256", sri: $digest }, file: "artifact.tar", format: "tar", sizeBytes: $size },
+          platform: { abi: "musl", architecture: "x86_64", os: "linux" },
+          runtime: { inspectionContract: "elf-static/v1", kind: "self-contained" },
+          schema: "buck-build-product/v1",
+          semanticProvenance: { recipe: "fixture/v1", target: "//fixture:tool", toolchain: "fixture/v1" }
+        }' > "$out/descriptor.json"
+      '';
+
+  staticElfProduct = mkElfProduct {
+    name = "buck2-static-elf-product";
+    cc = pkgs.pkgsStatic.stdenv.cc;
+    static = true;
+  };
+  dynamicElfProduct = mkElfProduct {
+    name = "buck2-dynamic-elf-product";
+    cc = pkgs.stdenv.cc;
+  };
+  storeReferenceElfProduct =
+    pkgs.runCommand "buck2-store-reference-elf-product"
+      {
+        nativeBuildInputs = [
+          pkgs.pkgsStatic.stdenv.cc
+          pkgs.gnutar
+          pkgs.jq
+          pkgs.openssl
+        ];
+      }
+      ''
+        mkdir -p payload/bin "$out"
+        printf '%s\n' 'int main(void) { return 0; }' > fixture.c
+        $CC -static fixture.c -o payload/bin/fixture-tool
+        printf '%s\n' ${pkgs.hello} >> payload/bin/fixture-tool
+        tar --create --format=gnu --sort=name --mtime=@1 --owner=0 --group=0 --numeric-owner \
+          --file "$out/artifact.tar" --directory payload .
+        digest="sha256-$(openssl dgst -sha256 -binary "$out/artifact.tar" | openssl base64 -A)"
+        size="$(stat --format=%s "$out/artifact.tar")"
+        jq -cn --arg digest "$digest" --argjson size "$size" '{
+          entrypoints: ["bin/fixture-tool"], name: "fixture-tool",
+          payload: { digest: { algorithm: "sha256", sri: $digest }, file: "artifact.tar", format: "tar", sizeBytes: $size },
+          platform: { abi: "musl", architecture: "x86_64", os: "linux" },
+          runtime: { inspectionContract: "elf-static/v1", kind: "self-contained" },
+          schema: "buck-build-product/v1",
+          semanticProvenance: { recipe: "fixture/v1", target: "//fixture:tool", toolchain: "fixture/v1" }
+        }' > "$out/descriptor.json"
+      '';
+
+  importProduct =
+    product: platform:
+    let
+      descriptor = builtins.fromJSON (builtins.readFile "${product}/descriptor.json");
+    in
+    importArtifact {
+      inherit descriptor;
+      expectedDescriptorDigest = (import ../buck2-build-product-contract.nix).descriptorDigest descriptor;
+      expectedPlatform = platform;
+      artifact = "${product}/artifact.tar";
+    };
 in
 {
   portableExport = mkExport portableSource;
+  inherit
+    dynamicExport
+    failingVersionReadelf
+    emptyVersionReadelf
+    multilineInterpreterReadelf
+    ;
   storeReferenceExport = mkExport storeReferenceSource;
   escapingSymlinkExport = mkExport escapingSymlinkSource;
   reservedMetadataExport = mkExport reservedMetadataSource;
@@ -82,6 +294,38 @@ in
       "bin/fixture-tool"
     ];
   };
+  staticElfImport = importProduct staticElfProduct {
+    os = "linux";
+    architecture = "x86_64";
+    abi = "musl";
+  };
+  dynamicElfImport = importProduct dynamicElfProduct {
+    os = "linux";
+    architecture = "x86_64";
+    abi = "musl";
+  };
+  storeReferenceElfImport = importProduct storeReferenceElfProduct {
+    os = "linux";
+    architecture = "x86_64";
+    abi = "musl";
+  };
+  foreignArchitectureImport =
+    let
+      original = builtins.fromJSON (builtins.readFile "${staticElfProduct}/descriptor.json");
+      descriptor = original // {
+        platform = {
+          os = "linux";
+          architecture = "aarch64";
+          abi = "musl";
+        };
+      };
+    in
+    importArtifact {
+      inherit descriptor;
+      expectedDescriptorDigest = (import ../buck2-build-product-contract.nix).descriptorDigest descriptor;
+      expectedPlatform = descriptor.platform;
+      artifact = "${staticElfProduct}/artifact.tar";
+    };
 
   mkImport =
     {

--- a/nix/workspace-tools/lib/tests/buck2-bridge.sh
+++ b/nix/workspace-tools/lib/tests/buck2-bridge.sh
@@ -145,7 +145,7 @@ dynamic_export="$(build_expr "($base_expr).dynamicExport")"
 export BUCK2_BRIDGE_DYNAMIC_EXPORT="$dynamic_export"
 jq -e '
   (.runtime.neededLibraries | index("libfixture[bracket].so")) != null and
-  (.runtime.symbolVersionFloors | index("F O")) != null and
+  (.runtime.symbolVersionFloors | index("F  Flags: O")) != null and
   (.runtime.symbolVersionFloors | index("F")) == null and
   (.runtime.symbolVersionFloors | index("LOCAL_DEFINITION")) == null
 ' "$dynamic_export/descriptor.json" >/dev/null
@@ -216,7 +216,7 @@ expect_command_failure "DT_NEEDED mutation" "DT_NEEDED mismatch" \
 rm -rf "$needed_root"
 
 symbol_root="$(mutation_root)"
-first_version="$(jq -er '.runtime.symbolVersionFloors[] | select(. == "F O")' "$dynamic_export/descriptor.json")"
+first_version="$(jq -er '.runtime.symbolVersionFloors[] | select(. == "F  Flags: O")' "$dynamic_export/descriptor.json")"
 case "$first_version" in
   *9) mutated_version="${first_version%?}8" ;;
   *) mutated_version="${first_version%?}9" ;;

--- a/nix/workspace-tools/lib/tests/buck2-bridge.sh
+++ b/nix/workspace-tools/lib/tests/buck2-bridge.sh
@@ -141,6 +141,150 @@ expect_build_failure \
   "runtime inspector is not available for self-contained" \
   "$unsupported_runtime_expr"
 
+dynamic_export="$(build_expr "($base_expr).dynamicExport")"
+export BUCK2_BRIDGE_DYNAMIC_EXPORT="$dynamic_export"
+jq -e '
+  (.runtime.neededLibraries | index("libfixture[bracket].so")) != null and
+  (.runtime.symbolVersionFloors | index("F O")) != null and
+  (.runtime.symbolVersionFloors | index("F")) == null and
+  (.runtime.symbolVersionFloors | index("LOCAL_DEFINITION")) == null
+' "$dynamic_export/descriptor.json" >/dev/null
+dynamic_import_expr="let
+  $common_let
+  exported = builtins.storePath (builtins.getEnv \"BUCK2_BRIDGE_DYNAMIC_EXPORT\");
+  descriptor = builtins.fromJSON (builtins.readFile (exported + \"/descriptor.json\"));
+in test.mkImport {
+  inherit descriptor;
+  expectedDescriptorDigest = contract.descriptorDigest descriptor;
+  expectedPlatform = descriptor.platform;
+  artifact = exported + \"/artifact.tar\";
+}"
+dynamic_import="$(build_expr "$dynamic_import_expr")"
+[ -x "$dynamic_import/bin/fixture-tool" ] || {
+  echo "buck2-bridge-test: admitted dynamic entrypoint is missing" >&2
+  exit 1
+}
+
+inspector_expr="let
+  $common_let
+in import (repo + \"/nix/workspace-tools/lib/buck2-runtime-inspect-elf-dynamic.nix\") { inherit pkgs; }"
+inspector_out="$(build_expr "$inspector_expr")"
+patchelf_out="$(build_expr "let $common_let in pkgs.patchelf")"
+rpath_root="$(mktemp -d)"
+tar --extract --file "$dynamic_export/artifact.tar" --directory "$rpath_root"
+chmod u+w "$rpath_root/bin/fixture-tool"
+"$patchelf_out/bin/patchelf" --set-rpath /hostile/runtime/path "$rpath_root/bin/fixture-tool"
+expect_command_failure \
+  "undeclared ELF runtime path" \
+  "RPATH/RUNPATH must be absent" \
+  "$inspector_out" "$dynamic_export/descriptor.json" "$rpath_root"
+rm -rf "$rpath_root"
+
+mutation_root() {
+  local root
+  root="$(mktemp -d)"
+  tar --extract --file "$dynamic_export/artifact.tar" --directory "$root"
+  chmod u+w "$root/bin/fixture-tool"
+  printf '%s\n' "$root"
+}
+
+class_root="$(mutation_root)"
+printf '\x01' | dd of="$class_root/bin/fixture-tool" bs=1 seek=4 conv=notrunc status=none
+expect_command_failure "ELF class mutation" "ELF class mismatch" \
+  "$inspector_out" "$dynamic_export/descriptor.json" "$class_root"
+rm -rf "$class_root"
+
+machine_root="$(mutation_root)"
+printf '\xb7\x00' | dd of="$machine_root/bin/fixture-tool" bs=1 seek=18 conv=notrunc status=none
+expect_command_failure "ELF machine mutation" "ELF machine mismatch" \
+  "$inspector_out" "$dynamic_export/descriptor.json" "$machine_root"
+rm -rf "$machine_root"
+
+interpreter_root="$(mutation_root)"
+mutated_interpreter='/wrong/interpreter: [loader]'
+"$patchelf_out/bin/patchelf" --set-interpreter "$mutated_interpreter" "$interpreter_root/bin/fixture-tool"
+expect_command_failure "ELF interpreter mutation" \
+  "ELF interpreter mismatch for bin/fixture-tool: expected /lib64/ld-linux-x86-64.so.2, got $mutated_interpreter" \
+  "$inspector_out" "$dynamic_export/descriptor.json" "$interpreter_root"
+rm -rf "$interpreter_root"
+
+needed_root="$(mutation_root)"
+bracket_needed="$(jq -er '.runtime.neededLibraries[] | select(contains("["))' "$dynamic_export/descriptor.json")"
+"$patchelf_out/bin/patchelf" --replace-needed "$bracket_needed" 'libfixture[changed].so' "$needed_root/bin/fixture-tool"
+expect_command_failure "DT_NEEDED mutation" "DT_NEEDED mismatch" \
+  "$inspector_out" "$dynamic_export/descriptor.json" "$needed_root"
+rm -rf "$needed_root"
+
+symbol_root="$(mutation_root)"
+first_version="$(jq -er '.runtime.symbolVersionFloors[] | select(. == "F O")' "$dynamic_export/descriptor.json")"
+case "$first_version" in
+  *9) mutated_version="${first_version%?}8" ;;
+  *) mutated_version="${first_version%?}9" ;;
+esac
+escaped_version="${first_version//./\\.}"
+sed -i "s/$escaped_version/$mutated_version/g" "$symbol_root/bin/fixture-tool"
+expect_command_failure "symbol versions mutation" "symbol-version mismatch" \
+  "$inspector_out" "$dynamic_export/descriptor.json" "$symbol_root"
+rm -rf "$symbol_root"
+
+clean_root="$(mutation_root)"
+multiline_interpreter_inspector_expr="let
+  $common_let
+in import (repo + \"/nix/workspace-tools/lib/buck2-runtime-inspect-elf-dynamic.nix\") {
+  inherit pkgs;
+  readelf = builtins.toString test.multilineInterpreterReadelf;
+}"
+multiline_interpreter_inspector_out="$(build_expr "$multiline_interpreter_inspector_expr")"
+expect_command_failure \
+  "multiline PT_INTERP observation" \
+  "malformed ELF program interpreter observation: bin/fixture-tool" \
+  "$multiline_interpreter_inspector_out" "$dynamic_export/descriptor.json" "$clean_root"
+
+failing_inspector_expr="let
+  $common_let
+in import (repo + \"/nix/workspace-tools/lib/buck2-runtime-inspect-elf-dynamic.nix\") {
+  inherit pkgs;
+  readelf = builtins.toString test.failingVersionReadelf;
+}"
+failing_inspector_out="$(build_expr "$failing_inspector_expr")"
+expect_command_failure "readelf version-info failure" "readelf --version-info failed" \
+  "$failing_inspector_out" "$dynamic_export/descriptor.json" "$clean_root"
+
+empty_descriptor="$(mktemp)"
+jq '.runtime.symbolVersionFloors = []' "$dynamic_export/descriptor.json" >"$empty_descriptor"
+empty_inspector_expr="let
+  $common_let
+in import (repo + \"/nix/workspace-tools/lib/buck2-runtime-inspect-elf-dynamic.nix\") {
+  inherit pkgs;
+  readelf = builtins.toString test.emptyVersionReadelf;
+}"
+empty_inspector_out="$(build_expr "$empty_inspector_expr")"
+"$empty_inspector_out" "$empty_descriptor" "$clean_root"
+rm -rf "$clean_root"
+rm -f "$empty_descriptor"
+
+tampered_archive="$(mktemp)"
+cp "$dynamic_export/artifact.tar" "$tampered_archive"
+printf x | dd of="$tampered_archive" bs=1 seek=1024 conv=notrunc status=none
+export BUCK2_BRIDGE_TAMPERED_ARCHIVE="$tampered_archive"
+expect_build_failure \
+  "payload tampering before archive scan" \
+  "payload digest mismatch" \
+  "let
+    $common_let
+    exported = builtins.storePath (builtins.getEnv \"BUCK2_BRIDGE_DYNAMIC_EXPORT\");
+    descriptor = builtins.fromJSON (builtins.readFile (exported + \"/descriptor.json\"));
+  in test.mkImport {
+    inherit descriptor;
+    expectedDescriptorDigest = contract.descriptorDigest descriptor;
+    expectedPlatform = descriptor.platform;
+    artifact = builtins.path {
+      path = builtins.getEnv \"BUCK2_BRIDGE_TAMPERED_ARCHIVE\";
+      name = \"tampered-artifact.tar\";
+    };
+  }"
+rm -f "$tampered_archive"
+
 duplicate_import_entrypoint_expr="let
   $common_let
   exported = builtins.storePath (builtins.getEnv \"BUCK2_BRIDGE_EXPORT_OUT\");
@@ -199,6 +343,35 @@ scan_expr="let
   $common_let
 in import (repo + \"/nix/workspace-tools/lib/buck2-artifact-scan.nix\") { inherit pkgs; }"
 scan_out="$(build_expr "$scan_expr")"
+
+store_reference_root="$(mktemp -d)"
+tar --extract --file "$dynamic_export/artifact.tar" --directory "$store_reference_root"
+chmod u+w "$store_reference_root/bin/fixture-tool"
+printf '%s' '/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-host-leak' \
+  >>"$store_reference_root/bin/fixture-tool"
+expect_command_failure \
+  "dynamic payload store reference" \
+  "forbidden Nix store reference" \
+  "$scan_out" tree "$store_reference_root"
+rm -rf "$store_reference_root"
+
+unreadable_archive_root="$(mktemp -d)"
+unreadable_extract_root="$(mktemp -d)"
+unreadable_archive="$(mktemp)"
+printf '%s\n' '/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-unreadable-leak' \
+  >"$unreadable_archive_root/unreadable"
+tar --create --mode=000 --file "$unreadable_archive" \
+  --directory "$unreadable_archive_root" unreadable
+tar --extract --file "$unreadable_archive" \
+  --directory "$unreadable_extract_root"
+[ ! -r "$unreadable_extract_root/unreadable" ] \
+  || fail "unreadable archive fixture unexpectedly remained readable"
+expect_command_failure \
+  "unreadable archive member store reference" \
+  "failed to scan tree for forbidden Nix store references" \
+  "$scan_out" tree "$unreadable_extract_root"
+chmod u+r "$unreadable_extract_root/unreadable"
+rm -rf "$unreadable_archive_root" "$unreadable_extract_root" "$unreadable_archive"
 
 portable_symlink_root="$(mktemp -d)"
 mkdir -p "$portable_symlink_root/bin" "$portable_symlink_root/lib"
@@ -327,4 +500,4 @@ expect_command_failure \
   "$scan_out" archive "$concatenated_root.tar"
 rm -rf "$concatenated_root" "$concatenated_root.tar" "$concatenated_root-second.tar"
 
-echo "buck2-bridge-test: PASS export=$export_out buck_runinfo=executed importer=fail-closed"
+echo "buck2-bridge-test: PASS export=$export_out buck_runinfo=executed dynamic_import=$dynamic_import"

--- a/nix/workspace-tools/lib/tests/buck2-build-product-contract.sh
+++ b/nix/workspace-tools/lib/tests/buck2-build-product-contract.sh
@@ -166,6 +166,53 @@ expect_eval_failure \
     entrypoints = [ "bin/fixture\runsafe" ];
   })'
 
+expect_eval_failure \
+  "tab entrypoint" \
+  "descriptor.entrypoints must be safe relative paths" \
+  'contract.canonicalDescriptorJson (valid // {
+    entrypoints = [ "bin/fixture\tunsafe" ];
+  })'
+
+expect_eval_failure \
+  "escape entrypoint" \
+  "descriptor.entrypoints must be safe relative paths" \
+  'contract.canonicalDescriptorJson (valid // {
+    entrypoints = [ (builtins.fromJSON "\"bin/fixture\\u001bunsafe\"") ];
+  })'
+
+expect_eval_failure \
+  "non-canonical sha256 trailing digit" \
+  "descriptor.payload.digest.sri must be a sha256 SRI digest" \
+  'contract.canonicalDescriptorJson (valid // {
+    payload = valid.payload // {
+      digest = valid.payload.digest // {
+        sri = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB=";
+      };
+    };
+  })'
+
+expect_eval_failure \
+  "missing sha256 padding" \
+  "descriptor.payload.digest.sri must be a sha256 SRI digest" \
+  'contract.canonicalDescriptorJson (valid // {
+    payload = valid.payload // {
+      digest = valid.payload.digest // {
+        sri = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+      };
+    };
+  })'
+
+expect_eval_failure \
+  "sha256 digest of 31 bytes" \
+  "descriptor.payload.digest.sri must be a sha256 SRI digest" \
+  'contract.canonicalDescriptorJson (valid // {
+    payload = valid.payload // {
+      digest = valid.payload.digest // {
+        sri = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==";
+      };
+    };
+  })'
+
 semantic_change_digest="$(eval_raw 'contract.descriptorDigest (valid // {
   semanticProvenance = valid.semanticProvenance // { recipe = "fixture-tool/v2"; };
 })')"
@@ -182,12 +229,14 @@ expect_eval_failure \
   })'
 
 for variant in interpreter elf-dynamic mach-o-dynamic self-contained; do
+  platform_override=''
   case "$variant" in
     interpreter)
       runtime='{ kind = "interpreter"; runtimeId = "bun"; runtimeContract = "bun-1.2/v1"; program = "bin/fixture-tool"; }'
       ;;
     elf-dynamic)
-      runtime='{ kind = "elf-dynamic"; machine = "x86_64"; loaderClass = "glibc"; neededLibraries = [ "libc.so.6" ]; symbolVersionFloors = [ "GLIBC_2.39" ]; runpathPolicy = "nix-realized/v1"; }'
+      runtime='{ kind = "elf-dynamic"; inspectionContract = "elf-dynamic/v1"; elfClass = "ELF64"; machine = "x86_64"; interpreter = "/lib64/ld-linux-x86-64.so.2"; neededLibraries = [ "libc.so.6" ]; symbolVersionFloors = [ "GLIBC_2.39" ]; rpathPolicy = "empty/v1"; }'
+      platform_override='platform = valid.platform // { abi = "glibc"; };'
       ;;
     mach-o-dynamic)
       runtime='{ kind = "mach-o-dynamic"; architecture = "arm64"; minimumOs = "14.0"; dylibs = [ "/usr/lib/libSystem.B.dylib" ]; installNamePolicy = "system-only/v1"; rpathPolicy = "none/v1"; signingPolicy = "adhoc/v1"; }'
@@ -196,7 +245,125 @@ for variant in interpreter elf-dynamic mach-o-dynamic self-contained; do
       runtime='{ kind = "self-contained"; inspectionContract = "elf-static/v1"; }'
       ;;
   esac
-  eval_raw "contract.descriptorDigest (valid // { runtime = $runtime; })" >/dev/null
+  eval_raw "contract.descriptorDigest (valid // { $platform_override runtime = $runtime; })" >/dev/null
+done
+
+expect_eval_failure \
+  "missing ELF inspection contract" \
+  "descriptor.runtime is missing fields: inspectionContract" \
+  'contract.descriptorDigest (valid // {
+    runtime = {
+      kind = "elf-dynamic";
+      elfClass = "ELF64";
+      machine = "x86_64";
+      interpreter = "/lib64/ld-linux-x86-64.so.2";
+      neededLibraries = [ "libc.so.6" ];
+      symbolVersionFloors = [ "GLIBC_2.39" ];
+      rpathPolicy = "empty/v1";
+    };
+  })'
+
+expect_eval_failure \
+  "legacy ELF runtime field" \
+  "descriptor.runtime has unknown fields: loaderClass" \
+  'contract.descriptorDigest (valid // {
+    runtime = {
+      kind = "elf-dynamic";
+      inspectionContract = "elf-dynamic/v1";
+      elfClass = "ELF64";
+      machine = "x86_64";
+      interpreter = "/lib64/ld-linux-x86-64.so.2";
+      neededLibraries = [ "libc.so.6" ];
+      symbolVersionFloors = [ "GLIBC_2.39" ];
+      rpathPolicy = "empty/v1";
+      loaderClass = "glibc";
+    };
+  })'
+
+expect_eval_failure \
+  "ELF machine and platform architecture mismatch" \
+  "descriptor.runtime.machine must match descriptor.platform.architecture" \
+  'contract.descriptorDigest (valid // {
+    platform = valid.platform // { abi = "glibc"; };
+    runtime = {
+      kind = "elf-dynamic";
+      inspectionContract = "elf-dynamic/v1";
+      elfClass = "ELF64";
+      machine = "aarch64";
+      interpreter = "/lib/ld-linux-aarch64.so.1";
+      neededLibraries = [ "libc.so.6" ];
+      symbolVersionFloors = [ "GLIBC_2.39" ];
+      rpathPolicy = "empty/v1";
+    };
+  })'
+
+expect_eval_failure \
+  "dynamic ELF on a non-Linux platform" \
+  "elf-dynamic requires descriptor.platform.os = linux" \
+  'contract.descriptorDigest (valid // {
+    platform = valid.platform // { os = "darwin"; abi = "glibc"; };
+    runtime = {
+      kind = "elf-dynamic";
+      inspectionContract = "elf-dynamic/v1";
+      elfClass = "ELF64";
+      machine = "x86_64";
+      interpreter = "/lib64/ld-linux-x86-64.so.2";
+      neededLibraries = [ "libc.so.6" ];
+      symbolVersionFloors = [ "GLIBC_2.39" ];
+      rpathPolicy = "empty/v1";
+    };
+  })'
+
+expect_eval_failure \
+  "dynamic ELF ABI mismatch" \
+  "currently requires descriptor.platform.abi = glibc" \
+  'contract.descriptorDigest (valid // {
+    runtime = {
+      kind = "elf-dynamic";
+      inspectionContract = "elf-dynamic/v1";
+      elfClass = "ELF64";
+      machine = "x86_64";
+      interpreter = "/lib64/ld-linux-x86-64.so.2";
+      neededLibraries = [ "libc.so.6" ];
+      symbolVersionFloors = [ "GLIBC_2.39" ];
+      rpathPolicy = "empty/v1";
+    };
+  })'
+
+expect_eval_failure \
+  "dynamic ELF loader and ABI mismatch" \
+  "interpreter does not prove the declared glibc architecture" \
+  'contract.descriptorDigest (valid // {
+    platform = valid.platform // { abi = "glibc"; };
+    runtime = {
+      kind = "elf-dynamic";
+      inspectionContract = "elf-dynamic/v1";
+      elfClass = "ELF64";
+      machine = "x86_64";
+      interpreter = "/lib/ld-musl-x86_64.so.1";
+      neededLibraries = [ "libc.so" ];
+      symbolVersionFloors = [ ];
+      rpathPolicy = "empty/v1";
+    };
+  })'
+
+for field in neededLibraries symbolVersionFloors; do
+  expect_eval_failure \
+    "dynamic ELF $field control character" \
+    "descriptor.runtime.$field entries must not contain control characters" \
+    "contract.descriptorDigest (valid // {
+      platform = valid.platform // { abi = \"glibc\"; };
+      runtime = {
+        kind = \"elf-dynamic\";
+        inspectionContract = \"elf-dynamic/v1\";
+        elfClass = \"ELF64\";
+        machine = \"x86_64\";
+        interpreter = \"/lib64/ld-linux-x86-64.so.2\";
+        neededLibraries = if \"$field\" == \"neededLibraries\" then [ \"libone.so\\nlibtwo.so\" ] else [ \"libc.so.6\" ];
+        symbolVersionFloors = if \"$field\" == \"symbolVersionFloors\" then [ \"GLIBC_2.34\\nGLIBC_2.35\" ] else [ \"GLIBC_2.39\" ];
+        rpathPolicy = \"empty/v1\";
+      };
+    })"
 done
 
 echo "buck2-build-product-contract-test: PASS digest=$descriptor_digest"

--- a/packages/@overeng/buck2-launcher/README.md
+++ b/packages/@overeng/buck2-launcher/README.md
@@ -8,6 +8,8 @@ target, dependency, or task graph.
 bun packages/@overeng/buck2-launcher/src/cli.ts \
   --buck /nix/store/...-buck2/bin/buck2 \
   --buck-version 2026-04-14-7600cb8 \
+  --repository-revision "$(git rev-parse HEAD)" \
+  --execution-platform x86_64-linux \
   --closure-manifest //packages/app:check=.buck2/closures/app-check.json \
   --print-command \
   -- build //packages/app:check
@@ -34,7 +36,9 @@ Each run writes a mode-0600 `buck-run-receipt/v1` beneath
 small index, not a replacement for Buck's event log or build report. It contains
 content descriptors rather than absolute evidence paths and never copies raw
 argv, action commands, environments, reproducers, or Buck's absolute
-`project_root`.
+`project_root`. Callers must provide the exact repository revision and Buck
+execution platform explicitly; the launcher does not infer either from ambient
+Git or from its own host architecture.
 
 Outcomes deliberately distinguish:
 
@@ -57,11 +61,12 @@ other causes remain `partial` or `unknown` until their own canonical manifests
 are supplied.
 
 Closure inputs must be generated Buck projection descriptors using schema v1
-(`closure.task.label`) or v2 (`closure.request.label`). The versioned label must
-match `LABEL`, and provenance must name `effect-utils/genie/buck2`. Duplicate
-labels, malformed descriptors, and label mismatches fail before Buck executes.
-The receipt hashes validated canonical JSON, so whitespace and object-key order
-do not change closure identity.
+(`closure.task.label`) or v2/v3 (`closure.request.label`). The versioned label
+must match `LABEL`, and provenance must name `effect-utils/genie/buck2`.
+Schema v3 additionally requires its source path and exact generated-file
+warning. Duplicate labels, malformed descriptors, and label mismatches fail
+before Buck executes. The receipt hashes validated canonical JSON, so whitespace
+and object-key order do not change closure identity.
 
 Explicit run IDs are single-use. The launcher creates each receipt directory
 exclusively and fails before invoking Buck if that directory already exists.

--- a/packages/@overeng/buck2-launcher/src/cli.ts
+++ b/packages/@overeng/buck2-launcher/src/cli.ts
@@ -10,6 +10,8 @@ interface ParsedCli {
   readonly closureManifests: ReadonlyArray<ClosureManifestInput>
   readonly compareReceipt?: string
   readonly buckVersion?: string
+  readonly repositoryRevision?: string
+  readonly executionPlatform?: string
   readonly launcherRunId?: string
   readonly printCommand: boolean
   readonly dryRun: boolean
@@ -23,6 +25,8 @@ Runs an already-realized Buck binary directly and writes buck-run-receipt/v1 evi
 Options:
   --buck PATH                  Buck binary (or BUCK2_BIN)
   --buck-version VERSION       Pinned machine version for receipt correlation
+  --repository-revision REV    Exact repository revision for receipt provenance
+  --execution-platform SYSTEM  Exact Buck execution platform (for example x86_64-linux)
   --evidence-dir DIR           Receipt root (default: XDG state directory)
   --run-id ID                  Safe receipt directory name for machine-readable lookup
   --closure-manifest LABEL=PATH  Exact closure manifest; repeatable
@@ -49,6 +53,8 @@ export const parseCli = (args: ReadonlyArray<string>, env: NodeJS.ProcessEnv): P
   let evidenceRoot: string | undefined
   let compareReceipt: string | undefined
   let buckVersion = env.BUCK2_MACHINE_VERSION
+  let repositoryRevision = env.BUCK2_REPOSITORY_REVISION
+  let executionPlatform = env.BUCK2_EXECUTION_PLATFORM
   let launcherRunId: string | undefined
   let printCommand = false
   let dryRun = false
@@ -57,6 +63,8 @@ export const parseCli = (args: ReadonlyArray<string>, env: NodeJS.ProcessEnv): P
     const arg = own[index]!
     if (arg === '--buck') buck = takeValue(own, index++, arg)
     else if (arg === '--buck-version') buckVersion = takeValue(own, index++, arg)
+    else if (arg === '--repository-revision') repositoryRevision = takeValue(own, index++, arg)
+    else if (arg === '--execution-platform') executionPlatform = takeValue(own, index++, arg)
     else if (arg === '--evidence-dir') evidenceRoot = takeValue(own, index++, arg)
     else if (arg === '--run-id') launcherRunId = takeValue(own, index++, arg)
     else if (arg === '--compare-receipt') compareReceipt = takeValue(own, index++, arg)
@@ -76,8 +84,16 @@ export const parseCli = (args: ReadonlyArray<string>, env: NodeJS.ProcessEnv): P
     else throw new Error(`unknown launcher option: ${arg}`)
   }
   if (buck === undefined || buck.trim() === '') throw new Error('--buck or BUCK2_BIN is required')
+  if (dryRun === false && (repositoryRevision === undefined || repositoryRevision.trim() === '')) {
+    throw new Error('--repository-revision or BUCK2_REPOSITORY_REVISION is required')
+  }
+  if (dryRun === false && (executionPlatform === undefined || executionPlatform.trim() === '')) {
+    throw new Error('--execution-platform or BUCK2_EXECUTION_PLATFORM is required')
+  }
   return {
     buck,
+    ...(repositoryRevision === undefined ? {} : { repositoryRevision }),
+    ...(executionPlatform === undefined ? {} : { executionPlatform }),
     ...(evidenceRoot === undefined ? {} : { evidenceRoot: resolve(evidenceRoot) }),
     closureManifests,
     ...(compareReceipt === undefined ? {} : { compareReceipt: resolve(compareReceipt) }),
@@ -102,11 +118,16 @@ export const main = async (args = process.argv.slice(2)): Promise<number> => {
   if (parsed.printCommand)
     process.stderr.write(`buck2-launcher: ${quoteCommand(parsed.buck, parsed.buckArgs)}\n`)
   if (parsed.dryRun) return 0
+  if (parsed.repositoryRevision === undefined || parsed.executionPlatform === undefined) {
+    throw new Error('launcher identity invariant violated')
+  }
   try {
     const result = await launchBuck({
       buckBinary: parsed.buck,
       buckArgs: parsed.buckArgs,
       cwd: process.cwd(),
+      repositoryRevision: parsed.repositoryRevision,
+      executionPlatform: parsed.executionPlatform,
       ...(parsed.evidenceRoot === undefined ? {} : { evidenceRoot: parsed.evidenceRoot }),
       closureManifests: parsed.closureManifests,
       ...(parsed.compareReceipt === undefined ? {} : { compareReceipt: parsed.compareReceipt }),

--- a/packages/@overeng/buck2-launcher/src/cli.unit.test.ts
+++ b/packages/@overeng/buck2-launcher/src/cli.unit.test.ts
@@ -23,15 +23,37 @@ describe('buck2-launcher CLI boundary', () => {
         '//pkg:x',
         '--local-only',
       ],
-      {},
+      {
+        BUCK2_REPOSITORY_REVISION: '0123456789abcdef0123456789abcdef01234567',
+        BUCK2_EXECUTION_PLATFORM: 'x86_64-linux',
+      },
     )
     expect(parsed.buckArgs).toEqual(['build', '//pkg:x', '--local-only'])
     expect(parsed.printCommand).toBe(true)
     expect(parsed.launcherRunId).toBe('e2e-42')
+    expect(parsed.repositoryRevision).toBe('0123456789abcdef0123456789abcdef01234567')
+    expect(parsed.executionPlatform).toBe('x86_64-linux')
   })
 
   it('requires an already-resolved binary rather than evaluating Nix or devenv', () => {
     expect(() => parseCli(['--', 'build', '//:x'], {})).toThrow('--buck or BUCK2_BIN is required')
+  })
+
+  it('requires explicit revision and execution-platform provenance', () => {
+    expect(() => parseCli(['--buck', '/nix/store/a/buck2', '--', 'build', '//:x'], {})).toThrow(
+      'BUCK2_REPOSITORY_REVISION',
+    )
+    expect(() =>
+      parseCli(['--buck', '/nix/store/a/buck2', '--', 'build', '//:x'], {
+        BUCK2_REPOSITORY_REVISION: '0123456789abcdef0123456789abcdef01234567',
+      }),
+    ).toThrow('BUCK2_EXECUTION_PLATFORM')
+  })
+
+  it('keeps dry-run command preview backward compatible without receipt identity', () => {
+    expect(
+      parseCli(['--buck', '/nix/store/a/buck2', '--dry-run', '--', 'build', '//:x'], {}),
+    ).toMatchObject({ dryRun: true, printCommand: true, buckArgs: ['build', '//:x'] })
   })
 
   it('rejects evidence flag collisions with a bypass instruction', () => {

--- a/packages/@overeng/buck2-launcher/src/launcher.ts
+++ b/packages/@overeng/buck2-launcher/src/launcher.ts
@@ -176,6 +176,8 @@ const requestedTargetsFromReport = (report: Record<string, unknown> | undefined)
 
 const loadPreviousReceipt = async (
   path: string | undefined,
+  repositoryRevision: string,
+  executionPlatform: string,
 ): Promise<BuckRunReceipt | undefined> => {
   if (path === undefined) return undefined
   let bytes: string
@@ -199,6 +201,19 @@ const loadPreviousReceipt = async (
     throw new Error(`explicit compare receipt is unsupported or invalid: ${path}`, {
       cause: error,
     })
+  }
+  if (receipt.repositoryRevision === undefined || receipt.executionPlatform === undefined) {
+    throw new Error(`explicit compare receipt has no repository/platform identity: ${path}`)
+  }
+  if (receipt.repositoryRevision !== repositoryRevision) {
+    throw new Error(
+      `explicit compare receipt repository revision does not match current run: ${path}`,
+    )
+  }
+  if (receipt.executionPlatform !== executionPlatform) {
+    throw new Error(
+      `explicit compare receipt execution platform does not match current run: ${path}`,
+    )
   }
   if (receipt.observation.complete === false) {
     throw new Error(`explicit compare receipt is incomplete: ${path}`)
@@ -293,7 +308,11 @@ export const launchBuck = async (options: LaunchOptions): Promise<LaunchResult> 
   assertSupportedCommand(options.buckArgs)
   const [closures, previous] = await Promise.all([
     prepareClosures(options.closureManifests ?? []),
-    loadPreviousReceipt(options.compareReceipt),
+    loadPreviousReceipt(
+      options.compareReceipt,
+      options.repositoryRevision,
+      options.executionPlatform,
+    ),
   ])
   const now = options.now ?? (() => new Date())
   const launcherRunId = options.launcherRunId ?? randomUUID()

--- a/packages/@overeng/buck2-launcher/src/launcher.ts
+++ b/packages/@overeng/buck2-launcher/src/launcher.ts
@@ -13,6 +13,8 @@ import {
   descriptorForClosureManifest,
   descriptorForFile,
   explainClosures,
+  isExecutionPlatform,
+  isRepositoryRevision,
   isSafePathComponent,
   materializationsSemanticallyComplete,
   normalizeActions,
@@ -36,6 +38,8 @@ export interface LaunchOptions {
   readonly closureManifests?: ReadonlyArray<ClosureManifestInput>
   readonly compareReceipt?: string
   readonly buckMachineVersion?: string
+  readonly repositoryRevision: string
+  readonly executionPlatform: string
   readonly launcherRunId?: string
   readonly now?: () => Date
   readonly stderr?: NodeJS.WritableStream
@@ -174,11 +178,32 @@ const loadPreviousReceipt = async (
   path: string | undefined,
 ): Promise<BuckRunReceipt | undefined> => {
   if (path === undefined) return undefined
+  let bytes: string
   try {
-    return decodeReceipt(JSON.parse(await readFile(path, 'utf8')))
-  } catch {
-    return undefined
+    bytes = await readFile(path, 'utf8')
+  } catch (error) {
+    throw new Error(`explicit compare receipt is missing or unreadable: ${path}`, { cause: error })
   }
+
+  let value: unknown
+  try {
+    value = JSON.parse(bytes)
+  } catch (error) {
+    throw new Error(`explicit compare receipt is malformed JSON: ${path}`, { cause: error })
+  }
+
+  let receipt: BuckRunReceipt
+  try {
+    receipt = decodeReceipt(value)
+  } catch (error) {
+    throw new Error(`explicit compare receipt is unsupported or invalid: ${path}`, {
+      cause: error,
+    })
+  }
+  if (receipt.observation.complete === false) {
+    throw new Error(`explicit compare receipt is incomplete: ${path}`)
+  }
+  return receipt
 }
 
 const outputsFromReport = (
@@ -258,9 +283,18 @@ const prepareClosures = async (
 }
 
 export const launchBuck = async (options: LaunchOptions): Promise<LaunchResult> => {
+  if (isRepositoryRevision(options.repositoryRevision) === false) {
+    throw new Error('repository revision must be an exact 40- or 64-character Git revision')
+  }
+  if (isExecutionPlatform(options.executionPlatform) === false) {
+    throw new Error('execution platform must be a portable platform identifier')
+  }
   assertNoReservedEvidenceFlags(options.buckArgs)
   assertSupportedCommand(options.buckArgs)
-  const closures = await prepareClosures(options.closureManifests ?? [])
+  const [closures, previous] = await Promise.all([
+    prepareClosures(options.closureManifests ?? []),
+    loadPreviousReceipt(options.compareReceipt),
+  ])
   const now = options.now ?? (() => new Date())
   const launcherRunId = options.launcherRunId ?? randomUUID()
   if (isSafePathComponent(launcherRunId) === false) {
@@ -301,31 +335,24 @@ export const launchBuck = async (options: LaunchOptions): Promise<LaunchResult> 
   const ended = now()
 
   try {
-    const [
-      whatRanQuery,
-      materializedQuery,
-      report,
-      eventLogDescriptor,
-      buildReportDescriptor,
-      previous,
-    ] = await Promise.all([
-      runChild({
-        binary: options.buckBinary,
-        args: ['log', 'what-ran', '--format', 'json', '--emit-cache-queries', eventLogPath],
-        cwd: options.cwd,
-        stdio: 'capture',
-      }),
-      runChild({
-        binary: options.buckBinary,
-        args: ['log', 'what-materialized', '--format', 'json', eventLogPath],
-        cwd: options.cwd,
-        stdio: 'capture',
-      }),
-      readBuildReport(buildReportPath),
-      descriptorForFile(eventLogPath, 'application/x-ndjson'),
-      descriptorForFile(buildReportPath, 'application/json'),
-      loadPreviousReceipt(options.compareReceipt),
-    ])
+    const [whatRanQuery, materializedQuery, report, eventLogDescriptor, buildReportDescriptor] =
+      await Promise.all([
+        runChild({
+          binary: options.buckBinary,
+          args: ['log', 'what-ran', '--format', 'json', '--emit-cache-queries', eventLogPath],
+          cwd: options.cwd,
+          stdio: 'capture',
+        }),
+        runChild({
+          binary: options.buckBinary,
+          args: ['log', 'what-materialized', '--format', 'json', eventLogPath],
+          cwd: options.cwd,
+          stdio: 'capture',
+        }),
+        readBuildReport(buildReportPath),
+        descriptorForFile(eventLogPath, 'application/x-ndjson'),
+        descriptorForFile(buildReportPath, 'application/json'),
+      ])
     const whatRanParse = parseJsonLinesComplete(whatRanQuery.stdout)
     const materializedParse = parseJsonLinesComplete(materializedQuery.stdout)
     const actions = normalizeActions(whatRanParse.rows)
@@ -358,7 +385,7 @@ export const launchBuck = async (options: LaunchOptions): Promise<LaunchResult> 
       ...(buildReportDescriptor === undefined ? ['build-report-file'] : []),
     ]
     const observationComplete = incompleteReasons.length === 0
-    const previousTrusted = previous?.observation.complete === true ? previous : undefined
+    const previousTrusted = previous
     const outputs = outputsFromReport(report)
     const success = commandResult.exitCode === 0
     const fallback = !observationComplete
@@ -386,6 +413,8 @@ export const launchBuck = async (options: LaunchOptions): Promise<LaunchResult> 
       schema: 'buck-run-receipt/v1',
       launcherRunId,
       ...(buckInvocationId === undefined ? {} : { buckInvocationId }),
+      repositoryRevision: options.repositoryRevision,
+      executionPlatform: options.executionPlatform,
       command: {
         kind: sanitizeEvidenceText(buckCommand(options.buckArgs) ?? 'unknown'),
         requestedTargets: requestedTargetsFromReport(report),

--- a/packages/@overeng/buck2-launcher/src/launcher.unit.test.ts
+++ b/packages/@overeng/buck2-launcher/src/launcher.unit.test.ts
@@ -160,6 +160,53 @@ describe('launchBuck process boundary', () => {
     ).rejects.toThrow('explicit compare receipt is incomplete')
   })
 
+  it.each([
+    {
+      name: 'repository revision',
+      previousRevision: '1111111111111111111111111111111111111111',
+      previousPlatform: 'x86_64-linux',
+      currentRevision: '2222222222222222222222222222222222222222',
+      currentPlatform: 'x86_64-linux',
+      diagnostic: 'repository revision does not match current run',
+    },
+    {
+      name: 'execution platform',
+      previousRevision: '1111111111111111111111111111111111111111',
+      previousPlatform: 'aarch64-linux',
+      currentRevision: '1111111111111111111111111111111111111111',
+      currentPlatform: 'x86_64-linux',
+      diagnostic: 'execution platform does not match current run',
+    },
+  ])('rejects a cross-$name comparison receipt before executing Buck', async (identity) => {
+    const root = await mkdtemp(join(tmpdir(), `buck2-launcher-compare-${identity.name}-`))
+    const binary = join(root, 'fake-buck2')
+    await writeFile(binary, fakeBuckSource)
+    await chmod(binary, 0o700)
+    const first = await launchBuckRaw({
+      buckBinary: binary,
+      buckArgs: ['build', 'root//:check'],
+      cwd: root,
+      evidenceRoot: join(root, 'evidence'),
+      repositoryRevision: identity.previousRevision,
+      executionPlatform: identity.previousPlatform,
+      launcherRunId: 'identity-before',
+    })
+    if (first.receiptPath === undefined) throw new Error('first launch did not write a receipt')
+
+    await expect(
+      launchBuckRaw({
+        buckBinary: join(root, 'does-not-exist'),
+        buckArgs: ['build', 'root//:check'],
+        cwd: root,
+        evidenceRoot: join(root, 'evidence'),
+        repositoryRevision: identity.currentRevision,
+        executionPlatform: identity.currentPlatform,
+        compareReceipt: first.receiptPath,
+        launcherRunId: 'identity-after',
+      }),
+    ).rejects.toThrow(identity.diagnostic)
+  })
+
   it('rejects inexact receipt identity before executing Buck', async () => {
     const root = await mkdtemp(join(tmpdir(), 'buck2-launcher-identity-'))
     await expect(

--- a/packages/@overeng/buck2-launcher/src/launcher.unit.test.ts
+++ b/packages/@overeng/buck2-launcher/src/launcher.unit.test.ts
@@ -5,7 +5,14 @@ import { join } from 'node:path'
 
 import { describe, expect, it } from 'vitest'
 
-import { launchBuck } from './launcher.ts'
+import { launchBuck as launchBuckRaw, type LaunchOptions } from './launcher.ts'
+
+const launchBuck = (options: Omit<LaunchOptions, 'repositoryRevision' | 'executionPlatform'>) =>
+  launchBuckRaw({
+    ...options,
+    repositoryRevision: '0123456789abcdef0123456789abcdef01234567',
+    executionPlatform: 'x86_64-linux',
+  })
 
 const fakeBuckSource = `#!/usr/bin/env node
 const fs = require('node:fs')
@@ -91,6 +98,82 @@ const closureManifest = (label = 'root//:check') => {
 }
 
 describe('launchBuck process boundary', () => {
+  it.each([
+    ['missing', undefined],
+    ['malformed', '{not-json'],
+    ['unsupported', JSON.stringify({ schema: 'buck-run-receipt/v999' })],
+  ])(
+    'rejects an explicitly requested %s comparison receipt before executing Buck',
+    async (kind, body) => {
+      const root = await mkdtemp(join(tmpdir(), `buck2-launcher-compare-${kind}-`))
+      const compareReceipt = join(root, 'compare-receipt.json')
+      if (body !== undefined) await writeFile(compareReceipt, body)
+
+      await expect(
+        launchBuck({
+          buckBinary: join(root, 'does-not-exist'),
+          buckArgs: ['build', 'root//:check'],
+          cwd: root,
+          evidenceRoot: join(root, 'evidence'),
+          compareReceipt,
+          launcherRunId: `compare-${kind}`,
+        }),
+      ).rejects.toThrow(`explicit compare receipt is ${kind}`)
+    },
+  )
+
+  it('rejects an explicitly requested incomplete comparison receipt before executing Buck', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'buck2-launcher-compare-incomplete-'))
+    const binary = join(root, 'fake-buck2')
+    await writeFile(binary, fakeBuckSource)
+    await chmod(binary, 0o700)
+    const first = await launchBuck({
+      buckBinary: binary,
+      buckArgs: ['build', 'root//:check'],
+      cwd: root,
+      evidenceRoot: join(root, 'evidence'),
+      launcherRunId: 'before-incomplete',
+    })
+    if (first.receiptPath === undefined) throw new Error('first launch did not write a receipt')
+    const incomplete = JSON.parse(await readFile(first.receiptPath, 'utf8')) as Record<
+      string,
+      unknown
+    >
+    incomplete.observation = {
+      complete: false,
+      verdict: 'incomplete',
+      reasons: ['event-log'],
+      whatRan: { exitCode: 0, parseComplete: true, semanticComplete: true, records: 1 },
+      materialized: { exitCode: 0, parseComplete: true, semanticComplete: true, records: 0 },
+    }
+    await writeFile(first.receiptPath, JSON.stringify(incomplete))
+
+    await expect(
+      launchBuck({
+        buckBinary: join(root, 'does-not-exist'),
+        buckArgs: ['build', 'root//:check'],
+        cwd: root,
+        evidenceRoot: join(root, 'evidence'),
+        compareReceipt: first.receiptPath,
+        launcherRunId: 'after-incomplete',
+      }),
+    ).rejects.toThrow('explicit compare receipt is incomplete')
+  })
+
+  it('rejects inexact receipt identity before executing Buck', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'buck2-launcher-identity-'))
+    await expect(
+      launchBuckRaw({
+        buckBinary: join(root, 'does-not-exist'),
+        buckArgs: ['build', 'root//:check'],
+        cwd: root,
+        evidenceRoot: join(root, 'evidence'),
+        repositoryRevision: 'main',
+        executionPlatform: 'x86_64-linux',
+      }),
+    ).rejects.toThrow('exact 40- or 64-character Git revision')
+  })
+
   it('runs Buck directly, preserves target args, and writes a sanitized receipt', async () => {
     const root = await mkdtemp(join(tmpdir(), 'buck2-launcher-test-'))
     const binary = join(root, 'fake-buck2')
@@ -113,6 +196,8 @@ describe('launchBuck process boundary', () => {
     expect(result.receipt).toMatchObject({
       schema: 'buck-run-receipt/v1',
       buckInvocationId: '11111111-1111-4111-8111-111111111111',
+      repositoryRevision: '0123456789abcdef0123456789abcdef01234567',
+      executionPlatform: 'x86_64-linux',
       command: { kind: 'build', requestedTargets: ['root//:check'] },
       outcomes: { local_execution: 1 },
       closures: [{ label: 'root//:check' }],

--- a/packages/@overeng/buck2-launcher/src/receipt.ts
+++ b/packages/@overeng/buck2-launcher/src/receipt.ts
@@ -28,6 +28,10 @@ export interface BuckRunReceipt {
   readonly schema: 'buck-run-receipt/v1'
   readonly launcherRunId: string
   readonly buckInvocationId?: string
+  /** Added during v1; absent only on receipts written by older launchers. */
+  readonly repositoryRevision?: string
+  /** Added during v1; absent only on receipts written by older launchers. */
+  readonly executionPlatform?: string
   readonly command: { readonly kind: string; readonly requestedTargets: ReadonlyArray<string> }
   readonly status: {
     readonly exitCode: number
@@ -100,6 +104,11 @@ export const BuckRunReceiptJsonSchema = {
     schema: { const: 'buck-run-receipt/v1' },
     launcherRunId: { type: 'string', pattern: '^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$' },
     buckInvocationId: { type: 'string', minLength: 1 },
+    repositoryRevision: { type: 'string', pattern: '^(?:[a-f0-9]{40}|[a-f0-9]{64})$' },
+    executionPlatform: {
+      type: 'string',
+      pattern: '^[A-Za-z0-9][A-Za-z0-9._+-]{0,127}$',
+    },
     command: {
       type: 'object',
       required: ['kind', 'requestedTargets'],
@@ -231,6 +240,10 @@ export const BuckRunReceiptJsonSchema = {
       },
     },
   },
+  dependentRequired: {
+    repositoryRevision: ['executionPlatform'],
+    executionPlatform: ['repositoryRevision'],
+  },
   $defs: {
     digest: { type: 'string', pattern: '^sha256:[a-f0-9]{64}$' },
     descriptor: {
@@ -282,6 +295,21 @@ export const decodeReceipt = (value: unknown): BuckRunReceipt => {
   }
   if (root.buckInvocationId !== undefined)
     receiptString(root.buckInvocationId, '$.buckInvocationId')
+  const hasRepositoryRevision = root.repositoryRevision !== undefined
+  const hasExecutionPlatform = root.executionPlatform !== undefined
+  if (hasRepositoryRevision !== hasExecutionPlatform) {
+    throw new Error('receipt v1 identity fields must either both be present or both be absent')
+  }
+  if (hasRepositoryRevision) {
+    const repositoryRevision = receiptString(root.repositoryRevision, '$.repositoryRevision')
+    if (isRepositoryRevision(repositoryRevision) === false) {
+      throw new Error('receipt $.repositoryRevision must be an exact Git revision')
+    }
+    const executionPlatform = receiptString(root.executionPlatform, '$.executionPlatform')
+    if (isExecutionPlatform(executionPlatform) === false) {
+      throw new Error('receipt $.executionPlatform must be a portable platform identifier')
+    }
+  }
   const command = receiptObject(root.command, '$.command')
   receiptString(command.kind, '$.command.kind')
   receiptStringArray(command.requestedTargets, '$.command.requestedTargets')
@@ -391,6 +419,10 @@ const actionOutcomes = new Set<ActionOutcome>([
 
 export const isSafePathComponent = (value: string): boolean =>
   /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/u.test(value)
+export const isRepositoryRevision = (value: string): boolean =>
+  /^(?:[a-f0-9]{40}|[a-f0-9]{64})$/u.test(value)
+export const isExecutionPlatform = (value: string): boolean =>
+  /^[A-Za-z0-9][A-Za-z0-9._+-]{0,127}$/u.test(value)
 const receiptObject = (value: unknown, path: string): Record<string, unknown> => {
   if (typeof value !== 'object' || value === null || Array.isArray(value))
     throw new Error(`receipt ${path} must be an object`)
@@ -574,7 +606,7 @@ export const descriptorForClosureManifest = async (
   if (root.schemaVersion === 3) {
     stringAt(provenance.source, '$.provenance.source')
     if (provenance.warning !== 'GENERATED FILE - DO NOT EDIT') {
-      throw new Error('$.provenance.warning must identify the schema-3 manifest as generated')
+      throw new Error('closure manifest $.provenance.warning must be GENERATED FILE - DO NOT EDIT')
     }
   }
   const semanticData = {
@@ -611,6 +643,8 @@ const sensitiveKeyWords = new Set([
   'credentials',
   'key',
   'password',
+  'passphrase',
+  'passwd',
   'secret',
   'token',
 ])

--- a/packages/@overeng/buck2-launcher/src/receipt.unit.test.ts
+++ b/packages/@overeng/buck2-launcher/src/receipt.unit.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto'
-import { mkdtemp, readFile, writeFile } from 'node:fs/promises'
+import { mkdtemp, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -26,6 +26,39 @@ const descriptor = (hex: string): EvidenceDescriptor => ({
 })
 
 describe('Buck receipt normalization', () => {
+  const legacyReceipt = {
+    schema: 'buck-run-receipt/v1',
+    launcherRunId: 'legacy-run',
+    command: { kind: 'build', requestedTargets: ['//:x'] },
+    status: { exitCode: 1, success: false },
+    timing: { startedAt: '2026-01-01T00:00:00Z', endedAt: '2026-01-01T00:00:01Z', durationMs: 1 },
+    buck: {},
+    evidence: {},
+    observation: {
+      complete: false,
+      verdict: 'incomplete',
+      reasons: ['legacy receipt'],
+      whatRan: { exitCode: 1, parseComplete: false, semanticComplete: false, records: 0 },
+      materialized: { exitCode: 1, parseComplete: false, semanticComplete: false, records: 0 },
+    },
+    outputs: [],
+    closures: [],
+    actions: [],
+    outcomes: {},
+    materialization: { records: 0, files: 0, bytes: 0 },
+    explanation: { status: 'unknown', changedDimensions: [], note: 'legacy receipt' },
+  } as const
+
+  it('decodes pre-identity v1 receipts but rejects partial identity', () => {
+    expect(decodeReceipt(legacyReceipt)).toMatchObject({ launcherRunId: 'legacy-run' })
+    expect(() =>
+      decodeReceipt({
+        ...legacyReceipt,
+        repositoryRevision: '0123456789abcdef0123456789abcdef01234567',
+      }),
+    ).toThrow('identity fields must either both be present or both be absent')
+  })
+
   it('keeps DICE reuse distinct from cache hits and execution', () => {
     const actions = normalizeActions([
       {
@@ -69,11 +102,21 @@ describe('Buck receipt normalization', () => {
 
   it('redacts header and space-delimited credential forms', () => {
     const result = sanitizeEvidenceText(
-      'authorization: Bearer header-secret token: token-secret --api-key cli-secret',
+      'authorization: Bearer header-secret token: token-secret --api-key cli-secret --passwd passwd-secret --passphrase passphrase-secret',
     )
     expect(result).not.toContain('header-secret')
     expect(result).not.toContain('token-secret')
     expect(result).not.toContain('cli-secret')
+    expect(result).not.toContain('passwd-secret')
+    expect(result).not.toContain('passphrase-secret')
+  })
+
+  it('redacts password aliases in structured evidence', () => {
+    const result = sanitizeEvidenceText(
+      JSON.stringify({ passphrase: 'json-passphrase-secret', passwd: 'json-passwd-secret' }),
+    )
+    expect(result).not.toContain('json-passphrase-secret')
+    expect(result).not.toContain('json-passwd-secret')
   })
 
   it('redacts authorization schemes and credentials from normalized action identities', () => {
@@ -298,7 +341,7 @@ describe('Buck receipt normalization', () => {
         ...generatedSemantic,
         provenance: {
           ...value.provenance,
-          source: 'buck2/generated-v3.json.genie.ts',
+          source: 'packages/example/BUCK.genie.ts',
           warning: 'GENERATED FILE - DO NOT EDIT',
           semanticFingerprint: `sha256:${createHash('sha256')
             .update(
@@ -317,18 +360,38 @@ describe('Buck receipt normalization', () => {
     await expect(descriptorForClosureManifest(generatedV3, 'root//:check')).resolves.toMatchObject({
       mediaType: 'application/json',
     })
-    const validGeneratedV3 = await readFile(generatedV3, 'utf8')
-    for (const [field, value] of [
-      ['source', undefined],
-      ['warning', 'handwritten'],
-    ] as const) {
-      const malformed = JSON.parse(validGeneratedV3) as Record<string, unknown>
-      const malformedProvenance = malformed.provenance as Record<string, unknown>
-      if (value === undefined) delete malformedProvenance[field]
-      else malformedProvenance[field] = value
-      await writeFile(generatedV3, JSON.stringify(malformed))
+    for (const provenance of [
+      { ...value.provenance, warning: 'GENERATED FILE - DO NOT EDIT' },
+      { ...value.provenance, source: 'packages/example/BUCK.genie.ts' },
+      {
+        ...value.provenance,
+        source: 'packages/example/BUCK.genie.ts',
+        warning: 'not the generated contract warning',
+      },
+    ]) {
+      await writeFile(
+        generatedV3,
+        JSON.stringify({
+          schemaVersion: 3,
+          ...generatedSemantic,
+          provenance: {
+            ...provenance,
+            semanticFingerprint: `sha256:${createHash('sha256')
+              .update(
+                JSON.stringify(
+                  canonical({
+                    generator: 'effect-utils/genie/buck2',
+                    schemaVersion: 3,
+                    semanticData: generatedSemantic,
+                  }),
+                ),
+              )
+              .digest('hex')}`,
+          },
+        }),
+      )
       await expect(descriptorForClosureManifest(generatedV3, 'root//:check')).rejects.toThrow(
-        field === 'source' ? '$.provenance.source' : '$.provenance.warning',
+        /provenance\.(source|warning)/u,
       )
     }
     await writeFile(
@@ -338,7 +401,7 @@ describe('Buck receipt normalization', () => {
         ...generatedSemantic,
         provenance: {
           ...value.provenance,
-          source: 'buck2/generated-v3.json.genie.ts',
+          source: 'packages/example/BUCK.genie.ts',
           warning: 'GENERATED FILE - DO NOT EDIT',
           semanticFingerprint: `sha256:${createHash('sha256')
             .update(JSON.stringify(canonical(generatedSemantic)))
@@ -356,6 +419,8 @@ describe('Buck receipt normalization', () => {
       decodeReceipt({
         schema: 'buck-run-receipt/v1',
         launcherRunId: 'x',
+        repositoryRevision: '0123456789abcdef0123456789abcdef01234567',
+        executionPlatform: 'x86_64-linux',
         closures: [],
         actions: [],
       }),

--- a/scripts/buck2-benchmark/lib.mjs
+++ b/scripts/buck2-benchmark/lib.mjs
@@ -143,3 +143,35 @@ export const parseJsonl = (text) => {
   }
   return records
 }
+
+/** Fail unless Buck's measured invalidation matches the reviewed product graph. */
+export const assertBuckInvalidation = ({ records, runs, expectedRelevantActions }) => {
+  const samplesFor = (phase) =>
+    records.filter(
+      (record) =>
+        record.kind === 'sample' &&
+        record.engine === 'buck2' &&
+        record.phase === phase &&
+        record.warmup === false,
+    )
+  const requireMeasured = (phase) => {
+    const samples = samplesFor(phase)
+    if (samples.length !== runs)
+      throw new Error(`Buck invalidation ${phase}: expected ${runs} samples, got ${samples.length}`)
+    for (const sample of samples)
+      if (sample.status !== 'ok' || sample.buckLogStatus !== 'ok')
+        throw new Error(
+          `Buck invalidation ${phase}: every sample must have complete Buck log evidence`,
+        )
+    return samples
+  }
+  for (const phase of ['warm-noop', 'irrelevant-edit'])
+    for (const sample of requireMeasured(phase))
+      if (sample.actionCount !== 0 || sample.materializationCount !== 0)
+        throw new Error(`Buck invalidation ${phase}: expected zero actions and materializations`)
+  for (const sample of requireMeasured('relevant-edit'))
+    if (sample.actionCount !== expectedRelevantActions)
+      throw new Error(
+        `Buck invalidation relevant-edit: expected ${expectedRelevantActions} actions, got ${sample.actionCount}`,
+      )
+}

--- a/scripts/buck2-benchmark/lib.unit.test.mjs
+++ b/scripts/buck2-benchmark/lib.unit.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 
 import {
+  assertBuckInvalidation,
   countNonEmptyLines,
   parseJsonl,
   parseMaterializations,
@@ -9,7 +10,44 @@ import {
   summarizeSamples,
 } from './lib.mjs'
 
+const invalidationSample = ({ phase, actionCount, materializationCount }) => ({
+  kind: 'sample',
+  engine: 'buck2',
+  phase,
+  warmup: false,
+  status: 'ok',
+  buckLogStatus: 'ok',
+  actionCount,
+  materializationCount,
+})
+
 describe('buck2 benchmark parsers', () => {
+  it('requires exact warm, irrelevant, and relevant invalidation evidence', () => {
+    const records = [
+      invalidationSample({ phase: 'warm-noop', actionCount: 0, materializationCount: 0 }),
+      invalidationSample({ phase: 'irrelevant-edit', actionCount: 0, materializationCount: 0 }),
+      invalidationSample({ phase: 'relevant-edit', actionCount: 3, materializationCount: 2 }),
+    ]
+    assert.doesNotThrow(() =>
+      assertBuckInvalidation({ records, runs: 1, expectedRelevantActions: 3 }),
+    )
+    assert.throws(
+      () => assertBuckInvalidation({ records, runs: 1, expectedRelevantActions: 4 }),
+      /expected 4 actions/u,
+    )
+    assert.throws(
+      () =>
+        assertBuckInvalidation({
+          records: [
+            invalidationSample({ phase: 'warm-noop', actionCount: 1, materializationCount: 0 }),
+            ...records.slice(1),
+          ],
+          runs: 1,
+          expectedRelevantActions: 3,
+        }),
+      /expected zero actions and materializations/u,
+    )
+  })
   it('uses the nearest-rank percentile definition', () => {
     assert.equal(percentile({ values: [5, 1, 4, 2, 3], fraction: 0.5 }), 3)
     assert.equal(percentile({ values: [1, 2, 3, 4, 5], fraction: 0.95 }), 5)

--- a/scripts/buck2-invalidation-e2e.sh
+++ b/scripts/buck2-invalidation-e2e.sh
@@ -5,6 +5,7 @@ repo_root="${1:?usage: buck2-invalidation-e2e.sh REPO_ROOT BUCK2_BIN}"
 buck2_bin="${2:?usage: buck2-invalidation-e2e.sh REPO_ROOT BUCK2_BIN}"
 stage0_config="${BUCK2_STAGE0_CONFIG:?BUCK2_STAGE0_CONFIG is required}"
 target="//buck2/evidence:package_evidence"
+expected_action="root//buck2/evidence:package_evidence (buck2_package_evidence package_evidence)"
 isolation="invalidation-e2e-$$-$RANDOM"
 tracked_source="$repo_root/buck2/evidence/source.txt"
 sha256_bin="${SHA256_BIN:-sha256sum}"
@@ -52,9 +53,21 @@ trap 'exit 143' TERM
 # the checked-in fixture in place.
 cp -p "$repo_root/.buckconfig" "$test_root/.buckconfig"
 cp -R "$repo_root/buck2" "$test_root/buck2"
-cp -R "$repo_root/toolchains" "$test_root/toolchains"
+mkdir -p "$test_root/toolchains"
+cp -p "$repo_root/toolchains/configured.bzl" "$test_root/toolchains/configured.bzl"
+cat >"$test_root/toolchains/BUCK" <<'EOF'
+load(":configured.bzl", "configured_exec")
+
+configured_exec(
+    name = "package_evidence_tool",
+    path = read_config("buck2_stage0", "package_evidence_tool", ""),
+    visibility = ["PUBLIC"],
+)
+EOF
 baseline_source="$test_root/baseline-source.txt"
 cp -p "$source_path" "$baseline_source"
+irrelevant_path="$test_root/buck2/evidence/irrelevant.txt"
+printf '%s\n' 'not an input of package_evidence' >"$irrelevant_path"
 
 build_and_observe() {
   phase="$1"
@@ -71,35 +84,80 @@ build_and_observe() {
     echo "buck2-invalidation-e2e: $phase did not report a materialized artifact" >&2
     return 1
   }
-  what_ran="$($buck2_bin --isolation-dir "$isolation" log what-ran)"
-  action_count="$(printf '%s\n' "$what_ran" | "$awk_bin" 'NF { count += 1 } END { print count + 0 }')"
+  what_ran="$($buck2_bin --isolation-dir "$isolation" log what-ran --format tabulated --skip-cache-hits)"
+  action_count="$(printf '%s\n' "$what_ran" | "$awk_bin" -F '\t' 'NF { count += 1 } END { print count + 0 }')"
+  action_set="$(printf '%s\n' "$what_ran" | "$awk_bin" -F '\t' 'NF {
+    identity = $2
+    sub(/ \([^)]*#[0-9a-f]+\)/, "", identity)
+    print identity
+  }')"
   artifact_digest="$($sha256_bin "$artifact" | "$awk_bin" '{ print $1 }')"
-  printf '%s %s\n' "$artifact_digest" "$action_count"
+  printf '%s\t%s\t%s\n' "$artifact_digest" "$action_count" "$action_set"
+}
+
+assert_zero_actions() {
+  phase="$1"
+  count="$2"
+  actions="$3"
+  [ "$count" -eq 0 ] && [ -z "$actions" ] || {
+    echo "buck2-invalidation-e2e: $phase ran $count actions, expected none: $actions" >&2
+    exit 1
+  }
+}
+
+assert_relevant_action() {
+  phase="$1"
+  count="$2"
+  actions="$3"
+  [ "$count" -eq 1 ] && [ "$actions" = "$expected_action" ] || {
+    echo "buck2-invalidation-e2e: $phase action set mismatch" >&2
+    echo "expected: $expected_action" >&2
+    echo "actual:   $actions" >&2
+    exit 1
+  }
 }
 
 cd "$test_root"
-read -r baseline_digest _baseline_actions < <(build_and_observe baseline)
+IFS=$'\t' read -r baseline_digest baseline_actions baseline_action_set < <(build_and_observe baseline)
+assert_relevant_action baseline "$baseline_actions" "$baseline_action_set"
 
-printf '\nbuck2 invalidation probe %s\n' "$isolation" >> "$source_path"
-read -r mutated_digest mutated_actions < <(build_and_observe mutation)
-[ "$mutated_actions" -eq 1 ] || {
-  echo "buck2-invalidation-e2e: mutation ran $mutated_actions actions, expected exactly 1" >&2
+IFS=$'\t' read -r warm_digest warm_actions warm_action_set < <(build_and_observe warm-noop)
+assert_zero_actions warm-noop "$warm_actions" "$warm_action_set"
+[ "$warm_digest" = "$baseline_digest" ] || {
+  echo "buck2-invalidation-e2e: warm no-op changed artifact identity" >&2
   exit 1
 }
+
+touch -m -d '@1' "$source_path"
+IFS=$'\t' read -r mtime_digest mtime_actions mtime_action_set < <(build_and_observe mtime-only)
+assert_zero_actions mtime-only "$mtime_actions" "$mtime_action_set"
+[ "$mtime_digest" = "$baseline_digest" ] || {
+  echo "buck2-invalidation-e2e: mtime-only change changed artifact identity" >&2
+  exit 1
+}
+
+printf '%s\n' "irrelevant edit $isolation" >>"$irrelevant_path"
+IFS=$'\t' read -r irrelevant_digest irrelevant_actions irrelevant_action_set < <(build_and_observe irrelevant-edit)
+assert_zero_actions irrelevant-edit "$irrelevant_actions" "$irrelevant_action_set"
+[ "$irrelevant_digest" = "$baseline_digest" ] || {
+  echo "buck2-invalidation-e2e: irrelevant edit changed artifact identity" >&2
+  exit 1
+}
+
+printf '\nbuck2 invalidation probe %s\n' "$isolation" >> "$source_path"
+IFS=$'\t' read -r mutated_digest mutated_actions mutated_action_set < <(build_and_observe relevant-edit)
+assert_relevant_action relevant-edit "$mutated_actions" "$mutated_action_set"
 [ "$mutated_digest" != "$baseline_digest" ] || {
   echo "buck2-invalidation-e2e: mutation did not change the artifact digest" >&2
   exit 1
 }
 
 cp -p "$baseline_source" "$source_path"
-read -r restored_digest restored_actions < <(build_and_observe restore)
-[ "$restored_actions" -eq 1 ] || {
-  echo "buck2-invalidation-e2e: restore ran $restored_actions actions, expected exactly 1" >&2
-  exit 1
-}
+IFS=$'\t' read -r restored_digest restored_actions restored_action_set < <(build_and_observe restore)
+assert_relevant_action restore "$restored_actions" "$restored_action_set"
 [ "$restored_digest" = "$baseline_digest" ] || {
   echo "buck2-invalidation-e2e: restored artifact digest differs from baseline" >&2
   exit 1
 }
 
-echo "buck2-invalidation-e2e: PASS mutation_actions=1 restore_actions=1 digest_restored=true"
+echo "buck2-invalidation-e2e: PASS warm=0 mtime=0 irrelevant=0 relevant=1 restore=1 digest_restored=true"


### PR DESCRIPTION
## Outcome

Closes the final independent-review gaps above #1078 without rewriting the already reviewed foundation layers.

- binds sanitized receipts to exact repository revision and execution platform
- validates schema-3 provenance and narrows generated-file markings
- keeps mutation-free shell observability on an existing non-mutating task
- hardens canonical product paths, SRI, platform, and configured Rust identities
- admits one exact dynamic-ELF runtime through an independent Nix inspector
- adds hostile descriptor, archive, ELF, platform, credential, and identity controls

This is a child of #1078 in native GitHub stack #1074. Review fixes intentionally live here so earlier PR heads remain stable; the stack must merge atomically in order.

## Evidence

- 52 Buck launcher focused tests / 108 assertions
- canonical product-contract suite with hostile RED controls
- `buck2:nix-bridge:check` GREEN
- `buck2:rust-musl:check` GREEN
- `lint:check`, `genie:check`, Nix parsing/formatting, generated-attribute assertions, and `git diff --check` GREEN
- independent review findings were reproduced RED and fixed GREEN; the final exact head requires fresh CI

## Exact identity

- Base: `c122ab2b2fe25bf514de324797d66652bd131e88`
- Head: `96adfa7fbd4b352270debc0997c37725eab5f4b6`

Native stack #1074, position 10 of 12. Part of #1050. Cleanup tracked in #1065.