### PR TITLE
docs(dmp): make Buck2 the single build authority

### DIFF
--- a/context/dependency-materialization/.decisions/0010-select-buck2-build-authority.md
+++ b/context/dependency-materialization/.decisions/0010-select-buck2-build-authority.md
@@ -1,0 +1,41 @@
+# 0010 Select Buck2 As Repo-Local Build Authority
+
+Status: accepted
+
+## Context
+
+DMP-R11 requires one declared authority for repo-local compilation, generation,
+tests, bundles, and dependency/product artifacts. The repository needs one
+hermetic graph rather than permanent overlapping pnpm, Nix, and task-runner
+build graphs.
+
+## Decision
+
+Select Buck2 as the repo-local build authority. Buck2 actions own repo-local
+compilation, generation, tests, bundles, and immutable dependency/product
+artifacts for consumers in their declared scope.
+
+Nix remains the authority for host tooling, activation, deployment, services,
+secrets, and explicit system wrappers. Nix consumes declared immutable Buck2
+artifacts at that boundary. pnpm remains a package-authoring and live-development
+surface where required; it is not a second repo-local build authority.
+
+The current implementation divergence and its exact resolution conditions are
+tracked by
+[DELTA-003](../.delta/DELTA-003-buck2-single-build-authority.md).
+
+## Non-Goals
+
+- Reproduce every existing pnpm or Nix adapter abstraction inside Buck2.
+- Make Buck2 responsible for host activation, deployment, services, secrets, or
+  system package management.
+- Run Buck2 against a mutable checkout during Nix activation or deployment.
+- Preserve a second build authority as a permanent fallback.
+
+## Consequences
+
+- Each Buck2 scope must name its consumers and artifact contracts explicitly.
+- Nix/Buck integration is an immutable artifact handoff, not nested build
+  orchestration.
+- Temporary implementation overlap is tracked as a delta and removed when its
+  scoped resolution signals hold.

