### PR TITLE
feat(notion-react): export the NodeKey cache-key encoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- **@overeng/notion-react**: export `NodeKey`, the encoder for the
+  `k:<blockKey>` / `p:<index>` node keys the reconciler assigns to
+  candidate/cache tree entries (#1121). The internal key derivation now
+  routes through the same encoder, so consumers that construct or index
+  into a `CacheTree` out-of-band can no longer drift from the scheme
+  `buildCandidateTree` / `diff` actually produce.
+
 - **devenv pnpm / Genie**: add root-local, read-only source generations for
   composed workspaces. Aggregate roots declare cross-repository source inputs,
   Genie projects matching `file:` overrides, and the shared pnpm transaction

--- a/packages/@overeng/notion-react/docs/api.md
+++ b/packages/@overeng/notion-react/docs/api.md
@@ -159,12 +159,20 @@ Empirical constraints (from `tmp/notion-618/experiments/findings.md`):
 ## Keys
 
 ```ts
-import { blockKey } from '@overeng/notion-react'
+import { blockKey, NodeKey } from '@overeng/notion-react'
 blockKey('task-42') // "b:task-42"
+NodeKey.keyed(blockKey('task-42')) // "k:b:task-42"
+NodeKey.positional(0) // "p:0"
 ```
 
-Namespaces a business id so multiple renderers can share a cache
-without collisions. See
+`blockKey` namespaces a business id so multiple renderers can share a
+cache without collisions. `NodeKey` is the encoder for the node keys
+the reconciler assigns to candidate/cache tree entries: `keyed` for
+elements with an explicit `blockKey` prop, `positional` for the
+sibling-index fallback. The internal key derivation routes through the
+same encoder, so consumers that construct or index into a `CacheTree`
+out-of-band must use it instead of hand-rolling the `k:`/`p:`
+prefixes. See
 [Concepts → Keys and identity](./concepts/keys-and-identity.md).
 
 ## Cache

--- a/packages/@overeng/notion-react/docs/concepts/keys-and-identity.md
+++ b/packages/@overeng/notion-react/docs/concepts/keys-and-identity.md
@@ -50,15 +50,21 @@ mid-sibling operations: every later positional key shifts, so the
 diff emits remove + re-insert for the tail instead of a single
 insert.
 
-The derived key is prefixed internally: `k:<blockKey>` for explicit
-keys, `p:<index>` for positional. The `blockKey(businessId)` helper
-returns `"b:<id>"`, useful if you share a cache across multiple
+The derived key is prefixed: `k:<blockKey>` for explicit keys,
+`p:<index>` for positional. The exported `NodeKey` encoder is the
+source of this scheme — the reconciler derives every candidate/cache
+key through it, and consumers that construct or index into a
+`CacheTree` from outside (e.g. to seed or inspect a cache) must do the
+same rather than hand-rolling the prefixes. The `blockKey(businessId)`
+helper returns `"b:<id>"`, useful if you share a cache across multiple
 renderers and want a collision-proof namespace.
 
 ```ts
-import { blockKey } from '@overeng/notion-react'
+import { blockKey, NodeKey } from '@overeng/notion-react'
 
 blockKey('task-42') // "b:task-42"
+NodeKey.keyed(blockKey('task-42')) // "k:b:task-42"
+NodeKey.positional(3) // "p:3"
 ```
 
 ## Invariants

--- a/packages/@overeng/notion-react/docs/vrs/requirements.md
+++ b/packages/@overeng/notion-react/docs/vrs/requirements.md
@@ -130,7 +130,11 @@ host-config, or cache are implemented (see [spec.md](./spec.md) for that).
   produces one `remove`. No collateral reorders when neighbors are stable.
 - **R07 Keyed identity:** Block identity across renders must be derivable
   from an explicit `blockKey`-style hint. In its absence, siblings fall
-  back to positional keys per T02.
+  back to positional keys per T02. The key encoding is public contract:
+  consumers that construct or index into a `CacheTree` out-of-band must
+  be able to derive the exact node keys through an exported encoder, and
+  the internal derivation must route through that same encoder so the two
+  cannot drift.
 
 ### Must be Effect-native
 

--- a/packages/@overeng/notion-react/docs/vrs/spec.md
+++ b/packages/@overeng/notion-react/docs/vrs/spec.md
@@ -280,10 +280,12 @@ stale cache entries into mutation planning without an explicit migration.
 
 ### Key derivation (R07)
 
-`instanceKey(inst, index) = inst.blockKey ?? "p:<index>"`, prefixed with
-`"k:"` for explicit keys. React's `key` prop is forwarded via the
-`blockKey` host prop (helper `blockKey(businessId)` returns `"b:<id>"`
-for namespacing).
+`instanceKey(inst, index) = NodeKey.keyed(inst.blockKey) | NodeKey.positional(index)`.
+The `NodeKey` encoder (`keys.ts`, exported) is the single source of the
+`k:<blockKey>` / `p:<index>` scheme; `instanceKey` routes through it so
+external cache constructors and the reconciler cannot disagree on the
+encoding. React's `key` prop is forwarded via the `blockKey` host prop
+(helper `blockKey(businessId)` returns `"b:<id>"` for namespacing).
 
 ### Hashing
 

--- a/packages/@overeng/notion-react/src/renderer/keys.ts
+++ b/packages/@overeng/notion-react/src/renderer/keys.ts
@@ -5,3 +5,18 @@
  * and you want to avoid collisions with unrelated keys.
  */
 export const blockKey = (business: string): string => `b:${business}`
+
+/**
+ * Encoder for the node keys the reconciler assigns to candidate/cache tree
+ * entries. `buildCandidateTree` derives every node's `key` through exactly
+ * these two constructors, and `candidateToCache` persists them verbatim, so
+ * consumers that need to address a cache entry (e.g. to seed or inspect a
+ * cache out-of-band) MUST go through this encoder rather than hand-rolling
+ * the `k:`/`p:` prefixes.
+ */
+export const NodeKey = {
+  /** Key for an element that carries an explicit `blockKey` prop. */
+  keyed: (blockKey: string): string => `k:${blockKey}`,
+  /** Positional fallback key for an element without a `blockKey`, by sibling index. */
+  positional: (index: number): string => `p:${index}`,
+}

--- a/packages/@overeng/notion-react/src/renderer/keys.unit.test.tsx
+++ b/packages/@overeng/notion-react/src/renderer/keys.unit.test.tsx
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+
+import { Heading2, Paragraph, Toggle } from '../components/blocks.ts'
+import { blockKey, NodeKey } from './keys.ts'
+import { buildCandidateTree, candidateToCache, diff } from './sync-diff.ts'
+
+const ROOT = '00000000-0000-4000-8000-000000000001'
+
+/**
+ * Contract test for the `NodeKey` encoder: the keys it produces MUST be
+ * byte-identical to the keys `buildCandidateTree` assigns, or any consumer
+ * that addresses cache entries via the encoder (the whole point of exporting
+ * it) diffs against phantom keys and rebuilds the page.
+ */
+describe('NodeKey encoder', () => {
+  it('matches the keys buildCandidateTree assigns', () => {
+    const tree = buildCandidateTree(
+      <>
+        <Heading2>unkeyed heading</Heading2>
+        <Paragraph blockKey="intro">keyed paragraph</Paragraph>
+        <Toggle blockKey={blockKey('s1')} title="business-keyed toggle">
+          <Paragraph>nested unkeyed</Paragraph>
+        </Toggle>
+      </>,
+      ROOT,
+    )
+    expect(tree.children.map((c) => c.key)).toEqual([
+      NodeKey.positional(0),
+      NodeKey.keyed('intro'),
+      NodeKey.keyed(blockKey('s1')),
+    ])
+    // Nested siblings restart positional numbering per parent.
+    expect(tree.children[2]!.children[0]!.key).toBe(NodeKey.positional(0))
+    // The `b:` business namespace composes with the `k:` encoding.
+    expect(tree.children[2]!.key).toBe('k:b:s1')
+  })
+
+  it('round-trips through the cache: encoder-addressed entries are retained by diff', () => {
+    const element = (
+      <>
+        <Paragraph blockKey="a">alpha</Paragraph>
+        <Paragraph>positional</Paragraph>
+      </>
+    )
+    const candidate = buildCandidateTree(element, ROOT)
+    // Materialize ids as a successful sync would, then snapshot the cache.
+    const assign = (nodes: readonly (typeof candidate.children)[number][]): void => {
+      for (const [i, n] of nodes.entries()) {
+        n.blockId = `${n.key}-id-${i}`
+        assign(n.children)
+      }
+    }
+    assign(candidate.children)
+    const cache = candidateToCache(candidate, 3)
+    expect(cache.children.map((c) => c.key)).toEqual([NodeKey.keyed('a'), NodeKey.positional(1)])
+    // A rebuilt candidate diffs to zero ops against the cache written with
+    // encoder-shaped keys — key identity is stable across render → cache.
+    expect(diff(cache, buildCandidateTree(element, ROOT))).toEqual([])
+  })
+})

--- a/packages/@overeng/notion-react/src/renderer/mod.ts
+++ b/packages/@overeng/notion-react/src/renderer/mod.ts
@@ -16,7 +16,7 @@ export {
   type InlineComponent,
   type RichTextItem,
 } from './flatten-rich-text.ts'
-export { blockKey } from './keys.ts'
+export { blockKey, NodeKey } from './keys.ts'
 export { NotionSyncError, CacheError } from './errors.ts'
 export {
   renderToNotion,

--- a/packages/@overeng/notion-react/src/renderer/sync-diff.ts
+++ b/packages/@overeng/notion-react/src/renderer/sync-diff.ts
@@ -19,6 +19,7 @@ import {
   projectIcon,
   projectTitleSpans,
 } from './icons.ts'
+import { NodeKey } from './keys.ts'
 import type { PageOp } from './op-buffer.ts'
 import { OpBuffer } from './op-buffer.ts'
 
@@ -100,7 +101,7 @@ const hashProps = (props: Record<string, unknown>): string => {
 }
 
 const instanceKey = (inst: Instance, index: number): string =>
-  inst.blockKey !== undefined ? `k:${inst.blockKey}` : `p:${index}`
+  inst.blockKey !== undefined ? NodeKey.keyed(inst.blockKey) : NodeKey.positional(index)
 
 const hashAny = (value: unknown): string => {
   const s = stableStringify(value)


### PR DESCRIPTION
## Outcome

Export `NodeKey`, the encoder for the `k:<blockKey>` / `p:<index>` node keys the reconciler assigns to candidate/cache tree entries, and route the internal key derivation through it so the exported encoder cannot drift from what `buildCandidateTree` / `diff` actually produce.

Closes #1121.

## Why

Consumers composing the exported deep primitives (`buildCandidateTree`, `diff`, `candidateToCache`, `CacheTree`) had to hardcode the private key scheme. A downstream consumer (the Blocky publication flow, same lineage as #1100) pinned `k:` locally and hit a live publication crash when a lookup used the unencoded key. Exporting the encoder was recorded as a follow-up of that work.

## Changes

- new `NodeKey = { keyed, positional }` in `renderer/keys.ts`, exported from the package root
- `sync-diff.ts`'s `instanceKey` now derives keys through `NodeKey` (no behavior change; keys are byte-identical)
- docs: api.md Keys section, concepts/keys-and-identity.md, VRS R07 extended with the public-encoder constraint, spec key-derivation section, changelog

## Evidence

- `notion-react`: 366 passed, 1 skipped (baseline 364 + 2 new)
- new tests: encoder ↔ `buildCandidateTree` agreement (keyed, positional, nested positional restarts, `blockKey('s1')` → `'k:b:s1'` namespace composition); a `CacheTree` written with encoder-shaped keys diffs to zero ops against a fresh render
- TypeScript build passed (`tsc -b tsconfig.check.json`)
- lint + format green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | unknown |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.237 |
| `agent_runtime` | Claude Code 2.1.237 |
| `tooling_profile` | dotfiles@ffce621 |
</details>
<!-- agent-footer:end -->