### PR TITLE
fix(pnpm): resolve source aliases by manifest boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,8 +65,8 @@ All notable changes to this project will be documented in this file.
   `file:` packages through pnpm's exact package-map locator before removing
   transient Source Input aliases. Restored CLI workspaces now resolve the
   logical package manifest and source instead of an empty virtual-store target;
-  repeated peer-context groups are normalized as one locator suffix, and the
-  prepared artifact layout advances to `v19`.
+  the declared alias manifest owns the source-path boundary while nested peer
+  context remains opaque, and the prepared artifact layout advances to `v19`.
 
 - **devenv observability verification**: enable native Devenv task activities
   during trace capture while preserving task stderr and a diagnostic copy.

--- a/context/dependency-materialization/03-nix-prepared-deps/spec.md
+++ b/context/dependency-materialization/03-nix-prepared-deps/spec.md
@@ -84,13 +84,19 @@ real logical directory rather than the transient alias:
 - ordinary `file:` packages use pnpm's `.package-map.json`
   locator-to-target mapping, which retains the exact peer-context variant.
 
-Both paths consume pnpm's selected locator identity. Package-name or virtual
-directory scans are not selectors. For an ordinary `file:` target, this relink
-is required because pnpm accepts the manifest-only alias for frozen resolution
-but materializes no package source bytes from it. `.devenv` is then removed,
-and the prepared output must contain neither alias state nor broken references.
-This compatibility bridge does not run the live Source Input publisher, copy
-its generations, or add source-only files to manifest freshness.
+Both paths consume pnpm's selected locator identity. For an ordinary `file:`
+target, the longest locator prefix with a declared staged alias `package.json`
+is the logical source-path boundary; any remaining locator suffix is opaque
+pnpm-owned context. The alias manifest therefore owns source identity while
+`.package-map.json` owns the exact materialized target. Package-name scans,
+virtual-directory scans, and peer-suffix parsers are not selectors.
+
+This relink is required because pnpm accepts the manifest-only alias for frozen
+resolution but materializes no package source bytes from it. `.devenv` is then
+removed, and the prepared output must contain neither alias state nor broken
+references. This compatibility bridge does not run the live Source Input
+publisher, copy its generations, or add source-only files to manifest
+freshness.
 
 ## Install Policy
 
@@ -161,10 +167,11 @@ the final package.
 The full logical source snapshot is present before prepared dependency data is
 overlaid. Relinked injected and ordinary local-file package targets therefore
 resolve through the same logical source directories after overlay. The focused
-`prepared-workspace-source-input-file-links` regression covers an ordinary
-locator with several adjacent peer-context groups, verifies the exact
-package-map target is relinked, removes the transient alias, and still resolves
-package source bytes.
+`prepared-workspace-source-input-file-links` regression covers a real-shaped
+ordinary locator with nested peer context and a logical path containing
+parentheses, preserves wrong-alias and escaping-source negative controls,
+verifies the exact package-map targets are relinked, removes the transient
+aliases, and still resolves package source bytes.
 
 Downstream restore must not use pnpm to reconstruct dependency state.
 

--- a/nix/workspace-tools/lib/mk-pnpm-cli/tests/fixtures/downstream/flake.nix
+++ b/nix/workspace-tools/lib/mk-pnpm-cli/tests/fixtures/downstream/flake.nix
@@ -351,36 +351,50 @@
             }
             ''
               fixture="$PWD/fixture"
-              logical_path=repos/effect-utils/packages/@overeng/utils
-              wrong_logical_path=repos/effect-utils/packages/@overeng/wrong-utils
-              locator='@overeng/utils@file:.devenv/pnpm-source-inputs/current/repos/effect-utils/packages/@overeng/utils(effect@3.21.4)(react-dom@19.2.4)(react@19.2.4)'
-              virtual_path='.pnpm/@overeng+utils@file+.devenv+pnpm-source-inputs+current+repos+effect-utils+packages+@overeng+utils/node_modules/@overeng/utils'
+              logical_path=repos/private-shared/packages/@overeng/geist-design-system
+              wrong_logical_path=repos/private-shared/packages/@overeng/wrong-geist-design-system
+              parentheses_logical_path='repos/private-shared/packages/@overeng/path(with-parentheses)'
+              locator='@overeng/geist-design-system@file:.devenv/pnpm-source-inputs/current/repos/private-shared/packages/@overeng/geist-design-system(react-aria-components@1.19.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwind-variants@1.0.0(tailwindcss@4.3.1))'
+              parentheses_locator='@overeng/path-with-parentheses@file:.devenv/pnpm-source-inputs/current/repos/private-shared/packages/@overeng/path(with-parentheses)(vite@8.0.16(@types/node@26.0.0)(yaml@2.9.0))'
+              virtual_path='.pnpm/@overeng+geist-design-system@file+.devenv+pnpm-source-inputs+current+repos+private-shared+packages+@overeng+geist-design-system/node_modules/@overeng/geist-design-system'
+              parentheses_virtual_path='.pnpm/@overeng+path-with-parentheses@file+.devenv+pnpm-source-inputs+current+repos+private-shared+packages+@overeng+path-with-parentheses/node_modules/@overeng/path-with-parentheses'
               mkdir -p \
                 "$fixture/$logical_path/src" \
                 "$fixture/$wrong_logical_path" \