--- a/context/dependency-materialization/.delta/DELTA-003-buck2-single-build-authority.md
+++ b/context/dependency-materialization/.delta/DELTA-003-buck2-single-build-authority.md
@@ -1,0 +1,106 @@
+# DELTA-003: Legacy dependency adapters overlap Buck2 build authority
+
+Status: open
+
+## Divergence
+
+[Decision 0010](../.decisions/0010-select-buck2-build-authority.md) selects
+Buck2 as the repo-local build authority, but the consumers of two adapter
+families still use other build paths: composed pnpm source staging plus Nix
+prepared dependencies, and workspace-staged CI runtime helpers. These adapters
+are temporary compatibility surfaces. They may receive correctness fixes for
+existing consumers but must not gain consumers, broader APIs, or a Buck2
+translation of their internal abstractions.
+
+## VRS
+
+- [DMP.BUCK-R06](../05-buck2-evidence/requirements.md) requires Buck2 to be the
+  only build authority for consumers in its declared scope.
+- [DMP-R11 and DMP-R24](../requirements.md) require one Authoritative
+  Materializer and reject a parallel steady-state topology authority.
+- [Decision 0010](../.decisions/0010-select-buck2-build-authority.md) selects
+  Buck2 and defines its boundary with Nix and pnpm.
+- [The Buck2 spec](../05-buck2-evidence/spec.md) records the current
+  evidence-only implementation boundary.
+
+## Legacy Adapter Census
+
+### Composed pnpm source staging and prepared dependencies
+
+| Surface                 | Owned implementation                                                                                                                                                                                                                                                                                  |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Genie public projection | `workspaceClosureReference` in `packages/@overeng/genie/src/runtime/package-json/mod.ts`; `pnpmSourceInputStagePath` and `projectPnpmSourceInputs` in `packages/@overeng/genie/src/runtime/pnpm-workspace/mod.ts`; re-exports in `packages/@overeng/genie/src/runtime/mod.ts` and `genie/external.ts` |
+| Live source generations | `sourceInputPaths`, `stageSourceInputs`, `checkSourceInputs`, and `gcSourceInputs` in `nix/devenv-modules/tasks/shared/pnpm.nix`; `nix/devenv-modules/tasks/shared/stage-pnpm-source-inputs.mjs`; `.devenv/pnpm-source-inputs`                                                                        |
+| Prepared-deps contract  | `workspaceManifestContract.sourceInputStagePath` and `workspaceManifestContract.sourceInputPaths` plus manifest-alias creation in `nix/workspace-tools/lib/mk-pnpm-cli.nix`                                                                                                                           |
+| Prepared-deps relinking | `sourceProjectDirForLocator`, `.package-map.json` source selection, and local-source relinking in `nix/workspace-tools/lib/mk-pnpm-deps.nix`                                                                                                                                                          |
+| Focused evidence        | `nix/devenv-modules/tasks/shared/tests/pnpm-source-input-staging.test.sh`, `pnpm-source-input-refresh.integration.test.sh`, the source-input cases in `pnpm-task-smoke.test.sh`, and `nix/workspace-tools/lib/mk-pnpm-cli/tests/fixtures/downstream`                                                  |
+
+### Workspace-staged CI runtime helpers
+
+| Surface                            | Owned implementation                                                                                                                                                                                                     |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Helper preparation and consumption | `preparedCiRuntimeScriptsDir` and helper references in `genie/ci-workflow/shared.ts`, `genie/ci-workflow/setup.ts`, and `genie/ci-workflow.ts`; generated `.github/workflows/ci.yml` consumers under `.genie-ci-runtime` |
+| Admission validation               | `preparedCiRuntimeScriptsPath`, `prepareCiScriptsStepName`, `installNixInvalidatesPreparedCiRuntime`, and `validatePreparedCiRuntimeScriptsSetup` in `packages/@overeng/genie/src/runtime/github-workflow/mod.ts`        |
+| Focused evidence                   | prepared-runtime cases in `packages/@overeng/genie/src/runtime/github-workflow/github-workflow.unit.test.ts` and `ci-workflow-helpers.unit.test.ts`                                                                      |
+
+No file or symbol in this census is a permanent Buck2 API. Historical
+changelog and decision records remain historical evidence after removal.
+
+## Resolution Approach
+
+Move only the consumers of the surfaces in this census directly to declared
+Buck2 dependency/product artifacts. Nix activation and deployment consume
+content-addressed artifact paths and must not invoke Buck2 against a mutable
+checkout. Censused CI consumers invoke Buck2 targets or repository-owned
+commands directly, without copying helper scripts through a workspace path that
+setup steps can invalidate.
+
+Delete the adapters in one contraction stack after consumer cutover:
+
+1. remove downstream generation and consumption of the source-input contract;
+2. remove the Genie projection APIs and prepared-deps contract reader;
+3. remove live source-generation staging and its state;
+4. remove prepared-deps source-locator relinking and its compatibility fixtures;
+5. remove CI helper staging and its admission validator together; and
+6. update the live-pnpm and prepared-deps VRS to remove the retired mechanisms.
+
+Do not remove the CI admission validator alone: that weakens the existing
+adapter without reducing the helper lifecycle it protects.
+
+## Direction
+
+remove implementation after Buck2 consumer cutover
+
+## Resolution Signal
+
+- Every consumer of a composed-source or prepared-dependency surface in this
+  census has a declared Buck2 target that produces the corresponding immutable
+  dependency or product artifact and evidence naming `buck2` as materialization
+  authority.
+- Consumer-level conformance covers lifecycle-script refusal, selected source
+  identity, nested and repeated peer contexts, paths containing parentheses,
+  traversal refusal, native dependency classification, and supported Linux and
+  Darwin targets.
+- A repository-wide consumer census fails CI if a new reference to
+  `projectPnpmSourceInputs`, `workspaceClosureReference`,
+  `workspaceManifestContract.sourceInputStagePath`,
+  `workspaceManifestContract.sourceInputPaths`, `.devenv/pnpm-source-inputs`, or
+  `.genie-ci-runtime` appears outside this delta or historical changelog and
+  decision records.
+- The contraction gate runs the following zero-match census after removing this
+  delta; any output fails the gate:
+
+  ```sh
+  rg -n \
+    --glob '!CHANGELOG.md' \
+    --glob '!context/**/.decisions/**' \
+    '(projectPnpmSourceInputs|workspaceClosureReference|sourceInputStagePath|sourceInputPaths|\.devenv/pnpm-source-inputs|\.genie-ci-runtime)' \
+    .
+  ```
+
+- After consumer cutover, the same census requires zero non-historical matches
+  and every implementation and focused-evidence surface listed above is absent.
+- The generated workflow freshness check, Buck2 tests, supported-platform
+  canaries for the censused consumers, and the repository `check:all` gate pass
+  without any censused adapter.
+- This delta is removed in the same contraction stack.

