### PR TITLE
Decide snapshot authorization in the tested predicate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,18 @@ All notable changes to this project will be documented in this file.
   provider layer construction/provision, scope teardown, retry behavior, and
   external-store subscriber observations.
 
+### Changed
+
+- **genie/ci-workflow**: decide PR snapshot authorization in the tested
+  predicate. Both the `authorize` and the pre-publish recheck now invoke
+  `isAuthorizedSnapshotState` through a new `authorize` CLI mode instead of
+  restating the decision in bash, so the code gating publication is the code the
+  boundary suite covers. The fork trust label becomes a required
+  `--trust-label` argument rather than a hardcoded constant, and an empty label
+  fails loudly instead of silently matching nothing. The validator is sparse
+  checked out at `github.workflow_sha`, never from the pull request under
+  evaluation.
+
 ### Fixed
 
 - **devenv pnpm installs**: refresh nixpkgs so pnpm runs on Node 24.18.1,

--- a/genie/ci-scripts/pr-snapshot-artifact.mjs
+++ b/genie/ci-scripts/pr-snapshot-artifact.mjs
@@ -183,10 +183,12 @@ export const isAuthorizedSnapshotState = ({
   labelNames,
   reviewDecision,
   reviews,
+  trustLabel,
 }) => {
   if (headSha !== currentHeadSha) return false
   if (headRepository !== repository) {
-    return Array.isArray(labelNames) === true && labelNames.includes('ci:publish-snapshot')
+    if (typeof trustLabel !== 'string' || trustLabel === '') fail('Fork trust label is required')
+    return Array.isArray(labelNames) === true && labelNames.includes(trustLabel)
   }
   return isAuthorizedReviewState({ headSha, currentHeadSha, reviewDecision, reviews })
 }
@@ -498,6 +500,43 @@ if (
               packageStates: JSON.parse(await readFile(args['state-file'], 'utf8')),
               hasVerifiedReceipt: args['verified-receipt'] === 'true',
             })
-          : fail(`Unknown mode: ${mode}`)
+          : mode === 'snapshot-identity'
+            ? {
+                version: snapshotVersion({
+                  prNumber: args['pr-number'],
+                  headSha: args['head-sha'],
+                }),
+                npmTag: snapshotTag({ prNumber: args['pr-number'], headSha: args['head-sha'] }),
+              }
+            : mode === 'producer-attempt'
+              ? {
+                  runAttempt: successfulProducerAttempt({
+                    jobs: JSON.parse(await readFile(args['jobs-file'], 'utf8')),
+                    jobName: args['job-name'],
+                  }),
+                }
+              : mode === 'select-producer-run'
+                ? {
+                    run: selectEligibleProducerRun({
+                      runs: JSON.parse(await readFile(args['runs-file'], 'utf8')),
+                      headRepository: args['head-repository'],
+                      headBranch: args['head-branch'],
+                      headSha: args['head-sha'],
+                    }),
+                  }
+                : mode === 'authorize'
+                  ? {
+                      authorized: isAuthorizedSnapshotState({
+                        repository: args.repository,
+                        headRepository: args['head-repository'],
+                        headSha: args['head-sha'],
+                        currentHeadSha: args['current-head-sha'],
+                        labelNames: JSON.parse(args['label-names']),
+                        reviewDecision: args['review-decision'],
+                        reviews: JSON.parse(await readFile(args['reviews-file'], 'utf8')),
+                        trustLabel: args['trust-label'],
+                      }),
+                    }
+                  : fail(`Unknown mode: ${mode}`)
   process.stdout.write(`${JSON.stringify(result)}\n`)
 }

--- a/genie/ci-scripts/pr-snapshot-artifact.test.mjs
+++ b/genie/ci-scripts/pr-snapshot-artifact.test.mjs
@@ -210,6 +210,29 @@ test('requires the authoritative required-review decision', () => {
   )
 })
 