+                "$fixture/$parentheses_logical_path/src" \
                 "$fixture/.devenv/pnpm-source-inputs/current/$logical_path" \
+                "$fixture/.devenv/pnpm-source-inputs/current/$parentheses_logical_path" \
                 "$fixture/node_modules/$virtual_path/node_modules/effect" \
+                "$fixture/node_modules/$parentheses_virtual_path" \
                 "$fixture/node_modules/@overeng"
 
               cat > "$fixture/$logical_path/package.json" <<'JSON'
-              {"name":"@overeng/utils","exports":{"./node/example":"./src/example.js"}}
+              {"name":"@overeng/geist-design-system","exports":{"./example":"./src/example.js"}}
               JSON
               cat > "$fixture/$logical_path/src/example.js" <<'JS'
               export const example = true
               JS
               cat > "$fixture/$wrong_logical_path/package.json" <<'JSON'
-              {"name":"@overeng/wrong-utils"}
+              {"name":"@overeng/wrong-geist-design-system"}
               JSON
+              cat > "$fixture/$parentheses_logical_path/package.json" <<'JSON'
+              {"name":"@overeng/path-with-parentheses"}
+              JSON
+              cat > "$fixture/$parentheses_logical_path/src/example.js" <<'JS'
+              export const parenthesesExample = true
+              JS
               touch "$fixture/node_modules/$virtual_path/node_modules/effect/retained-dependency"
               ln -s "$(realpath --relative-to="$fixture/.devenv/pnpm-source-inputs/current/$logical_path" "$fixture/$wrong_logical_path/package.json")" \
                 "$fixture/.devenv/pnpm-source-inputs/current/$logical_path/package.json"
+              ln -s "$(realpath --relative-to="$fixture/.devenv/pnpm-source-inputs/current/$parentheses_logical_path" "$fixture/$parentheses_logical_path/package.json")" \
+                "$fixture/.devenv/pnpm-source-inputs/current/$parentheses_logical_path/package.json"
               cat > "$fixture/node_modules/.package-map.json" <<JSON
-              {"packages":{"$locator":{"url":"./$virtual_path"}}}
+              {"packages":{"$locator":{"url":"./$virtual_path"},"$parentheses_locator":{"url":"./$parentheses_virtual_path"}}}
               JSON
               cat > "$fixture/node_modules/.modules.yaml" <<'JSON'
               {"injectedDeps":{}}
               JSON
-              ln -s "../$virtual_path" "$fixture/node_modules/@overeng/utils"
+              ln -s "../$virtual_path" "$fixture/node_modules/@overeng/geist-design-system"
 
               if (cd "$fixture" && PREPARED_WORKSPACE_PLACEHOLDER=/__pnpm_prepared_workspace__ \
                 node ${pureEvalFixture.passthru.depsBuildsByInstallRoot.root.rewritePreparedWorkspaceScript}) 2> "$fixture/wrong-alias.log"; then
@@ -409,12 +423,18 @@
                 node ${pureEvalFixture.passthru.depsBuildsByInstallRoot.root.rewritePreparedWorkspaceScript})
 
               package_target="$fixture/node_modules/$virtual_path"
+              parentheses_package_target="$fixture/node_modules/$parentheses_virtual_path"
               test -L "$package_target"
               test -f "$package_target/package.json"
               test -f "$package_target/src/example.js"
               test "$(realpath "$package_target")" = "$(realpath "$fixture/$logical_path")"
+              test -L "$parentheses_package_target"
+              test -f "$parentheses_package_target/src/example.js"
+              test "$(realpath "$parentheses_package_target")" = \
+                "$(realpath "$fixture/$parentheses_logical_path")"
               rm -rf "$fixture/.devenv"
               test -f "$package_target/src/example.js"
+              test -f "$parentheses_package_target/src/example.js"
 
               touch "$out"
             '';

--- a/nix/workspace-tools/lib/mk-pnpm-deps.nix
+++ b/nix/workspace-tools/lib/mk-pnpm-deps.nix
@@ -196,31 +196,42 @@ let
         return null;
       }
 
