### PR TITLE
fix(tasks): stabilize staged-source verification

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -671,6 +671,11 @@ in
     description = "Build, test, lint, and format-check standalone Rust crates";
     exec = trace.exec "cargo:check" ''
       set -euo pipefail
+      export CARGO_TARGET_DIR="$(${./nix/devenv-modules/tasks/shared/cargo-target-dir.sh} \
+        "$PWD" \
+        cargo-check \
+        "''${XDG_CACHE_HOME:-$HOME/.cache}")"
+      mkdir -p "$CARGO_TARGET_DIR"
       ${lib.concatMapStringsSep "\n" (crate: ''
         echo "::group::${crate.name}"
         (

--- a/devenv.nix
+++ b/devenv.nix
@@ -672,19 +672,15 @@ in
     exec = trace.exec "cargo:check" ''
       set -euo pipefail
       export CARGO_TARGET_DIR="$(${./nix/devenv-modules/tasks/shared/cargo-target-dir.sh} \
-        "$PWD" \
+        ${lib.escapeShellArg config.devenv.root} \
         cargo-check \
         "''${XDG_CACHE_HOME:-$HOME/.cache}")"
       mkdir -p "$CARGO_TARGET_DIR"
       ${lib.concatMapStringsSep "\n" (crate: ''
         echo "::group::${crate.name}"
-        (
-          cd "${crate.path}"
-          cargo build --release
-          cargo test
-          cargo clippy -- -D warnings
-          cargo fmt --check
-        )
+        ${./nix/devenv-modules/tasks/shared/cargo-check-crate.sh} \
+          ${lib.escapeShellArg config.devenv.root} \
+          ${lib.escapeShellArg crate.path}
         echo "::endgroup::"
       '') rustCrates}
     '';

--- a/nix/devenv-modules/tasks/shared/bootstrap-closure.nix
+++ b/nix/devenv-modules/tasks/shared/bootstrap-closure.nix
@@ -37,9 +37,11 @@
 { lib, pkgs, ... }:
 let
   trace = import ../lib/trace.nix { inherit lib; };
+  sourceFilter = import ./bootstrap-source-filter.nix;
   effectUtilsSrc = builtins.path {
     path = ../../../..;
     name = "effect-utils-source";
+    filter = sourceFilter;
   };
   checkerPkg = import (effectUtilsSrc + "/packages/@overeng/genie/nix/bootstrap-closure-check.nix") {
     inherit pkgs;

--- a/nix/devenv-modules/tasks/shared/bootstrap-source-filter.nix
+++ b/nix/devenv-modules/tasks/shared/bootstrap-source-filter.nix
@@ -1,0 +1,6 @@
+path: _type:
+let
+  name = builtins.baseNameOf (toString path);
+in
+builtins.match "([.]oxlint-with-plugins[.].*[.]json|[.][0-9a-f]+-[0-9a-f]+[.]bun-build)" name
+== null

--- a/nix/devenv-modules/tasks/shared/cargo-check-crate.sh
+++ b/nix/devenv-modules/tasks/shared/cargo-check-crate.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workspace_root="${1:?workspace root is required}"
+crate_path="${2:?crate path is required}"
+
+workspace_root="$(cd "$workspace_root" && pwd -P)"
+crate_root="$(cd "$workspace_root/$crate_path" && pwd -P)"
+case "$crate_root/" in
+  "$workspace_root"/*) ;;
+  *)
+    echo "cargo crate path escapes the workspace: $crate_path" >&2
+    exit 1
+    ;;
+esac
+
+cd "$crate_root"
+cargo build --release
+cargo test
+cargo clippy -- -D warnings
+cargo fmt --check

--- a/nix/devenv-modules/tasks/shared/cargo-target-dir.sh
+++ b/nix/devenv-modules/tasks/shared/cargo-target-dir.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workspace_root="${1:?workspace root is required}"
+task_name="${2:?task name is required}"
+cache_root="${3:?cache root is required}"
+
+case "$workspace_root:$cache_root" in
+  /*:/*) ;;
+  *)
+    echo "cargo target workspace and cache roots must be absolute" >&2
+    exit 1
+    ;;
+esac
+
+workspace_key="$(printf '%s' "$workspace_root" | sha256sum | cut -c1-16)"
+task_key="$(printf '%s' "$task_name" | tr -c 'A-Za-z0-9._-' '-')"
+target_dir="$cache_root/effect-utils/cargo-target/$workspace_key/$task_key"
+
+case "$target_dir/" in
+  "$workspace_root"/*)
+    echo "cargo target directory must remain outside the workspace" >&2
+    exit 1
+    ;;
+esac
+
+printf '%s\n' "$target_dir"

--- a/nix/devenv-modules/tasks/shared/source-input-staging-fs.mjs
+++ b/nix/devenv-modules/tasks/shared/source-input-staging-fs.mjs
@@ -1,0 +1,20 @@
+import * as Fs from 'node:fs/promises'
+import * as Path from 'node:path'
+
+const makeDirectoriesWritable = async (root, fs) => {
+  const { mode } = await fs.stat(root)
+  await fs.chmod(root, mode | 0o200)
+  for (const entry of await fs.readdir(root, { withFileTypes: true })) {
+    if (entry.isDirectory()) await makeDirectoriesWritable(Path.join(root, entry.name), fs)
+  }
+}
+
+/** Removes an immutable staging tree after restoring only directory owner-write bits. */
+export const removeStagingTree = async (root, fs = Fs) => {
+  try {
+    await makeDirectoriesWritable(root, fs)
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw error
+  }
+  await fs.rm(root, { force: true, recursive: true })
+}

--- a/nix/devenv-modules/tasks/shared/stage-pnpm-source-inputs.mjs
+++ b/nix/devenv-modules/tasks/shared/stage-pnpm-source-inputs.mjs
@@ -3,6 +3,8 @@ import * as Fs from 'node:fs/promises'
 import * as Path from 'node:path'
 import process from 'node:process'
 
+import { removeStagingTree } from './source-input-staging-fs.mjs'
+
 const [mode, workspaceArg, stageArg, ...sourcePaths] = process.argv.slice(2)
 if (
   !['check', 'gc', 'publish'].includes(mode) ||
@@ -180,6 +182,7 @@ try {
 
 await Fs.mkdir(generationsRoot, { recursive: true })
 const nextRoot = await Fs.mkdtemp(Path.join(generationsRoot, '.next-'))
+let unpublishedRoot = nextRoot
 try {
   for (const [sourcePath, sourceRoot] of sourceRoots) {
     const target = Path.join(nextRoot, sourcePath)
@@ -206,16 +209,13 @@ try {
   const generationRoot = Path.join(generationsRoot, `${before.identity}-${Crypto.randomUUID()}`)
   await Fs.rename(nextRoot, generationRoot)
   await Fs.chmod(generationRoot, 0o555)
+  unpublishedRoot = generationRoot
   const pointer = Path.join(stageRoot, `.current-${process.pid}-${Crypto.randomUUID()}`)
   await Fs.symlink(Path.relative(stageRoot, generationRoot), pointer)
   await Fs.rename(pointer, currentPath)
+  unpublishedRoot = undefined
   await validatePublished(before)
 } catch (error) {
-  try {
-    await makeWritable(nextRoot)
-  } catch (cleanupError) {
-    if (cleanupError?.code !== 'ENOENT') throw cleanupError
-  }
-  await Fs.rm(nextRoot, { force: true, recursive: true })
+  if (unpublishedRoot !== undefined) await removeStagingTree(unpublishedRoot)
   throw error
 }

--- a/nix/devenv-modules/tasks/shared/tests/bootstrap-source-filter.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/bootstrap-source-filter.test.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tests_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source_filter="$tests_dir/../bootstrap-source-filter.nix"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+fixture="$tmpdir/fixture"
+mkdir -p "$fixture/nested"
+printf 'source\n' > "$fixture/source.ts"
+printf '{}\n' > "$fixture/.oxlintrc.json"
+printf 'lookalike\n' > "$fixture/.oxlint-with-plugins-source.json.ts"
+printf '{}\n' > "$fixture/.oxlint-with-plugins.root.json"
+printf '{}\n' > "$fixture/nested/.oxlint-with-plugins.nested.json"
+printf 'lookalike\n' > "$fixture/.source.bun-build"
+printf 'transient\n' > "$fixture/.18ce97f2f777fbdf-00000000.bun-build"
+printf 'transient\n' > "$fixture/nested/.0123abcd-deadbeef.bun-build"
+
+snapshot="$(nix eval --raw --impure --expr "
+  toString (builtins.path {
+    path = $fixture;
+    name = \"bootstrap-source-filter-fixture\";
+    filter = import $source_filter;
+  })
+")"
+
+test -f "$snapshot/source.ts"
+test -f "$snapshot/.oxlintrc.json"
+test -f "$snapshot/.oxlint-with-plugins-source.json.ts"
+test ! -e "$snapshot/.oxlint-with-plugins.root.json"
+test ! -e "$snapshot/nested/.oxlint-with-plugins.nested.json"
+test -f "$snapshot/.source.bun-build"
+test ! -e "$snapshot/.18ce97f2f777fbdf-00000000.bun-build"
+test ! -e "$snapshot/nested/.0123abcd-deadbeef.bun-build"
+
+echo "bootstrap source filter test passed"

--- a/nix/devenv-modules/tasks/shared/tests/cargo-target-isolation.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/cargo-target-isolation.test.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 tests_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 root="${DEVENV_ROOT:-$(cd "$tests_dir/../../../../.." && pwd)}"
 target_dir_script="$tests_dir/../cargo-target-dir.sh"
+check_crate_script="$tests_dir/../cargo-check-crate.sh"
 tmpdir="$(mktemp -d)"
 writer_pid=""
 trap 'test -z "$writer_pid" || kill "$writer_pid" 2>/dev/null || true; rm -rf "$tmpdir"' EXIT
@@ -14,11 +15,71 @@ cache_root="$tmpdir/cache"
 mkdir -p "$workspace_a/source" "$workspace_b" "$cache_root"
 printf 'fixture\n' > "$workspace_a/source/input.txt"
 
-grep -qF 'export CARGO_TARGET_DIR="$(${./nix/devenv-modules/tasks/shared/cargo-target-dir.sh}' \
-  "$root/devenv.nix" || {
-  echo "FAIL: cargo:check does not use the isolated target-directory helper" >&2
+fake_bin="$tmpdir/bin"
+fixture_root="$tmpdir/cargo-root"
+task_cache_root="$tmpdir/task-cache"
+mkdir -p \
+  "$fake_bin" \
+  "$fixture_root/packages/@overeng/otelite" \
+  "$fixture_root/packages/@overeng/otel-scrape" \
+  "$task_cache_root"
+printf '[package]\nname = "otelite"\nversion = "0.0.0"\n' \
+  > "$fixture_root/packages/@overeng/otelite/Cargo.toml"
+printf '[package]\nname = "otel-scrape"\nversion = "0.0.0"\n' \
+  > "$fixture_root/packages/@overeng/otel-scrape/Cargo.toml"
+cat > "$fake_bin/cargo" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+test -f Cargo.toml
+printf '%s\t%s\t%s\n' "$PWD" "$CARGO_TARGET_DIR" "$*" >> "$CARGO_CALLS"
+SH
+chmod +x "$fake_bin/cargo"
+
+nix-instantiate --eval --strict --json --expr "
+  let
+    root = $root;
+    flake = builtins.getFlake (toString root);
+    pkgs = import flake.inputs.nixpkgs { system = builtins.currentSystem; };
+    module = import (root + /devenv.nix) {
+      inherit pkgs;
+      inputs = flake.inputs;
+      config = { devenv.root = \"$fixture_root\"; };
+      lib = pkgs.lib;
+    };
+  in module.tasks.\"cargo:check\".exec
+" | jq -r . > "$tmpdir/cargo-check-task"
+chmod +x "$tmpdir/cargo-check-task"
+perl -0pi -e '
+  s#/nix/store/[^"\s]*-cargo-target-dir[.]sh#'"$target_dir_script"'#g;
+  s#/nix/store/[^"\s]*-cargo-check-crate[.]sh#'"$check_crate_script"'#g;
+' "$tmpdir/cargo-check-task"
+
+(
+  cd /tmp
+  PATH="$fake_bin:$PATH" \
+    CARGO_CALLS="$tmpdir/cargo-calls" \
+    XDG_CACHE_HOME="$task_cache_root" \
+    OTEL_SPAN_BIN="$tmpdir/missing-otel-span" \
+    "$tmpdir/cargo-check-task"
+)
+
+expected_target="$($target_dir_script "$fixture_root" cargo-check "$task_cache_root")"
+test "$(wc -l < "$tmpdir/cargo-calls")" -eq 8
+awk -F '\t' -v root="$fixture_root/packages/@overeng" -v target="$expected_target" '
+  $1 != root "/otelite" && $1 != root "/otel-scrape" { exit 1 }
+  $2 != target { exit 1 }
+  END { if (NR != 8) exit 1 }
+' "$tmpdir/cargo-calls"
+for command in 'build --release' test 'clippy -- -D warnings' 'fmt --check'; do
+  test "$(awk -F '\t' -v command="$command" '$3 == command { count++ } END { print count + 0 }' \
+    "$tmpdir/cargo-calls")" -eq 2
+done
+
+mkdir -p "$tmpdir/outside"
+if "$check_crate_script" "$fixture_root" ../../outside >/dev/null 2>&1; then
+  echo "FAIL: workspace-escaping cargo crate path was accepted" >&2
   exit 1
-}
+fi
 
 target_a="$($target_dir_script "$workspace_a" cargo-check "$cache_root")"
 target_a_again="$($target_dir_script "$workspace_a" cargo-check "$cache_root")"

--- a/nix/devenv-modules/tasks/shared/tests/cargo-target-isolation.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/cargo-target-isolation.test.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tests_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root="${DEVENV_ROOT:-$(cd "$tests_dir/../../../../.." && pwd)}"
+target_dir_script="$tests_dir/../cargo-target-dir.sh"
+tmpdir="$(mktemp -d)"
+writer_pid=""
+trap 'test -z "$writer_pid" || kill "$writer_pid" 2>/dev/null || true; rm -rf "$tmpdir"' EXIT
+
+workspace_a="$tmpdir/checkouts/a"
+workspace_b="$tmpdir/checkouts/b"
+cache_root="$tmpdir/cache"
+mkdir -p "$workspace_a/source" "$workspace_b" "$cache_root"
+printf 'fixture\n' > "$workspace_a/source/input.txt"
+
+grep -qF 'export CARGO_TARGET_DIR="$(${./nix/devenv-modules/tasks/shared/cargo-target-dir.sh}' \
+  "$root/devenv.nix" || {
+  echo "FAIL: cargo:check does not use the isolated target-directory helper" >&2
+  exit 1
+}
+
+target_a="$($target_dir_script "$workspace_a" cargo-check "$cache_root")"
+target_a_again="$($target_dir_script "$workspace_a" cargo-check "$cache_root")"
+target_b="$($target_dir_script "$workspace_b" cargo-check "$cache_root")"
+target_other_task="$($target_dir_script "$workspace_a" cargo-test "$cache_root")"
+
+test "$target_a" = "$target_a_again"
+test "$target_a" != "$target_b"
+test "$target_a" != "$target_other_task"
+case "$target_a/" in
+  "$workspace_a"/*)
+    echo "FAIL: cargo target directory is inside the checkout" >&2
+    exit 1
+    ;;
+esac
+
+mkdir -p "$target_a/release/deps"
+(
+  while true; do
+    temp_file="$target_a/release/deps/rmeta-concurrent"
+    : > "$temp_file"
+    rm -f "$temp_file"
+  done
+) &
+writer_pid=$!
+
+for _ in 1 2 3 4 5; do
+  snapshot="$(nix eval --raw --impure --expr \
+    "toString (builtins.path { path = $workspace_a; name = \"cargo-target-isolation-snapshot-$_\"; })")"
+  test -f "$snapshot/source/input.txt"
+  test ! -e "$snapshot/target"
+done
+
+kill "$writer_pid"
+wait "$writer_pid" 2>/dev/null || true
+writer_pid=""
+
+if $target_dir_script "$workspace_a" cargo-check "$workspace_a/.cache" >/dev/null 2>&1; then
+  echo "FAIL: workspace-contained cache root was accepted" >&2
+  exit 1
+fi
+
+echo "cargo target isolation test passed"

--- a/nix/devenv-modules/tasks/shared/tests/pnpm-source-input-refresh.integration.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/pnpm-source-input-refresh.integration.test.sh
@@ -32,7 +32,7 @@ printf '{"name":"fixture-root","private":true,"packageManager":"pnpm@11.8.0","de
   "$stable_stage_path" > "$workspace/package.json"
 
 install_fixture() {
-  "${pnpm_command[@]}" --dir "$workspace" install \
+  DEVENV_TASK_PASSTHROUGH=1 "${pnpm_command[@]}" --dir "$workspace" install \
     --store-dir "$workspace/.devenv/pnpm-store" \
     --config.enable-global-virtual-store=false \
     --config.virtual-store-dir=node_modules/.pnpm \

--- a/nix/devenv-modules/tasks/shared/tests/pnpm-source-input-staging.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/pnpm-source-input-staging.test.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 stager="$script_dir/../stage-pnpm-source-inputs.mjs"
+staging_fs="$script_dir/../source-input-staging-fs.mjs"
 tmpdir="$(mktemp -d)"
 trap 'chmod -R u+w "$tmpdir" 2>/dev/null || true; rm -rf "$tmpdir"' EXIT
 
@@ -85,5 +86,39 @@ if node "$stager" publish "$workspace" .devenv/pnpm-source-inputs repos/demo/pac
   echo "FAIL: directory symlink cycle was accepted" >&2
   exit 1
 fi
+
+cleanup_workspace="$tmpdir/cleanup-workspace"
+mkdir -p \
+  "$cleanup_workspace/repos/demo/packages/pkg" \
+  "$cleanup_workspace/.devenv/pnpm-source-inputs/generations"
+printf 'cleanup\n' > "$cleanup_workspace/repos/demo/packages/pkg/value.txt"
+chmod 0555 "$cleanup_workspace/.devenv/pnpm-source-inputs"
+if node "$stager" publish "$cleanup_workspace" .devenv/pnpm-source-inputs repos/demo/packages/pkg 2>/dev/null; then
+  echo "FAIL: publishing through an unwritable pointer root unexpectedly succeeded" >&2
+  exit 1
+fi
+if find "$cleanup_workspace/.devenv/pnpm-source-inputs/generations" \
+  -mindepth 1 -maxdepth 1 | grep -q .; then
+  echo "FAIL: failed publication retained a partial read-only generation" >&2
+  exit 1
+fi
+
+node --input-type=module - "$staging_fs" <<'JS'
+import assert from 'node:assert/strict'
+
+const { removeStagingTree } = await import(process.argv[2])
+const calls = []
+const fs = {
+  stat: async () => ({ mode: 0o551 }),
+  chmod: async (path, mode) => calls.push(['chmod', path, mode]),
+  readdir: async () => [],
+  rm: async (path, options) => calls.push(['rm', path, options]),
+}
+await removeStagingTree('/fixture/.next-generation', fs)
+assert.deepEqual(calls, [
+  ['chmod', '/fixture/.next-generation', 0o751],
+  ['rm', '/fixture/.next-generation', { force: true, recursive: true }],
+])
+JS
 
 echo "pnpm source input staging tests passed"


### PR DESCRIPTION
## Problem

Merged staged-source work exposed four shared verification failures: Cargo wrote into the snapshotted worktree and resolved crates from the invocation CWD, failed pnpm publications could leave read-only generations on macOS, the hermetic pnpm fixture lacked explicit task authority, and bootstrap snapshots raced transient oxlint and Bun files.

## Goal

Make source staging and repository-wide verification deterministic across task CWDs, platforms, and concurrent source snapshots.

## Decisions

- Keep Cargo artifacts outside the checkout, keyed by canonical checkout and task.
- Anchor every Cargo crate operation to the evaluated Devenv root and reject traversal or symlink escape.
- Track the unpublished source generation across rename; add owner-write without replacing other mode bits before cleanup.
- Scope DEVENV_TASK_PASSTHROUGH=1 to the one hermetic fixture install.
- Filter only exact tool-generated oxlint and Bun transient basenames from bootstrap source snapshots; arbitrary untracked source remains authoritative.

## Verification

- Focused staging, refresh, Cargo task-wiring and containment, and bootstrap-filter tests: PASS.
- CI=1 devenv tasks run check:quick: PASS.
- CI=1 devenv tasks run check:all: PASS on exact 019c64f91.
- Independent final review: PASS.

## Complexity

Four narrow commits, 11 files, 288 insertions and 14 deletions. The larger test delta is failure-capable coverage of task wiring and race boundaries.

## Concerns

- Cargo target caches are intentionally outside the checkout and are not source authority.
- Bootstrap filtering is deliberately exact-name based; new transient families require explicit evidence and tests.

## Friction & bottlenecks

- Qualification exposed a misleading /tmp/Cargo.toml ancestor only in disposable worktrees; final proof ran from the canonical Megarepo hierarchy.
- Managed Nix GC recovered capacity before the terminal full gate.

## Follow-ups

- Rebase staged-source projection PR #1102 onto this branch, then requalify its downstream Jellyfin consumer.

## References

- Parent staging PR #1101
- schickling/dotfiles#1880