### PR TITLE
fix(pnpm): project staged source policy into prepared roots

### DIFF
--- a/nix/devenv-modules/tasks/shared/pnpm.nix
+++ b/nix/devenv-modules/tasks/shared/pnpm.nix
@@ -104,9 +104,12 @@ let
   nodeModulesProjectionScript = pkgs.writeText "check-node-modules-projection-health.cjs" (
     builtins.readFile ./check-node-modules-projection-health.cjs
   );
-  stageSourceInputsScript = pkgs.writeText "stage-pnpm-source-inputs.mjs" (
-    builtins.readFile ./stage-pnpm-source-inputs.mjs
-  );
+  sourceInputStagingScripts = pkgs.runCommand "pnpm-source-input-staging" { } ''
+    mkdir -p "$out"
+    cp ${./stage-pnpm-source-inputs.mjs} "$out/stage-pnpm-source-inputs.mjs"
+    cp ${./source-input-staging-fs.mjs} "$out/source-input-staging-fs.mjs"
+  '';
+  stageSourceInputsScript = "${sourceInputStagingScripts}/stage-pnpm-source-inputs.mjs";
   sourceStagePath = ".devenv/pnpm-source-inputs";
   pnpmInstallPolicy = import ../../../workspace-tools/lib/pnpm-install-policy.nix { inherit lib; };
   effectivePnpmLockMutatorPkg =

--- a/nix/devenv-modules/tasks/shared/tests/pnpm-task-smoke.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/pnpm-task-smoke.test.sh
@@ -207,6 +207,38 @@ mkdir -p "$workspace/.devenv/task-cache" "$workspace/.pnpm-home-a/store/v11" "$w
 echo "Preflight: pnpmPkg is exec-only guard backing, not a profile package"
 assert_eq 1 "$(eval_pnpm_package_count)" "pnpm module packages should contain the pnpm guard only"
 
+echo "Preflight: Nix-built pnpm wrapper closes over source-input staging modules"
+wrapper_closure_expr="$tmpdir/pnpm-wrapper-closure.nix"
+cat > "$wrapper_closure_expr" <<'EOF'
+let
+  root = /. + builtins.getEnv "EFFECT_UTILS_TEST_ROOT";
+  flake = builtins.getFlake (toString root);
+  pkgs = import flake.inputs.nixpkgs { system = builtins.currentSystem; };
+  module = (import (root + "/nix/devenv-modules/tasks/shared/pnpm.nix") {
+    packages = [ ];
+    sourceInputPaths = [ "repos/demo" ];
+    pnpmPkg = pkgs.writeShellScriptBin "pnpm" "exit 0";
+  }) {
+    inherit pkgs;
+    lib = pkgs.lib;
+    config = { devenv.root = "/build/workspace"; };
+  };
+  wrapper = pkgs.writeShellScript "pnpm-install-wrapper" module.tasks."pnpm:install".exec;
+in
+pkgs.runCommand "pnpm-source-input-staging-wrapper-closure" {
+  nativeBuildInputs = [ pkgs.nodejs pkgs.gnugrep ];
+} ''
+  workspace="$PWD/workspace"
+  mkdir -p "$workspace/repos/demo"
+  printf '%s\n' '{"name":"demo"}' > "$workspace/repos/demo/package.json"
+  stager=$(grep -oE "/nix/store/[^'[:space:]]*stage-pnpm-source-inputs.mjs" ${wrapper} | head -n 1)
+  node "$stager" publish "$workspace" .devenv/pnpm-source-inputs repos/demo
+  test -f "$workspace/.devenv/pnpm-source-inputs/current/repos/demo/package.json"
+  touch "$out"
+''
+EOF
+EFFECT_UTILS_TEST_ROOT="$ROOT" nix build --no-link --impure --file "$wrapper_closure_expr"
+
 cat > "$workspace/package.json" <<'EOF'
 {"name":"smoke-workspace","private":true}
 EOF

