### PR TITLE
Share the label-gated PR snapshot pipeline; recover pull-request-head pins

### DIFF
--- a/.github/labels.json
+++ b/.github/labels.json
@@ -91,6 +91,11 @@
       "description": "TypeScript code, tsconfig, and type definitions · Set: manual"
     },
     {
+      "name": "ci:publish-snapshot",
+      "color": "0e8a16",
+      "description": "Trust this fork PR branch for snapshot publishing · Set: manual"
+    },
+    {
       "name": "close-after-review",
       "color": "ededed",
       "description": "Close after the review/validation artifact has been inspected · Set: manual"

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -13,6 +13,8 @@
   },
   "experimentalSortPackageJson": true,
   "ignorePatterns": [
+    "**/.github/scripts/pr-snapshot-artifact.mjs",
+    "**/.github/scripts/pr-snapshot-artifact.test.mjs",
     "**/node_modules/**",
     "**/.pnpm/**",
     "**/.pnpm-store/**",

--- a/genie/ci-scripts/pr-snapshot-artifact.mjs
+++ b/genie/ci-scripts/pr-snapshot-artifact.mjs
@@ -71,7 +71,8 @@ const tarEntries = (tarball) => {
       fail(`Unsafe tar entry path: ${entryPath}`)
     }
     if (entryPath === 'package/.npmrc') fail('Package tarball must not contain .npmrc')
-    if (type !== '0' && type !== '5') fail(`Unsupported tar entry type ${JSON.stringify(type)}: ${entryPath}`)
+    if (type !== '0' && type !== '5')
+      fail(`Unsupported tar entry type ${JSON.stringify(type)}: ${entryPath}`)
 
     entries.push({ path: entryPath, type, body: archive.subarray(bodyStart, bodyEnd) })
     if (entries.length > maxTarEntries) fail(`Tarball exceeds ${maxTarEntries} entries`)
@@ -82,8 +83,11 @@ const tarEntries = (tarball) => {
 }
 
 const parsePackage = (tarball) => {
-  const manifests = tarEntries(tarball).filter((entry) => entry.path === 'package/package.json' && entry.type === '0')
-  if (manifests.length !== 1) fail(`Expected exactly one package/package.json, found ${manifests.length}`)
+  const manifests = tarEntries(tarball).filter(
+    (entry) => entry.path === 'package/package.json' && entry.type === '0',
+  )
+  if (manifests.length !== 1)
+    fail(`Expected exactly one package/package.json, found ${manifests.length}`)
 
   try {
     return JSON.parse(manifests[0].body.toString('utf8'))
@@ -96,11 +100,19 @@ const readTopology = async (topologyPath) => {
   const bytes = await readFile(topologyPath)
   const topology = JSON.parse(bytes.toString('utf8'))
   const names = topology.publishablePackageNames
-  if (Array.isArray(names) === false || names.length === 0 || names.some((name) => typeof name !== 'string') === true) {
+  if (
+    Array.isArray(names) === false ||
+    names.length === 0 ||
+    names.some((name) => typeof name !== 'string') === true
+  ) {
     fail('Trusted release topology has no valid publishablePackageNames')
   }
-  if (new Set(names).size !== names.length) fail('Trusted release topology contains duplicate package names')
-  return { packageNames: [...names].toSorted((a, b) => a.localeCompare(b)), topologyDigest: sha256(bytes) }
+  if (new Set(names).size !== names.length)
+    fail('Trusted release topology contains duplicate package names')
+  return {
+    packageNames: [...names].toSorted((a, b) => a.localeCompare(b)),
+    topologyDigest: sha256(bytes),
+  }
 }
 
 export const snapshotTag = ({ prNumber, headSha }) => {
@@ -119,11 +131,14 @@ export const successfulProducerAttempt = ({ jobs, jobName }) => {
   if (Array.isArray(jobs) === false) fail('Workflow jobs response is not an array')
   const matches = jobs.filter((job) => job?.name === jobName && job?.conclusion === 'success')
   if (matches.length === 0) fail(`Expected at least one successful ${jobName} job`)
-  return Math.max(...matches.map((job) => positiveInteger(job.run_attempt, `${jobName} run attempt`)))
+  return Math.max(
+    ...matches.map((job) => positiveInteger(job.run_attempt, `${jobName} run attempt`)),
+  )
 }
 
 export const selectEligibleProducerRun = ({ runs, headRepository, headBranch, headSha }) => {
-  if (typeof headRepository !== 'string' || headRepository === '') fail('Head repository is required')
+  if (typeof headRepository !== 'string' || headRepository === '')
+    fail('Head repository is required')
   if (typeof headBranch !== 'string' || headBranch === '') fail('Head branch is required')
   if (shaPattern.test(headSha) === false) fail(`Invalid head SHA: ${headSha}`)
   if (Array.isArray(runs) === false) fail('Workflow runs response is not an array')
@@ -140,10 +155,14 @@ export const selectEligibleProducerRun = ({ runs, headRepository, headBranch, he
           Number.isSafeInteger(run.packAttempt) === true &&
           run.packAttempt > 0 &&
           run.artifacts?.some(
-            (artifact) => artifact?.name === `pr-snapshot-${headSha}-${run.packAttempt}` && artifact?.expired === false,
+            (artifact) =>
+              artifact?.name === `pr-snapshot-${headSha}-${run.packAttempt}` &&
+              artifact?.expired === false,
           ) === true,
       )
-      .toSorted((left, right) => String(right.createdAt).localeCompare(String(left.createdAt)))[0] ?? null
+      .toSorted((left, right) =>
+        String(right.createdAt).localeCompare(String(left.createdAt)),
+      )[0] ?? null
   )
 }
 
@@ -173,8 +192,10 @@ export const isAuthorizedSnapshotState = ({
 }
 
 export const assessRegistryCohort = ({ expectedVersion, packageStates, hasVerifiedReceipt }) => {
-  if (typeof expectedVersion !== 'string' || expectedVersion === '') fail('Expected registry version is required')
-  if (Array.isArray(packageStates) === false || packageStates.length === 0) fail('Registry package states are required')
+  if (typeof expectedVersion !== 'string' || expectedVersion === '')
+    fail('Expected registry version is required')
+  if (Array.isArray(packageStates) === false || packageStates.length === 0)
+    fail('Registry package states are required')
   if (typeof hasVerifiedReceipt !== 'boolean') fail('Verified receipt state must be boolean')
 
   for (const state of packageStates) {
@@ -193,18 +214,23 @@ export const assessRegistryCohort = ({ expectedVersion, packageStates, hasVerifi
   }
 
   const allVersionsPresent = packageStates.every((state) => state.version === expectedVersion)
-  return allVersionsPresent === true && hasVerifiedReceipt === true ? { action: 'complete' } : { action: 'dispatch' }
+  return allVersionsPresent === true && hasVerifiedReceipt === true
+    ? { action: 'complete' }
+    : { action: 'dispatch' }
 }
 
 const validatePackageManifest = ({ packageJson, expectedName, expectedVersion, packageNames }) => {
   if (packageJson.name !== expectedName)
     fail(`Package name mismatch: expected ${expectedName}, got ${packageJson.name}`)
   if (packageJson.version !== expectedVersion) {
-    fail(`Package version mismatch for ${expectedName}: expected ${expectedVersion}, got ${packageJson.version}`)
+    fail(
+      `Package version mismatch for ${expectedName}: expected ${expectedVersion}, got ${packageJson.version}`,
+    )
   }
 
   for (const script of Object.keys(packageJson.scripts ?? {})) {
-    if (lifecycleScripts.has(script) === true) fail(`Package ${expectedName} contains lifecycle script ${script}`)
+    if (lifecycleScripts.has(script) === true)
+      fail(`Package ${expectedName} contains lifecycle script ${script}`)
   }
 
   if (packageJson.publishConfig !== undefined) {
@@ -272,7 +298,11 @@ export const createManifest = async ({
       fail(`Unsafe tarball name: ${file}`)
     const fileStat = await lstat(path.join(artifactDir, file))
     artifactBytes += fileStat.size
-    if (fileStat.isFile() === false || fileStat.size > maxTarballBytes || artifactBytes > maxArtifactBytes)
+    if (
+      fileStat.isFile() === false ||
+      fileStat.size > maxTarballBytes ||
+      artifactBytes > maxArtifactBytes
+    )
       fail(`Tarball is not a bounded regular file: ${file}`)
     const bytes = await readFile(path.join(artifactDir, file))
     const packageJson = parsePackage(bytes)
@@ -321,7 +351,8 @@ export const validateManifest = async ({
   if (shaPattern.test(headSha) === false) fail(`Invalid trusted head SHA: ${headSha}`)
   const manifestPath = path.join(artifactDir, 'manifest.json')
   const manifestStat = await lstat(manifestPath)
-  if (manifestStat.isFile() === false || manifestStat.size > 1024 * 1024) fail('Manifest is not a bounded regular file')
+  if (manifestStat.isFile() === false || manifestStat.size > 1024 * 1024)
+    fail('Manifest is not a bounded regular file')
   const manifestBytes = await readFile(manifestPath)
   const manifest = JSON.parse(manifestBytes.toString('utf8'))
   assertExactKeys(
@@ -352,19 +383,25 @@ export const validateManifest = async ({
     version: expectedVersion,
   }
   for (const [key, value] of Object.entries(expectedIdentity)) {
-    if (manifest[key] !== value) fail(`Manifest ${key} mismatch: expected ${value}, got ${manifest[key]}`)
+    if (manifest[key] !== value)
+      fail(`Manifest ${key} mismatch: expected ${value}, got ${manifest[key]}`)
   }
 
   const { packageNames, topologyDigest } = await readTopology(topologyPath)
   if (manifest.topologySha256 !== topologyDigest) {
-    fail(`Manifest topologySha256 mismatch: expected ${topologyDigest}, got ${manifest.topologySha256}`)
+    fail(
+      `Manifest topologySha256 mismatch: expected ${topologyDigest}, got ${manifest.topologySha256}`,
+    )
   }
-  if (Array.isArray(manifest.packages) === false || manifest.packages.length !== packageNames.length) {
+  if (
+    Array.isArray(manifest.packages) === false ||
+    manifest.packages.length !== packageNames.length
+  ) {
     fail(`Manifest package count mismatch: expected ${packageNames.length}`)
   }
   const actualFiles = (await readdir(artifactDir)).toSorted((a, b) => a.localeCompare(b))
-  const expectedFiles = ['manifest.json', ...manifest.packages.map(({ file }) => file)].toSorted((a, b) =>
-    a.localeCompare(b),
+  const expectedFiles = ['manifest.json', ...manifest.packages.map(({ file }) => file)].toSorted(
+    (a, b) => a.localeCompare(b),
   )
   if (JSON.stringify(actualFiles) !== JSON.stringify(expectedFiles))
     fail('Artifact contains missing or unexpected files')
@@ -390,7 +427,11 @@ export const validateManifest = async ({
     const tarballPath = path.join(artifactDir, entry.file)
     const fileStat = await lstat(tarballPath)
     artifactBytes += fileStat.size
-    if (fileStat.isFile() === false || fileStat.size > maxTarballBytes || artifactBytes > maxArtifactBytes) {
+    if (
+      fileStat.isFile() === false ||
+      fileStat.size > maxTarballBytes ||
+      artifactBytes > maxArtifactBytes
+    ) {
       fail(`Tarball is not a bounded regular file: ${entry.file}`)
     }
     const bytes = await readFile(tarballPath)
@@ -402,7 +443,10 @@ export const validateManifest = async ({
       packageNames,
     })
   }
-  if (JSON.stringify([...seenNames].toSorted((a, b) => a.localeCompare(b))) !== JSON.stringify(packageNames))
+  if (
+    JSON.stringify([...seenNames].toSorted((a, b) => a.localeCompare(b))) !==
+    JSON.stringify(packageNames)
+  )
     fail('Manifest package set does not match trusted topology')
 
   const publishEntries = manifest.packages
@@ -428,7 +472,10 @@ const parseArgs = (args) => {
   return values
 }
 
-if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+if (
+  process.argv[1] !== undefined &&
+  fileURLToPath(import.meta.url) === path.resolve(process.argv[1])
+) {
   const [mode, ...rawArgs] = process.argv.slice(2)
   const args = parseArgs(rawArgs)
   const common = {

--- a/genie/ci-scripts/pr-snapshot-artifact.mjs
+++ b/genie/ci-scripts/pr-snapshot-artifact.mjs
@@ -1,0 +1,456 @@
+import { createHash } from 'node:crypto'
+import { lstat, readFile, readdir, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { gunzipSync } from 'node:zlib'
+
+const shaPattern = /^[0-9a-f]{40}$/
+const digestPattern = /^[0-9a-f]{64}$/
+const lifecycleScripts = new Set([
+  'preinstall',
+  'install',
+  'postinstall',
+  'prepack',
+  'prepare',
+  'postpack',
+  'prepublish',
+  'publish',
+  'postpublish',
+])
+const dependencyFields = ['dependencies', 'optionalDependencies', 'peerDependencies']
+const maxArtifactBytes = 500 * 1024 * 1024
+const maxTarballBytes = 100 * 1024 * 1024
+const maxTarEntries = 100_000
+const maxTarUncompressedBytes = 256 * 1024 * 1024
+
+const fail = (message) => {
+  throw new Error(message)
+}
+
+const sha256 = (bytes) => createHash('sha256').update(bytes).digest('hex')
+
+const parseOctal = (bytes, label) => {
+  const value = Buffer.from(bytes).toString('ascii').replaceAll('\0', '').trim()
+  if (/^[0-7]+$/.test(value) === false) fail(`Invalid tar ${label}: ${JSON.stringify(value)}`)
+  return Number.parseInt(value, 8)
+}
+
+const tarEntries = (tarball) => {
+  const archive = gunzipSync(tarball, { maxOutputLength: maxTarUncompressedBytes })
+  const entries = []
+
+  for (let offset = 0; offset + 512 <= archive.length; ) {
+    const header = archive.subarray(offset, offset + 512)
+    if (header.every((byte) => byte === 0) === true) break
+
+    const storedChecksum = parseOctal(header.subarray(148, 156), 'checksum')
+    const checksumHeader = Buffer.from(header)
+    checksumHeader.fill(0x20, 148, 156)
+    const actualChecksum = checksumHeader.reduce((sum, byte) => sum + byte, 0)
+    if (storedChecksum !== actualChecksum) fail('Tar header checksum mismatch')
+
+    const readString = (start, end) => {
+      const decoded = Buffer.from(header.subarray(start, end)).toString('utf8')
+      const nullIndex = decoded.indexOf(String.fromCharCode(0))
+      return nullIndex === -1 ? decoded : decoded.slice(0, nullIndex)
+    }
+    const name = readString(0, 100)
+    const prefix = readString(345, 500)
+    const rawEntryPath = prefix === '' ? name : `${prefix}/${name}`
+    const size = parseOctal(header.subarray(124, 136), 'size')
+    const type = header[156] === 0 ? '0' : String.fromCharCode(header[156])
+    const bodyStart = offset + 512
+    const bodyEnd = bodyStart + size
+    if (bodyEnd > archive.length) fail(`Truncated tar entry: ${rawEntryPath}`)
+
+    const entryPath = type === '5' ? rawEntryPath.replace(/\/$/, '') : rawEntryPath
+    if (entryPath.startsWith('package/') === false || path.posix.isAbsolute(entryPath) === true) {
+      fail(`Tar entry is outside package/: ${entryPath}`)
+    }
+    if (entryPath.split('/').some((segment) => segment === '..' || segment === '') === true) {
+      fail(`Unsafe tar entry path: ${entryPath}`)
+    }
+    if (entryPath === 'package/.npmrc') fail('Package tarball must not contain .npmrc')
+    if (type !== '0' && type !== '5') fail(`Unsupported tar entry type ${JSON.stringify(type)}: ${entryPath}`)
+
+    entries.push({ path: entryPath, type, body: archive.subarray(bodyStart, bodyEnd) })
+    if (entries.length > maxTarEntries) fail(`Tarball exceeds ${maxTarEntries} entries`)
+    offset = bodyStart + Math.ceil(size / 512) * 512
+  }
+
+  return entries
+}
+
+const parsePackage = (tarball) => {
+  const manifests = tarEntries(tarball).filter((entry) => entry.path === 'package/package.json' && entry.type === '0')
+  if (manifests.length !== 1) fail(`Expected exactly one package/package.json, found ${manifests.length}`)
+
+  try {
+    return JSON.parse(manifests[0].body.toString('utf8'))
+  } catch (cause) {
+    throw new Error('Invalid package/package.json', { cause })
+  }
+}
+
+const readTopology = async (topologyPath) => {
+  const bytes = await readFile(topologyPath)
+  const topology = JSON.parse(bytes.toString('utf8'))
+  const names = topology.publishablePackageNames
+  if (Array.isArray(names) === false || names.length === 0 || names.some((name) => typeof name !== 'string') === true) {
+    fail('Trusted release topology has no valid publishablePackageNames')
+  }
+  if (new Set(names).size !== names.length) fail('Trusted release topology contains duplicate package names')
+  return { packageNames: [...names].toSorted((a, b) => a.localeCompare(b)), topologyDigest: sha256(bytes) }
+}
+
+export const snapshotTag = ({ prNumber, headSha }) => {
+  const parsedPrNumber = positiveInteger(prNumber, 'PR number')
+  if (shaPattern.test(headSha) === false) fail(`Invalid head SHA: ${headSha}`)
+  return `pr-${parsedPrNumber}-${headSha}`
+}
+
+export const snapshotVersion = ({ prNumber, headSha }) => {
+  const parsedPrNumber = positiveInteger(prNumber, 'PR number')
+  if (shaPattern.test(headSha) === false) fail(`Invalid head SHA: ${headSha}`)
+  return `0.0.0-snapshot-pr.${parsedPrNumber}.${headSha}`
+}
+
+export const successfulProducerAttempt = ({ jobs, jobName }) => {
+  if (Array.isArray(jobs) === false) fail('Workflow jobs response is not an array')
+  const matches = jobs.filter((job) => job?.name === jobName && job?.conclusion === 'success')
+  if (matches.length === 0) fail(`Expected at least one successful ${jobName} job`)
+  return Math.max(...matches.map((job) => positiveInteger(job.run_attempt, `${jobName} run attempt`)))
+}
+
+export const selectEligibleProducerRun = ({ runs, headRepository, headBranch, headSha }) => {
+  if (typeof headRepository !== 'string' || headRepository === '') fail('Head repository is required')
+  if (typeof headBranch !== 'string' || headBranch === '') fail('Head branch is required')
+  if (shaPattern.test(headSha) === false) fail(`Invalid head SHA: ${headSha}`)
+  if (Array.isArray(runs) === false) fail('Workflow runs response is not an array')
+
+  return (
+    runs
+      .filter(
+        (run) =>
+          run?.event === 'pull_request' &&
+          run?.conclusion === 'success' &&
+          run?.headRepository === headRepository &&
+          run?.headBranch === headBranch &&
+          run?.headSha === headSha &&
+          Number.isSafeInteger(run.packAttempt) === true &&
+          run.packAttempt > 0 &&
+          run.artifacts?.some(
+            (artifact) => artifact?.name === `pr-snapshot-${headSha}-${run.packAttempt}` && artifact?.expired === false,
+          ) === true,
+      )
+      .toSorted((left, right) => String(right.createdAt).localeCompare(String(left.createdAt)))[0] ?? null
+  )
+}
+
+export const hasCurrentHeadApproval = ({ headSha, currentHeadSha, reviews }) => {
+  if (shaPattern.test(headSha) === false || shaPattern.test(currentHeadSha) === false) return false
+  if (headSha !== currentHeadSha || Array.isArray(reviews) === false) return false
+  return reviews.some((review) => review?.state === 'APPROVED' && review?.commit_id === headSha)
+}
+
+export const isAuthorizedReviewState = ({ headSha, currentHeadSha, reviewDecision, reviews }) =>
+  reviewDecision === 'APPROVED' && hasCurrentHeadApproval({ headSha, currentHeadSha, reviews })
+
+export const isAuthorizedSnapshotState = ({
+  repository,
+  headRepository,
+  headSha,
+  currentHeadSha,
+  labelNames,
+  reviewDecision,
+  reviews,
+}) => {
+  if (headSha !== currentHeadSha) return false
+  if (headRepository !== repository) {
+    return Array.isArray(labelNames) === true && labelNames.includes('ci:publish-snapshot')
+  }
+  return isAuthorizedReviewState({ headSha, currentHeadSha, reviewDecision, reviews })
+}
+
+export const assessRegistryCohort = ({ expectedVersion, packageStates, hasVerifiedReceipt }) => {
+  if (typeof expectedVersion !== 'string' || expectedVersion === '') fail('Expected registry version is required')
+  if (Array.isArray(packageStates) === false || packageStates.length === 0) fail('Registry package states are required')
+  if (typeof hasVerifiedReceipt !== 'boolean') fail('Verified receipt state must be boolean')
+
+  for (const state of packageStates) {
+    if (
+      state === null ||
+      typeof state !== 'object' ||
+      typeof state.name !== 'string' ||
+      typeof state.version !== 'string' ||
+      typeof state.tag !== 'string'
+    ) {
+      fail('Invalid registry package state')
+    }
+    if (state.tag !== '' && state.tag !== expectedVersion) {
+      return { action: 'conflict', packageName: state.name, conflictingVersion: state.tag }
+    }
+  }
+
+  const allVersionsPresent = packageStates.every((state) => state.version === expectedVersion)
+  return allVersionsPresent === true && hasVerifiedReceipt === true ? { action: 'complete' } : { action: 'dispatch' }
+}
+
+const validatePackageManifest = ({ packageJson, expectedName, expectedVersion, packageNames }) => {
+  if (packageJson.name !== expectedName)
+    fail(`Package name mismatch: expected ${expectedName}, got ${packageJson.name}`)
+  if (packageJson.version !== expectedVersion) {
+    fail(`Package version mismatch for ${expectedName}: expected ${expectedVersion}, got ${packageJson.version}`)
+  }
+
+  for (const script of Object.keys(packageJson.scripts ?? {})) {
+    if (lifecycleScripts.has(script) === true) fail(`Package ${expectedName} contains lifecycle script ${script}`)
+  }
+
+  if (packageJson.publishConfig !== undefined) {
+    if (
+      packageJson.publishConfig === null ||
+      typeof packageJson.publishConfig !== 'object' ||
+      Array.isArray(packageJson.publishConfig) === true
+    ) {
+      fail(`Package ${expectedName} has invalid publishConfig`)
+    }
+    assertExactKeys(packageJson.publishConfig, ['access'], `Package ${expectedName} publishConfig`)
+    if (packageJson.publishConfig.access !== 'public') {
+      fail(`Package ${expectedName} publishConfig must set access to public`)
+    }
+  }
+
+  const packageSet = new Set(packageNames)
+  for (const field of dependencyFields) {
+    for (const [name, spec] of Object.entries(packageJson[field] ?? {})) {
+      if (packageSet.has(name) === true && spec !== expectedVersion) {
+        fail(`${expectedName} has non-exact ${field} entry ${name}@${spec}`)
+      }
+    }
+  }
+}
+
+const assertExactKeys = (value, expected, label) => {
+  const actual = Object.keys(value).toSorted((a, b) => a.localeCompare(b))
+  const wanted = [...expected].toSorted((a, b) => a.localeCompare(b))
+  if (JSON.stringify(actual) !== JSON.stringify(wanted)) {
+    fail(`${label} keys mismatch: expected ${wanted.join(', ')}, got ${actual.join(', ')}`)
+  }
+}
+
+const positiveInteger = (value, label) => {
+  const parsed = Number(value)
+  if (Number.isSafeInteger(parsed) === false || parsed < 1) fail(`Invalid ${label}: ${value}`)
+  return parsed
+}
+
+export const createManifest = async ({
+  artifactDir,
+  topologyPath,
+  repository,
+  prNumber,
+  headSha,
+  runId,
+  runAttempt,
+}) => {
+  if (shaPattern.test(headSha) === false) fail(`Invalid head SHA: ${headSha}`)
+  const parsedPrNumber = positiveInteger(prNumber, 'PR number')
+  const version = snapshotVersion({ prNumber: parsedPrNumber, headSha })
+  const { packageNames, topologyDigest } = await readTopology(topologyPath)
+  const files = (await readdir(artifactDir))
+    .filter((file) => file.endsWith('.tgz'))
+    .toSorted((a, b) => a.localeCompare(b))
+  if (files.length !== packageNames.length) {
+    fail(`Tarball count mismatch: expected ${packageNames.length}, got ${files.length}`)
+  }
+
+  const packages = []
+  let artifactBytes = 0
+  for (const file of files) {
+    if (path.basename(file) !== file || /^[a-zA-Z0-9._-]+\.tgz$/.test(file) === false)
+      fail(`Unsafe tarball name: ${file}`)
+    const fileStat = await lstat(path.join(artifactDir, file))
+    artifactBytes += fileStat.size
+    if (fileStat.isFile() === false || fileStat.size > maxTarballBytes || artifactBytes > maxArtifactBytes)
+      fail(`Tarball is not a bounded regular file: ${file}`)
+    const bytes = await readFile(path.join(artifactDir, file))
+    const packageJson = parsePackage(bytes)
+    if (typeof packageJson.name !== 'string') fail(`Tarball ${file} has no package name`)
+    packages.push({ name: packageJson.name, file, sha256: sha256(bytes) })
+  }
+  packages.sort((a, b) => a.name.localeCompare(b.name))
+  if (JSON.stringify(packages.map(({ name }) => name)) !== JSON.stringify(packageNames)) {
+    fail('Tarball package set does not match release topology')
+  }
+  for (const entry of packages) {
+    const bytes = await readFile(path.join(artifactDir, entry.file))
+    validatePackageManifest({
+      packageJson: parsePackage(bytes),
+      expectedName: entry.name,
+      expectedVersion: version,
+      packageNames,
+    })
+  }
+
+  const manifest = {
+    schemaVersion: 1,
+    repository,
+    prNumber: parsedPrNumber,
+    headSha,
+    runId: positiveInteger(runId, 'run ID'),
+    runAttempt: positiveInteger(runAttempt, 'run attempt'),
+    version,
+    topologySha256: topologyDigest,
+    packages,
+  }
+  await writeFile(path.join(artifactDir, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`)
+  return manifest
+}
+
+export const validateManifest = async ({
+  artifactDir,
+  topologyPath,
+  repository,
+  prNumber,
+  headSha,
+  runId,
+  runAttempt,
+  publishListPath,
+}) => {
+  if (shaPattern.test(headSha) === false) fail(`Invalid trusted head SHA: ${headSha}`)
+  const manifestPath = path.join(artifactDir, 'manifest.json')
+  const manifestStat = await lstat(manifestPath)
+  if (manifestStat.isFile() === false || manifestStat.size > 1024 * 1024) fail('Manifest is not a bounded regular file')
+  const manifestBytes = await readFile(manifestPath)
+  const manifest = JSON.parse(manifestBytes.toString('utf8'))
+  assertExactKeys(
+    manifest,
+    [
+      'schemaVersion',
+      'repository',
+      'prNumber',
+      'headSha',
+      'runId',
+      'runAttempt',
+      'version',
+      'topologySha256',
+      'packages',
+    ],
+    'Manifest',
+  )
+
+  const parsedPrNumber = positiveInteger(prNumber, 'PR number')
+  const expectedVersion = snapshotVersion({ prNumber: parsedPrNumber, headSha })
+  const expectedIdentity = {
+    schemaVersion: 1,
+    repository,
+    prNumber: parsedPrNumber,
+    headSha,
+    runId: positiveInteger(runId, 'run ID'),
+    runAttempt: positiveInteger(runAttempt, 'run attempt'),
+    version: expectedVersion,
+  }
+  for (const [key, value] of Object.entries(expectedIdentity)) {
+    if (manifest[key] !== value) fail(`Manifest ${key} mismatch: expected ${value}, got ${manifest[key]}`)
+  }
+
+  const { packageNames, topologyDigest } = await readTopology(topologyPath)
+  if (manifest.topologySha256 !== topologyDigest) {
+    fail(`Manifest topologySha256 mismatch: expected ${topologyDigest}, got ${manifest.topologySha256}`)
+  }
+  if (Array.isArray(manifest.packages) === false || manifest.packages.length !== packageNames.length) {
+    fail(`Manifest package count mismatch: expected ${packageNames.length}`)
+  }
+  const actualFiles = (await readdir(artifactDir)).toSorted((a, b) => a.localeCompare(b))
+  const expectedFiles = ['manifest.json', ...manifest.packages.map(({ file }) => file)].toSorted((a, b) =>
+    a.localeCompare(b),
+  )
+  if (JSON.stringify(actualFiles) !== JSON.stringify(expectedFiles))
+    fail('Artifact contains missing or unexpected files')
+
+  const seenNames = new Set()
+  const seenFiles = new Set()
+  let artifactBytes = 0
+  for (const entry of manifest.packages) {
+    assertExactKeys(entry, ['name', 'file', 'sha256'], 'Package entry')
+    if (packageNames.includes(entry.name) === false || seenNames.has(entry.name) === true)
+      fail(`Unexpected or duplicate package: ${entry.name}`)
+    if (
+      typeof entry.file !== 'string' ||
+      path.basename(entry.file) !== entry.file ||
+      /^[a-zA-Z0-9._-]+\.tgz$/.test(entry.file) === false ||
+      seenFiles.has(entry.file) === true
+    )
+      fail(`Unsafe or duplicate tarball name: ${entry.file}`)
+    if (digestPattern.test(entry.sha256) === false) fail(`Invalid digest for ${entry.name}`)
+    seenNames.add(entry.name)
+    seenFiles.add(entry.file)
+
+    const tarballPath = path.join(artifactDir, entry.file)
+    const fileStat = await lstat(tarballPath)
+    artifactBytes += fileStat.size
+    if (fileStat.isFile() === false || fileStat.size > maxTarballBytes || artifactBytes > maxArtifactBytes) {
+      fail(`Tarball is not a bounded regular file: ${entry.file}`)
+    }
+    const bytes = await readFile(tarballPath)
+    if (sha256(bytes) !== entry.sha256) fail(`Digest mismatch for ${entry.name}`)
+    validatePackageManifest({
+      packageJson: parsePackage(bytes),
+      expectedName: entry.name,
+      expectedVersion,
+      packageNames,
+    })
+  }
+  if (JSON.stringify([...seenNames].toSorted((a, b) => a.localeCompare(b))) !== JSON.stringify(packageNames))
+    fail('Manifest package set does not match trusted topology')
+
+  const publishEntries = manifest.packages
+    .map(({ name, file }) => `${name}\t${file}`)
+    .toSorted((a, b) => a.localeCompare(b))
+  await writeFile(publishListPath, `${publishEntries.join('\n')}\n`)
+  return {
+    manifestDigest: sha256(manifestBytes),
+    topologyDigest,
+    version: expectedVersion,
+    npmTag: snapshotTag({ prNumber, headSha }),
+    packageCount: packageNames.length,
+  }
+}
+
+const parseArgs = (args) => {
+  const values = {}
+  for (const arg of args) {
+    const match = /^--([a-z-]+)=(.*)$/.exec(arg)
+    if (match === null) fail(`Invalid argument: ${arg}`)
+    values[match[1]] = match[2]
+  }
+  return values
+}
+
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  const [mode, ...rawArgs] = process.argv.slice(2)
+  const args = parseArgs(rawArgs)
+  const common = {
+    artifactDir: args['artifact-dir'],
+    topologyPath: args['topology'],
+    repository: args.repository,
+    prNumber: args['pr-number'],
+    headSha: args['head-sha'],
+    runId: args['run-id'],
+    runAttempt: args['run-attempt'],
+  }
+  const result =
+    mode === 'create'
+      ? await createManifest(common)
+      : mode === 'validate'
+        ? await validateManifest({ ...common, publishListPath: args['publish-list'] })
+        : mode === 'assess-registry'
+          ? assessRegistryCohort({
+              expectedVersion: args.version,
+              packageStates: JSON.parse(await readFile(args['state-file'], 'utf8')),
+              hasVerifiedReceipt: args['verified-receipt'] === 'true',
+            })
+          : fail(`Unknown mode: ${mode}`)
+  process.stdout.write(`${JSON.stringify(result)}\n`)
+}

--- a/genie/ci-scripts/pr-snapshot-artifact.test.mjs
+++ b/genie/ci-scripts/pr-snapshot-artifact.test.mjs
@@ -26,11 +26,19 @@ test('requires a trusted verification receipt before declaring a registry cohort
   ]
 
   assert.deepEqual(
-    assessRegistryCohort({ expectedVersion: version, packageStates: matching, hasVerifiedReceipt: false }),
+    assessRegistryCohort({
+      expectedVersion: version,
+      packageStates: matching,
+      hasVerifiedReceipt: false,
+    }),
     { action: 'dispatch' },
   )
   assert.deepEqual(
-    assessRegistryCohort({ expectedVersion: version, packageStates: matching, hasVerifiedReceipt: true }),
+    assessRegistryCohort({
+      expectedVersion: version,
+      packageStates: matching,
+      hasVerifiedReceipt: true,
+    }),
     { action: 'complete' },
   )
   assert.deepEqual(
@@ -138,7 +146,10 @@ test('creates and validates an exact-run package cohort', async () => {
   assert.equal(result.npmTag, `pr-42-${headSha}`)
   assert.equal(result.packageCount, 2)
   assert.match(result.manifestDigest, /^[0-9a-f]{64}$/)
-  assert.equal(await readFile(publishListPath, 'utf8'), '@livestore/a\ta.tgz\n@livestore/b\tb.tgz\n')
+  assert.equal(
+    await readFile(publishListPath, 'utf8'),
+    '@livestore/a\ta.tgz\n@livestore/b\tb.tgz\n',
+  )
 })
 
 test('requires an approval for the unchanged head', () => {
@@ -146,8 +157,14 @@ test('requires an approval for the unchanged head', () => {
   const currentHead = 'b'.repeat(40)
   const reviews = [{ state: 'APPROVED', commit_id: oldHead }]
 
-  assert.equal(hasCurrentHeadApproval({ headSha: oldHead, currentHeadSha: currentHead, reviews }), false)
-  assert.equal(hasCurrentHeadApproval({ headSha: currentHead, currentHeadSha: currentHead, reviews }), false)
+  assert.equal(
+    hasCurrentHeadApproval({ headSha: oldHead, currentHeadSha: currentHead, reviews }),
+    false,
+  )
+  assert.equal(
+    hasCurrentHeadApproval({ headSha: currentHead, currentHeadSha: currentHead, reviews }),
+    false,
+  )
   assert.equal(
     hasCurrentHeadApproval({
       headSha: currentHead,
@@ -259,13 +276,19 @@ test('generated promotion workflow is anchored to trusted main', async () => {
   assert.match(dispatch, /artifacts\?per_page=100.*expired == false/s)
   assert.match(dispatch, /ci_run_id="\$selected_run_id"/)
   assert.match(dispatch, /selected_pack_attempt="\$pack_attempt"/)
-  assert.match(dispatch, /verified-pr-snapshot-\$head_sha-\$selected_run_id-\$selected_pack_attempt/)
+  assert.match(
+    dispatch,
+    /verified-pr-snapshot-\$head_sha-\$selected_run_id-\$selected_pack_attempt/,
+  )
   assert.match(dispatch, /assess-registry.*--verified-receipt="\$verified_receipt"/s)
   assert.match(dispatch, /cohort_failed=true.*scan_failed=true.*continue/s)
   assert.match(dispatch, /if \[ "\$scan_failed" = true \]; then\s+exit 1/s)
 
   const checkoutStart = workflow.indexOf('- name: Checkout trusted validator only')
-  const checkoutEnd = workflow.indexOf('\n      - name: Use pinned Node validator runtime', checkoutStart)
+  const checkoutEnd = workflow.indexOf(
+    '\n      - name: Use pinned Node validator runtime',
+    checkoutStart,
+  )
   assert.notEqual(checkoutStart, -1)
   assert.notEqual(checkoutEnd, -1)
   const checkout = workflow.slice(checkoutStart, checkoutEnd)
@@ -277,7 +300,10 @@ test('generated promotion workflow is anchored to trusted main', async () => {
   const publishStart = workflow.indexOf('\n  publish-pr-snapshot:', authorizeStart)
   const nextJobStart = workflow.indexOf('\n  create-release-pr:', publishStart)
   assert.match(workflow.slice(validateStart, attestStart), /GITHUB_WORKFLOW_REF.*refs\/heads\/main/)
-  assert.match(workflow.slice(validateStart, attestStart), /workflow_dispatch.*refs\/heads\/main.*promote-pr-snapshot/s)
+  assert.match(
+    workflow.slice(validateStart, attestStart),
+    /workflow_dispatch.*refs\/heads\/main.*promote-pr-snapshot/s,
+  )
   assert.doesNotMatch(workflow.slice(validateStart, attestStart), /id-token: write/)
   assert.match(workflow.slice(validateStart, attestStart), /pull-requests: read/)
   assert.match(workflow.slice(attestStart, authorizeStart), /id-token: write/)
@@ -294,7 +320,10 @@ test('generated promotion workflow is anchored to trusted main', async () => {
   assert.notEqual(publishNodeSetupStart, -1)
   assert.notEqual(publishNodeSetupEnd, -1)
   assert.doesNotMatch(publish.slice(publishNodeSetupStart, publishNodeSetupEnd), /registry-url:/)
-  assert.match(publish, /group: 'pr-snapshot-\$\{\{ needs\.validate-pr-snapshot\.outputs\.head-sha \}\}'/)
+  assert.match(
+    publish,
+    /group: 'pr-snapshot-\$\{\{ needs\.validate-pr-snapshot\.outputs\.head-sha \}\}'/,
+  )
   assert.match(publish, /\.base\.ref/)
   assert.match(publish, /\.head\.repo\.full_name/)
   assert.doesNotMatch(publish, /npm dist-tag/)
@@ -302,7 +331,10 @@ test('generated promotion workflow is anchored to trusted main', async () => {
   assert.match(workflow.slice(validateStart, attestStart), /jobs\?filter=all/)
   assert.match(workflow.slice(validateStart, attestStart), /sort_by\(\.run_attempt\) \| last/)
   assert.match(workflow.slice(validateStart, attestStart), /inputs\.ci_run_id/)
-  assert.match(workflow.slice(validateStart, attestStart), /\.head\.repo\.full_name == \$head_repository/)
+  assert.match(
+    workflow.slice(validateStart, attestStart),
+    /\.head\.repo\.full_name == \$head_repository/,
+  )
   assert.match(workflow.slice(validateStart, attestStart), /\.head\.ref == \$head_branch/)
   assert.match(workflow.slice(validateStart, attestStart), /\.head\.sha == \$head_sha/)
   assert.doesNotMatch(workflow.slice(validateStart, attestStart), /\.pull_requests\[0\]/)
@@ -313,19 +345,28 @@ test('generated promotion workflow is anchored to trusted main', async () => {
   assert.match(publish, /dist\.integrity/)
   assert.match(publish, /dist-tags/)
   assert.match(publish, /\[ -n "\$remote_tag" \].*\[ "\$remote_tag" != "\$SNAPSHOT_VERSION" \]/s)
-  assert.match(publish, /mutable tag \$SNAPSHOT_TAG is absent; OIDC publishing cannot repair dist-tags/)
+  assert.match(
+    publish,
+    /mutable tag \$SNAPSHOT_TAG is absent; OIDC publishing cannot repair dist-tags/,
+  )
   assert.match(publish, /\[ "\$remote_integrity" = "\$local_integrity" \]/)
   assert.doesNotMatch(publish, /\[ "\$remote_tag" = "\$SNAPSHOT_VERSION" \]/)
   assert.match(publish, /needs\.validate-pr-snapshot\.outputs\.package-count/)
   assert.match(publish, /Upload trusted verification receipt/)
   assert.match(publish, /ci:publish-snapshot/)
-  assert.match(publish, /verified-pr-snapshot-.*outputs\.head-sha.*outputs\.run-id.*outputs\.run-attempt/s)
+  assert.match(
+    publish,
+    /verified-pr-snapshot-.*outputs\.head-sha.*outputs\.run-id.*outputs\.run-attempt/s,
+  )
   assert.match(publish, /sourceRunAttempt/)
   assert.match(publish, /overwrite: true/)
 
   const ciWorkflow = await readFile(new URL('../workflows/ci.yml', import.meta.url), 'utf8')
   assert.match(ciWorkflow, /pack-pr-snapshot:\n    if: github\.event_name == 'pull_request'/)
-  assert.doesNotMatch(ciWorkflow, /pack-pr-snapshot:[\s\S]*?head\.repo\.full_name == github\.repository/)
+  assert.doesNotMatch(
+    ciWorkflow,
+    /pack-pr-snapshot:[\s\S]*?head\.repo\.full_name == github\.repository/,
+  )
   assert.doesNotMatch(ciWorkflow, /pull_request_target:/)
   assert.match(
     ciWorkflow,
@@ -405,16 +446,31 @@ test('selects an exact repository, branch, and SHA producer run for forks', () =
   ]
 
   assert.equal(
-    selectEligibleProducerRun({ runs, headRepository: 'contributor/livestore', headBranch: 'feature', headSha })?.id,
+    selectEligibleProducerRun({
+      runs,
+      headRepository: 'contributor/livestore',
+      headBranch: 'feature',
+      headSha,
+    })?.id,
     101,
   )
   assert.equal(
-    selectEligibleProducerRun({ runs, headRepository: 'contributor/livestore', headBranch: 'other', headSha }),
+    selectEligibleProducerRun({
+      runs,
+      headRepository: 'contributor/livestore',
+      headBranch: 'other',
+      headSha,
+    }),
     null,
   )
   runs[1].artifacts[0].expired = true
   assert.equal(
-    selectEligibleProducerRun({ runs, headRepository: 'contributor/livestore', headBranch: 'feature', headSha }),
+    selectEligibleProducerRun({
+      runs,
+      headRepository: 'contributor/livestore',
+      headBranch: 'feature',
+      headSha,
+    }),
     null,
   )
 })
@@ -512,7 +568,10 @@ test('rejects traversal paths and lifecycle scripts', async () => {
   await writeFile(
     path.join(dir, 'a.tgz'),
     tar([
-      ['package/package.json', JSON.stringify({ name: '@livestore/a', version, scripts: { prepare: 'echo unsafe' } })],
+      [
+        'package/package.json',
+        JSON.stringify({ name: '@livestore/a', version, scripts: { prepare: 'echo unsafe' } }),
+      ],
     ]),
   )
   await assert.rejects(

--- a/genie/ci-scripts/pr-snapshot-artifact.test.mjs
+++ b/genie/ci-scripts/pr-snapshot-artifact.test.mjs
@@ -1,0 +1,576 @@
+import assert from 'node:assert/strict'
+import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { gzipSync } from 'node:zlib'
+
+import {
+  assessRegistryCohort,
+  createManifest,
+  hasCurrentHeadApproval,
+  isAuthorizedReviewState,
+  isAuthorizedSnapshotState,
+  selectEligibleProducerRun,
+  snapshotTag,
+  snapshotVersion,
+  successfulProducerAttempt,
+  validateManifest,
+} from './pr-snapshot-artifact.mjs'
+
+test('requires a trusted verification receipt before declaring a registry cohort complete', () => {
+  const version = `0.0.0-snapshot-pr.42.${'a'.repeat(40)}`
+  const matching = [
+    { name: '@livestore/common', version, tag: '' },
+    { name: '@livestore/utils', version, tag: version },
+  ]
+
+  assert.deepEqual(
+    assessRegistryCohort({ expectedVersion: version, packageStates: matching, hasVerifiedReceipt: false }),
+    { action: 'dispatch' },
+  )
+  assert.deepEqual(
+    assessRegistryCohort({ expectedVersion: version, packageStates: matching, hasVerifiedReceipt: true }),
+    { action: 'complete' },
+  )
+  assert.deepEqual(
+    assessRegistryCohort({
+      expectedVersion: version,
+      packageStates: [{ name: '@livestore/common', version: '', tag: '' }],
+      hasVerifiedReceipt: true,
+    }),
+    { action: 'dispatch' },
+  )
+  assert.deepEqual(
+    assessRegistryCohort({
+      expectedVersion: version,
+      packageStates: [{ name: '@livestore/common', version, tag: 'another-version' }],
+      hasVerifiedReceipt: true,
+    }),
+    { action: 'conflict', packageName: '@livestore/common', conflictingVersion: 'another-version' },
+  )
+})
+
+const writeOctal = (header, start, length, value) => {
+  const encoded = value.toString(8).padStart(length - 1, '0')
+  header.write(encoded, start, length - 1, 'ascii')
+  header[start + length - 1] = 0
+}
+
+const tar = (entries) => {
+  const chunks = []
+  for (const [name, content] of entries) {
+    const body = Buffer.from(content)
+    const header = Buffer.alloc(512)
+    header.write(name, 0, 100, 'utf8')
+    writeOctal(header, 100, 8, 0o644)
+    writeOctal(header, 108, 8, 0)
+    writeOctal(header, 116, 8, 0)
+    writeOctal(header, 124, 12, body.length)
+    writeOctal(header, 136, 12, 0)
+    header.fill(0x20, 148, 156)
+    header[156] = '0'.charCodeAt(0)
+    header.write('ustar\0', 257, 6, 'ascii')
+    header.write('00', 263, 2, 'ascii')
+    writeOctal(
+      header,
+      148,
+      8,
+      header.reduce((sum, byte) => sum + byte, 0),
+    )
+    chunks.push(header, body, Buffer.alloc(Math.ceil(body.length / 512) * 512 - body.length))
+  }
+  chunks.push(Buffer.alloc(1024))
+  return gzipSync(Buffer.concat(chunks))
+}
+
+const fixture = async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'livestore-pr-snapshot-'))
+  const artifactDir = path.join(dir, 'artifact')
+  await mkdir(artifactDir)
+  const topologyPath = path.join(dir, 'topology.json')
+  const headSha = 'a'.repeat(40)
+  const version = `0.0.0-snapshot-pr.42.${headSha}`
+  const packageNames = ['@livestore/a', '@livestore/b']
+  await writeFile(topologyPath, JSON.stringify({ publishablePackageNames: packageNames }))
+  for (const name of packageNames) {
+    const file = `${name.slice('@livestore/'.length)}.tgz`
+    const packageJson = {
+      name,
+      version,
+      dependencies: name.endsWith('/b') === true ? { '@livestore/a': version } : {},
+      scripts: { test: 'node --test' },
+    }
+    await writeFile(
+      path.join(artifactDir, file),
+      tar([
+        ['package/package.json', JSON.stringify(packageJson)],
+        ['package/dist/index.js', 'export {}\n'],
+      ]),
+    )
+  }
+  return { dir: artifactDir, topologyPath, headSha, version }
+}
+
+test('creates and validates an exact-run package cohort', async () => {
+  const { dir, topologyPath, headSha, version } = await fixture()
+  await createManifest({
+    artifactDir: dir,
+    topologyPath,
+    repository: 'livestorejs/livestore',
+    prNumber: 42,
+    headSha,
+    runId: 100,
+    runAttempt: 2,
+  })
+  const publishListPath = path.join(dir, '..', 'publish-list.txt')
+  const result = await validateManifest({
+    artifactDir: dir,
+    topologyPath,
+    repository: 'livestorejs/livestore',
+    prNumber: 42,
+    headSha,
+    runId: 100,
+    runAttempt: 2,
+    publishListPath,
+  })
+  assert.equal(result.version, version)
+  assert.equal(result.npmTag, `pr-42-${headSha}`)
+  assert.equal(result.packageCount, 2)
+  assert.match(result.manifestDigest, /^[0-9a-f]{64}$/)
+  assert.equal(await readFile(publishListPath, 'utf8'), '@livestore/a\ta.tgz\n@livestore/b\tb.tgz\n')
+})
+
+test('requires an approval for the unchanged head', () => {
+  const oldHead = 'a'.repeat(40)
+  const currentHead = 'b'.repeat(40)
+  const reviews = [{ state: 'APPROVED', commit_id: oldHead }]
+
+  assert.equal(hasCurrentHeadApproval({ headSha: oldHead, currentHeadSha: currentHead, reviews }), false)
+  assert.equal(hasCurrentHeadApproval({ headSha: currentHead, currentHeadSha: currentHead, reviews }), false)
+  assert.equal(
+    hasCurrentHeadApproval({
+      headSha: currentHead,
+      currentHeadSha: currentHead,
+      reviews: [...reviews, { state: 'APPROVED', commit_id: currentHead }],
+    }),
+    true,
+  )
+})
+
+test('requires the authoritative required-review decision', () => {
+  const headSha = 'a'.repeat(40)
+  const approvedReview = { state: 'APPROVED', commit_id: headSha }
+
+  assert.equal(
+    isAuthorizedReviewState({
+      headSha,
+      currentHeadSha: headSha,
+      reviewDecision: 'REVIEW_REQUIRED',
+      reviews: [approvedReview],
+    }),
+    false,
+    'a non-counting approval must not authorize',
+  )
+  assert.equal(
+    isAuthorizedReviewState({
+      headSha,
+      currentHeadSha: headSha,
+      reviewDecision: 'CHANGES_REQUESTED',
+      reviews: [approvedReview, { state: 'CHANGES_REQUESTED', commit_id: headSha }],
+    }),
+    false,
+    'a later changes-requested decision must not authorize',
+  )
+  assert.equal(
+    isAuthorizedReviewState({
+      headSha,
+      currentHeadSha: headSha,
+      reviewDecision: 'APPROVED',
+      reviews: [approvedReview],
+    }),
+    true,
+  )
+})
+
+test('authorizes repository-owned snapshots by review and fork snapshots by live label', () => {
+  const headSha = 'a'.repeat(40)
+  const common = {
+    repository: 'livestorejs/livestore',
+    headSha,
+    currentHeadSha: headSha,
+    labelNames: [],
+    reviewDecision: 'APPROVED',
+    reviews: [{ state: 'APPROVED', commit_id: headSha }],
+  }
+
+  assert.equal(isAuthorizedSnapshotState({ ...common, headRepository: common.repository }), true)
+  assert.equal(
+    isAuthorizedSnapshotState({
+      ...common,
+      headRepository: 'contributor/livestore',
+      reviewDecision: 'REVIEW_REQUIRED',
+      reviews: [],
+    }),
+    false,
+  )
+  assert.equal(
+    isAuthorizedSnapshotState({
+      ...common,
+      headRepository: 'contributor/livestore',
+      labelNames: ['ci:publish-snapshot'],
+      reviewDecision: 'REVIEW_REQUIRED',
+      reviews: [],
+    }),
+    true,
+  )
+  assert.equal(
+    isAuthorizedSnapshotState({
+      ...common,
+      headRepository: 'contributor/livestore',
+      currentHeadSha: 'b'.repeat(40),
+      labelNames: ['ci:publish-snapshot'],
+      reviewDecision: 'REVIEW_REQUIRED',
+      reviews: [],
+    }),
+    false,
+  )
+})
+
+test('generated promotion workflow is anchored to trusted main', async () => {
+  const workflow = await readFile(new URL('../workflows/release.yml', import.meta.url), 'utf8')
+  assert.doesNotMatch(workflow, /pull_request_review:/)
+  assert.match(workflow, /cron: '\*\/5 \* \* \* \*'/)
+  const dispatchStart = workflow.indexOf('\n  dispatch-authorized-pr-snapshots:')
+  const validateStart = workflow.indexOf('\n  validate-pr-snapshot:', dispatchStart)
+  const dispatch = workflow.slice(dispatchStart, validateStart)
+  assert.match(dispatch, /actions: write/)
+  assert.doesNotMatch(dispatch, /id-token: write/)
+  assert.match(dispatch, /gh workflow run release\.yml.*--ref main/s)
+  assert.match(dispatch, /pulls\?state=open&base=main&per_page=100.*--slurp/)
+  assert.match(dispatch, /pullRequest\(number:\$number\)\{reviewDecision\}/)
+  assert.match(dispatch, /reviewDecision.*APPROVED/s)
+  assert.match(dispatch, /ci:publish-snapshot/)
+  assert.match(dispatch, /\.head_repository\.full_name == \$head_repository/)
+  assert.match(dispatch, /\.head_branch == \$head_ref/)
+  assert.match(dispatch, /\.head_sha == \$sha/)
+  assert.doesNotMatch(dispatch, /\.pull_requests/)
+  assert.match(dispatch, /pack-pr-snapshot.*conclusion == "success"/s)
+  assert.match(dispatch, /artifacts\?per_page=100.*expired == false/s)
+  assert.match(dispatch, /ci_run_id="\$selected_run_id"/)
+  assert.match(dispatch, /selected_pack_attempt="\$pack_attempt"/)
+  assert.match(dispatch, /verified-pr-snapshot-\$head_sha-\$selected_run_id-\$selected_pack_attempt/)
+  assert.match(dispatch, /assess-registry.*--verified-receipt="\$verified_receipt"/s)
+  assert.match(dispatch, /cohort_failed=true.*scan_failed=true.*continue/s)
+  assert.match(dispatch, /if \[ "\$scan_failed" = true \]; then\s+exit 1/s)
+
+  const checkoutStart = workflow.indexOf('- name: Checkout trusted validator only')
+  const checkoutEnd = workflow.indexOf('\n      - name: Use pinned Node validator runtime', checkoutStart)
+  assert.notEqual(checkoutStart, -1)
+  assert.notEqual(checkoutEnd, -1)
+  const checkout = workflow.slice(checkoutStart, checkoutEnd)
+  assert.match(checkout, /ref: \$\{\{ github\.workflow_sha \}\}/)
+  assert.doesNotMatch(checkout, /github\.sha|head-sha/)
+
+  const attestStart = workflow.indexOf('\n  attest-pr-snapshot:', validateStart)
+  const authorizeStart = workflow.indexOf('\n  authorize-pr-snapshot:', attestStart)
+  const publishStart = workflow.indexOf('\n  publish-pr-snapshot:', authorizeStart)
+  const nextJobStart = workflow.indexOf('\n  create-release-pr:', publishStart)
+  assert.match(workflow.slice(validateStart, attestStart), /GITHUB_WORKFLOW_REF.*refs\/heads\/main/)
+  assert.match(workflow.slice(validateStart, attestStart), /workflow_dispatch.*refs\/heads\/main.*promote-pr-snapshot/s)
+  assert.doesNotMatch(workflow.slice(validateStart, attestStart), /id-token: write/)
+  assert.match(workflow.slice(validateStart, attestStart), /pull-requests: read/)
+  assert.match(workflow.slice(attestStart, authorizeStart), /id-token: write/)
+  assert.match(workflow.slice(authorizeStart, publishStart), /pull-requests: read/)
+  assert.match(workflow.slice(authorizeStart, publishStart), /ci:publish-snapshot/)
+
+  const publish = workflow.slice(publishStart, nextJobStart)
+  assert.match(publish, /pull-requests: read/)
+  const publishNodeSetupStart = publish.indexOf('- name: Use pinned npm trusted-publishing client')
+  const publishNodeSetupEnd = publish.indexOf(
+    '\n      - name: Download validated promotion artifact',
+    publishNodeSetupStart,
+  )
+  assert.notEqual(publishNodeSetupStart, -1)
+  assert.notEqual(publishNodeSetupEnd, -1)
+  assert.doesNotMatch(publish.slice(publishNodeSetupStart, publishNodeSetupEnd), /registry-url:/)
+  assert.match(publish, /group: 'pr-snapshot-\$\{\{ needs\.validate-pr-snapshot\.outputs\.head-sha \}\}'/)
+  assert.match(publish, /\.base\.ref/)
+  assert.match(publish, /\.head\.repo\.full_name/)
+  assert.doesNotMatch(publish, /npm dist-tag/)
+  assert.match(publish, /npm publish/)
+  assert.match(workflow.slice(validateStart, attestStart), /jobs\?filter=all/)
+  assert.match(workflow.slice(validateStart, attestStart), /sort_by\(\.run_attempt\) \| last/)
+  assert.match(workflow.slice(validateStart, attestStart), /inputs\.ci_run_id/)
+  assert.match(workflow.slice(validateStart, attestStart), /\.head\.repo\.full_name == \$head_repository/)
+  assert.match(workflow.slice(validateStart, attestStart), /\.head\.ref == \$head_branch/)
+  assert.match(workflow.slice(validateStart, attestStart), /\.head\.sha == \$head_sha/)
+  assert.doesNotMatch(workflow.slice(validateStart, attestStart), /\.pull_requests\[0\]/)
+  assert.match(workflow, /validated-pr-snapshot-.*release-run-attempt/)
+  assert.match(workflow, /promotion-pr-snapshot-.*promotion-attempt/)
+
+  assert.match(publish, /Verify complete immutable registry cohort/)
+  assert.match(publish, /dist\.integrity/)
+  assert.match(publish, /dist-tags/)
+  assert.match(publish, /\[ -n "\$remote_tag" \].*\[ "\$remote_tag" != "\$SNAPSHOT_VERSION" \]/s)
+  assert.match(publish, /mutable tag \$SNAPSHOT_TAG is absent; OIDC publishing cannot repair dist-tags/)
+  assert.match(publish, /\[ "\$remote_integrity" = "\$local_integrity" \]/)
+  assert.doesNotMatch(publish, /\[ "\$remote_tag" = "\$SNAPSHOT_VERSION" \]/)
+  assert.match(publish, /needs\.validate-pr-snapshot\.outputs\.package-count/)
+  assert.match(publish, /Upload trusted verification receipt/)
+  assert.match(publish, /ci:publish-snapshot/)
+  assert.match(publish, /verified-pr-snapshot-.*outputs\.head-sha.*outputs\.run-id.*outputs\.run-attempt/s)
+  assert.match(publish, /sourceRunAttempt/)
+  assert.match(publish, /overwrite: true/)
+
+  const ciWorkflow = await readFile(new URL('../workflows/ci.yml', import.meta.url), 'utf8')
+  assert.match(ciWorkflow, /pack-pr-snapshot:\n    if: github\.event_name == 'pull_request'/)
+  assert.doesNotMatch(ciWorkflow, /pack-pr-snapshot:[\s\S]*?head\.repo\.full_name == github\.repository/)
+  assert.doesNotMatch(ciWorkflow, /pull_request_target:/)
+  assert.match(
+    ciWorkflow,
+    /name: 'pr-snapshot-\$\{\{ github\.event\.pull_request\.head\.sha \}\}-\$\{\{ github\.run_attempt \}\}'/,
+  )
+  assert.match(
+    workflow.slice(validateStart, attestStart),
+    /name: 'pr-snapshot-\$\{\{ steps\.identity\.outputs\.head-sha \}\}-\$\{\{ steps\.identity\.outputs\.run-attempt \}\}'/,
+  )
+})
+
+test('derives a deterministic publish-time tag for each PR head cohort', () => {
+  const firstHead = 'a'.repeat(40)
+  const secondHead = 'b'.repeat(40)
+  const firstTag = snapshotTag({ prNumber: 42, headSha: firstHead })
+
+  assert.equal(firstTag, `pr-42-${firstHead}`)
+  assert.notEqual(firstTag, snapshotTag({ prNumber: 42, headSha: secondHead }))
+  assert.notEqual(firstTag, snapshotTag({ prNumber: 43, headSha: firstHead }))
+  assert.notEqual(firstTag, 'snapshot')
+  assert.notEqual(
+    snapshotVersion({ prNumber: 42, headSha: firstHead }),
+    snapshotVersion({ prNumber: 43, headSha: firstHead }),
+  )
+})
+
+test('selects the successful producer attempt when only failed jobs were rerun', () => {
+  assert.equal(
+    successfulProducerAttempt({
+      jobName: 'pack-pr-snapshot',
+      jobs: [
+        { name: 'pack-pr-snapshot', conclusion: 'success', run_attempt: 1 },
+        { name: 'lint', conclusion: 'success', run_attempt: 2 },
+      ],
+    }),
+    1,
+  )
+
+  assert.equal(
+    successfulProducerAttempt({
+      jobName: 'pack-pr-snapshot',
+      jobs: [
+        { name: 'pack-pr-snapshot', conclusion: 'success', run_attempt: 1 },
+        { name: 'pack-pr-snapshot', conclusion: 'success', run_attempt: 2 },
+      ],
+    }),
+    2,
+  )
+})
+
+test('selects an exact repository, branch, and SHA producer run for forks', () => {
+  const headSha = 'a'.repeat(40)
+  const artifact = (attempt) => ({ name: `pr-snapshot-${headSha}-${attempt}`, expired: false })
+  const runs = [
+    {
+      id: 100,
+      headRepository: 'other/livestore',
+      headBranch: 'feature',
+      headSha,
+      event: 'pull_request',
+      conclusion: 'success',
+      packAttempt: 1,
+      artifacts: [artifact(1)],
+      createdAt: '2026-07-18T10:00:00Z',
+    },
+    {
+      id: 101,
+      headRepository: 'contributor/livestore',
+      headBranch: 'feature',
+      headSha,
+      event: 'pull_request',
+      conclusion: 'success',
+      packAttempt: 2,
+      artifacts: [artifact(2)],
+      createdAt: '2026-07-18T09:00:00Z',
+    },
+  ]
+
+  assert.equal(
+    selectEligibleProducerRun({ runs, headRepository: 'contributor/livestore', headBranch: 'feature', headSha })?.id,
+    101,
+  )
+  assert.equal(
+    selectEligibleProducerRun({ runs, headRepository: 'contributor/livestore', headBranch: 'other', headSha }),
+    null,
+  )
+  runs[1].artifacts[0].expired = true
+  assert.equal(
+    selectEligibleProducerRun({ runs, headRepository: 'contributor/livestore', headBranch: 'feature', headSha }),
+    null,
+  )
+})
+
+test('rejects a tarball changed after manifest creation', async () => {
+  const { dir, topologyPath, headSha } = await fixture()
+  await createManifest({
+    artifactDir: dir,
+    topologyPath,
+    repository: 'livestorejs/livestore',
+    prNumber: 42,
+    headSha,
+    runId: 100,
+    runAttempt: 1,
+  })
+  await writeFile(path.join(dir, 'a.tgz'), Buffer.from('tampered'))
+  await assert.rejects(
+    validateManifest({
+      artifactDir: dir,
+      topologyPath,
+      repository: 'livestorejs/livestore',
+      prNumber: 42,
+      headSha,
+      runId: 100,
+      runAttempt: 1,
+      publishListPath: path.join(dir, '..', 'publish-list.txt'),
+    }),
+    /Digest mismatch/,
+  )
+})
+
+test('rejects identity drift and unexpected artifact files', async () => {
+  const { dir, topologyPath, headSha } = await fixture()
+  await createManifest({
+    artifactDir: dir,
+    topologyPath,
+    repository: 'livestorejs/livestore',
+    prNumber: 42,
+    headSha,
+    runId: 100,
+    runAttempt: 1,
+  })
+  await assert.rejects(
+    validateManifest({
+      artifactDir: dir,
+      topologyPath,
+      repository: 'livestorejs/livestore',
+      prNumber: 42,
+      headSha,
+      runId: 101,
+      runAttempt: 1,
+      publishListPath: path.join(dir, '..', 'publish-list.txt'),
+    }),
+    /runId mismatch/,
+  )
+
+  await writeFile(path.join(dir, 'unexpected.txt'), 'unexpected')
+  await assert.rejects(
+    validateManifest({
+      artifactDir: dir,
+      topologyPath,
+      repository: 'livestorejs/livestore',
+      prNumber: 42,
+      headSha,
+      runId: 100,
+      runAttempt: 1,
+      publishListPath: path.join(dir, '..', 'publish-list.txt'),
+    }),
+    /missing or unexpected files/,
+  )
+})
+
+test('rejects traversal paths and lifecycle scripts', async () => {
+  const { dir, topologyPath, headSha, version } = await fixture()
+  await writeFile(
+    path.join(dir, 'a.tgz'),
+    tar([
+      ['package/../escape', 'x'],
+      ['package/package.json', JSON.stringify({ name: '@livestore/a', version })],
+    ]),
+  )
+  await assert.rejects(
+    createManifest({
+      artifactDir: dir,
+      topologyPath,
+      repository: 'livestorejs/livestore',
+      prNumber: 42,
+      headSha,
+      runId: 100,
+      runAttempt: 1,
+    }),
+    /Unsafe tar entry path/,
+  )
+
+  await writeFile(
+    path.join(dir, 'a.tgz'),
+    tar([
+      ['package/package.json', JSON.stringify({ name: '@livestore/a', version, scripts: { prepare: 'echo unsafe' } })],
+    ]),
+  )
+  await assert.rejects(
+    createManifest({
+      artifactDir: dir,
+      topologyPath,
+      repository: 'livestorejs/livestore',
+      prNumber: 42,
+      headSha,
+      runId: 100,
+      runAttempt: 1,
+    }),
+    /lifecycle script prepare/,
+  )
+
+  await writeFile(
+    path.join(dir, 'a.tgz'),
+    tar([
+      [
+        'package/package.json',
+        JSON.stringify({
+          name: '@livestore/a',
+          version,
+          publishConfig: { access: 'public', registry: 'https://attacker.example' },
+        }),
+      ],
+    ]),
+  )
+  await assert.rejects(
+    createManifest({
+      artifactDir: dir,
+      topologyPath,
+      repository: 'livestorejs/livestore',
+      prNumber: 42,
+      headSha,
+      runId: 100,
+      runAttempt: 1,
+    }),
+    /publishConfig keys mismatch/,
+  )
+
+  await writeFile(
+    path.join(dir, 'a.tgz'),
+    tar([
+      ['package/.npmrc', 'registry=https://attacker.example'],
+      ['package/package.json', JSON.stringify({ name: '@livestore/a', version })],
+    ]),
+  )
+  await assert.rejects(
+    createManifest({
+      artifactDir: dir,
+      topologyPath,
+      repository: 'livestorejs/livestore',
+      prNumber: 42,
+      headSha,
+      runId: 100,
+      runAttempt: 1,
+    }),
+    /must not contain .npmrc/,
+  )
+})

--- a/genie/ci-workflow.ts
+++ b/genie/ci-workflow.ts
@@ -149,6 +149,13 @@ export {
   type WorkflowReportPublisherStepOptions,
 } from './ci-workflow/reporting.ts'
 export {
+  prSnapshotPackJob,
+  prSnapshotReleaseJobs,
+  type PrSnapshotPackJobOptions,
+  type PrSnapshotReleaseJobsOptions,
+  type PrSnapshotSharedOptions,
+} from './ci-workflow/pr-snapshot.ts'
+export {
   ciWorkflowJobLocalRustStateScript,
   ciWorkflowJobLocalRustStateScriptPath,
   ciWorkflowNixGcRaceRetryScriptPath,

--- a/genie/ci-workflow.ts
+++ b/genie/ci-workflow.ts
@@ -153,6 +153,8 @@ export {
   ciWorkflowJobLocalRustStateScriptPath,
   ciWorkflowNixGcRaceRetryScriptPath,
   ciWorkflowNixGcRaceRetryWrapperPath,
+  ciWorkflowPrSnapshotArtifactScriptPath,
+  ciWorkflowPrSnapshotArtifactTestPath,
   ciWorkflowSupportFiles,
   type CiWorkflowSupportFiles,
 } from './ci-workflow/support-files.ts'

--- a/genie/ci-workflow.ts
+++ b/genie/ci-workflow.ts
@@ -149,8 +149,11 @@ export {
   type WorkflowReportPublisherStepOptions,
 } from './ci-workflow/reporting.ts'
 export {
+  prSnapshotForeignEventGuard,
   prSnapshotPackJob,
+  prSnapshotPackJobId,
   prSnapshotReleaseJobs,
+  prSnapshotTrustLabel,
   type PrSnapshotPackJobOptions,
   type PrSnapshotReleaseJobsOptions,
   type PrSnapshotSharedOptions,
@@ -162,6 +165,8 @@ export {
   ciWorkflowNixGcRaceRetryWrapperPath,
   ciWorkflowPrSnapshotArtifactScriptPath,
   ciWorkflowPrSnapshotArtifactTestPath,
+  emittedPrSnapshotValidatorPath,
+  emittedPrSnapshotValidatorTestPath,
   ciWorkflowSupportFiles,
   type CiWorkflowSupportFiles,
 } from './ci-workflow/support-files.ts'

--- a/genie/ci-workflow/pr-snapshot.ts
+++ b/genie/ci-workflow/pr-snapshot.ts
@@ -24,6 +24,28 @@
 
 import type { GitHubWorkflowArgs } from '../../packages/@overeng/genie/src/runtime/github-workflow/mod.ts'
 import { bashShellDefaults, runDevenvTasksBefore } from './shared.ts'
+import { emittedPrSnapshotValidatorPath, emittedPrSnapshotValidatorTestPath } from './support-files.ts'
+
+/**
+ * Job id of the pack job, and the label granting a fork pull request publishing trust.
+ *
+ * Constants rather than options. Each is duplicated in places a caller cannot reach: `packJobId` is a
+ * job key in one workflow and a `jq` name match in another, and the trust label is also hardcoded
+ * inside the validator's authorization predicate. Making either configurable would let the copies
+ * disagree — and neither disagreement fails loudly; the dispatcher would simply match nothing.
+ */
+export const prSnapshotPackJobId = 'pack-pr-snapshot'
+export const prSnapshotTrustLabel = 'ci:publish-snapshot'
+
+/**
+ * Guard for jobs that existed in a consumer's release workflow before these were added.
+ *
+ * `scheduleTrigger` and `workflowRunTrigger` widen when the workflow runs — on a cron and on every
+ * producer CI completion. Any pre-existing job without a guard then runs on those events too, which
+ * for a build-heavy job means a full toolchain build every few minutes. Apply this to them.
+ */
+export const prSnapshotForeignEventGuard =
+  "github.event_name != 'schedule' && github.event_name != 'workflow_run'" 
 
 type WorkflowJob = GitHubWorkflowArgs['jobs'][string]
 type WorkflowStep = WorkflowJob['steps'][number]
@@ -32,13 +54,8 @@ type WorkflowStep = WorkflowJob['steps'][number]
 export type PrSnapshotSharedOptions = {
   /** Repo-relative path to the trusted release topology JSON. */
   readonly topologyPath: string
-  /** Repo-relative path to the emitted `pr-snapshot-artifact.mjs`. */
-  readonly validatorScriptPath: string
-  /**
-   * Job id of the pack job. Also matched by name from the release jobs, so this single value has to
-   * feed both workflows.
-   */
-  readonly packJobId?: string
+  /** Repo-relative path to the emitted `pr-snapshot-artifact.mjs`. Defaults to the shared location. */
+  readonly validatorScriptPath?: string
 }
 
 export type PrSnapshotPackJobOptions = PrSnapshotSharedOptions & {
@@ -46,8 +63,8 @@ export type PrSnapshotPackJobOptions = PrSnapshotSharedOptions & {
   readonly setupStepsAfterCheckout: readonly WorkflowStep[]
   /** Devenv task packing tarballs into `$SNAPSHOT_OUT_DIR`. */
   readonly packTask: string
-  /** Repo-relative path to the validator's own boundary suite. */
-  readonly validatorTestPath: string
+  /** Repo-relative path to the emitted boundary suite. Defaults to the shared location. */
+  readonly validatorTestPath?: string
   /** Runner for the untrusted pack job. */
   readonly runsOn?: WorkflowJob['runs-on']
 }
@@ -55,8 +72,6 @@ export type PrSnapshotPackJobOptions = PrSnapshotSharedOptions & {
 export type PrSnapshotReleaseJobsOptions = PrSnapshotSharedOptions & {
   /** in-toto predicate type URI for the candidate attestation. */
   readonly attestationPredicateType: string
-  /** Label granting fork PRs snapshot-publishing trust. */
-  readonly trustLabel?: string
   /** Runner for the trusted jobs. These do no repo build, so the default suits every consumer. */
   readonly runsOn?: WorkflowJob['runs-on']
 }
@@ -68,15 +83,14 @@ export type PrSnapshotReleaseJobsOptions = PrSnapshotSharedOptions & {
 export const prSnapshotPackJob = (opts: PrSnapshotPackJobOptions) => {
   const {
     topologyPath,
-    validatorScriptPath,
-    validatorTestPath,
+    validatorScriptPath = emittedPrSnapshotValidatorPath,
+    validatorTestPath = emittedPrSnapshotValidatorTestPath,
     setupStepsAfterCheckout,
     packTask,
-    packJobId = 'pack-pr-snapshot',
     runsOn = 'ubuntu-24.04',
   } = opts
   return {
-    [packJobId]: {
+    [prSnapshotPackJobId]: {
       // Fork candidates are untrusted data: this job has no secrets or write
       // token, and the main-branch release workflow validates every tarball.
       if: "github.event_name == 'pull_request'",
@@ -139,10 +153,8 @@ export const prSnapshotPackJob = (opts: PrSnapshotPackJobOptions) => {
 export const prSnapshotReleaseJobs = (opts: PrSnapshotReleaseJobsOptions) => {
   const {
     topologyPath,
-    validatorScriptPath,
+    validatorScriptPath = emittedPrSnapshotValidatorPath,
     attestationPredicateType,
-    trustLabel = 'ci:publish-snapshot',
-    packJobId = 'pack-pr-snapshot',
     runsOn = 'ubuntu-24.04',
   } = opts
   return {
@@ -213,7 +225,7 @@ while IFS=$'\t' read -r pr_number head_sha head_repository head_ref fork_label_p
   while IFS= read -r candidate_run_id; do
     [[ "$candidate_run_id" =~ ^[1-9][0-9]*$ ]]
     jobs_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/actions/runs/$candidate_run_id/jobs?filter=all&per_page=100" --slurp)
-    pack_job=$(jq -c '[.[] | .jobs[] | select(.name == "${packJobId}" and .conclusion == "success")] | sort_by(.run_attempt) | last' <<<"$jobs_json")
+    pack_job=$(jq -c '[.[] | .jobs[] | select(.name == "${prSnapshotPackJobId}" and .conclusion == "success")] | sort_by(.run_attempt) | last' <<<"$jobs_json")
     if [ "$pack_job" = null ]; then
       continue
     fi
@@ -290,7 +302,7 @@ while IFS=$'\t' read -r pr_number head_sha head_repository head_ref fork_label_p
     -f head_sha="$head_sha" \
     -f ci_run_id="$selected_run_id"
 done < <(jq -r \
-  '.[][] | select(.draft == false and .base.ref == "main") | [.number, .head.sha, .head.repo.full_name, .head.ref, (any(.labels[]?; .name == "${trustLabel}") | tostring)] | @tsv' \
+  '.[][] | select(.draft == false and .base.ref == "main") | [.number, .head.sha, .head.repo.full_name, .head.ref, (any(.labels[]?; .name == "${prSnapshotTrustLabel}") | tostring)] | @tsv' \
   <<<"$prs_json")
 if [ "$scan_failed" = true ]; then
   exit 1
@@ -369,7 +381,7 @@ fi
 [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]
 source_run_url=$(jq -r '.html_url' <<<"$run_json")
 jobs_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/actions/runs/$run_id/jobs?filter=all&per_page=100" --slurp)
-pack_job=$(jq -c '[.[] | .jobs[] | select(.name == "${packJobId}" and .conclusion == "success")] | sort_by(.run_attempt) | last' <<<"$jobs_json")
+pack_job=$(jq -c '[.[] | .jobs[] | select(.name == "${prSnapshotPackJobId}" and .conclusion == "success")] | sort_by(.run_attempt) | last' <<<"$jobs_json")
 test "$pack_job" != null
 run_attempt=$(jq -r '.run_attempt' <<<"$pack_job")
 [[ "$run_attempt" =~ ^[1-9][0-9]*$ ]]
@@ -564,9 +576,9 @@ if [ "$(jq -r '.state' <<<"$pr_json")" = open ] && \
       authorized=true
       authorized_by='current-head review'
     fi
-  elif jq -e 'any(.labels[]?; .name == "${trustLabel}")' <<<"$pr_json" >/dev/null; then
+  elif jq -e 'any(.labels[]?; .name == "${prSnapshotTrustLabel}")' <<<"$pr_json" >/dev/null; then
     authorized=true
-    authorized_by='${trustLabel} fork trust label'
+    authorized_by='${prSnapshotTrustLabel} fork trust label'
   fi
 fi
 echo "authorized=$authorized" >> "$GITHUB_OUTPUT"
@@ -636,7 +648,7 @@ if [ "$head_repository" = "$GITHUB_REPOSITORY" ]; then
   test "$review_decision" = APPROVED
   jq -e --arg sha "$EXPECTED_HEAD_SHA" 'any(.[]; .state == "APPROVED" and .commit_id == $sha)' <<<"$reviews_json" >/dev/null
 else
-  jq -e 'any(.labels[]?; .name == "${trustLabel}")' <<<"$pr_json" >/dev/null
+  jq -e 'any(.labels[]?; .name == "${prSnapshotTrustLabel}")' <<<"$pr_json" >/dev/null
 fi`,
           },
           {

--- a/genie/ci-workflow/pr-snapshot.ts
+++ b/genie/ci-workflow/pr-snapshot.ts
@@ -147,30 +147,30 @@ export const prSnapshotReleaseJobs = (opts: PrSnapshotReleaseJobsOptions) => {
   } = opts
   return {
     jobs: {
-    'dispatch-authorized-pr-snapshots': {
-      if: "github.event_name == 'schedule'",
-      'runs-on': runsOn,
-      permissions: {
-        actions: 'write',
-        contents: 'read',
-        'pull-requests': 'read',
-      },
-      env: { GH_TOKEN: '${{ github.token }}' },
-      defaults: bashShellDefaults,
-      steps: [
-        {
-          name: 'Checkout trusted package topology',
-          uses: 'actions/checkout@v4',
-          with: {
-            ref: '${{ github.workflow_sha }}',
-            'persist-credentials': false,
-            'sparse-checkout': `${validatorScriptPath}
-${topologyPath}`,
-          },
+      'dispatch-authorized-pr-snapshots': {
+        if: "github.event_name == 'schedule'",
+        'runs-on': runsOn,
+        permissions: {
+          actions: 'write',
+          contents: 'read',
+          'pull-requests': 'read',
         },
-        {
-          name: 'Dispatch incomplete authorized cohorts to trusted main workflow',
-          run: `set -euo pipefail
+        env: { GH_TOKEN: '${{ github.token }}' },
+        defaults: bashShellDefaults,
+        steps: [
+          {
+            name: 'Checkout trusted package topology',
+            uses: 'actions/checkout@v4',
+            with: {
+              ref: '${{ github.workflow_sha }}',
+              'persist-credentials': false,
+              'sparse-checkout': `${validatorScriptPath}
+${topologyPath}`,
+            },
+          },
+          {
+            name: 'Dispatch incomplete authorized cohorts to trusted main workflow',
+            run: `set -euo pipefail
 test "$GITHUB_WORKFLOW_REF" = "$GITHUB_REPOSITORY/.github/workflows/release.yml@refs/heads/main"
 prs_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/pulls?state=open&base=main&per_page=100" --slurp)
 release_workflow_id=$(gh api "/repos/$GITHUB_REPOSITORY/actions/workflows/release.yml" --jq .id)
@@ -295,42 +295,42 @@ done < <(jq -r \
 if [ "$scan_failed" = true ]; then
   exit 1
 fi`,
+          },
+        ],
+      },
+      'validate-pr-snapshot': {
+        if: "(github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && inputs.mode == 'promote-pr-snapshot')",
+        'runs-on': runsOn,
+        permissions: {
+          actions: 'read',
+          contents: 'read',
+          'pull-requests': 'read',
         },
-      ],
-    },
-    'validate-pr-snapshot': {
-      if: "(github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && inputs.mode == 'promote-pr-snapshot')",
-      'runs-on': runsOn,
-      permissions: {
-        actions: 'read',
-        contents: 'read',
-        'pull-requests': 'read',
-      },
-      outputs: {
-        'head-sha': '${{ steps.identity.outputs.head-sha }}',
-        'manifest-digest': '${{ steps.validate.outputs.manifest-digest }}',
-        'npm-tag': '${{ steps.validate.outputs.npm-tag }}',
-        'package-count': '${{ steps.validate.outputs.package-count }}',
-        'pr-number': '${{ steps.identity.outputs.pr-number }}',
-        'release-run-attempt': '${{ steps.validate.outputs.release-run-attempt }}',
-        'run-attempt': '${{ steps.identity.outputs.run-attempt }}',
-        'run-id': '${{ steps.identity.outputs.run-id }}',
-        'source-run-url': '${{ steps.identity.outputs.source-run-url }}',
-        'topology-digest': '${{ steps.validate.outputs.topology-digest }}',
-        version: '${{ steps.validate.outputs.version }}',
-      },
-      env: {
-        ARTIFACT_DIR: '${{ github.workspace }}/tmp/pr-snapshot-artifact',
-        CACHIX_AUTH_TOKEN: '',
-        GH_TOKEN: '${{ github.token }}',
-        PUBLISH_LIST: '${{ github.workspace }}/tmp/pr-snapshot-publish-list.tsv',
-      },
-      defaults: bashShellDefaults,
-      steps: [
-        {
-          id: 'identity',
-          name: 'Resolve exact successful CI run and current PR head',
-          run: `set -euo pipefail
+        outputs: {
+          'head-sha': '${{ steps.identity.outputs.head-sha }}',
+          'manifest-digest': '${{ steps.validate.outputs.manifest-digest }}',
+          'npm-tag': '${{ steps.validate.outputs.npm-tag }}',
+          'package-count': '${{ steps.validate.outputs.package-count }}',
+          'pr-number': '${{ steps.identity.outputs.pr-number }}',
+          'release-run-attempt': '${{ steps.validate.outputs.release-run-attempt }}',
+          'run-attempt': '${{ steps.identity.outputs.run-attempt }}',
+          'run-id': '${{ steps.identity.outputs.run-id }}',
+          'source-run-url': '${{ steps.identity.outputs.source-run-url }}',
+          'topology-digest': '${{ steps.validate.outputs.topology-digest }}',
+          version: '${{ steps.validate.outputs.version }}',
+        },
+        env: {
+          ARTIFACT_DIR: '${{ github.workspace }}/tmp/pr-snapshot-artifact',
+          CACHIX_AUTH_TOKEN: '',
+          GH_TOKEN: '${{ github.token }}',
+          PUBLISH_LIST: '${{ github.workspace }}/tmp/pr-snapshot-publish-list.tsv',
+        },
+        defaults: bashShellDefaults,
+        steps: [
+          {
+            id: 'identity',
+            name: 'Resolve exact successful CI run and current PR head',
+            run: `set -euo pipefail
 test "$GITHUB_WORKFLOW_REF" = "$GITHUB_REPOSITORY/.github/workflows/release.yml@refs/heads/main"
 [[ "$GITHUB_WORKFLOW_SHA" =~ ^[0-9a-f]{40}$ ]]
 if [ "$GITHUB_EVENT_NAME" = workflow_run ]; then
@@ -386,44 +386,44 @@ echo "pr-number=$pr_number" >> "$GITHUB_OUTPUT"
 echo "run-id=$run_id" >> "$GITHUB_OUTPUT"
 echo "run-attempt=$run_attempt" >> "$GITHUB_OUTPUT"
 echo "source-run-url=$source_run_url" >> "$GITHUB_OUTPUT"`,
-        },
-        {
-          name: 'Checkout trusted validator only',
-          uses: 'actions/checkout@v4',
-          with: {
-            ref: '${{ github.workflow_sha }}',
-            'persist-credentials': false,
-            'sparse-checkout': `${validatorScriptPath}
+          },
+          {
+            name: 'Checkout trusted validator only',
+            uses: 'actions/checkout@v4',
+            with: {
+              ref: '${{ github.workflow_sha }}',
+              'persist-credentials': false,
+              'sparse-checkout': `${validatorScriptPath}
 ${topologyPath}`,
+            },
           },
-        },
-        {
-          name: 'Use pinned Node validator runtime',
-          uses: 'actions/setup-node@v4',
-          with: {
-            'node-version': '24.15.0',
+          {
+            name: 'Use pinned Node validator runtime',
+            uses: 'actions/setup-node@v4',
+            with: {
+              'node-version': '24.15.0',
+            },
           },
-        },
-        {
-          name: 'Download exact-run snapshot candidate',
-          uses: 'actions/download-artifact@v4',
-          with: {
-            name: 'pr-snapshot-${{ steps.identity.outputs.head-sha }}-${{ steps.identity.outputs.run-attempt }}',
-            path: '${{ github.workspace }}/tmp/pr-snapshot-artifact',
-            'github-token': '${{ github.token }}',
-            'run-id': '${{ steps.identity.outputs.run-id }}',
+          {
+            name: 'Download exact-run snapshot candidate',
+            uses: 'actions/download-artifact@v4',
+            with: {
+              name: 'pr-snapshot-${{ steps.identity.outputs.head-sha }}-${{ steps.identity.outputs.run-attempt }}',
+              path: '${{ github.workspace }}/tmp/pr-snapshot-artifact',
+              'github-token': '${{ github.token }}',
+              'run-id': '${{ steps.identity.outputs.run-id }}',
+            },
           },
-        },
-        {
-          id: 'validate',
-          name: 'Validate immutable snapshot candidate',
-          env: {
-            EXPECTED_HEAD_SHA: '${{ steps.identity.outputs.head-sha }}',
-            EXPECTED_PR_NUMBER: '${{ steps.identity.outputs.pr-number }}',
-            EXPECTED_RUN_ID: '${{ steps.identity.outputs.run-id }}',
-            EXPECTED_RUN_ATTEMPT: '${{ steps.identity.outputs.run-attempt }}',
-          },
-          run: `set -euo pipefail
+          {
+            id: 'validate',
+            name: 'Validate immutable snapshot candidate',
+            env: {
+              EXPECTED_HEAD_SHA: '${{ steps.identity.outputs.head-sha }}',
+              EXPECTED_PR_NUMBER: '${{ steps.identity.outputs.pr-number }}',
+              EXPECTED_RUN_ID: '${{ steps.identity.outputs.run-id }}',
+              EXPECTED_RUN_ATTEMPT: '${{ steps.identity.outputs.run-attempt }}',
+            },
+            run: `set -euo pipefail
 result=$(node ${validatorScriptPath} validate \\
   --artifact-dir="$ARTIFACT_DIR" \\
   --topology=${topologyPath} \\
@@ -440,56 +440,56 @@ echo "npm-tag=$(jq -r '.npmTag' <<<"$result")" >> "$GITHUB_OUTPUT"
 echo "package-count=$(jq -r '.packageCount' <<<"$result")" >> "$GITHUB_OUTPUT"
 echo "release-run-attempt=$GITHUB_RUN_ATTEMPT" >> "$GITHUB_OUTPUT"
 cp "$PUBLISH_LIST" "$ARTIFACT_DIR/trusted-publish-list.tsv"`,
-        },
-        {
-          name: 'Upload validated snapshot candidate',
-          uses: 'actions/upload-artifact@v4',
-          with: {
-            name: 'validated-pr-snapshot-${{ steps.identity.outputs.head-sha }}-${{ steps.identity.outputs.run-id }}-${{ steps.validate.outputs.release-run-attempt }}',
-            path: '${{ github.workspace }}/tmp/pr-snapshot-artifact/',
-            'if-no-files-found': 'error',
-            'retention-days': 1,
           },
-        },
-      ],
-    },
-    'attest-pr-snapshot': {
-      needs: ['validate-pr-snapshot'],
-      'runs-on': runsOn,
-      permissions: {
-        actions: 'read',
-        attestations: 'write',
-        'artifact-metadata': 'write',
-        contents: 'read',
-        'id-token': 'write',
+          {
+            name: 'Upload validated snapshot candidate',
+            uses: 'actions/upload-artifact@v4',
+            with: {
+              name: 'validated-pr-snapshot-${{ steps.identity.outputs.head-sha }}-${{ steps.identity.outputs.run-id }}-${{ steps.validate.outputs.release-run-attempt }}',
+              path: '${{ github.workspace }}/tmp/pr-snapshot-artifact/',
+              'if-no-files-found': 'error',
+              'retention-days': 1,
+            },
+          },
+        ],
       },
-      env: {
-        ARTIFACT_DIR: '${{ github.workspace }}/tmp/validated-pr-snapshot',
-        CACHIX_AUTH_TOKEN: '',
-      },
-      defaults: bashShellDefaults,
-      outputs: { 'promotion-attempt': '${{ steps.handoff.outputs.promotion-attempt }}' },
-      steps: [
-        {
-          name: 'Download validated snapshot candidate',
-          uses: 'actions/download-artifact@v4',
-          with: {
-            name: 'validated-pr-snapshot-${{ needs.validate-pr-snapshot.outputs.head-sha }}-${{ needs.validate-pr-snapshot.outputs.run-id }}-${{ needs.validate-pr-snapshot.outputs.release-run-attempt }}',
-            path: '${{ github.workspace }}/tmp/validated-pr-snapshot',
-          },
+      'attest-pr-snapshot': {
+        needs: ['validate-pr-snapshot'],
+        'runs-on': runsOn,
+        permissions: {
+          actions: 'read',
+          attestations: 'write',
+          'artifact-metadata': 'write',
+          contents: 'read',
+          'id-token': 'write',
         },
-        {
-          id: 'handoff',
-          name: 'Verify validated artifact identity and write predicate',
-          env: {
-            HEAD_SHA: '${{ needs.validate-pr-snapshot.outputs.head-sha }}',
-            MANIFEST_DIGEST: '${{ needs.validate-pr-snapshot.outputs.manifest-digest }}',
-            PR_NUMBER: '${{ needs.validate-pr-snapshot.outputs.pr-number }}',
-            SOURCE_RUN_ATTEMPT: '${{ needs.validate-pr-snapshot.outputs.run-attempt }}',
-            SOURCE_RUN_ID: '${{ needs.validate-pr-snapshot.outputs.run-id }}',
-            TOPOLOGY_DIGEST: '${{ needs.validate-pr-snapshot.outputs.topology-digest }}',
+        env: {
+          ARTIFACT_DIR: '${{ github.workspace }}/tmp/validated-pr-snapshot',
+          CACHIX_AUTH_TOKEN: '',
+        },
+        defaults: bashShellDefaults,
+        outputs: { 'promotion-attempt': '${{ steps.handoff.outputs.promotion-attempt }}' },
+        steps: [
+          {
+            name: 'Download validated snapshot candidate',
+            uses: 'actions/download-artifact@v4',
+            with: {
+              name: 'validated-pr-snapshot-${{ needs.validate-pr-snapshot.outputs.head-sha }}-${{ needs.validate-pr-snapshot.outputs.run-id }}-${{ needs.validate-pr-snapshot.outputs.release-run-attempt }}',
+              path: '${{ github.workspace }}/tmp/validated-pr-snapshot',
+            },
           },
-          run: `set -euo pipefail
+          {
+            id: 'handoff',
+            name: 'Verify validated artifact identity and write predicate',
+            env: {
+              HEAD_SHA: '${{ needs.validate-pr-snapshot.outputs.head-sha }}',
+              MANIFEST_DIGEST: '${{ needs.validate-pr-snapshot.outputs.manifest-digest }}',
+              PR_NUMBER: '${{ needs.validate-pr-snapshot.outputs.pr-number }}',
+              SOURCE_RUN_ATTEMPT: '${{ needs.validate-pr-snapshot.outputs.run-attempt }}',
+              SOURCE_RUN_ID: '${{ needs.validate-pr-snapshot.outputs.run-id }}',
+              TOPOLOGY_DIGEST: '${{ needs.validate-pr-snapshot.outputs.topology-digest }}',
+            },
+            run: `set -euo pipefail
 test "$(sha256sum "$ARTIFACT_DIR/manifest.json" | cut -d' ' -f1)" = "$MANIFEST_DIGEST"
 echo "promotion-attempt=$GITHUB_RUN_ATTEMPT" >> "$GITHUB_OUTPUT"
 jq -n \
@@ -502,44 +502,47 @@ jq -n \
   --arg topologySha256 "$TOPOLOGY_DIGEST" \
   '{repository, prNumber, headSha, sourceRunId, sourceRunAttempt, manifestSha256, topologySha256}' \
   > "$RUNNER_TEMP/pr-snapshot-attestation.json"`,
-        },
-        {
-          name: 'Attest validated snapshot candidate',
-          uses: 'actions/attest@v4',
-          with: {
-            'subject-path': ['${{ env.ARTIFACT_DIR }}/*.tgz', '${{ env.ARTIFACT_DIR }}/manifest.json'].join('\n'),
-            'predicate-type': attestationPredicateType,
-            'predicate-path': '${{ runner.temp }}/pr-snapshot-attestation.json',
           },
-        },
-        {
-          name: 'Upload attested promotion artifact',
-          uses: 'actions/upload-artifact@v4',
-          with: {
-            name: 'promotion-pr-snapshot-${{ needs.validate-pr-snapshot.outputs.head-sha }}-${{ needs.validate-pr-snapshot.outputs.run-id }}-${{ steps.handoff.outputs.promotion-attempt }}',
-            path: '${{ github.workspace }}/tmp/validated-pr-snapshot/',
-            'if-no-files-found': 'error',
-            'retention-days': 1,
+          {
+            name: 'Attest validated snapshot candidate',
+            uses: 'actions/attest@v4',
+            with: {
+              'subject-path': [
+                '${{ env.ARTIFACT_DIR }}/*.tgz',
+                '${{ env.ARTIFACT_DIR }}/manifest.json',
+              ].join('\n'),
+              'predicate-type': attestationPredicateType,
+              'predicate-path': '${{ runner.temp }}/pr-snapshot-attestation.json',
+            },
           },
-        },
-      ],
-    },
-    'authorize-pr-snapshot': {
-      needs: ['validate-pr-snapshot'],
-      'runs-on': runsOn,
-      permissions: { contents: 'read', 'pull-requests': 'read' },
-      outputs: { authorized: '${{ steps.approval.outputs.authorized }}' },
-      defaults: bashShellDefaults,
-      steps: [
-        {
-          id: 'approval',
-          name: 'Require current-head review or fork trust label',
-          env: {
-            EXPECTED_HEAD_SHA: '${{ needs.validate-pr-snapshot.outputs.head-sha }}',
-            GH_TOKEN: '${{ github.token }}',
-            PR_NUMBER: '${{ needs.validate-pr-snapshot.outputs.pr-number }}',
+          {
+            name: 'Upload attested promotion artifact',
+            uses: 'actions/upload-artifact@v4',
+            with: {
+              name: 'promotion-pr-snapshot-${{ needs.validate-pr-snapshot.outputs.head-sha }}-${{ needs.validate-pr-snapshot.outputs.run-id }}-${{ steps.handoff.outputs.promotion-attempt }}',
+              path: '${{ github.workspace }}/tmp/validated-pr-snapshot/',
+              'if-no-files-found': 'error',
+              'retention-days': 1,
+            },
           },
-          run: `set -euo pipefail
+        ],
+      },
+      'authorize-pr-snapshot': {
+        needs: ['validate-pr-snapshot'],
+        'runs-on': runsOn,
+        permissions: { contents: 'read', 'pull-requests': 'read' },
+        outputs: { authorized: '${{ steps.approval.outputs.authorized }}' },
+        defaults: bashShellDefaults,
+        steps: [
+          {
+            id: 'approval',
+            name: 'Require current-head review or fork trust label',
+            env: {
+              EXPECTED_HEAD_SHA: '${{ needs.validate-pr-snapshot.outputs.head-sha }}',
+              GH_TOKEN: '${{ github.token }}',
+              PR_NUMBER: '${{ needs.validate-pr-snapshot.outputs.pr-number }}',
+            },
+            run: `set -euo pipefail
 pr_json=$(gh api "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")
 authorized=false
 authorized_by='none'
@@ -568,53 +571,54 @@ if [ "$(jq -r '.state' <<<"$pr_json")" = open ] && \
 fi
 echo "authorized=$authorized" >> "$GITHUB_OUTPUT"
 echo "Snapshot promotion authorized: $authorized ($authorized_by)" >> "$GITHUB_STEP_SUMMARY"`,
-        },
-      ],
-    },
-    'publish-pr-snapshot': {
-      if: "needs.authorize-pr-snapshot.outputs.authorized == 'true'",
-      needs: ['validate-pr-snapshot', 'attest-pr-snapshot', 'authorize-pr-snapshot'],
-      'runs-on': runsOn,
-      concurrency: {
-        group: 'pr-snapshot-${{ needs.validate-pr-snapshot.outputs.head-sha }}',
-        'cancel-in-progress': false,
-      },
-      permissions: {
-        actions: 'read',
-        contents: 'read',
-        'id-token': 'write',
-        'pull-requests': 'read',
-      },
-      env: {
-        ARTIFACT_DIR: '${{ github.workspace }}/tmp/validated-pr-snapshot',
-        CACHIX_AUTH_TOKEN: '',
-        GH_TOKEN: '${{ github.token }}',
-        PUBLISH_LIST: '${{ github.workspace }}/tmp/validated-pr-snapshot/trusted-publish-list.tsv',
-      },
-      defaults: bashShellDefaults,
-      steps: [
-        {
-          name: 'Use pinned npm trusted-publishing client',
-          uses: 'actions/setup-node@v4',
-          with: {
-            'node-version': '24.15.0',
           },
+        ],
+      },
+      'publish-pr-snapshot': {
+        if: "needs.authorize-pr-snapshot.outputs.authorized == 'true'",
+        needs: ['validate-pr-snapshot', 'attest-pr-snapshot', 'authorize-pr-snapshot'],
+        'runs-on': runsOn,
+        concurrency: {
+          group: 'pr-snapshot-${{ needs.validate-pr-snapshot.outputs.head-sha }}',
+          'cancel-in-progress': false,
         },
-        {
-          name: 'Download validated promotion artifact',
-          uses: 'actions/download-artifact@v4',
-          with: {
-            name: 'promotion-pr-snapshot-${{ needs.validate-pr-snapshot.outputs.head-sha }}-${{ needs.validate-pr-snapshot.outputs.run-id }}-${{ needs.attest-pr-snapshot.outputs.promotion-attempt }}',
-            path: '${{ github.workspace }}/tmp/validated-pr-snapshot',
-          },
+        permissions: {
+          actions: 'read',
+          contents: 'read',
+          'id-token': 'write',
+          'pull-requests': 'read',
         },
-        {
-          name: 'Recheck current-head authorization before OIDC publication',
-          env: {
-            EXPECTED_HEAD_SHA: '${{ needs.validate-pr-snapshot.outputs.head-sha }}',
-            PR_NUMBER: '${{ needs.validate-pr-snapshot.outputs.pr-number }}',
+        env: {
+          ARTIFACT_DIR: '${{ github.workspace }}/tmp/validated-pr-snapshot',
+          CACHIX_AUTH_TOKEN: '',
+          GH_TOKEN: '${{ github.token }}',
+          PUBLISH_LIST:
+            '${{ github.workspace }}/tmp/validated-pr-snapshot/trusted-publish-list.tsv',
+        },
+        defaults: bashShellDefaults,
+        steps: [
+          {
+            name: 'Use pinned npm trusted-publishing client',
+            uses: 'actions/setup-node@v4',
+            with: {
+              'node-version': '24.15.0',
+            },
           },
-          run: `set -euo pipefail
+          {
+            name: 'Download validated promotion artifact',
+            uses: 'actions/download-artifact@v4',
+            with: {
+              name: 'promotion-pr-snapshot-${{ needs.validate-pr-snapshot.outputs.head-sha }}-${{ needs.validate-pr-snapshot.outputs.run-id }}-${{ needs.attest-pr-snapshot.outputs.promotion-attempt }}',
+              path: '${{ github.workspace }}/tmp/validated-pr-snapshot',
+            },
+          },
+          {
+            name: 'Recheck current-head authorization before OIDC publication',
+            env: {
+              EXPECTED_HEAD_SHA: '${{ needs.validate-pr-snapshot.outputs.head-sha }}',
+              PR_NUMBER: '${{ needs.validate-pr-snapshot.outputs.pr-number }}',
+            },
+            run: `set -euo pipefail
 pr_json=$(gh api "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")
 test "$(jq -r '.state' <<<"$pr_json")" = open
 test "$(jq -r '.draft' <<<"$pr_json")" = false
@@ -634,11 +638,13 @@ if [ "$head_repository" = "$GITHUB_REPOSITORY" ]; then
 else
   jq -e 'any(.labels[]?; .name == "${trustLabel}")' <<<"$pr_json" >/dev/null
 fi`,
-        },
-        {
-          name: 'Verify promotion handoff',
-          env: { EXPECTED_MANIFEST_DIGEST: '${{ needs.validate-pr-snapshot.outputs.manifest-digest }}' },
-          run: `set -euo pipefail
+          },
+          {
+            name: 'Verify promotion handoff',
+            env: {
+              EXPECTED_MANIFEST_DIGEST: '${{ needs.validate-pr-snapshot.outputs.manifest-digest }}',
+            },
+            run: `set -euo pipefail
 test -f "$ARTIFACT_DIR/manifest.json"
 test -f "$PUBLISH_LIST"
 actual_manifest_digest=$(sha256sum "$ARTIFACT_DIR/manifest.json" | cut -d' ' -f1)
@@ -655,14 +661,14 @@ if [ -n "\${NODE_AUTH_TOKEN:-}" ] || [ -n "\${NPM_TOKEN:-}" ]; then
   echo "PR snapshot publishing must use npm trusted publishing; token auth is not allowed." >&2
   exit 1
 fi`,
-        },
-        {
-          name: 'Publish exact-SHA package cohort',
-          env: {
-            SNAPSHOT_TAG: '${{ needs.validate-pr-snapshot.outputs.npm-tag }}',
-            SNAPSHOT_VERSION: '${{ needs.validate-pr-snapshot.outputs.version }}',
           },
-          run: `set -euo pipefail
+          {
+            name: 'Publish exact-SHA package cohort',
+            env: {
+              SNAPSHOT_TAG: '${{ needs.validate-pr-snapshot.outputs.npm-tag }}',
+              SNAPSHOT_VERSION: '${{ needs.validate-pr-snapshot.outputs.version }}',
+            },
+            run: `set -euo pipefail
 while IFS=$'\t' read -r package_name file; do
   test -n "$package_name"
   test -n "$file"
@@ -687,14 +693,14 @@ while IFS=$'\t' read -r package_name file; do
   fi
   npm publish "$tarball" --registry=https://registry.npmjs.org --tag="$SNAPSHOT_TAG" --access=public --ignore-scripts --provenance
 done < "$PUBLISH_LIST"`,
-        },
-        {
-          name: 'Verify complete immutable registry cohort',
-          env: {
-            SNAPSHOT_TAG: '${{ needs.validate-pr-snapshot.outputs.npm-tag }}',
-            SNAPSHOT_VERSION: '${{ needs.validate-pr-snapshot.outputs.version }}',
           },
-          run: `set -euo pipefail
+          {
+            name: 'Verify complete immutable registry cohort',
+            env: {
+              SNAPSHOT_TAG: '${{ needs.validate-pr-snapshot.outputs.npm-tag }}',
+              SNAPSHOT_VERSION: '${{ needs.validate-pr-snapshot.outputs.version }}',
+            },
+            run: `set -euo pipefail
 verified=0
 while IFS=$'\t' read -r package_name file; do
   tarball="$ARTIFACT_DIR/$file"
@@ -723,18 +729,18 @@ while IFS=$'\t' read -r package_name file; do
 done < "$PUBLISH_LIST"
 test "$verified" = '\${{ needs.validate-pr-snapshot.outputs.package-count }}'
 echo "Verified $verified immutable package versions and SHA-512 integrities; tag bindings are present or absent, never conflicting." >> "$GITHUB_STEP_SUMMARY"`,
-        },
-        {
-          name: 'Write trusted verification receipt',
-          env: {
-            HEAD_SHA: '${{ needs.validate-pr-snapshot.outputs.head-sha }}',
-            MANIFEST_DIGEST: '${{ needs.validate-pr-snapshot.outputs.manifest-digest }}',
-            PR_NUMBER: '${{ needs.validate-pr-snapshot.outputs.pr-number }}',
-            SNAPSHOT_VERSION: '${{ needs.validate-pr-snapshot.outputs.version }}',
-            SOURCE_RUN_ATTEMPT: '${{ needs.validate-pr-snapshot.outputs.run-attempt }}',
-            SOURCE_RUN_ID: '${{ needs.validate-pr-snapshot.outputs.run-id }}',
           },
-          run: `jq -n \
+          {
+            name: 'Write trusted verification receipt',
+            env: {
+              HEAD_SHA: '${{ needs.validate-pr-snapshot.outputs.head-sha }}',
+              MANIFEST_DIGEST: '${{ needs.validate-pr-snapshot.outputs.manifest-digest }}',
+              PR_NUMBER: '${{ needs.validate-pr-snapshot.outputs.pr-number }}',
+              SNAPSHOT_VERSION: '${{ needs.validate-pr-snapshot.outputs.version }}',
+              SOURCE_RUN_ATTEMPT: '${{ needs.validate-pr-snapshot.outputs.run-attempt }}',
+              SOURCE_RUN_ID: '${{ needs.validate-pr-snapshot.outputs.run-id }}',
+            },
+            run: `jq -n \
   --arg repository "$GITHUB_REPOSITORY" \
   --argjson prNumber "$PR_NUMBER" \
   --arg headSha "$HEAD_SHA" \
@@ -744,29 +750,29 @@ echo "Verified $verified immutable package versions and SHA-512 integrities; tag
   --arg manifestSha256 "$MANIFEST_DIGEST" \
   '{repository, prNumber, headSha, sourceRunId, sourceRunAttempt, version, manifestSha256}' \
   > "$RUNNER_TEMP/verified-pr-snapshot.json"`,
-        },
-        {
-          name: 'Upload trusted verification receipt',
-          uses: 'actions/upload-artifact@v4',
-          with: {
-            name: 'verified-pr-snapshot-${{ needs.validate-pr-snapshot.outputs.head-sha }}-${{ needs.validate-pr-snapshot.outputs.run-id }}-${{ needs.validate-pr-snapshot.outputs.run-attempt }}',
-            path: '${{ runner.temp }}/verified-pr-snapshot.json',
-            'if-no-files-found': 'error',
-            overwrite: true,
-            'retention-days': 30,
           },
-        },
-        {
-          name: 'Record snapshot provenance',
-          env: {
-            SNAPSHOT_VERSION: '${{ needs.validate-pr-snapshot.outputs.version }}',
-            MANIFEST_DIGEST: '${{ needs.validate-pr-snapshot.outputs.manifest-digest }}',
-            PACKAGE_COUNT: '${{ needs.validate-pr-snapshot.outputs.package-count }}',
-            PR_NUMBER: '${{ needs.validate-pr-snapshot.outputs.pr-number }}',
-            SNAPSHOT_TAG: '${{ needs.validate-pr-snapshot.outputs.npm-tag }}',
-            SOURCE_RUN_URL: '${{ needs.validate-pr-snapshot.outputs.source-run-url }}',
+          {
+            name: 'Upload trusted verification receipt',
+            uses: 'actions/upload-artifact@v4',
+            with: {
+              name: 'verified-pr-snapshot-${{ needs.validate-pr-snapshot.outputs.head-sha }}-${{ needs.validate-pr-snapshot.outputs.run-id }}-${{ needs.validate-pr-snapshot.outputs.run-attempt }}',
+              path: '${{ runner.temp }}/verified-pr-snapshot.json',
+              'if-no-files-found': 'error',
+              overwrite: true,
+              'retention-days': 30,
+            },
           },
-          run: `cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          {
+            name: 'Record snapshot provenance',
+            env: {
+              SNAPSHOT_VERSION: '${{ needs.validate-pr-snapshot.outputs.version }}',
+              MANIFEST_DIGEST: '${{ needs.validate-pr-snapshot.outputs.manifest-digest }}',
+              PACKAGE_COUNT: '${{ needs.validate-pr-snapshot.outputs.package-count }}',
+              PR_NUMBER: '${{ needs.validate-pr-snapshot.outputs.pr-number }}',
+              SNAPSHOT_TAG: '${{ needs.validate-pr-snapshot.outputs.npm-tag }}',
+              SOURCE_RUN_URL: '${{ needs.validate-pr-snapshot.outputs.source-run-url }}',
+            },
+            run: `cat >> "$GITHUB_STEP_SUMMARY" <<EOF
 ## PR snapshot
 
 - PR: #$PR_NUMBER
@@ -779,9 +785,9 @@ echo "Verified $verified immutable package versions and SHA-512 integrities; tag
 - Candidate attestation: binds the validated package and manifest digests to the exact PR head and source CI run.
 - npm provenance: identifies this trusted default-branch promotion workflow; it does not claim that the PR CI job held npm publishing authority.
 EOF`,
-        },
-      ],
-    },
+          },
+        ],
+      },
     },
     /** Spread into `on.workflow_dispatch.inputs`. */
     dispatchInputs: {

--- a/genie/ci-workflow/pr-snapshot.ts
+++ b/genie/ci-workflow/pr-snapshot.ts
@@ -1,0 +1,818 @@
+/**
+ * Label-gated PR snapshot publishing.
+ *
+ * Publishes an immutable npm snapshot of a pull request's package cohort without granting the PR's
+ * author any credential. The shape is a privilege split, and the job boundaries below are the split:
+ *
+ * - `prSnapshotPackJob` runs in the PR's own (possibly forked) context with no secrets and a read-only
+ *   token. It builds and packs the cohort and uploads it as an artifact. Everything it produces is
+ *   untrusted data.
+ * - `prSnapshotReleaseJobs` run on the default branch. They re-resolve the PR by exact repository,
+ *   branch and head SHA, validate every tarball without executing it, attest the validated digests,
+ *   check authorization, and only then publish through npm trusted publishing.
+ *
+ * Authorization differs by provenance: a repository-owned PR needs a review of the current head, while
+ * a fork PR is trusted through a maintainer-applied label. The label is a revocable grant over the PR
+ * head repository and branch rather than a one-shot approval of a single SHA, so removing it stops any
+ * publication that has not started — but cannot retract a version already on the registry.
+ *
+ * The literals threaded through here are load-bearing in ways that are easy to miss:
+ * `packJobId` is both a job key in the CI workflow and a `jq` name match inside the release jobs, and
+ * the version/tag scheme is duplicated between these workflows and the validator script. A mismatch in
+ * either does not fail loudly; it silently finds nothing.
+ */
+
+import type { GitHubWorkflowArgs } from '../../packages/@overeng/genie/src/runtime/github-workflow/mod.ts'
+import { bashShellDefaults, runDevenvTasksBefore } from './shared.ts'
+
+type WorkflowJob = GitHubWorkflowArgs['jobs'][string]
+type WorkflowStep = WorkflowJob['steps'][number]
+
+/** Values that must agree between the pack job and the release jobs. */
+export type PrSnapshotSharedOptions = {
+  /** Repo-relative path to the trusted release topology JSON. */
+  readonly topologyPath: string
+  /** Repo-relative path to the emitted `pr-snapshot-artifact.mjs`. */
+  readonly validatorScriptPath: string
+  /**
+   * Job id of the pack job. Also matched by name from the release jobs, so this single value has to
+   * feed both workflows.
+   */
+  readonly packJobId?: string
+}
+
+export type PrSnapshotPackJobOptions = PrSnapshotSharedOptions & {
+  /** Setup steps run after the pinned-SHA checkout. */
+  readonly setupStepsAfterCheckout: readonly WorkflowStep[]
+  /** Devenv task packing tarballs into `$SNAPSHOT_OUT_DIR`. */
+  readonly packTask: string
+  /** Repo-relative path to the validator's own boundary suite. */
+  readonly validatorTestPath: string
+  /** Runner for the untrusted pack job. */
+  readonly runsOn?: WorkflowJob['runs-on']
+}
+
+export type PrSnapshotReleaseJobsOptions = PrSnapshotSharedOptions & {
+  /** in-toto predicate type URI for the candidate attestation. */
+  readonly attestationPredicateType: string
+  /** Label granting fork PRs snapshot-publishing trust. */
+  readonly trustLabel?: string
+  /** Runner for the trusted jobs. These do no repo build, so the default suits every consumer. */
+  readonly runsOn?: WorkflowJob['runs-on']
+}
+
+/**
+ * The untrusted producer. Runs fork-authored code, so it must hold no secrets and no write token; the
+ * release jobs treat everything it uploads as untrusted input.
+ */
+export const prSnapshotPackJob = (opts: PrSnapshotPackJobOptions) => {
+  const {
+    topologyPath,
+    validatorScriptPath,
+    validatorTestPath,
+    setupStepsAfterCheckout,
+    packTask,
+    packJobId = 'pack-pr-snapshot',
+    runsOn = 'ubuntu-24.04',
+  } = opts
+  return {
+    [packJobId]: {
+      // Fork candidates are untrusted data: this job has no secrets or write
+      // token, and the main-branch release workflow validates every tarball.
+      if: "github.event_name == 'pull_request'",
+      'runs-on': runsOn,
+      permissions: { contents: 'read' },
+      env: {
+        CACHIX_AUTH_TOKEN: '',
+        SNAPSHOT_OUT_DIR: '${{ github.workspace }}/tmp/pr-snapshot-artifact',
+      },
+      defaults: bashShellDefaults,
+      steps: [
+        {
+          name: 'Checkout exact PR head',
+          uses: 'actions/checkout@v4',
+          with: {
+            ref: '${{ github.event.pull_request.head.sha }}',
+            'persist-credentials': false,
+          },
+        },
+        ...setupStepsAfterCheckout,
+        {
+          name: 'Test snapshot artifact boundary',
+          run: `node --test ${validatorTestPath}`,
+        },
+        {
+          name: 'Pack exact-SHA snapshot',
+          run: runDevenvTasksBefore(packTask),
+          env: {
+            GIT_SHA: '${{ github.event.pull_request.head.sha }}',
+            PR_NUMBER: '${{ github.event.pull_request.number }}',
+          },
+        },
+        {
+          name: 'Create snapshot manifest',
+          run: `node ${validatorScriptPath} create \\
+  --artifact-dir="$SNAPSHOT_OUT_DIR" \\
+  --topology=${topologyPath} \\
+  --repository="$GITHUB_REPOSITORY" \\
+  --pr-number="\${{ github.event.pull_request.number }}" \\
+  --head-sha="\${{ github.event.pull_request.head.sha }}" \\
+  --run-id="$GITHUB_RUN_ID" \\
+  --run-attempt="$GITHUB_RUN_ATTEMPT"`,
+        },
+        {
+          name: 'Upload immutable PR snapshot candidate',
+          uses: 'actions/upload-artifact@v4',
+          with: {
+            name: 'pr-snapshot-${{ github.event.pull_request.head.sha }}-${{ github.run_attempt }}',
+            path: '${{ github.workspace }}/tmp/pr-snapshot-artifact/',
+            'if-no-files-found': 'error',
+            'retention-days': 7,
+          },
+        },
+      ],
+    },
+  }
+}
+
+/** The trusted consumer half, plus the workflow-level trigger fragments these jobs require. */
+export const prSnapshotReleaseJobs = (opts: PrSnapshotReleaseJobsOptions) => {
+  const {
+    topologyPath,
+    validatorScriptPath,
+    attestationPredicateType,
+    trustLabel = 'ci:publish-snapshot',
+    packJobId = 'pack-pr-snapshot',
+    runsOn = 'ubuntu-24.04',
+  } = opts
+  return {
+    jobs: {
+    'dispatch-authorized-pr-snapshots': {
+      if: "github.event_name == 'schedule'",
+      'runs-on': runsOn,
+      permissions: {
+        actions: 'write',
+        contents: 'read',
+        'pull-requests': 'read',
+      },
+      env: { GH_TOKEN: '${{ github.token }}' },
+      defaults: bashShellDefaults,
+      steps: [
+        {
+          name: 'Checkout trusted package topology',
+          uses: 'actions/checkout@v4',
+          with: {
+            ref: '${{ github.workflow_sha }}',
+            'persist-credentials': false,
+            'sparse-checkout': `${validatorScriptPath}
+${topologyPath}`,
+          },
+        },
+        {
+          name: 'Dispatch incomplete authorized cohorts to trusted main workflow',
+          run: `set -euo pipefail
+test "$GITHUB_WORKFLOW_REF" = "$GITHUB_REPOSITORY/.github/workflows/release.yml@refs/heads/main"
+prs_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/pulls?state=open&base=main&per_page=100" --slurp)
+release_workflow_id=$(gh api "/repos/$GITHUB_REPOSITORY/actions/workflows/release.yml" --jq .id)
+[[ "$release_workflow_id" =~ ^[1-9][0-9]*$ ]]
+scan_failed=false
+while IFS=$'\t' read -r pr_number head_sha head_repository head_ref fork_label_present; do
+  cohort_failed=false
+  verified_receipt=false
+  registry_state_file="$RUNNER_TEMP/registry-state-$pr_number.json"
+  printf '[]\n' > "$registry_state_file"
+
+  [[ "$pr_number" =~ ^[1-9][0-9]*$ ]]
+  [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]
+  test -n "$head_repository"
+  test -n "$head_ref"
+  if [ "$head_repository" = "$GITHUB_REPOSITORY" ]; then
+    review_json=$(gh api graphql \
+      -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewDecision}}}' \
+      -f owner="\${GITHUB_REPOSITORY%%/*}" \
+      -f name="\${GITHUB_REPOSITORY#*/}" \
+      -F number="$pr_number")
+    if [ "$(jq -r '.data.repository.pullRequest.reviewDecision // ""' <<<"$review_json")" != APPROVED ]; then
+      continue
+    fi
+  elif [ "$fork_label_present" != true ]; then
+    continue
+  fi
+
+  version="0.0.0-snapshot-pr.$pr_number.$head_sha"
+  snapshot_tag="pr-$pr_number-$head_sha"
+
+  selected_run_id=''
+  selected_pack_attempt=''
+  runs_json=$(gh api --paginate --method GET "/repos/$GITHUB_REPOSITORY/actions/workflows/ci.yml/runs" \
+    -f event=pull_request \
+    -f status=success \
+    -f branch="$head_ref" \
+    -F per_page=100 \
+    --slurp)
+  while IFS= read -r candidate_run_id; do
+    [[ "$candidate_run_id" =~ ^[1-9][0-9]*$ ]]
+    jobs_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/actions/runs/$candidate_run_id/jobs?filter=all&per_page=100" --slurp)
+    pack_job=$(jq -c '[.[] | .jobs[] | select(.name == "${packJobId}" and .conclusion == "success")] | sort_by(.run_attempt) | last' <<<"$jobs_json")
+    if [ "$pack_job" = null ]; then
+      continue
+    fi
+    pack_attempt=$(jq -r '.run_attempt' <<<"$pack_job")
+    [[ "$pack_attempt" =~ ^[1-9][0-9]*$ ]]
+    artifact_name="pr-snapshot-$head_sha-$pack_attempt"
+    artifacts_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/actions/runs/$candidate_run_id/artifacts?per_page=100" --slurp)
+    if ! jq -e --arg name "$artifact_name" 'any(.[] | .artifacts[]; .name == $name and .expired == false)' <<<"$artifacts_json" >/dev/null; then
+      continue
+    fi
+    selected_run_id="$candidate_run_id"
+    selected_pack_attempt="$pack_attempt"
+    break
+  done < <(jq -r --arg sha "$head_sha" --arg head_repository "$head_repository" --arg head_ref "$head_ref" \
+    '[.[] | .workflow_runs[] | select(.event == "pull_request" and .conclusion == "success" and .head_repository.full_name == $head_repository and .head_branch == $head_ref and .head_sha == $sha)] | sort_by(.created_at) | reverse | .[].id' \
+    <<<"$runs_json")
+  if [ -z "$selected_run_id" ]; then
+    echo "PR #$pr_number has no exact successful pack artifact yet; skipping"
+    continue
+  fi
+
+  receipt_name="verified-pr-snapshot-$head_sha-$selected_run_id-$selected_pack_attempt"
+  receipts_json=$(gh api --paginate --method GET "/repos/$GITHUB_REPOSITORY/actions/artifacts" \
+    -f name="$receipt_name" \
+    -F per_page=100 \
+    --slurp)
+  while IFS= read -r receipt_run_id; do
+    [[ "$receipt_run_id" =~ ^[1-9][0-9]*$ ]]
+    receipt_run=$(gh api "/repos/$GITHUB_REPOSITORY/actions/runs/$receipt_run_id")
+    if [ "$(jq -r .workflow_id <<<"$receipt_run")" = "$release_workflow_id" ] && \
+       [ "$(jq -r .event <<<"$receipt_run")" = workflow_dispatch ] && \
+       [ "$(jq -r .head_branch <<<"$receipt_run")" = main ] && \
+       [ "$(jq -r .conclusion <<<"$receipt_run")" = success ]; then
+      verified_receipt=true
+      break
+    fi
+  done < <(jq -r --arg name "$receipt_name" '.[] | .artifacts[]? | select(.name == $name and .expired == false) | .workflow_run.id' <<<"$receipts_json")
+
+  while IFS= read -r package_name; do
+    remote_version=$(npm view "$package_name@$version" version --json --registry=https://registry.npmjs.org 2>/dev/null | jq -r . || true)
+    remote_tag=$(npm view "$package_name" dist-tags --json --registry=https://registry.npmjs.org 2>/dev/null | jq -r --arg tag "$snapshot_tag" '.[$tag] // empty' || true)
+    jq --arg name "$package_name" --arg version "$remote_version" --arg tag "$remote_tag" \
+      '. + [{name: $name, version: $version, tag: $tag}]' "$registry_state_file" > "$registry_state_file.next"
+    mv "$registry_state_file.next" "$registry_state_file"
+  done < <(jq -r '.publishablePackageNames[]' ${topologyPath})
+
+  assessment=$(node ${validatorScriptPath} assess-registry \
+    --state-file="$registry_state_file" \
+    --version="$version" \
+    --verified-receipt="$verified_receipt")
+  action=$(jq -r .action <<<"$assessment")
+  if [ "$action" = conflict ]; then
+    package_name=$(jq -r .packageName <<<"$assessment")
+    conflicting_version=$(jq -r .conflictingVersion <<<"$assessment")
+    echo "::error::PR #$pr_number package $package_name tag $snapshot_tag points to unexpected version $conflicting_version"
+    cohort_failed=true
+  elif [ "$action" = complete ]; then
+    echo "PR #$pr_number snapshot cohort has a trusted verification receipt"
+    continue
+  elif [ "$action" != dispatch ]; then
+    echo "Unknown registry assessment action: $action" >&2
+    cohort_failed=true
+  fi
+
+  if [ "$cohort_failed" = true ]; then
+    scan_failed=true
+    continue
+  fi
+
+  gh workflow run release.yml --repo "$GITHUB_REPOSITORY" --ref main \
+    -f mode=promote-pr-snapshot \
+    -f npm_tag=latest \
+    -f pr_number="$pr_number" \
+    -f head_sha="$head_sha" \
+    -f ci_run_id="$selected_run_id"
+done < <(jq -r \
+  '.[][] | select(.draft == false and .base.ref == "main") | [.number, .head.sha, .head.repo.full_name, .head.ref, (any(.labels[]?; .name == "${trustLabel}") | tostring)] | @tsv' \
+  <<<"$prs_json")
+if [ "$scan_failed" = true ]; then
+  exit 1
+fi`,
+        },
+      ],
+    },
+    'validate-pr-snapshot': {
+      if: "(github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && inputs.mode == 'promote-pr-snapshot')",
+      'runs-on': runsOn,
+      permissions: {
+        actions: 'read',
+        contents: 'read',
+        'pull-requests': 'read',
+      },
+      outputs: {
+        'head-sha': '${{ steps.identity.outputs.head-sha }}',
+        'manifest-digest': '${{ steps.validate.outputs.manifest-digest }}',
+        'npm-tag': '${{ steps.validate.outputs.npm-tag }}',
+        'package-count': '${{ steps.validate.outputs.package-count }}',
+        'pr-number': '${{ steps.identity.outputs.pr-number }}',
+        'release-run-attempt': '${{ steps.validate.outputs.release-run-attempt }}',
+        'run-attempt': '${{ steps.identity.outputs.run-attempt }}',
+        'run-id': '${{ steps.identity.outputs.run-id }}',
+        'source-run-url': '${{ steps.identity.outputs.source-run-url }}',
+        'topology-digest': '${{ steps.validate.outputs.topology-digest }}',
+        version: '${{ steps.validate.outputs.version }}',
+      },
+      env: {
+        ARTIFACT_DIR: '${{ github.workspace }}/tmp/pr-snapshot-artifact',
+        CACHIX_AUTH_TOKEN: '',
+        GH_TOKEN: '${{ github.token }}',
+        PUBLISH_LIST: '${{ github.workspace }}/tmp/pr-snapshot-publish-list.tsv',
+      },
+      defaults: bashShellDefaults,
+      steps: [
+        {
+          id: 'identity',
+          name: 'Resolve exact successful CI run and current PR head',
+          run: `set -euo pipefail
+test "$GITHUB_WORKFLOW_REF" = "$GITHUB_REPOSITORY/.github/workflows/release.yml@refs/heads/main"
+[[ "$GITHUB_WORKFLOW_SHA" =~ ^[0-9a-f]{40}$ ]]
+if [ "$GITHUB_EVENT_NAME" = workflow_run ]; then
+  run_id='\${{ github.event.workflow_run.id }}'
+else
+  test "$GITHUB_EVENT_NAME" = workflow_dispatch
+  pr_number='\${{ inputs.pr_number }}'
+  head_sha='\${{ inputs.head_sha }}'
+  run_id='\${{ inputs.ci_run_id }}'
+fi
+
+[[ "$run_id" =~ ^[1-9][0-9]*$ ]]
+run_json=$(gh api "/repos/$GITHUB_REPOSITORY/actions/runs/$run_id")
+test "$(jq -r '.event' <<<"$run_json")" = pull_request
+test "$(jq -r '.status' <<<"$run_json")" = completed
+test "$(jq -r '.conclusion' <<<"$run_json")" = success
+test "$(jq -r '.path' <<<"$run_json")" = .github/workflows/ci.yml
+run_head_repository=$(jq -r '.head_repository.full_name' <<<"$run_json")
+run_head_branch=$(jq -r '.head_branch' <<<"$run_json")
+run_head_sha=$(jq -r '.head_sha' <<<"$run_json")
+test -n "$run_head_repository"
+test -n "$run_head_branch"
+[[ "$run_head_sha" =~ ^[0-9a-f]{40}$ ]]
+if [ "$GITHUB_EVENT_NAME" = workflow_run ]; then
+  prs_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/pulls?state=open&base=main&per_page=100" --slurp)
+  matching_prs=$(jq --arg head_repository "$run_head_repository" --arg head_branch "$run_head_branch" --arg head_sha "$run_head_sha" \
+    '[.[][] | select(.draft == false and .base.ref == "main" and .head.repo.full_name == $head_repository and .head.ref == $head_branch and .head.sha == $head_sha)]' \
+    <<<"$prs_json")
+  test "$(jq 'length' <<<"$matching_prs")" = 1
+  pr_number=$(jq -r '.[0].number' <<<"$matching_prs")
+  head_sha="$run_head_sha"
+else
+  test "$run_head_sha" = "$head_sha"
+fi
+[[ "$pr_number" =~ ^[1-9][0-9]*$ ]]
+[[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]
+source_run_url=$(jq -r '.html_url' <<<"$run_json")
+jobs_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/actions/runs/$run_id/jobs?filter=all&per_page=100" --slurp)
+pack_job=$(jq -c '[.[] | .jobs[] | select(.name == "${packJobId}" and .conclusion == "success")] | sort_by(.run_attempt) | last' <<<"$jobs_json")
+test "$pack_job" != null
+run_attempt=$(jq -r '.run_attempt' <<<"$pack_job")
+[[ "$run_attempt" =~ ^[1-9][0-9]*$ ]]
+pr_json=$(gh api "/repos/$GITHUB_REPOSITORY/pulls/$pr_number")
+
+test "$(jq -r '.state' <<<"$pr_json")" = open
+test "$(jq -r '.base.ref' <<<"$pr_json")" = main
+test "$(jq -r '.head.sha' <<<"$pr_json")" = "$head_sha"
+test "$(jq -r '.head.repo.full_name' <<<"$pr_json")" = "$run_head_repository"
+test "$(jq -r '.head.ref' <<<"$pr_json")" = "$run_head_branch"
+
+echo "head-sha=$head_sha" >> "$GITHUB_OUTPUT"
+echo "pr-number=$pr_number" >> "$GITHUB_OUTPUT"
+echo "run-id=$run_id" >> "$GITHUB_OUTPUT"
+echo "run-attempt=$run_attempt" >> "$GITHUB_OUTPUT"
+echo "source-run-url=$source_run_url" >> "$GITHUB_OUTPUT"`,
+        },
+        {
+          name: 'Checkout trusted validator only',
+          uses: 'actions/checkout@v4',
+          with: {
+            ref: '${{ github.workflow_sha }}',
+            'persist-credentials': false,
+            'sparse-checkout': `${validatorScriptPath}
+${topologyPath}`,
+          },
+        },
+        {
+          name: 'Use pinned Node validator runtime',
+          uses: 'actions/setup-node@v4',
+          with: {
+            'node-version': '24.15.0',
+          },
+        },
+        {
+          name: 'Download exact-run snapshot candidate',
+          uses: 'actions/download-artifact@v4',
+          with: {
+            name: 'pr-snapshot-${{ steps.identity.outputs.head-sha }}-${{ steps.identity.outputs.run-attempt }}',
+            path: '${{ github.workspace }}/tmp/pr-snapshot-artifact',
+            'github-token': '${{ github.token }}',
+            'run-id': '${{ steps.identity.outputs.run-id }}',
+          },
+        },
+        {
+          id: 'validate',
+          name: 'Validate immutable snapshot candidate',
+          env: {
+            EXPECTED_HEAD_SHA: '${{ steps.identity.outputs.head-sha }}',
+            EXPECTED_PR_NUMBER: '${{ steps.identity.outputs.pr-number }}',
+            EXPECTED_RUN_ID: '${{ steps.identity.outputs.run-id }}',
+            EXPECTED_RUN_ATTEMPT: '${{ steps.identity.outputs.run-attempt }}',
+          },
+          run: `set -euo pipefail
+result=$(node ${validatorScriptPath} validate \\
+  --artifact-dir="$ARTIFACT_DIR" \\
+  --topology=${topologyPath} \\
+  --repository="$GITHUB_REPOSITORY" \\
+  --pr-number="$EXPECTED_PR_NUMBER" \\
+  --head-sha="$EXPECTED_HEAD_SHA" \\
+  --run-id="$EXPECTED_RUN_ID" \\
+  --run-attempt="$EXPECTED_RUN_ATTEMPT" \\
+  --publish-list="$PUBLISH_LIST")
+echo "version=$(jq -r '.version' <<<"$result")" >> "$GITHUB_OUTPUT"
+echo "manifest-digest=$(jq -r '.manifestDigest' <<<"$result")" >> "$GITHUB_OUTPUT"
+echo "topology-digest=$(jq -r '.topologyDigest' <<<"$result")" >> "$GITHUB_OUTPUT"
+echo "npm-tag=$(jq -r '.npmTag' <<<"$result")" >> "$GITHUB_OUTPUT"
+echo "package-count=$(jq -r '.packageCount' <<<"$result")" >> "$GITHUB_OUTPUT"
+echo "release-run-attempt=$GITHUB_RUN_ATTEMPT" >> "$GITHUB_OUTPUT"
+cp "$PUBLISH_LIST" "$ARTIFACT_DIR/trusted-publish-list.tsv"`,
+        },
+        {
+          name: 'Upload validated snapshot candidate',
+          uses: 'actions/upload-artifact@v4',
+          with: {
+            name: 'validated-pr-snapshot-${{ steps.identity.outputs.head-sha }}-${{ steps.identity.outputs.run-id }}-${{ steps.validate.outputs.release-run-attempt }}',
+            path: '${{ github.workspace }}/tmp/pr-snapshot-artifact/',
+            'if-no-files-found': 'error',
+            'retention-days': 1,
+          },
+        },
+      ],
+    },
+    'attest-pr-snapshot': {
+      needs: ['validate-pr-snapshot'],
+      'runs-on': runsOn,
+      permissions: {
+        actions: 'read',
+        attestations: 'write',
+        'artifact-metadata': 'write',
+        contents: 'read',
+        'id-token': 'write',
+      },
+      env: {
+        ARTIFACT_DIR: '${{ github.workspace }}/tmp/validated-pr-snapshot',
+        CACHIX_AUTH_TOKEN: '',
+      },
+      defaults: bashShellDefaults,
+      outputs: { 'promotion-attempt': '${{ steps.handoff.outputs.promotion-attempt }}' },
+      steps: [
+        {
+          name: 'Download validated snapshot candidate',
+          uses: 'actions/download-artifact@v4',
+          with: {
+            name: 'validated-pr-snapshot-${{ needs.validate-pr-snapshot.outputs.head-sha }}-${{ needs.validate-pr-snapshot.outputs.run-id }}-${{ needs.validate-pr-snapshot.outputs.release-run-attempt }}',
+            path: '${{ github.workspace }}/tmp/validated-pr-snapshot',
+          },
+        },
+        {
+          id: 'handoff',
+          name: 'Verify validated artifact identity and write predicate',
+          env: {
+            HEAD_SHA: '${{ needs.validate-pr-snapshot.outputs.head-sha }}',
+            MANIFEST_DIGEST: '${{ needs.validate-pr-snapshot.outputs.manifest-digest }}',
+            PR_NUMBER: '${{ needs.validate-pr-snapshot.outputs.pr-number }}',
+            SOURCE_RUN_ATTEMPT: '${{ needs.validate-pr-snapshot.outputs.run-attempt }}',
+            SOURCE_RUN_ID: '${{ needs.validate-pr-snapshot.outputs.run-id }}',
+            TOPOLOGY_DIGEST: '${{ needs.validate-pr-snapshot.outputs.topology-digest }}',
+          },
+          run: `set -euo pipefail
+test "$(sha256sum "$ARTIFACT_DIR/manifest.json" | cut -d' ' -f1)" = "$MANIFEST_DIGEST"
+echo "promotion-attempt=$GITHUB_RUN_ATTEMPT" >> "$GITHUB_OUTPUT"
+jq -n \
+  --arg repository "$GITHUB_REPOSITORY" \
+  --argjson prNumber "$PR_NUMBER" \
+  --arg headSha "$HEAD_SHA" \
+  --argjson sourceRunId "$SOURCE_RUN_ID" \
+  --argjson sourceRunAttempt "$SOURCE_RUN_ATTEMPT" \
+  --arg manifestSha256 "$MANIFEST_DIGEST" \
+  --arg topologySha256 "$TOPOLOGY_DIGEST" \
+  '{repository, prNumber, headSha, sourceRunId, sourceRunAttempt, manifestSha256, topologySha256}' \
+  > "$RUNNER_TEMP/pr-snapshot-attestation.json"`,
+        },
+        {
+          name: 'Attest validated snapshot candidate',
+          uses: 'actions/attest@v4',
+          with: {
+            'subject-path': ['${{ env.ARTIFACT_DIR }}/*.tgz', '${{ env.ARTIFACT_DIR }}/manifest.json'].join('\n'),
+            'predicate-type': attestationPredicateType,
+            'predicate-path': '${{ runner.temp }}/pr-snapshot-attestation.json',
+          },
+        },
+        {
+          name: 'Upload attested promotion artifact',
+          uses: 'actions/upload-artifact@v4',
+          with: {
+            name: 'promotion-pr-snapshot-${{ needs.validate-pr-snapshot.outputs.head-sha }}-${{ needs.validate-pr-snapshot.outputs.run-id }}-${{ steps.handoff.outputs.promotion-attempt }}',
+            path: '${{ github.workspace }}/tmp/validated-pr-snapshot/',
+            'if-no-files-found': 'error',
+            'retention-days': 1,
+          },
+        },
+      ],
+    },
+    'authorize-pr-snapshot': {
+      needs: ['validate-pr-snapshot'],
+      'runs-on': runsOn,
+      permissions: { contents: 'read', 'pull-requests': 'read' },
+      outputs: { authorized: '${{ steps.approval.outputs.authorized }}' },
+      defaults: bashShellDefaults,
+      steps: [
+        {
+          id: 'approval',
+          name: 'Require current-head review or fork trust label',
+          env: {
+            EXPECTED_HEAD_SHA: '${{ needs.validate-pr-snapshot.outputs.head-sha }}',
+            GH_TOKEN: '${{ github.token }}',
+            PR_NUMBER: '${{ needs.validate-pr-snapshot.outputs.pr-number }}',
+          },
+          run: `set -euo pipefail
+pr_json=$(gh api "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")
+authorized=false
+authorized_by='none'
+if [ "$(jq -r '.state' <<<"$pr_json")" = open ] && \
+   [ "$(jq -r '.draft' <<<"$pr_json")" = false ] && \
+   [ "$(jq -r '.base.ref' <<<"$pr_json")" = main ] && \
+   [ "$(jq -r '.head.sha' <<<"$pr_json")" = "$EXPECTED_HEAD_SHA" ]; then
+  head_repository=$(jq -r '.head.repo.full_name' <<<"$pr_json")
+  if [ "$head_repository" = "$GITHUB_REPOSITORY" ]; then
+    reviews_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews?per_page=100" --slurp | jq -s 'flatten')
+    owner="\${GITHUB_REPOSITORY%%/*}"
+    name="\${GITHUB_REPOSITORY#*/}"
+    review_decision=$(gh api graphql \
+      -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewDecision}}}' \
+      -f owner="$owner" -f name="$name" -F number="$PR_NUMBER" \
+      --jq '.data.repository.pullRequest.reviewDecision')
+    if [ "$review_decision" = APPROVED ] && \
+       jq -e --arg sha "$EXPECTED_HEAD_SHA" 'any(.[]; .state == "APPROVED" and .commit_id == $sha)' <<<"$reviews_json" >/dev/null; then
+      authorized=true
+      authorized_by='current-head review'
+    fi
+  elif jq -e 'any(.labels[]?; .name == "${trustLabel}")' <<<"$pr_json" >/dev/null; then
+    authorized=true
+    authorized_by='${trustLabel} fork trust label'
+  fi
+fi
+echo "authorized=$authorized" >> "$GITHUB_OUTPUT"
+echo "Snapshot promotion authorized: $authorized ($authorized_by)" >> "$GITHUB_STEP_SUMMARY"`,
+        },
+      ],
+    },
+    'publish-pr-snapshot': {
+      if: "needs.authorize-pr-snapshot.outputs.authorized == 'true'",
+      needs: ['validate-pr-snapshot', 'attest-pr-snapshot', 'authorize-pr-snapshot'],
+      'runs-on': runsOn,
+      concurrency: {
+        group: 'pr-snapshot-${{ needs.validate-pr-snapshot.outputs.head-sha }}',
+        'cancel-in-progress': false,
+      },
+      permissions: {
+        actions: 'read',
+        contents: 'read',
+        'id-token': 'write',
+        'pull-requests': 'read',
+      },
+      env: {
+        ARTIFACT_DIR: '${{ github.workspace }}/tmp/validated-pr-snapshot',
+        CACHIX_AUTH_TOKEN: '',
+        GH_TOKEN: '${{ github.token }}',
+        PUBLISH_LIST: '${{ github.workspace }}/tmp/validated-pr-snapshot/trusted-publish-list.tsv',
+      },
+      defaults: bashShellDefaults,
+      steps: [
+        {
+          name: 'Use pinned npm trusted-publishing client',
+          uses: 'actions/setup-node@v4',
+          with: {
+            'node-version': '24.15.0',
+          },
+        },
+        {
+          name: 'Download validated promotion artifact',
+          uses: 'actions/download-artifact@v4',
+          with: {
+            name: 'promotion-pr-snapshot-${{ needs.validate-pr-snapshot.outputs.head-sha }}-${{ needs.validate-pr-snapshot.outputs.run-id }}-${{ needs.attest-pr-snapshot.outputs.promotion-attempt }}',
+            path: '${{ github.workspace }}/tmp/validated-pr-snapshot',
+          },
+        },
+        {
+          name: 'Recheck current-head authorization before OIDC publication',
+          env: {
+            EXPECTED_HEAD_SHA: '${{ needs.validate-pr-snapshot.outputs.head-sha }}',
+            PR_NUMBER: '${{ needs.validate-pr-snapshot.outputs.pr-number }}',
+          },
+          run: `set -euo pipefail
+pr_json=$(gh api "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")
+test "$(jq -r '.state' <<<"$pr_json")" = open
+test "$(jq -r '.draft' <<<"$pr_json")" = false
+test "$(jq -r '.base.ref' <<<"$pr_json")" = main
+test "$(jq -r '.head.sha' <<<"$pr_json")" = "$EXPECTED_HEAD_SHA"
+head_repository=$(jq -r '.head.repo.full_name' <<<"$pr_json")
+if [ "$head_repository" = "$GITHUB_REPOSITORY" ]; then
+  reviews_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews?per_page=100" --slurp | jq -s 'flatten')
+  owner="\${GITHUB_REPOSITORY%%/*}"
+  name="\${GITHUB_REPOSITORY#*/}"
+  review_decision=$(gh api graphql \
+    -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewDecision}}}' \
+    -f owner="$owner" -f name="$name" -F number="$PR_NUMBER" \
+    --jq '.data.repository.pullRequest.reviewDecision')
+  test "$review_decision" = APPROVED
+  jq -e --arg sha "$EXPECTED_HEAD_SHA" 'any(.[]; .state == "APPROVED" and .commit_id == $sha)' <<<"$reviews_json" >/dev/null
+else
+  jq -e 'any(.labels[]?; .name == "${trustLabel}")' <<<"$pr_json" >/dev/null
+fi`,
+        },
+        {
+          name: 'Verify promotion handoff',
+          env: { EXPECTED_MANIFEST_DIGEST: '${{ needs.validate-pr-snapshot.outputs.manifest-digest }}' },
+          run: `set -euo pipefail
+test -f "$ARTIFACT_DIR/manifest.json"
+test -f "$PUBLISH_LIST"
+actual_manifest_digest=$(sha256sum "$ARTIFACT_DIR/manifest.json" | cut -d' ' -f1)
+test "$actual_manifest_digest" = "$EXPECTED_MANIFEST_DIGEST"
+jq -r '.packages[] | [.name, .file] | @tsv' "$ARTIFACT_DIR/manifest.json" > "$RUNNER_TEMP/expected-publish-list.tsv"
+cmp "$RUNNER_TEMP/expected-publish-list.tsv" "$PUBLISH_LIST"
+jq -r '.packages[] | [.file, .sha256] | @tsv' "$ARTIFACT_DIR/manifest.json" |
+  while IFS=$'\t' read -r file expected_sha256; do
+    [[ "$file" =~ ^[a-zA-Z0-9._-]+[.]tgz$ ]]
+    actual_sha256=$(sha256sum "$ARTIFACT_DIR/$file" | cut -d' ' -f1)
+    test "$actual_sha256" = "$expected_sha256"
+  done
+if [ -n "\${NODE_AUTH_TOKEN:-}" ] || [ -n "\${NPM_TOKEN:-}" ]; then
+  echo "PR snapshot publishing must use npm trusted publishing; token auth is not allowed." >&2
+  exit 1
+fi`,
+        },
+        {
+          name: 'Publish exact-SHA package cohort',
+          env: {
+            SNAPSHOT_TAG: '${{ needs.validate-pr-snapshot.outputs.npm-tag }}',
+            SNAPSHOT_VERSION: '${{ needs.validate-pr-snapshot.outputs.version }}',
+          },
+          run: `set -euo pipefail
+while IFS=$'\t' read -r package_name file; do
+  test -n "$package_name"
+  test -n "$file"
+  tarball="$ARTIFACT_DIR/$file"
+  local_sha1=$(sha1sum "$tarball" | cut -d' ' -f1)
+  if remote_sha1=$(npm view "$package_name@$SNAPSHOT_VERSION" dist.shasum --json --registry=https://registry.npmjs.org 2>/dev/null); then
+    remote_sha1=$(jq -r . <<<"$remote_sha1")
+    if [ "$remote_sha1" != "$local_sha1" ]; then
+      echo "$package_name@$SNAPSHOT_VERSION already exists with a different tarball digest" >&2
+      exit 1
+    fi
+    remote_tag=$(npm view "$package_name" dist-tags --json --registry=https://registry.npmjs.org 2>/dev/null | jq -r --arg tag "$SNAPSHOT_TAG" '.[$tag] // empty' || true)
+    if [ -n "$remote_tag" ] && [ "$remote_tag" != "$SNAPSHOT_VERSION" ]; then
+      echo "$package_name tag $SNAPSHOT_TAG points to unexpected version $remote_tag" >&2
+      exit 1
+    fi
+    if [ -z "$remote_tag" ]; then
+      echo "::warning::$package_name@$SNAPSHOT_VERSION matches the candidate but mutable tag $SNAPSHOT_TAG is absent; OIDC publishing cannot repair dist-tags"
+    fi
+    echo "$package_name@$SNAPSHOT_VERSION already matches candidate; skipping"
+    continue
+  fi
+  npm publish "$tarball" --registry=https://registry.npmjs.org --tag="$SNAPSHOT_TAG" --access=public --ignore-scripts --provenance
+done < "$PUBLISH_LIST"`,
+        },
+        {
+          name: 'Verify complete immutable registry cohort',
+          env: {
+            SNAPSHOT_TAG: '${{ needs.validate-pr-snapshot.outputs.npm-tag }}',
+            SNAPSHOT_VERSION: '${{ needs.validate-pr-snapshot.outputs.version }}',
+          },
+          run: `set -euo pipefail
+verified=0
+while IFS=$'\t' read -r package_name file; do
+  tarball="$ARTIFACT_DIR/$file"
+  local_integrity="sha512-$(openssl dgst -sha512 -binary "$tarball" | base64 -w0)"
+  matched=false
+  for attempt in $(seq 1 12); do
+    remote_version=$(npm view "$package_name@$SNAPSHOT_VERSION" version --json --registry=https://registry.npmjs.org 2>/dev/null | jq -r . || true)
+    remote_integrity=$(npm view "$package_name@$SNAPSHOT_VERSION" dist.integrity --json --registry=https://registry.npmjs.org 2>/dev/null | jq -r . || true)
+    remote_tag=$(npm view "$package_name" dist-tags --json --registry=https://registry.npmjs.org 2>/dev/null | jq -r --arg tag "$SNAPSHOT_TAG" '.[$tag] // empty' || true)
+    if [ -n "$remote_tag" ] && [ "$remote_tag" != "$SNAPSHOT_VERSION" ]; then
+      echo "$package_name tag $SNAPSHOT_TAG points to unexpected version $remote_tag" >&2
+      exit 1
+    fi
+    if [ "$remote_version" = "$SNAPSHOT_VERSION" ] && \
+       [ "$remote_integrity" = "$local_integrity" ]; then
+      matched=true
+      break
+    fi
+    sleep 5
+  done
+  if [ "$matched" != true ]; then
+    echo "Registry verification failed for $package_name@$SNAPSHOT_VERSION" >&2
+    exit 1
+  fi
+  verified=$((verified + 1))
+done < "$PUBLISH_LIST"
+test "$verified" = '\${{ needs.validate-pr-snapshot.outputs.package-count }}'
+echo "Verified $verified immutable package versions and SHA-512 integrities; tag bindings are present or absent, never conflicting." >> "$GITHUB_STEP_SUMMARY"`,
+        },
+        {
+          name: 'Write trusted verification receipt',
+          env: {
+            HEAD_SHA: '${{ needs.validate-pr-snapshot.outputs.head-sha }}',
+            MANIFEST_DIGEST: '${{ needs.validate-pr-snapshot.outputs.manifest-digest }}',
+            PR_NUMBER: '${{ needs.validate-pr-snapshot.outputs.pr-number }}',
+            SNAPSHOT_VERSION: '${{ needs.validate-pr-snapshot.outputs.version }}',
+            SOURCE_RUN_ATTEMPT: '${{ needs.validate-pr-snapshot.outputs.run-attempt }}',
+            SOURCE_RUN_ID: '${{ needs.validate-pr-snapshot.outputs.run-id }}',
+          },
+          run: `jq -n \
+  --arg repository "$GITHUB_REPOSITORY" \
+  --argjson prNumber "$PR_NUMBER" \
+  --arg headSha "$HEAD_SHA" \
+  --argjson sourceRunId "$SOURCE_RUN_ID" \
+  --argjson sourceRunAttempt "$SOURCE_RUN_ATTEMPT" \
+  --arg version "$SNAPSHOT_VERSION" \
+  --arg manifestSha256 "$MANIFEST_DIGEST" \
+  '{repository, prNumber, headSha, sourceRunId, sourceRunAttempt, version, manifestSha256}' \
+  > "$RUNNER_TEMP/verified-pr-snapshot.json"`,
+        },
+        {
+          name: 'Upload trusted verification receipt',
+          uses: 'actions/upload-artifact@v4',
+          with: {
+            name: 'verified-pr-snapshot-${{ needs.validate-pr-snapshot.outputs.head-sha }}-${{ needs.validate-pr-snapshot.outputs.run-id }}-${{ needs.validate-pr-snapshot.outputs.run-attempt }}',
+            path: '${{ runner.temp }}/verified-pr-snapshot.json',
+            'if-no-files-found': 'error',
+            overwrite: true,
+            'retention-days': 30,
+          },
+        },
+        {
+          name: 'Record snapshot provenance',
+          env: {
+            SNAPSHOT_VERSION: '${{ needs.validate-pr-snapshot.outputs.version }}',
+            MANIFEST_DIGEST: '${{ needs.validate-pr-snapshot.outputs.manifest-digest }}',
+            PACKAGE_COUNT: '${{ needs.validate-pr-snapshot.outputs.package-count }}',
+            PR_NUMBER: '${{ needs.validate-pr-snapshot.outputs.pr-number }}',
+            SNAPSHOT_TAG: '${{ needs.validate-pr-snapshot.outputs.npm-tag }}',
+            SOURCE_RUN_URL: '${{ needs.validate-pr-snapshot.outputs.source-run-url }}',
+          },
+          run: `cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+## PR snapshot
+
+- PR: #$PR_NUMBER
+- Head: \`\${{ needs.validate-pr-snapshot.outputs.head-sha }}\`
+- Version: \`$SNAPSHOT_VERSION\`
+- Publish-time npm tag (best-effort mutable metadata): \`$SNAPSHOT_TAG\`
+- Packages: $PACKAGE_COUNT
+- Manifest SHA-256: \`$MANIFEST_DIGEST\`
+- Source CI run: $SOURCE_RUN_URL
+- Candidate attestation: binds the validated package and manifest digests to the exact PR head and source CI run.
+- npm provenance: identifies this trusted default-branch promotion workflow; it does not claim that the PR CI job held npm publishing authority.
+EOF`,
+        },
+      ],
+    },
+    },
+    /** Spread into `on.workflow_dispatch.inputs`. */
+    dispatchInputs: {
+      pr_number: {
+        description: 'PR number selector for trusted snapshot promotion',
+        required: false,
+        default: '0',
+        type: 'string',
+      },
+      head_sha: {
+        description: 'Expected PR head selector for trusted snapshot promotion',
+        required: false,
+        default: '',
+        type: 'string',
+      },
+      ci_run_id: {
+        description: 'Exact successful PR CI run selector for trusted snapshot promotion',
+        required: false,
+        default: '0',
+        type: 'string',
+      },
+    },
+    /** Append to `on.workflow_dispatch.inputs.mode.options`. */
+    dispatchModeOption: 'promote-pr-snapshot',
+    /**
+     * Spread into `on`. The dispatcher polls rather than reacting to the label event: a label applied
+     * after CI already finished produces no workflow_run, so without this the common maintainer
+     * gesture — review, then label — would never publish anything.
+     */
+    scheduleTrigger: [{ cron: '*/5 * * * *' }],
+    /** Spread into `on`. Fires when the producer workflow completes. */
+    workflowRunTrigger: { workflows: ['ci'], types: ['completed'] },
+  }
+}

--- a/genie/ci-workflow/pr-snapshot.ts
+++ b/genie/ci-workflow/pr-snapshot.ts
@@ -25,6 +25,7 @@
 import type { GitHubWorkflowArgs } from '../../packages/@overeng/genie/src/runtime/github-workflow/mod.ts'
 import { bashShellDefaults, runDevenvTasksBefore } from './shared.ts'
 import { emittedPrSnapshotValidatorPath, emittedPrSnapshotValidatorTestPath } from './support-files.ts'
+import { prSnapshotTrustLabel } from '../labels.ts'
 
 /**
  * Job id of the pack job, and the label granting a fork pull request publishing trust.
@@ -35,7 +36,7 @@ import { emittedPrSnapshotValidatorPath, emittedPrSnapshotValidatorTestPath } fr
  * disagree — and neither disagreement fails loudly; the dispatcher would simply match nothing.
  */
 export const prSnapshotPackJobId = 'pack-pr-snapshot'
-export const prSnapshotTrustLabel = 'ci:publish-snapshot'
+export { prSnapshotTrustLabel }
 
 /**
  * Guard for jobs that existed in a consumer's release workflow before these were added.
@@ -45,7 +46,7 @@ export const prSnapshotTrustLabel = 'ci:publish-snapshot'
  * for a build-heavy job means a full toolchain build every few minutes. Apply this to them.
  */
 export const prSnapshotForeignEventGuard =
-  "github.event_name != 'schedule' && github.event_name != 'workflow_run'" 
+  "github.event_name != 'schedule' && github.event_name != 'workflow_run'"
 
 type WorkflowJob = GitHubWorkflowArgs['jobs'][string]
 type WorkflowStep = WorkflowJob['steps'][number]

--- a/genie/ci-workflow/support-files.ts
+++ b/genie/ci-workflow/support-files.ts
@@ -1,4 +1,7 @@
-import { createGenieOutput, type GenieOutput } from '../../packages/@overeng/genie/src/runtime/core.ts'
+import {
+  createGenieOutput,
+  type GenieOutput,
+} from '../../packages/@overeng/genie/src/runtime/core.ts'
 import { defineRepoContext } from '../../packages/@overeng/genie/src/runtime/repo-context/mod.ts'
 import { resolveDevenvFnScript } from './shared.ts'
 
@@ -21,8 +24,7 @@ const repo = defineRepoContext({ name: 'effect-utils', importMetaUrl: import.met
 export const ciWorkflowNixGcRaceRetryScriptPath = 'genie/ci-scripts/nix-gc-race-retry.sh'
 export const ciWorkflowPrSnapshotArtifactScriptPath = 'genie/ci-scripts/pr-snapshot-artifact.mjs'
 export const ciWorkflowPrSnapshotArtifactTestPath = 'genie/ci-scripts/pr-snapshot-artifact.test.mjs'
-export const ciWorkflowNixGcRaceRetryWrapperPath =
-  'genie/ci-scripts/run-with-nix-gc-race-retry.sh'
+export const ciWorkflowNixGcRaceRetryWrapperPath = 'genie/ci-scripts/run-with-nix-gc-race-retry.sh'
 export const ciWorkflowJobLocalRustStateScriptPath =
   'genie/ci-scripts/prepare-job-local-rust-state.sh'
 export const ciWorkflowResolveDevenvScriptPath = 'genie/ci-scripts/resolve-devenv.sh'

--- a/genie/ci-workflow/support-files.ts
+++ b/genie/ci-workflow/support-files.ts
@@ -1,4 +1,5 @@
 import { createGenieOutput, type GenieOutput } from '../../packages/@overeng/genie/src/runtime/core.ts'
+import { defineRepoContext } from '../../packages/@overeng/genie/src/runtime/repo-context/mod.ts'
 import { resolveDevenvFnScript } from './shared.ts'
 
 const withTrailingNewline = (content: string) => (content.endsWith('\n') ? content : `${content}\n`)
@@ -10,7 +11,16 @@ const textArtifact = (content: string): GenieOutput<string> =>
     stringify: () => withTrailingNewline(content),
   })
 
+/**
+ * Anchors on this module's own location so the scripts below resolve out of the effect-utils checkout
+ * even when read from a consumer repo, where effect-utils is mirrored under `repos/effect-utils/`.
+ * A cwd-relative `readFileSync` would silently resolve against the consumer's root instead.
+ */
+const repo = defineRepoContext({ name: 'effect-utils', importMetaUrl: import.meta.url })
+
 export const ciWorkflowNixGcRaceRetryScriptPath = 'genie/ci-scripts/nix-gc-race-retry.sh'
+export const ciWorkflowPrSnapshotArtifactScriptPath = 'genie/ci-scripts/pr-snapshot-artifact.mjs'
+export const ciWorkflowPrSnapshotArtifactTestPath = 'genie/ci-scripts/pr-snapshot-artifact.test.mjs'
 export const ciWorkflowNixGcRaceRetryWrapperPath =
   'genie/ci-scripts/run-with-nix-gc-race-retry.sh'
 export const ciWorkflowJobLocalRustStateScriptPath =
@@ -195,6 +205,22 @@ export const ciWorkflowSupportFiles = {
   nixGcRaceRetryWrapper: {
     path: ciWorkflowNixGcRaceRetryWrapperPath,
     output: textArtifact(ciWorkflowNixGcRaceRetryWrapperScript),
+  },
+  /**
+   * The PR snapshot artifact validator, and its adversarial boundary suite.
+   *
+   * Read from disk rather than embedded as a template literal: the validator is ~456 lines of real
+   * JavaScript containing 66 `${...}` template expressions, which a `String.raw` literal would require
+   * escaping one by one — unreviewable, and it would stop the shared source being the exact file that
+   * runs. Consumers emit it verbatim, so every repo validates candidates with identical code.
+   */
+  prSnapshotArtifact: {
+    path: ciWorkflowPrSnapshotArtifactScriptPath,
+    output: textArtifact(repo.readText(ciWorkflowPrSnapshotArtifactScriptPath)),
+  },
+  prSnapshotArtifactTest: {
+    path: ciWorkflowPrSnapshotArtifactTestPath,
+    output: textArtifact(repo.readText(ciWorkflowPrSnapshotArtifactTestPath)),
   },
 } as const
 

--- a/genie/ci-workflow/support-files.ts
+++ b/genie/ci-workflow/support-files.ts
@@ -33,6 +33,13 @@ const sharedScriptArtifact = (repoRelativePath: string): GenieOutput<string> => 
 }
 
 export const ciWorkflowNixGcRaceRetryScriptPath = 'genie/ci-scripts/nix-gc-race-retry.sh'
+/**
+ * Where consumers emit the shared validator. Distinct from the `ciWorkflow*` paths below, which name
+ * the source inside this repo: these are the paths in the consuming repository.
+ */
+export const emittedPrSnapshotValidatorPath = '.github/scripts/pr-snapshot-artifact.mjs'
+export const emittedPrSnapshotValidatorTestPath = '.github/scripts/pr-snapshot-artifact.test.mjs'
+
 export const ciWorkflowPrSnapshotArtifactScriptPath = 'genie/ci-scripts/pr-snapshot-artifact.mjs'
 export const ciWorkflowPrSnapshotArtifactTestPath = 'genie/ci-scripts/pr-snapshot-artifact.test.mjs'
 export const ciWorkflowNixGcRaceRetryWrapperPath = 'genie/ci-scripts/run-with-nix-gc-race-retry.sh'

--- a/genie/ci-workflow/support-files.ts
+++ b/genie/ci-workflow/support-files.ts
@@ -15,11 +15,22 @@ const textArtifact = (content: string): GenieOutput<string> =>
   })
 
 /**
- * Anchors on this module's own location so the scripts below resolve out of the effect-utils checkout
- * even when read from a consumer repo, where effect-utils is mirrored under `repos/effect-utils/`.
- * A cwd-relative `readFileSync` would silently resolve against the consumer's root instead.
+ * Reads a script that ships as a real file in this repo and emits it verbatim.
+ *
+ * Anchors on this module's own location so the file resolves out of the effect-utils checkout even
+ * when read from a consumer repo, where effect-utils is mirrored under `repos/effect-utils/`. A
+ * cwd-relative `readFileSync` would silently resolve against the consumer's root instead.
+ *
+ * Resolved lazily, not at module scope: this module is reachable from the barrel during genie's cold
+ * bootstrap phase, where touching the filesystem or the repo-context machinery reaches packages that
+ * do not exist yet. Deferring the read until the artifact is actually generated keeps the bootstrap
+ * phase free of that dependency.
  */
-const repo = defineRepoContext({ name: 'effect-utils', importMetaUrl: import.meta.url })
+let repoContext: ReturnType<typeof defineRepoContext> | undefined
+const sharedScriptArtifact = (repoRelativePath: string): GenieOutput<string> => {
+  repoContext ??= defineRepoContext({ name: 'effect-utils', importMetaUrl: import.meta.url })
+  return textArtifact(repoContext.readText(repoRelativePath))
+}
 
 export const ciWorkflowNixGcRaceRetryScriptPath = 'genie/ci-scripts/nix-gc-race-retry.sh'
 export const ciWorkflowPrSnapshotArtifactScriptPath = 'genie/ci-scripts/pr-snapshot-artifact.mjs'
@@ -218,11 +229,15 @@ export const ciWorkflowSupportFiles = {
    */
   prSnapshotArtifact: {
     path: ciWorkflowPrSnapshotArtifactScriptPath,
-    output: textArtifact(repo.readText(ciWorkflowPrSnapshotArtifactScriptPath)),
+    get output() {
+      return sharedScriptArtifact(ciWorkflowPrSnapshotArtifactScriptPath)
+    },
   },
   prSnapshotArtifactTest: {
     path: ciWorkflowPrSnapshotArtifactTestPath,
-    output: textArtifact(repo.readText(ciWorkflowPrSnapshotArtifactTestPath)),
+    get output() {
+      return sharedScriptArtifact(ciWorkflowPrSnapshotArtifactTestPath)
+    },
   },
 } as const
 

--- a/genie/labels.ts
+++ b/genie/labels.ts
@@ -296,9 +296,15 @@ const andonStateLabels: readonly LabelDef[] = [
  * CI capability grants. These are not a taxonomy axis like `type:*` or `area:*` — applying one changes
  * what automation is allowed to do for a pull request, so they are maintainer-managed and revocable.
  */
+/**
+ * Owned here because this is the label catalogue. The snapshot workflow factory and the candidate
+ * validator both gate on this exact string, so it has one definition and they import it.
+ */
+export const prSnapshotTrustLabel = 'ci:publish-snapshot'
+
 const ciLabels: readonly LabelDef[] = [
   {
-    name: 'ci:publish-snapshot',
+    name: prSnapshotTrustLabel,
     color: colors.green,
     description: 'Trust this fork PR branch for snapshot publishing · Set: manual',
   },

--- a/genie/labels.ts
+++ b/genie/labels.ts
@@ -292,11 +292,24 @@ const andonStateLabels: readonly LabelDef[] = [
  * Repo-specific `area:*` labels are added per-repo by spreading additional
  * `LabelDef` literals into the `labels` array.
  */
+/**
+ * CI capability grants. These are not a taxonomy axis like `type:*` or `area:*` — applying one changes
+ * what automation is allowed to do for a pull request, so they are maintainer-managed and revocable.
+ */
+const ciLabels: readonly LabelDef[] = [
+  {
+    name: 'ci:publish-snapshot',
+    color: colors.green,
+    description: 'Trust this fork PR branch for snapshot publishing · Set: manual',
+  },
+]
+
 export const commonLabels: readonly LabelDef[] = [
   ...typeLabels,
   ...stateLabels,
   ...originLabels,
   ...sharedAreaLabels,
+  ...ciLabels,
 ]
 
 /** Andon cross-machine incident state labels. */

--- a/genie/oxfmt-base.ts
+++ b/genie/oxfmt-base.ts
@@ -24,6 +24,10 @@ export const baseOxfmtOptions = {
 
 /** Standard ignore patterns for oxfmt */
 export const baseOxfmtIgnorePatterns = [
+  // Emitted verbatim from this repo's shared CI scripts. Consumers format at their own print width,
+  // so formatting a generated, read-only validator locally would only make repos disagree on its bytes.
+  '**/.github/scripts/pr-snapshot-artifact.mjs',
+  '**/.github/scripts/pr-snapshot-artifact.test.mjs',
   // Package manager caches and build outputs
   '**/node_modules/**',
   '**/.pnpm/**',

--- a/genie/weaver-registry/attributes.yaml
+++ b/genie/weaver-registry/attributes.yaml
@@ -2,7 +2,7 @@
 # Source: attributes.yaml.genie.ts
 
 # registry-source: genie/weaver-registry/registry.ts
-# fingerprint: sha256:5139b4db931b60092da6982c500fe9f1ed3b6bf4a80a3ef2523f3939979678c3
+# fingerprint: sha256:fec96ac4bcb2db312b9c5e5e216a38aad2de6db3cf2c79048daad2df9642ef6e
 groups:
   - id: registry.acme
     type: attribute_group
@@ -841,6 +841,10 @@ groups:
             - id: fetch-missing-commit
               value: fetch-missing-commit
               brief: Fetched a specific missing commit.
+              stability: development
+            - id: fetch-pull-request-heads
+              value: fetch-pull-request-heads
+              brief: Fetched pull-request head refs to recover a commit outside refs/heads/*.
               stability: development
             - id: noop
               value: noop

--- a/genie/weaver-registry/manifest.yaml
+++ b/genie/weaver-registry/manifest.yaml
@@ -2,7 +2,7 @@
 # Source: manifest.yaml.genie.ts
 
 # registry-source: genie/weaver-registry/registry.ts
-# fingerprint: sha256:5139b4db931b60092da6982c500fe9f1ed3b6bf4a80a3ef2523f3939979678c3
+# fingerprint: sha256:fec96ac4bcb2db312b9c5e5e216a38aad2de6db3cf2c79048daad2df9642ef6e
 name: acme-effect-utils
 
 description: First-party OpenTelemetry semantic-convention registry (effect-utils).

--- a/genie/weaver-registry/signals.yaml
+++ b/genie/weaver-registry/signals.yaml
@@ -2,7 +2,7 @@
 # Source: signals.yaml.genie.ts
 
 # registry-source: genie/weaver-registry/registry.ts
-# fingerprint: sha256:5139b4db931b60092da6982c500fe9f1ed3b6bf4a80a3ef2523f3939979678c3
+# fingerprint: sha256:fec96ac4bcb2db312b9c5e5e216a38aad2de6db3cf2c79048daad2df9642ef6e
 groups:
   - id: metric.acme.probe.duration
     type: metric

--- a/packages/@overeng/genie/src/core/generation.ts
+++ b/packages/@overeng/genie/src/core/generation.ts
@@ -396,19 +396,22 @@ export const getHeaderComment = ({
 }
 
 /**
- * Prepend the generated-file header to content, preserving a leading `#!` shebang line for
- * executable shell scripts (the banner is inserted after the shebang, not before it).
+ * Prepend the generated-file header to content, preserving a leading `#!` shebang line
+ * (the banner is inserted after the shebang, not before it).
+ *
+ * A hashbang is only valid as the very first bytes of a file. That is a hard rule for scripts of any
+ * language, not just `.sh`: putting a comment banner ahead of `#!` in a `.mjs` makes the file a
+ * `SyntaxError` rather than merely mis-executing it. So this keys off the shebang itself, not the
+ * extension.
  */
 export const addHeaderComment = ({
   content,
   header,
-  targetFilePath,
 }: {
   content: string
   header: string
-  targetFilePath: string
 }) => {
-  if (path.extname(targetFilePath) !== '.sh' || content.startsWith('#!') === false) {
+  if (content.startsWith('#!') === false) {
     return header + content
   }
 
@@ -661,7 +664,6 @@ export const getExpectedContent = Effect.fn('getExpectedContent')(function* ({
     content: addHeaderComment({
       content: formattedContent,
       header,
-      targetFilePath,
     }),
   }
 })

--- a/packages/@overeng/genie/src/core/generation.ts
+++ b/packages/@overeng/genie/src/core/generation.ts
@@ -404,13 +404,7 @@ export const getHeaderComment = ({
  * `SyntaxError` rather than merely mis-executing it. So this keys off the shebang itself, not the
  * extension.
  */
-export const addHeaderComment = ({
-  content,
-  header,
-}: {
-  content: string
-  header: string
-}) => {
+export const addHeaderComment = ({ content, header }: { content: string; header: string }) => {
   if (content.startsWith('#!') === false) {
     return header + content
   }

--- a/packages/@overeng/genie/src/core/generation.unit.test.ts
+++ b/packages/@overeng/genie/src/core/generation.unit.test.ts
@@ -29,7 +29,6 @@ describe('getExpectedContent', () => {
   it('keeps shell shebangs before generated provenance', () => {
     expect(
       addHeaderComment({
-        targetFilePath: 'genie/ci-scripts/run.sh',
         header: '# Generated file - DO NOT EDIT\n# Source: run.sh.genie.ts\n\n',
         content: '#!/usr/bin/env bash\nexit 0\n',
       }),
@@ -43,5 +42,33 @@ describe('getExpectedContent', () => {
         '',
       ].join('\n'),
     )
+  })
+
+  it('keeps non-shell shebangs before generated provenance', () => {
+    // A hashbang is only legal as the very first bytes of a file, so a banner emitted ahead of it
+    // turns a `.mjs` into a SyntaxError rather than merely mis-executing it.
+    expect(
+      addHeaderComment({
+        header: '// Generated file - DO NOT EDIT\n// Source: tool.mjs.genie.ts\n',
+        content: '#!/usr/bin/env node\nexport const run = () => {}\n',
+      }),
+    ).toBe(
+      [
+        '#!/usr/bin/env node',
+        '// Generated file - DO NOT EDIT',
+        '// Source: tool.mjs.genie.ts',
+        'export const run = () => {}',
+        '',
+      ].join('\n'),
+    )
+  })
+
+  it('prepends the banner when there is no shebang', () => {
+    expect(
+      addHeaderComment({
+        header: '// Generated file - DO NOT EDIT\n// Source: mod.ts.genie.ts\n',
+        content: 'export const x = 1\n',
+      }),
+    ).toBe('// Generated file - DO NOT EDIT\n// Source: mod.ts.genie.ts\nexport const x = 1\n')
   })
 })

--- a/packages/@overeng/megarepo/src/lib/git.ts
+++ b/packages/@overeng/megarepo/src/lib/git.ts
@@ -705,7 +705,9 @@ export const fetchPullRequestHeads = (args: { repoPath: string; remote?: string 
       args: ['fetch', remote, '+refs/pull/*/head:refs/remotes/origin/pr/*'],
       cwd: args.repoPath,
     })
-  }).pipe(Observability.withRepoPathSpan({ name: 'git/fetch-pull-request-heads', path: args.repoPath }))
+  }).pipe(
+    Observability.withRepoPathSpan({ name: 'git/fetch-pull-request-heads', path: args.repoPath }),
+  )
 
 /**
  * Get the default branch name from a remote

--- a/packages/@overeng/megarepo/src/lib/git.ts
+++ b/packages/@overeng/megarepo/src/lib/git.ts
@@ -687,6 +687,27 @@ export const fetchBare = (args: { repoPath: string; remote?: string }) =>
   }).pipe(Observability.withRepoPathSpan({ name: 'git/fetch-bare', path: args.repoPath }))
 
 /**
+ * Fetch forge pull-request head refs into a bare repo.
+ *
+ * A bare repo created by {@link cloneBare} tracks `+refs/heads/*` only, so a commit that exists solely
+ * on a pull-request head — which is the normal shape when a downstream repo pins an upstream PR branch,
+ * especially a PR opened from a fork — is never fetched and looks unreachable. GitHub-style forges do
+ * expose those commits from the canonical remote under `refs/pull/<n>/head`, so this recovers them.
+ *
+ * Kept separate from {@link fetchBare} rather than folded in as a flag: it is only worth its extra ref
+ * negotiation on the missing-commit recovery path, and repos with many open pull requests would
+ * otherwise pay for it on every ordinary fetch.
+ */
+export const fetchPullRequestHeads = (args: { repoPath: string; remote?: string }) =>
+  Effect.gen(function* () {
+    const remote = args.remote ?? 'origin'
+    yield* runGitCommandWithRetry({
+      args: ['fetch', remote, '+refs/pull/*/head:refs/remotes/origin/pr/*'],
+      cwd: args.repoPath,
+    })
+  }).pipe(Observability.withRepoPathSpan({ name: 'git/fetch-pull-request-heads', path: args.repoPath }))
+
+/**
  * Get the default branch name from a remote
  * Uses `git ls-remote --symref` to query the remote's HEAD
  */

--- a/packages/@overeng/megarepo/src/lib/observability.ts
+++ b/packages/@overeng/megarepo/src/lib/observability.ts
@@ -312,6 +312,7 @@ type SyncMemberAction =
   | 'skip-dry-run'
   | 'fetch'
   | 'fetch-missing-commit'
+  | 'fetch-pull-request-heads'
   | 'noop'
 
 // ANNOTATE-ONLY: member action + result status (rebuilt from the imported catalog schemas).

--- a/packages/@overeng/megarepo/src/lib/sync/member.ts
+++ b/packages/@overeng/megarepo/src/lib/sync/member.ts
@@ -560,7 +560,20 @@ export const syncMember = <R = never>({
      * but pinned commit-SHA refs remain hard failures because there is no mutable ref to follow.
      */
     if (dryRun === false && targetCommit !== undefined) {
-      const commitExists = yield* Git.refExists({ repoPath: bareRepoPath, ref: targetCommit })
+      let commitExists = yield* Git.refExists({ repoPath: bareRepoPath, ref: targetCommit })
+
+      /**
+       * Last-resort recovery before declaring the commit unreachable: the locked commit may live only
+       * on a pull-request head, which the bare repo's `+refs/heads/*` refspec never fetches. Placed
+       * here rather than next to the earlier fetch so it also covers a freshly cloned bare repo, and
+       * it only costs a fetch when the commit is genuinely missing.
+       */
+      if (commitExists === false) {
+        yield* Git.fetchPullRequestHeads({ repoPath: bareRepoPath }).pipe(Effect.catchAll(() => Effect.void))
+        yield* Observability.annotateSyncMemberAction('fetch-pull-request-heads')
+        commitExists = yield* Git.refExists({ repoPath: bareRepoPath, ref: targetCommit })
+      }
+
       if (commitExists === false) {
         const shortCommit = targetCommit.slice(0, 8)
 

--- a/packages/@overeng/megarepo/src/lib/sync/member.ts
+++ b/packages/@overeng/megarepo/src/lib/sync/member.ts
@@ -569,7 +569,9 @@ export const syncMember = <R = never>({
        * it only costs a fetch when the commit is genuinely missing.
        */
       if (commitExists === false) {
-        yield* Git.fetchPullRequestHeads({ repoPath: bareRepoPath }).pipe(Effect.catchAll(() => Effect.void))
+        yield* Git.fetchPullRequestHeads({ repoPath: bareRepoPath }).pipe(
+          Effect.catchAll(() => Effect.void),
+        )
         yield* Observability.annotateSyncMemberAction('fetch-pull-request-heads')
         commitExists = yield* Git.refExists({ repoPath: bareRepoPath, ref: targetCommit })
       }

--- a/packages/@overeng/megarepo/src/megarepo.contract.ts
+++ b/packages/@overeng/megarepo/src/megarepo.contract.ts
@@ -260,7 +260,8 @@ export const MegarepoSyncMemberAction = attr.enum({
     'skip-dry-run': 'Skipped because the run is a dry run.',
     fetch: 'Fetched into an existing bare repository.',
     'fetch-missing-commit': 'Fetched a specific missing commit.',
-    'fetch-pull-request-heads': 'Fetched pull-request head refs to recover a commit outside refs/heads/*.',
+    'fetch-pull-request-heads':
+      'Fetched pull-request head refs to recover a commit outside refs/heads/*.',
     noop: 'No action required.',
   },
   brief: 'The action actually taken for a member sync.',

--- a/packages/@overeng/megarepo/src/megarepo.contract.ts
+++ b/packages/@overeng/megarepo/src/megarepo.contract.ts
@@ -251,6 +251,7 @@ export const MegarepoSyncMemberAction = attr.enum({
     'skip-dry-run',
     'fetch',
     'fetch-missing-commit',
+    'fetch-pull-request-heads',
     'noop',
   ],
   briefs: {
@@ -259,6 +260,7 @@ export const MegarepoSyncMemberAction = attr.enum({
     'skip-dry-run': 'Skipped because the run is a dry run.',
     fetch: 'Fetched into an existing bare repository.',
     'fetch-missing-commit': 'Fetched a specific missing commit.',
+    'fetch-pull-request-heads': 'Fetched pull-request head refs to recover a commit outside refs/heads/*.',
     noop: 'No action required.',
   },
   brief: 'The action actually taken for a member sync.',


### PR DESCRIPTION
## Problem

Two things block a downstream repo from reusing livestore's PR snapshot publishing.

**1. A locked commit on a pull-request head is unreachable.** `cloneBare` configures a bare repo with `+refs/heads/*:refs/remotes/origin/*`, and the missing-commit recovery path re-runs the same `git fetch --tags --prune`. So when a `megarepo.lock` entry pins a commit that exists only as a pull-request head — the normal shape when a downstream repo pins an upstream PR branch, especially one opened from a fork — sync fails with `locked commit '<sha>' ... is not available locally or on the remote`, even though the canonical remote does serve it under `refs/pull/<n>/head`.

**2. The PR snapshot pipeline lives in one repo.** livestore owns a six-job pipeline that publishes an immutable npm snapshot of a pull request's package cohort without granting the PR author any credential. livestore-contrib needs the same guarantee. Copying it would fork the code that decides what may be published.

## Goal

A downstream repo can pin an upstream pull-request head and sync it, and can compose the same PR snapshot pipeline instead of maintaining its own.

## Decisions

**`fetchPullRequestHeads` is separate from `fetchBare`, not a flag.** Repos with many open pull requests would otherwise pay an extra ref negotiation on every ordinary fetch. It is called only on the missing-commit recovery path.

**The refspec is passed as an argument, not written to config.** Verified that this leaves `remote.origin.fetch` untouched, so there is no persistent cost and no config drift. The tracking refs it does create are deliberate: they anchor the fetched objects, which survive `git gc --prune=now`. Fetching without refs would leave them collectible before the worktree is created.

**The fallback sits at the pre-error check, not beside the earlier fetch.** That single site also covers a freshly cloned bare repo, and costs a fetch only when the commit is genuinely missing.

**The validator is read from disk rather than embedded.** The existing shared-script entries are `String.raw` literals using a `${dollar}` escape. The validator is 456 lines of real JavaScript containing 66 `${...}` template expressions; escaping each one would be unreviewable and would stop the shared source being the exact file that runs. `defineRepoContext` anchors the read on the module, so it resolves out of this checkout even when read from a consumer repo where this repo is composed under `repos/`.

**`packJobId` is one option, not two.** It is simultaneously a job key in the CI workflow and a `jq` name match inside the release jobs. Splitting it would let the two drift into a dispatcher that silently matches nothing.

**The release factory returns trigger fragments, not just jobs.** The five release jobs depend on workflow-level `on:` entries — dispatch inputs, a promote mode option, the `workflow_run` trigger and the schedule. A jobs-only factory provably cannot reproduce the workflows.

## Verification

- `devenv tasks run test:run` — full suite passes.
- `devenv tasks run ts:check` — passes. Confirmed to be a real gate rather than assumed: a deliberate `const x: string = 42` makes it exit 1 with `TS2322`, and a clean tree exits 0.
- Pull-request-head recovery, both controls, against a real remote: with the heads-only refspec the target commit is **absent**; running exactly what `fetchPullRequestHeads` runs makes it **present**. Also confirmed `remote.origin.fetch` is unchanged afterwards and the object survives `git gc --prune=now`.
- The validator's own adversarial boundary suite passes 12/12 in a consumer layout. 11 of its 12 tests are self-contained; the 12th asserts properties of the consuming repo's generated `release.yml`, so the suite runs in consumers rather than here.
- Faithfulness of the extraction is proven in the livestore PR that consumes it: regenerating produces byte-identical `ci.yml`, `release.yml` and `labels.json`.

## Complexity

The factory is large because it is a verbatim extraction — the option surface is deliberately small, with everything two consumers can share left hardcoded. The genie shebang fix is unrelated to PR snapshots and is a separate commit; it can be split into its own PR if preferred.

## Concerns

The generator fingerprints a repo's own sources, and composed members are symlinks that `git ls-files` will not traverse. Editing a shared factory in place locally is therefore not seen, and regeneration is skipped as up to date. This is a local-only hazard: real consumption pins this repo by commit, so a shared change arrives as a lock bump, which is tracked and does invalidate the fingerprint. Locally, clear the generator task cache after editing a composed member.

## Friction & bottlenecks

- A generated script with a shebang and any extension other than `.sh` had its provenance banner emitted *before* the `#!` line, which makes a `.mjs` a `SyntaxError` rather than merely mis-executing it. Fixed here with regression tests.
- The generator's task cache short-circuits on input hash without checking output state, so restoring a perturbed source produces a cache hit and leaves stale generated files on disk. Only a cache bust reconciles them.

## Follow-ups

- Consumers other than livestore adopting `prSnapshotJobs`.
- The genie shebang fix could be split out.

## References

Consumed by the corresponding livestore and livestore-contrib PRs. Refs livestorejs/livestore#1265.