--- a/context/dependency-materialization/01-live-pnpm/requirements.md
+++ b/context/dependency-materialization/01-live-pnpm/requirements.md
@@ -108,10 +108,10 @@ parallel Dependency Graph.
   Refines: DMP-R02, DMP-R11, DMP-R12.
 - **DMP.LIVE-R13 Root-scoped source isolation:** When a composed topology
   consumes canonical source owned by another Materialization Root, the
-  aggregate root must expose one read-only, validated source generation to its Package
-  Instances. Writes through a consumer must not alter canonical source, and
-  writable source-generation state must not be shared across Materialization
-  Roots or create consumer-scoped materialization authority.
+  aggregate root must expose one read-only, validated source generation to its
+  Package Instances. Writes through a consumer must not alter canonical source,
+  and writable source-generation state must not be shared across
+  Materialization Roots or create consumer-scoped materialization authority.
   Refines: DMP-R11, DMP-R12, DMP-R23.
 - **DMP.LIVE-R14 Boundary-convergent source refresh:** Managed readiness,
   install, update, and deduplicate entrypoints must derive source-generation

--- a/context/dependency-materialization/05-buck2-evidence/requirements.md
+++ b/context/dependency-materialization/05-buck2-evidence/requirements.md
@@ -1,22 +1,24 @@
-# Buck2 Evidence Requirements
+# Buck2 Realization Requirements
 
 ## Context
 
-Buck2 evidence is the initial Buck2 boundary for dependency materialization.
-Buck2 may consume deterministic dependency facts before it owns hermetic
-dependency building or host-local pnpm repair.
+These requirements define the Buck2 realization of dependency materialization:
+declared evidence, hermetic dependency/product artifacts, and build authority
+for the consumers within its scope.
 
 ## Assumptions
 
 - **A01 Materialization Profile identity:** Buck2 evidence consumes the shared
   DMP Materialization Profile identity.
-- **A02 No live repair:** Live mutable pnpm install and repair remain outside
-  Buck2 until a hermetic action is proven.
+- **A02 System boundary:** Nix retains host tooling, activation, deployment,
+  services, secrets, and system wrappers. Live mutable pnpm install and repair
+  remain outside Buck2 actions.
 
 ## Acceptable Tradeoffs
 
-- **T01 Evidence first:** Buck2 may start with Materialization Profile evidence
-  targets instead of full dependency materialization targets.
+- **T01 Evidence-only targets:** A Buck2 target may emit Materialization Profile
+  evidence without materializing dependencies when it does not claim artifact
+  or build authority for that consumer.
 
 ## Requirements
 
@@ -26,7 +28,8 @@ dependency building or host-local pnpm repair.
   dependency inputs or immutable artifacts, not ambient pnpm store contents.
   Refines: DMP-R09, DMP-R10.
 - **DMP.BUCK-R02 Stable evidence:** Evidence must include Materialization Profile
