### PR TITLE
fix(observability): record native setup task spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **devenv observability verification**: enable native Devenv task activities
+  during trace capture while preserving task stderr and a diagnostic copy.
+
 - **genie/ci-workflow**: preserve prepared CI helper scripts between workflow
   steps by staging their runtime artifacts in the job workspace without their
   generator sources, and reject retry-helper use when another checkout would

--- a/nix/devenv-modules/observability.nix
+++ b/nix/devenv-modules/observability.nix
@@ -77,11 +77,18 @@ let
               bash -ceu '
                 export OTEL_EXPORTER_OTLP_ENDPOINT="$OTELITE_HTTP_ENDPOINT"
                 export DEVENV_TUI=false
-                exec devenv tasks run "$1" \
+                exec 3>&2
+                export OTEL_TASK_STDERR_FD=3
+                devenv --verbose tasks run "$1" \
                   --mode "$2" \
                   --no-tui \
-                  --trace-to "otlp-grpc:''${OTELITE_GRPC_ENDPOINT}"
-              ' bash "$target_task" "$task_mode" \
+                  --trace-to "otlp-grpc:''${OTELITE_GRPC_ENDPOINT}" \
+                  2>"$3/devenv-verbose.log" || {
+                    status=$?
+                    cat "$3/devenv-verbose.log" >&2
+                    exit "$status"
+                  }
+              ' bash "$target_task" "$task_mode" "$capture_dir" \
               | tee "$summary_file"
 
           ${otelite}/bin/otelite inspect "$capture_dir/capture" \
@@ -113,17 +120,24 @@ let
             --arg bridge "$bridge_task" \
             --arg project ${lib.escapeShellArg project} '
             ([.[] | select(
-              .service == "devenv"
-              and .name == $bridge
-              and .attrs["devenv.activity.kind"] == "task"
-            )][0].span_id) as $native
-            | $native != null
-              and any(.[];
                 .service == "effect-utils-devenv"
                 and .name == "devenv.task.exec"
                 and .attrs["task.name"] == $bridge
                 and .attrs["devenv.project.name"] == $project
-                and .parent_span_id == $native
+              )][0]) as $effect
+            | $effect != null
+              and any(.[];
+                .service == "devenv"
+                and .name == $bridge
+                and .attrs["devenv.activity.kind"] == "task"
+                and .span_id == $effect.parent_span_id
+                and .trace_id == $effect.trace_id
+              )
+              and any(.[];
+                .service == "devenv"
+                and .name == "execute command"
+                and .parent_span_id == $effect.parent_span_id
+                and .trace_id == $effect.trace_id
               )
           ' "$spans_file" >/dev/null
 

--- a/nix/devenv-modules/tasks/lib/trace.nix
+++ b/nix/devenv-modules/tasks/lib/trace.nix
@@ -171,15 +171,20 @@ let
       if [ -n "''${OTEL_DEVENV_PROJECT:-}" ]; then
         _otel_project_attr=(--attr "devenv.project.name=$OTEL_DEVENV_PROJECT")
       fi
-      OTEL_EXPORTER_OTLP_ENDPOINT="''${OTELITE_HTTP_ENDPOINT:-''${OTEL_EXPORTER_OTLP_ENDPOINT:-}}" \
-        "''${OTEL_SPAN_BIN:-otel-span}" run "effect-utils-devenv" "devenv.task.exec" \
-        "''${_otel_project_attr[@]}" \
-        --attr "tool.name=devenv" \
-        --attr "task.name=${taskName}" \
-        --attr "task.phase=exec" \
-        --attr "task.cached=false" \
-        --attr "span.label=${taskName}" \
-        -- bash -c ${lib.escapeShellArg execBody}
+      (
+        if [ -n "''${OTEL_TASK_STDERR_FD:-}" ]; then
+          exec 2>&"$OTEL_TASK_STDERR_FD"
+        fi
+        OTEL_EXPORTER_OTLP_ENDPOINT="''${OTELITE_HTTP_ENDPOINT:-''${OTEL_EXPORTER_OTLP_ENDPOINT:-}}" \
+          "''${OTEL_SPAN_BIN:-otel-span}" run "effect-utils-devenv" "devenv.task.exec" \
+          "''${_otel_project_attr[@]}" \
+          --attr "tool.name=devenv" \
+          --attr "task.name=${taskName}" \
+          --attr "task.phase=exec" \
+          --attr "task.cached=false" \
+          --attr "span.label=${taskName}" \
+          -- bash -c ${lib.escapeShellArg execBody}
+      )
     else
       ${execBody}
     fi

