### PR TITLE
chore(cli-contract): centralize CLI output normalization in utils-dev (#1118)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,11 @@ All notable changes to this project will be documented in this file.
   unchanged.
 
 ### Added
+- **@overeng/utils-dev**: add a shared `normalizeCliOutput` helper at the
+  `./cli-contract` export for CLI contract baselines. Each masking policy
+  (ANSI, log timestamps, checkout root, local-source suffix) is an explicit
+  option defaulting to `false`, so consumers state their policy instead of
+  drifting between copies; five contract suites now consume it.
 
 - **devenv pnpm / Genie**: add root-local, read-only source generations for
   composed workspaces. Aggregate roots declare cross-repository source inputs,

--- a/nix/oxc-config-plugin.nix
+++ b/nix/oxc-config-plugin.nix
@@ -29,7 +29,7 @@ let
     pnpm = pinnedPnpm;
   };
   packageDir = "packages/@overeng/oxc-config";
-  pnpmDepsHash = "sha256-9DMo0vLBwwLnXLrPhXdaSFerztCNiHbZR0POu7uR694=";
+  pnpmDepsHash = "sha256-gQGOoJ6vWIayzofbi93Y52aWa7lVkB3BLYyPbzylb9k=";
 
   srcPath =
     if builtins.isAttrs src && builtins.hasAttr "outPath" src then