--- a/nix/workspace-tools/lib/mk-pnpm-cli.nix
+++ b/nix/workspace-tools/lib/mk-pnpm-cli.nix
@@ -568,7 +568,6 @@ let
       '') declaredSourceInputPathsValidated
     )
   );
-
   # Read workspace closure dirs from the generated package.json ($genie.workspaceClosureDirs).
   # Pre-computed by genie at generation time, avoiding import-from-derivation (IFD).
   # Future alternative: NixOS/nix#15380 (builtins.wasm) could compute this natively at eval time.
@@ -792,6 +791,52 @@ let
     workspaceSuffixLines rootPnpmWorkspaceYaml
   );
 
+  workspacePolicyFileLocators =
+    let
+      normalizeLine = lib.replaceStrings [ ".devenv/pnpm-source-inputs/current/" ] [ "" ];
+      locatorFromLine =
+        line:
+        let
+          matched = builtins.match "[[:space:]]*'?([^']+)'?:[[:space:]]*'?file:((\.\./)*)(repos/[A-Za-z0-9@._/+~-]+).*" (
+            normalizeLine line
+          );
+        in
+        if matched == null then
+          null
+        else
+          {
+            expectedName = lib.trim (builtins.elemAt matched 0);
+            dir = builtins.elemAt matched 3;
+          };
+    in
+    builtins.filter (locator: locator != null) (
+      map locatorFromLine (lib.splitString "\n" rootPnpmWorkspaceYaml)
+    );
+  workspacePolicyFileLocatorDirs = lib.unique (
+    map (
+      locator:
+      let
+        manifestPath = resolveEvalSourceFor "${locator.dir}/package.json";
+        manifest =
+          if !builtins.pathExists manifestPath then
+            throw "mk-pnpm-cli: workspace policy file locator target is missing: ${locator.dir}"
+          else
+            builtins.fromJSON (builtins.readFile manifestPath);
+      in
+      if (manifest.name or null) != locator.expectedName then
+        throw "mk-pnpm-cli: workspace policy file locator ${locator.dir} expected ${locator.expectedName}, found ${
+          toString (manifest.name or null)
+        }"
+      else
+        locator.dir
+    ) workspacePolicyFileLocators
+  );
+  workspacePolicyOnlyFileLocatorDirs = builtins.filter (
+    dir:
+    !(lib.elem dir workspaceClosureDirs)
+    && (!hasDeclaredSourceInputPaths || lib.elem dir declaredSourceInputPaths)
+  ) workspacePolicyFileLocatorDirs;
+
   # These are the files that define dependency identity for the aggregate root.
   # Keep this list narrow so source-only edits do not invalidate prepared deps,
   # but broad enough that any manifest / workspace policy drift still does.
@@ -801,6 +846,7 @@ let
   ];
   optionalRootWorkspaceFiles = [
     ".npmrc"
+    ".pnpmfile.cjs"
     "pnpm-install-contract.json"
     "tsconfig.base.json"
   ];
@@ -1045,6 +1091,24 @@ let
       cp ${workspaceYamlFile} "$out/${targetPath}"
     '';
 