--- a/nix/devenv-modules/tasks/shared/tests/observability-capture.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/observability-capture.test.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="${DEVENV_ROOT:-$(cd "$TESTS_DIR/../../../../.." && pwd)}"
+
+capture_source="$ROOT/nix/devenv-modules/observability.nix"
+trace_source="$ROOT/nix/devenv-modules/tasks/lib/trace.nix"
+
+awk 'index($0, "devenv --verbose tasks run \"$1\" \\") { found = 1 } END { exit !found }' "$capture_source" || {
+  echo "FAIL: observability capture must enable verbose Devenv task activities" >&2
+  exit 1
+}
+
+awk 'index($0, "export OTEL_TASK_STDERR_FD=3") { found = 1 } END { exit !found }' "$capture_source" \
+  && awk 'index($0, "exec 2>&\"$OTEL_TASK_STDERR_FD\"") { found = 1 } END { exit !found }' "$trace_source" || {
+  echo "FAIL: observability capture must preserve successful task stderr" >&2
+  exit 1
+}
+
+lineage_filter='([.[] | select(.service == "effect-utils-devenv" and .name == "devenv.task.exec")][0]) as $effect
+  | $effect != null
+    and any(.[];
+      .service == "devenv"
+      and .name == "setup:gate"
+      and .span_id == $effect.parent_span_id
+      and .trace_id == $effect.trace_id
+    )
+    and any(.[];
+      .service == "devenv"
+      and .name == "execute command"
+      and .parent_span_id == $effect.parent_span_id
+      and .trace_id == $effect.trace_id
+    )'
+
+valid_lineage='[
+  {"service":"devenv","name":"setup:gate","trace_id":"other-trace","span_id":"other-task","parent_span_id":"other-root"},
+  {"service":"devenv","name":"setup:gate","trace_id":"trace","span_id":"task","parent_span_id":"root"},
+  {"service":"devenv","name":"execute command","trace_id":"trace","span_id":"execute","parent_span_id":"task"},
+  {"service":"effect-utils-devenv","name":"devenv.task.exec","trace_id":"trace","span_id":"bridge","parent_span_id":"task"}
+]'
+
+printf '%s\n' "$valid_lineage" | jq -e "$lineage_filter" >/dev/null || {
+  echo "FAIL: observability capture must admit a bridge parented by a native task with an execute child" >&2
+  exit 1
+}
+
+unrelated_execute='[
+  {"service":"devenv","name":"setup:gate","trace_id":"trace","span_id":"task","parent_span_id":"root"},
+  {"service":"devenv","name":"execute command","trace_id":"trace","span_id":"execute","parent_span_id":"other-task"},
+  {"service":"effect-utils-devenv","name":"devenv.task.exec","trace_id":"trace","span_id":"bridge","parent_span_id":"task"}
+]'
+
+if printf '%s\n' "$unrelated_execute" | jq -e "$lineage_filter" >/dev/null; then
+  echo "FAIL: observability capture must reject an unrelated execute command span" >&2
+  exit 1
+fi
+
+unrelated_bridge='[
+  {"service":"devenv","name":"setup:gate","trace_id":"trace","span_id":"task","parent_span_id":"root"},
+  {"service":"devenv","name":"execute command","trace_id":"trace","span_id":"execute","parent_span_id":"task"},
+  {"service":"effect-utils-devenv","name":"devenv.task.exec","trace_id":"trace","span_id":"bridge","parent_span_id":"other-task"}
+]'
+
+if printf '%s\n' "$unrelated_bridge" | jq -e "$lineage_filter" >/dev/null; then
+  echo "FAIL: observability capture must reject a bridge outside the native task lineage" >&2
+  exit 1
+fi
+
+echo "observability capture test passed"


### PR DESCRIPTION
## Problem

The shared setup trace verifier requires native Devenv root and task spans, but its nested Devenv invocation does not enable the verbosity level at which Devenv 2.2.2 records task activities. A successful `setup:gate` therefore produces only the independent Effect bridge span and the verifier exits 1.

## Goal

Make the shared verifier capture the native spans it already asserts, without weakening its trace-structure contract.

## Decisions

- Enable `--verbose` only inside the hermetic capture boundary. This preserves normal task output while asking Devenv to record task activities for the verification run.
- Keep the native-root, native-task, and bridged-child assertions intact rather than accepting an incomplete trace.
- Stack this semantic fix above #1092 so downstream consumers can pin one exact revision containing both CI prerequisites.

## Verification

- Regression test: `bash nix/devenv-modules/tasks/shared/tests/observability-capture.test.sh` - pass.
- Repository quick gate: `CI=1 devenv tasks run check:quick --no-tui` - pass (PTY `effect-utils.otel-verifier.check-quick`, exit 0).
- Minimal reproduction: Devenv 2.2.2 writes a zero-byte `json:file` trace for `setup:gate` at default verbosity; adding `-v` writes native root/task activities.
- Downstream `schickling.dev` verifier against this exact revision is being run before handoff.

## Complexity

No new abstraction or dependency; one capture flag and one regression test.

## Concerns

Verbose recording can produce more trace data during explicit profile/verification captures. It is scoped to those captures.

## Friction & bottlenecks

The failed verifier emitted only `{}` because its intermediate assertions suppress `jq` output. The preserved capture and a JSON-file falsification were needed to identify the absent native producer.

## Follow-ups

None.

## References

- Stacked on #1092.
- Downstream failure: schickling/schickling.dev#138.