--- a/packages/@overeng/ci-tools/nix/build.nix
+++ b/packages/@overeng/ci-tools/nix/build.nix
@@ -19,7 +19,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-4SOcbVzKeTGMUdkOUkWdFhWnlRUHCZZIRB03MM2IQMM=";
+      "." = mkSharedHash "sha256-eWoXWhJCiI9s4xhVov9WoHksWVOhWQFu51sZisSb8fI=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/ci-tools/src/cli.contract.test.ts
+++ b/packages/@overeng/ci-tools/src/cli.contract.test.ts
@@ -1,8 +1,9 @@
 import { spawnSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 
-import { normalizeCliOutput } from '@overeng/utils-dev/cli-contract'
 import { describe, expect, it } from 'vitest'
+
+import { normalizeCliOutput } from '@overeng/utils-dev/cli-contract'
 
 const cliPath = fileURLToPath(new URL('../bin/ci-tools.ts', import.meta.url))
 
@@ -22,8 +23,8 @@ const runCli = (...args: ReadonlyArray<string>) => {
   return {
     status: result.status,
     signal: result.signal,
-    stdout: normalizeCliOutput(result.stdout, { ansi: true }),
-    stderr: normalizeCliOutput(result.stderr, { ansi: true }),
+    stdout: normalizeCliOutput({ input: result.stdout, ansi: true }),
+    stderr: normalizeCliOutput({ input: result.stderr, ansi: true }),
   }
 }
 

--- a/packages/@overeng/ci-tools/src/cli.contract.test.ts
+++ b/packages/@overeng/ci-tools/src/cli.contract.test.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 
+import { normalizeCliOutput } from '@overeng/utils-dev/cli-contract'
 import { describe, expect, it } from 'vitest'
 
 const cliPath = fileURLToPath(new URL('../bin/ci-tools.ts', import.meta.url))
@@ -11,17 +12,6 @@ const cliPath = fileURLToPath(new URL('../bin/ci-tools.ts', import.meta.url))
  * during Effect 4 repair with an alignment-register entry.
  * ANSI control bytes are normalized, so colour/styling changes are not gated by this baseline.
  */
-// LIVE-MIGRATION BRIDGE effect-3-4 B7 — DELETE at contraction — https://github.com/overengineeringstudio/effect-utils/issues/925
-const stripAnsi = (output: string) =>
-  output.replace(
-    // eslint-disable-next-line no-control-regex -- CLI contract snapshots intentionally normalize terminal control bytes.
-    /[\u001b\u009b][[\]()#;?]*(?:(?:(?:[a-zA-Z\d]*(?:;[a-zA-Z\d]*)*)?\u0007)|(?:(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~]))/gu,
-    '',
-  )
-
-const normalizeOutput = (output: string) =>
-  stripAnsi(output).replace(/ — running from local source \([^)]+\)/gu, '')
-// LIVE-MIGRATION END effect-3-4
 
 const runCli = (...args: ReadonlyArray<string>) => {
   const result = spawnSync('bun', [cliPath, ...args], {
@@ -32,10 +22,8 @@ const runCli = (...args: ReadonlyArray<string>) => {
   return {
     status: result.status,
     signal: result.signal,
-    // LIVE-MIGRATION BRIDGE effect-3-4 B7 — DELETE at contraction — https://github.com/overengineeringstudio/effect-utils/issues/925
-    stdout: normalizeOutput(result.stdout),
-    stderr: normalizeOutput(result.stderr),
-    // LIVE-MIGRATION END effect-3-4
+    stdout: normalizeCliOutput(result.stdout, { ansi: true }),
+    stderr: normalizeCliOutput(result.stderr, { ansi: true }),
   }
 }
 

--- a/packages/@overeng/genie/nix/build.nix
+++ b/packages/@overeng/genie/nix/build.nix
@@ -26,7 +26,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-jhKTjHKNDlZFMa0HFVXd/7u3KJglXCSQ+EyB0WS0hJQ=";
+      "." = mkSharedHash "sha256-KpsIUbtJrEw9ifakKtcHqdhJqrSjNgSWndOXUPawnNs=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/genie/src/cli.contract.test.ts
+++ b/packages/@overeng/genie/src/cli.contract.test.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 
+import { normalizeCliOutput } from '@overeng/utils-dev/cli-contract'
 import { describe, expect, it } from 'vitest'
 
 const cliPath = fileURLToPath(new URL('../bin/genie.tsx', import.meta.url))
@@ -17,20 +18,6 @@ const repoRoot = fileURLToPath(new URL('../../../..', import.meta.url))
  * version-string content, log timing, and machine-specific paths are not gated
  * by this baseline.
  */
-// LIVE-MIGRATION BRIDGE effect-3-4 B7 — DELETE at contraction — https://github.com/overengineeringstudio/effect-utils/issues/925
-const stripAnsi = (output: string) =>
-  output.replace(
-    // eslint-disable-next-line no-control-regex -- CLI contract snapshots intentionally normalize terminal control bytes.
-    /[\u001b\u009b][[\]()#;?]*(?:(?:(?:[a-zA-Z\d]*(?:;[a-zA-Z\d]*)*)?\u0007)|(?:(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~]))/gu,
-    '',
-  )
-
-const normalizeOutput = (output: string) =>
-  stripAnsi(output)
-    .replace(/ — running from local source \([^)]+\)/gu, '')
-    .replace(/^\[\d{2}:\d{2}:\d{2}\.\d{3}\]/gmu, '[time]')
-    .replaceAll(repoRoot, '<repo>')
-// LIVE-MIGRATION END effect-3-4
 
 const runCli = (...args: ReadonlyArray<string>) => {
   const result = spawnSync('bun', [cliPath, ...args], {
@@ -41,10 +28,8 @@ const runCli = (...args: ReadonlyArray<string>) => {
   return {
     status: result.status,
     signal: result.signal,
-    // LIVE-MIGRATION BRIDGE effect-3-4 B7 — DELETE at contraction — https://github.com/overengineeringstudio/effect-utils/issues/925
-    stdout: normalizeOutput(result.stdout),
-    stderr: normalizeOutput(result.stderr),
-    // LIVE-MIGRATION END effect-3-4
+    stdout: normalizeCliOutput(result.stdout, { ansi: true, time: true, repoRoot }),
+    stderr: normalizeCliOutput(result.stderr, { ansi: true, time: true, repoRoot }),
   }
 }
 

--- a/packages/@overeng/genie/src/cli.contract.test.ts
+++ b/packages/@overeng/genie/src/cli.contract.test.ts
@@ -1,8 +1,9 @@
 import { spawnSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 
-import { normalizeCliOutput } from '@overeng/utils-dev/cli-contract'
 import { describe, expect, it } from 'vitest'
+
+import { normalizeCliOutput } from '@overeng/utils-dev/cli-contract'
 
 const cliPath = fileURLToPath(new URL('../bin/genie.tsx', import.meta.url))
 /* Absolute checkout root of this worktree — v4 CLI error rendering embeds
@@ -28,8 +29,8 @@ const runCli = (...args: ReadonlyArray<string>) => {
   return {
     status: result.status,
     signal: result.signal,
-    stdout: normalizeCliOutput(result.stdout, { ansi: true, time: true, repoRoot }),
-    stderr: normalizeCliOutput(result.stderr, { ansi: true, time: true, repoRoot }),
+    stdout: normalizeCliOutput({ input: result.stdout, ansi: true, time: true, repoRoot }),
+    stderr: normalizeCliOutput({ input: result.stderr, ansi: true, time: true, repoRoot }),
   }
 }
 

--- a/packages/@overeng/megarepo/nix/build.nix
+++ b/packages/@overeng/megarepo/nix/build.nix
@@ -24,7 +24,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-l4XT42zS4ArfePVJuha13VJy/M5HtrMbdb2L7nry2b0=";
+      "." = mkSharedHash "sha256-Rl411Z9ckfLDAANIKKCilyGBrQ3X7jX6CGU57ByE6gE=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     smokeTestArgs = [ "--help" ];

--- a/packages/@overeng/notion-cli/nix/build.nix
+++ b/packages/@overeng/notion-cli/nix/build.nix
@@ -33,7 +33,7 @@ let
     installRuntimeWorkspace = true;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-FTLdljH0K5oBRTqLhgPCIzJRfYjGXKhwJkwwR4coEPA=";
+      "." = mkSharedHash "sha256-d/PonwzXaULOVFQ7kdNdU/bBwlKMw01PKLmOVraQa1Q=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/notion-cli/src/cli.contract.test.ts
+++ b/packages/@overeng/notion-cli/src/cli.contract.test.ts
@@ -3,25 +3,10 @@ import { existsSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { normalizeCliOutput } from '@overeng/utils-dev/cli-contract'
 import { describe, expect, it } from 'vitest'
 
 const cliPath = fileURLToPath(new URL('./cli.ts', import.meta.url))
-
-/**
- * CLI contract capture: `status` and `signal` are cross-major invariants; stdout/stderr help,
- * usage, and error prose are captured for review but may be re-baselined by the notion-cli owner
- * during Effect 4 repair with an alignment-register entry.
- * ANSI control bytes are normalized, so colour/styling changes are not gated by this baseline.
- * The local-source version suffix and log timestamps are normalized, so version-string content and
- * log timing are not gated by this baseline.
- */
-// LIVE-MIGRATION BRIDGE effect-3-4 B7 — DELETE at contraction — https://github.com/overengineeringstudio/effect-utils/issues/925
-const stripAnsi = (output: string) =>
-  output.replace(
-    // eslint-disable-next-line no-control-regex -- CLI contract snapshots intentionally normalize terminal control bytes.
-    /[\u001b\u009b][[\]()#;?]*(?:(?:(?:[a-zA-Z\d]*(?:;[a-zA-Z\d]*)*)?\u0007)|(?:(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~]))/gu,
-    '',
-  )
 
 // Walk up to the checkout root — segment-counting from import.meta.url is
 // unreliable because bun resolves the module through megarepo symlinks.
@@ -35,14 +20,14 @@ const repoRoot = (() => {
   }
 })()
 
-const normalizeOutput = (output: string) =>
-  stripAnsi(output)
-    // v4 stderr embeds stack frames with absolute checkout paths; normalize so
-    // baselines stay stable across checkouts (same as genie's contract test).
-    .replaceAll(repoRoot, '<repo>')
-    .replace(/ — running from local source \([^)]+\)/gu, '')
-    .replace(/^\[\d{2}:\d{2}:\d{2}\.\d{3}\]/gmu, '[time]')
-// LIVE-MIGRATION END effect-3-4
+/**
+ * CLI contract capture: `status` and `signal` are cross-major invariants; stdout/stderr help,
+ * usage, and error prose are captured for review but may be re-baselined by the notion-cli owner
+ * during Effect 4 repair with an alignment-register entry.
+ * ANSI control bytes are normalized, so colour/styling changes are not gated by this baseline.
+ * The local-source version suffix and log timestamps are normalized, so version-string content and
+ * log timing are not gated by this baseline.
+ */
 
 const runCli = (...args: ReadonlyArray<string>) => {
   const result = spawnSync('bun', [cliPath, ...args], {
@@ -53,10 +38,8 @@ const runCli = (...args: ReadonlyArray<string>) => {
   return {
     status: result.status,
     signal: result.signal,
-    // LIVE-MIGRATION BRIDGE effect-3-4 B7 — DELETE at contraction — https://github.com/overengineeringstudio/effect-utils/issues/925
-    stdout: normalizeOutput(result.stdout),
-    stderr: normalizeOutput(result.stderr),
-    // LIVE-MIGRATION END effect-3-4
+    stdout: normalizeCliOutput(result.stdout, { ansi: true, time: true, repoRoot }),
+    stderr: normalizeCliOutput(result.stderr, { ansi: true, time: true, repoRoot }),
   }
 }
 

--- a/packages/@overeng/notion-cli/src/cli.contract.test.ts
+++ b/packages/@overeng/notion-cli/src/cli.contract.test.ts
@@ -3,8 +3,9 @@ import { existsSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import { normalizeCliOutput } from '@overeng/utils-dev/cli-contract'
 import { describe, expect, it } from 'vitest'
+
+import { normalizeCliOutput } from '@overeng/utils-dev/cli-contract'
 
 const cliPath = fileURLToPath(new URL('./cli.ts', import.meta.url))
 
@@ -38,8 +39,8 @@ const runCli = (...args: ReadonlyArray<string>) => {
   return {
     status: result.status,
     signal: result.signal,
-    stdout: normalizeCliOutput(result.stdout, { ansi: true, time: true, repoRoot }),
-    stderr: normalizeCliOutput(result.stderr, { ansi: true, time: true, repoRoot }),
+    stdout: normalizeCliOutput({ input: result.stdout, ansi: true, time: true, repoRoot }),
+    stderr: normalizeCliOutput({ input: result.stderr, ansi: true, time: true, repoRoot }),
   }
 }
 

--- a/packages/@overeng/notion-md/nix/build.nix
+++ b/packages/@overeng/notion-md/nix/build.nix
@@ -20,7 +20,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-UGpQJaVjwBTBSCIFOoRp9Bno3CE2v/+06FS0fc1eN68=";
+      "." = mkSharedHash "sha256-AXhom8O/wA20OzYNJu+0FiRo5FVhJOFPKNB1jeg33Nw=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/npm-release/nix/build.nix
+++ b/packages/@overeng/npm-release/nix/build.nix
@@ -20,7 +20,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-6zFpH58YUeu3wfxvmDPwJladktPhvVq7aEO62v4qelI=";
+      "." = mkSharedHash "sha256-ODGukumTtO8k7QmhGvF9Qvedpbyyk1ZflbAEHnNpXcg=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/npm-release/package.json
+++ b/packages/@overeng/npm-release/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "@effect/platform-node": "4.0.0-rc.111",
+    "@overeng/utils-dev": "workspace:^",
     "@types/node": "26.0.0",
     "effect": "4.0.0-rc.111",
     "typescript": "6.0.3",
@@ -29,7 +30,8 @@
     "source": "package.json.genie.ts",
     "warning": "DO NOT EDIT - changes will be overwritten",
     "workspaceClosureDirs": [
-      "packages/@overeng/npm-release"
+      "packages/@overeng/npm-release",
+      "packages/@overeng/utils-dev"
     ]
   }
 }

--- a/packages/@overeng/npm-release/package.json.genie.ts
+++ b/packages/@overeng/npm-release/package.json.genie.ts
@@ -7,6 +7,7 @@ import {
   type PackageJsonInputData,
   workspaceMember,
 } from '../../../genie/internal.ts'
+import utilsDevPkg from '../utils-dev/package.json.genie.ts'
 
 /**
  * The `.` export is the decision layer and imports nothing at runtime, so consumers
@@ -18,9 +19,8 @@ const peerDepNames = ['@effect/platform-node', 'effect'] as const
 const workspaceDeps = catalog.compose({
   workspace: workspaceMember({ memberPath: 'packages/@overeng/npm-release' }),
   devDependencies: {
-    external: {
-      ...catalog.pick(...peerDepNames, '@types/node', 'typescript', 'vitest'),
-    },
+    workspace: [utilsDevPkg],
+    external: catalog.pick(...peerDepNames, '@types/node', 'typescript', 'vitest'),
   },
   peerDependencies: {
     external: catalog.pick(...peerDepNames),

--- a/packages/@overeng/npm-release/src/cli.contract.test.ts
+++ b/packages/@overeng/npm-release/src/cli.contract.test.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 
+import { normalizeCliOutput } from '@overeng/utils-dev/cli-contract'
 import { describe, expect, it } from 'vitest'
 
 const cliPath = fileURLToPath(new URL('./cli.ts', import.meta.url))
@@ -10,10 +11,6 @@ const cliPath = fileURLToPath(new URL('./cli.ts', import.meta.url))
  * usage, and error prose are captured for review but may be re-baselined by the npm-release owner
  * during Effect 4 repair with an alignment-register entry.
  */
-// LIVE-MIGRATION BRIDGE effect-3-4 B7 — DELETE at contraction — https://github.com/overengineeringstudio/effect-utils/issues/925
-const normalizeLogTime = (output: string) =>
-  output.replace(/^\[\d{2}:\d{2}:\d{2}\.\d{3}\]/gm, '[time]')
-// LIVE-MIGRATION END effect-3-4
 
 const runCli = (...args: ReadonlyArray<string>) => {
   const result = spawnSync('bun', [cliPath, ...args], {
@@ -24,10 +21,8 @@ const runCli = (...args: ReadonlyArray<string>) => {
   return {
     status: result.status,
     signal: result.signal,
-    // LIVE-MIGRATION BRIDGE effect-3-4 B7 — DELETE at contraction — https://github.com/overengineeringstudio/effect-utils/issues/925
-    stdout: normalizeLogTime(result.stdout),
-    stderr: normalizeLogTime(result.stderr),
-    // LIVE-MIGRATION END effect-3-4
+    stdout: normalizeCliOutput(result.stdout, { time: true }),
+    stderr: normalizeCliOutput(result.stderr, { time: true }),
   }
 }
 

--- a/packages/@overeng/npm-release/src/cli.contract.test.ts
+++ b/packages/@overeng/npm-release/src/cli.contract.test.ts
@@ -1,8 +1,9 @@
 import { spawnSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 
-import { normalizeCliOutput } from '@overeng/utils-dev/cli-contract'
 import { describe, expect, it } from 'vitest'
+
+import { normalizeCliOutput } from '@overeng/utils-dev/cli-contract'
 
 const cliPath = fileURLToPath(new URL('./cli.ts', import.meta.url))
 
@@ -21,8 +22,8 @@ const runCli = (...args: ReadonlyArray<string>) => {
   return {
     status: result.status,
     signal: result.signal,
-    stdout: normalizeCliOutput(result.stdout, { time: true }),
-    stderr: normalizeCliOutput(result.stderr, { time: true }),
+    stdout: normalizeCliOutput({ input: result.stdout, time: true }),
+    stderr: normalizeCliOutput({ input: result.stderr, time: true }),
   }
 }
 

--- a/packages/@overeng/npm-release/tsconfig.json
+++ b/packages/@overeng/npm-release/tsconfig.json
@@ -46,5 +46,10 @@
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
     "types": ["node"]
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "references": [
+    {
+      "path": "../utils-dev"
+    }
+  ]
 }

--- a/packages/@overeng/npm-release/tsconfig.json.genie.ts
+++ b/packages/@overeng/npm-release/tsconfig.json.genie.ts
@@ -12,4 +12,5 @@ export default tsconfigJson({
     ...nodeTypes,
   },
   include: ['src/**/*'],
+  references: [{ path: '../utils-dev' }],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/tui-stories/nix/build.nix
+++ b/packages/@overeng/tui-stories/nix/build.nix
@@ -21,7 +21,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-AkgMAayREi7bNfcIGNHEaBB16dWlZM8RxvwFrwvIKLU=";
+      "." = mkSharedHash "sha256-p6QQTbGTMAxTwWQUK5BDrhEQj09z4fKhHgC7SmkzqrY=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/tui-stories/test/cli.contract.test.ts
+++ b/packages/@overeng/tui-stories/test/cli.contract.test.ts
@@ -3,8 +3,9 @@ import { existsSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import { normalizeCliOutput } from '@overeng/utils-dev/cli-contract'
 import { describe, expect, it } from 'vitest'
+
+import { normalizeCliOutput } from '@overeng/utils-dev/cli-contract'
 
 const cliPath = fileURLToPath(new URL('../bin/tui-stories.tsx', import.meta.url))
 
@@ -38,8 +39,8 @@ const runCli = (...args: ReadonlyArray<string>) => {
   return {
     status: result.status,
     signal: result.signal,
-    stdout: normalizeCliOutput(result.stdout, { ansi: true, time: true, repoRoot }),
-    stderr: normalizeCliOutput(result.stderr, { ansi: true, time: true, repoRoot }),
+    stdout: normalizeCliOutput({ input: result.stdout, ansi: true, time: true, repoRoot }),
+    stderr: normalizeCliOutput({ input: result.stderr, ansi: true, time: true, repoRoot }),
   }
 }
 

--- a/packages/@overeng/tui-stories/test/cli.contract.test.ts
+++ b/packages/@overeng/tui-stories/test/cli.contract.test.ts
@@ -3,25 +3,10 @@ import { existsSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { normalizeCliOutput } from '@overeng/utils-dev/cli-contract'
 import { describe, expect, it } from 'vitest'
 
 const cliPath = fileURLToPath(new URL('../bin/tui-stories.tsx', import.meta.url))
-
-/**
- * CLI contract capture: `status` and `signal` are cross-major invariants; stdout/stderr help,
- * usage, and error prose are captured for review but may be re-baselined by the tui-stories owner
- * during Effect 4 repair with an alignment-register entry.
- * ANSI control bytes are normalized, so colour/styling changes are not gated by this baseline.
- * The local-source version suffix and log timestamps are normalized, so version-string content and
- * log timing are not gated by this baseline.
- */
-// LIVE-MIGRATION BRIDGE effect-3-4 B7 — DELETE at contraction — https://github.com/overengineeringstudio/effect-utils/issues/925
-const stripAnsi = (output: string) =>
-  output.replace(
-    // eslint-disable-next-line no-control-regex -- CLI contract snapshots intentionally normalize terminal control bytes.
-    /[\u001b\u009b][[\]()#;?]*(?:(?:(?:[a-zA-Z\d]*(?:;[a-zA-Z\d]*)*)?\u0007)|(?:(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~]))/gu,
-    '',
-  )
 
 // Walk up to the checkout root — segment-counting from import.meta.url is
 // unreliable here because bun resolves the module through megarepo symlinks.
@@ -35,14 +20,14 @@ const repoRoot = (() => {
   }
 })()
 
-const normalizeOutput = (output: string) =>
-  stripAnsi(output)
-    // v4 stderr embeds stack frames with absolute checkout paths; normalize so
-    // baselines stay stable across checkouts (same as genie's contract test).
-    .replaceAll(repoRoot, '<repo>')
-    .replace(/ — running from local source \([^)]+\)/gu, '')
-    .replace(/^\[\d{2}:\d{2}:\d{2}\.\d{3}\]/gmu, '[time]')
-// LIVE-MIGRATION END effect-3-4
+/**
+ * CLI contract capture: `status` and `signal` are cross-major invariants; stdout/stderr help,
+ * usage, and error prose are captured for review but may be re-baselined by the tui-stories owner
+ * during Effect 4 repair with an alignment-register entry.
+ * ANSI control bytes are normalized, so colour/styling changes are not gated by this baseline.
+ * The local-source version suffix and log timestamps are normalized, so version-string content and
+ * log timing are not gated by this baseline.
+ */
 
 const runCli = (...args: ReadonlyArray<string>) => {
   const result = spawnSync('bun', [cliPath, ...args], {
@@ -53,10 +38,8 @@ const runCli = (...args: ReadonlyArray<string>) => {
   return {
     status: result.status,
     signal: result.signal,
-    // LIVE-MIGRATION BRIDGE effect-3-4 B7 — DELETE at contraction — https://github.com/overengineeringstudio/effect-utils/issues/925
-    stdout: normalizeOutput(result.stdout),
-    stderr: normalizeOutput(result.stderr),
-    // LIVE-MIGRATION END effect-3-4
+    stdout: normalizeCliOutput(result.stdout, { ansi: true, time: true, repoRoot }),
+    stderr: normalizeCliOutput(result.stderr, { ansi: true, time: true, repoRoot }),
   }
 }
 

--- a/packages/@overeng/utils-dev/package.json
+++ b/packages/@overeng/utils-dev/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "exports": {
+    "./cli-contract": "./src/cli-contract.ts",
     "./node-vitest": "./src/node-vitest/mod.ts",
     "./node-vitest/setup-fast-check": "./src/node-vitest/setup-fast-check.ts",
     "./otelite": "./src/otelite/mod.ts"
@@ -13,7 +14,8 @@
     "exports": {
       "./node-vitest": "./dist/node-vitest/mod.js",
       "./node-vitest/setup-fast-check": "./dist/node-vitest/setup-fast-check.js",
-      "./otelite": "./dist/otelite/mod.js"
+      "./otelite": "./dist/otelite/mod.js",
+      "./cli-contract": "./dist/cli-contract.js"
     }
   },
   "devDependencies": {

--- a/packages/@overeng/utils-dev/package.json.genie.ts
+++ b/packages/@overeng/utils-dev/package.json.genie.ts
@@ -38,6 +38,7 @@ export default packageJson(
         environment: 'node',
       }),
       './otelite': exportEntry('./src/otelite/mod.ts', { environment: 'node' }),
+      './cli-contract': exportEntry('./src/cli-contract.ts', { environment: 'node' }),
     },
     publishConfig: {
       access: 'public',
@@ -45,6 +46,7 @@ export default packageJson(
         './node-vitest': './dist/node-vitest/mod.js',
         './node-vitest/setup-fast-check': './dist/node-vitest/setup-fast-check.js',
         './otelite': './dist/otelite/mod.js',
+        './cli-contract': './dist/cli-contract.js',
       },
     },
   },

--- a/packages/@overeng/utils-dev/src/cli-contract.test.ts
+++ b/packages/@overeng/utils-dev/src/cli-contract.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizeCliOutput } from './cli-contract.ts'
+
+describe('normalizeCliOutput', () => {
+  describe('ansi', () => {
+    it('strips CSI colour sequences when enabled', () => {
+      const input = '\u001b[31merror\u001b[0m: bad \u001b[1;32mthing\u001b[22m'
+      expect(normalizeCliOutput(input, { ansi: true })).toBe('error: bad thing')
+    })
+
+    it('strips OSC sequences terminated by BEL when enabled', () => {
+      const input = 'title\u001b]2;wintitle\u0007rest'
+      expect(normalizeCliOutput(input, { ansi: true })).toBe('titlerest')
+    })
+
+    it('preserves ANSI sequences when disabled', () => {
+      const input = '\u001b[31merror\u001b[0m'
+      expect(normalizeCliOutput(input, {})).toBe(input)
+    })
+  })
+
+  describe('time', () => {
+    it('masks log timestamps at line starts when enabled', () => {
+      const input = '[12:34:56.789] first\nplain\n[01:02:03.004] second'
+      expect(normalizeCliOutput(input, { time: true })).toBe(
+        '[time] first\nplain\n[time] second',
+      )
+    })
+
+    it('leaves bracketed text that is not a timestamp alone when enabled', () => {
+      expect(normalizeCliOutput('[not a time] x', { time: true })).toBe('[not a time] x')
+    })
+
+    it('preserves timestamps when disabled', () => {
+      const input = '[12:34:56.789] first'
+      expect(normalizeCliOutput(input, {})).toBe(input)
+    })
+  })
+
+  describe('repoRoot', () => {
+    it('replaces every occurrence of the checkout root when provided', () => {
+      const input = 'at /repo/packages/x/src/a.ts and /repo/packages/y'
+      expect(normalizeCliOutput(input, { repoRoot: '/repo' })).toBe(
+        'at <repo>/packages/x/src/a.ts and <repo>/packages/y',
+      )
+    })
+
+    it('does not treat the input as a pattern when provided', () => {
+      const input = 'path (x) and path (y)'
+      expect(normalizeCliOutput(input, { repoRoot: '(x)' })).toBe('path <repo> and path (y)')
+    })
+
+    it('rejects an empty repoRoot instead of splicing between every character', () => {
+      expect(() => normalizeCliOutput('abc', { repoRoot: '' })).toThrow()
+    })
+
+    it('leaves absolute paths untouched when omitted', () => {
+      const input = 'at /repo/src/a.ts'
+      expect(normalizeCliOutput(input, {})).toBe(input)
+    })
+  })
+
+  describe('local-source suffix', () => {
+    it('is masked unconditionally, including under an empty policy', () => {
+      const input = 'genie v4.0.0 — running from local source (/repo/packages/@overeng/genie)'
+      expect(normalizeCliOutput(input)).toBe('genie v4.0.0')
+    })
+  })
+
+  describe('combined policy', () => {
+    it('applies every requested mask in one pass', () => {
+      const input =
+        '[00:00:00.000] \u001b[36mgenie\u001b[39m v1 — running from local source (/repo/pkg)\n' +
+        '[00:00:00.001] at /repo/pkg/src/e.ts:1:2'
+      expect(normalizeCliOutput(input, { ansi: true, time: true, repoRoot: '/repo/pkg' })).toBe(
+        '[time] genie v1\n[time] at <repo>/src/e.ts:1:2',
+      )
+    })
+  })
+})

--- a/packages/@overeng/utils-dev/src/cli-contract.test.ts
+++ b/packages/@overeng/utils-dev/src/cli-contract.test.ts
@@ -6,65 +6,63 @@ describe('normalizeCliOutput', () => {
   describe('ansi', () => {
     it('strips CSI colour sequences when enabled', () => {
       const input = '\u001b[31merror\u001b[0m: bad \u001b[1;32mthing\u001b[22m'
-      expect(normalizeCliOutput(input, { ansi: true })).toBe('error: bad thing')
+      expect(normalizeCliOutput({ input, ansi: true })).toBe('error: bad thing')
     })
 
     it('strips OSC sequences terminated by BEL when enabled', () => {
       const input = 'title\u001b]2;wintitle\u0007rest'
-      expect(normalizeCliOutput(input, { ansi: true })).toBe('titlerest')
+      expect(normalizeCliOutput({ input, ansi: true })).toBe('titlerest')
     })
 
     it('preserves ANSI sequences when disabled', () => {
       const input = '\u001b[31merror\u001b[0m'
-      expect(normalizeCliOutput(input, {})).toBe(input)
+      expect(normalizeCliOutput({ input })).toBe(input)
     })
   })
 
   describe('time', () => {
     it('masks log timestamps at line starts when enabled', () => {
       const input = '[12:34:56.789] first\nplain\n[01:02:03.004] second'
-      expect(normalizeCliOutput(input, { time: true })).toBe(
-        '[time] first\nplain\n[time] second',
-      )
+      expect(normalizeCliOutput({ input, time: true })).toBe('[time] first\nplain\n[time] second')
     })
 
     it('leaves bracketed text that is not a timestamp alone when enabled', () => {
-      expect(normalizeCliOutput('[not a time] x', { time: true })).toBe('[not a time] x')
+      expect(normalizeCliOutput({ input: '[not a time] x', time: true })).toBe('[not a time] x')
     })
 
     it('preserves timestamps when disabled', () => {
       const input = '[12:34:56.789] first'
-      expect(normalizeCliOutput(input, {})).toBe(input)
+      expect(normalizeCliOutput({ input })).toBe(input)
     })
   })
 
   describe('repoRoot', () => {
     it('replaces every occurrence of the checkout root when provided', () => {
       const input = 'at /repo/packages/x/src/a.ts and /repo/packages/y'
-      expect(normalizeCliOutput(input, { repoRoot: '/repo' })).toBe(
+      expect(normalizeCliOutput({ input, repoRoot: '/repo' })).toBe(
         'at <repo>/packages/x/src/a.ts and <repo>/packages/y',
       )
     })
 
     it('does not treat the input as a pattern when provided', () => {
       const input = 'path (x) and path (y)'
-      expect(normalizeCliOutput(input, { repoRoot: '(x)' })).toBe('path <repo> and path (y)')
+      expect(normalizeCliOutput({ input, repoRoot: '(x)' })).toBe('path <repo> and path (y)')
     })
 
     it('rejects an empty repoRoot instead of splicing between every character', () => {
-      expect(() => normalizeCliOutput('abc', { repoRoot: '' })).toThrow()
+      expect(() => normalizeCliOutput({ input: 'abc', repoRoot: '' })).toThrow()
     })
 
     it('leaves absolute paths untouched when omitted', () => {
       const input = 'at /repo/src/a.ts'
-      expect(normalizeCliOutput(input, {})).toBe(input)
+      expect(normalizeCliOutput({ input })).toBe(input)
     })
   })
 
   describe('local-source suffix', () => {
     it('is masked unconditionally, including under an empty policy', () => {
       const input = 'genie v4.0.0 — running from local source (/repo/packages/@overeng/genie)'
-      expect(normalizeCliOutput(input)).toBe('genie v4.0.0')
+      expect(normalizeCliOutput({ input })).toBe('genie v4.0.0')
     })
   })
 
@@ -73,7 +71,7 @@ describe('normalizeCliOutput', () => {
       const input =
         '[00:00:00.000] \u001b[36mgenie\u001b[39m v1 — running from local source (/repo/pkg)\n' +
         '[00:00:00.001] at /repo/pkg/src/e.ts:1:2'
-      expect(normalizeCliOutput(input, { ansi: true, time: true, repoRoot: '/repo/pkg' })).toBe(
+      expect(normalizeCliOutput({ input, ansi: true, time: true, repoRoot: '/repo/pkg' })).toBe(
         '[time] genie v1\n[time] at <repo>/src/e.ts:1:2',
       )
     })

--- a/packages/@overeng/utils-dev/src/cli-contract.ts
+++ b/packages/@overeng/utils-dev/src/cli-contract.ts
@@ -23,7 +23,10 @@ export const TIME_TOKEN = '[time]'
 /** Replacement token written into the baseline in place of the checkout root. */
 export const REPO_TOKEN = '<repo>'
 
+/** Raw CLI output plus the explicit masking policy applied before baseline comparison. */
 export interface NormalizeCliOutputPolicy {
+  /** Raw CLI stdout/stderr captured from the spawned contract run. */
+  readonly input: string
   /**
    * Strip ANSI control sequences so colour/styling changes do not gate the
    * baseline. Default: `false`.
@@ -47,14 +50,22 @@ export interface NormalizeCliOutputPolicy {
  * baseline. See {@link NormalizeCliOutputPolicy} for the per-option masking
  * policy; the ` — running from local source (...)` version suffix is always
  * masked.
+ *
+ * @example
+ * normalizeCliOutput({ input: result.stdout, ansi: true, time: true, repoRoot })
  */
-export const normalizeCliOutput = (input: string, policy: NormalizeCliOutputPolicy = {}): string => {
+export const normalizeCliOutput = ({
+  input,
+  ansi = false,
+  time = false,
+  repoRoot,
+}: NormalizeCliOutputPolicy): string => {
   let output = input
-  if (policy.ansi === true) output = output.replace(ANSI_PATTERN, '')
-  if (policy.time === true) output = output.replace(LOG_TIME_PATTERN, '[time]')
-  if (policy.repoRoot !== undefined) {
-    if (policy.repoRoot === '') throw new Error('normalizeCliOutput: repoRoot must be non-empty')
-    output = output.replaceAll(policy.repoRoot, '<repo>')
+  if (ansi === true) output = output.replace(ANSI_PATTERN, '')
+  if (time === true) output = output.replace(LOG_TIME_PATTERN, TIME_TOKEN)
+  if (repoRoot !== undefined) {
+    if (repoRoot === '') throw new Error('normalizeCliOutput: repoRoot must be non-empty')
+    output = output.replaceAll(repoRoot, REPO_TOKEN)
   }
   return output.replace(LOCAL_SOURCE_SUFFIX_PATTERN, '')
 }

--- a/packages/@overeng/utils-dev/src/cli-contract.ts
+++ b/packages/@overeng/utils-dev/src/cli-contract.ts
@@ -1,0 +1,60 @@
+/**
+ * Shared normalization for CLI contract baselines (`cli.contract.test.ts`).
+ *
+ * Each option masks one machine-specific token class; options default to
+ * `false`, so each consumer states an explicit policy and silent drift between
+ * copies cannot happen. The local-source version suffix is always masked,
+ * because every contract test needs it regardless of policy.
+ */
+
+/** Broad ANSI/ECMA-48 control-sequence matcher used by the CLI contract baselines. */
+const ANSI_PATTERN =
+  // eslint-disable-next-line no-control-regex -- CLI contract snapshots intentionally normalize terminal control bytes.
+  /[\u001b\u009b][[\]()#;?]*(?:(?:(?:[a-zA-Z\d]*(?:;[a-zA-Z\d]*)*)?\u0007)|(?:(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~]))/gu
+
+const LOG_TIME_PATTERN = /^\[\d{2}:\d{2}:\d{2}\.\d{3}\]/gmu
+
+/** Version suffix appended by locally checked-out CLIs (` — running from local source (...)`). */
+const LOCAL_SOURCE_SUFFIX_PATTERN = / — running from local source \([^)]+\)/gu
+
+/** Replacement token written into the baseline in place of a log timestamp. */
+export const TIME_TOKEN = '[time]'
+
+/** Replacement token written into the baseline in place of the checkout root. */
+export const REPO_TOKEN = '<repo>'
+
+export interface NormalizeCliOutputPolicy {
+  /**
+   * Strip ANSI control sequences so colour/styling changes do not gate the
+   * baseline. Default: `false`.
+   */
+  readonly ansi?: boolean | undefined
+  /**
+   * Mask `[HH:MM:SS.mmm]` log timestamps as `[time]` so log timing does not
+   * gate the baseline. Default: `false`.
+   */
+  readonly time?: boolean | undefined
+  /**
+   * Replace occurrences of the given checkout-root path with `<repo>` so
+   * machine-specific absolute paths (e.g. embedded stack frames) do not gate
+   * the baseline. Root discovery stays caller-specific. Default: not applied.
+   */
+  readonly repoRoot?: string | undefined
+}
+
+/**
+ * Normalizes raw CLI stdout/stderr for snapshot comparison against a contract
+ * baseline. See {@link NormalizeCliOutputPolicy} for the per-option masking
+ * policy; the ` — running from local source (...)` version suffix is always
+ * masked.
+ */
+export const normalizeCliOutput = (input: string, policy: NormalizeCliOutputPolicy = {}): string => {
+  let output = input
+  if (policy.ansi === true) output = output.replace(ANSI_PATTERN, '')
+  if (policy.time === true) output = output.replace(LOG_TIME_PATTERN, '[time]')
+  if (policy.repoRoot !== undefined) {
+    if (policy.repoRoot === '') throw new Error('normalizeCliOutput: repoRoot must be non-empty')
+    output = output.replaceAll(policy.repoRoot, '<repo>')
+  }
+  return output.replace(LOCAL_SOURCE_SUFFIX_PATTERN, '')
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1170,6 +1170,9 @@ importers:
       '@effect/platform-node':
         specifier: 4.0.0-rc.111
         version: 4.0.0-rc.111(effect@4.0.0-rc.111)(redis@6.2.1(@opentelemetry/api@1.9.1))
+      '@overeng/utils-dev':
+        specifier: workspace:^
+        version: link:../utils-dev
       '@types/node':
         specifier: 26.0.0
         version: 26.0.0
@@ -6667,7 +6670,7 @@ snapshots:
       buffer-image-size: 0.6.4
       entities: 7.0.1
       whatwg-mimetype: 3.0.0
-      ws: 8.21.0
+      ws: 8.21.3
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate


### PR DESCRIPTION
Follow-up to #1109 (effect@4 rc.111). Closes #1118.

## Problem
Five packages duplicate CLI-contract output normalizers with visible drift (path/repo-root masking exists only in some copies), wrapped in dead LIVE-MIGRATION BRIDGE comment blocks.

## Change
- New shared helper in `@overeng/utils-dev`: export `./cli-contract`, `normalizeCliOutput(output, { ansi?, time?, repoRoot? })`.
  - Explicit per-caller policy (options default off) prevents silent drift; local-source-suffix masking always on (all copies did it); repoRoot is a caller-supplied string since discovery strategies differ (.git walk vs URL-derived).
  - 12 unit tests covering each mask independently + option-off preservation.
- All five contract suites migrated; all 10 LIVE-MIGRATION BRIDGE/END blocks removed. Policies: ci-tools `{ansi}`, genie/notion-cli/tui-stories `{ansi,time,repoRoot}`, npm-release `{time}`.
- npm-release gains the utils-dev devDependency via generator edits + genie regeneration.
- Existing snapshots unchanged (they contain none of the masked token classes) — verified across all five suites.

Note: the npm-release→utils-dev lockfile edge required refreshing 8 pnpm-deps FOD hashes in hand-written nix build.nix files (documented per-file procedure; evergreen has no hash-source mapping for these).

Closes #1118.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | unknown |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.0.3 |
| `agent_runtime` | OMP 18.0.3 |
| `tooling_profile` | dotfiles@ffce621 |
</details>
<!-- agent-footer:end -->