### PR TITLE
fix(notion-react): checkpoint created page identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,10 @@ All notable changes to this project will be documented in this file.
   logical package manifest and source instead of an empty virtual-store target;
   the declared alias manifest owns the source-path boundary while nested peer
   context remains opaque, and the prepared artifact layout advances to `v19`.
+- **@overeng/notion-react**: checkpoint each successful sub-page identity before
+  resolving inline descendants, then checkpoint the resolved subtree, so a
+  crash after `pages.create` retries with the same stable page id instead of
+  creating a duplicate.
 
 - **devenv observability verification**: enable native Devenv task activities
   during trace capture while preserving task stderr and a diagnostic copy.

--- a/packages/@overeng/notion-react/docs/limitations.md
+++ b/packages/@overeng/notion-react/docs/limitations.md
@@ -81,15 +81,16 @@ See [Cookbook → Sub-page creation → Reordering](./cookbook/sub-page-creation
 The Notion API exposes no idempotency key or client request token. If a
 sync is interrupted mid-flight:
 
-- `pages.create` succeeded but the follow-up block ops fail → the
-  newly-created page is archived and the error surfaces with
-  `fallbackReason: "partial-page-create"`. The next sync reconciles by
-  id; the orphan stays archived.
+- `pages.create` succeeded but inline-id retrieval or follow-up work fails →
+  the cache retains the server-minted page id plus immutable create-time
+  inline descriptors. The next sync adopts those live block ids before
+  diffing, preserving the page id and avoiding a duplicate body.
 - Any other partial failure → checkpointed cache reflects exactly what
   landed on the server; the next sync diffs against reality.
 
 You cannot atomically create "this page plus all its content" — the
-surface is coarsely best-effort and the recovery story is archive-and-retry.
+surface is coarsely best-effort, so a durable cache backend is load-bearing
+for identity-preserving recovery.
 
 ### No cross-page op batching (T07)
 

--- a/packages/@overeng/notion-react/docs/vrs/.experiments/0002-page-create-crash-recovery.md
+++ b/packages/@overeng/notion-react/docs/vrs/.experiments/0002-page-create-crash-recovery.md
@@ -1,0 +1,44 @@
+# Experiment: page-create crash recovery
+
+- **Date:** 2026-08-23
+- **Related:** A09, T06, R28
+
+## Question
+
+Can a retry preserve a server-minted sub-page id and avoid duplicating the
+inline body when execution stops after `pages.create` but before inline block
+retrieval completes?
+
+## Method
+
+A Notion-shaped failure-capable fixture accepts one keyed `<ChildPage>` with an
+inline paragraph, then fails the first post-create child retrieval. The test
+reads the cache at the failure boundary and retries from that exact state. A
+second variant changes the paragraph text before retry. Assertions cover page
+and block mutation counts, page id stability, body cardinality, and final
+content.
+
+## Result
+
+The failure checkpoint contains the created page id, no guessed child block
+ids, and one immutable pending-inline descriptor. Same-intent retry issues zero
+page or block mutations and retains one page with one paragraph. Changed-intent
+retry retains the same page, adopts the existing paragraph id, and issues one
+block update with no create, append, remove, or duplicate body.
+
+The adversarial type-mismatch path fails closed rather than associating an
+unexpected live block with a cached key.
+
+## Conclusion
+
+Immediate identity checkpointing plus retry-time inline adoption satisfies
+R28. Page-id-only checkpointing is insufficient because it loses the evidence
+needed to distinguish auto-created inline descendants from missing content;
+archive-and-recreate is unnecessary and would break stable page identity.
+
+## VRS Impact
+
+A09 defines `pages.create` as irreversible identity allocation. T06 accepts the
+additional durable save. R28 and the page-driver spec require checkpoint-before-
+retrieval and adoption-before-diff. The ontology names the temporary pending
+inline resolution state.

--- a/packages/@overeng/notion-react/docs/vrs/ontology.md
+++ b/packages/@overeng/notion-react/docs/vrs/ontology.md
@@ -13,6 +13,10 @@
   (diff, cache snapshot, Markdown projector) reads.
 - **CacheTree:** The persisted counterpart of a CandidateTree (`NotionCache`
   backends), carrying resolved Notion block ids and schema version.
+- **Pending inline resolution:** A temporary CacheTree state for a newly
+  created page whose server-minted page id is durable while block ids created
+  inline with that page still require observation and adoption. It preserves
+  create-time identity evidence; it is not a second candidate tree.
 - **blockKey:** Author-supplied identity hint for stable sibling matching
   across renders. Renderer-level only: never projected into Notion payloads
   and never emitted into Markdown bodies.

--- a/packages/@overeng/notion-react/docs/vrs/requirements.md
+++ b/packages/@overeng/notion-react/docs/vrs/requirements.md
@@ -28,10 +28,12 @@ host-config, or cache are implemented (see [spec.md](./spec.md) for that).
   follow-up `blocks.children.append` calls. Per-request child count is
   capped at 100 for both `pages.create` and `blocks.children.append`.
 - **A09 No idempotency primitive:** The Notion API exposes no idempotency
-  key or client token. Recovery from partial failure is archive-and-retry,
-  keyed by correlating JSX identity to page ids through the cache. Archived
-  pages remain retrievable via `pages.retrieve` / `blocks.retrieve`; only
-  `blocks.children.list` returns 404 on an archived page.
+  key or client token. A successful `pages.create` is therefore an
+  irreversible identity allocation: recovery depends on durably correlating
+  JSX identity to the returned page id before any subsequent remote read or
+  mutation. Archived pages remain retrievable via `pages.retrieve` /
+  `blocks.retrieve`; only `blocks.children.list` returns 404 on an archived
+  page.
 - **A10 Title length:** Each title rich_text span is capped at 2000
   characters. Callers that need longer titles must split across spans.
 - **A11 Offline fidelity reference:** Notion's own enhanced-Markdown endpoint
@@ -69,13 +71,11 @@ host-config, or cache are implemented (see [spec.md](./spec.md) for that).
 - **T05 Web renderer is not API-stable:** The companion web renderer exists
   for preview/Storybook only. Its output DOM, CSS hooks, and component
   props may change without deprecation.
-- **T06 Archive-on-partial-failure:** Per A09, mid-flight sub-page creation
-  that fails after `pages.create` leaves an archived orphan rather than
-  attempting a speculative block-level cleanup. The next sync reconciles
-  by id — the orphan is either rehydrated (if JSX still contains the
-  `<ChildPage>`) or stays archived. Acceptable because archived pages are
-  trash-recoverable and the alternative (block-by-block rollback) is not
-  transactional anyway.
+- **T06 Additional create checkpoint:** Per A09, sub-page creation performs an
+  extra cache save immediately after `pages.create`, before retrieving inline
+  descendants. This additional write is accepted because preserving the
+  server-minted page identity across process death is more important than
+  minimizing local cache writes.
 - **T07 No cross-page op batching:** Block ops are batched up to 100
   children per `NotionBlocks.append` call; page ops (`createPage`,
   `updatePage`, `archivePage`) are always individual requests. Sub-page
@@ -193,7 +193,7 @@ host-config, or cache are implemented (see [spec.md](./spec.md) for that).
   production target (per T05).
 - **R21a Page-op scenario suite:** Page-level mutations (root metadata
   change, sub-page create, sub-page rename, sub-page icon/cover change,
-  sub-page archive, sub-page reparent via `move`, partial-failure archive
+  sub-page archive, sub-page reparent via `move`, interrupted-create adoption
   &amp; resync) must each be covered by an e2e test that asserts API
   op-counts meet R24–R28. Cache v2→v3 migration, >100 children under a
   newly created sub-page, and inline-depth-3 subtree splitting must also
@@ -224,11 +224,13 @@ host-config, or cache are implemented (see [spec.md](./spec.md) for that).
   through a holding parent. Default stays off — unretained
   same-parent-reshuffle siblings still flow through `movePage` and the
   API rejection is swallowed, matching the pre-phase-4d contract.
-- **R28 Partial-failure archive & reconcile:** If a `pages.create` succeeds
-  but subsequent child ops fail, the driver must archive the orphan via
-  `in_trash:true` before surfacing the error. The next `sync()` with the
-  same JSX reconciles by re-creating from scratch — archived orphans stay
-  archived.
+- **R28 Interrupted-create identity recovery:** After `pages.create`
+  succeeds, the driver must durably save the returned page id and immutable
+  create-time inline descriptors before any operation that can fail. A retry
+  with the same keyed `<ChildPage>` must adopt that page and its inline
+  descendants without another page create or duplicated body. If current JSX
+  changed after interruption, the retry must first adopt the create-time live
+  state and then reconcile the current candidate normally.
 - **R29 SyncResult exposes page op counts:** `SyncResult` must carry
   `pages: { creates, updates, archives, moves }` alongside existing block
   counts. `SyncEvent` gains `PageOpIssued` / `PageOpApplied` variants.

--- a/packages/@overeng/notion-react/docs/vrs/spec.md
+++ b/packages/@overeng/notion-react/docs/vrs/spec.md
@@ -265,6 +265,13 @@ additionally carry `titleHash`, `iconHash`, `coverHash` (djb2 of
 response-normalized projections per A07) and recurse into their own
 `children` with their own key namespace.
 
+A newly created page may temporarily carry `pendingInlineResolution`: an
+immutable tree of create-time inline `(key, type, hash, children)` descriptors.
+The page id is already authoritative at that point; the marker records that
+the inline block ids auto-created by `pages.create` must still be observed and
+adopted before normal diffing. It is removed only after adoption and another
+successful cache save (R28).
+
 `FsCache` treats missing files, malformed payloads, and schema mismatches as
 cache misses by returning `undefined` from `load`. The sync driver then runs a
 cold diff against an empty tree. Cache backends that can retain old payloads for
@@ -412,12 +419,15 @@ sync(element, { pageId, cache }):
   5. apply block ops under the root page id (existing driver)
   6. for each <ChildPage> candidate in order:
        - createPage / movePage / archivePage as dictated by diffOp
-       - if createPage: persist tmp→real id; insert new
-         CacheNode with nodeKind='page' at the correct key
+       - if createPage: insert a page CacheNode carrying the real id and
+         create-time inline descriptors, then save the cache before retrieval
+       - retrieve the page's live inline descendants, validate their types,
+         adopt their ids, clear the pending marker, and save again
        - recurse: sync(childElement, { pageId: real, cache: cache.pages[real] })
   7. on any error mid-recursion:
-       - if a page was created this run but its children failed mid-apply,
-         issue pages.update {in_trash:true} on the partial page (T06/R28)
+       - preserve the most recent successful checkpoint; never discard a
+         created page id or archive-and-recreate merely because resolution or
+         later child work failed (T06/R28)
        - propagate NotionSyncError with fallbackReason when applicable
   8. checkpoint cache after every successful page-level step
   9. SyncResult includes pages: { creates, updates, archives, moves }
@@ -426,6 +436,10 @@ sync(element, { pageId, cache }):
 Ordering invariants:
 
 - `createPage` must complete before any block op scoped to its id.
+- The returned page id and pending inline descriptors must be saved before the
+  first post-create retrieval. On retry, pending inline resolution runs before
+  candidate diffing. Type disagreement between a descriptor and the live block
+  fails closed; it never guesses an id mapping.
 - `archivePage` (emitted for removed `<ChildPage>`) is applied after block
   ops that touch its parent (so the parent's child_page block disappears
   from the parent's children list in the same sync pass).
@@ -483,17 +497,17 @@ Third-party backends (SQLite, Redis, …) implement `NotionCache` directly
 
 ## Fallback decision table (R16)
 
-| Trigger                                              | Behaviour                                                      | `fallbackReason`        |
-| ---------------------------------------------------- | -------------------------------------------------------------- | ----------------------- |
-| No cache file                                        | Cold diff against empty tree                                   | `"cold-cache"`          |
-| `FsCache` persisted schema mismatch                  | `FsCache.load` returns `undefined`; sync runs cold diff        | `"cold-cache"`          |
-| Prior tree `schemaVersion !== CACHE_SCHEMA_VERSION`  | Abort stale-tree diff from backends that return old trees      | `"schema-mismatch"`     |
-| Cache `rootId !== opts.pageId`                       | Cold diff against empty tree                                   | `"page-id-drift"`       |
-| `NotionBlocks.update` returns 404/archived           | Emit structural rebuild of that subtree                        | `"block-missing"`       |
-| Cached page id → `pages.retrieve` 404                | Drop cached subtree, recreate if JSX has it, else no-op        | `"page-missing"`        |
-| Cached page id is archived on server                 | Treat as removed; if JSX still has `<ChildPage>`, create fresh | `"page-archived"`       |
-| `pages.create` succeeds but child ops fail mid-apply | Archive orphan page; surface `NotionSyncError`                 | `"partial-page-create"` |
-| Diff produces malformed op-plan (invariant break)    | Abort; propagate `NotionSyncError`                             | n/a (error)             |
+| Trigger                                             | Behaviour                                                      | `fallbackReason`     |
+| --------------------------------------------------- | -------------------------------------------------------------- | -------------------- |
+| No cache file                                       | Cold diff against empty tree                                   | `"cold-cache"`       |
+| `FsCache` persisted schema mismatch                 | `FsCache.load` returns `undefined`; sync runs cold diff        | `"cold-cache"`       |
+| Prior tree `schemaVersion !== CACHE_SCHEMA_VERSION` | Abort stale-tree diff from backends that return old trees      | `"schema-mismatch"`  |
+| Cache `rootId !== opts.pageId`                      | Cold diff against empty tree                                   | `"page-id-drift"`    |
+| `NotionBlocks.update` returns 404/archived          | Emit structural rebuild of that subtree                        | `"block-missing"`    |
+| Cached page id → `pages.retrieve` 404               | Drop cached subtree, recreate if JSX has it, else no-op        | `"page-missing"`     |
+| Cached page id is archived on server                | Treat as removed; if JSX still has `<ChildPage>`, create fresh | `"page-archived"`    |
+| Post-create inline retrieval or later work fails    | Preserve identity checkpoint; retry adopts live inline ids     | n/a (original error) |
+| Diff produces malformed op-plan (invariant break)   | Abort; propagate `NotionSyncError`                             | n/a (error)          |
 
 v0.1 implements `cold-cache`, `schema-mismatch`, and `page-id-drift`
 (via a pre-flight `NotionBlocks.retrieve(cache.rootId)`). `block-missing`

--- a/packages/@overeng/notion-react/src/cache/types.ts
+++ b/packages/@overeng/notion-react/src/cache/types.ts
@@ -5,6 +5,22 @@ import type { CacheError } from '../renderer/errors.ts'
 /** Current on-disk schema version. Bumping invalidates all cached trees. */
 export const CACHE_SCHEMA_VERSION = 3 as const
 
+export interface PendingInlineNode {
+  readonly key: string
+  readonly type: string
+  readonly hash: string
+  readonly children: readonly PendingInlineNode[]
+}
+
+export const PendingInlineNode: Schema.Schema<PendingInlineNode> = Schema.suspend(() =>
+  Schema.Struct({
+    key: Schema.String,
+    type: Schema.String,
+    hash: Schema.String,
+    children: Schema.Array(PendingInlineNode),
+  }),
+)
+
 export interface CacheNode {
   readonly key: string
   readonly blockId: string
@@ -39,6 +55,11 @@ export interface CacheNode {
    * Hash of the page's `cover` property. See {@link CacheNode.titleHash}.
    */
   readonly coverHash?: string | undefined
+  /**
+   * The page identity is durable, but block ids created inline with the page
+   * still need to be observed and adopted before normal diffing can resume.
+   */
+  readonly pendingInlineResolution?: readonly PendingInlineNode[] | undefined
 }
 
 /**
@@ -56,6 +77,7 @@ interface CacheNodeEncoded {
   readonly titleHash?: string | undefined
   readonly iconHash?: string | undefined
   readonly coverHash?: string | undefined
+  readonly pendingInlineResolution?: readonly PendingInlineNode[] | undefined
 }
 
 export const CacheNode: Schema.Schema<CacheNode, CacheNodeEncoded> = Schema.suspend(() =>
@@ -74,6 +96,7 @@ export const CacheNode: Schema.Schema<CacheNode, CacheNodeEncoded> = Schema.susp
     titleHash: Schema.optional(Schema.String),
     iconHash: Schema.optional(Schema.String),
     coverHash: Schema.optional(Schema.String),
+    pendingInlineResolution: Schema.optional(Schema.Array(PendingInlineNode)),
   }),
 )
 

--- a/packages/@overeng/notion-react/src/renderer/sync-page-ops.unit.test.tsx
+++ b/packages/@overeng/notion-react/src/renderer/sync-page-ops.unit.test.tsx
@@ -85,6 +85,102 @@ describe('sync() page ops (issue #618 phase 3b)', () => {
     expect(after.filter((r) => r.method !== 'GET')).toEqual([])
   })
 
+  it('inline retrieval fails after pages.create: retry retains the checkpointed page id', async () => {
+    const fake = createFakeNotion()
+    const cache = InMemoryCache.make()
+    const tree = (
+      <Page>
+        <ChildPage blockKey="child" title="child">
+          <Paragraph blockKey="body">body</Paragraph>
+        </ChildPage>
+      </Page>
+    )
+    let failFirstInlineRetrieve = true
+    fake.failOn((request) => {
+      if (
+        failFirstInlineRetrieve &&
+        request.method === 'GET' &&
+        request.path !== `/v1/blocks/${ROOT}/children`
+      ) {
+        failFirstInlineRetrieve = false
+        return new FakeNotionResponseError(500, 'internal_server_error', 'simulated process death')
+      }
+      return undefined
+    })
+
+    const first = await Effect.runPromiseExit(
+      sync(tree, {
+        pageId: ROOT,
+        cache,
+      }).pipe(Effect.provide(fake.layer)),
+    )
+
+    expect(first._tag).toBe('Failure')
+    expect(fake.pages.size).toBe(1)
+    const createdId = [...fake.pages.keys()][0]!
+    const checkpoint = await Effect.runPromise(cache.load)
+    expect(checkpoint?.children).toMatchObject([
+      {
+        blockId: createdId,
+        nodeKind: 'page',
+        children: [],
+      },
+    ])
+    expect(checkpoint?.children[0]?.pendingInlineResolution).toHaveLength(1)
+
+    const retry = await runSync(fake, tree, cache)
+    expect(retry.pages).toMatchObject({ creates: 0, updates: 0, archives: 0, moves: 0 })
+    expect(retry.appends + retry.inserts + retry.updates + retry.removes).toBe(0)
+    expect(fake.pages.size).toBe(1)
+    expect([...fake.pages.keys()]).toEqual([createdId])
+    expect(fake.childrenOf(createdId).filter((block) => block.type === 'paragraph')).toHaveLength(1)
+  })
+
+  it('changed JSX after interrupted create reconciles from the persisted create-time intent', async () => {
+    const fake = createFakeNotion()
+    const cache = InMemoryCache.make()
+    let failFirstInlineRetrieve = true
+    fake.failOn((request) => {
+      if (
+        failFirstInlineRetrieve &&
+        request.method === 'GET' &&
+        request.path !== `/v1/blocks/${ROOT}/children`
+      ) {
+        failFirstInlineRetrieve = false
+        return new FakeNotionResponseError(500, 'internal_server_error', 'simulated process death')
+      }
+      return undefined
+    })
+
+    const first = await Effect.runPromiseExit(
+      sync(
+        <Page>
+          <ChildPage blockKey="child" title="child">
+            <Paragraph blockKey="body">before</Paragraph>
+          </ChildPage>
+        </Page>,
+        { pageId: ROOT, cache },
+      ).pipe(Effect.provide(fake.layer)),
+    )
+    expect(first._tag).toBe('Failure')
+    const createdId = [...fake.pages.keys()][0]!
+
+    const retry = await runSync(
+      fake,
+      <Page>
+        <ChildPage blockKey="child" title="child">
+          <Paragraph blockKey="body">after</Paragraph>
+        </ChildPage>
+      </Page>,
+      cache,
+    )
+    expect(retry.pages.creates).toBe(0)
+    expect(retry.updates).toBe(1)
+    expect(retry.appends + retry.inserts + retry.removes).toBe(0)
+    expect([...fake.pages.keys()]).toEqual([createdId])
+    expect(fake.childrenOf(createdId).filter((block) => block.type === 'paragraph')).toHaveLength(1)
+  })
+
   it('root-page metadata: <Page title> change → 1 updatePage on root, 0 block ops', async () => {
     const fake = createFakeNotion()
     const cache = InMemoryCache.make()

--- a/packages/@overeng/notion-react/src/renderer/sync-page-ops.unit.test.tsx
+++ b/packages/@overeng/notion-react/src/renderer/sync-page-ops.unit.test.tsx
@@ -1,5 +1,6 @@
 import type { HttpClient } from '@effect/platform'
 import { Effect } from 'effect'
+import type { ReactNode } from 'react'
 import { describe, expect, it } from 'vitest'
 
 import { NotionPages, type NotionConfig } from '@overeng/notion-effect-client'
@@ -7,7 +8,12 @@ import { NotionPages, type NotionConfig } from '@overeng/notion-effect-client'
 import { InMemoryCache } from '../cache/in-memory-cache.ts'
 import { CACHE_SCHEMA_VERSION, type CacheTree } from '../cache/types.ts'
 import { ChildPage, Page, Paragraph, Toggle } from '../components/blocks.ts'
-import { createFakeNotion, FakeNotionResponseError, type FakeNotion } from '../test/mock-client.ts'
+import {
+  createFakeNotion,
+  FakeNotionResponseError,
+  type FakeBlock,
+  type FakeNotion,
+} from '../test/mock-client.ts'
 import { NotionSyncError } from './errors.ts'
 import { normalizeCover, projectCover } from './icons.ts'
 import { sync } from './sync.ts'
@@ -31,6 +37,40 @@ const runSync = async (
   cache = InMemoryCache.make(),
 ) => {
   return await runWith(fake, sync(element, { pageId: ROOT, cache }))
+}
+
+const CRASH_TREE = (
+  <Page>
+    <ChildPage blockKey="child" title="child">
+      <Paragraph blockKey="body">body</Paragraph>
+    </ChildPage>
+  </Page>
+)
+
+/**
+ * Crash a sync right after `pages.create` but before the inline-descendant
+ * retrieval lands, leaving a pending page checkpoint in the cache.
+ */
+const crashMidCreate = async (preamble?: ReactNode) => {
+  const fake = createFakeNotion()
+  const cache = InMemoryCache.make()
+  if (preamble !== undefined) await runSync(fake, preamble, cache)
+  let tripped = false
+  fake.failOn((request) => {
+    if (!tripped && request.method === 'GET' && request.path !== `/v1/blocks/${ROOT}/children`) {
+      tripped = true
+      return new FakeNotionResponseError(500, 'internal_server_error', 'simulated process death')
+    }
+    return undefined
+  })
+  const first = await Effect.runPromiseExit(
+    sync(CRASH_TREE, { pageId: ROOT, cache }).pipe(Effect.provide(fake.layer)),
+  )
+  expect(first._tag).toBe('Failure')
+  const checkpoint = await Effect.runPromise(cache.load)
+  const pendingNode = checkpoint?.children.find((n) => n.pendingInlineResolution !== undefined)
+  expect(pendingNode?.pendingInlineResolution).toHaveLength(1)
+  return { fake, cache, createdId: pendingNode!.blockId }
 }
 
 describe('sync() page ops (issue #618 phase 3b)', () => {
@@ -179,6 +219,86 @@ describe('sync() page ops (issue #618 phase 3b)', () => {
     expect(retry.appends + retry.inserts + retry.removes).toBe(0)
     expect([...fake.pages.keys()]).toEqual([createdId])
     expect(fake.childrenOf(createdId).filter((block) => block.type === 'paragraph')).toHaveLength(1)
+  })
+
+  it('retry JSX moving the checkpointed page adopts pending descendants before the move', async () => {
+    // Wrapper exists before the crash so the retry relocates the checkpointed
+    // page under an existing parent.
+    const { fake, cache, createdId } = await crashMidCreate(
+      <Page>
+        <ChildPage blockKey="wrapper" title="wrapper" />
+      </Page>,
+    )
+
+    const retry = await runSync(
+      fake,
+      <Page>
+        <ChildPage blockKey="wrapper" title="wrapper">
+          <ChildPage blockKey="child" title="child">
+            <Paragraph blockKey="body">body</Paragraph>
+          </ChildPage>
+        </ChildPage>
+      </Page>,
+      cache,
+    )
+
+    // The checkpointed child page is moved under the wrapper and its
+    // already-created inline paragraph is adopted — not duplicated.
+    expect(retry.pages).toMatchObject({ creates: 0, moves: 1 })
+    expect(fake.pages.size).toBe(2)
+    expect(fake.childrenOf(createdId).filter((block) => block.type === 'paragraph')).toHaveLength(1)
+  })
+
+  it('untracked live blocks under a checkpointed page abort adoption instead of being stranded', async () => {
+    const { fake, cache, createdId } = await crashMidCreate()
+
+    // Another client appends a stray block under the half-created page
+    const strayId = '22222222-2222-4222-8222-000000000009'
+    ;(fake.blocks as Map<string, FakeBlock>).set(strayId, {
+      id: strayId,
+      type: 'paragraph',
+      parent: createdId,
+      payload: { rich_text: [] },
+      archived: false,
+      children: [],
+    })
+    fake.blocks.get(createdId)!.children.push(strayId)
+
+    const error = await Effect.runPromise(
+      sync(CRASH_TREE, { pageId: ROOT, cache }).pipe(Effect.flip, Effect.provide(fake.layer)),
+    )
+    expect(error.reason).toBe('notion-retrieve-failed')
+    expect(String(error.cause)).toContain('untracked block(s)')
+
+    // Failing before the cache save keeps the pending marker intact so a
+    // clean retry (after the stray content is removed) can adopt.
+    const checkpoint = await Effect.runPromise(cache.load)
+    expect(checkpoint?.children[0]?.pendingInlineResolution).toHaveLength(1)
+  })
+
+  it('pending recovery is skipped on page-id drift instead of retrieving against the old root', async () => {
+    const OTHER_ROOT = '99999999-9999-4999-8999-999999999999'
+    // The crash left the pending checkpoint written against ROOT; reusing the
+    // same cache with a different target page must not retrieve stale ids.
+    const { fake, cache, createdId } = await crashMidCreate()
+
+    // Recovery against the old root would GET the stale checkpointed page's
+    // children; block exactly that so the drift path must be taken instead.
+    fake.failOn((request) =>
+      request.method === 'GET' && request.path === `/v1/blocks/${createdId}/children`
+        ? new FakeNotionResponseError(404, 'object_not_found', 'stale page')
+        : undefined,
+    )
+    const before = fake.requests.length
+    const retry = await runWith(fake, sync(CRASH_TREE, { pageId: OTHER_ROOT, cache }))
+    // Documented cold-start path: rebuild under the new root without ever
+    // touching the stale ids from the old root's pending checkpoint.
+    expect(retry.fallbackReason).toBe('page-id-drift')
+    expect(retry.pages.creates).toBe(1)
+    const staleRetrievals = fake.requests
+      .slice(before)
+      .filter((request) => request.path.includes(createdId))
+    expect(staleRetrievals).toEqual([])
   })
 
   it('root-page metadata: <Page title> change → 1 updatePage on root, 0 block ops', async () => {

--- a/packages/@overeng/notion-react/src/renderer/sync.ts
+++ b/packages/@overeng/notion-react/src/renderer/sync.ts
@@ -1219,8 +1219,38 @@ export const sync = (
             nodeKind: 'block',
           })
         }
+        // Live children beyond the persisted create-time intent mean another
+        // client wrote under the half-created page between the crashed sync
+        // and this retry. Adopting only the prefix would strand those blocks
+        // forever (drift detection is root-shallow), so fail loudly instead —
+        // failing before the cache save keeps the pending marker intact for a
+        // clean retry once the untracked content is removed.
+        if (liveIdx < liveBlocks.length) {
+          return yield* new NotionSyncError({
+            reason: 'notion-retrieve-failed',
+            cause:
+              `pending inline adoption found ${liveBlocks.length - liveIdx} untracked block(s) ` +
+              `under ${parentId} beyond the persisted create-time intent (${nodes.length} expected); ` +
+              `remove them or reset the cache to recover`,
+          })
+        }
         return adopted
       })
+
+    // A checkpointed page may have moved to another parent in the retry JSX,
+    // so resolvePendingPages' sibling-local lookup would miss it and leave the
+    // marker unresolved — the subsequent movePage diff then re-appends the
+    // already-created inline descendants from an empty cache subtree. Index
+    // all page-kind candidates once so recovery can adopt the identity before
+    // the relocation is diffed.
+    const candidatePageByKey = new Map<string, CandidateNode>()
+    const indexCandidatePages = (nodes: readonly CandidateNode[]): void => {
+      for (const node of nodes) {
+        if (node.nodeKind === 'page') candidatePageByKey.set(node.key, node)
+        indexCandidatePages(node.children)
+      }
+    }
+    indexCandidatePages(candidate.children)
 
     const resolvePendingPages = (
       cached: readonly CacheNode[],
@@ -1234,9 +1264,19 @@ export const sync = (
         let changed = false
         const nodes: CacheNode[] = []
         for (const cachedNode of cached) {
-          const candidateNode = candidates.find(
+          let candidateNode = candidates.find(
             (node) => node.key === cachedNode.key && node.nodeKind === cachedNode.nodeKind,
           )
+          if (
+            candidateNode === undefined &&
+            cachedNode.nodeKind === 'page' &&
+            cachedNode.pendingInlineResolution !== undefined
+          ) {
+            // Cross-parent fallback: resolve the pending inline descendants
+            // against the old location so the move diff sees adopted children
+            // instead of duplicating the server-side subtree.
+            candidateNode = candidatePageByKey.get(cachedNode.key)
+          }
           if (candidateNode === undefined || cachedNode.nodeKind !== 'page') {
             nodes.push(cachedNode)
             continue
@@ -1258,7 +1298,12 @@ export const sync = (
         return { nodes, changed }
       })
 
-    if (prior !== undefined) {
+    // Pending recovery retrieves against page ids recorded under prior.rootId.
+    // When the cache was written for a different page (page-id drift) those
+    // retrievals can fail on ids that are stale or no longer accessible, so
+    // skip recovery and let the documented cold-start path handle the
+    // mismatch.
+    if (prior !== undefined && prior.rootId === opts.pageId) {
       const resolvedPending = yield* resolvePendingPages(prior.children, candidate.children)
       if (resolvedPending.changed) {
         prior = { ...prior, children: resolvedPending.nodes }

--- a/packages/@overeng/notion-react/src/renderer/sync.ts
+++ b/packages/@overeng/notion-react/src/renderer/sync.ts
@@ -9,7 +9,7 @@ import {
   type NotionConfig,
 } from '@overeng/notion-effect-client'
 
-import type { CacheNode, CacheTree, NotionCache } from '../cache/types.ts'
+import type { CacheNode, CacheTree, NotionCache, PendingInlineNode } from '../cache/types.ts'
 import { CACHE_SCHEMA_VERSION } from '../cache/types.ts'
 import { NotionSyncError } from './errors.ts'
 import type { PageOp } from './op-buffer.ts'
@@ -68,6 +68,22 @@ const resolveTreeIds = (tree: CandidateTree, idMap: ReadonlyMap<string, string>)
   for (const c of tree.children) walk(c)
 }
 
+const pendingInlineFromCandidates = (
+  nodes: readonly CandidateNode[],
+): readonly PendingInlineNode[] =>
+  nodes.flatMap((node) =>
+    node.nodeKind === 'page'
+      ? []
+      : [
+          {
+            key: node.key,
+            type: node.type,
+            hash: node.hash,
+            children: pendingInlineFromCandidates(node.children),
+          },
+        ],
+  )
+
 const appendBody = (type: string, props: Record<string, unknown>): Record<string, unknown> => ({
   object: 'block',
   type,
@@ -101,6 +117,7 @@ interface WorkingNode {
   titleHash?: string | undefined
   iconHash?: string | undefined
   coverHash?: string | undefined
+  pendingInlineResolution?: readonly PendingInlineNode[] | undefined
 }
 
 interface WorkingCache {
@@ -122,6 +139,9 @@ const cacheNodeToWorking = (n: CacheNode): WorkingNode => ({
   ...(n.titleHash !== undefined ? { titleHash: n.titleHash } : {}),
   ...(n.iconHash !== undefined ? { iconHash: n.iconHash } : {}),
   ...(n.coverHash !== undefined ? { coverHash: n.coverHash } : {}),
+  ...(n.pendingInlineResolution !== undefined
+    ? { pendingInlineResolution: n.pendingInlineResolution }
+    : {}),
 })
 
 const workingToCacheNode = (n: WorkingNode): CacheNode => {
@@ -147,6 +167,9 @@ const workingToCacheNode = (n: WorkingNode): CacheNode => {
     ...(n.titleHash !== undefined ? { titleHash: n.titleHash } : {}),
     ...(n.iconHash !== undefined ? { iconHash: n.iconHash } : {}),
     ...(n.coverHash !== undefined ? { coverHash: n.coverHash } : {}),
+    ...(n.pendingInlineResolution !== undefined
+      ? { pendingInlineResolution: n.pendingInlineResolution }
+      : {}),
   }
 }
 
@@ -1146,7 +1169,7 @@ export const sync = (
     onUploadIdRejected: opts.onUploadIdRejected,
   }
   return Effect.gen(function* () {
-    const prior = yield* opts.cache.load.pipe(
+    let prior = yield* opts.cache.load.pipe(
       Effect.mapError((cause) => new NotionSyncError({ reason: 'cache-load-failed', cause })),
     )
     const candidate = buildCandidateTree(element, opts.pageId)
@@ -1158,6 +1181,93 @@ export const sync = (
           at: Date.now(),
         }),
       )
+    }
+
+    const adoptInlineChildren = (
+      parentId: string,
+      nodes: readonly PendingInlineNode[],
+    ): Effect.Effect<readonly CacheNode[], NotionSyncError, NotionConfig | HttpClient.HttpClient> =>
+      Effect.gen(function* () {
+        const live = yield* Stream.runCollect(
+          NotionBlocks.retrieveChildrenStream({ blockId: parentId }),
+        ).pipe(
+          Effect.mapError(
+            (cause) => new NotionSyncError({ reason: 'notion-retrieve-failed', cause }),
+          ),
+        )
+        const liveBlocks = Chunk.toReadonlyArray(live)
+        const adopted: CacheNode[] = []
+        let liveIdx = 0
+        for (const node of nodes) {
+          const server = liveBlocks[liveIdx]
+          if (server === undefined) break
+          liveIdx += 1
+          if (server.type !== node.type) {
+            return yield* new NotionSyncError({
+              reason: 'notion-retrieve-failed',
+              cause: `pending inline type mismatch: expected ${node.type}, got ${server.type}`,
+            })
+          }
+          const children =
+            node.children.length === 0 ? [] : yield* adoptInlineChildren(server.id, node.children)
+          adopted.push({
+            key: node.key,
+            blockId: server.id,
+            type: node.type,
+            hash: node.hash,
+            children,
+            nodeKind: 'block',
+          })
+        }
+        return adopted
+      })
+
+    const resolvePendingPages = (
+      cached: readonly CacheNode[],
+      candidates: readonly CandidateNode[],
+    ): Effect.Effect<
+      { readonly nodes: readonly CacheNode[]; readonly changed: boolean },
+      NotionSyncError,
+      NotionConfig | HttpClient.HttpClient
+    > =>
+      Effect.gen(function* () {
+        let changed = false
+        const nodes: CacheNode[] = []
+        for (const cachedNode of cached) {
+          const candidateNode = candidates.find(
+            (node) => node.key === cachedNode.key && node.nodeKind === cachedNode.nodeKind,
+          )
+          if (candidateNode === undefined || cachedNode.nodeKind !== 'page') {
+            nodes.push(cachedNode)
+            continue
+          }
+          candidateNode.blockId = cachedNode.blockId
+          if (cachedNode.pendingInlineResolution !== undefined) {
+            const children = yield* adoptInlineChildren(
+              cachedNode.blockId,
+              cachedNode.pendingInlineResolution,
+            )
+            nodes.push({ ...cachedNode, children, pendingInlineResolution: undefined })
+            changed = true
+            continue
+          }
+          const nested = yield* resolvePendingPages(cachedNode.children, candidateNode.children)
+          nodes.push(nested.changed ? { ...cachedNode, children: nested.nodes } : cachedNode)
+          changed = changed || nested.changed
+        }
+        return { nodes, changed }
+      })
+
+    if (prior !== undefined) {
+      const resolvedPending = yield* resolvePendingPages(prior.children, candidate.children)
+      if (resolvedPending.changed) {
+        prior = { ...prior, children: resolvedPending.nodes }
+        yield* opts.cache
+          .save(prior)
+          .pipe(
+            Effect.mapError((cause) => new NotionSyncError({ reason: 'cache-save-failed', cause })),
+          )
+      }
     }
 
     const coldBaseline: ColdBaseline = opts.coldBaseline ?? 'clean'
@@ -1288,7 +1398,7 @@ export const sync = (
         : emptyCache(opts.pageId)
       : drifted
         ? driftedBase(opts.pageId, liveTopLevelIds, prior)
-        : prior
+        : (prior ?? emptyCache(opts.pageId))
     /* Working base mirrors diffBase for warm drift (no ghost leakage risk —
        we only copy prior entries whose blockIds are still live server-side,
        so they're real confirmed entries). For cold paths we stay empty. */
@@ -1300,7 +1410,7 @@ export const sync = (
             rootId: opts.pageId,
             children: diffBase.children.filter((c) => !c.key.startsWith('drift:')),
           }
-        : prior
+        : (prior ?? emptyCache(opts.pageId))
     const fallbackReason: SyncFallbackReason | undefined = pageIdDrift
       ? 'page-id-drift'
       : drifted
@@ -1353,6 +1463,12 @@ export const sync = (
       for (const c of prior.children) indexHash(c)
     }
     const idMap = new Map<string, string>()
+    const candidateByPlaceholderId = new Map<string, CandidateNode>()
+    const indexCandidate = (node: CandidateNode): void => {
+      if (node.blockId !== undefined) candidateByPlaceholderId.set(node.blockId, node)
+      for (const child of node.children) indexCandidate(child)
+    }
+    for (const child of candidate.children) indexCandidate(child)
     // Working copy of the cache tree — updated after each successful op,
     // flushed to the backend as a per-batch checkpoint (#102). On
     // mid-sync failure the cache reflects server state up to the last
@@ -1595,7 +1711,43 @@ export const sync = (
         }
         idMap.set(op.tmpPageId, createdId)
         const inlineCands = (op.inlineCandidates ?? []) as readonly CandidateNode[]
-        yield* resolveInlineChildrenIds(createdId, op, inlineCands, idMap)
+        const pageCandidate = candidateByPlaceholderId.get(op.tmpPageId)
+        if (pageCandidate === undefined) {
+          return yield* new NotionSyncError({
+            reason: 'notion-page-create-failed',
+            cause: `missing candidate for ${op.tmpPageId}`,
+          })
+        }
+        const pageNode = buildSubtreeFromCandidate(pageCandidate)
+        if (pageNode === undefined) {
+          return yield* new NotionSyncError({
+            reason: 'notion-page-create-failed',
+            cause: `unresolved created page ${op.tmpPageId}`,
+          })
+        }
+        if (inlineCands.length > 0) {
+          pageNode.pendingInlineResolution = pendingInlineFromCandidates(inlineCands)
+        }
+        workingAppend(working, resolvedParentId, pageNode, undefined)
+        yield* flushCheckpoint
+
+        // pages.create is an irreversible identity allocation, so the page id
+        // is durable before the retrieval needed to resolve inline block ids.
+        // Once those descendants resolve, replace the identity-only node with
+        // the complete materialized subtree and checkpoint again.
+        if (inlineCands.length > 0) {
+          yield* resolveInlineChildrenIds(createdId, op, inlineCands, idMap)
+          const pageWithInlineChildren = buildSubtreeFromCandidate(pageCandidate)
+          if (pageWithInlineChildren === undefined) {
+            return yield* new NotionSyncError({
+              reason: 'notion-page-create-failed',
+              cause: `unresolved created page ${op.tmpPageId}`,
+            })
+          }
+          workingRemove(working, createdId)
+          workingAppend(working, resolvedParentId, pageWithInlineChildren, undefined)
+          yield* flushCheckpoint
+        }
 
         if (onEvent !== undefined) {
           onEvent(


### PR DESCRIPTION
## Outcome

Make JSX page creation crash-safe by checkpointing the server-minted page identity and immutable create-time inline descriptors before subsequent reconciliation.

## Why

Previously, a process could die after Notion accepted `pages.create` but before the local cache recorded the new page. Retrying from the old cache could recreate the page. Checkpointing only the page ID was still insufficient: a retry saw no inline descendants and could duplicate the initial body.

## Changes

- persist the created page ID immediately after `pages.create`
- persist immutable descriptors for inline descendants created with the page
- on retry, retrieve and adopt the exact live descendants before diffing
- validate adopted block types and fail closed on inconsistent live state
- keep current JSX as an independent candidate, so changed-intent retries reconcile normally

## Evidence

- `notion-react`: 361 passed, 1 skipped
- TypeScript build passed
- `devenv tasks run check:quick` passed
- independent adversarial review passed
- failure-capable tests cover same-intent retry, changed-intent retry, stable page identity, no duplicated inline body, and type mismatch rejection

## Rollout

This PR is ready for code review. The dependent Blocky additive-page flow will exercise the exact checkpoint through a separately approval-gated live dogfood; readiness does not authorize that Notion mutation. No Notion production mutation has been performed by this branch yet.

## VRS

- A09 models `pages.create` as irreversible identity allocation.
- T06 accepts the immediate durable checkpoint.
- R28 requires checkpoint-before-retrieval and adoption-before-diff.
- The ontology defines pending inline resolution.
- Experiment 0002 records same-intent, changed-intent, and type-mismatch recovery evidence.