-  identity, policy digest, input digests, and materialization authority.
+  identity, policy digest, input digests, materialization authority, and artifact
+  identity when an artifact is produced.
   Refines: DMP-R10.
 - **DMP.BUCK-R03 No secret keys:** Evidence must not include credentials or
   host-private paths.
@@ -34,10 +37,17 @@ dependency building or host-local pnpm repair.
 
 ### Must preserve authority boundaries
 
-- **DMP.BUCK-R04 No live ownership:** Buck2 evidence targets must not silently
-  run live pnpm install, shared-store GC, or repair.
+- **DMP.BUCK-R04 No ambient ownership:** Buck2 actions must not silently depend
+  on or mutate a live pnpm install, shared store, host cache, GC, or repair
+  surface.
   Refines: DMP-R11, DMP-R12.
-- **DMP.BUCK-R05 Future hermetic path:** A future Buck2 dependency builder must
-  declare the same Materialization Profile inputs and prove output equivalence
-  against the Nix or live realization it replaces.
+- **DMP.BUCK-R05 Hermetic artifact contract:** A Buck2 dependency builder must
+  declare the complete Materialization Profile inputs and prove that its output
+  satisfies the consumer-level dependency/product contract.
   Refines: DMP-R10, DMP-R16.
+- **DMP.BUCK-R06 Single build authority:** For every consumer in the declared
+  Buck2 scope, Buck2 must be the only build authority for repo-local
+  compilation, generation, tests, bundles, and dependency/product artifacts.
+  Other mechanisms may provide declared inputs or consume outputs, but must not
+  independently rebuild the same artifact contract.
+  Refines: DMP-R11, DMP-R24.

--- a/context/dependency-materialization/05-buck2-evidence/spec.md
+++ b/context/dependency-materialization/05-buck2-evidence/spec.md
@@ -1,7 +1,7 @@
 # Buck2 Evidence Spec
 
-This document specifies Buck2 dependency materialization evidence. It builds on
-[requirements.md](./requirements.md).
+This document specifies the current Buck2 dependency materialization evidence
+boundary. It builds on [requirements.md](./requirements.md).
 
 Status: **Draft**
 
@@ -11,9 +11,9 @@ Status: **Draft**
 | -------------- | -------------------------- |
 | Boundary       | DMP.BUCK-R01, DMP.BUCK-R04 |
 | Evidence Shape | DMP.BUCK-R02, DMP.BUCK-R03 |
-| Future Builder | DMP.BUCK-R05               |
+| Future Builder | DMP.BUCK-R05, DMP.BUCK-R06 |
 
-## Boundary
+## Current Boundary
 
 ```text
 package manifests
@@ -29,8 +29,13 @@ dependency-profile.evidence.json
 Buck2 task graph
 ```
 
-The initial Buck2 target emits evidence. It does not run live dependency
-installation or shared-store repair.
+The current Buck2 target emits evidence. It does not run dependency installation
+or shared-store repair and does not claim build authority for its consumers.
+
+[Decision 0010](../.decisions/0010-select-buck2-build-authority.md) selects
+Buck2 as the repo-local build authority. The difference between the current
+evidence-only boundary and that decision is recorded in
+[DELTA-003](../.delta/DELTA-003-buck2-single-build-authority.md).
 
 ## Evidence Shape
 
@@ -52,10 +57,10 @@ Paths are repo-relative and safe for public artifacts.
 
 ## Future Builder
 
-A future Buck2 action may materialize dependencies only when it:
+A Buck2 action may materialize dependencies only when it:
 
 1. declares the same profile inputs;
 2. disables lifecycle scripts by construction;
-3. proves output equivalence with the accepted profile realization;
-4. has an explicit repair and GC story for mutable state or uses immutable
-   outputs only.
+3. proves that its output satisfies the accepted consumer contract;
+4. uses immutable outputs and keeps mutable caches outside correctness; and
+5. is the sole build authority for the consumers in its declared scope.

