### PR TITLE
docs(effect-4): flip changelog + rc.111 follow-up register

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- **Repository-wide**: atomic Effect 4 cohort flip to `effect@4.0.0-rc.111`
+  (with `@effect/platform-node`, `@effect/vitest`, `@effect/opentelemetry`,
+  `@effect/atom-react`, all rc.111). Platform, CLI, RPC, Schema, AI, Cluster,
+  Workflow, SQL and Atom reactivity are now core modules
+  (`effect` / `effect/unstable/*`). Services use the v4 `Context.Service`
+  model; error handling uses `Effect.catch`/`catchCause`; forks are
+  `forkChild`/`forkDetach`; wire formats preserved via `DateFromString`/
+  `DateTimeUtcFromString`. The mixed-major duplicate exception and the v3
+  http.client span-header patch are retired — see
+  `context/effect-4/rc111-followups.md` for known behavior changes and
+  follow-ups.
 - **@overeng/tui-react, @overeng/tui-stories, @overeng/effect-react,
   @overeng/effect-schema-form, @overeng/effect-schema-form-aria**: migrate to
   effect@4.0.0-rc.111. Schema AST introspection updated to v4 node kinds

--- a/context/effect-4/rc111-followups.md
+++ b/context/effect-4/rc111-followups.md
@@ -1,0 +1,53 @@
+# Effect 4 rc.111 flip — follow-ups
+
+Companion to the atomic cohort flip (`effect@4.0.0-rc.111`). Items below are
+known post-flip work, grouped by kind. None block type-greenness; each needs an
+owner decision or upstream movement before/with test-suite convergence.
+
+## Upstream (Effect) issues to file / track
+
+1. **cli-A-nested-terminator-loss** — argv after `--` dropped in nested
+   commands (parser builds child input with `trailingOperands: []`). Blocks
+   dash-prefixed positionals in megarepo/notion-cli/tui-stories. Repro already
+   drafted in alignment register.
+2. **CLI validation help on stdout** (bucket C) — v4 prints full help to stdout
+   on validation failure; breaks JSON/NDJSON consumers. Needs compat rendering
+   or per-binary rebaseline.
+3. **ShowHelp `TypeError: Attempted to assign to readonly property` under Bun**
+   — thrown from CliError ShowHelp construction (`errorExitCode` class field)
+   after correct ERROR/exit-1 output; affects stderr bytes only.
+4. **FileSystem.watch always recursive** — `{ recursive: false }` removed;
+   megarepo/genie/notion-md watch loops need a shim or upstream restore of
+   non-recursive backends.
+5. **Prompt PTY ANSI byte drift** — shorter SGR/reset sequences; raw-terminal
+   parsers and PTY snapshots need owner review before rebaseline.
+
+## Wire/format decisions recorded during migration
+
+6. **RPC string request IDs accepted** — v3 rejected non-BigInt ids; wire
+   baseline updated. Decide client-side id validation policy or versioning for
+   persisted envelopes (see rpc-failure-cause-wire-shape).
+7. **`JSONSchema.make` → `Schema.toJsonSchemaDocument`** — generated JSON
+   Schema is now draft-2020-12 Document shape (megarepo generator artifact).
+8. **`NonEmptyTrimmedString` trim semantics dropped** in ci-tools provider
+   config schemas (`NonEmptyString` substitution); restore via
+   `.check(isTrimmed())` if external inputs are ever in scope.
+9. **Span-header allowlist patch retired** — re-express the v3
+   `@effect/platform` http.client header allowlist against core
+   `effect/unstable/http` tracing (platform-patch-analysis.md) before enabling
+   verbose Notion traffic spans again.
+
+## In-repo cleanup
+
+10. **Marker sweep**: resolve remaining `TODO(live-migration:effect-3-4)`
+    markers once differential baselines run green under rc.111
+    (`context/effect-4/check-baseline-*.ts` gates).
+11. **Test-suite convergence**: per-slice suites pass individually; full
+    monorepo vitest pass + baseline gates to be wired into devenv tasks and CI.
+12. **Pre-existing genie lint noise** (out of flip scope):
+    `genie/ci-scripts/pr-snapshot-artifact*.mjs` await-in-loop/named-args,
+    `genie/tsconfig-projects.ts` exports-first trio, `support-files.ts`
+    boolean-coercion, `pnpm-install-contract.json.genie.ts`,
+    `genie/otel-scrape-registry.ts` named-args.
+13. **Annotation key consumers**: Restate annotation ids moved symbol → namespaced
+    strings; downstream readers must switch to the exported constants.


### PR DESCRIPTION
Stacked on #1109 (must merge second).

## What
- Umbrella CHANGELOG entry for the rc.111 cohort flip
- \`context/effect-4/rc111-followups.md\`: follow-up register covering upstream issues to file (CLI terminator bug, help-on-stdout, Bun ShowHelp TypeError, watch recursion, PTY bytes), wire decisions needing owners (RPC string ids, JSONSchema draft-2020-12 output, NonEmptyTrimmedString trim policy), span-header allowlist re-expression, marker sweep (\`TODO(live-migration:effect-3-4)\`), and full-suite convergence wiring.