+  sanitizeLockfileConfigScript = pkgs.writeShellScript "sanitize-pnpm-lockfile-config" ''
+    set -euo pipefail
+    staged_root="$1"
+    install_dir="$2"
+    if [ "$install_dir" = "." ]; then
+      install_root="$staged_root"
+    else
+      install_root="$staged_root/$install_dir"
+    fi
+    if [ ! -f "$install_root/.pnpmfile.cjs" ]; then
+      ${pkgs.perl}/bin/perl -0pi -e 's/^pnpmfileChecksum:[^\n]*\n//m' "$install_root/pnpm-lock.yaml"
+    fi
+  '';
+
+  sanitizeLockfileConfigCmd = installDir: ''
+    ${sanitizeLockfileConfigScript} "$out" ${lib.escapeShellArg installDir}
+  '';
+
   /**
     Parse patch file paths from pnpm-workspace.yaml (pnpm 11+ format).
     In pnpm 11, patchedDependencies are declared in pnpm-workspace.yaml as:
@@ -1173,6 +1237,9 @@ let
     + builtins.concatStringsSep "\n" (
       map (dir: copyFileCmd "${dir}/package.json") aggregateOwnedWorkspaceClosureDirs
     )
+    + builtins.concatStringsSep "\n" (
+      map (dir: copyFileCmd "${dir}/package.json") workspacePolicyOnlyFileLocatorDirs
+    )
     + copyResolvedPatchFilesCmd {
       sourcePrefix = "";
       workspaceYamlContent = rootPnpmWorkspaceYaml;
@@ -1180,6 +1247,7 @@ let
     }
     + builtins.concatStringsSep "\n" (map stageExternalInstallRootManifestOnlyCmd externalInstallRoots)
     + stageRootSourceInputManifestAliasesCmd
+    + sanitizeLockfileConfigCmd "."
   );
 
   # Each external install root gets its own manifest-only derivation and its
@@ -1206,6 +1274,7 @@ let
           cp ${lib.escapeShellArg (toString (absoluteFileSourcePathFor "pnpm-lock.yaml"))} "$out/.root-patch-authority/pnpm-lock.yaml"
           cp ${lib.escapeShellArg (toString (absoluteFileSourcePathFor "pnpm-workspace.yaml"))} "$out/.root-patch-authority/pnpm-workspace.yaml"
         ''
+        + sanitizeLockfileConfigCmd root.installDir
       );
       lockfilePath = installRootScopedPath root.installDir "pnpm-lock.yaml";
       depsBuild = pnpmDepsHelper.mkDeps {
@@ -1536,6 +1605,9 @@ pkgs.stdenv.mkDerivation {
       dependencyMaterializationProfiles
       fodHashRepairTargets
       inheritRootPatchedDependenciesScript
+      sanitizeLockfileConfigScript
+      workspacePolicyFileLocatorDirs
+      workspacePolicyOnlyFileLocatorDirs
       ;
     installRoots = map (root: {
       inherit (root) attrName installDir lockfilePath;

--- a/nix/workspace-tools/lib/mk-pnpm-cli/tests/fixtures/downstream/fixture-workspace/pnpm-install-contract.json
+++ b/nix/workspace-tools/lib/mk-pnpm-cli/tests/fixtures/downstream/fixture-workspace/pnpm-install-contract.json
@@ -2,6 +2,7 @@
   "contract": "fixture/pnpm-install-contract",
   "workspaceManifestContract": {
     "sourceInputPaths": [
+      "repos/effect-utils/packages/@overeng/genie",
       "repos/effect-utils/packages/@overeng/utils"
     ],
     "sourceInputStagePath": ".devenv/pnpm-source-inputs/current"

--- a/nix/workspace-tools/lib/mk-pnpm-cli/tests/fixtures/downstream/fixture-workspace/pnpm-lock.yaml
+++ b/nix/workspace-tools/lib/mk-pnpm-cli/tests/fixtures/downstream/fixture-workspace/pnpm-lock.yaml
@@ -1,5 +1,8 @@
 lockfileVersion: '9.0'
 
+pnpmfileChecksum: sha256-fixture-stale-checksum
+packageExtensionsChecksum: sha256-fixture-package-extensions-checksum
+
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false

--- a/nix/workspace-tools/lib/mk-pnpm-cli/tests/fixtures/downstream/fixture-workspace/pnpm-workspace.yaml
+++ b/nix/workspace-tools/lib/mk-pnpm-cli/tests/fixtures/downstream/fixture-workspace/pnpm-workspace.yaml
@@ -3,6 +3,12 @@ packages:
 
 overrides:
   '@overeng/utils': file:.devenv/pnpm-source-inputs/current/repos/effect-utils/packages/@overeng/utils
+  '@overeng/genie': file:.devenv/pnpm-source-inputs/current/repos/effect-utils/packages/@overeng/genie
+
+packageExtensions:
+  fixture@1:
+    dependencies:
+      '@overeng/genie': file:.devenv/pnpm-source-inputs/current/repos/effect-utils/packages/@overeng/genie
 
 packageExtensions:
   fixture-package@1.0.0:

--- a/nix/workspace-tools/lib/mk-pnpm-cli/tests/fixtures/downstream/flake.nix
+++ b/nix/workspace-tools/lib/mk-pnpm-cli/tests/fixtures/downstream/flake.nix
@@ -89,6 +89,30 @@
           };
           smokeTestArgs = [ ];
         };
+        manifestMismatchEvaluation =
+          let
+            mismatchFixture = mkPnpmCli {
+              name = "mk-pnpm-cli-manifest-mismatch-fixture";
+              binaryName = "mk-pnpm-cli-manifest-mismatch-fixture";
+              entry = "app/src/mod.ts";
+              packageDir = "app";
+              workspaceRoot = ./fixture-workspace;
+              workspaceSources = {
+                "repos/effect-utils" = effectUtilsSource;
+                "repos/effect-utils/packages/@overeng/genie" = effectUtilsSource + "/packages/@overeng/utils";
+              };
+              depsBuilds = {
+                "." = {
+                  hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+                };
+                "repos/effect-utils" = {
+                  hash = "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=";
+                };
+              };
+              smokeTestArgs = [ ];
+            };
+          in
+          builtins.tryEval (builtins.deepSeq mismatchFixture.passthru.workspacePolicyFileLocatorDirs true);
         # Two consumers that differ ONLY in `name` but share the same external
         # install-root profile. Their prepared deps for that shared root must
         # collapse to one in-store derivation (profileKey dedup), while their
@@ -417,6 +441,125 @@
               test -f "$package_target/src/example.js"
 
               touch "$out"
+            '';
+        checks.prepared-workspace-staged-source-projection =
+          pkgs.runCommand "mk-pnpm-cli-prepared-workspace-staged-source-projection"
+            {
+              nativeBuildInputs = [ pkgs.nodejs ];
+            }
+            ''
+              fixture="$PWD/fixture"
+              mkdir -p "$fixture/repos/effect-utils/packages/@overeng/utils"
+              cat > "$fixture/pnpm-workspace.yaml" <<'YAML'
+              overrides:
+                '@overeng/utils': 'file:.devenv/pnpm-source-inputs/current/repos/effect-utils/packages/@overeng/utils'
+              YAML
+              cat > "$fixture/repos/effect-utils/packages/@overeng/utils/package.json" <<'JSON'
+              {"name":"@overeng/utils"}
+              JSON
+
+              ${pureEvalFixture.passthru.depsBuildsByInstallRoot.root.projectStagedSourceInputsScript} "$fixture"
+
+              projection="$fixture/.devenv/pnpm-source-inputs/current"
+              test -L "$projection"
+              test -f "$projection/repos/effect-utils/packages/@overeng/utils/package.json"
+
+              # The lock/workspace bytes remain untouched, preserving pnpm's
+              # packageExtensionsChecksum authority across the projection.
+              grep -qF 'file:.devenv/pnpm-source-inputs/current/repos/effect-utils' \
+                "$fixture/pnpm-workspace.yaml"
+
+              ${pureEvalFixture.passthru.depsBuildsByInstallRoot.root.purgePreparedWorkspaceStateScript} "$fixture"
+              test ! -e "$fixture/.devenv"
+
+              alias_manifest="$fixture/.devenv/pnpm-source-inputs/current/repos/effect-utils/packages/@overeng/utils/package.json"
+              mkdir -p "$(dirname "$alias_manifest")"
+              ln -s "$(realpath --relative-to="$(dirname "$alias_manifest")" "$fixture/repos/effect-utils/packages/@overeng/utils/package.json")" \
+                "$alias_manifest"
+              ${pureEvalFixture.passthru.depsBuildsByInstallRoot.root.projectStagedSourceInputsScript} "$fixture"
+              test ! -L "$fixture/.devenv/pnpm-source-inputs/current"
+              test "$(realpath "$alias_manifest")" = \
+                "$(realpath "$fixture/repos/effect-utils/packages/@overeng/utils/package.json")"
+
+              wrong="$PWD/wrong-existing-alias"
+              cp -R "$fixture" "$wrong"
+              mkdir -p "$wrong/repos/wrong"
+              printf '%s\n' '{"name":"wrong"}' > "$wrong/repos/wrong/package.json"
+              rm "$wrong/.devenv/pnpm-source-inputs/current/repos/effect-utils/packages/@overeng/utils/package.json"
+              ln -s "$(realpath --relative-to="$wrong/.devenv/pnpm-source-inputs/current/repos/effect-utils/packages/@overeng/utils" "$wrong/repos/wrong/package.json")" \
+                "$wrong/.devenv/pnpm-source-inputs/current/repos/effect-utils/packages/@overeng/utils/package.json"
+              if ${pureEvalFixture.passthru.depsBuildsByInstallRoot.root.projectStagedSourceInputsScript} "$wrong" 2> "$wrong.log"; then
+                echo "mismatched existing staged projection was accepted" >&2
+                exit 1
+              fi
+              grep -q 'does not select its logical manifest' "$wrong.log"
+
+              missing="$PWD/missing"
+              mkdir -p "$missing"
+              cp "$fixture/pnpm-workspace.yaml" "$missing/pnpm-workspace.yaml"
+              if ${pureEvalFixture.passthru.depsBuildsByInstallRoot.root.projectStagedSourceInputsScript} "$missing" 2>/dev/null; then
+                echo "missing staged locator target was accepted" >&2
+                exit 1
+              fi
+              test ! -e "$missing/.devenv"
+
+              escaped="$PWD/escaped"
+              mkdir -p "$escaped"
+              cat > "$escaped/pnpm-workspace.yaml" <<'YAML'
+              overrides:
+                bad: 'file:.devenv/pnpm-source-inputs/current/../outside'
+              YAML
+              if ${pureEvalFixture.passthru.depsBuildsByInstallRoot.root.projectStagedSourceInputsScript} "$escaped" 2>/dev/null; then
+                echo "escaping staged locator target was accepted" >&2
+                exit 1
+              fi
+              test ! -e "$escaped/.devenv"
+              touch "$out"
+            '';
+        checks.prepared-workspace-pnpmfile-checksum =
+          pkgs.runCommand "mk-pnpm-cli-prepared-workspace-pnpmfile-checksum" { }
+            ''
+              fixture="$PWD/fixture"
+              mkdir -p "$fixture/repos/nested"
+              for install_root in "$fixture" "$fixture/repos/nested"; do
+                cat > "$install_root/pnpm-lock.yaml" <<'YAML'
+              lockfileVersion: '9.0'
+              packageExtensionsChecksum: sha256-package-extensions-byte-identity
+              pnpmfileChecksum: sha256-pnpmfile-byte-identity
+              YAML
+                : > "$install_root/.pnpmfile.cjs"
+                cp "$install_root/pnpm-lock.yaml" "$install_root/pnpm-lock.yaml.before"
+              done
+
+              ${pureEvalFixture.passthru.sanitizeLockfileConfigScript} "$fixture" .
+              ${pureEvalFixture.passthru.sanitizeLockfileConfigScript} "$fixture" repos/nested
+              cmp "$fixture/pnpm-lock.yaml.before" "$fixture/pnpm-lock.yaml"
+              cmp "$fixture/repos/nested/pnpm-lock.yaml.before" "$fixture/repos/nested/pnpm-lock.yaml"
+
+              rm "$fixture/repos/nested/.pnpmfile.cjs"
+              ${pureEvalFixture.passthru.sanitizeLockfileConfigScript} "$fixture" repos/nested
+              grep -q '^packageExtensionsChecksum: sha256-package-extensions-byte-identity$' \
+                "$fixture/repos/nested/pnpm-lock.yaml"
+              if grep -q '^pnpmfileChecksum:' "$fixture/repos/nested/pnpm-lock.yaml"; then
+                echo "nested lock retained pnpmfileChecksum without pnpmfile" >&2
+                exit 1
+              fi
+              touch "$out"
+            '';
+        checks.prepared-workspace-policy-locator-validation =
+          pkgs.runCommand "mk-pnpm-cli-prepared-workspace-policy-locator-validation" { }
+            ''
+              if [ ${lib.escapeShellArg (builtins.toJSON manifestMismatchEvaluation.success)} != false ]; then
+                  echo "workspace policy locator manifest-name mismatch was accepted" >&2
+                  exit 1
+                fi
+                actual='${builtins.toJSON pureEvalFixture.passthru.workspacePolicyFileLocatorDirs}'
+                expected='["repos/effect-utils/packages/@overeng/utils","repos/effect-utils/packages/@overeng/genie"]'
+                if [ "$actual" != "$expected" ]; then
+                  echo "workspace policy locator targets were not deduplicated: $actual" >&2
+                  exit 1
+                fi
+                touch "$out"
             '';
       }
     );

--- a/nix/workspace-tools/lib/mk-pnpm-cli/tests/run.sh
+++ b/nix/workspace-tools/lib/mk-pnpm-cli/tests/run.sh
@@ -305,11 +305,35 @@ run_downstream_pure_eval_regression() {
     --override-input effect-utils "path:$WORKSPACE_REAL/repos/effect-utils" \
     "path:$DOWNSTREAM_DIR#checks.$SYSTEM.prepared-workspace-source-input-file-links"
 
+  echo "Check: prepared workspace projects staged source locators onto the logical closure"
+  nix build --no-link --no-write-lock-file \
+    --override-input effect-utils "path:$WORKSPACE_REAL/repos/effect-utils" \
+    "path:$DOWNSTREAM_DIR#checks.$SYSTEM.prepared-workspace-staged-source-projection"
+
+  echo "Check: pnpmfile checksum sanitization preserves present root and nested authority"
+  nix build --no-link --no-write-lock-file \
+    --override-input effect-utils "path:$WORKSPACE_REAL/repos/effect-utils" \
+    "path:$DOWNSTREAM_DIR#checks.$SYSTEM.prepared-workspace-pnpmfile-checksum"
+
+  echo "Check: workspace policy locator manifests validate identity and deduplicate"
+  nix build --no-link --no-write-lock-file \
+    --override-input effect-utils "path:$WORKSPACE_REAL/repos/effect-utils" \
+    "path:$DOWNSTREAM_DIR#checks.$SYSTEM.prepared-workspace-policy-locator-validation"
+
   echo "Check: downstream staged pnpm-workspace.yaml strips live-worktree pnpm settings"
   local deps_src
   deps_src="$(nix build --no-link --no-write-lock-file --print-out-paths \
     --override-input effect-utils "path:$WORKSPACE_REAL/repos/effect-utils" \
     "path:$DOWNSTREAM_DIR#packages.$SYSTEM.mk-pnpm-cli-pure-eval-fixture.passthru.depsSrcByInstallRoot.root")"
+  if grep -q '^pnpmfileChecksum:' "$deps_src/pnpm-lock.yaml"; then
+    echo "error: staged lockfile retained pnpmfileChecksum without a staged .pnpmfile.cjs" >&2
+    exit 1
+  fi
+  test "$(rg '^packageExtensionsChecksum:' "$deps_src/pnpm-lock.yaml")" = \
+    'packageExtensionsChecksum: sha256-fixture-package-extensions-checksum'
+  test -f "$deps_src/repos/effect-utils/packages/@overeng/genie/package.json"
+  test "$(jq -r .name "$deps_src/repos/effect-utils/packages/@overeng/genie/package.json")" = "@overeng/genie"
+  test ! -e "$deps_src/repos/effect-utils/packages/@overeng/genie/src"
   for key in \
     enableGlobalVirtualStore \
     globalVirtualStoreDir \

--- a/nix/workspace-tools/lib/mk-pnpm-deps.nix
+++ b/nix/workspace-tools/lib/mk-pnpm-deps.nix
@@ -480,6 +480,101 @@ let
 
     rewriteBinScripts(workspaceTarget);
   '';
+
+  projectStagedSourceInputsScript = pkgs.writeShellScript "project-staged-source-inputs" ''
+    set -euo pipefail
+
+    workspace_root="''${1:-.}"
+    staged_prefix=".devenv/pnpm-source-inputs/current/"
+
+    if ! ${pkgs.gnugrep}/bin/grep -RqsF \
+      --include=pnpm-lock.yaml \
+      --include=pnpm-workspace.yaml \
+      --include=package.json \
+      "$staged_prefix" \
+      "$workspace_root"; then
+      exit 0
+    fi
+
+    ${pnpmNodejs}/bin/node - "$workspace_root" <<'JS'
+    const fs = require("fs");
+    const path = require("path");
+
+    const workspaceRoot = path.resolve(process.argv[2]);
+    const authorityFiles = ["package.json", "pnpm-lock.yaml", "pnpm-workspace.yaml"];
+    const stagedLocator = /\.devenv\/pnpm-source-inputs\/current\/([^\s'"),]+?)(?=\([^/]|[\s'"),]|$)/g;
+    const pending = [workspaceRoot];
+    const targets = new Set();
+
+    while (pending.length > 0) {
+      const directory = pending.pop();
+      for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+        if (entry.name === ".devenv" || entry.name === "node_modules") continue;
+        const entryPath = path.join(directory, entry.name);
+        if (entry.isDirectory()) {
+          pending.push(entryPath);
+        } else if (entry.isFile() && authorityFiles.includes(entry.name)) {
+          const source = fs.readFileSync(entryPath, "utf8");
+          for (const match of source.matchAll(stagedLocator)) targets.add(match[1]);
+        }
+      }
+    }
+
+    for (const target of targets) {
+      const resolved = path.resolve(workspaceRoot, target);
+      const relative = path.relative(workspaceRoot, resolved);
+      if (relative.startsWith(".." + path.sep) || path.isAbsolute(relative)) {
+        throw new Error(`staged source-input locator escaped logical closure: ''${target}`);
+      }
+      if (!fs.existsSync(resolved)) {
+        throw new Error(`staged source-input locator is absent from logical closure: ''${target}`);
+      }
+    }
+
+    const projection = path.join(workspaceRoot, ".devenv/pnpm-source-inputs/current");
+    const projectionExists = (() => {
+      try {
+        fs.lstatSync(projection);
+        return true;
+      } catch (error) {
+        if (error.code === "ENOENT") return false;
+        throw error;
+      }
+    })();
+    if (projectionExists) {
+      for (const target of targets) {
+        const logicalManifest = path.join(workspaceRoot, target, "package.json");
+        const aliasManifest = path.join(projection, target, "package.json");
+        if (
+          !fs.existsSync(logicalManifest) ||
+          !fs.existsSync(aliasManifest) ||
+          fs.realpathSync(aliasManifest) !== fs.realpathSync(logicalManifest)
+        ) {
+          throw new Error(`existing staged source-input alias does not select its logical manifest: ''${target}`);
+        }
+      }
+    }
+    JS
+
+    projection="$workspace_root/.devenv/pnpm-source-inputs/current"
+    mkdir -p "$(dirname "$projection")"
+    if [ ! -e "$projection" ] && [ ! -L "$projection" ]; then
+      # Live installs resolve composed sources through a generation-switched
+      # `.devenv` path. The prepared source contains the same closure at its
+      # logical `repos/*` paths, while `.devenv` is intentionally excluded from
+      # the artifact. Recreate only the locator namespace for pnpm's frozen
+      # install; the normal prepared-output purge removes it afterwards.
+      ln -s ../.. "$projection"
+    fi
+  '';
+
+  purgePreparedWorkspaceStateScript = pkgs.writeShellScript "purge-prepared-workspace-state" ''
+    set -euo pipefail
+    workspace_root="''${1:-.}"
+    ${pkgs.findutils}/bin/find "$workspace_root" \
+      \( -type d -name .devenv -o -type d -name '.pnpm-store*' -o -type d -name '.pnpm-home*' \) \
+      -prune -exec rm -rf {} +
+  '';
 in
 {
   # Create a fixed-output derivation that prepares a workspace install tree.
@@ -692,6 +787,8 @@ in
 
                 ${preInstall}
 
+                ${projectStagedSourceInputsScript} .
+
                 # pnpm still mutates store metadata (for example index.db and
                 # projects/*), so the Nix build must use a private writable HOME/store
                 # even though the final archive is immutable.
@@ -829,9 +926,7 @@ in
                 # Live-worktree pnpm store state is mutable and path-sensitive.
                 # Prepared deps FODs own their private store through env/.npmrc
                 # and must archive only the materialized dependency graph.
-                find . \
-                  \( -type d -name .devenv -o -type d -name '.pnpm-store*' -o -type d -name '.pnpm-home*' \) \
-                  -prune -exec rm -rf {} +
+                ${purgePreparedWorkspaceStateScript} .
                 rm -f .pnpm-install-roots.txt
 
                 ${pnpmNodejs}/bin/node ${lib.escapeShellArg normalizePreparedTreeScript} .
@@ -886,7 +981,11 @@ in
       outputHash = pnpmDepsHash;
 
       passthru = {
-        inherit rewritePreparedWorkspaceScript;
+        inherit
+          projectStagedSourceInputsScript
+          purgePreparedWorkspaceStateScript
+          rewritePreparedWorkspaceScript
+          ;
       };
     };
 


### PR DESCRIPTION
## Problem

Prepared pnpm roots retain staged-source and `file:` policy locators, but their dependency source intentionally excludes writable `.devenv` state. Frozen installs therefore need a contained projection onto the declared immutable source closure without changing workspace policy bytes or activating undeclared package source.

## Goal

Make prepared roots faithfully materialize the declared staged-source and policy-only manifest closure while preserving the manifest-alias authority introduced by #1103.

## Decisions

- Keep #1103's staged locator and manifest-alias semantics as the source of truth; the older logical-locator rewrite and `.devenv`-absence contract are retired.
- Stage retained `file:` policy targets as manifest-only inputs after path containment and package-name validation; do not activate their source or dependencies.
- Project staged sources only for the frozen install, fail closed on missing, escaping, or pre-existing targets, and purge the projection before archival.
- Preserve `packageExtensionsChecksum`; retain `pnpmfileChecksum` only when the referenced pnpmfile is present.
- Package the staging entrypoint and its relative filesystem helper in one Nix store output so generated wrappers retain a complete ESM closure.

## Verification

- PASS: focused seven-check projection/checksum suite.
- PASS: `CI=1 devenv tasks run check:quick` on the final tree.
- PASS: real Nix-built `pnpm:install` wrapper regression plus all 36 pnpm smoke cases.
- PASS: refreshed `CI=1 devenv tasks run check:all` on exact commit `b8e5ca0b623591313a9e70bce7a7164db5dfeed8`; terminal exit 0 and `all checks passed!`.
- PASS: independent semantic/security review and `git diff --check`.

## Complexity

The extra logic remains inside the shared prepared-root boundary. Consumers keep one workspace policy and do not gain project-specific locator rewriting.

## Concerns

- Policy-only targets intentionally stage `package.json` only; future pnpm policy fields that inspect additional files must extend this explicit contract.
- Install-time projections are temporary and must remain coupled to the prepared-state cleanup gate.

## Friction & bottlenecks

- Rebase exposed a real authority conflict between the old locator rewrite and #1103's manifest aliases; the stack now uses one authority instead of attempting to preserve both.
- The first refreshed full gate was stopped below the 50 GiB floor; the serialized retry passed after managed Nix GC restored capacity.

## Follow-ups

- Repin schickling/dotfiles PR #1964 to this stack after merge and refresh its measured downstream fixed-output hashes with Evergreen.

## References

- Depends on #1103.
- Related: schickling/dotfiles#1964.
- Related incident: schickling/dotfiles#1880.