--- a/context/dependency-materialization/requirements.md
+++ b/context/dependency-materialization/requirements.md
@@ -3,8 +3,8 @@
 ## Context
 
 These requirements define the dependency materialization contract used by
-effect-utils live pnpm tasks, Nix prepared dependency artifacts, CI jobs, and
-future Buck2 dependency evidence.
+effect-utils live pnpm tasks, immutable dependency artifacts, CI jobs, and
+declared repo-local build actions.
 
 Canonical shared terms and relationships are defined in
 [ontology.md](./ontology.md).
@@ -25,7 +25,7 @@ Subsystem requirements refine this root contract:
 - [04-store-authority](./04-store-authority/requirements.md) defines shared
   content, repair, prune, and GC authority.
 - [05-buck2-evidence](./05-buck2-evidence/requirements.md) defines the Buck2
-  evidence boundary.
+  realization and evidence boundary.
 - [06-observability](./06-observability/requirements.md) defines producer facts
   for materialization telemetry.
 - [07-verification](./07-verification/requirements.md) defines the proof,
@@ -38,15 +38,15 @@ Subsystem requirements refine this root contract:
 
 - **A01 pnpm base:** The supported package-manager surface is pnpm 11 with the
   repo's canonical workspace topology and lockfile.
-- **A02 Nix authority:** Native tools, compiled native bindings, and runtime
-  binaries that cannot be treated as pure package artifacts are supplied by Nix
-  or explicit wrappers, not by pnpm lifecycle scripts.
-- **A03 Materialization Profile consumers:** Prepared dependency artifacts and
-  Buck2 evidence use one immutable Materialization Profile vocabulary for
-  equivalent dependency inputs. Live installs use their declared inputs and
-  install contract directly.
-- **A04 Prepared artifacts are data:** Prepared pnpm dependency FODs are data
-  artifacts. Build-time executable shims and native/build outputs are
+- **A02 System integration authority:** Native tools, compiled native bindings,
+  and runtime binaries that cannot be treated as pure package artifacts are
+  supplied by explicit system inputs or wrappers, not by pnpm lifecycle scripts.
+- **A03 Materialization Profile consumers:** Immutable dependency artifacts and
+  build evidence use one Materialization Profile vocabulary for equivalent
+  dependency inputs. Live installs use their declared inputs and install
+  contract directly.
+- **A04 Dependency artifacts are data:** Immutable dependency artifacts contain
+  dependency data. Build-time executable shims and native/build outputs are
   projection or build-layer concerns unless explicitly modeled as pure package
   data.
 
@@ -82,15 +82,16 @@ Subsystem requirements refine this root contract:
 - **DMP-R03 No approve-builds gate:** `allowBuilds`, `onlyBuiltDependencies`,
   `pnpm approve-builds`, and related pnpm build-approval mechanisms must not be
   the primary trust boundary for effect-utils-managed installs.
-- **DMP-R04 Native purity:** Native dependencies must be represented as Nix
-  inputs, explicit wrappers, or pure package artifacts selected without running
+- **DMP-R04 Native purity:** Native dependencies must be represented as explicit
+  system inputs, wrappers, or pure package artifacts selected without running
   lifecycle scripts.
 
 ### Must separate dependency data from projections
 
-- **DMP-R05 Prepared FOD data surface:** A prepared pnpm dependency artifact
-  must contain only deterministic dependency data required by downstream
-  restores. It must not archive mutable pnpm store/home/state paths.
+- **DMP-R05 Dependency artifact data surface:** An immutable dependency artifact
+  must contain only deterministic dependency data required by declared
+  consumers. It must not archive mutable package-manager store, home, or state
+  paths.
 - **DMP-R06 Bin projection ownership:** `node_modules/.bin` entries are
   executable projection state. They must be created, checked, and repaired by a
   deterministic projection step rather than by dependency lifecycle scripts.
@@ -104,22 +105,24 @@ Subsystem requirements refine this root contract:
 
 ### Must make materialization identity explicit
 
