### PR TITLE
feat(playwright): pass web server environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- **@overeng/utils**: allow shared Playwright web-server configs to pass typed
+  environment variables to the server process.
 - **@overeng/megarepo**: add a read-only `mr store gc --generated-artifacts
 --dry-run` planner for safely identifying stale ignored build artifacts. The
   planner requires external agent-liveness evidence and fails closed on

--- a/packages/@overeng/utils/src/node/playwright/config/config.unit.test.ts
+++ b/packages/@overeng/utils/src/node/playwright/config/config.unit.test.ts
@@ -1,0 +1,27 @@
+import { expect } from 'vitest'
+
+import { Vitest } from '@overeng/utils-dev/node-vitest'
+
+import { createPlaywrightConfig } from './mod.ts'
+
+Vitest.describe('createPlaywrightConfig', () => {
+  Vitest.it('passes web server environment variables to Playwright', async () => {
+    const config = await createPlaywrightConfig({
+      testDir: './tests',
+      webServer: {
+        command: 'vite --port {{port}}',
+        env: {
+          CATALOG_API_URL: 'http://127.0.0.1:43210',
+          DEVENV_TASK_PASSTHROUGH: '1',
+        },
+      },
+    })
+
+    expect(config.webServer).toMatchObject({
+      env: {
+        CATALOG_API_URL: 'http://127.0.0.1:43210',
+        DEVENV_TASK_PASSTHROUGH: '1',
+      },
+    })
+  })
+})

--- a/packages/@overeng/utils/src/node/playwright/config/mod.ts
+++ b/packages/@overeng/utils/src/node/playwright/config/mod.ts
@@ -21,6 +21,8 @@ export interface WebServerConfig {
   command: string
   /** Working directory for the command */
   cwd?: string
+  /** Additional environment variables for the web server process. */
+  env?: Readonly<Record<string, string>>
   /** Timeout for server startup in ms (default: 30_000) */
   timeout?: number
   /**
@@ -95,6 +97,7 @@ export const createPlaywrightConfig = async (
   const {
     command,
     cwd,
+    env,
     timeout: serverTimeout = 30_000,
     portEnvVar = 'PW_TEST_PORT',
   } = webServerConfig
@@ -142,6 +145,7 @@ export const createPlaywrightConfig = async (
     webServer: {
       command: resolvedCommand,
       ...(cwd !== undefined ? { cwd } : {}),
+      ...(env !== undefined ? { env } : {}),
       url,
       timeout: serverTimeout,
       stdout: 'pipe',


### PR DESCRIPTION
## Problem

The shared Playwright config factory accepts the server command and working directory but discards typed environment settings. Consumers with an auxiliary test service must encode environment variables into a shell command.

## Goal

Let consumers pass Playwright web-server environment variables through the shared config contract.

## Decisions

Expose Playwright's existing web-server environment boundary rather than adding a consumer-specific port abstraction. Generic port allocation remains owned by the existing network helpers.

## Verification

- Failure-capable unit regression: failed before the implementation and passes afterward.
- `CI=1 devenv tasks run check:quick --no-tui`: pass.
- `check:all`: held by existing repository-wide formatting drift in six unrelated files and an OTel setup snapshot race with concurrent Rust target writes.

## Complexity

One optional field and direct pass-through; no new dependency or lifecycle abstraction.

## Concerns

None specific to this change.

## Friction & bottlenecks

The repository-wide full gate currently mixes source snapshots with concurrent build outputs and has unrelated formatting drift, so it cannot provide a clean full-suite result for this branch.

## Follow-ups

- Retarget the PTG dynamic-port PR to this branch, then remove its command-string environment wiring.

## References

- Refs schickling/schickling.dev#141
- Enables schickling/schickling.dev#142