-      // pnpm appends one parenthesized group per resolved peer to the directory
-      // locator. The declared source path itself is the prefix before the
-      // complete adjacent suffix.
       const sourcePathWithPeerContext = locator.slice(
         locatorIndex + sourceInputLocatorPrefix.length
       );
-      const sourcePath = sourcePathWithPeerContext.replace(/(?:\([^/()]*\))+$/, "");
       const sourceInputStageRoot = path.resolve(
         lockfileDir,
         ".devenv/pnpm-source-inputs/current"
       );
-      const sourceProjectAliasDir = path.resolve(
-        sourceInputStageRoot,
-        sourcePath
-      );
-      if (
-        sourceProjectAliasDir === sourceInputStageRoot ||
-        !isWithin(sourceInputStageRoot, sourceProjectAliasDir)
-      ) {
-        throw new Error(`source-input package locator escaped its stage root: ''${locator}`);
-      }
 
-      const sourceProjectAliasManifest = path.join(sourceProjectAliasDir, "package.json");
-      if (!fs.existsSync(sourceProjectAliasManifest)) {
-        throw new Error(`source-input package alias is missing package.json: ''${sourceProjectAliasDir}`);
+      // The generated manifest alias is the owned boundary between the declared
+      // logical path and pnpm's opaque peer context. Select the longest existing
+      // alias prefix instead of duplicating pnpm's nested locator grammar.
+      let sourcePath;
+      let sourceProjectAliasManifest;
+      let escapedSourcePath = false;
+      for (let end = sourcePathWithPeerContext.length; end > 0; end -= 1) {
+        if (end !== sourcePathWithPeerContext.length && sourcePathWithPeerContext[end] !== "(") {
+          continue;
+        }
+        const candidateSourcePath = sourcePathWithPeerContext.slice(0, end);
+        const candidateAliasDir = path.resolve(sourceInputStageRoot, candidateSourcePath);
+        if (candidateAliasDir === sourceInputStageRoot || !isWithin(sourceInputStageRoot, candidateAliasDir)) {
+          escapedSourcePath = true;
+          continue;
+        }
+        const candidateManifest = path.join(candidateAliasDir, "package.json");
+        if (fs.existsSync(candidateManifest)) {
+          sourcePath = candidateSourcePath;
+          sourceProjectAliasManifest = candidateManifest;
+          break;
+        }
+      }
+      if (sourceProjectAliasManifest === undefined) {
+        if (escapedSourcePath) {
+          throw new Error(`source-input package locator escaped its stage root: ''${locator}`);
+        }
+        throw new Error(`source-input package alias is missing package.json: ''${sourceInputStageRoot}/''${sourcePathWithPeerContext}`);
       }
       const sourceProjectDir = path.resolve(lockfileDir, sourcePath);
       if (!isWithin(workspaceRoot, sourceProjectDir)) {


### PR DESCRIPTION
## Problem

#1106 normalized adjacent peer groups, but pnpm locators can contain nested and scoped peer context. A downstream canary still failed to find the staged Source Input alias for such a locator.

## Goal

Restore ordinary local `file:` packages through their declared staged alias regardless of the shape of pnpm's appended peer context.

## Decisions

- `.package-map.json` continues to own the exact locator-to-target mapping.
- The generated staged alias `package.json` owns the logical source-path boundary.
- The resolver selects the longest eligible locator prefix with that manifest and treats the remaining suffix as opaque pnpm context.
- No pnpm peer-locator grammar is duplicated.

## Verification

- `prepared-workspace-source-input-file-links`: failed before the implementation with the exact nested fixture; passes after.
- `prepared-workspace-injected-locator-identity`: passes.
- `devenv tasks run lint:check --no-tui`: passes.
- `nix-instantiate --parse` on both edited Nix files: passes.
- `nixfmt --check` on both edited Nix files: passes.
- `bash -n nix/workspace-tools/lib/mk-pnpm-cli/tests/run.sh`: passes.
- `git diff --check`: passes.

## Complexity

This replaces a peer-suffix regex with a local authority lookup against manifests the Source Input staging contract already generates. It adds no module, format, dependency, or secondary selector.

## Concerns

The prefix lookup is linear in locator length and only runs for Source Input `file:` locators during prepared-dependency rewriting.

## Friction and bottlenecks

The earlier regression modeled adjacent peer groups rather than the nested real lockfile shape. This change adds a real-shaped nested locator, a logical path containing parentheses, and retains the wrong-alias and escaping-source negative controls.

## Follow-ups

None.

## References

- Follow-up to #1106.