-- **DMP-R09 Materialization Profile identity:** When prepared dependency or
-  Buck2 evidence groups equivalent immutable dependency work, its stable
-  Materialization Profile identity must derive from topology, dependency
-  inputs, package-manager policy, and toolchain inputs, not physical root or
-  storage placement.
-- **DMP-R10 Shared Materialization Profile schema:** Nix prepared dependency
-  artifacts and Buck2 evidence must use the same Materialization Profile fields
-  when describing equivalent dependency work.
+- **DMP-R09 Materialization Profile identity:** When an immutable artifact or
+  build-evidence target groups equivalent dependency work, its stable
+  Materialization Profile identity must derive from topology, dependency inputs,
+  package-manager policy, and toolchain inputs, not physical root or storage
+  placement.
+- **DMP-R10 Shared Materialization Profile schema:** Artifact producers and
+  build-evidence targets must use the same Materialization Profile fields when
+  describing equivalent dependency work.
 - **DMP-R11 Topology and edge authority:** Each Materialization Root must name
-  authoritative workspace topology and one Authoritative Materializer.
+  authoritative workspace topology and exactly one Authoritative Materializer.
+  The repository must also declare exactly one build authority for repo-local
+  compilation, generation, tests, bundles, and dependency/product artifacts.
   Package-local or sibling-root state must not become authoritative implicitly.
-  Only the Authoritative Materializer may
-  select or change the Package Instance targeted by a Dependency Edge. A
-  faithful restore may reproduce an already-selected edge, and repair may
-  discard an owned realization and reinvoke the Authoritative Materializer;
-  neither may select a replacement target.
+  Only the Authoritative Materializer may select or change the Package Instance
+  targeted by a Dependency Edge. A faithful restore may reproduce an
+  already-selected edge, and repair may discard an owned realization and
+  reinvoke the Authoritative Materializer; neither may select a replacement
+  target.
 
 ### Must preserve correctness under sharing
 
@@ -138,9 +141,9 @@ Subsystem requirements refine this root contract:
 
 ### Must be measured and verifiable
 
-- **DMP-R16 Real-repo gates:** Changes to storage sharing, prepared artifact
-  purity, or projection ownership must be validated on at least one real
-  downstream graph in addition to synthetic fixtures.
+- **DMP-R16 Real-repo gates:** Changes to build authority, storage sharing,
+  artifact purity, or projection ownership must be validated on at least one
+  real downstream graph in addition to synthetic fixtures.
 - **DMP-R17 Negative lifecycle tests:** Test fixtures must prove that managed
   install plus projection does not run `preinstall`, `install`, `postinstall`,
   `prepare`, rebuild, or approval paths.
@@ -178,4 +181,4 @@ Subsystem requirements refine this root contract:
   lifecycle-free and atomic, consumers cannot mutate the result, and corruption
   or eviction can be repaired without coordinating those consumers. Root-local
   mutable realization is a compatibility boundary, not the long-term reuse
-  ideal.
+  ideal. A reusable artifact producer must not create a parallel build authority.

--- a/context/dependency-materialization/spec.md
+++ b/context/dependency-materialization/spec.md
@@ -13,7 +13,7 @@ This spec defines:
 - the separation between dependency data, executable projections, and native
   build outputs;
 - the prepared dependency FOD purity boundary;
-- the prepared dependency profile shape shared by Nix and Buck2 evidence;
+- the prepared dependency profile shape shared by Nix and build evidence;
 - the repair, doctor, and benchmark gates for changing the policy.
 
 This spec does not define package-specific native integrations. Those belong in
@@ -30,7 +30,7 @@ dependency-materialization/
     01-fod-hash-evidence/   cross-system FOD hash evidence
     02-native-node-packages/ native package classification and grafting
   04-store-authority/        shared content, repair, prune, and GC authority
