### PR TITLE
fix(pnpm): parse repeated peer locator suffixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,8 @@ All notable changes to this project will be documented in this file.
   `file:` packages through pnpm's exact package-map locator before removing
   transient Source Input aliases. Restored CLI workspaces now resolve the
   logical package manifest and source instead of an empty virtual-store target;
-  the prepared artifact layout advances to `v19`.
+  repeated peer-context groups are normalized as one locator suffix, and the
+  prepared artifact layout advances to `v19`.
 
 - **devenv observability verification**: enable native Devenv task activities
   during trace capture while preserving task stderr and a diagnostic copy.

--- a/context/dependency-materialization/03-nix-prepared-deps/spec.md
+++ b/context/dependency-materialization/03-nix-prepared-deps/spec.md
@@ -162,8 +162,9 @@ The full logical source snapshot is present before prepared dependency data is
 overlaid. Relinked injected and ordinary local-file package targets therefore
 resolve through the same logical source directories after overlay. The focused
 `prepared-workspace-source-input-file-links` regression covers an ordinary
-locator with a peer-context suffix, verifies the exact package-map target is
-relinked, removes the transient alias, and still resolves package source bytes.
+locator with several adjacent peer-context groups, verifies the exact
+package-map target is relinked, removes the transient alias, and still resolves
+package source bytes.
 
 Downstream restore must not use pnpm to reconstruct dependency state.
 

--- a/nix/workspace-tools/lib/mk-pnpm-cli/tests/fixtures/downstream/flake.nix
+++ b/nix/workspace-tools/lib/mk-pnpm-cli/tests/fixtures/downstream/flake.nix
@@ -353,7 +353,7 @@
               fixture="$PWD/fixture"
               logical_path=repos/effect-utils/packages/@overeng/utils
               wrong_logical_path=repos/effect-utils/packages/@overeng/wrong-utils
-              locator='@overeng/utils@file:.devenv/pnpm-source-inputs/current/repos/effect-utils/packages/@overeng/utils(a02d012e)'
+              locator='@overeng/utils@file:.devenv/pnpm-source-inputs/current/repos/effect-utils/packages/@overeng/utils(effect@3.21.4)(react-dom@19.2.4)(react@19.2.4)'
               virtual_path='.pnpm/@overeng+utils@file+.devenv+pnpm-source-inputs+current+repos+effect-utils+packages+@overeng+utils/node_modules/@overeng/utils'
               mkdir -p \
                 "$fixture/$logical_path/src" \

--- a/nix/workspace-tools/lib/mk-pnpm-deps.nix
+++ b/nix/workspace-tools/lib/mk-pnpm-deps.nix
@@ -196,12 +196,13 @@ let
         return null;
       }
 
-      // pnpm appends a parenthesized peer-context suffix to the directory
-      // locator. The declared source path itself is the prefix before it.
+      // pnpm appends one parenthesized group per resolved peer to the directory
+      // locator. The declared source path itself is the prefix before the
+      // complete adjacent suffix.
       const sourcePathWithPeerContext = locator.slice(
         locatorIndex + sourceInputLocatorPrefix.length
       );
-      const sourcePath = sourcePathWithPeerContext.replace(/\([^/()]*\)$/, "");
+      const sourcePath = sourcePathWithPeerContext.replace(/(?:\([^/()]*\))+$/, "");
       const sourceInputStageRoot = path.resolve(
         lockfileDir,
         ".devenv/pnpm-source-inputs/current"


### PR DESCRIPTION
## Problem

The prepared-dependency source locator parser removed only the final pnpm
peer-context group. A package with several peers therefore retained earlier
`(peer@version)` groups in its Source Input path and failed alias lookup during
dependency normalization.

The failure was observed by the exact-head
[`pnpm-fod-canary` job](https://github.com/schickling/dotfiles/actions/runs/32682125192/job/97300514590).

## Goal

Normalize pnpm locators with any number of adjacent peer-context groups to the
declared Source Input path while preserving pnpm's package-map target selection.

## Decisions

- Strip the complete trailing sequence of parenthesized peer groups, rather
  than one group.
- Keep `.package-map.json` as the only ordinary local-file target selector;
  package names and virtual-store directory scans remain non-authoritative.
- Extend the existing focused fixture with three adjacent peer groups instead
  of adding a second test harness.

## Verification

- Regression fixture failed from exact base
  `9b569730ed5a526fccb4e3f10fb36f4f16ac87fa` before the parser change.
- PASS: `prepared-workspace-source-input-file-links` focused Nix check.
- PASS: existing `prepared-workspace-injected-locator-identity` Nix check.
- PASS: `nix-instantiate --parse` for both edited Nix files.
- PASS: `nixfmt --check` for both edited Nix files.
- PASS: shell syntax check and `git diff --check`.
- Full `check:all` is delegated to hosted CI; it was not rerun locally for this
  four-file parser regression.

## Complexity

No new abstraction or selector. The parser changes one suffix expression and
reuses the existing package-map regression surface.

## Concerns

The parser intentionally follows pnpm's current locator grammar: peer context
is encoded as adjacent trailing parenthesized groups whose contents contain no
path separator or nested parentheses.

## Friction & bottlenecks

- Friction: the original focused fixture covered only one peer-context group,
  while the first real multi-peer consumer exposed the repeated form.
- Bottlenecks: none; focused Nix checks completed in seconds.

## Follow-ups

None.

## References

- Canary evidence: https://github.com/schickling/dotfiles/actions/runs/32682125192/job/97300514590
- Related staged-source follow-up: #1103
