### PR TITLE
fix(ci-tools): restore trim validation of deploy provider outputs (#1116)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ All notable changes to this project will be documented in this file.
   CLI help/validation prose renders on stdout with new formatting, schema
   decode failure prose follows the v4 formatter, and SubscriptionRef change
   streams emit the initial value at subscribe time.
+- **@overeng/ci-tools**: restored trim validation of provider outputs at the
+  deploy boundaries — Netlify CLI/site JSON (`deploy_id`, `site_name`, `name`,
+  `account_slug`) and Vercel project JSON (`id`, `name`) now reject
+  whitespace-only values as invalid provider output instead of accepting them.
 
 - **@overeng/content-address, @overeng/kdl-effect, @overeng/otel-contract**:
   migrate to effect@4.0.0-rc.111. `Schema.pattern`/`maxLength`/

--- a/packages/@overeng/ci-tools/src/deploy-domain.ts
+++ b/packages/@overeng/ci-tools/src/deploy-domain.ts
@@ -11,7 +11,7 @@ import {
 } from './deploy-domain.contract.ts'
 import type { WorkflowReportRecord } from './mod.ts'
 
-const NonEmptyTrimmedString = Schema.NonEmptyString.check(
+export const NonEmptyTrimmedString = Schema.NonEmptyString.check(
   Schema.makeFilter((s: string) => s.trim().length === s.length),
 )
 

--- a/packages/@overeng/ci-tools/src/deploy-netlify.e2e.test.ts
+++ b/packages/@overeng/ci-tools/src/deploy-netlify.e2e.test.ts
@@ -6,7 +6,7 @@ import { join, resolve } from 'node:path'
 
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
-type ApiMode = 'ok' | 'unauthorized' | 'missing'
+type ApiMode = 'ok' | 'unauthorized' | 'missing' | 'blank-site'
 
 const repoRoot = resolve(import.meta.dirname, '../../../..')
 const cliPath = join(repoRoot, 'packages/@overeng/ci-tools/bin/ci-tools.ts')
@@ -99,6 +99,12 @@ beforeAll(async () => {
     }
     if (apiMode === 'missing') {
       response.writeHead(404, { connection: 'close' }).end('missing')
+      return
+    }
+    if (apiMode === 'blank-site') {
+      response
+        .writeHead(200, { 'content-type': 'application/json', connection: 'close' })
+        .end(JSON.stringify({ name: 'fake-site', account_slug: '   ' }))
       return
     }
     response
@@ -312,6 +318,40 @@ printf '{"deploy_id":"deploy123","site_name":"fake-site","deploy_url":"https://d
         retryable: false,
       })
     } finally {
+      rmSync(workspace.root, { recursive: true, force: true })
+    }
+  })
+
+  it('fails when Netlify site lookup returns a whitespace-only account slug', async () => {
+    apiMode = 'blank-site'
+    const workspace = makeWorkspace()
+    const reportFile = join(workspace.root, 'report.jsonl')
+    try {
+      const result = await runCiTools({
+        workdir: workspace.root,
+        fakeNetlifyBin: workspace.fakeNetlifyBin,
+        reportFile,
+        args: [
+          '--target',
+          'storybook',
+          '--artifact-dir',
+          workspace.artifactDir,
+          '--mode',
+          'prod',
+          '--site-name',
+          'fake-site',
+        ],
+      })
+      expect(result.status).not.toBe(0)
+
+      const record = readRecord(reportFile)
+      expect(record.status).toBe('failure')
+      expect(record.data).toMatchObject({
+        errorKind: 'ProviderProjectLookupFailed',
+        retryable: false,
+      })
+    } finally {
+      apiMode = 'ok'
       rmSync(workspace.root, { recursive: true, force: true })
     }
   })

