### PR TITLE
fix(ci-tools): handle Vercel 'already in use' alias collisions deterministically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,7 @@ All notable changes to this project will be documented in this file.
   plain `Context.Reference` values now, not classes — type-level references
   must use the exported shape types (e.g. `ProgressReporterShape`,
   `NotionThrottleShape`) instead of the tag name.
+
 ### Fixed
 
 - **@overeng/ci-tools**: handle Vercel `already in use` alias collisions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,15 @@ All notable changes to this project will be documented in this file.
   plain `Context.Reference` values now, not classes — type-level references
   must use the exported shape types (e.g. `ProgressReporterShape`,
   `NotionThrottleShape`) instead of the tag name.
+### Fixed
+
+- **@overeng/ci-tools**: handle Vercel `already in use` alias collisions
+  deterministically: resolve the current holder on collision, succeed when it
+  is a deployment of the same commit, recheck once for a same-project holder,
+  and fail fast with an actionable error naming the remedy when the host is
+  held outside the project (`AliasAssignmentFailed` carries the classified
+  inner failure and attempt count; workflow-report records report true
+  attempts).
 
 ### Added
 

--- a/context/ci-tools/requirements.md
+++ b/context/ci-tools/requirements.md
@@ -85,8 +85,9 @@ This document is constrained by [vision.md](./vision.md) and is implemented by
 - **R18 Hermetic task E2E:** Required E2E must exercise the real task launcher,
   real `ci-tools` CLI, and fake providers without external credentials.
 - **R19 Provider fake E2E:** Provider tests must cover success, lookup failure,
-  unauthorized credentials, invalid provider output, unsafe alias refusal, and
-  redaction.
+  unauthorized credentials, invalid provider output, unsafe alias refusal,
+  alias collision handling (same-commit holder, released holder, own-project
+  persistent holder, foreign-held holder), and redaction.
 - **R20 Live E2E guardrails:** Live E2E must require an explicit shared-project
   mode and reserved alias namespace before deploying to shared provider projects.
 - **R21 Live marker verification:** Live E2E must fetch the final deploy URL and

--- a/context/ci-tools/spec.md
+++ b/context/ci-tools/spec.md
@@ -203,17 +203,17 @@ Requirement trace: R06, R17.
 Expected failures are represented as `Schema.TaggedError` classes. The initial
 tags are:
 
-| Error tag                     | Retryable   | Meaning                                                                  |
-| ----------------------------- | ----------- | ------------------------------------------------------------------------ |
-| `MissingAuth`                 | no          | Required provider token env var is absent or empty                       |
-| `Unauthorized`                | no          | Provider rejected the token or account access                            |
-| `MissingBuildOutput`          | no          | Local artifact directory does not exist                                  |
-| `ProviderProjectLookupFailed` | yes         | Provider project/site lookup failed or returned incomplete metadata      |
-| `InvalidProviderOutput`       | no          | Provider CLI/API response does not decode to the expected schema         |
-| `ProviderOperationFailed`     | conditional | Provider command/API failed without a more specific classification       |
+| Error tag                     | Retryable   | Meaning                                                                                                          |
+| ----------------------------- | ----------- | ---------------------------------------------------------------------------------------------------------------- |
+| `MissingAuth`                 | no          | Required provider token env var is absent or empty                                                               |
+| `Unauthorized`                | no          | Provider rejected the token or account access                                                                    |
+| `MissingBuildOutput`          | no          | Local artifact directory does not exist                                                                          |
+| `ProviderProjectLookupFailed` | yes         | Provider project/site lookup failed or returned incomplete metadata                                              |
+| `InvalidProviderOutput`       | no          | Provider CLI/API response does not decode to the expected schema                                                 |
+| `ProviderOperationFailed`     | conditional | Provider command/API failed without a more specific classification                                               |
 | `AliasAssignmentFailed`       | no          | Alias could not be assigned after collision handling; carries the classified inner failure and the attempt count |
-| `UnsafeE2EAlias`              | no          | Live E2E attempted a shared-project alias outside the reserved namespace |
-| `VerificationFailed`          | yes         | Deployed URL did not serve the expected local fixture content            |
+| `UnsafeE2EAlias`              | no          | Live E2E attempted a shared-project alias outside the reserved namespace                                         |
+| `VerificationFailed`          | yes         | Deployed URL did not serve the expected local fixture content                                                    |
 
 Unexpected defects remain defects. They are not converted into expected domain
 errors unless the boundary has enough information to classify them.

--- a/context/ci-tools/spec.md
+++ b/context/ci-tools/spec.md
@@ -211,6 +211,7 @@ tags are:
 | `ProviderProjectLookupFailed` | yes         | Provider project/site lookup failed or returned incomplete metadata      |
 | `InvalidProviderOutput`       | no          | Provider CLI/API response does not decode to the expected schema         |
 | `ProviderOperationFailed`     | conditional | Provider command/API failed without a more specific classification       |
+| `AliasAssignmentFailed`       | no          | Alias could not be assigned after collision handling; carries the classified inner failure and the attempt count |
 | `UnsafeE2EAlias`              | no          | Live E2E attempted a shared-project alias outside the reserved namespace |
 | `VerificationFailed`          | yes         | Deployed URL did not serve the expected local fixture content            |
 
@@ -303,6 +304,16 @@ first runs `vercel pull` and `vercel build` locally, then passes the resulting
 `.vercel/output` directory to `ci-tools deploy vercel --artifact-kind
 prebuilt-output`. Team projects may pass `--scope-env` so the provider CLI is
 scoped without committing account identifiers.
+
+Prod and PR modes assign a deterministic `<aliasPrefix or target>.vercel.app`
+host (PR mode appends `-pr-<number>`). When Vercel reports the host as already
+in use, the adapter resolves the current holder: a deployment of the same
+commit succeeds immediately, a same-project holder is rechecked exactly once,
+and a holder outside the project fails fast with `AliasAssignmentFailed` whose
+message names the remedy (`--alias-prefix` with a globally unique value, or an
+explicit production domain). `*.vercel.app` hosts are a global namespace across
+Vercel accounts, so a derived name claimed by another account can never be
+assigned.
 
 Requirement trace: R13, R14, R15, R16, R17.
 

