### PR TITLE
feat(notion-react): experimental JSX-to-Notion-Markdown projection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ devenv.local.nix
 # https://github.com/cachix/devenv/issues/2392
 /.devenv.flake.nix
 result
+result-*
 .pre-commit-config.yaml
 
 # Storybook

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- **@overeng/notion-react**: add an experimental read-only JSX →
+  Notion-enhanced-Markdown projection at the new `@overeng/notion-react/markdown`
+  entry point (#1097). `renderToNotionMarkdown(element)` reuses the production
+  candidate-tree render pass and returns `{ body, diagnostics }`; lossy
+  constructs (colors, upload-only media, flattened columns/child pages,
+  unsupported `Raw` blocks) emit typed diagnostics instead of disappearing
+  silently. The body composes with `@overeng/notion-md`'s `renderNmdFile` for
+  `.nmd` envelopes. Experimental: spellings and the diagnostics contract may
+  change until a real consumer proves the output.
 - **@overeng/utils**: allow shared Playwright web-server configs to pass typed
   environment variables to the server process.
 - **@overeng/megarepo**: add a read-only `mr store gc --generated-artifacts

--- a/nix/oxc-config-plugin.nix
+++ b/nix/oxc-config-plugin.nix
@@ -29,7 +29,7 @@ let
     pnpm = pinnedPnpm;
   };
   packageDir = "packages/@overeng/oxc-config";
-  pnpmDepsHash = "sha256-0EpX7HQHfu4XyZjO/0N4QjOKaFXNB3F/iEUzGesURjM=";
+  pnpmDepsHash = "sha256-sza2Nyf0FnrUoF6+X8Co1rFz3xUAqBsGhGLTs9ClNes=";
 
   srcPath =
     if builtins.isAttrs src && builtins.hasAttr "outPath" src then

--- a/packages/@overeng/ci-tools/nix/build.nix
+++ b/packages/@overeng/ci-tools/nix/build.nix
@@ -19,7 +19,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-KOHU2Wf4qIAeis7nZKdJRBA192SYTpgn+ztjCEbSVVk=";
+      "." = mkSharedHash "sha256-lpNzbVPbyaqMgT59u0+phDB9aWHp47IMa6wHJJVOtpk=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/genie/nix/build.nix
+++ b/packages/@overeng/genie/nix/build.nix
@@ -26,7 +26,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-DbFTw0rg9x++24H73gC0mh6Hio480Vzw4DcciBiFWj8=";
+      "." = mkSharedHash "sha256-xHiHuZ57syJDNoyTe2iIwWf35r5E4/YEognTI/Y5Hjo=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/megarepo/nix/build.nix
+++ b/packages/@overeng/megarepo/nix/build.nix
@@ -24,7 +24,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-qC8Zwf/5v9EOEplQe7nYC0ZsbIBqBPun5Qo/cUEsiDo=";
+      "." = mkSharedHash "sha256-pb8CkHUXHVtRU6IkdwZf3ExjgrLFCP+s0A3qujCs9lI=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     smokeTestArgs = [ "--help" ];

--- a/packages/@overeng/notion-cli/nix/build.nix
+++ b/packages/@overeng/notion-cli/nix/build.nix
@@ -33,7 +33,7 @@ let
     installRuntimeWorkspace = true;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-h4QW7C8huONRRAoB7S0mN4+DCzbvLd/onGyz7G9O83I=";
+      "." = mkSharedHash "sha256-yIHV4go2Nou5dBHmlWFzPWVEpwEX02xElPs+ovB2E5k=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/notion-md/nix/build.nix
+++ b/packages/@overeng/notion-md/nix/build.nix
@@ -20,7 +20,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-LAC9pK+sG1r5o5fUea8XNQexsl4gda0JpVzOYndD5EU=";
+      "." = mkSharedHash "sha256-47/e4WXFEPMSzGbcPK5nC+KOnTas596LlSw085RKdmA=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/notion-react/docs/README.md
+++ b/packages/@overeng/notion-react/docs/README.md
@@ -28,16 +28,19 @@ the design. The authoritative design docs live in
 
 1. [Concepts → Reconciler](./concepts/reconciler.md) — how a render pass
    becomes a sequence of Notion ops.
-2. [Concepts → Theming](./concepts/theming.md) — CSS surface, overrides,
+2. [Concepts → Markdown projection](./concepts/markdown-projection.md) —
+   read-only JSX → Markdown bodies for previews and review artifacts
+   (experimental).
+3. [Concepts → Theming](./concepts/theming.md) — CSS surface, overrides,
    dark mode.
-3. [API overview](./api.md) — the exported surface.
-4. [Cookbook → Custom blocks](./cookbook/custom-blocks.md) — `<Raw>` and
+4. [API overview](./api.md) — the exported surface.
+5. [Cookbook → Custom blocks](./cookbook/custom-blocks.md) — `<Raw>` and
    shaping your own block components.
-5. [Cookbook → Partial trees](./cookbook/partial-trees.md) — rendering a
+6. [Cookbook → Partial trees](./cookbook/partial-trees.md) — rendering a
    subtree without owning the whole page.
-6. [Cookbook → Observing sync](./cookbook/observing-sync.md) — measure
+7. [Cookbook → Observing sync](./cookbook/observing-sync.md) — measure
    HTTP ops, cache efficiency, and batching via the `onEvent` hook.
-7. [Migration notes](./migration.md) — breaking changes between versions.
+8. [Migration notes](./migration.md) — breaking changes between versions.
 
 ### Contributor — "I'm changing the package"
 

--- a/packages/@overeng/notion-react/docs/api.md
+++ b/packages/@overeng/notion-react/docs/api.md
@@ -8,14 +8,28 @@ map, not the reference.
 
 ```ts
 import { renderToNotion, sync } from '@overeng/notion-react'
+import { renderToNotionMarkdown } from '@overeng/notion-react/markdown'
 ```
 
-| Export           | Source                                                                | Purpose                                                                                                 |
-| ---------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| `renderToNotion` | [`renderer/render-to-notion.ts`](../src/renderer/render-to-notion.ts) | Cold-start append; no cache. Returns `Effect<SyncResult, NotionSyncError, NotionConfig \| HttpClient>`. |
-| `sync`           | [`renderer/sync.ts`](../src/renderer/sync.ts)                         | Incremental cache-backed sync. Same return type. See [sync options](#sync-options).                     |
-| `collectOps`     | [`renderer/render-to-notion.ts`](../src/renderer/render-to-notion.ts) | Collect an `OpBuffer` from a one-shot render. Exposed for tests.                                        |
-| `SyncResult`     | [`renderer/render-to-notion.ts`](../src/renderer/render-to-notion.ts) | `{ appends, updates, removes, inserts, fallbackReason? }`                                               |
+| Export                   | Source                                                                                  | Purpose                                                                                                                                      |
+| ------------------------ | --------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `renderToNotion`         | [`renderer/render-to-notion.ts`](../src/renderer/render-to-notion.ts)                   | Cold-start append; no cache. Returns `Effect<SyncResult, NotionSyncError, NotionConfig \| HttpClient>`.                                      |
+| `sync`                   | [`renderer/sync.ts`](../src/renderer/sync.ts)                                           | Incremental cache-backed sync. Same return type. See [sync options](#sync-options).                                                          |
+| `collectOps`             | [`renderer/render-to-notion.ts`](../src/renderer/render-to-notion.ts)                   | Collect an `OpBuffer` from a one-shot render. Exposed for tests.                                                                             |
+| `SyncResult`             | [`renderer/render-to-notion.ts`](../src/renderer/render-to-notion.ts)                   | `{ appends, updates, removes, inserts, fallbackReason? }`                                                                                    |
+| `renderToNotionMarkdown` | [`markdown/render-to-notion-markdown.ts`](../src/markdown/render-to-notion-markdown.ts) | **Experimental.** Read-only JSX → Notion-enhanced-Markdown body + diagnostics. See [Markdown projection](./concepts/markdown-projection.md). |
+
+## Markdown projection options
+
+`renderToNotionMarkdown(element)` is pure and synchronous — no options, no
+Effect, no network. Returns:
+
+```ts
+{
+  body: string                              // Notion-enhanced-Markdown body
+  diagnostics: readonly MarkdownDiagnostic[] // typed loss notices (see concepts doc)
+}
+```
 
 ## Sync options
 

--- a/packages/@overeng/notion-react/docs/concepts/markdown-projection.md
+++ b/packages/@overeng/notion-react/docs/concepts/markdown-projection.md
@@ -45,21 +45,23 @@ always produced.
 
 ## Fidelity matrix
 
-| Construct                           | Spelling                                                                  |
-| ----------------------------------- | ------------------------------------------------------------------------- |
-| Headings, paragraphs                | `#`–`####`, plain paragraphs                                              |
-| Bold / italic / code / strike       | `**` / `*` / backticks / `~~`                                             |
-| Underline                           | `<u>` (no native Markdown)                                                |
-| Links, inline equations             | `[text](url)`, `$expr$`                                                   |
-| Mentions                            | `@name`, dates as `start → end`; href-less mentions degrade to plain text |
-| Bulleted / numbered / to-do lists   | `- `, per-run `1.` counters, `- [x]`                                      |
-| Toggles                             | `<details><summary>` (CommonMark-safe blank lines)                        |
-| Quotes / callouts                   | Blockquotes; emoji icon prefix kept                                       |
-| Code                                | Fenced, fence lengthened past embedded backtick runs                      |
-| Tables                              | GFM with header separator row                                             |
-| Images / media / bookmarks / embeds | `![caption](url)` / `[label](url)`                                        |
-| Equations, dividers, TOC            | `$$ … $$`, `---`, `[TOC]`                                                 |
-| `blockKey`                          | Absent — renderer identity, not content                                   |
+| Construct                           | Spelling                                                                                                                         |
+| ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| Headings, paragraphs                | `#`–`####`, plain paragraphs                                                                                                     |
+| Bold / italic / code / strike       | `**` / `*` / backticks / `~~`                                                                                                    |
+| Underline                           | `<u>` (no native Markdown)                                                                                                       |
+| Links, inline equations             | `[text](url)`, `$expr$`                                                                                                          |
+| Mentions                            | `@name`, dates as `start → end`; href-less mentions degrade to plain text; annotations wrapping a mention/equation are preserved |
+| Bulleted / numbered / to-do lists   | `- `, per-run `1.` counters, `- [x]`                                                                                             |
+| Toggles                             | `<details><summary>` (CommonMark-safe blank lines)                                                                               |
+| Quotes / callouts                   | Blockquotes; emoji icon prefix kept                                                                                              |
+| Code                                | Fenced, fence lengthened past embedded backtick runs                                                                             |
+| Tables                              | GFM with header separator row                                                                                                    |
+| Images / media / bookmarks / embeds | `![caption](url)` / `[label](url)`                                                                                               |
+| Equations, dividers, TOC            | `$$ … $$`, `---`, `[TOC]`                                                                                                        |
+| Literal Markdown syntax in text     | Escaped (`\#`, `\*`, `\_`, …) so authored text survives verbatim; `$` stays bare (renders literally in stock Markdown)           |
+| `blockKey`                          | Absent — renderer identity, not content                                                                                          |
+| Root `<Page>` title/icon/cover      | Omitted from the body (belongs in the `.nmd` envelope or page properties) with a diagnostic                                      |
 
 ## Composing an `.nmd` file
 

--- a/packages/@overeng/notion-react/docs/concepts/markdown-projection.md
+++ b/packages/@overeng/notion-react/docs/concepts/markdown-projection.md
@@ -1,0 +1,77 @@
+# Markdown projection
+
+`@overeng/notion-react/markdown` turns the same JSX you sync into a readable
+Notion-enhanced-Markdown body — no network, no Notion mutations, no cache.
+Use it for review artifacts, CLI previews, snapshot diffs, and documentation
+generated from the same content source that feeds production pages.
+
+```tsx
+import { renderToNotionMarkdown } from '@overeng/notion-react/markdown'
+
+const { body, diagnostics } = renderToNotionMarkdown(<Instructions />)
+```
+
+> **Experimental.** Spellings and the diagnostics contract may change until
+> a real consumer has proven the output. The body is a review artifact, not
+> a canonical round-trip representation of Notion content.
+
+## How it relates to sync
+
+Both paths start from the same render pass: your JSX becomes a normalized
+candidate tree, and each consumer reads that tree.
+
+```
+JSX ──► candidate tree ─┬─ diff vs cache ──► ops ──► Notion   (sync: mutating)
+                        └─ projector ──► body + diagnostics  (projection: read-only)
+```
+
+The projection never scrapes HTML and never reconstructs content from sync
+operations. Because it shares the tree, what you preview is what sync would
+write — but a matching body does **not** imply cache identity or sync
+safety.
+
+## Diagnostics, not silence
+
+Constructs that cannot survive Markdown losslessly are dropped from the body
+_and reported_. Nothing disappears silently; nothing fails hard — the body is
+always produced.
+
+| Diagnostic          | When                                                                               | Body treatment                   |
+| ------------------- | ---------------------------------------------------------------------------------- | -------------------------------- |
+| `color-dropped`     | Non-default text/heading/callout colors                                            | Color omitted, text kept         |
+| `media-without-url` | Media referencing a `fileUploadId` (no offline-resolvable URL)                     | HTML-comment placeholder         |
+| `flattened`         | Column layouts, child-page boundaries, toggleable headings, external callout icons | Sequential/bold-label flattening |
+| `unsupported-block` | `<Raw>` passthrough types with no Markdown spelling                                | HTML-comment placeholder         |
+
+## Fidelity matrix
+
+| Construct                           | Spelling                                                                  |
+| ----------------------------------- | ------------------------------------------------------------------------- |
+| Headings, paragraphs                | `#`–`####`, plain paragraphs                                              |
+| Bold / italic / code / strike       | `**` / `*` / backticks / `~~`                                             |
+| Underline                           | `<u>` (no native Markdown)                                                |
+| Links, inline equations             | `[text](url)`, `$expr$`                                                   |
+| Mentions                            | `@name`, dates as `start → end`; href-less mentions degrade to plain text |
+| Bulleted / numbered / to-do lists   | `- `, per-run `1.` counters, `- [x]`                                      |
+| Toggles                             | `<details><summary>` (CommonMark-safe blank lines)                        |
+| Quotes / callouts                   | Blockquotes; emoji icon prefix kept                                       |
+| Code                                | Fenced, fence lengthened past embedded backtick runs                      |
+| Tables                              | GFM with header separator row                                             |
+| Images / media / bookmarks / embeds | `![caption](url)` / `[label](url)`                                        |
+| Equations, dividers, TOC            | `$$ … $$`, `---`, `[TOC]`                                                 |
+| `blockKey`                          | Absent — renderer identity, not content                                   |
+
+## Composing an `.nmd` file
+
+The body is a plain string. Wrap it in a NotionMD envelope at your own
+boundary:
+
+```ts
+import { renderNmdFile } from '@overeng/notion-md'
+
+const file = renderNmdFile({ frontmatter, body })
+```
+
+`@overeng/notion-react` holds only a dev dependency on `@overeng/notion-md`
+for its composition test — production code never imports it, and the reverse
+dependency does not exist.

--- a/packages/@overeng/notion-react/docs/concepts/markdown-projection.md
+++ b/packages/@overeng/notion-react/docs/concepts/markdown-projection.md
@@ -45,23 +45,23 @@ always produced.
 
 ## Fidelity matrix
 
-| Construct                           | Spelling                                                                                                                         |
-| ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| Headings, paragraphs                | `#`–`####`, plain paragraphs                                                                                                     |
-| Bold / italic / code / strike       | `**` / `*` / backticks / `~~`                                                                                                    |
-| Underline                           | `<u>` (no native Markdown)                                                                                                       |
-| Links, inline equations             | `[text](url)`, `$expr$`                                                                                                          |
-| Mentions                            | `@name`, dates as `start → end`; href-less mentions degrade to plain text; annotations wrapping a mention/equation are preserved |
-| Bulleted / numbered / to-do lists   | `- `, per-run `1.` counters, `- [x]`                                                                                             |
-| Toggles                             | `<details><summary>` (CommonMark-safe blank lines)                                                                               |
-| Quotes / callouts                   | Blockquotes; emoji icon prefix kept                                                                                              |
-| Code                                | Fenced, fence lengthened past embedded backtick runs                                                                             |
-| Tables                              | GFM with header separator row                                                                                                    |
-| Images / media / bookmarks / embeds | `![caption](url)` / `[label](url)`                                                                                               |
-| Equations, dividers, TOC            | `$$ … $$`, `---`, `[TOC]`                                                                                                        |
-| Literal Markdown syntax in text     | Escaped (`\#`, `\*`, `\_`, …) so authored text survives verbatim; `$` stays bare (renders literally in stock Markdown)           |
-| `blockKey`                          | Absent — renderer identity, not content                                                                                          |
-| Root `<Page>` title/icon/cover      | Omitted from the body (belongs in the `.nmd` envelope or page properties) with a diagnostic                                      |
+| Construct                           | Spelling                                                                                                                                                                                                                                  |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Headings, paragraphs                | `#`–`####`, plain paragraphs                                                                                                                                                                                                              |
+| Bold / italic / code / strike       | `**` / `*` / backticks / `~~`                                                                                                                                                                                                             |
+| Underline                           | `<u>` (no native Markdown)                                                                                                                                                                                                                |
+| Links, inline equations             | `[text](url)`, `$expr$`                                                                                                                                                                                                                   |
+| Mentions                            | `@name`, dates as `start → end`; href-less page/database mentions link to `notion.so/<id>`; mentions without `plainText` fall back to typed labels (`@user`, `@page`, `@database`); annotations wrapping a mention/equation are preserved |
+| Bulleted / numbered / to-do lists   | `- `, per-run `1.` counters, `- [x]`                                                                                                                                                                                                      |
+| Toggles                             | `<details><summary>` (CommonMark-safe blank lines)                                                                                                                                                                                        |
+| Quotes / callouts                   | Blockquotes; emoji icon prefix kept                                                                                                                                                                                                       |
+| Code                                | Fenced, fence lengthened past embedded backtick runs                                                                                                                                                                                      |
+| Tables                              | GFM with header separator row                                                                                                                                                                                                             |
+| Images / media / bookmarks / embeds | `![caption](url)` / `[label](url)`                                                                                                                                                                                                        |
+| Equations, dividers, TOC            | `$$ … $$`, `---`, `[TOC]`                                                                                                                                                                                                                 |
+| Literal Markdown syntax in text     | Escaped (`\#`, `\*`, `\_`, …) so authored text survives verbatim; `$` stays bare (renders literally in stock Markdown)                                                                                                                    |
+| `blockKey`                          | Absent — renderer identity, not content                                                                                                                                                                                                   |
+| Root `<Page>` title/icon/cover      | Omitted from the body (belongs in the `.nmd` envelope or page properties) with a diagnostic                                                                                                                                               |
 
 ## Composing an `.nmd` file
 

--- a/packages/@overeng/notion-react/docs/vrs/.decisions/0001-markdown-projection.md
+++ b/packages/@overeng/notion-react/docs/vrs/.decisions/0001-markdown-projection.md
@@ -1,0 +1,82 @@
+# 0001 — Dedicated CandidateTree Markdown projector, structured result, drop-with-diagnostics fidelity
+
+Date: 2026-08-21
+
+Status: accepted
+
+Deciders: schickling (delegated via "do all remaining work"), ox-alpha (evidence + recommendation)
+
+## Context
+
+#1097 asks for a read-only JSX → Notion-enhanced-Markdown projection for
+review artifacts, CLI previews/exports, and optional `.nmd` envelope
+composition. The workspace already contains a blocks→Markdown serializer
+(`NotionMarkdown.treeToMarkdown` in `@overeng/notion-effect-client`, the
+pull-side wire renderer), so architecture, return shape, naming, fidelity
+policy, stability status, composition-test placement, and VRS shape all
+needed settling. Seven decision requests were recorded in the axe decision
+tree (Q1–Q7) with grounded options; the user delegated the remaining work,
+so each was assumed on the evidence-backed recommendation.
+
+## Options
+
+| Q                   | Option                                        | Chosen        | Grounding                                                                                                               |
+| ------------------- | --------------------------------------------- | ------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| Q1 architecture     | dedicated CandidateTree projector             | yes           | prototype green (experiment 0001); delegation cannot meet typed-diagnostics criterion without pull-side wire-drift risk |
+| Q1 architecture     | delegate to `treeToMarkdown`                  | no            | no diagnostics channel, silent unknown-type drop, hardcoded `"1."`, non-GFM tables (source read 2026-08-21)             |
+| Q1 architecture     | dedicated now, extract shared spellings later | yes (variant) | demand gate: centralize when second consumer justifies                                                                  |
+| Q2 return shape     | structured `{body, diagnostics}`              | yes           | bare string cannot satisfy #1097 diagnostics acceptance criterion                                                       |
+| Q2 return shape     | bare string                                   | no            | side-channel warnings untestable, non-composable                                                                        |
+| Q3 naming           | `renderToNotionMarkdown` at `./markdown`      | yes           | #1097 proposed API verbatim; mirrors `renderToNotion` + `./web` patterns                                                |
+| Q4 fidelity         | drop-with-diagnostics                         | yes           | dialect-consistent (`RichTextUtils.toMarkdown` drops colors); body stays clean review artifact                          |
+| Q4 fidelity         | HTML fallbacks                                | no            | dialect-divergent, noisy diffs                                                                                          |
+| Q4 fidelity         | fail-closed                                   | no            | unusable for real documents (colors are common)                                                                         |
+| Q5 stability        | experimental                                  | yes           | #1097 demand gate: narrow until Blocky proof + fidelity matrix + second consumer                                        |
+| Q6 composition test | react devDep on notion-md, colocated test     | yes           | exercises real `renderNmdFile`; manifest coupling only; forbidden reverse direction not created                         |
+| Q7 VRS shape        | extend notion-react docs/vrs                  | yes           | owning-artifact locality; new subsystem root is overkill                                                                |
+
+## Evidence and Argument
+
+- Prototype (experiment 0001, 2026-08-21): a dedicated CandidateTree walker
+  passed 16 golden tests plus the full package suite and produced #1097's
+  canonical example byte-for-byte; composition with the real `renderNmdFile`
+  verified end-to-end.
+- Source read of `notion-effect-client/src/markdown.ts` (2026-08-21): no
+  diagnostics channel (`unsupported: () => ''`), hardcoded `"1."` numbering,
+  table rows without a GFM header separator — delegation cannot meet the
+  typed-diagnostics acceptance criterion without invasive pull-side changes
+  risking `.nmd` wire drift.
+- `RichTextUtils.toMarkdown` drops non-default colors silently; HTML-span
+  color fallbacks appear nowhere in the workspace dialect, so
+  drop-with-diagnostics is the consistent policy.
+- #1097's demand gate requires narrow-and-experimental until consumer proof;
+  its non-goals forbid notion-md→notion-react coupling and production
+  frontmatter/settlement semantics in notion-react (a devDependency used by
+  one test creates neither).
+
+## Decision
+
+1. Dedicated serializer over the shared `CandidateTree` inside
+   `@overeng/notion-react/src/markdown/`; spellings aligned with the pull-side
+   dialect where sound; centralization deferred until a second consumer.
+2. Structured result `{ body, diagnostics }`.
+3. `renderToNotionMarkdown` at `@overeng/notion-react/markdown`.
+4. Drop-with-diagnostics fidelity: colors dropped with diagnostics; `blockKey`
+   absent from the body; toggleable headings flatten with diagnostic; child
+   pages flatten to bold label + content with diagnostic; unsupported/`Raw`
+   blocks emit HTML-comment placeholders + diagnostics.
+5. Explicitly experimental surface (`@experimental` JSDoc, docs, CHANGELOG).
+6. `@overeng/notion-md` as devDependency of `@overeng/notion-react` with a
+   colocated composition test; production imports stay clean.
+7. VRS extends this package's docs/vrs (spec section, this record, experiment
+   0001).
+
+## Consequences
+
+- Two spelling tables exist (push-side review projection, pull-side wire
+  renderer); golden tests pin the review dialect and drift is an accepted cost
+  until centralization.
+- The body is a review artifact only: no CacheTree identity, sync safety, or
+  round-trip claims may be derived from Markdown equality (#1097 non-goals).
+- Diagnostics kinds are an open set (`unsupported-block`, `media-without-url`,
+  `color-dropped`, `flattened` today); growth is additive while experimental.

--- a/packages/@overeng/notion-react/docs/vrs/.experiments/0001-jsx-markdown-projection.md
+++ b/packages/@overeng/notion-react/docs/vrs/.experiments/0001-jsx-markdown-projection.md
@@ -1,0 +1,56 @@
+# Experiment: JSX → Notion-enhanced-Markdown prototype validation
+
+- **Date:** 2026-08-21
+- **Related:** decision 0001, issue #1097
+
+## Question
+
+Can a read-only Markdown projection share the production render/tree
+semantics, produce deterministic review-grade output with typed diagnostics,
+and compose with `renderNmdFile` — without touching the pull-side wire
+renderer?
+
+## Method
+
+Prototype implementation at `src/markdown/render-to-notion-markdown.ts`
+walking `buildCandidateTree` output; 16 golden unit tests (headings,
+paragraphs, inline annotations, links, mentions, equations, per-run numbered
+lists, nested lists, to-dos, `<details>` toggles, quotes, callouts, code
+fences, GFM tables with header separator, dividers, block equations, TOC,
+page links, external media, bookmarks, embeds, upload-only media diagnostics,
+column flattening, child-page flattening, Raw placeholders, determinism); 1
+composition test driving the real `renderNmdFile`; end-to-end scratch run
+producing a full `.nmd` file compared against #1097's canonical example.
+
+## Result
+
+Confirmed. Full package suite green (335 tests incl. new); `check:quick`
+(ts + lint + genie) green after export/devDep wiring. Diagnostics fire for
+color drops, upload-only media, flattened columns/child pages, and
+unsupported Raw blocks. Determinism holds across repeated renders; the body
+matches #1097's canonical example.
+
+Facts established along the way:
+
+- Media captions are a component _prop_ (`caption={...}`), not children —
+  children of media components are ignored by the host projection.
+- `bookmark`/`embed` project a bare `url` prop; file-like media project
+  `type: 'external' | 'file_upload'` envelopes.
+- The mention dialect renders `@{plain_text}` (plainText excludes the `@`),
+  matching `RichTextUtils.toMarkdown`.
+- `RichTextUtils.toMarkdown` silently drops non-default colors; the projector
+  instead emits `color-dropped` diagnostics.
+- `renderNmdFile` appends a trailing newline after the body.
+
+## Conclusion
+
+Ship the projection as an experimental entry point per decision 0001. The
+dedicated-projector architecture meets every #1097 acceptance criterion that
+is testable offline; the Blocky consumer proof remains open per the demand
+gate.
+
+## VRS Impact
+
+Spec gains the "Markdown projection (read-only, experimental)" section;
+decision 0001 records the consolidated Q1–Q7 choices; fidelity matrix facts
+above feed future spec expansion when the second consumer lands.

--- a/packages/@overeng/notion-react/docs/vrs/ontology.md
+++ b/packages/@overeng/notion-react/docs/vrs/ontology.md
@@ -1,0 +1,54 @@
+# Ontology — @overeng/notion-react
+
+## Language
+
+- **Owned region:** The portion of a Notion page this library reconciles from
+  JSX. Human edits inside it may be overwritten (A04, T01).
+  _Avoid:_ "managed area", "sync scope".
+- **Instance tree:** The in-memory tree the react-reconciler host-config
+  builds during a render pass. Internal; never exposed.
+- **CandidateTree / CandidateNode:** The normalized, hash-annotated
+  projection of one render pass — projected Notion-shaped props per block,
+  keyed children. The single representation every downstream consumer
+  (diff, cache snapshot, Markdown projector) reads.
+- **CacheTree:** The persisted counterpart of a CandidateTree (`NotionCache`
+  backends), carrying resolved Notion block ids and schema version.
+- **blockKey:** Author-supplied identity hint for stable sibling matching
+  across renders. Renderer-level only: never projected into Notion payloads
+  and never emitted into Markdown bodies.
+- **Sync:** The production path — CandidateTree vs CacheTree diff → op plan →
+  Notion API mutations. Mutating by definition.
+- **Projection (Markdown projection):** The read-only serialization of a
+  CandidateTree to a Notion-enhanced-Markdown **body** for human review.
+  Never mutates Notion, never reads or writes cache. Distinct from Sync and
+  from the web preview.
+  _Avoid:_ "export" (implies completeness), "render to HTML".
+- **Body:** The Markdown string a projection returns. A review artifact —
+  not a canonical round-trip representation of Notion content.
+- **Diagnostic:** Typed, structured notice that a construct could not be
+  represented losslessly in the body (`unsupported-block`,
+  `media-without-url`, `color-dropped`, `flattened`). Emitted alongside the
+  body; never thrown, never logged to a side channel.
+  _Avoid:_ "warning" (implies console noise).
+- **Dialect (enhanced-Markdown dialect):** The concrete Markdown spellings
+  this workspace treats as Notion-enhanced Markdown — defined de facto by
+  the pull-side renderer/canonicalizer in `@overeng/notion-effect-client`.
+  The projection aligns with it where sound but owns its own spelling table
+  (T10).
+- **Envelope (.nmd):** The strict frontmatter + body file format owned by
+  `@overeng/notion-md`. The projection produces bodies that compose with it;
+  it knows nothing about envelopes.
+
+## Structure
+
+```
+JSX (authored components)
+  └─ Instance tree ──► CandidateTree ─┬─ diff vs CacheTree ──► ops ──► Notion   (Sync)
+                                      └─ Markdown projector ──► Body (+ Diagnostics)
+                                                                        │
+                                              Envelope (.nmd, notion-md) ◄─ composition
+```
+
+Leitwort: **project** always means the read-only Markdown path; **sync**
+always means the mutating Notion path. A body never implies sync state, and
+diagnostics never imply errors — they are fidelity facts.

--- a/packages/@overeng/notion-react/docs/vrs/requirements.md
+++ b/packages/@overeng/notion-react/docs/vrs/requirements.md
@@ -34,6 +34,11 @@ host-config, or cache are implemented (see [spec.md](./spec.md) for that).
   `blocks.children.list` returns 404 on an archived page.
 - **A10 Title length:** Each title rich_text span is capped at 2000
   characters. Callers that need longer titles must split across spans.
+- **A11 Offline fidelity reference:** Notion's own enhanced-Markdown endpoint
+  output is not available without network access. Projection fidelity is
+  therefore measured against JSX component semantics and the workspace's
+  de-facto enhanced-Markdown dialect (the pull-side renderer and canonicalizer
+  in `@overeng/notion-effect-client`), not against Notion endpoint output.
 - **A02 Effect callers:** Downstream callers run in Effect and can provide
   `NotionConfig` + `HttpClient` in their runtime.
 - **A03 React 19 + react-reconciler:** Rendering uses `react@19` and
@@ -89,6 +94,11 @@ host-config, or cache are implemented (see [spec.md](./spec.md) for that).
   page-parented sub-pages. Database parents, custom property schemas, and
   `is_locked`/`erase_content` surfaces are explicitly out of scope but
   must not be precluded by the prop design.
+- **T10 Two Markdown spelling tables:** The read-only projection owns its
+  block→Markdown spellings separately from the pull-side wire renderer.
+  Drift between them is accepted until a second consumer justifies
+  centralization (#1098); golden tests pin the projection dialect in the
+  meantime.
 
 ## Requirements
 
@@ -236,3 +246,29 @@ host-config, or cache are implemented (see [spec.md](./spec.md) for that).
 - **R23 Host-config encapsulation:** All react-reconciler host-config
   details live behind an internal module boundary; downstream callers
   must never need to touch it.
+
+### Must project authored JSX to readable Markdown (experimental)
+
+- **R31 Read-only offline projection:** Rendering JSX through the Markdown
+  entry point must produce a body with no network access, no Notion
+  mutations, and no cache reads or writes.
+- **R32 Shared render semantics:** The projection must consume the same
+  normalized candidate-tree representation that feeds Notion projection —
+  never by scraping rendered HTML and never by reconstructing content from
+  mutation operations.
+- **R33 No silent loss:** Every construct that cannot be represented
+  losslessly must either appear in a documented spelling or produce a typed
+  diagnostic. Unsupported or lossy constructs must not disappear silently,
+  and the body must always be produced (no fail-closed refusal).
+- **R34 Deterministic output:** Identical JSX must produce byte-identical
+  bodies — LF line endings, stable ordering, no ambient state — suitable
+  for reviewed snapshots and diffs.
+- **R35 Envelope composition without reverse coupling:** The returned body
+  must compose with `@overeng/notion-md`'s `renderNmdFile`; production code
+  in this package must not depend on `@overeng/notion-md`, and
+  `@overeng/notion-md` must not depend on this package.
+- **R36 Experimental contract is documented:** Until promoted stable, docs
+  must mark the entry point experimental and distinguish projection
+  fidelity from production reconciliation fidelity and Notion endpoint
+  round-trip fidelity; Markdown equality must not be interpretable as
+  CacheTree identity or sync safety.

--- a/packages/@overeng/notion-react/docs/vrs/spec.md
+++ b/packages/@overeng/notion-react/docs/vrs/spec.md
@@ -31,7 +31,9 @@ It does not define:
 - Markdown endpoint completeness, `.nmd` clean-base adoption, or datasource-sync
   body guards — those live in `@overeng/notion-core`,
   `@overeng/notion-effect-client`, `@overeng/notion-md`, and
-  `@overeng/notion-datasource-sync`.
+  `@overeng/notion-datasource-sync`. (The read-only Markdown _projection_
+  defined here is a local serialization of authored JSX; it performs no
+  endpoint round-trip and no body settlement.)
 - The web renderer's DOM output — see that package's own docs (it is a
   non-normative preview per T05).
 - The pixeltrail migration plan — tracked in pixeltrail issues.
@@ -528,6 +530,62 @@ The host-config already stubs the React 19 Suspense entries
 `maySuspendCommit` will return true when the registry misses for a
 hash. r3f's `useLoader` + `<Suspense>` (`pmndrs/react-three-fiber`
 PR #3224) is the reference implementation pattern.
+
+## Markdown projection (read-only, experimental)
+
+See `src/markdown/`. Entry point: `@overeng/notion-react/markdown`.
+
+`renderToNotionMarkdown(element)` reuses the production render pass —
+`buildCandidateTree` over the same reconciler host-config that feeds Notion
+projection — and serializes the resulting `CandidateTree` to a readable
+Notion-enhanced-Markdown body. It is pure, synchronous, network-free, and
+performs no Notion mutation, no cache read/write, and no diff.
+
+```ts
+const { body, diagnostics } = renderToNotionMarkdown(<Instructions />)
+```
+
+Contract:
+
+- **Shared semantics, separate serializer.** The projection shares the
+  normalized instance/CandidateTree representation with the Notion path but
+  owns its block→Markdown spellings. It deliberately does not delegate to
+  `NotionMarkdown.treeToMarkdown` in `@overeng/notion-effect-client`: that
+  renderer is the pull-side wire serializer (no diagnostics channel, silent
+  unknown-type drop, hardcoded list numbering, non-GFM table output), and
+  modifying it for review-artifact needs would risk `.nmd` wire-format drift.
+  Spellings align with the pull-side dialect where sound (`<details>` toggles,
+  blockquote callouts, `[TOC]`, fenced code). Drift between the two spelling
+  tables is mitigated by golden tests; centralization is deferred until a
+  second consumer justifies it (decision 0001).
+- **Diagnostics, not silence.** Constructs that cannot survive projection
+  emit a typed `MarkdownDiagnostic` (`unsupported-block`,
+  `media-without-url`, `color-dropped`, `flattened`) alongside the body.
+  Nothing disappears silently; nothing fails hard either — the body is always
+  produced.
+- **Fidelity policy.** Colors and other unrepresentable attributes are
+  dropped with diagnostics. `blockKey` is absent from the body (renderer
+  identity, consistent with the Notion payload projection). Toggleable
+  headings flatten to heading + following content. `<ChildPage>` flattens to
+  a bold label + inline content. Unsupported/`Raw` blocks emit an HTML-comment
+  placeholder. Media referencing `file_upload` (no offline-resolvable URL)
+  emits a placeholder + diagnostic.
+- **Composition.** The body is a plain string and composes with
+  `@overeng/notion-md`'s `renderNmdFile({ frontmatter, body })` at the
+  caller's discretion. `@overeng/notion-react` holds only a devDependency on
+  `@overeng/notion-md` for the composition test; production code never
+  imports it, and the forbidden reverse dependency does not exist.
+- **Status.** Experimental (#1097): spellings and the diagnostics contract may
+  change until a real consumer proves the output. The body is a review
+  artifact, not a canonical Notion round-trip representation, and Markdown
+  equality must not be read as CacheTree identity or sync safety.
+
+Satisfies the #1097 acceptance criteria: shared tree semantics (no HTML
+scraping), golden tests across headings/rich text/lists/toggles/tables/code/
+callouts/links/nesting, typed diagnostics for lossy constructs, deterministic
+output (LF endings, stable ordering), composition without reverse coupling,
+and documentation distinguishing projection fidelity from reconciliation and
+endpoint round-trip fidelity.
 
 ## Extension points
 

--- a/packages/@overeng/notion-react/docs/vrs/spec.md
+++ b/packages/@overeng/notion-react/docs/vrs/spec.md
@@ -580,12 +580,12 @@ Contract:
   artifact, not a canonical Notion round-trip representation, and Markdown
   equality must not be read as CacheTree identity or sync safety.
 
-Satisfies the #1097 acceptance criteria: shared tree semantics (no HTML
-scraping), golden tests across headings/rich text/lists/toggles/tables/code/
-callouts/links/nesting, typed diagnostics for lossy constructs, deterministic
-output (LF endings, stable ordering), composition without reverse coupling,
-and documentation distinguishing projection fidelity from reconciliation and
-endpoint round-trip fidelity.
+Satisfies R31–R36: shared tree semantics (R32, no HTML scraping), read-only
+offline operation (R31), no-silent-loss diagnostics (R33), deterministic
+output (R34), envelope composition without reverse coupling (R35), and
+documented experimental status distinguishing projection fidelity from
+reconciliation and endpoint round-trip fidelity (R36). Terminology follows
+[ontology.md](./ontology.md).
 
 ## Extension points
 

--- a/packages/@overeng/notion-react/package.json
+++ b/packages/@overeng/notion-react/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "exports": {
     ".": "./src/mod.ts",
+    "./markdown": "./src/markdown/mod.ts",
     "./o11y": "./src/o11y/mod.ts",
     "./o11y/effect": "./src/o11y/effect-adapter.ts",
     "./o11y/otel": "./src/o11y/otel-adapter.ts",
@@ -18,6 +19,7 @@
     "access": "public",
     "exports": {
       ".": "./dist/mod.js",
+      "./markdown": "./dist/markdown/mod.js",
       "./renderer": "./dist/renderer/mod.js",
       "./o11y": "./dist/o11y/mod.js",
       "./o11y/effect": "./dist/o11y/effect-adapter.js",
@@ -34,6 +36,9 @@
     "test:integration:e2e": "vitest run --config vitest.integration.config.ts e2e"
   },
   "dependencies": {
+    "@effect-atom/atom": "0.5.3",
+    "@effect-atom/atom-react": "0.5.0",
+    "@effect/cli": "0.75.2",
     "@effect/cluster": "0.59.0",
     "@effect/experimental": "0.60.0",
     "@effect/opentelemetry": "0.63.0",
@@ -42,16 +47,25 @@
     "@effect/rpc": "0.75.1",
     "@effect/vitest": "0.29.0",
     "@effect/workflow": "0.18.2",
+    "@opentui/core": "0.4.1",
+    "@opentui/react": "0.4.1",
     "@overeng/notion-effect-client": "workspace:^",
     "@overeng/notion-effect-schema": "workspace:^",
     "@overeng/otel-contract": "workspace:^",
     "@playwright/test": "1.61.0",
+    "@storybook/react": "10.4.6",
+    "@types/react": "19.2.17",
+    "@types/react-reconciler": "0.33.0",
     "effect": "3.21.4",
+    "react": "19.2.7",
+    "react-dom": "19.2.7",
+    "react-reconciler": "0.33.0",
     "vitest": "4.1.9"
   },
   "devDependencies": {
     "@effect/vitest": "0.29.0",
     "@opentelemetry/api": "1.9.1",
+    "@overeng/notion-md": "workspace:^",
     "@overeng/utils": "workspace:^",
     "@overeng/utils-dev": "workspace:^",
     "@storybook/react": "10.4.6",
@@ -100,8 +114,12 @@
       "packages/@overeng/notion-core",
       "packages/@overeng/notion-effect-client",
       "packages/@overeng/notion-effect-schema",
+      "packages/@overeng/notion-md",
+      "packages/@overeng/notion-property-write",
       "packages/@overeng/notion-react",
       "packages/@overeng/otel-contract",
+      "packages/@overeng/tui-core",
+      "packages/@overeng/tui-react",
       "packages/@overeng/utils",
       "packages/@overeng/utils-dev"
     ]

--- a/packages/@overeng/notion-react/package.json.genie.ts
+++ b/packages/@overeng/notion-react/package.json.genie.ts
@@ -9,6 +9,7 @@ import {
 } from '../../../genie/internal.ts'
 import notionEffectClientPkg from '../notion-effect-client/package.json.genie.ts'
 import notionEffectSchemaPkg from '../notion-effect-schema/package.json.genie.ts'
+import notionMdPkg from '../notion-md/package.json.genie.ts'
 import otelContractPkg from '../otel-contract/package.json.genie.ts'
 import utilsDevPkg from '../utils-dev/package.json.genie.ts'
 import utilsPkg from '../utils/package.json.genie.ts'
@@ -23,7 +24,7 @@ const workspaceDeps = catalog.compose({
     external: catalog.pick('@effect/platform'),
   },
   devDependencies: {
-    workspace: [utilsDevPkg, utilsPkg],
+    workspace: [notionMdPkg, utilsDevPkg, utilsPkg],
     external: {
       ...catalog.pick(
         ...peerDepNames,
@@ -56,6 +57,7 @@ export default packageJson(
     ...privatePackageDefaults,
     exports: {
       '.': exportEntry('./src/mod.ts', { environment: 'node' }),
+      './markdown': exportEntry('./src/markdown/mod.ts', { environment: 'node' }),
       './renderer': exportEntry('./src/renderer/mod.ts', { environment: 'browser' }),
       './o11y': exportEntry('./src/o11y/mod.ts', { environment: 'browser' }),
       './o11y/effect': exportEntry('./src/o11y/effect-adapter.ts', { environment: 'browser' }),
@@ -72,6 +74,7 @@ export default packageJson(
       access: 'public',
       exports: {
         '.': './dist/mod.js',
+        './markdown': './dist/markdown/mod.js',
         './renderer': './dist/renderer/mod.js',
         './o11y': './dist/o11y/mod.js',
         './o11y/effect': './dist/o11y/effect-adapter.js',

--- a/packages/@overeng/notion-react/src/markdown/composition.unit.test.tsx
+++ b/packages/@overeng/notion-react/src/markdown/composition.unit.test.tsx
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+
+import { renderNmdFile } from '@overeng/notion-md'
+
+import { Heading1, Paragraph, Toggle } from '../components/blocks.ts'
+import { renderToNotionMarkdown } from './render-to-notion-markdown.ts'
+
+describe('renderToNotionMarkdown -> notion-md composition', () => {
+  it('composes the projected body into an .nmd envelope without reverse coupling', () => {
+    const Instructions = () => (
+      <>
+        <Heading1>Blocky instructions</Heading1>
+        <Toggle blockKey="deploy" title="Deploy">
+          <Paragraph>Run the audited deploy command.</Paragraph>
+        </Toggle>
+      </>
+    )
+    const { body, diagnostics } = renderToNotionMarkdown(<Instructions />)
+    expect(diagnostics).toEqual([])
+    const file = renderNmdFile({
+      frontmatter: {
+        notion_md: {
+          version: 2,
+          api_version: '2026-03-11',
+          object: 'page',
+          source: 'local',
+          page_id: null,
+          parent: { _tag: 'workspace' },
+          page: {
+            title: 'Blocky instructions',
+            icon: null,
+            cover: null,
+            in_trash: false,
+            is_locked: false,
+          },
+          properties: {},
+        },
+      },
+      body,
+    })
+    expect(file).toMatchInlineSnapshot(`
+      "---
+      {
+        "notion_md": {
+          "version": 2,
+          "api_version": "2026-03-11",
+          "object": "page",
+          "source": "local",
+          "page_id": null,
+          "parent": {
+            "_tag": "workspace"
+          },
+          "page": {
+            "title": "Blocky instructions",
+            "icon": null,
+            "cover": null,
+            "in_trash": false,
+            "is_locked": false
+          },
+          "properties": {}
+        }
+      }
+      ---
+
+      # Blocky instructions
+
+      <details>
+      <summary>Deploy</summary>
+
+      Run the audited deploy command.
+
+      </details>
+      "
+    `)
+  })
+})

--- a/packages/@overeng/notion-react/src/markdown/mod.ts
+++ b/packages/@overeng/notion-react/src/markdown/mod.ts
@@ -1,0 +1,17 @@
+/**
+ * Read-only JSX -> Notion-enhanced-Markdown projection for review artifacts,
+ * CLI previews, and exports.
+ *
+ * @experimental Experimental surface (#1097): spellings and the diagnostics
+ * contract may change until a real consumer has proven the output. See
+ * `renderToNotionMarkdown` for the fidelity contract.
+ *
+ * @module
+ */
+
+export {
+  renderToNotionMarkdown,
+  type MarkdownDiagnostic,
+  type MarkdownDiagnosticKind,
+  type NotionMarkdownResult,
+} from './render-to-notion-markdown.ts'

--- a/packages/@overeng/notion-react/src/markdown/render-to-notion-markdown.ts
+++ b/packages/@overeng/notion-react/src/markdown/render-to-notion-markdown.ts
@@ -31,8 +31,6 @@ interface WalkState {
   readonly diagnostics: MarkdownDiagnostic[]
 }
 
-const DEFAULT_CALLOUT_ICON = '\u2139\uFE0F'
-
 const indentLines = ({ text, spaces }: { text: string; spaces: number }): string =>
   text
     .split('\n')
@@ -76,7 +74,10 @@ const renderMention = (opts: {
 }): string => {
   const { item, state } = opts
   const mention = item.mention as Record<string, unknown>
-  const plain = typeof item.plain_text === 'string' ? item.plain_text : ''
+  // Escape before any branch interpolates the label into Markdown syntax so
+  // authored punctuation like '[Q3]' or '*ops*' survives verbatim.
+  const rawPlain = typeof item.plain_text === 'string' ? item.plain_text : ''
+  const plain = escapeInlineMetacharacters(rawPlain)
   // Response-shaped rich text carries the resolved link at the item level;
   // authored mentions have no href and degrade to plain text.
   const hrefValue = (item as { href?: unknown }).href
@@ -129,7 +130,12 @@ const renderMention = (opts: {
  * and escaping every shell-style `$VAR` would destroy review readability.
  */
 const escapeInlineMetacharacters = (text: string): string =>
-  text.replaceAll(/([\\`*_[\]<>~])/g, '\\$1').replace(/!(?=\[)/g, '\\!')
+  text
+    .replaceAll(/([\\`*_[\]<>~])/g, '\\$1')
+    .replace(/!(?=\[)/g, '\\!')
+    // Neutralize entity-looking sequences so '&copy;' stays literal; a bare
+    // '&' that cannot begin an entity renders fine and stays untouched.
+    .replace(/&(?=[a-zA-Z]+;|#\d+;|#[xX][0-9a-fA-F]+;)/g, '\\&')
 
 /**
  * Escape line-initial block-structure markers (headings, quotes, list items,
@@ -266,7 +272,9 @@ const renderUrlBlock = (opts: { node: CandidateNode; state: WalkState }): string
 
 const renderResolvedUrl = (opts: { type: string; url: string; caption: string }): string => {
   const { type, url, caption } = opts
-  const label = caption !== '' ? escapeLinkLabel(caption) : null
+  // Caption text already flowed through renderRichText, which escapes
+  // Markdown metacharacters; escaping again would double the backslashes.
+  const label = caption !== '' ? caption : null
   switch (type) {
     case 'image':
       return `![${label ?? ''}](${url})`
@@ -279,7 +287,7 @@ const renderResolvedUrl = (opts: { type: string; url: string; caption: string })
     case 'file':
       return `[${label ?? 'File'}](${url})`
     case 'bookmark':
-      return `[${label ?? url}](${url})`
+      return `[${label ?? escapeLinkLabel(url)}](${url})`
     case 'embed':
       return `[${label ?? 'Embed'}](${url})`
     default:
@@ -301,8 +309,10 @@ const renderTable = (opts: { node: CandidateNode; state: WalkState }): string =>
     const cells = Array.isArray(row.props.cells) ? (row.props.cells as RichTextItem[][]) : []
     return cells.map((cell) => escapeTableCell(renderRichText({ items: cell, state: opts.state })))
   }
-  const firstRow = cellsOf(rows[0]!)
-  const columnCount = Math.max(...rows.map((row) => cellsOf(row).length))
+  // Render each row exactly once — cell rendering emits diagnostics, and
+  // re-rendering for width/header derivation would duplicate them.
+  const renderedRows = rows.map(cellsOf)
+  const columnCount = Math.max(...renderedRows.map((cells) => cells.length))
   const pad = (cells: string[]): string[] => {
     const padded = [...cells]
     while (padded.length < columnCount) padded.push('')
@@ -310,13 +320,9 @@ const renderTable = (opts: { node: CandidateNode; state: WalkState }): string =>
   }
   const hasColumnHeader = opts.node.props.has_column_header !== false
   const header = pad(
-    hasColumnHeader
-      ? firstRow
-      : columnCount > 0
-        ? Array.from({ length: columnCount }, () => '')
-        : [],
+    hasColumnHeader ? renderedRows[0]! : Array.from({ length: columnCount }, () => ''),
   )
-  const bodyRows = (hasColumnHeader ? rows.slice(1) : rows).map((row) => pad(cellsOf(row)))
+  const bodyRows = (hasColumnHeader ? renderedRows.slice(1) : renderedRows).map(pad)
   const lines = [
     `| ${header.join(' | ')} |`,
     `| ${header.map(() => '---').join(' | ')} |`,
@@ -441,7 +447,9 @@ const renderNode = (opts: {
           prefix = ''
         } else {
           const emoji = icon?.emoji
-          prefix = typeof emoji === 'string' ? `${emoji} ` : `${DEFAULT_CALLOUT_ICON} `
+          // Absent icons stay absent — the candidate carries no icon and
+          // inventing a default would fabricate authored content.
+          prefix = typeof emoji === 'string' ? `${emoji} ` : ''
         }
         if (props.color !== undefined && props.color !== 'default') {
           state.diagnostics.push({

--- a/packages/@overeng/notion-react/src/markdown/render-to-notion-markdown.ts
+++ b/packages/@overeng/notion-react/src/markdown/render-to-notion-markdown.ts
@@ -54,6 +54,22 @@ const escapeLinkLabel = (text: string): string => text.replaceAll('[', '\\[').re
 // Inline rich text -> Markdown
 // -----------------------------------------------------------------------------
 
+/**
+ * Resolve the mention discriminator. Authored `<Mention>` envelopes may omit
+ * the API-level `type` key entirely (e.g. `{ user: {... } }`, as used across
+ * the web stories), so fall back to key inference before giving up.
+ */
+const resolveMentionType = (mention: Record<string, unknown>): string | undefined => {
+  if (typeof mention.type === 'string') return mention.type
+  if (mention.user !== undefined) return 'user'
+  if (mention.page !== undefined) return 'page'
+  if (mention.database !== undefined) return 'database'
+  if (mention.date !== undefined) return 'date'
+  if (mention.link_preview !== undefined) return 'link_preview'
+  if (mention.template_mention !== undefined) return 'template_mention'
+  return undefined
+}
+
 const renderMention = (opts: {
   item: Extract<RichTextItem, { type: 'mention' }>
   state: WalkState
@@ -61,17 +77,18 @@ const renderMention = (opts: {
   const { item, state } = opts
   const mention = item.mention as Record<string, unknown>
   const plain = typeof item.plain_text === 'string' ? item.plain_text : ''
-  switch (mention.type) {
+  // Response-shaped rich text carries the resolved link at the item level;
+  // authored mentions have no href and degrade to plain text.
+  const hrefValue = (item as { href?: unknown }).href
+  const href = typeof hrefValue === 'string' ? hrefValue : undefined
+  switch (resolveMentionType(mention)) {
     case 'user':
-      return `@${plain}`
+      // Authored plainText frequently already carries the '@' prefix; never
+      // double it. Bare names get the dialect's '@' prefix.
+      return plain.startsWith('@') || plain === '' ? plain || '@' : `@${plain}`
     case 'page':
-    case 'database': {
-      const href =
-        typeof mention[mention.type] === 'object' && mention[mention.type] !== null
-          ? (mention[mention.type] as { href?: unknown }).href
-          : undefined
+    case 'database':
       return typeof href === 'string' ? `[${plain}](${href})` : plain
-    }
     case 'date': {
       const date = (mention.date ?? {}) as { start?: unknown; end?: unknown }
       const start = typeof date.start === 'string' ? date.start : ''
@@ -81,6 +98,11 @@ const renderMention = (opts: {
     case 'link_preview': {
       const url = (mention.link_preview as { url?: unknown } | undefined)?.url
       return typeof url === 'string' ? `[${plain}](${url})` : plain
+    }
+    case 'template_mention': {
+      const tm = (mention.template_mention ?? {}) as Record<string, unknown>
+      if (tm.template_mention_date !== undefined) return `@${String(tm.template_mention_date)}`
+      return '@me'
     }
     default:
       state.diagnostics.push({
@@ -255,18 +277,20 @@ const renderNode = (opts: {
     case 'heading_4': {
       const level = Number(node.type.slice(-1))
       const heading = `${'#'.repeat(level)} ${renderRichText({ items: richText, state })}`
+      // Emit before the toggleable early-return so colored toggleable
+      // headings still report the dropped color.
+      if (props.color !== undefined) {
+        state.diagnostics.push({
+          kind: 'color-dropped',
+          message: `heading color ${String(props.color)} dropped`,
+        })
+      }
       if (props.is_toggleable === true && node.children.length > 0) {
         state.diagnostics.push({
           kind: 'flattened',
           message: `toggleable heading rendered as flat heading + following content`,
         })
         return [heading, renderNodes({ nodes: node.children, state }).join('\n\n')].join('\n\n')
-      }
-      if (props.color !== undefined) {
-        state.diagnostics.push({
-          kind: 'color-dropped',
-          message: `heading color ${String(props.color)} dropped`,
-        })
       }
       return heading
     }
@@ -304,8 +328,16 @@ const renderNode = (opts: {
     case 'callout': {
       let prefix = ''
       if (node.type === 'callout') {
-        const icon = (props.icon as { emoji?: unknown } | undefined)?.emoji
-        prefix = typeof icon === 'string' ? `${icon} ` : `${DEFAULT_CALLOUT_ICON} `
+        const icon = props.icon as { type?: unknown; emoji?: unknown } | null | undefined
+        if (icon !== null && typeof icon === 'object' && icon.type === 'external') {
+          // An external icon URL has no inline spelling in a blockquote;
+          // dropping it silently would fabricate content (the default icon).
+          state.diagnostics.push({ kind: 'flattened', message: 'callout external icon dropped' })
+          prefix = ''
+        } else {
+          const emoji = icon?.emoji
+          prefix = typeof emoji === 'string' ? `${emoji} ` : `${DEFAULT_CALLOUT_ICON} `
+        }
         if (props.color !== undefined) {
           state.diagnostics.push({
             kind: 'color-dropped',
@@ -317,8 +349,14 @@ const renderNode = (opts: {
       const nested = children(node.children, 0)
       return nested === '' ? own : `${own}\n${quoteLines(nested)}`
     }
-    case 'code':
-      return `\`\`\`${typeof props.language === 'string' ? props.language : ''}\n${renderPlainText(richText)}\n\`\`\``
+    case 'code': {
+      const code = renderPlainText(richText)
+      // CommonMark closes a fence at a backtick run equal to the fence
+      // length, so the fence must be strictly longer than any run inside.
+      const longestRun = Math.max(0, ...[...code.matchAll(/`+/g)].map((m) => m[0].length))
+      const fence = '`'.repeat(Math.max(3, longestRun + 1))
+      return `${fence}${typeof props.language === 'string' ? props.language : ''}\n${code}\n${fence}`
+    }
     case 'divider':
       return '---'
     case 'equation':

--- a/packages/@overeng/notion-react/src/markdown/render-to-notion-markdown.ts
+++ b/packages/@overeng/notion-react/src/markdown/render-to-notion-markdown.ts
@@ -81,14 +81,21 @@ const renderMention = (opts: {
   // authored mentions have no href and degrade to plain text.
   const hrefValue = (item as { href?: unknown }).href
   const href = typeof hrefValue === 'string' ? hrefValue : undefined
-  switch (resolveMentionType(mention)) {
+  const type = resolveMentionType(mention)
+  switch (type) {
     case 'user':
       // Authored plainText frequently already carries the '@' prefix; never
       // double it. Bare names get the dialect's '@' prefix.
-      return plain.startsWith('@') || plain === '' ? plain || '@' : `@${plain}`
+      return plain.startsWith('@') || plain === '' ? plain || '@user' : `@${plain}`
     case 'page':
-    case 'database':
-      return typeof href === 'string' ? `[${plain}](${href})` : plain
+    case 'database': {
+      const label = plain !== '' ? plain : `@${type}`
+      if (typeof href === 'string') return `[${label}](${href})`
+      // Authored mentions carry an id but no href; resolve a deterministic
+      // notion.so URL offline so the mention's identity survives.
+      const id = (mention[type] as { id?: unknown } | undefined)?.id
+      return typeof id === 'string' && id !== '' ? `[${label}](${notionObjectUrl(id)})` : label
+    }
     case 'date': {
       const date = (mention.date ?? {}) as { start?: unknown; end?: unknown }
       const start = typeof date.start === 'string' ? date.start : ''
@@ -143,21 +150,35 @@ const escapeBlockStarts = (text: string): string =>
 /** Apply annotation wrappers + color diagnostics uniformly to any inner string. */
 const wrapWithAnnotations = (opts: {
   core: string
+  /** Unescaped source text; used verbatim inside code spans (backslashes are literal there). */
+  rawCore?: string
   annotations: RichTextItem['annotations']
   state: WalkState
 }): string => {
-  const { core, annotations, state } = opts
+  const { core, rawCore, annotations, state } = opts
   if (annotations.color !== 'default') {
     state.diagnostics.push({
       kind: 'color-dropped',
       message: `text color ${String(annotations.color)} dropped`,
     })
   }
-  let wrapped = core
+  let wrapped: string
+  if (annotations.code === true) {
+    // CommonMark renders backslashes literally inside code spans and closes
+    // the span at an equal-length backtick run, so use the raw source and a
+    // delimiter strictly longer than any embedded run. Content that starts or
+    // ends with a backtick needs padding spaces to stay inside the span.
+    const raw = rawCore ?? core
+    const longestRun = Math.max(0, ...[...raw.matchAll(/`+/g)].map((m) => m[0].length))
+    const delim = '`'.repeat(Math.max(1, longestRun + 1))
+    const padded = raw.startsWith('`') || raw.endsWith('`') ? ` ${raw} ` : raw
+    wrapped = `${delim}${padded}${delim}`
+  } else {
+    wrapped = core
+  }
   if (annotations.bold === true) wrapped = `**${wrapped}**`
   if (annotations.italic === true) wrapped = `*${wrapped}*`
   if (annotations.strikethrough === true) wrapped = `~~${wrapped}~~`
-  if (annotations.code === true) wrapped = `\`${wrapped}\``
   if (annotations.underline === true) wrapped = `<u>${wrapped}</u>`
   return wrapped
 }
@@ -187,6 +208,7 @@ const renderInlineItem = (opts: { item: RichTextItem; state: WalkState }): strin
 
   const wrapped = wrapWithAnnotations({
     core: escapeBlockStarts(escapeInlineMetacharacters(core)),
+    rawCore: core,
     annotations: item.annotations,
     state,
   })
@@ -532,7 +554,14 @@ export const renderToNotionMarkdown = (element: ReactNode): NotionMarkdownResult
   const state: WalkState = { diagnostics: [] }
   // Root <Page> metadata belongs to the .nmd envelope / page properties, not
   // the body; report its omission so the result stays loss-accounted (R33).
-  if (tree.rootPage !== undefined) {
+  // buildCandidateTree records an empty rootPage for a bare <Page> wrapper,
+  // so only diagnose when an actual metadata field was authored.
+  const hasRootMetadata =
+    tree.rootPage !== undefined &&
+    (tree.rootPage.title !== undefined ||
+      tree.rootPage.icon !== undefined ||
+      tree.rootPage.cover !== undefined)
+  if (hasRootMetadata) {
     state.diagnostics.push({
       kind: 'flattened',
       message:

--- a/packages/@overeng/notion-react/src/markdown/render-to-notion-markdown.ts
+++ b/packages/@overeng/notion-react/src/markdown/render-to-notion-markdown.ts
@@ -1,0 +1,413 @@
+import type { ReactNode } from 'react'
+
+import { notionObjectUrl } from '@overeng/notion-effect-schema'
+
+import type { RichTextItem } from '../renderer/flatten-rich-text.ts'
+import { buildCandidateTree } from '../renderer/sync-diff.ts'
+import type { CandidateNode, CandidateTree } from '../renderer/sync-diff.ts'
+
+/**
+ * Why a projected construct lost information on its way to Markdown. The body
+ * is always produced; diagnostics describe what a reader must not assume is
+ * losslessly represented.
+ */
+export type MarkdownDiagnosticKind =
+  | 'unsupported-block'
+  | 'media-without-url'
+  | 'color-dropped'
+  | 'flattened'
+
+export interface MarkdownDiagnostic {
+  readonly kind: MarkdownDiagnosticKind
+  readonly message: string
+}
+
+export interface NotionMarkdownResult {
+  readonly body: string
+  readonly diagnostics: readonly MarkdownDiagnostic[]
+}
+
+interface WalkState {
+  readonly diagnostics: MarkdownDiagnostic[]
+}
+
+const DEFAULT_CALLOUT_ICON = '\u2139\uFE0F'
+
+const indentLines = ({ text, spaces }: { text: string; spaces: number }): string =>
+  text
+    .split('\n')
+    .map((line) => (line === '' ? line : `${' '.repeat(spaces)}${line}`))
+    .join('\n')
+
+const quoteLines = (text: string): string =>
+  text
+    .split('\n')
+    .map((line) => (line === '' ? '>' : `> ${line}`))
+    .join('\n')
+
+const escapeTableCell = (text: string): string =>
+  text.replaceAll('|', '\\|').replaceAll('\n', '<br>')
+
+const escapeLinkLabel = (text: string): string => text.replaceAll('[', '\\[').replaceAll(']', '\\]')
+
+// -----------------------------------------------------------------------------
+// Inline rich text -> Markdown
+// -----------------------------------------------------------------------------
+
+const renderMention = (opts: {
+  item: Extract<RichTextItem, { type: 'mention' }>
+  state: WalkState
+}): string => {
+  const { item, state } = opts
+  const mention = item.mention as Record<string, unknown>
+  const plain = typeof item.plain_text === 'string' ? item.plain_text : ''
+  switch (mention.type) {
+    case 'user':
+      return `@${plain}`
+    case 'page':
+    case 'database': {
+      const href =
+        typeof mention[mention.type] === 'object' && mention[mention.type] !== null
+          ? (mention[mention.type] as { href?: unknown }).href
+          : undefined
+      return typeof href === 'string' ? `[${plain}](${href})` : plain
+    }
+    case 'date': {
+      const date = (mention.date ?? {}) as { start?: unknown; end?: unknown }
+      const start = typeof date.start === 'string' ? date.start : ''
+      const end = typeof date.end === 'string' ? date.end : undefined
+      return end !== undefined ? `${start} \u2192 ${end}` : start
+    }
+    case 'link_preview': {
+      const url = (mention.link_preview as { url?: unknown } | undefined)?.url
+      return typeof url === 'string' ? `[${plain}](${url})` : plain
+    }
+    default:
+      state.diagnostics.push({
+        kind: 'unsupported-block',
+        message: `mention of type ${String(mention.type)} rendered as plain text`,
+      })
+      return plain
+  }
+}
+
+const renderInlineItem = (opts: { item: RichTextItem; state: WalkState }): string => {
+  const { item, state } = opts
+  if (item.type === 'equation') return `$${item.equation.expression}$`
+  if (item.type === 'mention') return renderMention({ item, state })
+
+  const [, leading = '', core = '', trailing = ''] =
+    item.text.content.match(/^(\s*)([\s\S]*?)(\s*)$/) ?? []
+  if (core === '') return item.text.content
+
+  const ann = item.annotations
+  if (ann.color !== 'default') {
+    state.diagnostics.push({ kind: 'color-dropped', message: `text color ${ann.color} dropped` })
+  }
+  let wrapped = core
+  if (ann.bold === true) wrapped = `**${wrapped}**`
+  if (ann.italic === true) wrapped = `*${wrapped}*`
+  if (ann.strikethrough === true) wrapped = `~~${wrapped}~~`
+  if (ann.code === true) wrapped = `\`${wrapped}\``
+  if (ann.underline === true) wrapped = `<u>${wrapped}</u>`
+
+  const withAnnotations = `${leading}${wrapped}${trailing}`
+  return item.text.link === null ? withAnnotations : `[${withAnnotations}](${item.text.link.url})`
+}
+
+const renderRichText = (opts: { items: readonly RichTextItem[]; state: WalkState }): string =>
+  opts.items.map((item) => renderInlineItem({ item, state: opts.state })).join('')
+
+/** Plain-text concatenation for contexts where Markdown annotations must not apply (code fences). */
+const renderPlainText = (items: readonly RichTextItem[]): string =>
+  items
+    .map((item) => {
+      if (item.type === 'text') return item.text.content
+      if (item.type === 'equation') return item.equation.expression
+      return typeof item.plain_text === 'string' ? item.plain_text : ''
+    })
+    .join('')
+
+// -----------------------------------------------------------------------------
+// Block tree -> Markdown
+// -----------------------------------------------------------------------------
+
+const renderUrlBlock = (opts: { node: CandidateNode; state: WalkState }): string => {
+  const { node, state } = opts
+  const captionItems = Array.isArray(node.props.caption)
+    ? (node.props.caption as RichTextItem[])
+    : []
+  const caption = renderRichText({ items: captionItems, state })
+  const url = typeof node.props.url === 'string' ? node.props.url : undefined
+
+  if (url === undefined && node.props.file_upload !== undefined) {
+    const id = (node.props.file_upload as { id?: unknown }).id
+    state.diagnostics.push({
+      kind: 'media-without-url',
+      message: `${node.type} references file_upload ${String(id)} which has no resolvable URL offline`,
+    })
+    return `<!-- ${node.type}: unresolvable upload ${String(id)} -->`
+  }
+  if (url === undefined) {
+    const external = (node.props.external as { url?: unknown } | undefined)?.url
+    if (typeof external !== 'string') {
+      state.diagnostics.push({
+        kind: 'media-without-url',
+        message: `${node.type} has no source URL`,
+      })
+      return `<!-- ${node.type}: missing source -->`
+    }
+    return renderResolvedUrl({ type: node.type, url: external, caption })
+  }
+  return renderResolvedUrl({ type: node.type, url, caption })
+}
+
+const renderResolvedUrl = (opts: { type: string; url: string; caption: string }): string => {
+  const { type, url, caption } = opts
+  const label = caption !== '' ? escapeLinkLabel(caption) : null
+  switch (type) {
+    case 'image':
+      return `![${label ?? ''}](${url})`
+    case 'video':
+      return `[${label ?? 'Video'}](${url})`
+    case 'audio':
+      return `[${label ?? 'Audio'}](${url})`
+    case 'pdf':
+      return `[${label ?? 'PDF'}](${url})`
+    case 'file':
+      return `[${label ?? 'File'}](${url})`
+    case 'bookmark':
+      return `[${label ?? url}](${url})`
+    case 'embed':
+      return `[${label ?? 'Embed'}](${url})`
+    default:
+      return `[${label ?? type}](${url})`
+  }
+}
+
+const renderTable = (opts: { node: CandidateNode; state: WalkState }): string => {
+  const rows = opts.node.children.filter((child) => child.type === 'table_row')
+  if (rows.length === 0) return ''
+  const cellsOf = (row: CandidateNode): string[] => {
+    const cells = Array.isArray(row.props.cells) ? (row.props.cells as RichTextItem[][]) : []
+    return cells.map((cell) => escapeTableCell(renderRichText({ items: cell, state: opts.state })))
+  }
+  const firstRow = cellsOf(rows[0]!)
+  const columnCount = Math.max(...rows.map((row) => cellsOf(row).length))
+  const pad = (cells: string[]): string[] => {
+    const padded = [...cells]
+    while (padded.length < columnCount) padded.push('')
+    return padded
+  }
+  const hasColumnHeader = opts.node.props.has_column_header !== false
+  const header = pad(
+    hasColumnHeader
+      ? firstRow
+      : columnCount > 0
+        ? Array.from({ length: columnCount }, () => '')
+        : [],
+  )
+  const bodyRows = (hasColumnHeader ? rows.slice(1) : rows).map((row) => pad(cellsOf(row)))
+  const lines = [
+    `| ${header.join(' | ')} |`,
+    `| ${header.map(() => '---').join(' | ')} |`,
+    ...bodyRows.map((row) => `| ${row.join(' | ')} |`),
+  ]
+  return lines.join('\n')
+}
+
+const unsupportedPlaceholder = (opts: {
+  node: CandidateNode
+  reason: string
+  state: WalkState
+}): string => {
+  opts.state.diagnostics.push({
+    kind: 'unsupported-block',
+    message: `${opts.node.type} block emitted as placeholder (${opts.reason})`,
+  })
+  return `<!-- unsupported block: ${opts.node.type} -->`
+}
+
+/**
+ * Render one candidate node to an UNINDENTED Markdown fragment. Parents apply
+ * indentation when embedding fragments under list markers or quotes.
+ */
+const renderNode = (opts: {
+  node: CandidateNode
+  ordinal: number | undefined
+  state: WalkState
+}): string => {
+  const { node, ordinal, state } = opts
+  const props = node.props
+  const children = (nodes: readonly CandidateNode[], spaces: number): string => {
+    const parts = renderNodes({ nodes, state })
+    return parts.length === 0 ? '' : indentLines({ text: parts.join('\n\n'), spaces })
+  }
+
+  const richText = Array.isArray(props.rich_text) ? (props.rich_text as RichTextItem[]) : []
+
+  switch (node.type) {
+    case 'paragraph':
+      return renderRichText({ items: richText, state })
+    case 'heading_1':
+    case 'heading_2':
+    case 'heading_3':
+    case 'heading_4': {
+      const level = Number(node.type.slice(-1))
+      const heading = `${'#'.repeat(level)} ${renderRichText({ items: richText, state })}`
+      if (props.is_toggleable === true && node.children.length > 0) {
+        state.diagnostics.push({
+          kind: 'flattened',
+          message: `toggleable heading rendered as flat heading + following content`,
+        })
+        return [heading, renderNodes({ nodes: node.children, state }).join('\n\n')].join('\n\n')
+      }
+      if (props.color !== undefined) {
+        state.diagnostics.push({
+          kind: 'color-dropped',
+          message: `heading color ${String(props.color)} dropped`,
+        })
+      }
+      return heading
+    }
+    case 'bulleted_list_item': {
+      const marker = '- '
+      const nested = children(node.children, marker.length)
+      return nested === ''
+        ? `${marker}${renderRichText({ items: richText, state })}`
+        : `${marker}${renderRichText({ items: richText, state })}\n${nested}`
+    }
+    case 'numbered_list_item': {
+      const n = ordinal ?? 1
+      const marker = `${n}. `
+      const nested = children(node.children, marker.length)
+      return nested === ''
+        ? `${marker}${renderRichText({ items: richText, state })}`
+        : `${marker}${renderRichText({ items: richText, state })}\n${nested}`
+    }
+    case 'to_do': {
+      const checkbox = props.checked === true ? '[x]' : '[ ]'
+      const marker = `- ${checkbox} `
+      const nested = children(node.children, marker.length)
+      return nested === ''
+        ? `${marker}${renderRichText({ items: richText, state })}`
+        : `${marker}${renderRichText({ items: richText, state })}\n${nested}`
+    }
+    case 'toggle': {
+      const title = renderRichText({ items: richText, state })
+      const inner = renderNodes({ nodes: node.children, state })
+      return inner.length === 0
+        ? `<details>\n<summary>${title}</summary>\n</details>`
+        : `<details>\n<summary>${title}</summary>\n\n${inner.join('\n\n')}\n\n</details>`
+    }
+    case 'quote':
+    case 'callout': {
+      let prefix = ''
+      if (node.type === 'callout') {
+        const icon = (props.icon as { emoji?: unknown } | undefined)?.emoji
+        prefix = typeof icon === 'string' ? `${icon} ` : `${DEFAULT_CALLOUT_ICON} `
+        if (props.color !== undefined) {
+          state.diagnostics.push({
+            kind: 'color-dropped',
+            message: `callout color ${String(props.color)} dropped`,
+          })
+        }
+      }
+      const own = quoteLines(`${prefix}${renderRichText({ items: richText, state })}`)
+      const nested = children(node.children, 0)
+      return nested === '' ? own : `${own}\n${quoteLines(nested)}`
+    }
+    case 'code':
+      return `\`\`\`${typeof props.language === 'string' ? props.language : ''}\n${renderPlainText(richText)}\n\`\`\``
+    case 'divider':
+      return '---'
+    case 'equation':
+      return `$$\n${typeof props.expression === 'string' ? props.expression : ''}\n$$`
+    case 'table_of_contents':
+      return '[TOC]'
+    case 'image':
+    case 'video':
+    case 'audio':
+    case 'file':
+    case 'pdf':
+    case 'bookmark':
+    case 'embed':
+      return renderUrlBlock({ node, state })
+    case 'link_to_page':
+      return `[Link to page](${notionObjectUrl(typeof props.page_id === 'string' ? props.page_id : '')})`
+    case 'table':
+      return renderTable({ node, state })
+    case 'column_list':
+      state.diagnostics.push({
+        kind: 'flattened',
+        message: 'column layout flattened to sequential blocks',
+      })
+      return renderNodes({ nodes: node.children, state }).join('\n\n')
+    case 'column':
+      return renderNodes({ nodes: node.children, state }).join('\n\n')
+    default: {
+      if (node.nodeKind === 'page') {
+        const title = typeof props.title === 'string' ? props.title : 'Untitled'
+        state.diagnostics.push({
+          kind: 'flattened',
+          message: `child page boundary flattened: "${title}" rendered as bold label + inline content`,
+        })
+        const inner = renderNodes({ nodes: node.children, state })
+        const label = `**${title}** (child page)`
+        return inner.length === 0 ? label : `${label}\n\n${inner.join('\n\n')}`
+      }
+      if (richText.length > 0 || props.template !== undefined) {
+        const own = renderRichText({ items: richText, state })
+        const inner = renderNodes({ nodes: node.children, state })
+        state.diagnostics.push({
+          kind: 'unsupported-block',
+          message: `${node.type} block rendered generically from rich_text`,
+        })
+        return inner.length === 0
+          ? own
+          : [own, inner.join('\n\n')].filter((s) => s !== '').join('\n\n')
+      }
+      return unsupportedPlaceholder({ node, reason: 'no Markdown spelling', state })
+    }
+  }
+}
+
+const renderNodes = (opts: { nodes: readonly CandidateNode[]; state: WalkState }): string[] => {
+  const out: string[] = []
+  let previousWasNumbered = false
+  let counter = 0
+  for (const node of opts.nodes) {
+    let ordinal: number | undefined
+    if (node.type === 'numbered_list_item') {
+      counter = previousWasNumbered ? counter + 1 : 1
+      ordinal = counter
+      previousWasNumbered = true
+    } else {
+      previousWasNumbered = false
+    }
+    const md = renderNode({ node, ordinal, state: opts.state })
+    if (md !== '') out.push(md)
+  }
+  return out
+}
+
+/**
+ * Project authored JSX through the same normalized render/tree pass that feeds
+ * Notion projection, then serialize the resulting candidate tree to a readable
+ * Notion-enhanced-Markdown body. Pure, synchronous, and network-free.
+ *
+ * Read-only by contract: nothing here mutates Notion and no cache is read or
+ * written. Constructs that cannot survive the projection emit diagnostics
+ * instead of disappearing silently.
+ *
+ * @experimental Experimental surface (#1097): spellings and the diagnostics
+ * contract may change until a real consumer (Blocky preview/export) has proven
+ * the output and the fidelity matrix is complete. Do not treat the body as a
+ * canonical Notion round-trip representation.
+ */
+export const renderToNotionMarkdown = (element: ReactNode): NotionMarkdownResult => {
+  const tree: CandidateTree = buildCandidateTree(element, '__markdown__')
+  const state: WalkState = { diagnostics: [] }
+  const parts = renderNodes({ nodes: tree.children, state })
+  return { body: parts.join('\n\n'), diagnostics: state.diagnostics }
+}

--- a/packages/@overeng/notion-react/src/markdown/render-to-notion-markdown.ts
+++ b/packages/@overeng/notion-react/src/markdown/render-to-notion-markdown.ts
@@ -48,6 +48,17 @@ const escapeTableCell = (text: string): string =>
 
 const escapeLinkLabel = (text: string): string => text.replaceAll('[', '\\[').replaceAll(']', '\\]')
 
+/**
+ * Escape a Markdown link destination so an unbalanced parenthesis or space
+ * cannot terminate it early. Parentheses are backslash-escaped (CommonMark
+ * decodes them back into the URL); destinations containing whitespace are
+ * angle-wrapped with inner `<`, `>`, `\` escaped.
+ */
+const escapeLinkDestination = (url: string): string =>
+  /\s/.test(url)
+    ? `<${url.replace(/([<>\\])/g, '\\$1')}>`
+    : url.replaceAll('(', '\\(').replaceAll(')', '\\)')
+
 // -----------------------------------------------------------------------------
 // Inline rich text -> Markdown
 // -----------------------------------------------------------------------------
@@ -91,11 +102,13 @@ const renderMention = (opts: {
     case 'page':
     case 'database': {
       const label = plain !== '' ? plain : `@${type}`
-      if (typeof href === 'string') return `[${label}](${href})`
+      if (typeof href === 'string') return `[${label}](${escapeLinkDestination(href)})`
       // Authored mentions carry an id but no href; resolve a deterministic
       // notion.so URL offline so the mention's identity survives.
       const id = (mention[type] as { id?: unknown } | undefined)?.id
-      return typeof id === 'string' && id !== '' ? `[${label}](${notionObjectUrl(id)})` : label
+      return typeof id === 'string' && id !== ''
+        ? `[${label}](${escapeLinkDestination(notionObjectUrl(id))})`
+        : label
     }
     case 'date': {
       const date = (mention.date ?? {}) as { start?: unknown; end?: unknown }
@@ -105,7 +118,9 @@ const renderMention = (opts: {
     }
     case 'link_preview': {
       const url = (mention.link_preview as { url?: unknown } | undefined)?.url
-      return typeof url === 'string' ? `[${plain}](${url})` : plain
+      if (typeof url !== 'string') return plain
+      const label = plain !== '' ? plain : url || '@link_preview'
+      return `[${label}](${escapeLinkDestination(url)})`
     }
     case 'template_mention': {
       const tm = (mention.template_mention ?? {}) as Record<string, unknown>
@@ -220,13 +235,29 @@ const renderInlineItem = (opts: { item: RichTextItem; state: WalkState }): strin
   })
 
   const withAnnotations = `${leading}${wrapped}${trailing}`
-  return item.text.link === null ? withAnnotations : `[${withAnnotations}](${item.text.link.url})`
+  return item.text.link === null
+    ? withAnnotations
+    : `[${withAnnotations}](${escapeLinkDestination(item.text.link.url)})`
 }
 
 const renderRichText = (opts: { items: readonly RichTextItem[]; state: WalkState }): string =>
   opts.items.map((item) => renderInlineItem({ item, state: opts.state })).join('')
 
 /** Plain-text concatenation for contexts where Markdown annotations must not apply (code fences). */
+/** Does this item carry formatting a code fence cannot represent? */
+const hasCodeUnrepresentableFormatting = (item: RichTextItem): boolean => {
+  if (item.type !== 'text') return true
+  if (item.text.link !== null) return true
+  const ann = item.annotations
+  return (
+    ann.bold === true ||
+    ann.italic === true ||
+    ann.strikethrough === true ||
+    ann.underline === true ||
+    ann.color !== 'default'
+  )
+}
+
 const renderPlainText = (items: readonly RichTextItem[]): string =>
   items
     .map((item) => {
@@ -245,7 +276,24 @@ const renderUrlBlock = (opts: { node: CandidateNode; state: WalkState }): string
   const captionItems = Array.isArray(node.props.caption)
     ? (node.props.caption as RichTextItem[])
     : []
-  const caption = renderRichText({ items: captionItems, state })
+  // Markdown links cannot nest, so caption links flatten to their inner text
+  // before the caption becomes a label of the media link.
+  let captionHadLink = false
+  const caption = captionItems
+    .map((item) => {
+      if (item.type === 'text' && item.text.link !== null) {
+        captionHadLink = true
+        return renderInlineItem({ item: { ...item, text: { ...item.text, link: null } }, state })
+      }
+      return renderInlineItem({ item, state })
+    })
+    .join('')
+  if (captionHadLink) {
+    state.diagnostics.push({
+      kind: 'flattened',
+      message: `${node.type} caption link flattened to plain text`,
+    })
+  }
   const url = typeof node.props.url === 'string' ? node.props.url : undefined
 
   if (url === undefined && node.props.file_upload !== undefined) {
@@ -277,21 +325,21 @@ const renderResolvedUrl = (opts: { type: string; url: string; caption: string })
   const label = caption !== '' ? caption : null
   switch (type) {
     case 'image':
-      return `![${label ?? ''}](${url})`
+      return `![${label ?? ''}](${escapeLinkDestination(url)})`
     case 'video':
-      return `[${label ?? 'Video'}](${url})`
+      return `[${label ?? 'Video'}](${escapeLinkDestination(url)})`
     case 'audio':
-      return `[${label ?? 'Audio'}](${url})`
+      return `[${label ?? 'Audio'}](${escapeLinkDestination(url)})`
     case 'pdf':
-      return `[${label ?? 'PDF'}](${url})`
+      return `[${label ?? 'PDF'}](${escapeLinkDestination(url)})`
     case 'file':
-      return `[${label ?? 'File'}](${url})`
+      return `[${label ?? 'File'}](${escapeLinkDestination(url)})`
     case 'bookmark':
-      return `[${label ?? escapeLinkLabel(url)}](${url})`
+      return `[${label ?? escapeLinkLabel(url)}](${escapeLinkDestination(url)})`
     case 'embed':
-      return `[${label ?? 'Embed'}](${url})`
+      return `[${label ?? 'Embed'}](${escapeLinkDestination(url)})`
     default:
-      return `[${label ?? type}](${url})`
+      return `[${label ?? type}](${escapeLinkDestination(url)})`
   }
 }
 
@@ -364,7 +412,18 @@ const renderNode = (opts: {
   switch (node.type) {
     case 'paragraph': {
       const own = renderRichText({ items: richText, state })
-      if (node.children.length === 0) return own
+      if (node.children.length === 0) {
+        // Empty paragraphs are deliberate blank blocks in Notion; Markdown
+        // has no content spelling for one, so report the drop instead of
+        // silently erasing it.
+        if (own === '') {
+          state.diagnostics.push({
+            kind: 'flattened',
+            message: 'empty paragraph dropped',
+          })
+        }
+        return own
+      }
       // Notion paragraphs can carry nested blocks; Markdown has no spelling
       // for "block nested under a paragraph", so children follow as sibling
       // blocks and the hierarchy loss is diagnosed (R33).
@@ -466,11 +525,21 @@ const renderNode = (opts: {
     }
     case 'code': {
       const code = renderPlainText(richText)
+      // Fenced Markdown cannot preserve inline formatting; report its loss.
+      if (richText.some(hasCodeUnrepresentableFormatting)) {
+        state.diagnostics.push({
+          kind: 'flattened',
+          message: 'inline formatting dropped inside code block',
+        })
+      }
       // CommonMark closes a fence at a backtick run equal to the fence
       // length, so the fence must be strictly longer than any run inside.
       const longestRun = Math.max(0, ...[...code.matchAll(/`+/g)].map((m) => m[0].length))
       const fence = '`'.repeat(Math.max(3, longestRun + 1))
-      return `${fence}${typeof props.language === 'string' ? props.language : ''}\n${code}\n${fence}`
+      // Newline-terminated content already separates from the closing fence;
+      // appending another would add an empty line to the literal code.
+      const body = code.endsWith('\n') ? code : `${code}\n`
+      return `${fence}${typeof props.language === 'string' ? props.language : ''}\n${body}${fence}`
     }
     case 'divider':
       return '---'
@@ -487,7 +556,7 @@ const renderNode = (opts: {
     case 'embed':
       return renderUrlBlock({ node, state })
     case 'link_to_page':
-      return `[Link to page](${notionObjectUrl(typeof props.page_id === 'string' ? props.page_id : '')})`
+      return `[Link to page](${escapeLinkDestination(notionObjectUrl(typeof props.page_id === 'string' ? props.page_id : ''))})`
     case 'table':
       return renderTable({ node, state })
     case 'column_list':

--- a/packages/@overeng/notion-react/src/markdown/render-to-notion-markdown.ts
+++ b/packages/@overeng/notion-react/src/markdown/render-to-notion-markdown.ts
@@ -356,8 +356,19 @@ const renderNode = (opts: {
   const richText = Array.isArray(props.rich_text) ? (props.rich_text as RichTextItem[]) : []
 
   switch (node.type) {
-    case 'paragraph':
-      return renderRichText({ items: richText, state })
+    case 'paragraph': {
+      const own = renderRichText({ items: richText, state })
+      if (node.children.length === 0) return own
+      // Notion paragraphs can carry nested blocks; Markdown has no spelling
+      // for "block nested under a paragraph", so children follow as sibling
+      // blocks and the hierarchy loss is diagnosed (R33).
+      state.diagnostics.push({
+        kind: 'flattened',
+        message: 'paragraph child blocks rendered as sibling blocks',
+      })
+      const inner = renderNodes({ nodes: node.children, state })
+      return inner.length === 0 ? own : [own, ...inner].filter((s) => s !== '').join('\n\n')
+    }
     case 'heading_1':
     case 'heading_2':
     case 'heading_3':
@@ -365,8 +376,9 @@ const renderNode = (opts: {
       const level = Number(node.type.slice(-1))
       const heading = `${'#'.repeat(level)} ${renderRichText({ items: richText, state })}`
       // Emit before the toggleable early-return so colored toggleable
-      // headings still report the dropped color.
-      if (props.color !== undefined) {
+      // headings still report the dropped color. Explicit 'default' has
+      // nothing to lose and must not be diagnosed.
+      if (props.color !== undefined && props.color !== 'default') {
         state.diagnostics.push({
           kind: 'color-dropped',
           message: `heading color ${String(props.color)} dropped`,
@@ -388,9 +400,11 @@ const renderNode = (opts: {
     case 'bulleted_list_item': {
       const marker = '- '
       const nested = children(node.children, marker.length)
+      // Blank line before nested content: without it CommonMark treats the
+      // first child as lazy continuation of the item's paragraph.
       return nested === ''
         ? `${marker}${renderRichText({ items: richText, state })}`
-        : `${marker}${renderRichText({ items: richText, state })}\n${nested}`
+        : `${marker}${renderRichText({ items: richText, state })}\n\n${nested}`
     }
     case 'numbered_list_item': {
       const n = ordinal ?? 1
@@ -398,7 +412,7 @@ const renderNode = (opts: {
       const nested = children(node.children, marker.length)
       return nested === ''
         ? `${marker}${renderRichText({ items: richText, state })}`
-        : `${marker}${renderRichText({ items: richText, state })}\n${nested}`
+        : `${marker}${renderRichText({ items: richText, state })}\n\n${nested}`
     }
     case 'to_do': {
       const checkbox = props.checked === true ? '[x]' : '[ ]'
@@ -406,7 +420,7 @@ const renderNode = (opts: {
       const nested = children(node.children, marker.length)
       return nested === ''
         ? `${marker}${renderRichText({ items: richText, state })}`
-        : `${marker}${renderRichText({ items: richText, state })}\n${nested}`
+        : `${marker}${renderRichText({ items: richText, state })}\n\n${nested}`
     }
     case 'toggle': {
       const title = renderRichText({ items: richText, state })
@@ -429,7 +443,7 @@ const renderNode = (opts: {
           const emoji = icon?.emoji
           prefix = typeof emoji === 'string' ? `${emoji} ` : `${DEFAULT_CALLOUT_ICON} `
         }
-        if (props.color !== undefined) {
+        if (props.color !== undefined && props.color !== 'default') {
           state.diagnostics.push({
             kind: 'color-dropped',
             message: `callout color ${String(props.color)} dropped`,
@@ -438,7 +452,9 @@ const renderNode = (opts: {
       }
       const own = quoteLines(`${prefix}${renderRichText({ items: richText, state })}`)
       const nested = children(node.children, 0)
-      return nested === '' ? own : `${own}\n${quoteLines(nested)}`
+      // '>' separator line splits quoted child blocks into distinct
+      // paragraphs instead of one soft-wrapped quote paragraph.
+      return nested === '' ? own : `${own}\n>\n${quoteLines(nested)}`
     }
     case 'code': {
       const code = renderPlainText(richText)

--- a/packages/@overeng/notion-react/src/markdown/render-to-notion-markdown.ts
+++ b/packages/@overeng/notion-react/src/markdown/render-to-notion-markdown.ts
@@ -113,25 +113,83 @@ const renderMention = (opts: {
   }
 }
 
+/**
+ * Escape characters that would otherwise be interpreted as Markdown inline
+ * syntax when they appear in authored plain text. Applied to unannotated
+ * text runs before the serializer adds its own wrappers, so authored
+ * literals like `# not a heading` or `*not italic*` survive verbatim.
+ * `$` is deliberately not escaped: stock CommonMark/GFM render it literally,
+ * and escaping every shell-style `$VAR` would destroy review readability.
+ */
+const escapeInlineMetacharacters = (text: string): string =>
+  text.replaceAll(/([\\`*_[\]<>~])/g, '\\$1').replace(/!(?=\[)/g, '\\!')
+
+/**
+ * Escape line-initial block-structure markers (headings, quotes, list items,
+ * thematic breaks) that would restructure the body if left verbatim.
+ */
+const escapeBlockStarts = (text: string): string =>
+  text
+    .split('\n')
+    .map((line) => {
+      const match = line.match(
+        /^(\s*)(#{1,6}(?:\s|$)|>(?:\s|$)|[-*+](?:\s|$)|\d{1,9}[.)](?:\s|$)|[-*_]{3,}\s*$)/,
+      )
+      if (match === null) return line
+      return `${match[1]}\\${match[2]}${line.slice(match[0].length)}`
+    })
+    .join('\n')
+
+/** Apply annotation wrappers + color diagnostics uniformly to any inner string. */
+const wrapWithAnnotations = (opts: {
+  core: string
+  annotations: RichTextItem['annotations']
+  state: WalkState
+}): string => {
+  const { core, annotations, state } = opts
+  if (annotations.color !== 'default') {
+    state.diagnostics.push({
+      kind: 'color-dropped',
+      message: `text color ${String(annotations.color)} dropped`,
+    })
+  }
+  let wrapped = core
+  if (annotations.bold === true) wrapped = `**${wrapped}**`
+  if (annotations.italic === true) wrapped = `*${wrapped}*`
+  if (annotations.strikethrough === true) wrapped = `~~${wrapped}~~`
+  if (annotations.code === true) wrapped = `\`${wrapped}\``
+  if (annotations.underline === true) wrapped = `<u>${wrapped}</u>`
+  return wrapped
+}
+
 const renderInlineItem = (opts: { item: RichTextItem; state: WalkState }): string => {
   const { item, state } = opts
-  if (item.type === 'equation') return `$${item.equation.expression}$`
-  if (item.type === 'mention') return renderMention({ item, state })
+  // Mentions and equations carry their annotation frame on the item itself
+  // (flattenRichText bakes it in), so route through the same wrapper as text.
+  if (item.type === 'equation') {
+    return wrapWithAnnotations({
+      core: `$${item.equation.expression}$`,
+      annotations: item.annotations,
+      state,
+    })
+  }
+  if (item.type === 'mention') {
+    return wrapWithAnnotations({
+      core: renderMention({ item, state }),
+      annotations: item.annotations,
+      state,
+    })
+  }
 
   const [, leading = '', core = '', trailing = ''] =
     item.text.content.match(/^(\s*)([\s\S]*?)(\s*)$/) ?? []
   if (core === '') return item.text.content
 
-  const ann = item.annotations
-  if (ann.color !== 'default') {
-    state.diagnostics.push({ kind: 'color-dropped', message: `text color ${ann.color} dropped` })
-  }
-  let wrapped = core
-  if (ann.bold === true) wrapped = `**${wrapped}**`
-  if (ann.italic === true) wrapped = `*${wrapped}*`
-  if (ann.strikethrough === true) wrapped = `~~${wrapped}~~`
-  if (ann.code === true) wrapped = `\`${wrapped}\``
-  if (ann.underline === true) wrapped = `<u>${wrapped}</u>`
+  const wrapped = wrapWithAnnotations({
+    core: escapeBlockStarts(escapeInlineMetacharacters(core)),
+    annotations: item.annotations,
+    state,
+  })
 
   const withAnnotations = `${leading}${wrapped}${trailing}`
   return item.text.link === null ? withAnnotations : `[${withAnnotations}](${item.text.link.url})`
@@ -210,6 +268,13 @@ const renderResolvedUrl = (opts: { type: string; url: string; caption: string })
 const renderTable = (opts: { node: CandidateNode; state: WalkState }): string => {
   const rows = opts.node.children.filter((child) => child.type === 'table_row')
   if (rows.length === 0) return ''
+  // GFM has no first-column header flag; the authored distinction is lost.
+  if (opts.node.props.has_row_header === true) {
+    opts.state.diagnostics.push({
+      kind: 'flattened',
+      message: 'table row-header semantics dropped (no GFM spelling)',
+    })
+  }
   const cellsOf = (row: CandidateNode): string[] => {
     const cells = Array.isArray(row.props.cells) ? (row.props.cells as RichTextItem[][]) : []
     return cells.map((cell) => escapeTableCell(renderRichText({ items: cell, state: opts.state })))
@@ -285,12 +350,16 @@ const renderNode = (opts: {
           message: `heading color ${String(props.color)} dropped`,
         })
       }
-      if (props.is_toggleable === true && node.children.length > 0) {
+      // The toggle affordance itself is lost even when the heading currently
+      // has no children, so diagnose on is_toggleable alone.
+      if (props.is_toggleable === true) {
         state.diagnostics.push({
           kind: 'flattened',
           message: `toggleable heading rendered as flat heading + following content`,
         })
-        return [heading, renderNodes({ nodes: node.children, state }).join('\n\n')].join('\n\n')
+        if (node.children.length > 0) {
+          return [heading, renderNodes({ nodes: node.children, state }).join('\n\n')].join('\n\n')
+        }
       }
       return heading
     }
@@ -385,13 +454,28 @@ const renderNode = (opts: {
       return renderNodes({ nodes: node.children, state }).join('\n\n')
     default: {
       if (node.nodeKind === 'page') {
-        const title = typeof props.title === 'string' ? props.title : 'Untitled'
+        // Prefer the normalized title spans (covers both string and
+        // span-array authored forms) over the raw prop.
+        const spans = Array.isArray(node.title) ? node.title : undefined
+        const spanText = spans
+          ?.map((span) => {
+            if (typeof span.plain_text === 'string') return span.plain_text
+            const content = (span.text as { content?: unknown } | undefined)?.content
+            return typeof content === 'string' ? content : ''
+          })
+          .join('')
+        const title =
+          spanText !== undefined && spanText !== ''
+            ? spanText
+            : typeof props.title === 'string'
+              ? props.title
+              : 'Untitled'
         state.diagnostics.push({
           kind: 'flattened',
           message: `child page boundary flattened: "${title}" rendered as bold label + inline content`,
         })
         const inner = renderNodes({ nodes: node.children, state })
-        const label = `**${title}** (child page)`
+        const label = `**${escapeInlineMetacharacters(title)}** (child page)`
         return inner.length === 0 ? label : `${label}\n\n${inner.join('\n\n')}`
       }
       if (richText.length > 0 || props.template !== undefined) {
@@ -446,6 +530,15 @@ const renderNodes = (opts: { nodes: readonly CandidateNode[]; state: WalkState }
 export const renderToNotionMarkdown = (element: ReactNode): NotionMarkdownResult => {
   const tree: CandidateTree = buildCandidateTree(element, '__markdown__')
   const state: WalkState = { diagnostics: [] }
+  // Root <Page> metadata belongs to the .nmd envelope / page properties, not
+  // the body; report its omission so the result stays loss-accounted (R33).
+  if (tree.rootPage !== undefined) {
+    state.diagnostics.push({
+      kind: 'flattened',
+      message:
+        'root page metadata (title/icon/cover) omitted from body; carry it in the .nmd envelope or page properties',
+    })
+  }
   const parts = renderNodes({ nodes: tree.children, state })
   return { body: parts.join('\n\n'), diagnostics: state.diagnostics }
 }

--- a/packages/@overeng/notion-react/src/markdown/render-to-notion-markdown.unit.test.tsx
+++ b/packages/@overeng/notion-react/src/markdown/render-to-notion-markdown.unit.test.tsx
@@ -16,6 +16,7 @@ import {
   Image,
   LinkToPage,
   NumberedListItem,
+  Page,
   Paragraph,
   Quote,
   Raw,
@@ -82,6 +83,98 @@ describe('renderToNotionMarkdown', () => {
     )
     expect(result.body).toBe('@priya @Launch Plan 2026-04-19')
     expect(result.diagnostics).toEqual([])
+  })
+
+  it('preserves annotations wrapping mentions and equations', () => {
+    const result = renderToNotionMarkdown(
+      <Paragraph>
+        <Bold>
+          <Mention mention={{ type: 'user', user: { id: 'u1' } }} plainText="alice" />
+        </Bold>{' '}
+        <Italic>
+          <InlineEquation expression="E=mc^2" />
+        </Italic>{' '}
+        <Color value="red">
+          <Mention mention={{ type: 'user', user: { id: 'u2' } }} plainText="bob" />
+        </Color>
+      </Paragraph>,
+    )
+    expect(result.body).toBe('**@alice** *$E=mc^2$* @bob')
+    expect(result.diagnostics).toEqual([
+      { kind: 'color-dropped', message: 'text color red dropped' },
+    ])
+  })
+
+  it('escapes authored Markdown metacharacters in literal text', () => {
+    const result = renderToNotionMarkdown(
+      <>
+        <Paragraph># not a heading</Paragraph>
+        <Paragraph>*not italic* and _not italic_</Paragraph>
+        <Paragraph>snake_case and 1. not-a-list</Paragraph>
+      </>,
+    )
+    const [heading, emphasis, plain] = result.body.split('\n\n')
+    expect(heading).toBe('\\# not a heading')
+    expect(emphasis).toBe('\\*not italic\\* and \\_not italic\\_')
+    expect(plain).toBe('snake\\_case and 1. not-a-list')
+  })
+
+  it('renders span-array child-page titles instead of Untitled', () => {
+    const result = renderToNotionMarkdown(
+      <ChildPage
+        title={[
+          { type: 'text', text: { content: 'Deploy' } },
+          { type: 'text', text: { content: ' Guide' } },
+        ]}
+      />,
+    )
+    expect(result.body).toBe('**Deploy Guide** (child page)')
+    expect(result.diagnostics).toEqual([
+      {
+        kind: 'flattened',
+        message:
+          'child page boundary flattened: "Deploy Guide" rendered as bold label + inline content',
+      },
+    ])
+  })
+
+  it('reports row-header semantics loss on tables', () => {
+    const result = renderToNotionMarkdown(
+      <Table hasColumnHeader hasRowHeader>
+        <TableRow cells={['A', 'B']} />
+        <TableRow cells={[1, 2]} />
+      </Table>,
+    )
+    expect(result.diagnostics).toEqual([
+      { kind: 'flattened', message: 'table row-header semantics dropped (no GFM spelling)' },
+    ])
+  })
+
+  it('diagnoses empty toggleable headings as flattened', () => {
+    const result = renderToNotionMarkdown(<Heading2 toggleable>Empty section</Heading2>)
+    expect(result.body).toBe('## Empty section')
+    expect(result.diagnostics).toEqual([
+      {
+        kind: 'flattened',
+        message: 'toggleable heading rendered as flat heading + following content',
+      },
+    ])
+  })
+
+  it('reports root Page metadata omission', () => {
+    const result = renderToNotionMarkdown(
+      <Page title="Review doc">
+        <Paragraph>content</Paragraph>
+      </Page>,
+    )
+    expect(result.body).toBe('content')
+    expect(result.diagnostics).toEqual([
+      {
+        kind: 'flattened',
+        message:
+          'root page metadata (title/icon/cover) omitted from body; carry it in the .nmd envelope or page properties',
+      },
+    ])
   })
 
   it('emits a diagnostic when a color annotation is dropped', () => {

--- a/packages/@overeng/notion-react/src/markdown/render-to-notion-markdown.unit.test.tsx
+++ b/packages/@overeng/notion-react/src/markdown/render-to-notion-markdown.unit.test.tsx
@@ -14,6 +14,7 @@ import {
   Heading1,
   Heading2,
   Image,
+  Video,
   LinkToPage,
   NumberedListItem,
   Page,
@@ -197,6 +198,62 @@ describe('renderToNotionMarkdown', () => {
       </>,
     )
     expect(result.diagnostics).toEqual([])
+  })
+
+  it('escapes link destinations and flattens caption links once per construct', () => {
+    const linked = renderToNotionMarkdown(
+      <Paragraph>
+        <Link href="https://example.com/a)b">doc</Link>
+      </Paragraph>,
+    )
+    expect(linked.body).toBe('[doc](https://example.com/a\\)b)')
+    const media = renderToNotionMarkdown(
+      <Video
+        url="https://example.com/v.mp4"
+        caption={<Link href="https://example.com/src">source</Link>}
+      />,
+    )
+    expect(media.body).toBe('[source](https://example.com/v.mp4)')
+    expect(media.diagnostics).toEqual([
+      { kind: 'flattened', message: 'video caption link flattened to plain text' },
+    ])
+  })
+
+  it('keeps newline-terminated code exact and diagnoses formatting inside fences', () => {
+    const trailing = renderToNotionMarkdown(<Code language="txt">{'x\n'}</Code>)
+    expect(trailing.body).toBe('```txt\nx\n```')
+    expect(trailing.diagnostics).toEqual([])
+    const annotated = renderToNotionMarkdown(
+      <Code language="txt">
+        <Bold>bold</Bold>
+      </Code>,
+    )
+    expect(annotated.body).toBe('```txt\nbold\n```')
+    expect(annotated.diagnostics).toEqual([
+      { kind: 'flattened', message: 'inline formatting dropped inside code block' },
+    ])
+  })
+
+  it('gives link-preview mentions a visible fallback', () => {
+    const result = renderToNotionMarkdown(
+      <Paragraph>
+        <Mention mention={{ type: 'link_preview', link_preview: { url: 'https://example.com' } }} />
+      </Paragraph>,
+    )
+    expect(result.body).toBe('[https://example.com](https://example.com)')
+    expect(result.diagnostics).toEqual([])
+  })
+
+  it('diagnoses empty paragraphs instead of erasing them', () => {
+    const result = renderToNotionMarkdown(
+      <>
+        <Paragraph>before</Paragraph>
+        <Paragraph />
+        <Paragraph>after</Paragraph>
+      </>,
+    )
+    expect(result.body).toBe('before\n\nafter')
+    expect(result.diagnostics).toEqual([{ kind: 'flattened', message: 'empty paragraph dropped' }])
   })
 
   it('preserves absent callout icons and escapes entity-like ampersands', () => {

--- a/packages/@overeng/notion-react/src/markdown/render-to-notion-markdown.unit.test.tsx
+++ b/packages/@overeng/notion-react/src/markdown/render-to-notion-markdown.unit.test.tsx
@@ -199,6 +199,45 @@ describe('renderToNotionMarkdown', () => {
     expect(result.diagnostics).toEqual([])
   })
 
+  it('preserves absent callout icons and escapes entity-like ampersands', () => {
+    const iconless = renderToNotionMarkdown(<Callout>plain note</Callout>)
+    expect(iconless.body).toBe('> plain note')
+    expect(iconless.diagnostics).toEqual([])
+    const entities = renderToNotionMarkdown(
+      <Paragraph>{'use &copy; and &#35; but a & bare'}</Paragraph>,
+    )
+    expect(entities.body).toBe('use \\&copy; and \\&#35; but a & bare')
+    expect(entities.diagnostics).toEqual([])
+  })
+
+  it('escapes mention labels interpolated into link syntax', () => {
+    const result = renderToNotionMarkdown(
+      <Paragraph>
+        <Mention mention={{ page: { id: 'p1' } }} plainText="[Q3]" />{' '}
+        <Mention mention={{ type: 'user', user: { id: 'u1' } }} plainText="*ops*" />
+      </Paragraph>,
+    )
+    expect(result.body).toBe('[\\[Q3\\]](https://notion.so/p1) @\\*ops\\*')
+  })
+
+  it('does not double-escape media caption labels', () => {
+    const result = renderToNotionMarkdown(<Image url="https://example.com/cat.png" caption="a]b" />)
+    expect(result.body).toBe('![a\\]b](https://example.com/cat.png)')
+  })
+
+  it('emits one diagnostic per lossy construct inside tables', () => {
+    const result = renderToNotionMarkdown(
+      <Table hasColumnHeader>
+        <TableRow cells={[<Color key="a" value="red">A</Color>, 'B']} />
+        <TableRow cells={[1, 2]} />
+        <TableRow cells={[3, 4]} />
+      </Table>,
+    )
+    expect(result.diagnostics).toEqual([
+      { kind: 'color-dropped', message: 'text color red dropped' },
+    ])
+  })
+
   it('renders span-array child-page titles instead of Untitled', () => {
     const result = renderToNotionMarkdown(
       <ChildPage

--- a/packages/@overeng/notion-react/src/markdown/render-to-notion-markdown.unit.test.tsx
+++ b/packages/@overeng/notion-react/src/markdown/render-to-notion-markdown.unit.test.tsx
@@ -81,7 +81,7 @@ describe('renderToNotionMarkdown', () => {
         <Mention mention={{ date: { start: '2026-04-19' } }} plainText="@2026-04-19" />
       </Paragraph>,
     )
-    expect(result.body).toBe('@priya @Launch Plan 2026-04-19')
+    expect(result.body).toBe('@priya [@Launch Plan](https://notion.so/p1) 2026-04-19')
     expect(result.diagnostics).toEqual([])
   })
 
@@ -117,6 +117,43 @@ describe('renderToNotionMarkdown', () => {
     expect(heading).toBe('\\# not a heading')
     expect(emphasis).toBe('\\*not italic\\* and \\_not italic\\_')
     expect(plain).toBe('snake\\_case and 1. not-a-list')
+  })
+
+  it('serializes inline code from raw content with a safe delimiter', () => {
+    const result = renderToNotionMarkdown(
+      <Paragraph>
+        <InlineCode>file_upload</InlineCode> and <InlineCode>a`b</InlineCode> and{' '}
+        <Bold>
+          <InlineCode>*raw*</InlineCode>
+        </Bold>
+      </Paragraph>,
+    )
+    expect(result.body).toBe('`file_upload` and ``a`b`` and **`*raw*`**')
+    expect(result.diagnostics).toEqual([])
+  })
+
+  it('falls back to typed labels and offline links for mentions without plainText', () => {
+    const result = renderToNotionMarkdown(
+      <Paragraph>
+        <Mention mention={{ page: { id: '5c2a3b4d-0000-4000-8000-000000000000' } }} /> and{' '}
+        <Mention mention={{ database: { id: 'db1' } }} /> and{' '}
+        <Mention mention={{ user: { id: 'u1' } }} />
+      </Paragraph>,
+    )
+    expect(result.body).toBe(
+      '[@page](https://notion.so/5c2a3b4d000040008000000000000000) and [@database](https://notion.so/db1) and @user',
+    )
+    expect(result.diagnostics).toEqual([])
+  })
+
+  it('does not diagnose metadata-free root Page wrappers', () => {
+    const result = renderToNotionMarkdown(
+      <Page>
+        <Paragraph>content</Paragraph>
+      </Page>,
+    )
+    expect(result.body).toBe('content')
+    expect(result.diagnostics).toEqual([])
   })
 
   it('renders span-array child-page titles instead of Untitled', () => {

--- a/packages/@overeng/notion-react/src/markdown/render-to-notion-markdown.unit.test.tsx
+++ b/packages/@overeng/notion-react/src/markdown/render-to-notion-markdown.unit.test.tsx
@@ -156,6 +156,49 @@ describe('renderToNotionMarkdown', () => {
     expect(result.diagnostics).toEqual([])
   })
 
+  it('renders paragraph child blocks as diagnosed siblings', () => {
+    const result = renderToNotionMarkdown(
+      <Paragraph>
+        parent
+        <Paragraph>child</Paragraph>
+      </Paragraph>,
+    )
+    expect(result.body).toMatchInlineSnapshot(`
+      "parent
+
+      child"
+    `)
+    expect(result.diagnostics).toEqual([
+      { kind: 'flattened', message: 'paragraph child blocks rendered as sibling blocks' },
+    ])
+  })
+
+  it('separates quoted child blocks with a blank quote line', () => {
+    const result = renderToNotionMarkdown(
+      <Quote>
+        parent
+        <Paragraph>child</Paragraph>
+      </Quote>,
+    )
+    expect(result.body).toMatchInlineSnapshot(`
+      "> parent
+      >
+      > child"
+    `)
+  })
+
+  it('treats explicit default colors as lossless', () => {
+    const result = renderToNotionMarkdown(
+      <>
+        <Callout color="default" icon="ℹ️">
+          plain
+        </Callout>
+        <Heading1 color="default">head</Heading1>
+      </>,
+    )
+    expect(result.diagnostics).toEqual([])
+  })
+
   it('renders span-array child-page titles instead of Untitled', () => {
     const result = renderToNotionMarkdown(
       <ChildPage
@@ -241,6 +284,7 @@ describe('renderToNotionMarkdown', () => {
       "1. first
 
       2. second
+
          - nested bullet
 
       3. third"

--- a/packages/@overeng/notion-react/src/markdown/render-to-notion-markdown.unit.test.tsx
+++ b/packages/@overeng/notion-react/src/markdown/render-to-notion-markdown.unit.test.tsx
@@ -1,0 +1,305 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  Bookmark,
+  BulletedListItem,
+  Callout,
+  ChildPage,
+  Code,
+  Column,
+  ColumnList,
+  Divider,
+  Embed,
+  Equation,
+  Heading1,
+  Heading2,
+  Image,
+  LinkToPage,
+  NumberedListItem,
+  Paragraph,
+  Quote,
+  Raw,
+  Table,
+  TableRow,
+  TableOfContents,
+  ToDo,
+  Toggle,
+} from '../components/blocks.ts'
+import {
+  Bold,
+  Color,
+  InlineCode,
+  InlineEquation,
+  Italic,
+  Link,
+  Mention,
+  Strikethrough,
+  Underline,
+} from '../components/inline.ts'
+import { renderToNotionMarkdown } from './render-to-notion-markdown.ts'
+
+describe('renderToNotionMarkdown', () => {
+  it('renders headings and paragraphs', () => {
+    const result = renderToNotionMarkdown(
+      <>
+        <Heading1>Title</Heading1>
+        <Paragraph>Body text.</Paragraph>
+        <Heading2>Sub</Heading2>
+      </>,
+    )
+    expect(result.body).toMatchInlineSnapshot(`
+      "# Title
+
+      Body text.
+
+      ## Sub"
+    `)
+    expect(result.diagnostics).toEqual([])
+  })
+
+  it('renders inline annotations, links, mentions and equations', () => {
+    const result = renderToNotionMarkdown(
+      <Paragraph>
+        <Bold>bold</Bold> <Italic>italic</Italic> <InlineCode>code</InlineCode>{' '}
+        <Strikethrough>gone</Strikethrough> <Underline>under</Underline>{' '}
+        <Link href="https://example.com">link</Link>{' '}
+        <Mention mention={{ type: 'user', user: { id: 'u1' } }} plainText="alice" />{' '}
+        <InlineEquation expression="E=mc^2" />
+      </Paragraph>,
+    )
+    expect(result.body).toMatchInlineSnapshot(
+      `"**bold** *italic* \`code\` ~~gone~~ <u>under</u> [link](https://example.com) @alice $E=mc^2$"`,
+    )
+  })
+
+  it('emits a diagnostic when a color annotation is dropped', () => {
+    const result = renderToNotionMarkdown(
+      <Paragraph>
+        normal <Color value="red">red</Color>
+      </Paragraph>,
+    )
+    expect(result.body).toBe('normal red')
+    expect(result.diagnostics).toEqual([
+      { kind: 'color-dropped', message: 'text color red dropped' },
+    ])
+  })
+
+  it('renders nested lists with per-run numbering', () => {
+    const result = renderToNotionMarkdown(
+      <>
+        <NumberedListItem>first</NumberedListItem>
+        <NumberedListItem>
+          second
+          <BulletedListItem>nested bullet</BulletedListItem>
+        </NumberedListItem>
+        <NumberedListItem>third</NumberedListItem>
+      </>,
+    )
+    expect(result.body).toMatchInlineSnapshot(`
+      "1. first
+
+      2. second
+         - nested bullet
+
+      3. third"
+    `)
+  })
+
+  it('renders to-dos', () => {
+    const result = renderToNotionMarkdown(
+      <>
+        <ToDo checked>done</ToDo>
+        <ToDo>open</ToDo>
+      </>,
+    )
+    expect(result.body).toMatchInlineSnapshot(`
+      "- [x] done
+
+      - [ ] open"
+    `)
+  })
+
+  it('renders toggles as details/summary (issue example)', () => {
+    const result = renderToNotionMarkdown(
+      <>
+        <Heading1>Blocky instructions</Heading1>
+        <Toggle blockKey="deploy" title="Deploy">
+          <Paragraph>Run the audited deploy command.</Paragraph>
+        </Toggle>
+      </>,
+    )
+    expect(result.body).toMatchInlineSnapshot(`
+      "# Blocky instructions
+
+      <details>
+      <summary>Deploy</summary>
+
+      Run the audited deploy command.
+
+      </details>"
+    `)
+    expect(result.diagnostics).toEqual([])
+  })
+
+  it('renders quotes and callouts', () => {
+    const result = renderToNotionMarkdown(
+      <>
+        <Quote>wisdom</Quote>
+        <Callout icon="⚠️" color="red_background">
+          careful
+        </Callout>
+      </>,
+    )
+    expect(result.body).toMatchInlineSnapshot(`
+      "> wisdom
+
+      > ⚠️ careful"
+    `)
+    expect(result.diagnostics).toEqual([
+      { kind: 'color-dropped', message: 'callout color red_background dropped' },
+    ])
+  })
+
+  it('renders code fences without inline markdown annotations', () => {
+    const result = renderToNotionMarkdown(
+      <Code language="ts">
+        <Bold>const</Bold> x = 1
+      </Code>,
+    )
+    expect(result.body).toMatchInlineSnapshot(`
+      "\`\`\`ts
+      const x = 1
+      \`\`\`"
+    `)
+  })
+
+  it('renders tables with a GFM header separator', () => {
+    const result = renderToNotionMarkdown(
+      <Table hasColumnHeader>
+        <TableRow cells={['A', 'B']} />
+        <TableRow cells={[1, 2]} />
+      </Table>,
+    )
+    expect(result.body).toMatchInlineSnapshot(`
+      "| A | B |
+      | --- | --- |
+      | 1 | 2 |"
+    `)
+  })
+
+  it('renders dividers, equations, toc and page links', () => {
+    const result = renderToNotionMarkdown(
+      <>
+        <Divider />
+        <Equation expression="a^2 + b^2 = c^2" />
+        <TableOfContents />
+        <LinkToPage pageId="5c2a3b4d-0000-4000-8000-000000000000" />
+      </>,
+    )
+    expect(result.body).toMatchInlineSnapshot(`
+      "---
+
+      $$
+      a^2 + b^2 = c^2
+      $$
+
+      [TOC]
+
+      [Link to page](https://notion.so/5c2a3b4d000040008000000000000000)"
+    `)
+  })
+
+  it('renders external media and bookmarks', () => {
+    const result = renderToNotionMarkdown(
+      <>
+        <Image url="https://example.com/cat.png" caption={<Bold>a cat</Bold>} />
+        <Bookmark url="https://example.com" />
+        <Embed url="https://youtube.com/watch?v=1" />
+      </>,
+    )
+    expect(result.body).toMatchInlineSnapshot(`
+      "![**a cat**](https://example.com/cat.png)
+
+      [https://example.com](https://example.com)
+
+      [Embed](https://youtube.com/watch?v=1)"
+    `)
+  })
+
+  it('diagnoses upload-only media instead of dropping it', () => {
+    const result = renderToNotionMarkdown(<Image fileUploadId="upload_123" />)
+    expect(result.body).toBe('<!-- image: unresolvable upload upload_123 -->')
+    expect(result.diagnostics).toEqual([
+      {
+        kind: 'media-without-url',
+        message: 'image references file_upload upload_123 which has no resolvable URL offline',
+      },
+    ])
+  })
+
+  it('flattens column layout with a diagnostic', () => {
+    const result = renderToNotionMarkdown(
+      <ColumnList>
+        <Column>
+          <Paragraph>left</Paragraph>
+        </Column>
+        <Column>
+          <Paragraph>right</Paragraph>
+        </Column>
+      </ColumnList>,
+    )
+    expect(result.body).toMatchInlineSnapshot(`
+      "left
+
+      right"
+    `)
+    expect(result.diagnostics).toEqual([
+      { kind: 'flattened', message: 'column layout flattened to sequential blocks' },
+    ])
+  })
+
+  it('flattens child pages into a bold label with content', () => {
+    const result = renderToNotionMarkdown(
+      <ChildPage title="Deploy Guide">
+        <Paragraph>step one</Paragraph>
+      </ChildPage>,
+    )
+    expect(result.body).toMatchInlineSnapshot(`
+      "**Deploy Guide** (child page)
+
+      step one"
+    `)
+    expect(result.diagnostics).toEqual([
+      {
+        kind: 'flattened',
+        message:
+          'child page boundary flattened: "Deploy Guide" rendered as bold label + inline content',
+      },
+    ])
+  })
+
+  it('emits placeholders plus diagnostics for unsupported raw blocks', () => {
+    const result = renderToNotionMarkdown(
+      <Raw type="child_database" content={{ title: 'Sprints' }} />,
+    )
+    expect(result.body).toBe('<!-- unsupported block: child_database -->')
+    expect(result.diagnostics).toEqual([
+      {
+        kind: 'unsupported-block',
+        message: 'child_database block emitted as placeholder (no Markdown spelling)',
+      },
+    ])
+  })
+
+  it('is deterministic across repeated renders', () => {
+    const element = (
+      <>
+        <Heading1>t</Heading1>
+        <Toggle title="x">
+          <Paragraph>y</Paragraph>
+        </Toggle>
+      </>
+    )
+    expect(renderToNotionMarkdown(element)).toEqual(renderToNotionMarkdown(element))
+  })
+})

--- a/packages/@overeng/notion-react/src/markdown/render-to-notion-markdown.unit.test.tsx
+++ b/packages/@overeng/notion-react/src/markdown/render-to-notion-markdown.unit.test.tsx
@@ -72,6 +72,18 @@ describe('renderToNotionMarkdown', () => {
     )
   })
 
+  it('normalizes authored mention forms (type-less envelopes, pre-prefixed plainText)', () => {
+    const result = renderToNotionMarkdown(
+      <Paragraph>
+        <Mention mention={{ user: { id: 'u1' } }} plainText="@priya" />{' '}
+        <Mention mention={{ page: { id: 'p1' } }} plainText="@Launch Plan" />{' '}
+        <Mention mention={{ date: { start: '2026-04-19' } }} plainText="@2026-04-19" />
+      </Paragraph>,
+    )
+    expect(result.body).toBe('@priya @Launch Plan 2026-04-19')
+    expect(result.diagnostics).toEqual([])
+  })
+
   it('emits a diagnostic when a color annotation is dropped', () => {
     const result = renderToNotionMarkdown(
       <Paragraph>
@@ -160,6 +172,37 @@ describe('renderToNotionMarkdown', () => {
     ])
   })
 
+  it('diagnoses external callout icons instead of fabricating a default', () => {
+    const result = renderToNotionMarkdown(
+      <Callout icon={{ external: 'https://example.com/icon.png' }}>careful</Callout>,
+    )
+    expect(result.body).toBe('> careful')
+    expect(result.diagnostics).toEqual([
+      { kind: 'flattened', message: 'callout external icon dropped' },
+    ])
+  })
+
+  it('reports color loss on toggleable headings with children', () => {
+    const result = renderToNotionMarkdown(
+      <Heading1 color="red" toggleable>
+        Section
+        <Paragraph>inside</Paragraph>
+      </Heading1>,
+    )
+    expect(result.body).toMatchInlineSnapshot(`
+      "# Section
+
+      inside"
+    `)
+    expect(result.diagnostics).toEqual([
+      { kind: 'color-dropped', message: 'heading color red dropped' },
+      {
+        kind: 'flattened',
+        message: 'toggleable heading rendered as flat heading + following content',
+      },
+    ])
+  })
+
   it('renders code fences without inline markdown annotations', () => {
     const result = renderToNotionMarkdown(
       <Code language="ts">
@@ -170,6 +213,18 @@ describe('renderToNotionMarkdown', () => {
       "\`\`\`ts
       const x = 1
       \`\`\`"
+    `)
+  })
+
+  it('lengthens the fence when the code contains backtick runs', () => {
+    const result = renderToNotionMarkdown(<Code language="md">{'# Title\n```\nfenced\n```'}</Code>)
+    expect(result.body).toMatchInlineSnapshot(`
+      "\`\`\`\`md
+      # Title
+      \`\`\`
+      fenced
+      \`\`\`
+      \`\`\`\`"
     `)
   })
 

--- a/packages/@overeng/notion-react/src/markdown/render-to-notion-markdown.unit.test.tsx
+++ b/packages/@overeng/notion-react/src/markdown/render-to-notion-markdown.unit.test.tsx
@@ -228,7 +228,14 @@ describe('renderToNotionMarkdown', () => {
   it('emits one diagnostic per lossy construct inside tables', () => {
     const result = renderToNotionMarkdown(
       <Table hasColumnHeader>
-        <TableRow cells={[<Color key="a" value="red">A</Color>, 'B']} />
+        <TableRow
+          cells={[
+            <Color key="a" value="red">
+              A
+            </Color>,
+            'B',
+          ]}
+        />
         <TableRow cells={[1, 2]} />
         <TableRow cells={[3, 4]} />
       </Table>,

--- a/packages/@overeng/notion-react/tsconfig.json
+++ b/packages/@overeng/notion-react/tsconfig.json
@@ -57,6 +57,9 @@
       "path": "../notion-effect-schema"
     },
     {
+      "path": "../notion-md"
+    },
+    {
       "path": "../otel-contract"
     },
     {

--- a/packages/@overeng/notion-react/tsconfig.json.genie.ts
+++ b/packages/@overeng/notion-react/tsconfig.json.genie.ts
@@ -20,6 +20,7 @@ export default tsconfigJson({
   references: [
     { path: '../notion-effect-client' },
     { path: '../notion-effect-schema' },
+    { path: '../notion-md' },
     { path: '../otel-contract' },
     { path: '../utils' },
     { path: '../utils-dev' },

--- a/packages/@overeng/npm-release/nix/build.nix
+++ b/packages/@overeng/npm-release/nix/build.nix
@@ -20,7 +20,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-evw+K1akyqdC5nttRINpUF3xlZ1ASp1qsdrNs4lKVQ0=";
+      "." = mkSharedHash "sha256-6zFpH58YUeu3wfxvmDPwJladktPhvVq7aEO62v4qelI=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/tui-stories/nix/build.nix
+++ b/packages/@overeng/tui-stories/nix/build.nix
@@ -21,7 +21,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-LK4w3JOeRzBwcVNzCpcMFv7nv2dEOX6yPVnvGJNXxG8=";
+      "." = mkSharedHash "sha256-5WFEBaMyzskP6zG0T2C42j8agmVCyC1vfW2yxwoLK0c=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1263,6 +1263,15 @@ importers:
 
   packages/@overeng/notion-react:
     dependencies:
+      '@effect-atom/atom':
+        specifier: 0.5.3
+        version: 0.5.3(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
+      '@effect-atom/atom-react':
+        specifier: 0.5.0
+        version: 0.5.0(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)(react@19.2.7)(scheduler@0.27.0)
+      '@effect/cli':
+        specifier: 0.75.2
+        version: 0.75.2(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
       '@effect/cluster':
         specifier: 0.59.0
         version: 0.59.0(2726862cc6f36e3b086be9ebab8bdc40)
@@ -1287,6 +1296,12 @@ importers:
       '@effect/workflow':
         specifier: 0.18.2
         version: 0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(@effect/rpc@0.75.1(@effect/platform@0.96.2(patch_hash=08d6466db56675b7a32a3a3c64815a5b784f583b310b6758471a97d3db6edd32)(effect@3.21.4))(effect@3.21.4))(effect@3.21.4)
+      '@opentui/core':
+        specifier: 0.4.1
+        version: 0.4.1(typescript@6.0.3)(web-tree-sitter@0.25.10)
+      '@opentui/react':
+        specifier: 0.4.1
+        version: 0.4.1(react-devtools-core@7.0.1)(react@19.2.7)(typescript@6.0.3)(web-tree-sitter@0.25.10)(ws@8.21.0)
       '@overeng/notion-effect-client':
         specifier: workspace:^
         version: link:../notion-effect-client
@@ -1299,46 +1314,18 @@ importers:
       '@playwright/test':
         specifier: 1.61.0
         version: 1.61.0
-      effect:
-        specifier: 3.21.4
-        version: 3.21.4
-      vitest:
-        specifier: 4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
-    devDependencies:
-      '@opentelemetry/api':
-        specifier: 1.9.1
-        version: 1.9.1
-      '@overeng/utils':
-        specifier: workspace:^
-        version: link:../utils
-      '@overeng/utils-dev':
-        specifier: workspace:^
-        version: link:../utils-dev
       '@storybook/react':
         specifier: 10.4.6
         version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(typescript@6.0.3)
-      '@storybook/react-vite':
-        specifier: 10.4.6
-        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
-      '@types/katex':
-        specifier: 0.16.8
-        version: 0.16.8
-      '@types/node':
-        specifier: 26.0.0
-        version: 26.0.0
       '@types/react':
         specifier: 19.2.17
         version: 19.2.17
-      '@types/react-dom':
-        specifier: 19.2.3
-        version: 19.2.3(@types/react@19.2.17)
       '@types/react-reconciler':
         specifier: 0.33.0
         version: 0.33.0(@types/react@19.2.17)
-      katex:
-        specifier: 0.17.0
-        version: 0.17.0
+      effect:
+        specifier: 3.21.4
+        version: 3.21.4
       react:
         specifier: 19.2.7
         version: 19.2.7
@@ -1348,6 +1335,37 @@ importers:
       react-reconciler:
         specifier: 0.33.0
         version: 0.33.0(react@19.2.7)
+      vitest:
+        specifier: 4.1.9
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+    devDependencies:
+      '@opentelemetry/api':
+        specifier: 1.9.1
+        version: 1.9.1
+      '@overeng/notion-md':
+        specifier: workspace:^
+        version: link:../notion-md
+      '@overeng/utils':
+        specifier: workspace:^
+        version: link:../utils
+      '@overeng/utils-dev':
+        specifier: workspace:^
+        version: link:../utils-dev
+      '@storybook/react-vite':
+        specifier: 10.4.6
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)))(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+      '@types/katex':
+        specifier: 0.16.8
+        version: 0.16.8
+      '@types/node':
+        specifier: 26.0.0
+        version: 26.0.0
+      '@types/react-dom':
+        specifier: 19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      katex:
+        specifier: 0.17.0
+        version: 0.17.0
       shiki:
         specifier: 4.2.0
         version: 4.2.0
@@ -2156,7 +2174,7 @@ packages:
   '@effect/vitest@0.29.0':
     resolution: {integrity: sha512-DvWr1aeEcaZ8mtu8hNVb4e3rEYvGEwQSr7wsNrW53t6nKYjkmjRICcvVEsXUhjoCblRHSxRsRV0TOt0+UmcvaQ==}
     peerDependencies:
-      effect: ^3.21.0
+      effect: 3.21.4
       vitest: ^3.2.0
 
   '@effect/workflow@0.18.2':

--- a/result-1
+++ b/result-1
@@ -1,0 +1,1 @@
+/nix/store/vf1s61xm88c7f10nlgi040dc36bf52k6-otelite-0.0.0

--- a/result-1
+++ b/result-1
@@ -1,1 +1,0 @@
-/nix/store/vf1s61xm88c7f10nlgi040dc36bf52k6-otelite-0.0.0

--- a/result-2
+++ b/result-2
@@ -1,1 +1,0 @@
-/nix/store/crxa9j7faiscfajwrayxzi28jsgci5ad-otel-scrape-0.0.0

--- a/result-2
+++ b/result-2
@@ -1,0 +1,1 @@
+/nix/store/crxa9j7faiscfajwrayxzi28jsgci5ad-otel-scrape-0.0.0


### PR DESCRIPTION
Closes #1097. Follow-up filed: #1098.

## What

New `@overeng/notion-react/markdown` entry point exposing `renderToNotionMarkdown(element)` — a read-only, pure, network-free projection of authored JSX to a readable Notion-enhanced-Markdown body for review artifacts, CLI previews/exports, and optional `.nmd` envelope composition.

```tsx
const { body, diagnostics } = renderToNotionMarkdown(<Instructions />)
// # Blocky instructions
//
// <details>
// <summary>Deploy</summary>
//
// Run the audited deploy command.
//
// </details>
```

## Design (recorded in docs/vrs/.decisions/0001)

- **Shared semantics, dedicated serializer.** Reuses the production `buildCandidateTree` pass (no HTML scraping, no mutation-op reconstruction). Delegation to the pull-side `treeToMarkdown` was rejected: no diagnostics channel, silent unknown-type drop, hardcoded list numbering, non-GFM tables — and modifying it risks `.nmd` wire drift (#1098 tracks eventual centralization).
- **Structured result.** `{ body, diagnostics }` with typed kinds: `unsupported-block`, `media-without-url`, `color-dropped`, `flattened`. Nothing disappears silently; nothing fails hard.
- **Fidelity policy.** Colors dropped with diagnostics; `blockKey` absent from the body; toggleable headings and child pages flatten with diagnostics; `Raw` blocks emit HTML-comment placeholders.
- **Composition without reverse coupling.** Body composes with `renderNmdFile({frontmatter, body})`; notion-md is a devDependency used only by the colocated composition test — production imports stay clean.
- **Explicitly experimental** per the #1097 demand gate (`@experimental` JSDoc + CHANGELOG note).

## Verification

- 17 new tests: golden coverage (headings, rich text, links, mentions, equations, per-run numbered lists, nested lists, to-dos, toggles, quotes, callouts, code fences, GFM tables with header separator, media, bookmarks, embeds, dividers, TOC, page links) + determinism + composition
- Full package suite green (335 tests); `check:all` green
- VRS strict-profile clean for new artifacts (spec section, decision 0001, experiment 0001)
- pnpm-deps FOD hashes refreshed for the lockfile change

## Non-goals honored

No Markdown in any production sync chain, no CacheTree/sync-safety claims from Markdown equality, no second identity/cache/sync model, no round-trip fidelity promise.