--- a/packages/@overeng/ci-tools/src/deploy-netlify.ts
+++ b/packages/@overeng/ci-tools/src/deploy-netlify.ts
@@ -16,6 +16,7 @@ import {
   DeployResultV1,
   InvalidProviderOutput,
   MissingAuth,
+  NonEmptyTrimmedString,
   ProviderOperationFailed,
   ProviderProjectLookupFailed,
   Unauthorized,
@@ -67,14 +68,14 @@ const HttpsUrlString = Schema.NonEmptyString.check(
 ).annotate({ identifier: 'CiTools.Netlify.HttpsUrlString' })
 
 const NetlifyDeployJson = Schema.Struct({
-  deploy_id: Schema.NonEmptyString,
-  site_name: Schema.NonEmptyString,
+  deploy_id: NonEmptyTrimmedString,
+  site_name: NonEmptyTrimmedString,
   deploy_url: HttpsUrlString,
 }).annotate({ identifier: 'CiTools.Netlify.DeployJson' })
 
 const NetlifySiteJson = Schema.Struct({
-  name: Schema.optional(Schema.NonEmptyString),
-  account_slug: Schema.optional(Schema.NonEmptyString),
+  name: Schema.optional(NonEmptyTrimmedString),
+  account_slug: Schema.optional(NonEmptyTrimmedString),
 }).annotate({ identifier: 'CiTools.Netlify.SiteJson' })
 
 const isoNow = () => new Date().toISOString()

--- a/packages/@overeng/ci-tools/src/deploy-vercel.e2e.test.ts
+++ b/packages/@overeng/ci-tools/src/deploy-vercel.e2e.test.ts
@@ -14,7 +14,7 @@ import { join, resolve } from 'node:path'
 
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
-type ApiMode = 'ok' | 'unauthorized' | 'missing'
+type ApiMode = 'ok' | 'unauthorized' | 'missing' | 'blank-project'
 
 const repoRoot = resolve(import.meta.dirname, '../../../..')
 const cliPath = join(repoRoot, 'packages/@overeng/ci-tools/bin/ci-tools.ts')
@@ -109,6 +109,12 @@ beforeAll(async () => {
     }
     if (apiMode === 'missing') {
       response.writeHead(404, { connection: 'close' }).end('missing')
+      return
+    }
+    if (apiMode === 'blank-project') {
+      response
+        .writeHead(200, { 'content-type': 'application/json', connection: 'close' })
+        .end(JSON.stringify({ id: '   ', name: '   ' }))
       return
     }
     response
@@ -542,6 +548,28 @@ exit 1
       })
       expect(result.status).not.toBe(0)
       expect(readRecord(reportFile).data).toMatchObject({ errorKind: 'Unauthorized' })
+      expect(existsSync(workspace.logPath)).toBe(false)
+    } finally {
+      apiMode = 'ok'
+      rmSync(workspace.root, { recursive: true, force: true })
+    }
+  })
+
+  it('fails before upload when API-first project lookup returns whitespace-only identity', async () => {
+    apiMode = 'blank-project'
+    const workspace = makeWorkspace()
+    const reportFile = join(workspace.root, 'report.jsonl')
+    try {
+      const result = await runCiTools({
+        workdir: workspace.root,
+        fakeVercelBin: workspace.fakeVercelBin,
+        reportFile,
+        args: ['--target', 'web', '--artifact-dir', workspace.artifactDir, '--mode', 'preview'],
+      })
+      expect(result.status).not.toBe(0)
+      expect(readRecord(reportFile).data).toMatchObject({
+        errorKind: 'ProviderProjectLookupFailed',
+      })
       expect(existsSync(workspace.logPath)).toBe(false)
     } finally {
       apiMode = 'ok'

--- a/packages/@overeng/ci-tools/src/deploy-vercel.ts
+++ b/packages/@overeng/ci-tools/src/deploy-vercel.ts
@@ -29,6 +29,7 @@ import {
   InvalidProviderOutput,
   MissingAuth,
   MissingBuildOutput,
+  NonEmptyTrimmedString,
   ProviderOperationFailed,
   ProviderProjectLookupFailed,
   Unauthorized,
@@ -80,8 +81,8 @@ export type VercelDeployCommandOptions = {
 }
 
 const VercelProjectJson = Schema.Struct({
-  id: Schema.optional(Schema.NonEmptyString),
-  name: Schema.optional(Schema.NonEmptyString),
+  id: Schema.optional(NonEmptyTrimmedString),
+  name: Schema.optional(NonEmptyTrimmedString),
 }).annotate({ identifier: 'CiTools.Vercel.ProjectJson' })
 
 const VercelProjectFileJson = Schema.fromJsonString(


### PR DESCRIPTION
Follow-up to #1109 (effect@4 rc.111). Closes #1116.

## Problem
The migration replaced `NonEmptyTrimmedString` with plain `NonEmptyString` in the ci-tools deploy provider schemas, so whitespace-only values from external provider output pass decoding and flow into deployment URL construction / site lookup.

## Change
- `deploy-domain.ts`: export the existing `NonEmptyTrimmedString` composition (`Schema.NonEmptyString.pipe(Schema.check(Schema.isTrimmed()))`) for reuse.
- `deploy-netlify.ts`: `NetlifyDeployJson.deploy_id/site_name` and `NetlifySiteJson.name/account_slug` restored to trimmed-nonempty. `deploy_url` untouched — its HTTPS pattern already rejects whitespace.
- `deploy-vercel.ts`: `VercelProjectJson.id/name` restored. `VercelProjectFileJson` untouched (encode-only generated output, not an external decode boundary).
- Tests: new e2e fixtures proving whitespace-only Netlify API `account_slug` and Vercel API id/name are rejected as typed failure records (verified these tests fail without the schema fix; note: whitespace-only `deploy_id` was already gated downstream by the HttpsUrl schema, so the Netlify test targets the genuinely unprotected boundary).

Closes #1116.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | unknown |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.0.3 |
| `agent_runtime` | OMP 18.0.3 |
| `tooling_profile` | dotfiles@ffce621 |
</details>
<!-- agent-footer:end -->