--- a/packages/@overeng/ci-tools/src/deploy-domain.ts
+++ b/packages/@overeng/ci-tools/src/deploy-domain.ts
@@ -335,7 +335,7 @@ export class AliasAssignmentFailed extends Schema.TaggedError<AliasAssignmentFai
   '@overeng/ci-tools/deploy/AliasAssignmentFailed',
 )('AliasAssignmentFailed', {
   failure: DeployFailure,
-  attempts: Schema.Positive,
+  attempts: PositiveInt,
 }) {}
 
 export const deployFailureRetryability = (failure: DeployFailure): boolean => {

--- a/packages/@overeng/ci-tools/src/deploy-domain.ts
+++ b/packages/@overeng/ci-tools/src/deploy-domain.ts
@@ -330,6 +330,14 @@ export const DeployFailure = Schema.Union([
 ]).annotate({ identifier: 'CiTools.Deploy.Failure' })
 export type DeployFailure = typeof DeployFailure.Type
 
+/** Raised when a Vercel alias could not be assigned after collision handling. */
+export class AliasAssignmentFailed extends Schema.TaggedError<AliasAssignmentFailed>(
+  '@overeng/ci-tools/deploy/AliasAssignmentFailed',
+)('AliasAssignmentFailed', {
+  failure: DeployFailure,
+  attempts: Schema.Positive,
+}) {}
+
 export const deployFailureRetryability = (failure: DeployFailure): boolean => {
   switch (failure._tag) {
     case 'ProviderProjectLookupFailed':

--- a/packages/@overeng/ci-tools/src/deploy-vercel.e2e.test.ts
+++ b/packages/@overeng/ci-tools/src/deploy-vercel.e2e.test.ts
@@ -103,10 +103,17 @@ const runCiTools = async (opts: {
 beforeAll(async () => {
   server = createServer((request, response) => {
     if (request.url?.startsWith('/v13/deployments/') === true) {
-      const ref = decodeURIComponent(
-        request.url.slice('/v13/deployments/'.length).split('?')[0] ?? '',
-      )
+      const url = new URL(request.url, 'http://localhost')
+      if (url.searchParams.get('teamId') !== 'fake-org') {
+        response.writeHead(400, { connection: 'close' }).end('missing team scope')
+        return
+      }
+      const ref = decodeURIComponent(url.pathname.slice('/v13/deployments/'.length))
       const commitSha = deploymentCommitShas[ref]
+      if (commitSha === 'transport-error') {
+        request.socket.destroy()
+        return
+      }
       if (commitSha === undefined) {
         response.writeHead(404, { connection: 'close' }).end('not found')
         return
@@ -117,6 +124,11 @@ beforeAll(async () => {
       return
     }
     if (request.url?.startsWith('/v4/aliases/') === true) {
+      const url = new URL(request.url, 'http://localhost')
+      if (url.searchParams.get('teamId') !== 'fake-org') {
+        response.writeHead(400, { connection: 'close' }).end('missing team scope')
+        return
+      }
       if (aliasHolder === undefined) {
         response.writeHead(404, { connection: 'close' }).end('not found')
         return
@@ -814,6 +826,34 @@ exit 1
       })
       expect(record.summary).toMatch(/alias/iu)
       expect(JSON.stringify(record)).toContain('already in use')
+    } finally {
+      rmSync(workspace.root, { recursive: true, force: true })
+    }
+  })
+
+  it('records the collision failure when deployment metadata is unavailable', async () => {
+    apiMode = 'ok'
+    deploymentCommitShas = { 'dpl-holder': 'transport-error' }
+    aliasHolder = { deploymentId: 'dpl-holder', projectId: 'fake-project' }
+    const workspace = makeCollisionWorkspace()
+    const reportFile = join(workspace.root, 'report.jsonl')
+    try {
+      const result = await runCiTools({
+        workdir: workspace.root,
+        fakeVercelBin: workspace.fakeVercelBin,
+        reportFile,
+        args: prodDeployArgs(workspace),
+        env: { FAKE_VERCEL_ALIAS_MODE: 'permanent' },
+      })
+      expect(result.status).not.toBe(0)
+      expect(countAliasAttempts(workspace.logPath)).toBe(2)
+      const record = readRecord(reportFile)
+      expect(record.data).toMatchObject({
+        errorKind: 'ProviderOperationFailed',
+        retryable: false,
+        attempts: 2,
+      })
+      expect(record.summary).toMatch(/alias/iu)
     } finally {
       rmSync(workspace.root, { recursive: true, force: true })
     }

--- a/packages/@overeng/ci-tools/src/deploy-vercel.e2e.test.ts
+++ b/packages/@overeng/ci-tools/src/deploy-vercel.e2e.test.ts
@@ -21,6 +21,8 @@ const cliPath = join(repoRoot, 'packages/@overeng/ci-tools/bin/ci-tools.ts')
 let apiMode: ApiMode = 'ok'
 let server: Server
 let apiBaseUrl = ''
+let deploymentCommitShas: Record<string, string> = {}
+let aliasHolder: { readonly deploymentId: string; readonly projectId?: string } | undefined
 
 const testProcessEnv = () => {
   const { DEVENV_TASK_OUTPUT_FILE: _taskOutputFile, ...env } = process.env
@@ -34,6 +36,7 @@ const readRecord = (path: string) => {
   if (line === undefined) throw new Error(`No workflow report record in ${path}`)
   return JSON.parse(line.slice('WORKFLOW_REPORT_V1: '.length)) as {
     readonly status: string
+    readonly summary?: string
     readonly links?: readonly { readonly url: string }[]
     readonly data?: Record<string, unknown>
   }
@@ -99,6 +102,30 @@ const runCiTools = async (opts: {
 
 beforeAll(async () => {
   server = createServer((request, response) => {
+    if (request.url?.startsWith('/v13/deployments/') === true) {
+      const ref = decodeURIComponent(
+        request.url.slice('/v13/deployments/'.length).split('?')[0] ?? '',
+      )
+      const commitSha = deploymentCommitShas[ref]
+      if (commitSha === undefined) {
+        response.writeHead(404, { connection: 'close' }).end('not found')
+        return
+      }
+      response
+        .writeHead(200, { 'content-type': 'application/json', connection: 'close' })
+        .end(JSON.stringify({ meta: { githubCommitSha: commitSha } }))
+      return
+    }
+    if (request.url?.startsWith('/v4/aliases/') === true) {
+      if (aliasHolder === undefined) {
+        response.writeHead(404, { connection: 'close' }).end('not found')
+        return
+      }
+      response
+        .writeHead(200, { 'content-type': 'application/json', connection: 'close' })
+        .end(JSON.stringify(aliasHolder))
+      return
+    }
     if (request.url !== '/v9/projects/fake-project?teamId=fake-org') {
       response.writeHead(404, { connection: 'close' }).end('not found')
       return
@@ -622,6 +649,200 @@ exit 1
       })
       expect(result.status).not.toBe(0)
       expect(readRecord(reportFile).data).toMatchObject({ errorKind: 'UnsafeE2EAlias' })
+    } finally {
+      rmSync(workspace.root, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('ci-tools deploy vercel alias collisions', () => {
+  type CollisionWorkspace = {
+    readonly root: string
+    readonly artifactDir: string
+    readonly fakeVercelBin: string
+    readonly logPath: string
+  }
+
+  const makeCollisionWorkspace = () => {
+    const root = mkdtempSync(join(tmpdir(), 'ci-tools-vercel-alias-'))
+    const artifactDir = join(root, 'static')
+    const binDir = join(root, 'bin')
+    mkdirSync(artifactDir)
+    mkdirSync(binDir)
+    writeFileSync(join(artifactDir, 'index.html'), 'vercel static marker')
+    const logPath = join(root, 'vercel.log')
+    const fakeVercelBin = join(binDir, 'vercel')
+    writeFileSync(
+      fakeVercelBin,
+      `#!/usr/bin/env bash
+set -euo pipefail
+printf 'cwd=%s args=%s\\n' "$PWD" "$*" >> "${logPath}"
+if [ "\${1:-}" = "deploy" ]; then
+  printf 'https://deploy-web.vercel.app\\n'
+  exit 0
+fi
+if [ "\${1:-}" = "alias" ]; then
+  case "\${FAKE_VERCEL_ALIAS_MODE:-permanent}" in
+    same-commit)
+      echo 'Error: The chosen alias "ptg.vercel.app" is already in use.' >&2
+      exit 1
+      ;;
+    release-after-retry)
+      attempts=$(( $(cat "\${FAKE_VERCEL_ATTEMPTS_FILE}" 2>/dev/null || echo 0) + 1 ))
+      printf '%s\\n' "$attempts" > "\${FAKE_VERCEL_ATTEMPTS_FILE}"
+      if [ "$attempts" -ge 2 ]; then
+        printf 'Aliased %s to %s\\n' "\${2:-}" "\${3:-}"
+        exit 0
+      fi
+      echo 'Error: The chosen alias "ptg.vercel.app" is already in use.' >&2
+      exit 1
+      ;;
+    *)
+      echo 'Error: The chosen alias "ptg.vercel.app" is already in use.' >&2
+      exit 1
+      ;;
+  esac
+fi
+echo "unexpected fake vercel invocation: $*" >&2
+exit 1
+`,
+      { mode: 0o755 },
+    )
+    return { root, artifactDir, fakeVercelBin, logPath }
+  }
+
+  const countAliasAttempts = (logPath: string) =>
+    (readFileSync(logPath, 'utf8').match(/args=alias /gu) ?? []).length
+
+  const prodDeployArgs = (workspace: CollisionWorkspace) => [
+    '--target',
+    'ptg',
+    '--artifact-dir',
+    workspace.artifactDir,
+    '--mode',
+    'prod',
+    '--scope-env',
+    'VERCEL_SCOPE',
+  ]
+
+  it('succeeds when an already-in-use alias is held by a deployment of the same commit', async () => {
+    apiMode = 'ok'
+    deploymentCommitShas = { 'deploy-web.vercel.app': 'sha-main', 'dpl-holder': 'sha-main' }
+    aliasHolder = { deploymentId: 'dpl-holder', projectId: 'fake-project' }
+    const workspace = makeCollisionWorkspace()
+    const reportFile = join(workspace.root, 'report.jsonl')
+    try {
+      const result = await runCiTools({
+        workdir: workspace.root,
+        fakeVercelBin: workspace.fakeVercelBin,
+        reportFile,
+        args: prodDeployArgs(workspace),
+        env: { FAKE_VERCEL_ALIAS_MODE: 'same-commit' },
+      })
+      if (result.status !== 0) {
+        console.error({ stdout: result.stdout, stderr: result.stderr })
+      }
+      expect(result.status).toBe(0)
+      expect(result.stdout).toContain('Vercel deploy URL: https://ptg.vercel.app')
+      expect(countAliasAttempts(workspace.logPath)).toBe(1)
+      const record = readRecord(reportFile)
+      expect(record.status).toBe('success')
+      expect(record.data).toMatchObject({
+        provider: 'vercel',
+        target: 'ptg',
+        mode: 'prod',
+        alias: 'ptg',
+        finalUrl: 'https://ptg.vercel.app/',
+        rawDeployUrl: 'https://deploy-web.vercel.app/',
+      })
+    } finally {
+      rmSync(workspace.root, { recursive: true, force: true })
+    }
+  })
+  it('rechecks once and succeeds when our project releases the alias', async () => {
+    apiMode = 'ok'
+    deploymentCommitShas = { 'deploy-web.vercel.app': 'sha-main', 'dpl-holder': 'sha-cron' }
+    aliasHolder = { deploymentId: 'dpl-holder', projectId: 'fake-project' }
+    const workspace = makeCollisionWorkspace()
+    const reportFile = join(workspace.root, 'report.jsonl')
+    try {
+      const result = await runCiTools({
+        workdir: workspace.root,
+        fakeVercelBin: workspace.fakeVercelBin,
+        reportFile,
+        args: prodDeployArgs(workspace),
+        env: {
+          FAKE_VERCEL_ALIAS_MODE: 'release-after-retry',
+          FAKE_VERCEL_ATTEMPTS_FILE: join(workspace.root, 'alias-attempts'),
+        },
+      })
+      if (result.status !== 0) {
+        console.error({ stdout: result.stdout, stderr: result.stderr })
+      }
+      expect(result.status).toBe(0)
+      expect(result.stdout).toContain('Vercel deploy URL: https://ptg.vercel.app')
+      expect(countAliasAttempts(workspace.logPath)).toBe(2)
+      const record = readRecord(reportFile)
+      expect(record.status).toBe('success')
+      expect(record.data).toMatchObject({ alias: 'ptg', finalUrl: 'https://ptg.vercel.app/' })
+    } finally {
+      rmSync(workspace.root, { recursive: true, force: true })
+    }
+  })
+
+  it('fails after one immediate recheck when our project keeps holding the alias', async () => {
+    apiMode = 'ok'
+    deploymentCommitShas = { 'deploy-web.vercel.app': 'sha-main', 'dpl-holder': 'sha-cron' }
+    aliasHolder = { deploymentId: 'dpl-holder', projectId: 'fake-project' }
+    const workspace = makeCollisionWorkspace()
+    const reportFile = join(workspace.root, 'report.jsonl')
+    try {
+      const result = await runCiTools({
+        workdir: workspace.root,
+        fakeVercelBin: workspace.fakeVercelBin,
+        reportFile,
+        args: prodDeployArgs(workspace),
+        env: { FAKE_VERCEL_ALIAS_MODE: 'permanent' },
+      })
+      expect(result.status).not.toBe(0)
+      expect(countAliasAttempts(workspace.logPath)).toBe(2)
+      const record = readRecord(reportFile)
+      expect(record.data).toMatchObject({
+        errorKind: 'ProviderOperationFailed',
+        retryable: false,
+        attempts: 2,
+      })
+      expect(record.summary).toMatch(/alias/iu)
+      expect(JSON.stringify(record)).toContain('already in use')
+    } finally {
+      rmSync(workspace.root, { recursive: true, force: true })
+    }
+  })
+
+  it('fails fast with an actionable error when the alias is held outside the project', async () => {
+    apiMode = 'ok'
+    deploymentCommitShas = { 'deploy-web.vercel.app': 'sha-main' }
+    aliasHolder = undefined
+    const workspace = makeCollisionWorkspace()
+    const reportFile = join(workspace.root, 'report.jsonl')
+    try {
+      const result = await runCiTools({
+        workdir: workspace.root,
+        fakeVercelBin: workspace.fakeVercelBin,
+        reportFile,
+        args: prodDeployArgs(workspace),
+        env: { FAKE_VERCEL_ALIAS_MODE: 'same-commit' },
+      })
+      expect(result.status).not.toBe(0)
+      expect(countAliasAttempts(workspace.logPath)).toBe(1)
+      const record = readRecord(reportFile)
+      expect(record.summary).toMatch(/--alias-prefix/iu)
+      expect(record.summary).toContain('ptg.vercel.app')
+      expect(record.data).toMatchObject({
+        errorKind: 'ProviderOperationFailed',
+        retryable: false,
+        attempts: 1,
+      })
     } finally {
       rmSync(workspace.root, { recursive: true, force: true })
     }

--- a/packages/@overeng/ci-tools/src/deploy-vercel.e2e.test.ts
+++ b/packages/@overeng/ci-tools/src/deploy-vercel.e2e.test.ts
@@ -15,10 +15,12 @@ import { join, resolve } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
 type ApiMode = 'ok' | 'unauthorized' | 'missing' | 'blank-project'
+type AliasApiMode = 'ok' | 'transient-error' | 'transport-error'
 
 const repoRoot = resolve(import.meta.dirname, '../../../..')
 const cliPath = join(repoRoot, 'packages/@overeng/ci-tools/bin/ci-tools.ts')
 let apiMode: ApiMode = 'ok'
+let aliasApiMode: AliasApiMode = 'ok'
 let server: Server
 let apiBaseUrl = ''
 let deploymentCommitShas: Record<string, string> = {}
@@ -127,6 +129,14 @@ beforeAll(async () => {
       const url = new URL(request.url, 'http://localhost')
       if (url.searchParams.get('teamId') !== 'fake-org') {
         response.writeHead(400, { connection: 'close' }).end('missing team scope')
+        return
+      }
+      if (aliasApiMode === 'transient-error') {
+        response.writeHead(503, { connection: 'close' }).end('temporarily unavailable')
+        return
+      }
+      if (aliasApiMode === 'transport-error') {
+        request.socket.destroy()
         return
       }
       if (aliasHolder === undefined) {
@@ -766,6 +776,7 @@ exit 1
         alias: 'ptg',
         finalUrl: 'https://ptg.vercel.app/',
         rawDeployUrl: 'https://deploy-web.vercel.app/',
+        attempts: 1,
       })
     } finally {
       rmSync(workspace.root, { recursive: true, force: true })
@@ -796,7 +807,11 @@ exit 1
       expect(countAliasAttempts(workspace.logPath)).toBe(2)
       const record = readRecord(reportFile)
       expect(record.status).toBe('success')
-      expect(record.data).toMatchObject({ alias: 'ptg', finalUrl: 'https://ptg.vercel.app/' })
+      expect(record.data).toMatchObject({
+        alias: 'ptg',
+        finalUrl: 'https://ptg.vercel.app/',
+        attempts: 2,
+      })
     } finally {
       rmSync(workspace.root, { recursive: true, force: true })
     }
@@ -884,6 +899,37 @@ exit 1
         attempts: 1,
       })
     } finally {
+      rmSync(workspace.root, { recursive: true, force: true })
+    }
+  })
+
+  it.each([
+    ['transient-error', 'ProviderOperationFailed'],
+    ['transport-error', 'ProviderProjectLookupFailed'],
+  ] as const)('preserves %s alias lookup failures as retryable', async (mode, errorKind) => {
+    apiMode = 'ok'
+    aliasApiMode = mode
+    deploymentCommitShas = {}
+    aliasHolder = undefined
+    const workspace = makeCollisionWorkspace()
+    const reportFile = join(workspace.root, 'report.jsonl')
+    try {
+      const result = await runCiTools({
+        workdir: workspace.root,
+        fakeVercelBin: workspace.fakeVercelBin,
+        reportFile,
+        args: prodDeployArgs(workspace),
+        env: { FAKE_VERCEL_ALIAS_MODE: 'permanent' },
+      })
+      expect(result.status).not.toBe(0)
+      expect(countAliasAttempts(workspace.logPath)).toBe(1)
+      expect(readRecord(reportFile).data).toMatchObject({
+        errorKind,
+        retryable: true,
+        attempts: 1,
+      })
+    } finally {
+      aliasApiMode = 'ok'
       rmSync(workspace.root, { recursive: true, force: true })
     }
   })

--- a/packages/@overeng/ci-tools/src/deploy-vercel.ts
+++ b/packages/@overeng/ci-tools/src/deploy-vercel.ts
@@ -46,8 +46,8 @@ import {
   writeGithubDeployOutputs,
 } from './deploy-io.ts'
 
-const decodeInputEither = Schema.decodeUnknownResult(DeployInputV1)
-const decodeResultEither = Schema.decodeUnknownResult(DeployResultV1)
+const decodeInputResult = Schema.decodeUnknownResult(DeployInputV1)
+const decodeDeployResult = Schema.decodeUnknownResult(DeployResultV1)
 
 export type VercelDeployCommandOptions = {
   readonly target: string
@@ -149,7 +149,7 @@ const vercelProductionDomains = (opts: {
 const decodeDeployInput = Effect.fn('ci-tools.deploy.vercel.decode-input')(function* (
   value: unknown,
 ) {
-  const decoded = decodeInputEither(value)
+  const decoded = decodeInputResult(value)
   if (Result.isSuccess(decoded) === true) return decoded.success
   return yield* new InvalidProviderOutput({
     provider: 'vercel',
@@ -209,6 +209,16 @@ const runVercelCommand = Effect.fn('ci-tools.deploy.vercel.command')(
 
 const vercelScopeArgs = (scope: string | undefined) =>
   scope === undefined ? [] : ['--scope', scope]
+
+const vercelCommandEnv = (opts: {
+  readonly projectId: string
+  readonly orgId: string
+  readonly teamId: string | undefined
+}) => ({
+  VERCEL_PROJECT_ID: opts.projectId,
+  VERCEL_ORG_ID: opts.orgId,
+  ...(opts.teamId === undefined ? {} : { VERCEL_TEAM_ID: opts.teamId }),
+})
 
 const buildEnvRecord = Effect.fn('ci-tools.deploy.vercel.build-env')(function* (opts: {
   readonly target: string
@@ -526,9 +536,7 @@ const prepareLocalPrebuiltOutput = Effect.fn('ci-tools.deploy.vercel.prepare-loc
     ]
     const commandEnv = {
       ...opts.buildEnv,
-      VERCEL_PROJECT_ID: opts.projectId,
-      VERCEL_ORG_ID: opts.orgId,
-      ...(opts.teamId === undefined ? {} : { VERCEL_TEAM_ID: opts.teamId }),
+      ...vercelCommandEnv(opts),
     }
 
     process.stdout.write(
@@ -748,11 +756,7 @@ const assignAliasResilient = (opts: {
             '--token',
             opts.authToken,
           ],
-          env: {
-            VERCEL_PROJECT_ID: opts.projectId,
-            VERCEL_ORG_ID: opts.orgId,
-            ...(opts.teamId === undefined ? {} : { VERCEL_TEAM_ID: opts.teamId }),
-          },
+          env: vercelCommandEnv(opts),
         }),
       })
 
@@ -990,11 +994,7 @@ const cleanupAlias = Effect.fn('ci-tools.deploy.vercel.cleanup-alias')(function*
       '--token',
       opts.authToken,
     ],
-    env: {
-      VERCEL_PROJECT_ID: opts.projectId,
-      VERCEL_ORG_ID: opts.orgId,
-      ...(opts.teamId === undefined ? {} : { VERCEL_TEAM_ID: opts.teamId }),
-    },
+    env: vercelCommandEnv(opts),
   }).pipe(Effect.result)
 
   if (Result.isFailure(result) === true || result.success.status !== 0) {
@@ -1219,11 +1219,7 @@ export const runVercelDeploy = Effect.fn('ci-tools.deploy.vercel')(function* (
             '--token',
             authTokenValue,
           ],
-          env: {
-            VERCEL_PROJECT_ID: projectId,
-            VERCEL_ORG_ID: orgId,
-            ...(teamId === undefined ? {} : { VERCEL_TEAM_ID: teamId }),
-          },
+          env: vercelCommandEnv({ projectId, orgId, teamId }),
         }),
       })
 
@@ -1296,11 +1292,7 @@ export const runVercelDeploy = Effect.fn('ci-tools.deploy.vercel')(function* (
               '--token',
               authTokenValue,
             ],
-            env: {
-              VERCEL_PROJECT_ID: projectId,
-              VERCEL_ORG_ID: orgId,
-              ...(teamId === undefined ? {} : { VERCEL_TEAM_ID: teamId }),
-            },
+            env: vercelCommandEnv({ projectId, orgId, teamId }),
           }),
         })
         if (domainResult.status !== 0) {
@@ -1320,7 +1312,7 @@ export const runVercelDeploy = Effect.fn('ci-tools.deploy.vercel')(function* (
         finalUrl = `https://${productionDomains[0]}`
       }
 
-      const preliminary = decodeResultEither({
+      const preliminary = decodeDeployResult({
         _tag: 'DeployResult',
         schemaVersion: 1,
         provider: 'vercel',
@@ -1373,7 +1365,7 @@ export const runVercelDeploy = Effect.fn('ci-tools.deploy.vercel')(function* (
             })
           : undefined
 
-      const decoded = decodeResultEither({
+      const decoded = decodeDeployResult({
         _tag: 'DeployResult',
         schemaVersion: 1,
         provider: 'vercel',

--- a/packages/@overeng/ci-tools/src/deploy-vercel.ts
+++ b/packages/@overeng/ci-tools/src/deploy-vercel.ts
@@ -24,6 +24,7 @@ import {
   type CleanupResult,
   type DeployFailure,
   DeployProviderOperation,
+  AliasAssignmentFailed,
   DeployResultV1,
   DeployVerifyOperation,
   InvalidProviderOutput,
@@ -93,6 +94,19 @@ const VercelProjectFileJson = Schema.fromJsonString(
 )
 const JsonUnknown = Schema.fromJsonString(Schema.Unknown)
 
+const VercelDeploymentJson = Schema.Struct({
+  meta: Schema.optional(Schema.Record({ key: Schema.String, value: Schema.Unknown })),
+}).annotations({ identifier: 'CiTools.Vercel.DeploymentJson' })
+
+const VercelAliasJson = Schema.Struct({
+  projectId: Schema.optional(Schema.NonEmptyTrimmedString),
+  deploymentId: Schema.optional(Schema.NonEmptyTrimmedString),
+  deployment: Schema.optional(
+    Schema.Struct({
+      url: Schema.optional(Schema.String),
+    }),
+  ),
+}).annotations({ identifier: 'CiTools.Vercel.AliasJson' })
 const isoNow = () => new Date().toISOString()
 
 const optional = (value: string | undefined) =>
@@ -636,6 +650,201 @@ const classifyVercelFailure = (opts: {
   })
 }
 
+
+const fetchVercelDeploymentCommitSha = Effect.fn('ci-tools.deploy.vercel.deployment-commit-sha')(
+  function* (opts: {
+    readonly target: string
+    readonly apiBaseUrl: string
+    readonly authToken: string
+    readonly teamId: string | undefined
+    readonly deploymentRef: string
+  }) {
+    const response = yield* fetchVercelJson({
+      target: opts.target,
+      apiBaseUrl: opts.apiBaseUrl,
+      authToken: opts.authToken,
+      path: `/v13/deployments/${encodeURIComponent(opts.deploymentRef)}${
+        opts.teamId === undefined ? '' : `?teamId=${encodeURIComponent(opts.teamId)}`
+      }`,
+    })
+    if (response.status < 200 || response.status >= 300) {
+      return undefined
+    }
+    const decoded = Schema.decodeUnknownEither(Schema.parseJson(VercelDeploymentJson))(response.text)
+    if (Either.isLeft(decoded) === true) {
+      return undefined
+    }
+    const commitSha = decoded.right.meta?.githubCommitSha
+    return typeof commitSha === 'string' && commitSha.length > 0 ? commitSha : undefined
+  },
+)
+
+type VercelAliasRecord = {
+  readonly projectId: string | undefined
+  readonly deploymentRef: string | undefined
+}
+
+const fetchVercelAliasRecord = Effect.fn('ci-tools.deploy.vercel.alias-record')(function* (opts: {
+  readonly target: string
+  readonly apiBaseUrl: string
+  readonly authToken: string
+  readonly teamId: string | undefined
+  readonly aliasHost: string
+}) {
+  const response = yield* fetchVercelJson({
+    target: opts.target,
+    apiBaseUrl: opts.apiBaseUrl,
+    authToken: opts.authToken,
+    path: `/v4/aliases/${encodeURIComponent(opts.aliasHost)}${
+      opts.teamId === undefined ? '' : `?teamId=${encodeURIComponent(opts.teamId)}`
+    }`,
+  }).pipe(Effect.catchAll(() => Effect.succeed(undefined)))
+  if (response === undefined || response.status < 200 || response.status >= 300) {
+    return undefined
+  }
+  const decoded = Schema.decodeUnknownEither(Schema.parseJson(VercelAliasJson))(response.text)
+  if (Either.isLeft(decoded) === true) {
+    return undefined
+  }
+  return {
+    projectId: decoded.right.projectId,
+    deploymentRef: decoded.right.deploymentId ?? decoded.right.deployment?.url ?? undefined,
+  } satisfies VercelAliasRecord
+})
+
+const assignAliasResilient = (opts: {
+  readonly target: string
+  readonly aliasHost: string
+  readonly rawDeployUrl: string
+  readonly vercelBin: string
+  readonly workDir: string
+  readonly scope: string | undefined
+  readonly authToken: string
+  readonly projectId: string
+  readonly orgId: string
+  readonly teamId: string | undefined
+  readonly apiBaseUrl: string
+}) =>
+  Effect.gen(function* () {
+  const deployHost = new URL(opts.rawDeployUrl).host
+
+  const runAliasAttempt = (attempt: number) =>
+    DeployProviderOperation.with({
+      attributes: {
+        provider: 'vercel',
+        target: opts.target,
+        attempt: String(attempt),
+      },
+      effect: runVercelCommand({
+        vercelBin: opts.vercelBin,
+        cwd: opts.workDir,
+        args: [
+          'alias',
+          opts.rawDeployUrl,
+          opts.aliasHost,
+          ...vercelScopeArgs(opts.scope),
+          '--token',
+          opts.authToken,
+        ],
+        env: {
+          VERCEL_PROJECT_ID: opts.projectId,
+          VERCEL_ORG_ID: opts.orgId,
+          ...(opts.teamId === undefined ? {} : { VERCEL_TEAM_ID: opts.teamId }),
+        },
+      }),
+    })
+
+  const first = yield* runAliasAttempt(1)
+  if (first.status === 0) {
+    return
+  }
+  const classifyFirstFailure = () =>
+    classifyVercelFailure({
+      target: opts.target,
+      status: first.status,
+      stdout: first.stdout,
+      stderr: first.stderr,
+      authToken: opts.authToken,
+      operation: 'alias',
+    })
+  if (/already in use/iu.test(`${first.stderr}\n${first.stdout}`) === false) {
+    return yield* new AliasAssignmentFailed({ failure: classifyFirstFailure(), attempts: 1 })
+  }
+
+  const holder = yield* fetchVercelAliasRecord({
+    target: opts.target,
+    apiBaseUrl: opts.apiBaseUrl,
+    authToken: opts.authToken,
+    teamId: opts.teamId,
+    aliasHost: opts.aliasHost,
+  })
+  let holderCommitSha: string | undefined
+  if (holder?.deploymentRef !== undefined) {
+    holderCommitSha = yield* fetchVercelDeploymentCommitSha({
+      target: opts.target,
+      apiBaseUrl: opts.apiBaseUrl,
+      authToken: opts.authToken,
+      teamId: opts.teamId,
+      deploymentRef: holder.deploymentRef,
+    })
+  }
+
+  if (holder?.projectId !== opts.projectId) {
+    // The alias is held outside this project (or is invisible to this team's
+    // token, e.g. a globally claimed <project>.vercel.app owned by another
+    return yield* new AliasAssignmentFailed({
+      failure: new ProviderOperationFailed({
+        provider: 'vercel',
+        target: opts.target,
+        operation: 'alias',
+        transient: false,
+        message:
+          `Vercel alias ${opts.aliasHost} is already used by a deployment this project does not own` +
+          `${holder === undefined ? '' : ` (project ${holder.projectId ?? 'unknown'})`}; ` +
+          `pick a unique name via --alias-prefix or attach a custom domain via --production-domain ` +
+          `instead of relying on ${opts.aliasHost}`,
+        diagnostics: {
+          ...(holder?.deploymentRef === undefined ? {} : { holderDeployment: holder.deploymentRef }),
+          ...(holderCommitSha === undefined ? {} : { holderCommitSha }),
+        },
+      }),
+      attempts: 1,
+    })
+  }
+
+  if (holderCommitSha !== undefined) {
+    const ourCommitSha = yield* fetchVercelDeploymentCommitSha({
+      target: opts.target,
+      apiBaseUrl: opts.apiBaseUrl,
+      authToken: opts.authToken,
+      teamId: opts.teamId,
+      deploymentRef: deployHost,
+    })
+    if (ourCommitSha === holderCommitSha) {
+      return
+    }
+  }
+
+  // Same project, different commit: the earlier deployment may be mid-cutover;
+  // recheck once immediately before giving up.
+  const second = yield* runAliasAttempt(2)
+  if (second.status === 0) {
+    return
+  }
+  return yield* new AliasAssignmentFailed({
+    failure: classifyVercelFailure({
+      target: opts.target,
+      status: second.status,
+      stdout: second.stdout,
+      stderr: second.stderr,
+      authToken: opts.authToken,
+      operation: 'alias',
+    }),
+    attempts: 2,
+  })
+})
+
+
 const verifyFinalUrlOnce = Effect.fn('ci-tools.deploy.vercel.verify-once')(function* (opts: {
   readonly target: string
   readonly finalUrl: URL
@@ -853,13 +1062,13 @@ export const runVercelDeploy = Effect.fn('ci-tools.deploy.vercel')(function* (
   })
 
   const authTokenValue = envValue(options.authTokenEnv)
-  const failWithRecord = (failure: DeployFailure) =>
+  const failWithRecord = (failure: DeployFailure, attempts = 1) =>
     emitWorkflowReportRecord({
       workflowReportOutputFile: options.workflowReportOutputFile,
       record: deployFailureRecord({
         input,
         failure,
-        attempts: 1,
+        attempts,
         createdAtUtc,
         secretValues: authTokenValue === undefined ? [] : [authTokenValue],
       }),
@@ -1018,8 +1227,8 @@ export const runVercelDeploy = Effect.fn('ci-tools.deploy.vercel')(function* (
       if (deployResult.status !== 0) {
         return yield* failWithRecord(
           classifyVercelFailure({
-            target: options.target,
             status: deployResult.status,
+            target: options.target,
             stdout: deployResult.stdout,
             stderr: deployResult.stderr,
             authToken: authTokenValue,
@@ -1047,41 +1256,23 @@ export const runVercelDeploy = Effect.fn('ci-tools.deploy.vercel')(function* (
       let finalUrl = rawDeployUrl
       if (alias !== undefined) {
         const aliasHost = `${alias}.vercel.app`
-        const aliasResult = yield* DeployProviderOperation.with({
-          attributes: {
-            provider: 'vercel',
-            target: input.target,
-          },
-          effect: runVercelCommand({
-            vercelBin: options.vercelBin,
-            cwd: preparedOutput.workDir,
-            args: [
-              'alias',
-              rawDeployUrl,
-              aliasHost,
-              ...vercelScopeArgs(scope),
-              '--token',
-              authTokenValue,
-            ],
-            env: {
-              VERCEL_PROJECT_ID: projectId,
-              VERCEL_ORG_ID: orgId,
-              ...(teamId === undefined ? {} : { VERCEL_TEAM_ID: teamId }),
-            },
-          }),
-        })
-        if (aliasResult.status !== 0) {
-          return yield* failWithRecord(
-            classifyVercelFailure({
-              target: options.target,
-              status: aliasResult.status,
-              stdout: aliasResult.stdout,
-              stderr: aliasResult.stderr,
-              authToken: authTokenValue,
-              operation: 'alias',
-            }),
-          )
-        }
+        yield* assignAliasResilient({
+          target: options.target,
+          aliasHost,
+          rawDeployUrl,
+          vercelBin: options.vercelBin,
+          workDir: preparedOutput.workDir,
+          scope,
+          authToken: authTokenValue,
+          projectId,
+          orgId,
+          teamId,
+          apiBaseUrl: options.vercelApiBaseUrl,
+        }).pipe(
+          Effect.catchTag('AliasAssignmentFailed', (error) =>
+            failWithRecord(error.failure, error.attempts),
+          ),
+        )
         finalUrl = `https://${aliasHost}`
       }
 

--- a/packages/@overeng/ci-tools/src/deploy-vercel.ts
+++ b/packages/@overeng/ci-tools/src/deploy-vercel.ts
@@ -708,13 +708,40 @@ const fetchVercelAliasRecord = Effect.fn('ci-tools.deploy.vercel.alias-record')(
     path: `/v4/aliases/${encodeURIComponent(opts.aliasHost)}${
       opts.teamId === undefined ? '' : `?teamId=${encodeURIComponent(opts.teamId)}`
     }`,
-  }).pipe(Effect.orElseSucceed(() => undefined))
-  if (response === undefined || response.status < 200 || response.status >= 300) {
+  })
+  if (response.status === 401 || response.status === 403) {
+    return yield* new Unauthorized({
+      provider: 'vercel',
+      target: opts.target,
+      message: 'Vercel API rejected deploy credentials while resolving an alias collision',
+      diagnostics: { apiStatus: String(response.status) },
+    })
+  }
+  if (response.status === 404) {
     return undefined
+  }
+  if (response.status < 200 || response.status >= 300) {
+    return yield* new ProviderOperationFailed({
+      provider: 'vercel',
+      target: opts.target,
+      operation: 'alias',
+      transient: response.status >= 500,
+      message: 'Vercel alias lookup failed while resolving an alias collision',
+      diagnostics: { apiStatus: String(response.status) },
+    })
   }
   const decoded = Schema.decodeUnknownResult(Schema.fromJsonString(VercelAliasJson))(response.text)
   if (Result.isFailure(decoded) === true) {
-    return undefined
+    return yield* new InvalidProviderOutput({
+      provider: 'vercel',
+      target: opts.target,
+      outputKind: 'provider-response',
+      message: 'Vercel alias lookup returned an invalid provider response',
+      diagnostics: {
+        apiStatus: String(response.status),
+        cause: String(decoded.failure),
+      },
+    })
   }
   return {
     projectId: decoded.success.projectId,
@@ -763,7 +790,7 @@ const assignAliasResilient = (opts: {
 
     const first = yield* runAliasAttempt(1)
     if (first.status === 0) {
-      return
+      return 1
     }
     const classifyFirstFailure = () =>
       classifyVercelFailure({
@@ -784,7 +811,7 @@ const assignAliasResilient = (opts: {
       authToken: opts.authToken,
       teamId: apiTeamId,
       aliasHost: opts.aliasHost,
-    })
+    }).pipe(Effect.mapError((failure) => new AliasAssignmentFailed({ failure, attempts: 1 })))
     let holderCommitSha: string | undefined
     if (holder?.deploymentRef !== undefined) {
       holderCommitSha = yield* fetchVercelDeploymentCommitSha({
@@ -830,7 +857,7 @@ const assignAliasResilient = (opts: {
         deploymentRef: deployHost,
       })
       if (ourCommitSha === holderCommitSha) {
-        return
+        return 1
       }
     }
 
@@ -838,7 +865,7 @@ const assignAliasResilient = (opts: {
     // recheck once immediately before giving up.
     const second = yield* runAliasAttempt(2)
     if (second.status === 0) {
-      return
+      return 2
     }
     return yield* new AliasAssignmentFailed({
       failure: classifyVercelFailure({
@@ -1254,9 +1281,10 @@ export const runVercelDeploy = Effect.fn('ci-tools.deploy.vercel')(function* (
       }
 
       let finalUrl = rawDeployUrl
+      let attempts = 1
       if (alias !== undefined) {
         const aliasHost = `${alias}.vercel.app`
-        yield* assignAliasResilient({
+        attempts = yield* assignAliasResilient({
           target: options.target,
           aliasHost,
           rawDeployUrl,
@@ -1325,7 +1353,7 @@ export const runVercelDeploy = Effect.fn('ci-tools.deploy.vercel')(function* (
         productionDomains,
         startedAtUtc: createdAtUtc,
         endedAtUtc: isoNow(),
-        attempts: 1,
+        attempts,
       })
 
       if (Result.isFailure(preliminary) === true) {
@@ -1378,7 +1406,7 @@ export const runVercelDeploy = Effect.fn('ci-tools.deploy.vercel')(function* (
         productionDomains,
         startedAtUtc: createdAtUtc,
         endedAtUtc: isoNow(),
-        attempts: 1,
+        attempts,
         ...(cleanup === undefined ? {} : { cleanup }),
       })
       if (Result.isFailure(decoded) === true) {

--- a/packages/@overeng/ci-tools/src/deploy-vercel.ts
+++ b/packages/@overeng/ci-tools/src/deploy-vercel.ts
@@ -700,7 +700,7 @@ const fetchVercelAliasRecord = Effect.fn('ci-tools.deploy.vercel.alias-record')(
     path: `/v4/aliases/${encodeURIComponent(opts.aliasHost)}${
       opts.teamId === undefined ? '' : `?teamId=${encodeURIComponent(opts.teamId)}`
     }`,
-  }).pipe(Effect.catch(() => Effect.succeed(undefined)))
+  }).pipe(Effect.orElseSucceed(() => undefined))
   if (response === undefined || response.status < 200 || response.status >= 300) {
     return undefined
   }

--- a/packages/@overeng/ci-tools/src/deploy-vercel.ts
+++ b/packages/@overeng/ci-tools/src/deploy-vercel.ts
@@ -23,8 +23,8 @@ import {
   DeployInputV1,
   type CleanupResult,
   type DeployFailure,
-  DeployProviderOperation,
   AliasAssignmentFailed,
+  DeployProviderOperation,
   DeployResultV1,
   DeployVerifyOperation,
   InvalidProviderOutput,
@@ -95,18 +95,19 @@ const VercelProjectFileJson = Schema.fromJsonString(
 const JsonUnknown = Schema.fromJsonString(Schema.Unknown)
 
 const VercelDeploymentJson = Schema.Struct({
-  meta: Schema.optional(Schema.Record({ key: Schema.String, value: Schema.Unknown })),
-}).annotations({ identifier: 'CiTools.Vercel.DeploymentJson' })
+  meta: Schema.optional(Schema.Record(Schema.String, Schema.Unknown)),
+}).annotate({ identifier: 'CiTools.Vercel.DeploymentJson' })
 
 const VercelAliasJson = Schema.Struct({
-  projectId: Schema.optional(Schema.NonEmptyTrimmedString),
-  deploymentId: Schema.optional(Schema.NonEmptyTrimmedString),
+  projectId: Schema.optional(Schema.NonEmptyString),
+  deploymentId: Schema.optional(Schema.NonEmptyString),
   deployment: Schema.optional(
     Schema.Struct({
       url: Schema.optional(Schema.String),
     }),
   ),
-}).annotations({ identifier: 'CiTools.Vercel.AliasJson' })
+}).annotate({ identifier: 'CiTools.Vercel.AliasJson' })
+
 const isoNow = () => new Date().toISOString()
 
 const optional = (value: string | undefined) =>
@@ -650,7 +651,6 @@ const classifyVercelFailure = (opts: {
   })
 }
 
-
 const fetchVercelDeploymentCommitSha = Effect.fn('ci-tools.deploy.vercel.deployment-commit-sha')(
   function* (opts: {
     readonly target: string
@@ -670,11 +670,13 @@ const fetchVercelDeploymentCommitSha = Effect.fn('ci-tools.deploy.vercel.deploym
     if (response.status < 200 || response.status >= 300) {
       return undefined
     }
-    const decoded = Schema.decodeUnknownEither(Schema.parseJson(VercelDeploymentJson))(response.text)
-    if (Either.isLeft(decoded) === true) {
+    const decoded = Schema.decodeUnknownResult(Schema.fromJsonString(VercelDeploymentJson))(
+      response.text,
+    )
+    if (Result.isFailure(decoded) === true) {
       return undefined
     }
-    const commitSha = decoded.right.meta?.githubCommitSha
+    const commitSha = decoded.success.meta?.githubCommitSha
     return typeof commitSha === 'string' && commitSha.length > 0 ? commitSha : undefined
   },
 )
@@ -698,17 +700,17 @@ const fetchVercelAliasRecord = Effect.fn('ci-tools.deploy.vercel.alias-record')(
     path: `/v4/aliases/${encodeURIComponent(opts.aliasHost)}${
       opts.teamId === undefined ? '' : `?teamId=${encodeURIComponent(opts.teamId)}`
     }`,
-  }).pipe(Effect.catchAll(() => Effect.succeed(undefined)))
+  }).pipe(Effect.catch(() => Effect.succeed(undefined)))
   if (response === undefined || response.status < 200 || response.status >= 300) {
     return undefined
   }
-  const decoded = Schema.decodeUnknownEither(Schema.parseJson(VercelAliasJson))(response.text)
-  if (Either.isLeft(decoded) === true) {
+  const decoded = Schema.decodeUnknownResult(Schema.fromJsonString(VercelAliasJson))(response.text)
+  if (Result.isFailure(decoded) === true) {
     return undefined
   }
   return {
-    projectId: decoded.right.projectId,
-    deploymentRef: decoded.right.deploymentId ?? decoded.right.deployment?.url ?? undefined,
+    projectId: decoded.success.projectId,
+    deploymentRef: decoded.success.deploymentId ?? decoded.success.deployment?.url ?? undefined,
   } satisfies VercelAliasRecord
 })
 
@@ -726,124 +728,125 @@ const assignAliasResilient = (opts: {
   readonly apiBaseUrl: string
 }) =>
   Effect.gen(function* () {
-  const deployHost = new URL(opts.rawDeployUrl).host
+    const deployHost = new URL(opts.rawDeployUrl).host
 
-  const runAliasAttempt = (attempt: number) =>
-    DeployProviderOperation.with({
-      attributes: {
-        provider: 'vercel',
-        target: opts.target,
-        attempt: String(attempt),
-      },
-      effect: runVercelCommand({
-        vercelBin: opts.vercelBin,
-        cwd: opts.workDir,
-        args: [
-          'alias',
-          opts.rawDeployUrl,
-          opts.aliasHost,
-          ...vercelScopeArgs(opts.scope),
-          '--token',
-          opts.authToken,
-        ],
-        env: {
-          VERCEL_PROJECT_ID: opts.projectId,
-          VERCEL_ORG_ID: opts.orgId,
-          ...(opts.teamId === undefined ? {} : { VERCEL_TEAM_ID: opts.teamId }),
+    const runAliasAttempt = (attempt: number) =>
+      DeployProviderOperation.with({
+        attributes: {
+          provider: 'vercel',
+          target: opts.target,
+          attempt: String(attempt),
         },
-      }),
-    })
+        effect: runVercelCommand({
+          vercelBin: opts.vercelBin,
+          cwd: opts.workDir,
+          args: [
+            'alias',
+            opts.rawDeployUrl,
+            opts.aliasHost,
+            ...vercelScopeArgs(opts.scope),
+            '--token',
+            opts.authToken,
+          ],
+          env: {
+            VERCEL_PROJECT_ID: opts.projectId,
+            VERCEL_ORG_ID: opts.orgId,
+            ...(opts.teamId === undefined ? {} : { VERCEL_TEAM_ID: opts.teamId }),
+          },
+        }),
+      })
 
-  const first = yield* runAliasAttempt(1)
-  if (first.status === 0) {
-    return
-  }
-  const classifyFirstFailure = () =>
-    classifyVercelFailure({
-      target: opts.target,
-      status: first.status,
-      stdout: first.stdout,
-      stderr: first.stderr,
-      authToken: opts.authToken,
-      operation: 'alias',
-    })
-  if (/already in use/iu.test(`${first.stderr}\n${first.stdout}`) === false) {
-    return yield* new AliasAssignmentFailed({ failure: classifyFirstFailure(), attempts: 1 })
-  }
-
-  const holder = yield* fetchVercelAliasRecord({
-    target: opts.target,
-    apiBaseUrl: opts.apiBaseUrl,
-    authToken: opts.authToken,
-    teamId: opts.teamId,
-    aliasHost: opts.aliasHost,
-  })
-  let holderCommitSha: string | undefined
-  if (holder?.deploymentRef !== undefined) {
-    holderCommitSha = yield* fetchVercelDeploymentCommitSha({
-      target: opts.target,
-      apiBaseUrl: opts.apiBaseUrl,
-      authToken: opts.authToken,
-      teamId: opts.teamId,
-      deploymentRef: holder.deploymentRef,
-    })
-  }
-
-  if (holder?.projectId !== opts.projectId) {
-    // The alias is held outside this project (or is invisible to this team's
-    // token, e.g. a globally claimed <project>.vercel.app owned by another
-    return yield* new AliasAssignmentFailed({
-      failure: new ProviderOperationFailed({
-        provider: 'vercel',
-        target: opts.target,
-        operation: 'alias',
-        transient: false,
-        message:
-          `Vercel alias ${opts.aliasHost} is already used by a deployment this project does not own` +
-          `${holder === undefined ? '' : ` (project ${holder.projectId ?? 'unknown'})`}; ` +
-          `pick a unique name via --alias-prefix or attach a custom domain via --production-domain ` +
-          `instead of relying on ${opts.aliasHost}`,
-        diagnostics: {
-          ...(holder?.deploymentRef === undefined ? {} : { holderDeployment: holder.deploymentRef }),
-          ...(holderCommitSha === undefined ? {} : { holderCommitSha }),
-        },
-      }),
-      attempts: 1,
-    })
-  }
-
-  if (holderCommitSha !== undefined) {
-    const ourCommitSha = yield* fetchVercelDeploymentCommitSha({
-      target: opts.target,
-      apiBaseUrl: opts.apiBaseUrl,
-      authToken: opts.authToken,
-      teamId: opts.teamId,
-      deploymentRef: deployHost,
-    })
-    if (ourCommitSha === holderCommitSha) {
+    const first = yield* runAliasAttempt(1)
+    if (first.status === 0) {
       return
     }
-  }
+    const classifyFirstFailure = () =>
+      classifyVercelFailure({
+        target: opts.target,
+        status: first.status,
+        stdout: first.stdout,
+        stderr: first.stderr,
+        authToken: opts.authToken,
+        operation: 'alias',
+      })
+    if (/already in use/iu.test(`${first.stderr}\n${first.stdout}`) === false) {
+      return yield* new AliasAssignmentFailed({ failure: classifyFirstFailure(), attempts: 1 })
+    }
 
-  // Same project, different commit: the earlier deployment may be mid-cutover;
-  // recheck once immediately before giving up.
-  const second = yield* runAliasAttempt(2)
-  if (second.status === 0) {
-    return
-  }
-  return yield* new AliasAssignmentFailed({
-    failure: classifyVercelFailure({
+    const holder = yield* fetchVercelAliasRecord({
       target: opts.target,
-      status: second.status,
-      stdout: second.stdout,
-      stderr: second.stderr,
+      apiBaseUrl: opts.apiBaseUrl,
       authToken: opts.authToken,
-      operation: 'alias',
-    }),
-    attempts: 2,
-  })
-})
+      teamId: opts.teamId,
+      aliasHost: opts.aliasHost,
+    })
+    let holderCommitSha: string | undefined
+    if (holder?.deploymentRef !== undefined) {
+      holderCommitSha = yield* fetchVercelDeploymentCommitSha({
+        target: opts.target,
+        apiBaseUrl: opts.apiBaseUrl,
+        authToken: opts.authToken,
+        teamId: opts.teamId,
+        deploymentRef: holder.deploymentRef,
+      })
+    }
 
+    if (holder?.projectId !== opts.projectId) {
+      // The alias is held outside this project (or is invisible to this team's
+      // token, e.g. a globally claimed <project>.vercel.app owned by another account).
+      return yield* new AliasAssignmentFailed({
+        failure: new ProviderOperationFailed({
+          provider: 'vercel',
+          target: opts.target,
+          operation: 'alias',
+          transient: false,
+          message:
+            `Vercel alias ${opts.aliasHost} is already used by a deployment this project does not own` +
+            `${holder === undefined ? '' : ` (project ${holder.projectId ?? 'unknown'})`}; ` +
+            `pick a unique name via --alias-prefix or attach a custom domain via --production-domain ` +
+            `instead of relying on ${opts.aliasHost}`,
+          diagnostics: {
+            ...(holder?.deploymentRef === undefined
+              ? {}
+              : { holderDeployment: holder.deploymentRef }),
+            ...(holderCommitSha === undefined ? {} : { holderCommitSha }),
+          },
+        }),
+        attempts: 1,
+      })
+    }
+
+    if (holderCommitSha !== undefined) {
+      const ourCommitSha = yield* fetchVercelDeploymentCommitSha({
+        target: opts.target,
+        apiBaseUrl: opts.apiBaseUrl,
+        authToken: opts.authToken,
+        teamId: opts.teamId,
+        deploymentRef: deployHost,
+      })
+      if (ourCommitSha === holderCommitSha) {
+        return
+      }
+    }
+
+    // Same project, different commit: the earlier deployment may be mid-cutover;
+    // recheck once immediately before giving up.
+    const second = yield* runAliasAttempt(2)
+    if (second.status === 0) {
+      return
+    }
+    return yield* new AliasAssignmentFailed({
+      failure: classifyVercelFailure({
+        target: opts.target,
+        status: second.status,
+        stdout: second.stdout,
+        stderr: second.stderr,
+        authToken: opts.authToken,
+        operation: 'alias',
+      }),
+      attempts: 2,
+    })
+  })
 
 const verifyFinalUrlOnce = Effect.fn('ci-tools.deploy.vercel.verify-once')(function* (opts: {
   readonly target: string
@@ -1227,8 +1230,8 @@ export const runVercelDeploy = Effect.fn('ci-tools.deploy.vercel')(function* (
       if (deployResult.status !== 0) {
         return yield* failWithRecord(
           classifyVercelFailure({
-            status: deployResult.status,
             target: options.target,
+            status: deployResult.status,
             stdout: deployResult.stdout,
             stderr: deployResult.stderr,
             authToken: authTokenValue,

--- a/packages/@overeng/ci-tools/src/deploy-vercel.ts
+++ b/packages/@overeng/ci-tools/src/deploy-vercel.ts
@@ -674,8 +674,8 @@ const fetchVercelDeploymentCommitSha = Effect.fn('ci-tools.deploy.vercel.deploym
       path: `/v13/deployments/${encodeURIComponent(opts.deploymentRef)}${
         opts.teamId === undefined ? '' : `?teamId=${encodeURIComponent(opts.teamId)}`
       }`,
-    })
-    if (response.status < 200 || response.status >= 300) {
+    }).pipe(Effect.orElseSucceed(() => undefined))
+    if (response === undefined || response.status < 200 || response.status >= 300) {
       return undefined
     }
     const decoded = Schema.decodeUnknownResult(Schema.fromJsonString(VercelDeploymentJson))(
@@ -737,6 +737,7 @@ const assignAliasResilient = (opts: {
 }) =>
   Effect.gen(function* () {
     const deployHost = new URL(opts.rawDeployUrl).host
+    const apiTeamId = opts.teamId ?? opts.orgId
 
     const runAliasAttempt = (attempt: number) =>
       DeployProviderOperation.with({
@@ -781,7 +782,7 @@ const assignAliasResilient = (opts: {
       target: opts.target,
       apiBaseUrl: opts.apiBaseUrl,
       authToken: opts.authToken,
-      teamId: opts.teamId,
+      teamId: apiTeamId,
       aliasHost: opts.aliasHost,
     })
     let holderCommitSha: string | undefined
@@ -790,7 +791,7 @@ const assignAliasResilient = (opts: {
         target: opts.target,
         apiBaseUrl: opts.apiBaseUrl,
         authToken: opts.authToken,
-        teamId: opts.teamId,
+        teamId: apiTeamId,
         deploymentRef: holder.deploymentRef,
       })
     }
@@ -825,7 +826,7 @@ const assignAliasResilient = (opts: {
         target: opts.target,
         apiBaseUrl: opts.apiBaseUrl,
         authToken: opts.authToken,
-        teamId: opts.teamId,
+        teamId: apiTeamId,
         deploymentRef: deployHost,
       })
       if (ourCommitSha === holderCommitSha) {


### PR DESCRIPTION
## Problem

`ci-tools deploy vercel --mode prod` assigns a stable `<project>.vercel.app` alias. The namespace is global across Vercel accounts. If another account owns the alias, Vercel rejects every assignment even though the deployment itself reached READY.

The collision is still live as of 2026-09-01: opening `https://ptg.vercel.app` redirects to the unrelated Pro Toronto Gutters site. Current `main` still treats any alias-command failure as a generic `ProviderOperationFailed`, so the operator does not get collision-specific diagnosis or recovery guidance.

## Goal

- Fail fast for foreign or unresolvable alias holders. Name the alias, blocker, and `--alias-prefix` remedy.
- Treat a same-commit holder as success.
- Recheck an own-project holder exactly once to cover release races.
- Preserve lookup transport and provider failures with correct retryability.

## Decisions

- Use holder-specific dispatch instead of general retry-with-backoff. A foreign holder cannot be released by this deployment.
- Keep same-commit success for redeploy races.
- Represent exhausted collision handling with `AliasAssignmentFailed`, including the inner failure and actual attempt count.
- Do not preflight ownership before upload. Ownership can change during deployment, and the post-deploy failure already supplies the required signal.

## Verification

Live browser experiment on 2026-09-01:

```text
https://ptg.vercel.app
→ https://www.protorontogutters.ca/
→ title: In Maintenance
```

Deterministic Vercel CLI end-to-end suite:

```text
devenv shell -- bun node_modules/vitest/vitest.mjs run src/deploy-vercel.e2e.test.ts --reporter=verbose
Test Files  1 passed (1)
Tests       19 passed (19)
```

The 19 scenarios include same-commit success, own-project release after one recheck, persistent own-project collision, unavailable deployment metadata, foreign-holder actionable failure, and transient/transport lookup failures.

Repository gates:

```text
devenv tasks run test:ci-tools --no-tui  # passed
devenv tasks run check:quick --no-tui    # passed
devenv tasks run check:all --no-tui      # passed on retry
```

## Complexity

One tagged error variant and explicit holder classification replace ambiguous generic failure handling. No external dependency was added.

## Concerns

Consumers with a globally colliding project name must still configure a unique `--alias-prefix`. The new error makes that required action explicit.

## Friction & bottlenecks

The first `check:all` attempt hit a transient concurrent devenv evaluation failure because a pnpm SQLite `index.db-shm` path disappeared during evaluation. An immediate retry passed without code changes.

## Follow-ups

None in this repository.

## References

- Root cause and consumer configuration: schickling/schickling.dev#150

<!-- agent-footer:begin v=2 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | dev3.direct.omp.kwct2pfm |
| `session` | dev3.kwct2pfm |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.0.11 |
| `agent_runtime` | OMP 18.0.11 |
| `tooling_profile` | dotfiles@5a8d579-dirty |
</details>
<!-- agent-footer:end -->