### PR TITLE
refactor(utils): make rewriteHelpSubcommand take pure user args (#1119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,13 @@ All notable changes to this project will be documented in this file.
   `andThen`/`catch`, string-union `LogLevel`, and `Metric.update`/
   `withAttributes` replace their removed v3 counterparts.
 
+- **@overeng/utils**: `rewriteHelpSubcommand` now takes and returns pure user
+  args instead of full `process.argv`. Callers must slice off the node/script
+  positions themselves (e.g. `rewriteHelpSubcommand(process.argv.slice(2))`);
+  passing full argv would silently misparse a leading `help` argument. The
+  behavior mapping `help <subcmd> [args...]` -> `<subcmd> --help [args...]` is
+  unchanged.
+
 ### Added
 
 - **devenv pnpm / Genie**: add root-local, read-only source generations for

--- a/context/effect-4/recipes/cli-contract.md
+++ b/context/effect-4/recipes/cli-contract.md
@@ -88,8 +88,8 @@ missing-required failure when the escaped positional is the required child argum
 | equals repeated flags | `ci-tools`, `tui-stories`                                         | v4 newly accepts equals form for `ci-tools` production-domain/build-env and `tui-stories --arg`; existing separate-form invocations are unchanged                                                                                                                                                                                              |
 | unknown flags         | every command                                                     | tracked commands have no variadic positional `Args`, so exit remains 1; the real change is v4 full help on stdout plus new stderr wording                                                                                                                                                                                                      |
 
-`megarepo`'s `rewriteHelpSubcommand(process.argv)` does not mitigate the terminator bug. It returns
-non-`help` argv unchanged (`utils/src/node/cli-help-rewrite.ts:2-8`), so
+`megarepo`'s `rewriteHelpSubcommand` does not mitigate the terminator bug. It returns
+non-`help` argv unchanged (`utils/src/node/cli-help-rewrite.ts:5-8`), so
 `mr add -- -dash-prefixed-repo` still reaches the broken v4 parser. For the custom
 `mr help add` form it appends `--help`; if the input itself contains `--`, the appended help flag
 lands after the terminator and is among the operands stranded on the parent. Normal

--- a/packages/@overeng/ci-tools/bin/ci-tools.ts
+++ b/packages/@overeng/ci-tools/bin/ci-tools.ts
@@ -29,7 +29,7 @@ const program = Effect.gen(function* () {
 
   yield* Cli.Command.runWith(ciToolsCommand, {
     version,
-  })(rewriteHelpSubcommand(process.argv).slice(2)).pipe(
+  })(rewriteHelpSubcommand(process.argv.slice(2))).pipe(
     Effect.scoped,
     CliVersion.enrichErrors,
     Effect.provideService(CliVersion, { name: 'ci-tools', version }),

--- a/packages/@overeng/genie/bin/genie.tsx
+++ b/packages/@overeng/genie/bin/genie.tsx
@@ -33,11 +33,7 @@ const program = Effect.gen(function* () {
 
   yield* Cli.Command.runWith(command, {
     version,
-  })(
-    // rewriteHelpSubcommand still speaks the effect 3 full-argv convention;
-    // v4 runWith wants pure args.
-    rewriteHelpSubcommand(process.argv).slice(2),
-  ).pipe(
+  })(rewriteHelpSubcommand(process.argv.slice(2))).pipe(
     Effect.scoped,
     CliVersion.enrichErrors,
     Effect.provideService(CliVersion, { name: 'genie', version }),

--- a/packages/@overeng/megarepo/bin/mr.ts
+++ b/packages/@overeng/megarepo/bin/mr.ts
@@ -69,7 +69,7 @@ const program = Effect.gen(function* () {
   })
 
   yield* Cli.Command.runWith(mrCommand, { version })(
-    rewriteHelpSubcommand(process.argv).slice(2),
+    rewriteHelpSubcommand(process.argv.slice(2)),
   ).pipe(
     Effect.scoped,
     CliVersion.enrichErrors,

--- a/packages/@overeng/megarepo/src/cli/mod.ts
+++ b/packages/@overeng/megarepo/src/cli/mod.ts
@@ -73,6 +73,4 @@ export const mrCommand = Cli.Command.make('mr').pipe(
 
 /** Exported CLI for external use */
 export const cli = (args: ReadonlyArray<string>) =>
-  Cli.Command.runWith(mrCommand, { version: MR_VERSION })(
-    rewriteHelpSubcommand(args),
-  )
+  Cli.Command.runWith(mrCommand, { version: MR_VERSION })(rewriteHelpSubcommand(args))

--- a/packages/@overeng/megarepo/src/cli/mod.ts
+++ b/packages/@overeng/megarepo/src/cli/mod.ts
@@ -74,5 +74,5 @@ export const mrCommand = Cli.Command.make('mr').pipe(
 /** Exported CLI for external use */
 export const cli = (args: ReadonlyArray<string>) =>
   Cli.Command.runWith(mrCommand, { version: MR_VERSION })(
-    rewriteHelpSubcommand(['mr', ...args]).slice(1),
+    rewriteHelpSubcommand(args),
   )

--- a/packages/@overeng/notion-cli/src/cli.ts
+++ b/packages/@overeng/notion-cli/src/cli.ts
@@ -157,9 +157,10 @@ const runNotionCliMain = async ({
     return
   }
 
-  // Effect v4 `Command.runWith` consumes user args only (no node/script prefix).
-  const rewrittenArgv = rewriteHelpSubcommand(argv).slice(2)
-  await runRootCli(rewrittenArgv)
+  // runNotionCliMain receives full argv; slice off the node/script positions at this
+  // boundary so the root-version check above keeps full-argv semantics while the helper
+  // and `runRootCli` see pure user args.
+  await runRootCli(rewriteHelpSubcommand(argv.slice(2)))
 }
 
 if (import.meta.main) {

--- a/packages/@overeng/tui-stories/bin/tui-stories.tsx
+++ b/packages/@overeng/tui-stories/bin/tui-stories.tsx
@@ -17,10 +17,8 @@ const version = resolveCliVersion({
   buildStamp,
 })
 
-// effect 4 CLI expects pure arguments (no program/script prefix), while
-// rewriteHelpSubcommand still speaks the effect 3 full-argv convention.
 Cli.Command.runWith(tuiStoriesCommand, { version })(
-  rewriteHelpSubcommand(process.argv).slice(2),
+  rewriteHelpSubcommand(process.argv.slice(2)),
 ).pipe(
   Effect.scoped,
   CliVersion.enrichErrors,

--- a/packages/@overeng/utils/src/node/cli-help-rewrite.ts
+++ b/packages/@overeng/utils/src/node/cli-help-rewrite.ts
@@ -1,9 +1,8 @@
-/** Rewrites `tool help <subcmd>` → `tool <subcmd> --help` for CLIs that lack a native `help` subcommand. */
-export const rewriteHelpSubcommand = (argv: readonly string[]): string[] => {
-  const [node, script, ...args] = argv
-  if (args[0] === 'help') {
-    const rest = args.slice(1)
-    return rest.length > 0 ? [node!, script!, ...rest, '--help'] : [node!, script!, '--help']
-  }
-  return [...argv]
+/**
+ * Rewrites `help <subcmd>` → `<subcmd> --help` for CLIs that lack a native `help` subcommand.
+ * Input and output are pure user args (no node/script positions).
+ */
+export const rewriteHelpSubcommand = (args: readonly string[]): string[] => {
+  const [head, ...rest] = args
+  return head === 'help' ? [...rest, '--help'] : [...args]
 }

--- a/packages/@overeng/utils/src/node/cli-help-rewrite.unit.test.ts
+++ b/packages/@overeng/utils/src/node/cli-help-rewrite.unit.test.ts
@@ -25,4 +25,12 @@ Vitest.describe('rewriteHelpSubcommand', () => {
   Vitest.it('preserves nested args: `help sub1 sub2` → `sub1 sub2 --help`', () => {
     expect(rewriteHelpSubcommand(['help', 'sub1', 'sub2'])).toEqual(['sub1', 'sub2', '--help'])
   })
+
+  Vitest.it('does not rewrite when `help` is not the first arg', () => {
+    expect(rewriteHelpSubcommand(['--flag', 'help', 'subcmd'])).toEqual(['--flag', 'help', 'subcmd'])
+  })
+
+  Vitest.it('passes through a leading `--` separator unchanged', () => {
+    expect(rewriteHelpSubcommand(['--', 'help', 'subcmd'])).toEqual(['--', 'help', 'subcmd'])
+  })
 })

--- a/packages/@overeng/utils/src/node/cli-help-rewrite.unit.test.ts
+++ b/packages/@overeng/utils/src/node/cli-help-rewrite.unit.test.ts
@@ -27,7 +27,11 @@ Vitest.describe('rewriteHelpSubcommand', () => {
   })
 
   Vitest.it('does not rewrite when `help` is not the first arg', () => {
-    expect(rewriteHelpSubcommand(['--flag', 'help', 'subcmd'])).toEqual(['--flag', 'help', 'subcmd'])
+    expect(rewriteHelpSubcommand(['--flag', 'help', 'subcmd'])).toEqual([
+      '--flag',
+      'help',
+      'subcmd',
+    ])
   })
 
   Vitest.it('passes through a leading `--` separator unchanged', () => {

--- a/packages/@overeng/utils/src/node/cli-help-rewrite.unit.test.ts
+++ b/packages/@overeng/utils/src/node/cli-help-rewrite.unit.test.ts
@@ -5,36 +5,24 @@ import { Vitest } from '@overeng/utils-dev/node-vitest'
 import { rewriteHelpSubcommand } from './cli-help-rewrite.ts'
 
 Vitest.describe('rewriteHelpSubcommand', () => {
-  Vitest.it('rewrites `tool help subcmd` → `tool subcmd --help`', () => {
-    expect(rewriteHelpSubcommand(['/usr/bin/node', '/app/cli.ts', 'help', 'commit'])).toEqual([
-      '/usr/bin/node',
-      '/app/cli.ts',
-      'commit',
-      '--help',
-    ])
+  Vitest.it('rewrites `help subcmd` → `subcmd --help`', () => {
+    expect(rewriteHelpSubcommand(['help', 'commit'])).toEqual(['commit', '--help'])
   })
 
-  Vitest.it('rewrites `tool help` (no subcmd) → `tool --help`', () => {
-    expect(rewriteHelpSubcommand(['/usr/bin/node', '/app/cli.ts', 'help'])).toEqual([
-      '/usr/bin/node',
-      '/app/cli.ts',
-      '--help',
-    ])
+  Vitest.it('rewrites `help` (no subcmd) → `--help`', () => {
+    expect(rewriteHelpSubcommand(['help'])).toEqual(['--help'])
   })
 
-  Vitest.it('passes through `tool subcmd --flag` unchanged', () => {
-    const argv = ['/usr/bin/node', '/app/cli.ts', 'subcmd', '--flag']
-    expect(rewriteHelpSubcommand(argv)).toEqual(argv)
+  Vitest.it('passes through `subcmd --flag` unchanged', () => {
+    const args = ['subcmd', '--flag']
+    expect(rewriteHelpSubcommand(args)).toEqual(args)
   })
 
-  Vitest.it('passes through `tool` (no args) unchanged', () => {
-    const argv = ['/usr/bin/node', '/app/cli.ts']
-    expect(rewriteHelpSubcommand(argv)).toEqual(argv)
+  Vitest.it('passes through empty input unchanged', () => {
+    expect(rewriteHelpSubcommand([])).toEqual([])
   })
 
-  Vitest.it('preserves nested args: `tool help sub1 sub2` → `tool sub1 sub2 --help`', () => {
-    expect(rewriteHelpSubcommand(['/usr/bin/node', '/app/cli.ts', 'help', 'sub1', 'sub2'])).toEqual(
-      ['/usr/bin/node', '/app/cli.ts', 'sub1', 'sub2', '--help'],
-    )
+  Vitest.it('preserves nested args: `help sub1 sub2` → `sub1 sub2 --help`', () => {
+    expect(rewriteHelpSubcommand(['help', 'sub1', 'sub2'])).toEqual(['sub1', 'sub2', '--help'])
   })
 })


### PR DESCRIPTION
Follow-up to #1109 (effect@4 rc.111). Closes #1119.

## Problem
`rewriteHelpSubcommand` accepts a full node/script argv (v3 `process.argv` convention), so every v4 caller must slice first — each differently. A future pure-args caller that forgets to slice silently loses its first two arguments.

## Change
- Helper now takes and returns pure user args; jsdoc states the contract.
- All six callers migrated, compensating `.slice()`s removed:
  - ci-tools, genie, megarepo bin/mr, tui-stories pass `process.argv.slice(2)`
  - notion-cli slices at the `runNotionCliMain` boundary after its full-argv root-version check
  - megarepo `src/cli/mod.ts` passes user args directly (drops the synthetic `['mr', ...args]` workaround)
- Unit tests rewritten for pure-args semantics incl. empty-input passthrough.
- Obsolete v3/v4 mismatch comments removed; recipe doc reference updated.

Clean breaking change: package is private workspace-only (no registry consumers). `tool help <subcmd>` → `tool <subcmd> --help` behavior preserved everywhere.

Closes #1119.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | unknown |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.0.3 |
| `agent_runtime` | OMP 18.0.3 |
| `tooling_profile` | dotfiles@ffce621 |
</details>
<!-- agent-footer:end -->