### PR TITLE
fix(ci): anchor helper sources to workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Genie CI workflows**: resolve checked-in helper scripts from the explicit
+  GitHub workspace root so custom runner working directories cannot hide them.
+
 ### Added
 
 - **devenv pnpm / Genie**: add root-local, read-only source generations for

--- a/genie/ci-workflow/shared.ts
+++ b/genie/ci-workflow/shared.ts
@@ -372,7 +372,7 @@ export const runDevenvTasksBeforeWithOptions = (
     opts,
   })
 
-export const defaultCiRuntimeScriptsDir = 'genie/ci-scripts'
+export const defaultCiRuntimeScriptsDir = '${{ github.workspace }}/genie/ci-scripts'
 export const preparedCiRuntimeScriptsDir = '${{ github.workspace }}/.genie-ci-runtime'
 export const prepareJobLocalRustState = `. "${preparedCiRuntimeScriptsDir}/prepare-job-local-rust-state.sh"`
 

--- a/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
@@ -196,7 +196,9 @@ describe('ci workflow retry helpers', () => {
   })
 
   it('emits compact calls to the checked-in retry helper script', () => {
-    expect(ciWorkflowSource).toContain("defaultCiRuntimeScriptsDir = 'genie/ci-scripts'")
+    expect(ciWorkflowSource).toContain(
+      "defaultCiRuntimeScriptsDir = '${{ github.workspace }}/genie/ci-scripts'",
+    )
     expect(ciWorkflowSource).toContain(
       "preparedCiRuntimeScriptsDir = '${{ github.workspace }}/.genie-ci-runtime'",
     )
@@ -236,6 +238,9 @@ describe('ci workflow retry helpers', () => {
       const checkoutIndex = jobBlock.indexOf('uses: actions/checkout@v6')
       const installNixIndex = jobBlock.indexOf('uses: DeterminateSystems/determinate-nix-action@v3')
       const prepareIndex = jobBlock.indexOf('Prepare CI helper scripts')
+      const workspaceSourceIndex = jobBlock.indexOf(
+        "scripts_src='${{ github.workspace }}/genie/ci-scripts'",
+      )
       const baselineCheckoutIndex = jobBlock.indexOf('Checkout CI measurement baseline ref')
       expect(checkoutIndex).toBeGreaterThanOrEqual(0)
       expect(checkoutIndex).toBeLessThan(helperIndex)
@@ -243,6 +248,7 @@ describe('ci workflow retry helpers', () => {
       expect(installNixIndex).toBeLessThan(prepareIndex)
       expect(prepareIndex).toBeGreaterThanOrEqual(0)
       expect(prepareIndex).toBeLessThan(helperIndex)
+      expect(workspaceSourceIndex).toBeGreaterThan(prepareIndex)
       if (baselineCheckoutIndex >= 0) {
         expect(baselineCheckoutIndex).toBeLessThan(prepareIndex)
       }


### PR DESCRIPTION
## Summary

- resolve checked-in Genie CI helpers from `${{ github.workspace }}`
- keep the prepared runtime rooted in the same explicit workspace
- assert generated consumers preserve the absolute source path and setup ordering

## Why

A dotfiles workflow-dispatch proof at exact head `fb13b0bcc039d292c7e94028ccd7d9a8f46da2b6` showed the checked-in `genie/ci-scripts` directory could not be found on custom runners even though it was present in the checkout. The runner shell's implicit working directory is not a stable ownership boundary; `github.workspace` is.

## Verification

- `git diff --check`
- focused Vitest: pending hosted CI (local pnpm environment is unavailable and the host is below its Nix capacity floor)