+test('a fork label only authorizes when it is the configured trust label', () => {
+  const headSha = 'c'.repeat(40)
+  const forked = {
+    repository: 'livestorejs/livestore',
+    headRepository: 'contributor/livestore',
+    headSha,
+    currentHeadSha: headSha,
+    reviewDecision: 'REVIEW_REQUIRED',
+    reviews: [],
+    trustLabel: 'ci:publish-snapshot',
+  }
+
+  assert.equal(isAuthorizedSnapshotState({ ...forked, labelNames: ['ci:publish-snapshot'] }), true)
+  // A different label — however plausible — grants nothing.
+  assert.equal(isAuthorizedSnapshotState({ ...forked, labelNames: ['ci:deploy-docs'] }), false)
+  // And an empty trust label must fail loudly rather than match nothing silently.
+  assert.throws(
+    () =>
+      isAuthorizedSnapshotState({ ...forked, labelNames: ['ci:publish-snapshot'], trustLabel: '' }),
+    /Fork trust label is required/,
+  )
+})
+
 test('authorizes repository-owned snapshots by review and fork snapshots by live label', () => {
   const headSha = 'a'.repeat(40)
   const common = {
@@ -219,6 +242,7 @@ test('authorizes repository-owned snapshots by review and fork snapshots by live
     labelNames: [],
     reviewDecision: 'APPROVED',
     reviews: [{ state: 'APPROVED', commit_id: headSha }],
+    trustLabel: 'ci:publish-snapshot',
   }
 
   assert.equal(isAuthorizedSnapshotState({ ...common, headRepository: common.repository }), true)

--- a/genie/ci-workflow/pr-snapshot.ts
+++ b/genie/ci-workflow/pr-snapshot.ts
@@ -23,9 +23,12 @@
  */
 
 import type { GitHubWorkflowArgs } from '../../packages/@overeng/genie/src/runtime/github-workflow/mod.ts'
-import { bashShellDefaults, runDevenvTasksBefore } from './shared.ts'
-import { emittedPrSnapshotValidatorPath, emittedPrSnapshotValidatorTestPath } from './support-files.ts'
 import { prSnapshotTrustLabel } from '../labels.ts'
+import { bashShellDefaults, runDevenvTasksBefore } from './shared.ts'
+import {
+  emittedPrSnapshotValidatorPath,
+  emittedPrSnapshotValidatorTestPath,
+} from './support-files.ts'
 
 /**
  * Job id of the pack job, and the label granting a fork pull request publishing trust.
@@ -35,6 +38,9 @@ import { prSnapshotTrustLabel } from '../labels.ts'
  * inside the validator's authorization predicate. Making either configurable would let the copies
  * disagree — and neither disagreement fails loudly; the dispatcher would simply match nothing.
  */
+/** Node runtime for the validator and the npm trusted-publishing client. */
+const nodeVersion = '24.15.0'
+
 export const prSnapshotPackJobId = 'pack-pr-snapshot'
 export { prSnapshotTrustLabel }
 
@@ -414,7 +420,7 @@ ${topologyPath}`,
             name: 'Use pinned Node validator runtime',
             uses: 'actions/setup-node@v4',
             with: {
-              'node-version': '24.15.0',
+              'node-version': nodeVersion,
             },
           },
           {
@@ -548,6 +554,22 @@ jq -n \
         defaults: bashShellDefaults,
         steps: [
           {
+            // The authorization decision is made by the validator, so this job needs it — checked out
+            // from the trusted workflow revision, never from the pull request under evaluation.
+            name: 'Checkout trusted validator only',
+            uses: 'actions/checkout@v4',
+            with: {
+              ref: '${{ github.workflow_sha }}',
+              'persist-credentials': false,
+              'sparse-checkout': validatorScriptPath,
+            },
+          },
+          {
+            name: 'Use pinned Node validator runtime',
+            uses: 'actions/setup-node@v4',
+            with: { 'node-version': nodeVersion },
+          },
+          {
             id: 'approval',
             name: 'Require current-head review or fork trust label',
             env: {
@@ -561,25 +583,31 @@ authorized=false
 authorized_by='none'
 if [ "$(jq -r '.state' <<<"$pr_json")" = open ] && \
    [ "$(jq -r '.draft' <<<"$pr_json")" = false ] && \
-   [ "$(jq -r '.base.ref' <<<"$pr_json")" = main ] && \
-   [ "$(jq -r '.head.sha' <<<"$pr_json")" = "$EXPECTED_HEAD_SHA" ]; then
+   [ "$(jq -r '.base.ref' <<<"$pr_json")" = main ]; then
   head_repository=$(jq -r '.head.repo.full_name' <<<"$pr_json")
-  if [ "$head_repository" = "$GITHUB_REPOSITORY" ]; then
-    reviews_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews?per_page=100" --slurp | jq -s 'flatten')
-    owner="\${GITHUB_REPOSITORY%%/*}"
-    name="\${GITHUB_REPOSITORY#*/}"
-    review_decision=$(gh api graphql \
-      -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewDecision}}}' \
-      -f owner="$owner" -f name="$name" -F number="$PR_NUMBER" \
-      --jq '.data.repository.pullRequest.reviewDecision')
-    if [ "$review_decision" = APPROVED ] && \
-       jq -e --arg sha "$EXPECTED_HEAD_SHA" 'any(.[]; .state == "APPROVED" and .commit_id == $sha)' <<<"$reviews_json" >/dev/null; then
-      authorized=true
+  reviews_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews?per_page=100" --slurp | jq -s 'flatten')
+  owner="\${GITHUB_REPOSITORY%%/*}"
+  name="\${GITHUB_REPOSITORY#*/}"
+  review_decision=$(gh api graphql \
+    -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewDecision}}}' \
+    -f owner="$owner" -f name="$name" -F number="$PR_NUMBER" \
+    --jq '.data.repository.pullRequest.reviewDecision' || echo '')
+  printf '%s' "$reviews_json" > "$RUNNER_TEMP/reviews.json"
+  authorized=$(node ${validatorScriptPath} authorize \
+    --repository="$GITHUB_REPOSITORY" \
+    --head-repository="$head_repository" \
+    --head-sha="$EXPECTED_HEAD_SHA" \
+    --current-head-sha="$(jq -r '.head.sha' <<<"$pr_json")" \
+    --label-names="$(jq -c '[.labels[]?.name]' <<<"$pr_json")" \
+    --review-decision="$review_decision" \
+    --reviews-file="$RUNNER_TEMP/reviews.json" \
+    --trust-label='${prSnapshotTrustLabel}' | jq -r '.authorized')
+  if [ "$authorized" = true ]; then
+    if [ "$head_repository" = "$GITHUB_REPOSITORY" ]; then
       authorized_by='current-head review'
+    else
+      authorized_by='${prSnapshotTrustLabel} fork trust label'
     fi
-  elif jq -e 'any(.labels[]?; .name == "${prSnapshotTrustLabel}")' <<<"$pr_json" >/dev/null; then
-    authorized=true
-    authorized_by='${prSnapshotTrustLabel} fork trust label'
   fi
 fi
 echo "authorized=$authorized" >> "$GITHUB_OUTPUT"
@@ -614,7 +642,18 @@ echo "Snapshot promotion authorized: $authorized ($authorized_by)" >> "$GITHUB_S
             name: 'Use pinned npm trusted-publishing client',
             uses: 'actions/setup-node@v4',
             with: {
-              'node-version': '24.15.0',
+              'node-version': nodeVersion,
+            },
+          },
+          {
+            // Needed for the pre-publication authorization recheck. Taken from the trusted workflow
+            // revision, never from the pull request being published.
+            name: 'Checkout trusted validator only',
+            uses: 'actions/checkout@v4',
+            with: {
+              ref: '${{ github.workflow_sha }}',
+              'persist-credentials': false,
+              'sparse-checkout': validatorScriptPath,
             },
           },
           {
@@ -636,21 +675,26 @@ pr_json=$(gh api "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")
 test "$(jq -r '.state' <<<"$pr_json")" = open
 test "$(jq -r '.draft' <<<"$pr_json")" = false
 test "$(jq -r '.base.ref' <<<"$pr_json")" = main
-test "$(jq -r '.head.sha' <<<"$pr_json")" = "$EXPECTED_HEAD_SHA"
 head_repository=$(jq -r '.head.repo.full_name' <<<"$pr_json")
-if [ "$head_repository" = "$GITHUB_REPOSITORY" ]; then
-  reviews_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews?per_page=100" --slurp | jq -s 'flatten')
-  owner="\${GITHUB_REPOSITORY%%/*}"
-  name="\${GITHUB_REPOSITORY#*/}"
-  review_decision=$(gh api graphql \
-    -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewDecision}}}' \
-    -f owner="$owner" -f name="$name" -F number="$PR_NUMBER" \
-    --jq '.data.repository.pullRequest.reviewDecision')
-  test "$review_decision" = APPROVED
-  jq -e --arg sha "$EXPECTED_HEAD_SHA" 'any(.[]; .state == "APPROVED" and .commit_id == $sha)' <<<"$reviews_json" >/dev/null
-else
-  jq -e 'any(.labels[]?; .name == "${prSnapshotTrustLabel}")' <<<"$pr_json" >/dev/null
-fi`,
+reviews_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews?per_page=100" --slurp | jq -s 'flatten')
+owner="\${GITHUB_REPOSITORY%%/*}"
+name="\${GITHUB_REPOSITORY#*/}"
+review_decision=$(gh api graphql \
+  -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewDecision}}}' \
+  -f owner="$owner" -f name="$name" -F number="$PR_NUMBER" \
+  --jq '.data.repository.pullRequest.reviewDecision' || echo '')
+printf '%s' "$reviews_json" > "$RUNNER_TEMP/recheck-reviews.json"
+# The same predicate the authorize job used, invoked again rather than restated. This is the
+# time-of-use check, so it must re-read live state — but it must not re-decide differently.
+test "$(node ${validatorScriptPath} authorize \
+  --repository="$GITHUB_REPOSITORY" \
+  --head-repository="$head_repository" \
+  --head-sha="$EXPECTED_HEAD_SHA" \
+  --current-head-sha="$(jq -r '.head.sha' <<<"$pr_json")" \
+  --label-names="$(jq -c '[.labels[]?.name]' <<<"$pr_json")" \
+  --review-decision="$review_decision" \
+  --reviews-file="$RUNNER_TEMP/recheck-reviews.json" \
+  --trust-label='${prSnapshotTrustLabel}' | jq -r '.authorized')" = true`,
           },
           {
             name: 'Verify promotion handoff',


### PR DESCRIPTION
## Problem

`isAuthorizedSnapshotState` is exported from the PR snapshot validator and covered by its boundary suite. Nothing called it.

The workflow reimplemented the same decision in bash — twice: once in `authorize-pr-snapshot`, and again in `publish-pr-snapshot`'s recheck immediately before npm OIDC publication. So the code deciding whether untrusted, fork-authored bytes may become an immutable published version was **not** the code under test, and the suite asserting that decision proved nothing about what actually ran. Two other tested exports, `successfulProducerAttempt` and `selectEligibleProducerRun`, were unreachable the same way.

Found by design review of the extraction in #1087.

## Goal

The decision has one implementation, and it is the one with tests.

## Decisions

**Invoke, don't restate.** Both sites call the predicate through a new `authorize` mode, following the pattern `assess-registry` already established — this finishes that approach rather than inventing one.

**The recheck stays a second invocation, not a second implementation.** Re-reading live state immediately before publication is the point of a time-of-use check, and that is preserved. What is removed is its ability to reach a *different* conclusion than the check that authorized it.

**The trust label becomes an argument.** It was hardcoded inside the predicate while also being threaded through the workflow — the third copy of that string, and the reason the workflow could have been pointed at a label the predicate ignored. An empty label now fails loudly rather than silently matching nothing.

**Validator checked out from the trusted revision.** `authorize` and `publish` gain a sparse checkout at `github.workflow_sha` — never from the pull request under evaluation.

## Before / after

**Before** — three implementations of one decision. The tested predicate sat unused while two hand-written bash copies made the real call:

```
                         ┌─────────────────────────────────────┐
  boundary suite ──────► │ isAuthorizedSnapshotState()         │  ← tested
                         │   (exported, never invoked)         │     never runs
                         └─────────────────────────────────────┘
                                        ✗ no caller

  authorize-pr-snapshot  ──►  bash copy #1  ──►  authorized=true/false
  publish-pr-snapshot    ──►  bash copy #2  ──►  test ... = true   ──►  npm publish
                                    ▲
                    two copies, free to drift from each other
                    and from the thing the tests actually assert
```

**After** — one implementation, and it is the tested one:

```
                         ┌─────────────────────────────────────┐
  boundary suite ──────► │ isAuthorizedSnapshotState()         │  ← tested
                         └──────────────▲──────────────────────┘     AND executed
                                        │
                         ┌──────────────┴──────────────┐
  authorize-pr-snapshot ─┤   node validator authorize  │
  publish-pr-snapshot   ─┤   --trust-label=<label>     ├──► npm publish
                         └─────────────────────────────┘
                    still two invocations (time-of-use recheck kept)
                    but they cannot reach different conclusions
```

### What this unlocks

| | Before | After |
|---|---|---|
| Decision sites | 3 (predicate + 2 bash copies) | 1 |
| Covered by tests | the copy nobody ran | the code that runs |
| Trust label | hardcoded in predicate **and** threaded through the workflow | a required argument; empty fails loudly |
| Wrong-label fork PR | passes tests, untested in practice | explicitly refused, with a case for it |
| Validator source | ambient | sparse checkout at `github.workflow_sha` (never the PR under evaluation) |

Concretely, a fork PR labelled `ci:deploy-docs` instead of the trust label used to be a scenario **no test covered and no implementation was known to reject**. It is now a failing case in the suite, decided by the same function CI calls.

## Verification

- Boundary suite: 12/13 pass. The one failure is `generated promotion workflow is anchored to trusted main`, which reads the *consuming* repo's `../workflows/release.yml`; it passes in consumers and cannot pass from this repo's source layout.
- New adversarial case: a fork pull request carrying a different plausible label (`ci:deploy-docs`) must not be authorized. The previous tests only exercised the correct label, so they would have passed even if the predicate ignored the label name entirely.
- New case: an empty trust label throws rather than matching nothing.
- `devenv tasks run ts:check` passes; generation is clean.

## Complexity

Net reduction. Roughly 35 lines of duplicated bash decision logic become two calls into an existing tested function; four new CLI modes are thin argument adapters over exports that already existed.

## Concerns

This changes publication-gating logic, so it deserves a careful read rather than a skim — particularly that the `authorize` mode's argument mapping matches what the bash previously computed, and that the recheck still fails closed.

The validator's own boundary suite cannot exercise the workflow wiring; that seam is only proven by a real snapshot publication. The livestore-contrib canary is the first end-to-end exercise of it.

## Follow-ups

- `pr-snapshot.ts` hand-rolls `actions/checkout@v4` while the shared `checkoutStep` is pinned to `@v6`; unifying needs `checkoutStep` extended with `persistCredentials` and `sparseCheckout`.

## References

Follows overengineeringstudio/effect-utils#1087. Refs livestorejs/livestore#1265.