-  05-buck2-evidence/         Buck2 evidence-only boundary
+  05-buck2-evidence/         current Buck2 evidence boundary
   06-observability/          producer facts and build-log bridge records
   07-verification/           proof, benchmark, and regression architecture
   08-ci-store-cache/         CI-profile pnpm store persistence and write coordination
@@ -59,19 +59,23 @@ canonical workspace inputs
   -> pure pnpm materialization
      -> dependency data
      -> pure executable projection
-     -> Nix/native wrapper integration
+     -> system/native wrapper integration
      -> prepared profile evidence and live health reports
 ```
 
-pnpm is responsible for resolving and linking package contents. It is not the
-authority for executing package lifecycle code in effect-utils-managed paths.
+pnpm is responsible for resolving and linking package contents in the current
+live and prepared realizations. It is not the authority for executing package
+lifecycle code in effect-utils-managed paths.
 
 The long-term reuse unit is a hermetic dependency artifact keyed by every input
 that can affect package identity and topology. It is constructed atomically,
 never mutated by consumers, and may be reused as broadly as compatibility
 permits. Today's root-local pnpm graph is the mutable compatibility boundary
 used where pnpm cannot yet expose that artifact; it is not the architectural
-ceiling.
+ceiling. [Decision 0010](./.decisions/0010-select-buck2-build-authority.md)
+selects Buck2 as the repo-local build authority. The current evidence-only
+divergence from that decision is recorded in
+[DELTA-003](./.delta/DELTA-003-buck2-single-build-authority.md).
 
 ## Strict pnpm Install Policy
 


### PR DESCRIPTION
## Problem

The dependency-materialization contract currently treats Nix prepared dependencies as the durable immutable build authority and Buck2 as evidence-only. Assuming a full Buck2 migration, that preserves overlapping repo-local dependency and build authorities and encourages the compatibility mechanisms from #1101, #1104, and #1107 to become permanent.

## Goal

Keep the root materialization contract engine-neutral while selecting Buck2 as the single repo-local build authority. Freeze the existing pnpm/Nix and copied-CI-helper adapters and define their deletion proof without translating their internal abstractions into Buck2.

## Decisions

- Make the root DMP require one declared repo-local build authority without coupling the root ontology to a specific engine.
- Record the Buck2 selection and the Nix/pnpm boundary in decision 0010.
- Keep the current Buck2 spec honest: the implementation is still evidence-only.
- Put all current migration state, exact bridge census, no-new-consumer rule, and deletion gates in temporary DELTA-003.
- Add only one requirement ID: `DMP.BUCK-R06`, enforcing one authority per declared consumer scope.

## Verification

- `oxfmt --check` passes for all eight touched Markdown files.
- `git diff --check origin/main...HEAD` passes.
- `devenv tasks run genie:check` completed without generated changes.
- Requirement audit confirms neither the earlier live-pnpm nor Nix subsystem depends on the later Buck subsystem.
- Independent VRS review findings were addressed: engine-neutral root, correct hierarchy direction, explicit decision record, current-state spec, and adapter-scoped convergence.
- Hosted CI is fully green. The initial macOS test job missed an unrelated OTEL fixture-fetch span; the isolated retry passed without a code change.
- Local `check:all` remained non-terminal in task loading for 13 minutes under shared host contention and was stopped. It is recorded as UNRUN, not PASS.

## Complexity

No production complexity. One decision and one temporary delta centralize authority and deletion state. No compatibility implementation is added.

## Concerns

The selected authority is not implemented yet. Existing consumers still require the adapters, so removing the safety checks or resolver independently would reduce correctness without reducing the underlying lifecycle.

## Friction & bottlenecks

The full local gate remained non-terminal before starting any child task despite a bounded retry. Hosted CI completed the full cross-platform matrix.

## Follow-ups

- Prove the first Buck-built dependency/product artifact for an existing adapter consumer.
- Move remaining consumers directly to Buck artifacts.
- Delete the complete bridge census and DELTA-003 in the same contraction stack.

## References

- Refs #1101
- Refs #1104
- Refs #1107
