### PR TITLE
feat(notion-md): export syncTree so the tree engine is usable as a library

### DIFF
--- a/packages/@overeng/notion-md/src/mod.ts
+++ b/packages/@overeng/notion-md/src/mod.ts
@@ -98,6 +98,7 @@ export type {
 } from './reconcile.ts'
 export { NOTION_MD_VERSION } from './version.ts'
 export { pageUrl, resolveCrossRefs, validateCrossRefTargets } from './cross-refs.ts'
+export { syncTree } from './tree.ts'
 export type { TreeOp, TreeSyncResult } from './tree.ts'
 export { isSingleFileTarget, resolveNmdTargets, runBatchWatch } from './batch.ts'
 export type {


### PR DESCRIPTION
## What

Export `syncTree` from `mod.ts`, next to the `TreeOp` / `TreeSyncResult` types that already describe its result.

```diff
+export { syncTree } from './tree.ts'
 export type { TreeOp, TreeSyncResult } from './tree.ts'
```

## Why

`syncTree` is the entry point to the directory-tree sync engine — derived hierarchy from directory layout, curated child-index validation, and index-based retirement. Every layer it needs is already public:

```ts
syncTree(opts: { root, rootPageId?, rootFile?, plan?, fromRemote?, pushOptions? })
  : Effect<TreeSyncResult, NmdError,
           FileSystem.FileSystem | NotionMdGateway | NmdStateStore>
```

`NotionMdGateway` / `NotionMdGatewayLive` (`mod.ts:45-46`) and `NmdStateStore` / `NmdStateStoreLive` (`mod.ts:66-67`) are exported; `FileSystem` is standard `@effect/platform`. So the engine's whole dependency surface is public and only the driver function is not.

Today the engine is reachable only through `path.ts` (`syncPath` / `planPath`), which is not in the package `exports` map (`.`, `./cli`, `./cli-program` — no wildcard) and whose only consumer in the repo is `tree.unit.test.ts`. A downstream consumer that wants tree semantics rather than the flat per-file batch has no supported way in.

I hit this building a docs publisher that needs a parent page plus its children reconciled as one unit, where the per-file batch cannot express the parent/child relationship.

## Behaviour

`syncTree` is unmodified and the CLI is untouched, so no existing call resolves differently.

One consequence worth stating, since the previous `tree.ts` export was type-only and therefore erased at runtime: importing this package now additionally loads `tree.ts`. The graph grows by exactly that one module — `tree.ts`'s local imports (`cross-refs`, `frontmatter`, `hash`, `model`, `observability`, `sync`, `tree-index`) are all already reachable from `mod.ts` via `reconcile.ts`, `editor-commands.ts`, `live.ts` and `state-store.ts`.

## Verification

`nix build .#notion-md` from this branch builds clean.

Happy to add a `--tree` CLI surface or wire `syncCommand` to `syncPath` in a follow-up if you'd prefer the engine reachable from the CLI too — that is a behaviour change to a shipped command, so I kept it out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
