### PR TITLE
Consume native st2 workspace activity snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- **@overeng/megarepo**: Consume native `st2.workspace-activity.v1` snapshots for generated-artifact planning. Incomplete, erroneous, expired, malformed, or non-canonical claims fail closed; only canonical active claims veto a plan.
+
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]

--- a/packages/@overeng/megarepo/README.md
+++ b/packages/@overeng/megarepo/README.md
@@ -86,28 +86,45 @@ Configure the host at `$MEGAREPO_STORE/.state/gc-config.json`:
     "enabled": true,
     "retentionMs": 86400000,
     "allowlist": ["node_modules", ".direnv", "target"],
-    "agentLivenessManifest": "/run/megarepo/agent-liveness.json"
+    "agentLivenessManifest": "/run/megarepo/st2-workspace-activity.json",
+    "agentLivenessEpoch": { "catalog": "/var/lib/st2/catalog", "host": "dev3" }
   }
 }
 ```
 
-The allowlist may contain only the compiled canonical classes. The liveness manifest is a
-short-lived snapshot produced by the host's agent manager:
+The allowlist may contain only the compiled canonical classes. The liveness manifest must be a
+native, short-lived `st2 workspace-activity --json` snapshot:
 
 ```json
 {
-  "version": 1,
-  "expiresAtMs": 1786572000000,
-  "activeWorkspacePaths": ["/absolute/path/to/a/store/worktree"]
+  "schemaVersion": "st2.workspace-activity.v1",
+  "producer": "st2",
+  "epoch": { "catalog": "/absolute/catalog", "host": "dev3", "catalogGeneration": 42 },
+  "capturedAt": "2026-08-14T08:00:00.000Z",
+  "expiresAt": "2026-08-14T08:01:00.000Z",
+  "complete": true,
+  "errors": [],
+  "claims": [
+    {
+      "workspace": "/absolute/path/to/a/store/worktree",
+      "agents": ["dev3.example.agent"],
+      "activeRuntimeIds": ["dev3.example.agent"],
+      "active": true
+    }
+  ]
 }
 ```
 
-Missing, invalid, or expired liveness data produces `unknown`. A candidate
+Missing, invalid, incomplete, erroneous, expired, or non-canonical liveness data produces
+`unknown`. The configured catalog and host admit the expected epoch; its catalog generation must
+remain unchanged across the pre-scan and post-scan reads. A candidate
 must also be Git-ignored, older than the retention window, absent from Megarepo's live set, and
 inside a clean registered worktree. A capped, timed recursive scan uses the newest nested mtime;
 symlinks or incomplete scans produce `unknown`. JSON results distinguish
 `would-delete`, `keep`, and `unknown` and include a deterministic `planSha256`. Mutation and
 `--expected-plan` are rejected until the deletion transaction has a separately verified design.
+The snapshot is planning evidence, not deletion authority; a future mutation path must independently
+revalidate process and filesystem liveness immediately before changing data.
 
 ## Documentation
 

--- a/packages/@overeng/megarepo/src/cli/commands/store/mod.ts
+++ b/packages/@overeng/megarepo/src/cli/commands/store/mod.ts
@@ -143,16 +143,44 @@ type GeneratedArtifactScan =
         | 'io'
     }
 
-const AgentLivenessManifest = Schema.Struct({
-  version: Schema.Literal(1),
-  expiresAtMs: Schema.Number,
-  activeWorkspacePaths: Schema.Array(Schema.String),
+const St2WorkspaceActivitySnapshot = Schema.Struct({
+  schemaVersion: Schema.Literal('st2.workspace-activity.v1'),
+  producer: Schema.Literal('st2'),
+  epoch: Schema.Struct({
+    catalog: Schema.String,
+    host: Schema.String,
+    catalogGeneration: Schema.NullOr(Schema.Number),
+  }),
+  capturedAt: Schema.String,
+  expiresAt: Schema.String,
+  complete: Schema.Boolean,
+  errors: Schema.Array(Schema.String),
+  claims: Schema.Array(
+    Schema.Struct({
+      workspace: Schema.String,
+      agents: Schema.Array(Schema.String),
+      activeRuntimeIds: Schema.Array(Schema.String),
+      active: Schema.Boolean,
+    }),
+  ),
 })
 
 type GeneratedArtifactRepoWorktrees = ReadonlyArray<{
   readonly repo: { readonly relativePath: string }
   readonly worktrees: ReadonlyArray<CollectedWorktree>
 }>
+
+type AdmittedSt2Epoch = {
+  readonly catalog: string
+  readonly host: string
+  readonly catalogGeneration: number | null
+}
+
+const isCanonicalSt2Timestamp = ({ value, epochMs }: { value: string; epochMs: number }): boolean =>
+  Number.isFinite(epochMs) === true && new Date(epochMs).toISOString() === value
+
+const isStrictlySortedUnique = (values: ReadonlyArray<string>): boolean =>
+  values.every((value, index) => index === 0 || values[index - 1]! < value)
 
 const encodeCanonicalPlan = Schema.encodeSync(Schema.parseJson(Schema.Unknown))
 
@@ -181,32 +209,88 @@ const planGeneratedArtifacts = ({
 > =>
   Effect.gen(function* () {
     const generatedResults: StoreGcResult[] = []
-    const readAgentActivePaths = (atMs: number): Effect.Effect<ReadonlySet<string> | undefined> =>
+    const readAgentActivity = ({
+      atMs,
+      admittedEpoch,
+    }: {
+      atMs: number
+      admittedEpoch?: AdmittedSt2Epoch | undefined
+    }): Effect.Effect<
+      { readonly activePaths: ReadonlySet<string>; readonly epoch: AdmittedSt2Epoch } | undefined
+    > =>
       Effect.gen(function* () {
-        if (config.generatedArtifacts.agentLivenessManifest === undefined) return undefined
+        if (
+          config.generatedArtifacts.agentLivenessManifest === undefined ||
+          config.generatedArtifacts.agentLivenessEpoch === undefined
+        ) {
+          return undefined
+        }
         const manifestContent = yield* fs
           .readFileString(config.generatedArtifacts.agentLivenessManifest)
           .pipe(Effect.orElseSucceed(() => undefined))
         if (manifestContent === undefined) return undefined
-        const parsed = yield* Schema.decodeUnknown(Schema.parseJson(AgentLivenessManifest))(
+        const parsed = yield* Schema.decodeUnknown(Schema.parseJson(St2WorkspaceActivitySnapshot))(
           manifestContent,
         ).pipe(Effect.orElseSucceed(() => undefined))
+        const capturedAtMs = parsed === undefined ? Number.NaN : Date.parse(parsed.capturedAt)
+        const expiresAtMs = parsed === undefined ? Number.NaN : Date.parse(parsed.expiresAt)
         if (
           parsed === undefined ||
-          Number.isFinite(parsed.expiresAtMs) === false ||
-          parsed.activeWorkspacePaths.some((path) => isNormalizedAbsolutePath(path) === false) ===
-            true ||
-          parsed.expiresAtMs < atMs
+          parsed.complete === false ||
+          parsed.errors.length > 0 ||
+          isCanonicalSt2Timestamp({ value: parsed.capturedAt, epochMs: capturedAtMs }) === false ||
+          isCanonicalSt2Timestamp({ value: parsed.expiresAt, epochMs: expiresAtMs }) === false ||
+          parsed.epoch.catalog !== config.generatedArtifacts.agentLivenessEpoch.catalog ||
+          parsed.epoch.host !== config.generatedArtifacts.agentLivenessEpoch.host ||
+          (parsed.epoch.catalogGeneration !== null &&
+            (Number.isSafeInteger(parsed.epoch.catalogGeneration) === false ||
+              parsed.epoch.catalogGeneration < 0)) ||
+          (admittedEpoch !== undefined &&
+            (parsed.epoch.catalog !== admittedEpoch.catalog ||
+              parsed.epoch.host !== admittedEpoch.host ||
+              parsed.epoch.catalogGeneration !== admittedEpoch.catalogGeneration)) ||
+          capturedAtMs > atMs ||
+          expiresAtMs < capturedAtMs ||
+          expiresAtMs - capturedAtMs > 5 * 60 * 1_000 ||
+          expiresAtMs <= atMs ||
+          isStrictlySortedUnique(parsed.claims.map((claim) => claim.workspace)) === false ||
+          parsed.claims.some(
+            (claim) =>
+              isNormalizedAbsolutePath(claim.workspace) === false ||
+              claim.agents.length === 0 ||
+              isStrictlySortedUnique(claim.agents) === false ||
+              isStrictlySortedUnique(claim.activeRuntimeIds) === false ||
+              claim.active !== claim.activeRuntimeIds.length > 0,
+          ) === true
         ) {
           return undefined
         }
         const canonicalPaths = yield* Effect.forEach(
-          parsed.activeWorkspacePaths,
-          (path) => fs.realPath(path).pipe(Effect.orElseSucceed(() => undefined)),
+          parsed.claims,
+          (claim) =>
+            fs.realPath(claim.workspace).pipe(
+              Effect.map((path) => ({ claim, path })),
+              Effect.orElseSucceed(() => undefined),
+            ),
           { concurrency: 1 },
         )
-        if (canonicalPaths.some((path) => path === undefined) === true) return undefined
-        return new Set(canonicalPaths.map((path) => normalizeStorePath(path!)))
+        if (
+          canonicalPaths.some(
+            (entry) =>
+              entry === undefined ||
+              normalizeStorePath(entry.path) !== normalizeStorePath(entry.claim.workspace),
+          ) === true
+        ) {
+          return undefined
+        }
+        return {
+          activePaths: new Set(
+            canonicalPaths.flatMap((entry) =>
+              entry?.claim.active === true ? [normalizeStorePath(entry.path)] : [],
+            ),
+          ),
+          epoch: parsed.epoch,
+        }
       })
     for (const { repo, worktrees } of repoWorktrees) {
       for (const worktree of worktrees) {
@@ -250,15 +334,17 @@ const planGeneratedArtifacts = ({
           const contained =
             canonicalArtifact !== undefined &&
             normalizeStorePath(canonicalArtifact) === expectedCanonicalArtifact
-          const agentActivePaths = yield* readAgentActivePaths(yield* readCurrentTimeMillis)
+          const agentActivity = yield* readAgentActivity({
+            atMs: yield* readCurrentTimeMillis,
+          })
           const agentLive =
             canonicalWorktree === undefined
               ? undefined
-              : agentActivePaths?.has(normalizeStorePath(canonicalWorktree))
+              : agentActivity?.activePaths.has(normalizeStorePath(canonicalWorktree))
           const cheapReason =
             config.generatedArtifacts.enabled === false
               ? 'generated-artifacts-disabled'
-              : agentActivePaths === undefined
+              : agentActivity === undefined
                 ? 'agent-liveness-unavailable'
                 : canonicalWorktree === undefined || contained === false
                   ? 'artifact-scan-incomplete'
@@ -285,10 +371,13 @@ const planGeneratedArtifacts = ({
             traversal?._tag === 'complete'
               ? yield* fs.realPath(artifactPath).pipe(Effect.orElseSucceed(() => undefined))
               : canonicalArtifact
-          const finalAgentActivePaths =
+          const finalAgentActivity =
             traversal?._tag === 'complete'
-              ? yield* readAgentActivePaths(yield* readCurrentTimeMillis)
-              : agentActivePaths
+              ? yield* readAgentActivity({
+                  atMs: yield* readCurrentTimeMillis,
+                  admittedEpoch: agentActivity?.epoch,
+                })
+              : agentActivity
           const finalRemovalStatus =
             traversal?._tag === 'complete'
               ? yield* Git.getWorktreeRemovalStatus(worktree.path).pipe(
@@ -322,9 +411,11 @@ const planGeneratedArtifacts = ({
                   finalCanonicalWorktree !== canonicalWorktree ||
                   finalCanonicalArtifact !== canonicalArtifact
                 ? 'artifact-scan-incomplete'
-                : finalAgentActivePaths === undefined
+                : finalAgentActivity === undefined
                   ? 'agent-liveness-unavailable'
-                  : finalAgentActivePaths.has(normalizeStorePath(finalCanonicalWorktree)) === true
+                  : finalAgentActivity.activePaths.has(
+                        normalizeStorePath(finalCanonicalWorktree),
+                      ) === true
                     ? 'live'
                     : finalRemovalStatus._tag === 'unknown'
                       ? 'cleanliness-unknown'

--- a/packages/@overeng/megarepo/src/cli/store-gc-generated.integration.test.ts
+++ b/packages/@overeng/megarepo/src/cli/store-gc-generated.integration.test.ts
@@ -99,19 +99,40 @@ const configure = ({
   config,
   manifest,
   activeWorkspacePaths = [],
-  expiresAtMs = NOW + DAY_MS,
+  expiresAtMs,
+  complete = true,
+  errors = [],
+  epoch = { catalog: '/var/lib/st2/catalog', host: 'test', catalogGeneration: 1 },
 }: {
   config: string
   manifest?: string | undefined
   activeWorkspacePaths?: ReadonlyArray<string>
   expiresAtMs?: number
+  complete?: boolean
+  errors?: ReadonlyArray<string>
+  epoch?: { readonly catalog: string; readonly host: string; readonly catalogGeneration: number }
 }) =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem
     if (manifest !== undefined) {
+      const capturedAtMs = Date.now()
       yield* fs.writeFileString(
         manifest,
-        encodeJson({ version: 1, expiresAtMs, activeWorkspacePaths }),
+        encodeJson({
+          schemaVersion: 'st2.workspace-activity.v1',
+          producer: 'st2',
+          epoch,
+          capturedAt: new Date(capturedAtMs).toISOString(),
+          expiresAt: new Date(expiresAtMs ?? capturedAtMs + 60_000).toISOString(),
+          complete,
+          errors,
+          claims: activeWorkspacePaths.map((workspace) => ({
+            workspace,
+            agents: ['test.agent'],
+            activeRuntimeIds: ['test.agent'],
+            active: true,
+          })),
+        }),
       )
     }
     yield* fs.writeFileString(
@@ -121,7 +142,12 @@ const configure = ({
           enabled: true,
           retentionMs: DAY_MS,
           allowlist: ['node_modules', 'dist'],
-          ...(manifest !== undefined ? { agentLivenessManifest: manifest } : {}),
+          ...(manifest !== undefined
+            ? {
+                agentLivenessManifest: manifest,
+                agentLivenessEpoch: { catalog: '/var/lib/st2/catalog', host: 'test' },
+              }
+            : {}),
         },
       }),
     )
@@ -211,6 +237,58 @@ describe('mr store gc --generated-artifacts', () => {
   )
 
   it.effect(
+    'keeps artifacts in a canonically claimed active workspace',
+    Effect.fnUntraced(
+      function* () {
+        const f = yield* fixture()
+        yield* oldIgnoredArtifact(f.worktree)
+        const canonicalWorktree = yield* FileSystem.FileSystem.pipe(
+          Effect.flatMap((fs) => fs.realPath(f.worktree)),
+        )
+        yield* configure({
+          config: f.config,
+          manifest: f.manifest,
+          activeWorkspacePaths: [canonicalWorktree],
+        })
+        const result = yield* runGc({ cwd: f.outside, storePath: f.storePath, args: ['--dry-run'] })
+        expect(generated(result.results, 'node_modules')).toMatchObject({
+          outcome: 'keep',
+          reason: 'live',
+        })
+      },
+      Effect.provide(NodeContext.layer),
+      Effect.scoped,
+    ),
+  )
+
+  it.effect(
+    'rejects snapshots from an unadmitted host or catalog',
+    Effect.fnUntraced(
+      function* () {
+        const f = yield* fixture()
+        yield* oldIgnoredArtifact(f.worktree)
+        for (const epoch of [
+          { catalog: '/var/lib/st2/catalog', host: 'other', catalogGeneration: 1 },
+          { catalog: '/var/lib/st2/other', host: 'test', catalogGeneration: 1 },
+        ]) {
+          yield* configure({ config: f.config, manifest: f.manifest, epoch })
+          const result = yield* runGc({
+            cwd: f.outside,
+            storePath: f.storePath,
+            args: ['--dry-run'],
+          })
+          expect(generated(result.results, 'node_modules')).toMatchObject({
+            outcome: 'unknown',
+            reason: 'agent-liveness-unavailable',
+          })
+        }
+      },
+      Effect.provide(NodeContext.layer),
+      Effect.scoped,
+    ),
+  )
+
+  it.effect(
     'recent nested activity keeps an old artifact root',
     Effect.fnUntraced(
       function* () {
@@ -252,6 +330,56 @@ describe('mr store gc --generated-artifacts', () => {
         expect(generated(expired.results, 'node_modules')?.reason).toBe(
           'agent-liveness-unavailable',
         )
+      },
+      Effect.provide(NodeContext.layer),
+      Effect.scoped,
+    ),
+  )
+
+  it.effect(
+    'incomplete or erroneous st2 snapshots fail closed',
+    Effect.fnUntraced(
+      function* () {
+        const f = yield* fixture()
+        yield* oldIgnoredArtifact(f.worktree)
+        for (const snapshot of [
+          { complete: false, errors: [] },
+          { complete: true, errors: ['runtime observation incomplete'] },
+        ]) {
+          yield* configure({ config: f.config, manifest: f.manifest, ...snapshot })
+          const result = yield* runGc({
+            cwd: f.outside,
+            storePath: f.storePath,
+            args: ['--dry-run'],
+          })
+          expect(generated(result.results, 'node_modules')).toMatchObject({
+            outcome: 'unknown',
+            reason: 'agent-liveness-unavailable',
+          })
+        }
+      },
+      Effect.provide(NodeContext.layer),
+      Effect.scoped,
+    ),
+  )
+
+  it.effect(
+    'does not accept the legacy ad-hoc liveness shape',
+    Effect.fnUntraced(
+      function* () {
+        const f = yield* fixture()
+        yield* oldIgnoredArtifact(f.worktree)
+        yield* configure({ config: f.config, manifest: f.manifest })
+        const fs = yield* FileSystem.FileSystem
+        yield* fs.writeFileString(
+          f.manifest,
+          encodeJson({ version: 1, expiresAtMs: NOW + DAY_MS, activeWorkspacePaths: [] }),
+        )
+        const result = yield* runGc({ cwd: f.outside, storePath: f.storePath, args: ['--dry-run'] })
+        expect(generated(result.results, 'node_modules')).toMatchObject({
+          outcome: 'unknown',
+          reason: 'agent-liveness-unavailable',
+        })
       },
       Effect.provide(NodeContext.layer),
       Effect.scoped,

--- a/packages/@overeng/megarepo/src/lib/store-gc-config.ts
+++ b/packages/@overeng/megarepo/src/lib/store-gc-config.ts
@@ -57,6 +57,7 @@ export interface StoreGcConfig {
     readonly retentionMs: number
     readonly allowlist: ReadonlyArray<StoreGcGeneratedArtifact>
     readonly agentLivenessManifest?: string | undefined
+    readonly agentLivenessEpoch?: { readonly catalog: string; readonly host: string } | undefined
   }
 }
 
@@ -83,6 +84,9 @@ const StoreGcConfigOverride = Schema.Struct({
       retentionMs: Schema.optional(Schema.Number),
       allowlist: Schema.optional(Schema.Array(Schema.Literal(...STORE_GC_GENERATED_ARTIFACTS))),
       agentLivenessManifest: Schema.optional(Schema.String),
+      agentLivenessEpoch: Schema.optional(
+        Schema.Struct({ catalog: Schema.String, host: Schema.String }),
+      ),
     }),
   ),
 })
@@ -119,6 +123,14 @@ export const mergeStoreGcConfig = (override: StoreGcConfigOverride): StoreGcConf
     override.generatedArtifacts?.agentLivenessManifest === undefined
       ? undefined
       : normalizedAbsolutePath(override.generatedArtifacts.agentLivenessManifest)
+  const agentLivenessEpoch = override.generatedArtifacts?.agentLivenessEpoch
+  const validAgentLivenessEpoch =
+    agentLivenessManifest !== undefined &&
+    agentLivenessEpoch !== undefined &&
+    normalizedAbsolutePath(agentLivenessEpoch.catalog) !== undefined &&
+    agentLivenessEpoch.host.length > 0
+      ? agentLivenessEpoch
+      : undefined
   return {
     absenceGraceMs: validDuration({
       value: override.absenceGraceMs,
@@ -145,7 +157,9 @@ export const mergeStoreGcConfig = (override: StoreGcConfigOverride): StoreGcConf
             DEFAULT_STORE_GC_CONFIG.generatedArtifacts.allowlist,
         ),
       ],
-      ...(agentLivenessManifest === undefined ? {} : { agentLivenessManifest }),
+      ...(validAgentLivenessEpoch === undefined
+        ? {}
+        : { agentLivenessManifest, agentLivenessEpoch: validAgentLivenessEpoch }),
     },
   }
 }

--- a/packages/@overeng/megarepo/src/lib/store-gc-config.unit.test.ts
+++ b/packages/@overeng/megarepo/src/lib/store-gc-config.unit.test.ts
@@ -90,6 +90,7 @@ describe('store-gc-config', () => {
             retentionMs: 42,
             allowlist: ['node_modules', '.direnv'],
             agentLivenessManifest: '/run/megarepo/agent-liveness.json',
+            agentLivenessEpoch: { catalog: '/var/lib/st2/catalog', host: 'dev3' },
           },
         }).generatedArtifacts,
       ).toEqual({
@@ -97,6 +98,7 @@ describe('store-gc-config', () => {
         retentionMs: 42,
         allowlist: ['node_modules', '.direnv'],
         agentLivenessManifest: '/run/megarepo/agent-liveness.json',
+        agentLivenessEpoch: { catalog: '/var/lib/st2/catalog', host: 'dev3' },
       })
     })
 
@@ -110,6 +112,17 @@ describe('store-gc-config', () => {
 
       expect(generatedArtifacts.allowlist).toEqual(['node_modules', '.direnv'])
       expect(generatedArtifacts.agentLivenessManifest).toBeUndefined()
+      expect(generatedArtifacts.agentLivenessEpoch).toBeUndefined()
+    })
+
+    it('requires the manifest and its admitted epoch together', () => {
+      const generatedArtifacts = mergeStoreGcConfig({
+        generatedArtifacts: {
+          agentLivenessManifest: '/run/megarepo/agent-liveness.json',
+        },
+      }).generatedArtifacts
+      expect(generatedArtifacts.agentLivenessManifest).toBeUndefined()
+      expect(generatedArtifacts.agentLivenessEpoch).toBeUndefined()
     })
   })
 


### PR DESCRIPTION
## Problem

Generated-artifact planning consumes an ad-hoc liveness JSON shape that no native producer owns. It cannot bind evidence to an st2 catalog/host/generation, so a fresh snapshot from the wrong epoch could be trusted.

## Goal

Consume the native `st2.workspace-activity.v1` envelope and fail closed unless its producer, completeness, freshness, admitted epoch, canonical claims, and active-state invariants are valid.

## Decisions

- Replace the legacy shape instead of retaining a shell or `jq` adapter.
- Require the configured catalog and host as the admitted epoch; require the catalog generation to remain stable across pre-scan and post-scan reads.
- Keep this planning-only. The snapshot is evidence, not deletion authority.

## Verification

- `oxfmt` on all six changed files.
- `oxlint` on all four changed TypeScript files: 0 warnings, 0 errors.
- `git diff --check`.
- Focused integration coverage includes missing, expired, incomplete, erroneous, legacy-shaped, non-canonical, wrong-host, wrong-catalog, and active-claim snapshots.
- Full tests are delegated to CI because this checkout intentionally did not materialize dependencies while the host is below its disk-space safety floor.

## Complexity

No dependency or adapter is added. The existing manifest reader gains the native schema and epoch admission.

## Concerns

The producer contract is coordinated separately; this PR does not pin or publish producer code. Mutation remains rejected.

## Friction & bottlenecks

Local dependency materialization was intentionally skipped due to host disk pressure.

## Follow-ups

A future deletion transaction must independently revalidate process and filesystem liveness immediately before mutation.

## References

Follows #1085.