### PR TITLE
fix(genie): preserve CI helpers across setup boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,8 +72,8 @@ All notable changes to this project will be documented in this file.
 
 - **genie/ci-workflow**: preserve prepared CI helper scripts between workflow
   steps by staging their runtime artifacts in the job workspace without their
-  generator sources, and reject retry-helper use when another checkout would
-  remove the prepared runtime.
+  generator sources, and reject every helper consumer unless preparation
+  follows the final workspace-cleaning checkout and Nix installation.
 
 - **devenv pnpm installs**: refresh nixpkgs so pnpm runs on Node 24.18.1,
   avoiding the Darwin Node 24.15 teardown hang after a completed workspace

--- a/packages/@overeng/genie/src/runtime/github-workflow/github-workflow.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/github-workflow/github-workflow.unit.test.ts
@@ -247,7 +247,7 @@ describe('githubWorkflow', () => {
     )
   })
 
-  it('rejects prepared CI retry script use without the preparation step', () => {
+  it('rejects prepared CI runtime script use without the preparation step', () => {
     const issues = getWorkflowValidationIssues({
       name: 'CI',
       on: { pull_request: githubWorkflowEvent.all },
@@ -272,12 +272,12 @@ describe('githubWorkflow', () => {
         severity: 'error',
         packageName: '.github/workflows/ci.yml',
         dependency: 'jobs.test.steps[1]',
-        rule: 'github-workflow-prepared-ci-retry-script-setup',
+        rule: 'github-workflow-prepared-ci-runtime-script-setup',
       }),
     )
   })
 
-  it('accepts prepared CI retry script use after the preparation step', () => {
+  it('accepts prepared CI runtime script use after the preparation step', () => {
     const issues = getWorkflowValidationIssues({
       name: 'CI',
       on: { pull_request: githubWorkflowEvent.all },
@@ -302,11 +302,52 @@ describe('githubWorkflow', () => {
     })
 
     expect(
-      issues.filter((issue) => issue.rule === 'github-workflow-prepared-ci-retry-script-setup'),
+      issues.filter((issue) => issue.rule === 'github-workflow-prepared-ci-runtime-script-setup'),
     ).toEqual([])
   })
 
-  it('rejects prepared CI retry script use when a checkout follows preparation', () => {
+  it('rejects every prepared CI runtime helper after a measurement-baseline checkout', () => {
+    for (const helperPath of [
+      'run-with-nix-gc-race-retry.sh',
+      'resolve-devenv.sh',
+      'prepare-job-local-rust-state.sh',
+    ]) {
+      const issues = getWorkflowValidationIssues({
+        name: 'CI',
+        on: { pull_request: githubWorkflowEvent.all },
+        jobs: {
+          test: {
+            'runs-on': 'ubuntu-latest',
+            steps: [
+              { uses: 'actions/checkout@v6' },
+              {
+                name: 'Prepare CI helper scripts',
+                run: 'echo prepared',
+              },
+              {
+                name: 'Checkout CI measurement baseline ref',
+                uses: 'actions/checkout@v6',
+              },
+              {
+                run: ". '${{ github.workspace }}/.genie-ci-runtime/" + helperPath + "'",
+              },
+            ],
+          },
+        },
+      })
+
+      expect(issues).toContainEqual(
+        expect.objectContaining({
+          severity: 'error',
+          packageName: '.github/workflows/ci.yml',
+          dependency: 'jobs.test.steps[3]',
+          rule: 'github-workflow-prepared-ci-runtime-script-setup',
+        }),
+      )
+    }
+  })
+
+  it('rejects prepared CI runtime helper use when Nix installation follows preparation', () => {
     const issues = getWorkflowValidationIssues({
       name: 'CI',
       on: { pull_request: githubWorkflowEvent.all },
@@ -314,17 +355,10 @@ describe('githubWorkflow', () => {
         test: {
           'runs-on': 'ubuntu-latest',
           steps: [
-            {
-              name: 'Prepare CI helper scripts',
-              run: 'echo prepared',
-            },
             { uses: 'actions/checkout@v6' },
-            {
-              run: [
-                "__genie_ci_retry_script='${{ github.workspace }}/.genie-ci-runtime/run-with-nix-gc-race-retry.sh'",
-                'bash "$__genie_ci_retry_script" test true',
-              ].join('\n'),
-            },
+            { name: 'Prepare CI helper scripts', run: 'echo prepared' },
+            { uses: 'DeterminateSystems/determinate-nix-action@v3' },
+            { run: ". '${{ github.workspace }}/.genie-ci-runtime/resolve-devenv.sh'" },
           ],
         },
       },
@@ -332,10 +366,8 @@ describe('githubWorkflow', () => {
 
     expect(issues).toContainEqual(
       expect.objectContaining({
-        severity: 'error',
-        packageName: '.github/workflows/ci.yml',
-        dependency: 'jobs.test.steps[2]',
-        rule: 'github-workflow-prepared-ci-retry-script-setup',
+        dependency: 'jobs.test.steps[3]',
+        rule: 'github-workflow-prepared-ci-runtime-script-setup',
       }),
     )
   })
@@ -364,7 +396,7 @@ describe('githubWorkflow', () => {
     expect(issues).toContainEqual(
       expect.objectContaining({
         dependency: 'jobs.test.steps[4]',
-        rule: 'github-workflow-prepared-ci-retry-script-setup',
+        rule: 'github-workflow-prepared-ci-runtime-script-setup',
       }),
     )
   })
@@ -393,7 +425,7 @@ describe('githubWorkflow', () => {
       })
 
       expect(
-        issues.filter((issue) => issue.rule === 'github-workflow-prepared-ci-retry-script-setup'),
+        issues.filter((issue) => issue.rule === 'github-workflow-prepared-ci-runtime-script-setup'),
       ).toEqual([])
     }
   })

--- a/packages/@overeng/genie/src/runtime/github-workflow/mod.ts
+++ b/packages/@overeng/genie/src/runtime/github-workflow/mod.ts
@@ -620,8 +620,7 @@ const validateGitHubWorkflowAdmissionSize = ({
   return []
 }
 
-const preparedCiRetryScriptPath =
-  '${{ github.workspace }}/.genie-ci-runtime/run-with-nix-gc-race-retry.sh'
+const preparedCiRuntimeScriptsPath = '${{ github.workspace }}/.genie-ci-runtime/'
 const prepareCiScriptsStepName = 'Prepare CI helper scripts'
 
 const stepName = (step: Step): string | undefined =>
@@ -650,7 +649,10 @@ const checkoutCleansWorkspaceRoot = (step: Step): boolean => {
   return checkoutAtWorkspaceRoot === true && cleanDisabled === false
 }
 
-const validatePreparedCiRetryScriptSetup = ({
+const installNixInvalidatesPreparedCiRuntime = (step: Step): boolean =>
+  stepUses(step)?.toLowerCase().startsWith('determinatesystems/determinate-nix-action@') === true
+
+const validatePreparedCiRuntimeScriptsSetup = ({
   args,
   location,
 }: {
@@ -661,20 +663,25 @@ const validatePreparedCiRetryScriptSetup = ({
 
   for (const [jobName, job] of Object.entries(args.jobs)) {
     let prepareIndex = -1
-    let workspaceCleaningCheckoutIndex = -1
+    let invalidatingStepIndex = -1
 
     for (const [index, step] of job.steps.entries()) {
       if (stepName(step) === prepareCiScriptsStepName) prepareIndex = index
-      if (checkoutCleansWorkspaceRoot(step) === true) workspaceCleaningCheckoutIndex = index
-      if (stepRun(step)?.includes(preparedCiRetryScriptPath) !== true) continue
-      if (prepareIndex >= 0 && prepareIndex > workspaceCleaningCheckoutIndex) continue
+      if (
+        checkoutCleansWorkspaceRoot(step) === true ||
+        installNixInvalidatesPreparedCiRuntime(step) === true
+      ) {
+        invalidatingStepIndex = index
+      }
+      if (stepRun(step)?.includes(preparedCiRuntimeScriptsPath) !== true) continue
+      if (prepareIndex >= 0 && prepareIndex > invalidatingStepIndex) continue
 
       issues.push({
         severity: 'error',
         packageName: location,
         dependency: `jobs.${jobName}.steps[${index}]`,
-        message: `jobs.${jobName} uses the prepared CI retry helper at ${preparedCiRetryScriptPath} without a preceding "${prepareCiScriptsStepName}" step. Add the CI runtime support preparation step after the final workspace-cleaning checkout and before retry-wrapped commands.`,
-        rule: 'github-workflow-prepared-ci-retry-script-setup',
+        message: `jobs.${jobName} uses a prepared CI runtime helper under ${preparedCiRuntimeScriptsPath} without a preceding "${prepareCiScriptsStepName}" step after the final workspace-cleaning checkout and Nix installation.`,
+        rule: 'github-workflow-prepared-ci-runtime-script-setup',
       })
     }
   }
@@ -700,7 +707,7 @@ const validateWorkflow = ({
 
   issues.push(...validateDocumentedGitHubLimits({ args, location }))
   issues.push(...validateGitHubWorkflowAdmissionSize({ yamlContent, location }))
-  issues.push(...validatePreparedCiRetryScriptSetup({ args, location }))
+  issues.push(...validatePreparedCiRuntimeScriptsSetup({ args, location }))
   issues.push(...validateDeterminateNixExtraConf({ args, location }))
   issues.push(
     ...validateGitHubExpressionStrings({


### PR DESCRIPTION
## Problem

Generated workflows stage runtime helpers in `github.workspace` so Determinate Nix setup cannot erase them. A later root-cleaning checkout, such as the optional measurement-baseline checkout, can still remove that runtime before `resolve-devenv` or another helper consumes it.

## Design

- Treat both root-cleaning `actions/checkout` and Determinate Nix installation as runtime-invalidating boundaries.
- Validate every literal `.genie-ci-runtime/*` consumer, rather than only the GC-retry helper.
- Require preparation after the latest invalidating boundary.
- Preserve valid nested-path and `clean: false` checkout behavior.

This keeps the invariant in the shared workflow owner; consumers only reorder the existing preparation step and need no local validator or new state.

## Verification

- PASS: focused GitHub workflow suites, 81 passed / 6 skipped.
- PASS: root TypeScript build.
- PASS: targeted oxlint and oxfmt.
- PASS: `git diff --check`.
- QUALIFIED: broad Genie suite reached 392 passed / 8 skipped; two existing environment/compiler-proof tests remain unavailable in this shell.
- QUALIFIED: direct Genie freshness reached only existing actionlint/strict-compiler environment admissions, with no runtime-ordering finding.

## Follow-up

After merge, dotfiles PR #1964 will pin this revision, move its single preparation step after baseline checkout and Nix installation, delete duplicate preparation steps, and regenerate workflows.
