### PR TITLE
refactor(effect-4): adopt Context.Reference lazy defaults for optional services (#1117)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,17 @@ All notable changes to this project will be documented in this file.
   passing full argv would silently misparse a leading `help` argument. The
   behavior mapping `help <subcmd> [args...]` -> `<subcmd> --help [args...]` is
   unchanged.
+- **@overeng/notion-datasource-sync, @overeng/notion-md,
+  @overeng/notion-effect-client, @overeng/tui-react**: migrate optional
+  service tags to effect@4 `Context.Reference` with lazy defaults
+  (`SyncProgress`, `ProgressReporter`, `NotionHttpTelemetry`,
+  `NotionThrottle`, `ViewOutputStreamTag`; plus tui-react's internal
+  skip-mode flag). Absent provisions now resolve lazily to the same no-op /
+  pass-through / stdout defaults the old `Effect.serviceOption` branches
+  produced; explicit layers and `provideService` still win. The tags are
+  plain `Context.Reference` values now, not classes — type-level references
+  must use the exported shape types (e.g. `ProgressReporterShape`,
+  `NotionThrottleShape`) instead of the tag name.
 
 ### Added
 - **@overeng/utils-dev**: add a shared `normalizeCliOutput` helper at the

--- a/packages/@overeng/notion-datasource-sync/src/core/progress.ts
+++ b/packages/@overeng/notion-datasource-sync/src/core/progress.ts
@@ -1,4 +1,4 @@
-import { Context, Effect, Option, Schema } from 'effect'
+import { Context, Effect, Schema } from 'effect'
 
 /** Coarse operation phases emitted by sync code for CLI/TUI progress. */
 export const SyncProgressPhase = Schema.Literals([
@@ -56,18 +56,14 @@ export type SyncProgressReporter = {
   readonly report: (event: SyncProgressEvent) => Effect.Effect<void>
 }
 
-/** Optional Effect service used by CLI/TUI surfaces to observe sync progress. */
-export class SyncProgress extends Context.Service<SyncProgress, SyncProgressReporter>()(
-  '@overeng/notion-datasource-sync/SyncProgress',
-) {}
+/** Optional Effect service used by CLI/TUI surfaces to observe sync progress.
+ * Defaults lazily to a no-op reporter when not explicitly provided; an explicit
+ * `Effect.provideService` always wins. */
+export const SyncProgress: Context.Reference<SyncProgressReporter> =
+  Context.Reference<SyncProgressReporter>('@overeng/notion-datasource-sync/SyncProgress', {
+    defaultValue: () => ({ report: () => Effect.void }),
+  })
 
-/** Emits a sync progress event when the optional progress service is available. */
+/** Emits a sync progress event to the progress reporter (no-op by default). */
 export const reportSyncProgress = (event: SyncProgressEvent): Effect.Effect<void> =>
-  Effect.serviceOption(SyncProgress).pipe(
-    Effect.flatMap((service) =>
-      Option.match(service, {
-        onNone: () => Effect.void,
-        onSome: (progress) => progress.report(event),
-      }),
-    ),
-  )
+  Effect.flatMap(SyncProgress, (progress) => progress.report(event))

--- a/packages/@overeng/notion-effect-client/src/internal/http.ts
+++ b/packages/@overeng/notion-effect-client/src/internal/http.ts
@@ -54,11 +54,14 @@ export type NotionHttpTelemetryReporter = {
   readonly report: (event: NotionHttpTelemetryEvent) => Effect.Effect<void>
 }
 
-/** Optional Effect service used by callers that want realtime HTTP/rate-limit visibility. */
-export class NotionHttpTelemetry extends Context.Service<
-  NotionHttpTelemetry,
-  NotionHttpTelemetryReporter
->()('@overeng/notion-effect-client/NotionHttpTelemetry') {}
+/** Optional Effect service used by callers that want realtime HTTP/rate-limit visibility.
+ * Defaults lazily to a no-op reporter when not explicitly provided; an explicit
+ * `Effect.provideService` always wins. */
+export const NotionHttpTelemetry: Context.Reference<NotionHttpTelemetryReporter> =
+  Context.Reference<NotionHttpTelemetryReporter>(
+    '@overeng/notion-effect-client/NotionHttpTelemetry',
+    { defaultValue: () => ({ report: () => Effect.void }) },
+  )
 
 /** Options for building a Notion API request */
 export interface BuildRequestOptions {
@@ -263,14 +266,7 @@ const annotateRateLimitSpan = (input: {
 }): Effect.Effect<void> => annotateNotionHttpRateLimitSpan(input)
 
 const reportHttpTelemetry = (event: NotionHttpTelemetryEvent): Effect.Effect<void> =>
-  Effect.serviceOption(NotionHttpTelemetry).pipe(
-    Effect.flatMap((service) =>
-      Option.match(service, {
-        onNone: () => Effect.void,
-        onSome: (telemetry) => telemetry.report(event),
-      }),
-    ),
-  )
+  Effect.flatMap(NotionHttpTelemetry, (telemetry) => telemetry.report(event))
 
 /**
  * Build a Notion API request with proper headers.
@@ -590,11 +586,8 @@ export const executeRequest = <A, I, R>({
     const runOnce =
       retryEnabled === false ? makeRequest() : Effect.retry(makeRequest(), retrySchedule)
 
-    const throttle = yield* Effect.serviceOption(NotionThrottle)
-    return yield* Option.match(throttle, {
-      onNone: () => runOnce,
-      onSome: (service) => service.apply(runOnce),
-    })
+    const throttle = yield* NotionThrottle
+    return yield* throttle.apply(runOnce)
   }).pipe(withNotionHttpSpan({ method, route: notionHttpRouteInfo({ method, path }) }))
 
 /** Options for GET request */

--- a/packages/@overeng/notion-effect-client/src/internal/throttle.ts
+++ b/packages/@overeng/notion-effect-client/src/internal/throttle.ts
@@ -22,16 +22,22 @@ export interface NotionThrottleOptions {
 
 /**
  * Optional global request throttle, shared across all Notion API calls made
- * through the client for the lifetime of the layer. Absent ⇒ no throttling
- * (per-request retries still apply).
+ * through the client for the lifetime of the layer. Defaults lazily to a
+ * pass-through throttle (no throttling; per-request retries still apply);
+ * an explicit `Layer.succeed`/`Effect.provideService` always wins.
  *
  * `apply` wraps one logical request (the whole retry loop) so a single token is
  * consumed per request, not per retry attempt.
  */
-export class NotionThrottle extends Context.Service<
-  NotionThrottle,
-  { readonly apply: <A, E, R>(effect: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R> }
->()('@overeng/notion-effect-client/NotionThrottle') {}
+export interface NotionThrottleShape {
+  readonly apply: <A, E, R>(effect: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>
+}
+
+/** Optional global request throttle reference; see {@link NotionThrottleShape}. */
+export const NotionThrottle: Context.Reference<NotionThrottleShape> =
+  Context.Reference<NotionThrottleShape>('@overeng/notion-effect-client/NotionThrottle', {
+    defaultValue: () => ({ apply: (effect) => effect }),
+  })
 
 /**
  * Build a {@link NotionThrottle} layer backed by an Effect-native `RateLimiter`
@@ -39,7 +45,7 @@ export class NotionThrottle extends Context.Service<
  * 1-second window (refill one token every `window / limit` ms), with an
  * optional `burst` of buffered tokens as the bucket capacity.
  */
-export const NotionThrottleLive = (options: NotionThrottleOptions): Layer.Layer<NotionThrottle> =>
+export const NotionThrottleLive = (options: NotionThrottleOptions): Layer.Layer<never> =>
   Layer.effect(
     NotionThrottle,
     Effect.gen(function* () {

--- a/packages/@overeng/notion-effect-client/src/mod.ts
+++ b/packages/@overeng/notion-effect-client/src/mod.ts
@@ -118,7 +118,7 @@ export { NotionHttpTelemetry, notionHttpRouteInfo, parseRateLimitHeaders } from 
 // Rate-limit pressure metrics (decision 0017 Half 2)
 export { NotionRateLimitMetrics } from './internal/metrics.ts'
 // Request throttle
-export type { NotionThrottleOptions } from './internal/throttle.ts'
+export type { NotionThrottleOptions, NotionThrottleShape } from './internal/throttle.ts'
 export { NotionThrottle, NotionThrottleLive } from './internal/throttle.ts'
 // Markdown converter
 export type {

--- a/packages/@overeng/notion-md/src/cli-program.ts
+++ b/packages/@overeng/notion-md/src/cli-program.ts
@@ -1027,8 +1027,8 @@ const makeEditCommand = (name: string) =>
                    * Staged write-path progress (R43–R45, decision 0018): wire the
                    * live stderr-line reporter ONLY on the `edit` push path, and
                    * only when stderr is a TTY — a piped/redirected write provides
-                   * nothing (Layer.empty → serviceOption None → silent), keeping
-                   * the path byte-identical and pipe-safe (R44/R45). Constructed
+                   * nothing (Layer.empty → lazy no-op Reference default → silent),
+                   * keeping the path byte-identical and pipe-safe (R44/R45). Constructed
                    * lazily inside the handler (no TUI graph, no #787 TDZ risk).
                    */
                   Effect.provide(

--- a/packages/@overeng/notion-md/src/progress.ts
+++ b/packages/@overeng/notion-md/src/progress.ts
@@ -1,4 +1,4 @@
-import { Context, Effect, Layer, Option } from 'effect'
+import { Context, Effect, Layer } from 'effect'
 
 /**
  * Stable, CLI-facing stage vocabulary for a write-path sync (R43). These ids are
@@ -30,23 +30,29 @@ export interface ProgressReporterShape {
   readonly note: (message: string) => Effect.Effect<void>
 }
 
-/** Render seam for staged write-path sync progress (decision 0018, R43–R45). */
-export class ProgressReporter extends Context.Service<ProgressReporter, ProgressReporterShape>()(
-  'ProgressReporter',
-) {}
+/** Render seam for staged write-path sync progress (decision 0018, R43–R45).
+ * Defaults lazily to a no-op reporter when not explicitly provided; an explicit
+ * `Layer.succeed`/`Effect.provideService` always wins. */
+export const ProgressReporter: Context.Reference<ProgressReporterShape> =
+  Context.Reference<ProgressReporterShape>('ProgressReporter', {
+    defaultValue: () => ({
+      stageActive: () => Effect.void,
+      stageSucceed: () => Effect.void,
+      stageSkip: () => Effect.void,
+      stageFail: () => Effect.void,
+      note: () => Effect.void,
+    }),
+  })
 
 /**
  * Emit a reporter call without adding to the engine's `R`, and swallowing ALL
  * failures and defects (R45): a render glitch can never change a result or exit
- * code. `Effect.serviceOption` requires nothing in `R` (returns
- * `Option<Service>`), so the engine stays render-agnostic; when no Layer is
- * provided the emit is a silent no-op.
+ * code. Reading the Reference contributes nothing to `R`, so the engine stays
+ * render-agnostic; without an explicit provision the lazy default is a silent
+ * no-op.
  */
 const emit = (f: (r: ProgressReporterShape) => Effect.Effect<void>): Effect.Effect<void> =>
-  Effect.serviceOption(ProgressReporter).pipe(
-    Effect.flatMap(Option.match({ onNone: () => Effect.void, onSome: f })),
-    Effect.catchCause(() => Effect.void),
-  )
+  Effect.flatMap(ProgressReporter, f).pipe(Effect.catchCause(() => Effect.void))
 
 /** Emit an `active` transition for a stage. */
 export const reportStageActive = (stage: ProgressStage): Effect.Effect<void> =>
@@ -101,25 +107,22 @@ const writeLine = (line: string): Effect.Effect<void> =>
  * `ProgressReporter` Tag seam lets the animated `TaskList` Layer drop in later
  * with no engine re-touch.
  */
-export const ProgressReporterStderrLines: Layer.Layer<ProgressReporter> = Layer.succeed(
-  ProgressReporter,
-  {
-    stageActive: (stage) => writeLine(`  · ${stage.label} …`),
-    stageSucceed: (stage) =>
-      writeLine(
-        stage.message === undefined ? `  ✓ ${stage.label}` : `  ✓ ${stage.label}  ${stage.message}`,
-      ),
-    stageSkip: (stage) => writeLine(`  · ${stage.label} (skipped)`),
-    stageFail: (stage) => writeLine(`  ✗ ${stage.label}`),
-    note: (message) => writeLine(`note: ${message}`),
-  } satisfies ProgressReporterShape,
-)
+export const ProgressReporterStderrLines: Layer.Layer<never> = Layer.succeed(ProgressReporter, {
+  stageActive: (stage) => writeLine(`  · ${stage.label} …`),
+  stageSucceed: (stage) =>
+    writeLine(
+      stage.message === undefined ? `  ✓ ${stage.label}` : `  ✓ ${stage.label}  ${stage.message}`,
+    ),
+  stageSkip: (stage) => writeLine(`  · ${stage.label} (skipped)`),
+  stageFail: (stage) => writeLine(`  ✗ ${stage.label}`),
+  note: (message) => writeLine(`note: ${message}`),
+} satisfies ProgressReporterShape)
 
 /**
- * Explicit no-op Layer for tests/clarity. (Absence of a Layer already no-ops via
- * `serviceOption`; this just makes the intent provable.)
+ * Explicit no-op Layer for tests/clarity. (The Reference default already no-ops;
+ * this just makes the intent provable.)
  */
-export const ProgressReporterNoop: Layer.Layer<ProgressReporter> = Layer.succeed(ProgressReporter, {
+export const ProgressReporterNoop: Layer.Layer<never> = Layer.succeed(ProgressReporter, {
   stageActive: () => Effect.void,
   stageSucceed: () => Effect.void,
   stageSkip: () => Effect.void,

--- a/packages/@overeng/notion-md/src/progress.unit.test.ts
+++ b/packages/@overeng/notion-md/src/progress.unit.test.ts
@@ -21,7 +21,7 @@ type ProgressEvent =
   | { readonly kind: 'note'; readonly message: string }
 
 /** A `ProgressReporter` Layer that records every emitted transition for assertions. */
-const capturingLayer = (sink: ProgressEvent[]): Layer.Layer<ProgressReporter> =>
+const capturingLayer = (sink: ProgressEvent[]): Layer.Layer<never> =>
   Layer.succeed(ProgressReporter, {
     stageActive: (stage) => Effect.sync(() => void sink.push({ kind: 'active', stage })),
     stageSucceed: (stage) => Effect.sync(() => void sink.push({ kind: 'succeed', stage })),
@@ -31,7 +31,7 @@ const capturingLayer = (sink: ProgressEvent[]): Layer.Layer<ProgressReporter> =>
   } satisfies ProgressReporterShape)
 
 /** A `ProgressReporter` Layer whose every method defects/fails — proves emit swallows it. */
-const hostileLayer: Layer.Layer<ProgressReporter> = Layer.succeed(ProgressReporter, {
+const hostileLayer: Layer.Layer<never> = Layer.succeed(ProgressReporter, {
   stageActive: () => Effect.die(new Error('hostile stageActive')),
   stageSucceed: () => Effect.fail(new Error('hostile stageSucceed') as never),
   stageSkip: () => Effect.die(new Error('hostile stageSkip')),
@@ -42,7 +42,7 @@ const hostileLayer: Layer.Layer<ProgressReporter> = Layer.succeed(ProgressReport
 const runEdit = <A, E>(
   effect: Effect.Effect<A, E, NotionMdGateway | NmdStateStore | NodeServicesEnv>,
   gateway: FakeGateway,
-  progressLayer?: Layer.Layer<ProgressReporter>,
+  progressLayer?: Layer.Layer<never>,
 ) => {
   const base = Layer.mergeAll(gateway.layer, stateStoreLayer, NodeServices.layer)
   const layer = progressLayer === undefined ? base : Layer.merge(base, progressLayer)
@@ -57,7 +57,7 @@ const ids = (events: ProgressEvent[]): string[] =>
 
 describe('progress (staged write-path sync indicator)', () => {
   it('R45: the edit push result is identical with no / capturing / hostile reporter', async () => {
-    const run = (progressLayer?: Layer.Layer<ProgressReporter>) => {
+    const run = (progressLayer?: Layer.Layer<never>) => {
       const gateway = new FakeGateway({ title: 'Doc', body: 'original line' })
       return runEdit(
         editEditorPage({

--- a/packages/@overeng/tui-react/src/effect/OutputMode.node.ts
+++ b/packages/@overeng/tui-react/src/effect/OutputMode.node.ts
@@ -163,7 +163,7 @@ export const detectLayer: Layer.Layer<OutputModeTag> = Layer.sync(OutputModeTag,
  * Most entry points (`run`, interactive TUIs) want the view on stdout. Provide
  * this alongside your `OutputModeTag` layer so setup functions have a default.
  */
-export const viewOutputStreamStdoutLayer: Layer.Layer<ViewOutputStreamTag> = Layer.succeed(
+export const viewOutputStreamStdoutLayer: Layer.Layer<never> = Layer.succeed(
   ViewOutputStreamTag,
   process.stdout,
 )
@@ -175,7 +175,7 @@ export const viewOutputStreamStdoutLayer: Layer.Layer<ViewOutputStreamTag> = Lay
  * is reserved for the result payload. Callers generally should not provide it
  * explicitly.
  */
-export const viewOutputStreamStderrLayer: Layer.Layer<ViewOutputStreamTag> = Layer.succeed(
+export const viewOutputStreamStderrLayer: Layer.Layer<never> = Layer.succeed(
   ViewOutputStreamTag,
   process.stderr,
 )

--- a/packages/@overeng/tui-react/src/effect/OutputMode.tsx
+++ b/packages/@overeng/tui-react/src/effect/OutputMode.tsx
@@ -280,12 +280,15 @@ export class OutputModeTag extends Context.Service<OutputModeTag, OutputMode>()(
  * view never pollutes the result stream; other entry points default to stdout.
  *
  * Implementations are a Node `WriteStream`-shaped value (both `process.stdout`
- * and `process.stderr` qualify). Default and stderr layers are in the Node
- * entry point (`OutputMode.node.ts`) to keep this module browser-safe.
+ * and `process.stderr` qualify). The Reference default is `process.stdout`;
+ * explicit layers in the Node entry point (`OutputMode.node.ts`) still bind
+ * stdout/stderr and always win over the default. Resolving the default touches
+ * `process.stdout`, so browser behavior is unchanged (it errors there).
  */
-export class ViewOutputStreamTag extends Context.Service<ViewOutputStreamTag, NodeJS.WriteStream>()(
-  '@overeng/tui-react/ViewOutputStream',
-) {}
+export const ViewOutputStreamTag: Context.Reference<NodeJS.WriteStream> =
+  Context.Reference<NodeJS.WriteStream>('@overeng/tui-react/ViewOutputStream', {
+    defaultValue: () => process.stdout,
+  })
 
 // =============================================================================
 // Environment Helpers (browser-safe — use typeof process guards)

--- a/packages/@overeng/tui-react/src/effect/TuiApp.tsx
+++ b/packages/@overeng/tui-react/src/effect/TuiApp.tsx
@@ -50,7 +50,6 @@ import {
   Function as Fn,
   Layer,
   Logger,
-  Option,
   PubSub,
   Schema,
   Stream,
@@ -479,10 +478,7 @@ export const createTuiApp = <S, A>(config: TuiAppConfig<S, A>): TuiApp<S, A> => 
       }
 
       // Check if mode output should be skipped (set by standalone run() with output schema)
-      const skipModeOutput = Option.getOrElse(
-        yield* Effect.serviceOption(SkipModeOutputTag),
-        () => false,
-      )
+      const skipModeOutput = yield* SkipModeOutputTag
 
       // Setup mode-specific behavior (only when not using explicit output schema on run())
       if (skipModeOutput === false) {
@@ -616,10 +612,7 @@ const setupProgressiveVisualWithView = ({
     // Default to stdout when no explicit view stream is provided (e.g. interactive
     // `run`). `runResult` overrides this to stderr to keep stdout clean for the
     // result payload.
-    const viewStream = Option.getOrElse(
-      yield* Effect.serviceOption(ViewOutputStreamTag),
-      () => process.stdout,
-    )
+    const viewStream = yield* ViewOutputStreamTag
     const root = createRoot({ terminalOrStream: viewStream })
 
     // Wrapper that provides Registry via our own context (avoids multiple React instance issues)
@@ -666,10 +659,7 @@ const setupFinalVisualWithAtom = ({
     // Resolve the view output stream up-front so the finalizer writes to the
     // correct channel. `runResult` binds this to stderr; other callers default
     // to stdout.
-    const viewStream = Option.getOrElse(
-      yield* Effect.serviceOption(ViewOutputStreamTag),
-      () => process.stdout,
-    )
+    const viewStream = yield* ViewOutputStreamTag
 
     yield* Effect.addFinalizer(() =>
       Effect.gen(function* () {

--- a/packages/@overeng/tui-react/src/effect/cli.tsx
+++ b/packages/@overeng/tui-react/src/effect/cli.tsx
@@ -28,7 +28,7 @@ import { Flag } from 'effect/unstable/cli'
 
 import { createLogCapture } from './LogCapture.ts'
 import { detectOutputMode, viewOutputStreamStdoutLayer } from './OutputMode.node.ts'
-import type { OutputModeTag, ViewOutputStreamTag } from './OutputMode.tsx'
+import type { OutputModeTag } from './OutputMode.tsx'
 import {
   type OutputMode,
   tty,
@@ -181,9 +181,7 @@ export const outputModeLayer = (value: OutputModeValue): Layer.Layer<OutputModeT
  * Prefer this over `outputModeLayer` when wiring a CLI main — it gives you
  * both dependencies in one call. `runTuiMain` uses it internally.
  */
-export const tuiRuntimeLayer = (
-  value: OutputModeValue,
-): Layer.Layer<OutputModeTag | ViewOutputStreamTag> =>
+export const tuiRuntimeLayer = (value: OutputModeValue): Layer.Layer<OutputModeTag> =>
   Layer.merge(outputModeLayer(value), viewOutputStreamStdoutLayer)
 
 /**


### PR DESCRIPTION
Follow-up to #1109 (effect@4 rc.111). Closes #1117.

## Problem
Optional services were consumed via `Effect.serviceOption` + `Option.match` plumbing at every call site. Effect v4 `Context.Reference` lazy defaults make these services total: no `Option` unwrapping, nothing added to `R`, default computed once and cached.

## Change
Migrated all listed tags to `Context.Reference` with lazy defaults (clean break on exported type identity — package set is private workspace-only):

| Tag | Default |
|---|---|
| `SyncProgress` (notion-datasource-sync) | no-op reporter `{ report: () => Effect.void }` |
| `ProgressReporter` (notion-md) | no-op reporter; `catchCause` swallowing preserved |
| `NotionHttpTelemetry` (notion-effect-client) | no-op telemetry reporter |
| `NotionThrottle` (notion-effect-client) | pass-through `{ apply: (effect) => effect }`; shape interface exported |
| `SkipModeOutputTag` (tui-react) | already a Reference — now read directly |
| `ViewOutputStreamTag` (tui-react) | lazy `process.stdout`; explicit stdout/stderr layers and stderr override kept |

Semantics verified against rc.111 `Context.ts`: explicit Layer/provide always wins over the default; defaults compute lazily on first miss and cache on the reference object. Zero `serviceOption` usages remain at the target sites. All four packages' test suites + full workspace ts:check green.

Closes #1117.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | unknown |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.0.3 |
| `agent_runtime` | OMP 18.0.3 |
| `tooling_profile` | dotfiles@ffce621 |
</details>
<!-- agent-footer:end -->