### PR TITLE
feat(notion-react): read-only plan() companion to sync()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,14 @@ All notable changes to this project will be documented in this file.
   into a `CacheTree` out-of-band can no longer drift from the scheme
   `buildCandidateTree` / `diff` actually produce.
 
+- **@overeng/notion-react**: add `plan()`, a read-only companion to `sync()`
+  (#1122). It computes the exact op sequence a sync would apply — through the
+  same pre-flight and diff code path, root-page metadata update included —
+  with zero writes: no Notion mutation, no cache save. `SyncPlan.empty` is a
+  post-publication fixpoint oracle. `staleness: 'live' | 'cache-only'` picks
+  between sync's GET-only shallow pre-flight (detects out-of-band drift) and
+  a zero-request pure cache×JSX check. `onEvent` emits the retrieve op events
+  and one `PlanComputed` from the existing `SyncEvent` union.
 - **devenv pnpm / Genie**: add root-local, read-only source generations for
   composed workspaces. Aggregate roots declare cross-repository source inputs,
   Genie projects matching `file:` overrides, and the shared pnpm transaction

--- a/packages/@overeng/notion-react/docs/api.md
+++ b/packages/@overeng/notion-react/docs/api.md
@@ -81,13 +81,13 @@ successful `sync()`, a `plan()` over the same element returns zero ops.
 
 `staleness`:
 
-| Value                | Behaviour                                                                                                                                                                                                              |
-| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `'live'` (default)   | Mirrors sync's shallow pre-flight: one top-level children GET + in-memory pending-marker adoption (never persisted). Detects out-of-band appends as `fallbackReason: 'cache-drift'`. GET-only — never a write.          |
-| `'cache-only'`       | Pure function of cache + JSX, zero API calls. Blind spots: out-of-band drift, the cold-`'clean'` baseline sweep's removes (they need the live child list), and pending-marker resolution. Use only against a fresh cache. |
+| Value              | Behaviour                                                                                                                                                                                                                 |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `'live'` (default) | Mirrors sync's shallow pre-flight: one top-level children GET + in-memory pending-marker adoption (never persisted). Detects out-of-band appends as `fallbackReason: 'cache-drift'`. GET-only — never a write.            |
+| `'cache-only'`     | Pure function of cache + JSX, zero API calls. Blind spots: out-of-band drift, the cold-`'clean'` baseline sweep's removes (they need the live child list), and pending-marker resolution. Use only against a fresh cache. |
 
 TOCTOU stance: there is no lock between `plan()` and a later `sync()`,
-so the *plan* can go stale — the applied result cannot, because `sync()`
+so the _plan_ can go stale — the applied result cannot, because `sync()`
 recomputes from scratch. Treat a plan as advisory for the observed
 instant; use the post-apply empty-plan check for proof of convergence.
 

--- a/packages/@overeng/notion-react/docs/api.md
+++ b/packages/@overeng/notion-react/docs/api.md
@@ -72,12 +72,22 @@ plan(element, {
 // → Effect<SyncPlan, NotionSyncError, NotionConfig | HttpClient>
 ```
 
-Computes the exact op sequence `sync()` would apply — through the same
-pre-flight and diff code path, including the root-page metadata
-`updatePage` that `sync()` applies outside its internal diff — without
-performing any write: no Notion mutation, no cache save. `SyncPlan.empty`
-doubles as a post-publication fixpoint oracle: immediately after a
-successful `sync()`, a `plan()` over the same element returns zero ops.
+Computes the ops `sync()` would apply — through the same pre-flight and
+diff code path, including the root-page metadata `updatePage` that
+`sync()` applies outside its internal diff — without performing any
+write: no Notion mutation, no cache save. `ops` is in diff-emission
+order, which is NOT `sync()`'s phased application schedule (the driver
+applies retained-sub-page-scoped block ops before retained-page
+`updatePage`s) — treat it as an operation set with per-scope order.
+
+`SyncPlan.empty` doubles as a post-publication fixpoint oracle:
+immediately after a successful, convergent `sync()`, a `plan()` over the
+same element returns zero ops. One exception: under the default
+`reorderSiblings: false`, a JSX reshuffle of retained `<ChildPage>`
+siblings emits a same-parent `movePage` that Notion rejects and `sync()`
+deliberately swallows (a documented no-op), so server sibling order
+never converges and subsequent live plans keep reporting that move — opt
+into `reorderSiblings: true` for a true fixpoint.
 
 `staleness`:
 

--- a/packages/@overeng/notion-react/docs/api.md
+++ b/packages/@overeng/notion-react/docs/api.md
@@ -7,7 +7,7 @@ map, not the reference.
 ## Entry points
 
 ```ts
-import { renderToNotion, sync } from '@overeng/notion-react'
+import { renderToNotion, sync, plan } from '@overeng/notion-react'
 import { renderToNotionMarkdown } from '@overeng/notion-react/markdown'
 ```
 
@@ -15,8 +15,10 @@ import { renderToNotionMarkdown } from '@overeng/notion-react/markdown'
 | ------------------------ | --------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | `renderToNotion`         | [`renderer/render-to-notion.ts`](../src/renderer/render-to-notion.ts)                   | Cold-start append; no cache. Returns `Effect<SyncResult, NotionSyncError, NotionConfig \| HttpClient>`.                                      |
 | `sync`                   | [`renderer/sync.ts`](../src/renderer/sync.ts)                                           | Incremental cache-backed sync. Same return type. See [sync options](#sync-options).                                                          |
+| `plan`                   | [`renderer/sync.ts`](../src/renderer/sync.ts)                                           | Read-only companion to `sync`: the ops a sync would apply, zero writes. Returns `Effect<SyncPlan, …>`. See [plan options](#plan-options).    |
 | `collectOps`             | [`renderer/render-to-notion.ts`](../src/renderer/render-to-notion.ts)                   | Collect an `OpBuffer` from a one-shot render. Exposed for tests.                                                                             |
 | `SyncResult`             | [`renderer/render-to-notion.ts`](../src/renderer/render-to-notion.ts)                   | `{ appends, updates, removes, inserts, fallbackReason? }`                                                                                    |
+| `SyncPlan`               | [`renderer/sync.ts`](../src/renderer/sync.ts)                                           | `{ ops, blocks, pages, fallbackReason, empty }` — `empty` is the fixpoint oracle.                                                            |
 | `renderToNotionMarkdown` | [`markdown/render-to-notion-markdown.ts`](../src/markdown/render-to-notion-markdown.ts) | **Experimental.** Read-only JSX → Notion-enhanced-Markdown body + diagnostics. See [Markdown projection](./concepts/markdown-projection.md). |
 
 ## Markdown projection options
@@ -55,6 +57,39 @@ sync(element, {
 
 See [Cookbook → Sub-page creation → Reordering](./cookbook/sub-page-creation.md#reordering-sibling-sub-pages-phase-4d)
 and [Limitations → Intra-parent sibling-page reorder](./limitations.md#intra-parent-sibling-page-reorder-dq7--opt-in).
+
+## Plan options
+
+```ts
+plan(element, {
+  pageId,
+  cache,
+  coldBaseline?,    // same semantics as sync()
+  reorderSiblings?, // same semantics as sync()
+  staleness?,       // 'live' (default) | 'cache-only'
+  onEvent?,         // retrieve op events + one PlanComputed; nothing else
+})
+// → Effect<SyncPlan, NotionSyncError, NotionConfig | HttpClient>
+```
+
+Computes the exact op sequence `sync()` would apply — through the same
+pre-flight and diff code path, including the root-page metadata
+`updatePage` that `sync()` applies outside its internal diff — without
+performing any write: no Notion mutation, no cache save. `SyncPlan.empty`
+doubles as a post-publication fixpoint oracle: immediately after a
+successful `sync()`, a `plan()` over the same element returns zero ops.
+
+`staleness`:
+
+| Value                | Behaviour                                                                                                                                                                                                              |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `'live'` (default)   | Mirrors sync's shallow pre-flight: one top-level children GET + in-memory pending-marker adoption (never persisted). Detects out-of-band appends as `fallbackReason: 'cache-drift'`. GET-only — never a write.          |
+| `'cache-only'`       | Pure function of cache + JSX, zero API calls. Blind spots: out-of-band drift, the cold-`'clean'` baseline sweep's removes (they need the live child list), and pending-marker resolution. Use only against a fresh cache. |
+
+TOCTOU stance: there is no lock between `plan()` and a later `sync()`,
+so the *plan* can go stale — the applied result cannot, because `sync()`
+recomputes from scratch. Treat a plan as advisory for the observed
+instant; use the post-apply empty-plan check for proof of convergence.
 
 ## Block components
 

--- a/packages/@overeng/notion-react/docs/vrs/.experiments/0003-plan-readonly-companion.md
+++ b/packages/@overeng/notion-react/docs/vrs/.experiments/0003-plan-readonly-companion.md
@@ -1,0 +1,53 @@
+# Experiment: read-only plan() parity with sync()
+
+- **Date:** 2026-08-25
+- **Related:** R37, R38, T11
+
+## Question
+
+Can a read-only `plan()` predict exactly what `sync()` would apply — including
+root-page metadata drift that sync handles outside its internal diff — without
+duplicating sync's logic and without issuing a single write?
+
+## Method
+
+`sync()`'s pre-flight was extracted into shared module-level helpers
+(`resolvePendingPages`, `topLevelDrifted`, `selectDiffBase`,
+`rootPageUpdateOpFor`) and `plan()` composed from the identical path. Against
+the Notion-shaped mock fixture: (a) cold and warm-incremental plans are
+compared to the subsequent sync's applied tallies; (b) a post-sync plan is
+asserted empty, including a `<Page>` + `<ChildPage>` + icon scenario where an
+icon change must plan as exactly one `pages.update`; (c) the mock request log
+is asserted GET-only during a `'live'` plan and untouched during
+`'cache-only'`; (d) an out-of-band append is planted behind the cache's back
+and both staleness modes are compared; (e) `onEvent` sequences are captured
+for both modes.
+
+## Result
+
+Cold and warm plans match the subsequent sync's applied block and page tallies
+exactly. The post-sync plan is empty in every scenario, and the icon-change
+plan carries exactly one root `updatePage` — omitting the root op would have
+passed the block-level fixpoint while missing real metadata drift. `'live'`
+plans issue only GETs and detect the out-of-band append as
+`fallbackReason: 'cache-drift'` with removes for the foreign block;
+`'cache-only'` issues zero requests and reports a (wrong, but by-contract)
+empty plan for the same state. Events: `'live'` emits
+`OpIssued`/`OpSucceeded` (kind `'retrieve'`) + one `PlanComputed`;
+`'cache-only'` emits `PlanComputed` only. Full suite green with sync behavior
+unchanged.
+
+## Conclusion
+
+Sharing sync's pre-flight as extracted helpers (rather than reimplementing a
+"read-only diff" externally) satisfies R37 by construction — the two paths
+cannot disagree about a given observed state. The root `updatePage` must be
+part of `SyncPlan.ops` for the fixpoint oracle to be trustworthy. The
+`'cache-only'` blind spots are inherent (they need the live child list), so
+R38 documents them instead of approximating.
+
+## VRS Impact
+
+R37 and R38 added; T11 records the TOCTOU stance (a plan can go stale, the
+applied result cannot). The spec gains the plan() section describing the
+shared helpers and event semantics.

--- a/packages/@overeng/notion-react/docs/vrs/requirements.md
+++ b/packages/@overeng/notion-react/docs/vrs/requirements.md
@@ -102,7 +102,7 @@ host-config, or cache are implemented (see [spec.md](./spec.md) for that).
 - **T11 A plan can go stale (TOCTOU):** There is no lock between a
   `plan()` and a later `sync()`; a concurrent writer can invalidate the
   plan in between. This is accepted because `sync()` recomputes from
-  scratch — the *plan* is what goes stale, never the applied result.
+  scratch — the _plan_ is what goes stale, never the applied result.
   Callers gating on a plan (pre-apply audit) must treat it as advisory
   for the observed instant, and use the post-apply empty-plan fixpoint
   check for proof.

--- a/packages/@overeng/notion-react/docs/vrs/requirements.md
+++ b/packages/@overeng/notion-react/docs/vrs/requirements.md
@@ -99,6 +99,13 @@ host-config, or cache are implemented (see [spec.md](./spec.md) for that).
   Drift between them is accepted until a second consumer justifies
   centralization (#1098); golden tests pin the projection dialect in the
   meantime.
+- **T11 A plan can go stale (TOCTOU):** There is no lock between a
+  `plan()` and a later `sync()`; a concurrent writer can invalidate the
+  plan in between. This is accepted because `sync()` recomputes from
+  scratch — the *plan* is what goes stale, never the applied result.
+  Callers gating on a plan (pre-apply audit) must treat it as advisory
+  for the observed instant, and use the post-apply empty-plan fixpoint
+  check for proof.
 
 ## Requirements
 
@@ -252,6 +259,23 @@ host-config, or cache are implemented (see [spec.md](./spec.md) for that).
 - **R23 Host-config encapsulation:** All react-reconciler host-config
   details live behind an internal module boundary; downstream callers
   must never need to touch it.
+
+### Must expose a read-only plan
+
+- **R37 Plan/sync parity:** `plan()` must compute the exact op sequence
+  `sync()` would apply for the same element and observed state — through
+  the same pre-flight and diff code path (shared helpers, not a
+  reimplementation), including the root-page metadata update `sync()`
+  applies outside its internal diff — while performing no write: no
+  Notion mutation and no cache save. An empty plan is the fixpoint
+  oracle: immediately after a successful `sync()` of the same element,
+  `plan()` must return zero ops.
+- **R38 Plan staleness is explicit:** The default `'live'` staleness
+  mirrors sync's shallow pre-flight with read-only calls and detects
+  out-of-band top-level drift; `'cache-only'` issues zero requests and
+  is a pure function of cache + JSX. The blind spots of `'cache-only'`
+  (out-of-band drift, cold-`'clean'` baseline removes, pending-marker
+  resolution) must be documented, not silently approximated.
 
 ### Must project authored JSX to readable Markdown (experimental)
 

--- a/packages/@overeng/notion-react/docs/vrs/spec.md
+++ b/packages/@overeng/notion-react/docs/vrs/spec.md
@@ -517,6 +517,49 @@ is a v0.2 addition — under v0.1, a 404 on a cache-referenced block
 propagates as a `NotionSyncError`. Callers receive the reason on the
 `SyncResult`.
 
+## plan() — read-only companion (R37–R38)
+
+`sync()`'s pre-flight is factored into shared module-level helpers —
+`resolvePendingPages` (pending-marker adoption), `topLevelDrifted`
+(shallow drift detection), `selectDiffBase` (cold/warm/drift base
+selection incl. the fallback decision table above), and
+`rootPageUpdateOpFor` (the root title/icon/cover `updatePage` that
+`sync()` applies *outside* its internal diff). `plan()` composes the
+same helpers with `diff()` and returns without applying:
+
+```ts
+interface SyncPlan {
+  ops: readonly DiffOp[] // exact sequence sync() would apply, root updatePage included
+  blocks: { appends; updates; inserts; removes }
+  pages: { creates; updates; archives; moves; reorders }
+  fallbackReason: SyncFallbackReason | undefined
+  empty: boolean // the fixpoint oracle
+}
+```
+
+Including the root `updatePage` in `ops` is load-bearing: without it
+the empty-plan fixpoint oracle would miss root metadata drift (an icon
+change plans as exactly one `pages.update`, matching what `sync()`
+applies).
+
+Staleness (R38, T11):
+
+- **`'live'` (default):** mirrors sync's shallow pre-flight — one
+  top-level children GET plus in-memory pending-marker adoption (never
+  persisted; plan() writes nothing). Detects out-of-band appends as
+  `fallbackReason: 'cache-drift'`. The plan can still go stale before a
+  later `sync()` (T11) — sync recomputes, so the applied result cannot.
+- **`'cache-only'`:** a pure function of cache + JSX, zero requests.
+  Blind to anything only the server knows: out-of-band drift, the
+  cold-`'clean'` baseline sweep (needs the live child list to plan its
+  removes), and pending-marker resolution.
+
+`onEvent` reuses the `SyncEvent` union for the read-only prefix: the
+`'live'` GET emits `OpIssued`/`OpSucceeded`/`OpFailed` with kind
+`'retrieve'`, and the computed plan emits one `PlanComputed`. No
+`SyncStart`/`SyncEnd`/`CacheOutcome` — plan probes must not skew
+cache-efficiency or sync-duration metrics aggregated across real syncs.
+
 ## Upload coordination
 
 See `src/renderer/upload-registry.ts`.

--- a/packages/@overeng/notion-react/docs/vrs/spec.md
+++ b/packages/@overeng/notion-react/docs/vrs/spec.md
@@ -524,7 +524,7 @@ propagates as a `NotionSyncError`. Callers receive the reason on the
 (shallow drift detection), `selectDiffBase` (cold/warm/drift base
 selection incl. the fallback decision table above), and
 `rootPageUpdateOpFor` (the root title/icon/cover `updatePage` that
-`sync()` applies *outside* its internal diff). `plan()` composes the
+`sync()` applies _outside_ its internal diff). `plan()` composes the
 same helpers with `diff()` and returns without applying:
 
 ```ts

--- a/packages/@overeng/notion-react/src/renderer/mod.ts
+++ b/packages/@overeng/notion-react/src/renderer/mod.ts
@@ -24,7 +24,7 @@ export {
   type SyncResult,
   type SyncFallbackReason,
 } from './render-to-notion.ts'
-export { sync } from './sync.ts'
+export { sync, plan, type SyncPlan, type PlanStaleness } from './sync.ts'
 export { SyncEvent, type SyncEventHandler } from './sync-events.ts'
 export {
   extractFileUploadId,

--- a/packages/@overeng/notion-react/src/renderer/plan.unit.test.tsx
+++ b/packages/@overeng/notion-react/src/renderer/plan.unit.test.tsx
@@ -1,0 +1,142 @@
+import type { HttpClient } from 'effect/unstable/http/HttpClient'
+import { Effect } from 'effect'
+import type { ReactNode } from 'react'
+import { describe, expect, it } from 'vitest'
+
+import { NotionBlocks, type NotionConfig } from '@overeng/notion-effect-client'
+
+import { InMemoryCache } from '../cache/in-memory-cache.ts'
+import { ChildPage, Heading2, Page, Paragraph, Toggle } from '../components/blocks.ts'
+import { createFakeNotion, type FakeNotion } from '../test/mock-client.ts'
+import { plan, sync } from './sync.ts'
+
+const ROOT = '00000000-0000-4000-8000-000000000001'
+
+const runWith = <A, E>(
+  fake: FakeNotion,
+  eff: Effect.Effect<A, E, HttpClient | NotionConfig>,
+): Promise<A> => Effect.runPromise(eff.pipe(Effect.provide(fake.layer)))
+
+const doc = (version: 1 | 2): ReactNode => (
+  <>
+    <Heading2>Stats</Heading2>
+    <Paragraph blockKey="summary">{version === 1 ? 'first summary' : 'edited summary'}</Paragraph>
+    {version === 2 ? <Paragraph blockKey="extra">brand new paragraph</Paragraph> : null}
+    <Toggle blockKey="t1" title="Details">
+      <Paragraph>{version === 1 ? 'nested body' : 'nested body v2'}</Paragraph>
+    </Toggle>
+  </>
+)
+
+const pageDoc = (icon: string): ReactNode => (
+  <Page title="Root title" icon={{ type: 'emoji', emoji: icon }}>
+    <Paragraph blockKey="intro">intro text</Paragraph>
+    <ChildPage blockKey="sub" title="Sub page">
+      <Paragraph>sub body</Paragraph>
+    </ChildPage>
+  </Page>
+)
+
+describe('plan() — read-only companion to sync()', () => {
+  it('(a) cold cache: plan predicts exactly what the subsequent sync applies', async () => {
+    const fake = createFakeNotion()
+    const cache = InMemoryCache.make()
+    const p = await runWith(fake, plan(doc(1), { pageId: ROOT, cache }))
+    expect(p.fallbackReason).toBe('cold-cache')
+    expect(p.empty).toBe(false)
+    const res = await runWith(fake, sync(doc(1), { pageId: ROOT, cache }))
+    expect({
+      appends: res.appends,
+      updates: res.updates,
+      inserts: res.inserts,
+      removes: res.removes,
+    }).toEqual(p.blocks)
+    expect(res.pages).toEqual(p.pages)
+  })
+
+  it('(a) warm cache + changed JSX: plan and sync agree on the incremental op set', async () => {
+    const fake = createFakeNotion()
+    const cache = InMemoryCache.make()
+    await runWith(fake, sync(doc(1), { pageId: ROOT, cache }))
+    const p = await runWith(fake, plan(doc(2), { pageId: ROOT, cache }))
+    expect(p.fallbackReason).toBeUndefined()
+    // v1 → v2: 'summary' + nested toggle body update, 'extra' inserted mid-siblings.
+    expect(p.blocks).toEqual({ appends: 0, updates: 2, inserts: 1, removes: 0 })
+    const res = await runWith(fake, sync(doc(2), { pageId: ROOT, cache }))
+    expect({
+      appends: res.appends,
+      updates: res.updates,
+      inserts: res.inserts,
+      removes: res.removes,
+    }).toEqual(p.blocks)
+    expect(res.pages).toEqual(p.pages)
+  })
+
+  it('(b) fixpoint: immediately after a successful sync, plan returns zero ops', async () => {
+    const fake = createFakeNotion()
+    const cache = InMemoryCache.make()
+    await runWith(fake, sync(doc(2), { pageId: ROOT, cache }))
+    const p = await runWith(fake, plan(doc(2), { pageId: ROOT, cache }))
+    expect(p.ops).toEqual([])
+    expect(p.empty).toBe(true)
+    expect(p.fallbackReason).toBeUndefined()
+    expect(p.blocks).toEqual({ appends: 0, updates: 0, inserts: 0, removes: 0 })
+    expect(p.pages).toEqual({ creates: 0, updates: 0, archives: 0, moves: 0, reorders: 0 })
+  })
+
+  it('(b) fixpoint covers root-page metadata and sub-pages; icon change is planned as one updatePage', async () => {
+    const fake = createFakeNotion()
+    const cache = InMemoryCache.make()
+    await runWith(fake, sync(pageDoc('🧭'), { pageId: ROOT, cache }))
+    const settled = await runWith(fake, plan(pageDoc('🧭'), { pageId: ROOT, cache }))
+    expect(settled.empty).toBe(true)
+
+    const changed = await runWith(fake, plan(pageDoc('🚀'), { pageId: ROOT, cache }))
+    expect(changed.empty).toBe(false)
+    expect(changed.blocks).toEqual({ appends: 0, updates: 0, inserts: 0, removes: 0 })
+    expect(changed.pages).toEqual({ creates: 0, updates: 1, archives: 0, moves: 0, reorders: 0 })
+    expect(changed.ops[0]).toMatchObject({ kind: 'updatePage', pageId: ROOT })
+    const res = await runWith(fake, sync(pageDoc('🚀'), { pageId: ROOT, cache }))
+    expect(res.pages).toEqual(changed.pages)
+  })
+
+  it('(c) plan issues zero write calls — GET-only in live mode, nothing at all in cache-only mode', async () => {
+    const fake = createFakeNotion()
+    const cache = InMemoryCache.make()
+    await runWith(fake, sync(doc(1), { pageId: ROOT, cache }))
+    const before = fake.requests.length
+    await runWith(fake, plan(doc(2), { pageId: ROOT, cache }))
+    const during = fake.requests.slice(before)
+    expect(during.length).toBeGreaterThan(0) // shallow drift pre-flight
+    expect(during.every((r) => r.method === 'GET')).toBe(true)
+
+    const beforeCacheOnly = fake.requests.length
+    const p = await runWith(fake, plan(doc(2), { pageId: ROOT, cache, staleness: 'cache-only' }))
+    expect(fake.requests.length).toBe(beforeCacheOnly)
+    // Same plan as live mode here — no out-of-band drift exists.
+    expect(p.blocks).toEqual({ appends: 0, updates: 2, inserts: 1, removes: 0 })
+  })
+
+  it('staleness stance: live plan sees out-of-band drift, cache-only plan cannot', async () => {
+    const fake = createFakeNotion()
+    const cache = InMemoryCache.make()
+    await runWith(fake, sync(doc(1), { pageId: ROOT, cache }))
+    // Another client appends a block behind the cache's back.
+    await runWith(
+      fake,
+      NotionBlocks.append({
+        blockId: ROOT,
+        children: [{ type: 'paragraph', paragraph: { rich_text: [] } }] as never,
+      }),
+    )
+    const live = await runWith(fake, plan(doc(1), { pageId: ROOT, cache }))
+    expect(live.fallbackReason).toBe('cache-drift')
+    expect(live.blocks.removes).toBeGreaterThan(0) // the foreign block gets cleaned up
+    const blind = await runWith(fake, plan(doc(1), { pageId: ROOT, cache, staleness: 'cache-only' }))
+    expect(blind.empty).toBe(true) // trusts the cache, so it cannot see the drift
+    // sync converges the drift; plan agrees the fixpoint is restored.
+    await runWith(fake, sync(doc(1), { pageId: ROOT, cache }))
+    const after = await runWith(fake, plan(doc(1), { pageId: ROOT, cache }))
+    expect(after.empty).toBe(true)
+  })
+})

--- a/packages/@overeng/notion-react/src/renderer/plan.unit.test.tsx
+++ b/packages/@overeng/notion-react/src/renderer/plan.unit.test.tsx
@@ -8,6 +8,7 @@ import { NotionBlocks, type NotionConfig } from '@overeng/notion-effect-client'
 import { InMemoryCache } from '../cache/in-memory-cache.ts'
 import { ChildPage, Heading2, Page, Paragraph, Toggle } from '../components/blocks.ts'
 import { createFakeNotion, type FakeNotion } from '../test/mock-client.ts'
+import type { SyncEvent } from './sync-events.ts'
 import { plan, sync } from './sync.ts'
 
 const ROOT = '00000000-0000-4000-8000-000000000001'
@@ -132,11 +133,40 @@ describe('plan() — read-only companion to sync()', () => {
     const live = await runWith(fake, plan(doc(1), { pageId: ROOT, cache }))
     expect(live.fallbackReason).toBe('cache-drift')
     expect(live.blocks.removes).toBeGreaterThan(0) // the foreign block gets cleaned up
-    const blind = await runWith(fake, plan(doc(1), { pageId: ROOT, cache, staleness: 'cache-only' }))
+    const blind = await runWith(
+      fake,
+      plan(doc(1), { pageId: ROOT, cache, staleness: 'cache-only' }),
+    )
     expect(blind.empty).toBe(true) // trusts the cache, so it cannot see the drift
     // sync converges the drift; plan agrees the fixpoint is restored.
     await runWith(fake, sync(doc(1), { pageId: ROOT, cache }))
     const after = await runWith(fake, plan(doc(1), { pageId: ROOT, cache }))
     expect(after.empty).toBe(true)
+  })
+
+  it('onEvent: live plan emits retrieve op events + one PlanComputed; cache-only emits PlanComputed only', async () => {
+    const fake = createFakeNotion()
+    const cache = InMemoryCache.make()
+    await runWith(fake, sync(doc(1), { pageId: ROOT, cache }))
+
+    const live: SyncEvent[] = []
+    await runWith(fake, plan(doc(2), { pageId: ROOT, cache, onEvent: (e) => live.push(e) }))
+    expect(live.map((e) => e._tag)).toEqual(['OpIssued', 'OpSucceeded', 'PlanComputed'])
+    expect(live[0]).toMatchObject({ kind: 'retrieve' })
+    expect(live[1]).toMatchObject({ kind: 'retrieve' })
+    // PlanComputed carries the block tallies of the computed plan.
+    expect(live[2]).toMatchObject({ pageId: ROOT, appends: 0, updates: 2, inserts: 1, removes: 0 })
+
+    const offline: SyncEvent[] = []
+    await runWith(
+      fake,
+      plan(doc(2), {
+        pageId: ROOT,
+        cache,
+        staleness: 'cache-only',
+        onEvent: (e) => offline.push(e),
+      }),
+    )
+    expect(offline.map((e) => e._tag)).toEqual(['PlanComputed'])
   })
 })

--- a/packages/@overeng/notion-react/src/renderer/plan.unit.test.tsx
+++ b/packages/@overeng/notion-react/src/renderer/plan.unit.test.tsx
@@ -1,5 +1,5 @@
-import type { HttpClient } from 'effect/unstable/http/HttpClient'
 import { Effect } from 'effect'
+import type { HttpClient } from 'effect/unstable/http/HttpClient'
 import type { ReactNode } from 'react'
 import { describe, expect, it } from 'vitest'
 

--- a/packages/@overeng/notion-react/src/renderer/sync.ts
+++ b/packages/@overeng/notion-react/src/renderer/sync.ts
@@ -2542,7 +2542,7 @@ export const plan = (
             id: retrieveOpId,
             kind: 'retrieve',
             durationMs: performance.now() - t0,
-            resultCount: Chunk.size(liveChildren),
+            resultCount: Array.from(liveChildren).length,
             at: Date.now(),
           }),
         )

--- a/packages/@overeng/notion-react/src/renderer/sync.ts
+++ b/packages/@overeng/notion-react/src/renderer/sync.ts
@@ -2415,10 +2415,13 @@ export const sync = (
 export type PlanStaleness = 'live' | 'cache-only'
 
 /**
- * Read-only sync plan. `ops` is the exact op sequence `sync()` would apply
- * (including the root-page `updatePage` when root metadata drifted, which
- * `sync()` applies outside its internal diff); the tallies mirror
- * `SyncResult`'s counters for the same element/cache state.
+ * Read-only sync plan. `ops` mirrors `sync()`'s pre-flight diff one-to-one
+ * (including the root-page `updatePage` when root metadata drifted) but is
+ * in DIFF-EMISSION order, not `sync()`'s phased application schedule — the
+ * driver applies retained-sub-page-scoped block ops before retained-page
+ * `updatePage`s. Treat `ops` as an operation set with per-scope order, not
+ * an execution trace; the tallies mirror `SyncResult`'s counters for the
+ * same element/cache state.
  */
 export interface SyncPlan {
   readonly ops: readonly DiffOp[]
@@ -2449,7 +2452,14 @@ export interface SyncPlan {
  * disagree about what a sync would do for a given observed state.
  *
  * The `empty` flag doubles as a post-publication fixpoint oracle: after a
- * successful `sync()`, `plan()` over the same element must return zero ops.
+ * successful, CONVERGENT `sync()`, `plan()` over the same element returns
+ * zero ops. One documented exception: under the default
+ * `reorderSiblings: false`, a JSX reshuffle of retained `<ChildPage>`
+ * siblings emits a same-parent `movePage` that Notion rejects and `sync()`
+ * deliberately swallows (a documented no-op — see `reorderSiblings`), so
+ * server sibling order never converges and every subsequent live `plan()`
+ * keeps reporting that move. Opt into `reorderSiblings: true` (or accept
+ * the drift) for a true fixpoint.
  *
  * `onEvent` mirrors `sync()`'s hook for the read-only prefix: the `'live'`
  * children GET emits `OpIssued`/`OpSucceeded`/`OpFailed` with kind

--- a/packages/@overeng/notion-react/src/renderer/sync.ts
+++ b/packages/@overeng/notion-react/src/renderer/sync.ts
@@ -28,6 +28,7 @@ import {
   diff,
   iconOrCoverDrift,
   tallyDiff,
+  tallyPageOps,
   type CandidateNode,
   type CandidateTree,
   type DiffOp,
@@ -1044,6 +1045,242 @@ const driftedBase = (
 }
 
 /**
+ * Adopt the inline descendants of a page that was created with inline
+ * `children` but whose block ids were never observed (mid-sync crash between
+ * `pages.create` and the id-resolution retrieve). Retrieves the live children
+ * under `parentId` and pairs them positionally against the persisted
+ * create-time intent. Shared verbatim between `sync()` (which persists the
+ * adopted tree) and `plan()` (which adopts in memory only).
+ */
+const adoptInlineChildren = (
+  parentId: string,
+  nodes: readonly PendingInlineNode[],
+): Effect.Effect<readonly CacheNode[], NotionSyncError, NotionConfig | HttpClient> =>
+  Effect.gen(function* () {
+    const live = yield* Stream.runCollect(
+      NotionBlocks.retrieveChildrenStream({ blockId: parentId }),
+    ).pipe(
+      Effect.mapError((cause) => new NotionSyncError({ reason: 'notion-retrieve-failed', cause })),
+    )
+    const liveBlocks = Array.from(live)
+    const adopted: CacheNode[] = []
+    let liveIdx = 0
+    for (const node of nodes) {
+      const server = liveBlocks[liveIdx]
+      if (server === undefined) break
+      liveIdx += 1
+      if (server.type !== node.type) {
+        return yield* new NotionSyncError({
+          reason: 'notion-retrieve-failed',
+          cause: `pending inline type mismatch: expected ${node.type}, got ${server.type}`,
+        })
+      }
+      const children =
+        node.children.length === 0 ? [] : yield* adoptInlineChildren(server.id, node.children)
+      adopted.push({
+        key: node.key,
+        blockId: server.id,
+        type: node.type,
+        hash: node.hash,
+        children,
+        nodeKind: 'block',
+      })
+    }
+    // Live children beyond the persisted create-time intent mean another
+    // client wrote under the half-created page between the crashed sync
+    // and this retry. Adopting only the prefix would strand those blocks
+    // forever (drift detection is root-shallow), so fail loudly instead —
+    // failing before the cache save keeps the pending marker intact for a
+    // clean retry once the untracked content is removed.
+    if (liveIdx < liveBlocks.length) {
+      return yield* new NotionSyncError({
+        reason: 'notion-retrieve-failed',
+        cause:
+          `pending inline adoption found ${liveBlocks.length - liveIdx} untracked block(s) ` +
+          `under ${parentId} beyond the persisted create-time intent (${nodes.length} expected); ` +
+          `remove them or reset the cache to recover`,
+      })
+    }
+    return adopted
+  })
+
+/** Index every page-kind candidate (at any depth) by blockKey. */
+const indexCandidatePagesByKey = (
+  children: readonly CandidateNode[],
+): Map<string, CandidateNode> => {
+  const out = new Map<string, CandidateNode>()
+  const walk = (nodes: readonly CandidateNode[]): void => {
+    for (const node of nodes) {
+      if (node.nodeKind === 'page') out.set(node.key, node)
+      walk(node.children)
+    }
+  }
+  walk(children)
+  return out
+}
+
+/**
+ * Resolve `pendingInlineResolution` markers left by a crashed createPage,
+ * adopting the live inline descendants into the cache tree and binding the
+ * page identity onto the matching candidate. A checkpointed page may have
+ * moved to another parent in the retry JSX, so a sibling-local lookup would
+ * miss it — `candidatePageByKey` provides the cross-parent fallback so
+ * recovery can adopt the identity before the relocation is diffed.
+ */
+const resolvePendingPages = ({
+  cached,
+  candidates,
+  candidatePageByKey,
+}: {
+  readonly cached: readonly CacheNode[]
+  readonly candidates: readonly CandidateNode[]
+  readonly candidatePageByKey: ReadonlyMap<string, CandidateNode>
+}): Effect.Effect<
+  { readonly nodes: readonly CacheNode[]; readonly changed: boolean },
+  NotionSyncError,
+  NotionConfig | HttpClient
+> =>
+  Effect.gen(function* () {
+    let changed = false
+    const nodes: CacheNode[] = []
+    for (const cachedNode of cached) {
+      let candidateNode = candidates.find(
+        (node) => node.key === cachedNode.key && node.nodeKind === cachedNode.nodeKind,
+      )
+      if (
+        candidateNode === undefined &&
+        cachedNode.nodeKind === 'page' &&
+        cachedNode.pendingInlineResolution !== undefined
+      ) {
+        // Cross-parent fallback: resolve the pending inline descendants
+        // against the old location so the move diff sees adopted children
+        // instead of duplicating the server-side subtree.
+        candidateNode = candidatePageByKey.get(cachedNode.key)
+      }
+      if (candidateNode === undefined || cachedNode.nodeKind !== 'page') {
+        nodes.push(cachedNode)
+        continue
+      }
+      candidateNode.blockId = cachedNode.blockId
+      if (cachedNode.pendingInlineResolution !== undefined) {
+        const children = yield* adoptInlineChildren(
+          cachedNode.blockId,
+          cachedNode.pendingInlineResolution,
+        )
+        nodes.push({ ...cachedNode, children, pendingInlineResolution: undefined })
+        changed = true
+        continue
+      }
+      const nested = yield* resolvePendingPages({
+        cached: cachedNode.children,
+        candidates: candidateNode.children,
+        candidatePageByKey,
+      })
+      nodes.push(nested.changed ? { ...cachedNode, children: nested.nodes } : cachedNode)
+      changed = changed || nested.changed
+    }
+    return { nodes, changed }
+  })
+
+/**
+ * Ordered top-level drift predicate (#105). Out-of-band reorders leave the
+ * block-id set intact but scramble order, and we must rebuild to converge —
+ * so this is sequence equality, not set equality.
+ */
+const topLevelDrifted = (
+  expectedIds: readonly string[],
+  liveIds: readonly string[],
+): boolean => {
+  if (liveIds.length !== expectedIds.length) return true
+  for (let k = 0; k < expectedIds.length; k++) {
+    if (liveIds[k] !== expectedIds[k]) return true
+  }
+  return false
+}
+
+/**
+ * Select the tree the diff runs against plus the fallback classification.
+ * Pure function of the cache/drift inputs so `sync()` and `plan()` cannot
+ * disagree about which base a given state diffs against.
+ */
+const selectDiffBase = ({
+  pageId,
+  prior,
+  schemaMismatch,
+  pageIdDrift,
+  coldBaseline,
+  drifted,
+  liveTopLevelIds,
+}: {
+  readonly pageId: string
+  readonly prior: CacheTree | undefined
+  readonly schemaMismatch: boolean
+  readonly pageIdDrift: boolean
+  readonly coldBaseline: ColdBaseline
+  readonly drifted: boolean
+  readonly liveTopLevelIds: readonly string[]
+}): {
+  readonly useCold: boolean
+  readonly coldClean: boolean
+  readonly diffBase: CacheTree
+  readonly fallbackReason: SyncFallbackReason | undefined
+} => {
+  const useCold = prior === undefined || pageIdDrift
+  const coldClean = useCold && coldBaseline === 'clean' && liveTopLevelIds.length > 0
+  const diffBase: CacheTree = useCold
+    ? coldClean
+      ? driftedBase(pageId, liveTopLevelIds, undefined)
+      : emptyCache(pageId)
+    : drifted
+      ? driftedBase(pageId, liveTopLevelIds, prior)
+      : (prior ?? emptyCache(pageId))
+  const fallbackReason: SyncFallbackReason | undefined = pageIdDrift
+    ? 'page-id-drift'
+    : drifted
+      ? 'cache-drift'
+      : prior === undefined
+        ? 'cold-cache'
+        : schemaMismatch
+          ? 'schema-mismatch'
+          : undefined
+  return { useCold, coldClean, diffBase, fallbackReason }
+}
+
+/**
+ * Root-page metadata drift (issue #618 phase 3b/4b) expressed as the
+ * `updatePage` op `sync()` would apply against the sync root, or `undefined`
+ * when nothing drifted. Shared between `sync()` (which applies it) and
+ * `plan()` (which reports it) so the two cannot disagree about root-metadata
+ * convergence.
+ */
+const rootPageUpdateOpFor = ({
+  candidate,
+  prior,
+  pageId,
+}: {
+  readonly candidate: CandidateTree
+  readonly prior: CacheTree | undefined
+  readonly pageId: string
+}): Extract<PageOp, { kind: 'updatePage' }> | undefined => {
+  const rootPage = candidate.rootPage
+  if (rootPage === undefined) return undefined
+  const titleDrift = rootPage.titleHash !== undefined && rootPage.titleHash !== prior?.rootTitleHash
+  // Phase 4b (#618): `null` sentinel on fresh root (no prior icon) is a
+  // no-op; the candidate null hash matches "unset" server state. Once a
+  // prior hash exists, candidate `null` drifts and emits `icon: null`.
+  const iconDrift = iconOrCoverDrift(rootPage.iconHash, prior?.rootIconHash)
+  const coverDrift = iconOrCoverDrift(rootPage.coverHash, prior?.rootCoverHash)
+  if (!titleDrift && !iconDrift && !coverDrift) return undefined
+  return {
+    kind: 'updatePage',
+    pageId,
+    ...(titleDrift ? { title: rootPage.title } : {}),
+    ...(iconDrift ? { icon: rootPage.icon } : {}),
+    ...(coverDrift ? { cover: rootPage.cover } : {}),
+  }
+}
+
+/**
  * Cache-backed incremental sync.
  *
  * Renders the JSX into an in-memory candidate tree, diffs it against the
@@ -1183,120 +1420,7 @@ export const sync = (
       )
     }
 
-    const adoptInlineChildren = (
-      parentId: string,
-      nodes: readonly PendingInlineNode[],
-    ): Effect.Effect<readonly CacheNode[], NotionSyncError, NotionConfig | HttpClient> =>
-      Effect.gen(function* () {
-        const live = yield* Stream.runCollect(
-          NotionBlocks.retrieveChildrenStream({ blockId: parentId }),
-        ).pipe(
-          Effect.mapError(
-            (cause) => new NotionSyncError({ reason: 'notion-retrieve-failed', cause }),
-          ),
-        )
-        const liveBlocks = Array.from(live)
-        const adopted: CacheNode[] = []
-        let liveIdx = 0
-        for (const node of nodes) {
-          const server = liveBlocks[liveIdx]
-          if (server === undefined) break
-          liveIdx += 1
-          if (server.type !== node.type) {
-            return yield* new NotionSyncError({
-              reason: 'notion-retrieve-failed',
-              cause: `pending inline type mismatch: expected ${node.type}, got ${server.type}`,
-            })
-          }
-          const children =
-            node.children.length === 0 ? [] : yield* adoptInlineChildren(server.id, node.children)
-          adopted.push({
-            key: node.key,
-            blockId: server.id,
-            type: node.type,
-            hash: node.hash,
-            children,
-            nodeKind: 'block',
-          })
-        }
-        // Live children beyond the persisted create-time intent mean another
-        // client wrote under the half-created page between the crashed sync
-        // and this retry. Adopting only the prefix would strand those blocks
-        // forever (drift detection is root-shallow), so fail loudly instead —
-        // failing before the cache save keeps the pending marker intact for a
-        // clean retry once the untracked content is removed.
-        if (liveIdx < liveBlocks.length) {
-          return yield* new NotionSyncError({
-            reason: 'notion-retrieve-failed',
-            cause:
-              `pending inline adoption found ${liveBlocks.length - liveIdx} untracked block(s) ` +
-              `under ${parentId} beyond the persisted create-time intent (${nodes.length} expected); ` +
-              `remove them or reset the cache to recover`,
-          })
-        }
-        return adopted
-      })
-
-    // A checkpointed page may have moved to another parent in the retry JSX,
-    // so resolvePendingPages' sibling-local lookup would miss it and leave the
-    // marker unresolved — the subsequent movePage diff then re-appends the
-    // already-created inline descendants from an empty cache subtree. Index
-    // all page-kind candidates once so recovery can adopt the identity before
-    // the relocation is diffed.
-    const candidatePageByKey = new Map<string, CandidateNode>()
-    const indexCandidatePages = (nodes: readonly CandidateNode[]): void => {
-      for (const node of nodes) {
-        if (node.nodeKind === 'page') candidatePageByKey.set(node.key, node)
-        indexCandidatePages(node.children)
-      }
-    }
-    indexCandidatePages(candidate.children)
-
-    const resolvePendingPages = (
-      cached: readonly CacheNode[],
-      candidates: readonly CandidateNode[],
-    ): Effect.Effect<
-      { readonly nodes: readonly CacheNode[]; readonly changed: boolean },
-      NotionSyncError,
-      NotionConfig | HttpClient
-    > =>
-      Effect.gen(function* () {
-        let changed = false
-        const nodes: CacheNode[] = []
-        for (const cachedNode of cached) {
-          let candidateNode = candidates.find(
-            (node) => node.key === cachedNode.key && node.nodeKind === cachedNode.nodeKind,
-          )
-          if (
-            candidateNode === undefined &&
-            cachedNode.nodeKind === 'page' &&
-            cachedNode.pendingInlineResolution !== undefined
-          ) {
-            // Cross-parent fallback: resolve the pending inline descendants
-            // against the old location so the move diff sees adopted children
-            // instead of duplicating the server-side subtree.
-            candidateNode = candidatePageByKey.get(cachedNode.key)
-          }
-          if (candidateNode === undefined || cachedNode.nodeKind !== 'page') {
-            nodes.push(cachedNode)
-            continue
-          }
-          candidateNode.blockId = cachedNode.blockId
-          if (cachedNode.pendingInlineResolution !== undefined) {
-            const children = yield* adoptInlineChildren(
-              cachedNode.blockId,
-              cachedNode.pendingInlineResolution,
-            )
-            nodes.push({ ...cachedNode, children, pendingInlineResolution: undefined })
-            changed = true
-            continue
-          }
-          const nested = yield* resolvePendingPages(cachedNode.children, candidateNode.children)
-          nodes.push(nested.changed ? { ...cachedNode, children: nested.nodes } : cachedNode)
-          changed = changed || nested.changed
-        }
-        return { nodes, changed }
-      })
+    const candidatePageByKey = indexCandidatePagesByKey(candidate.children)
 
     // Pending recovery retrieves against page ids recorded under prior.rootId.
     // When the cache was written for a different page (page-id drift) those
@@ -1304,7 +1428,11 @@ export const sync = (
     // skip recovery and let the documented cold-start path handle the
     // mismatch.
     if (prior !== undefined && prior.rootId === opts.pageId) {
-      const resolvedPending = yield* resolvePendingPages(prior.children, candidate.children)
+      const resolvedPending = yield* resolvePendingPages({
+        cached: prior.children,
+        candidates: candidate.children,
+        candidatePageByKey,
+      })
       if (resolvedPending.changed) {
         prior = { ...prior, children: resolvedPending.nodes }
         yield* opts.cache
@@ -1402,19 +1530,10 @@ export const sync = (
       // Drift detection only applies to the warm-cache path; the cold path
       // always cleans pre-existing children when `coldBaseline === 'clean'`.
       if (prior !== undefined && !schemaMismatch && !pageIdDrift) {
-        const expectedIds = prior.children.map((c) => c.blockId)
-        // Ordered sequence equality — out-of-band reorders leave the block-id
-        // set intact but scramble order, and we must rebuild to converge.
-        if (liveIds.length !== expectedIds.length) {
-          drifted = true
-        } else {
-          for (let k = 0; k < expectedIds.length; k++) {
-            if (liveIds[k] !== expectedIds[k]) {
-              drifted = true
-              break
-            }
-          }
-        }
+        drifted = topLevelDrifted(
+          prior.children.map((c) => c.blockId),
+          liveIds,
+        )
       }
     }
 
@@ -1424,7 +1543,6 @@ export const sync = (
     // removes for the orphaned blocks and appends for the candidate tree —
     // otherwise a drifted page would get duplicated content (old blocks
     // remain, new copies append) and never converge.
-    const useCold = useColdPath
     // `diffBase` feeds the diff algorithm; on drift (or cold-clean with
     // pre-existing live blocks) it carries synthetic `drift:*` ghost entries
     // so every live top-level block becomes a remove op. `workingBase` seeds
@@ -1436,14 +1554,15 @@ export const sync = (
     // against Notion populate it via `workingAppend`; pending removes
     // target ghost blockIds that are absent from `working.byId`, which is
     // a safe no-op.
-    const coldClean = useCold && coldBaseline === 'clean' && liveTopLevelIds.length > 0
-    const diffBase: CacheTree = useCold
-      ? coldClean
-        ? driftedBase(opts.pageId, liveTopLevelIds, undefined)
-        : emptyCache(opts.pageId)
-      : drifted
-        ? driftedBase(opts.pageId, liveTopLevelIds, prior)
-        : (prior ?? emptyCache(opts.pageId))
+    const { useCold, diffBase, fallbackReason } = selectDiffBase({
+      pageId: opts.pageId,
+      prior,
+      schemaMismatch,
+      pageIdDrift,
+      coldBaseline,
+      drifted,
+      liveTopLevelIds,
+    })
     /* Working base mirrors diffBase for warm drift (no ghost leakage risk —
        we only copy prior entries whose blockIds are still live server-side,
        so they're real confirmed entries). For cold paths we stay empty. */
@@ -1456,15 +1575,6 @@ export const sync = (
             children: diffBase.children.filter((c) => !c.key.startsWith('drift:')),
           }
         : (prior ?? emptyCache(opts.pageId))
-    const fallbackReason: SyncFallbackReason | undefined = pageIdDrift
-      ? 'page-id-drift'
-      : drifted
-        ? 'cache-drift'
-        : prior === undefined
-          ? 'cold-cache'
-          : schemaMismatch
-            ? 'schema-mismatch'
-            : undefined
 
     if (onEvent !== undefined) {
       const cacheKind: 'hit' | 'miss' | 'drift' | 'page-id-drift' = pageIdDrift
@@ -1653,53 +1763,45 @@ export const sync = (
     let pageCounts: PageOpCounts = emptyPageCounts()
     let partialCreateFallback = false
     const rootPage = candidate.rootPage
-    if (rootPage !== undefined) {
-      const priorT = prior?.rootTitleHash
-      const priorI = prior?.rootIconHash
-      const priorC = prior?.rootCoverHash
-      const titleDrift = rootPage.titleHash !== undefined && rootPage.titleHash !== priorT
-      // Phase 4b (#618): `null` sentinel on fresh root (no prior icon) is a
-      // no-op; the candidate null hash matches "unset" server state. Once a
-      // prior hash exists, candidate `null` drifts and emits `icon: null`.
-      const iconDrift = iconOrCoverDrift(rootPage.iconHash, priorI)
-      const coverDrift = iconOrCoverDrift(rootPage.coverHash, priorC)
-      if (titleDrift || iconDrift || coverDrift) {
-        const opId = o11y.nextOpId()
-        const t0 = performance.now()
-        if (onEvent !== undefined) {
-          onEvent(
-            SyncEvent.PageOpIssued({
-              id: opId,
-              kind: 'updatePage',
-              pageId: opts.pageId,
-              at: Date.now(),
-            }),
-          )
-        }
-        yield* NotionPages.update({
-          pageId: opts.pageId,
-          ...(titleDrift ? { properties: { title: { title: rootPage.title as never } } } : {}),
-          ...(iconDrift ? { icon: rootPage.icon as never } : {}),
-          ...(coverDrift ? { cover: rootPage.cover as never } : {}),
-        }).pipe(
-          Effect.mapError(
-            (cause) => new NotionSyncError({ reason: 'notion-page-update-failed', cause }),
-          ),
+    const rootUpdateOp = rootPageUpdateOpFor({ candidate, prior, pageId: opts.pageId })
+    if (rootUpdateOp !== undefined) {
+      const opId = o11y.nextOpId()
+      const t0 = performance.now()
+      if (onEvent !== undefined) {
+        onEvent(
+          SyncEvent.PageOpIssued({
+            id: opId,
+            kind: 'updatePage',
+            pageId: opts.pageId,
+            at: Date.now(),
+          }),
         )
-        if (onEvent !== undefined) {
-          onEvent(
-            SyncEvent.PageOpApplied({
-              id: opId,
-              kind: 'updatePage',
-              pageId: opts.pageId,
-              durationMs: performance.now() - t0,
-              at: Date.now(),
-            }),
-          )
-        }
-        o11y.opCount.n += 1
-        pageCounts = { ...pageCounts, updates: pageCounts.updates + 1 }
       }
+      yield* NotionPages.update({
+        pageId: opts.pageId,
+        ...(rootUpdateOp.title !== undefined
+          ? { properties: { title: { title: rootUpdateOp.title as never } } }
+          : {}),
+        ...(rootUpdateOp.icon !== undefined ? { icon: rootUpdateOp.icon as never } : {}),
+        ...(rootUpdateOp.cover !== undefined ? { cover: rootUpdateOp.cover as never } : {}),
+      }).pipe(
+        Effect.mapError(
+          (cause) => new NotionSyncError({ reason: 'notion-page-update-failed', cause }),
+        ),
+      )
+      if (onEvent !== undefined) {
+        onEvent(
+          SyncEvent.PageOpApplied({
+            id: opId,
+            kind: 'updatePage',
+            pageId: opts.pageId,
+            durationMs: performance.now() - t0,
+            at: Date.now(),
+          }),
+        )
+      }
+      o11y.opCount.n += 1
+      pageCounts = { ...pageCounts, updates: pageCounts.updates + 1 }
     }
 
     // Issue #618 follow-up: at the root scope, `pages.create` and block
@@ -2294,3 +2396,143 @@ export const sync = (
     ),
   )
 }
+
+/**
+ * How `plan()` treats potential cache staleness.
+ *
+ * `'live'` (default): mirror `sync()`'s pre-flight exactly — resolve pending
+ * inline markers (in memory; nothing is persisted) and fetch the page's live
+ * top-level children for shallow drift detection. The returned plan is what
+ * `sync()` would compute if invoked now, at the cost of read-only API calls.
+ * There is still no lock: a writer racing between `plan()` and a later
+ * `sync()` can invalidate the plan (sync re-computes, so it stays correct —
+ * the *plan* is what goes stale, never the applied result).
+ *
+ * `'cache-only'`: a pure function of cache + JSX — zero API calls. Cannot see
+ * out-of-band drift or resolve pending markers, so it diverges from `sync()`
+ * whenever the server moved out from under the cache (including the
+ * cold-`'clean'` baseline sweep, which needs the live child list to plan its
+ * removes). Use for offline "would anything change?" checks against a cache
+ * that is trusted to be fresh.
+ */
+export type PlanStaleness = 'live' | 'cache-only'
+
+/**
+ * Read-only sync plan. `ops` is the exact op sequence `sync()` would apply
+ * (including the root-page `updatePage` when root metadata drifted, which
+ * `sync()` applies outside its internal diff); the tallies mirror
+ * `SyncResult`'s counters for the same element/cache state.
+ */
+export interface SyncPlan {
+  readonly ops: readonly DiffOp[]
+  readonly blocks: {
+    readonly appends: number
+    readonly updates: number
+    readonly inserts: number
+    readonly removes: number
+  }
+  readonly pages: {
+    readonly creates: number
+    readonly updates: number
+    readonly archives: number
+    readonly moves: number
+    readonly reorders: number
+  }
+  readonly fallbackReason: SyncFallbackReason | undefined
+  /** `true` iff the page is already at the fixpoint: a sync now would write nothing. */
+  readonly empty: boolean
+}
+
+/**
+ * Read-only companion to {@link sync}: compute the plan `sync()` would apply
+ * for `element` against the current cache WITHOUT performing any write — no
+ * Notion mutation, no cache save. Composed from the same building blocks as
+ * `sync()`'s own pre-flight (`resolvePendingPages`, `topLevelDrifted`,
+ * `selectDiffBase`, `diff`, `rootPageUpdateOpFor`), so the two cannot
+ * disagree about what a sync would do for a given observed state.
+ *
+ * The `empty` flag doubles as a post-publication fixpoint oracle: after a
+ * successful `sync()`, `plan()` over the same element must return zero ops.
+ */
+export const plan = (
+  element: ReactNode,
+  opts: {
+    readonly pageId: string
+    readonly cache: NotionCache
+    readonly coldBaseline?: ColdBaseline
+    readonly reorderSiblings?: boolean | { readonly holdingParentId: string }
+    readonly staleness?: PlanStaleness
+  },
+): Effect.Effect<SyncPlan, NotionSyncError, NotionConfig | HttpClient> =>
+  Effect.gen(function* () {
+    const staleness: PlanStaleness = opts.staleness ?? 'live'
+    const coldBaseline: ColdBaseline = opts.coldBaseline ?? 'clean'
+    let prior = yield* opts.cache.load.pipe(
+      Effect.mapError((cause) => new NotionSyncError({ reason: 'cache-load-failed', cause })),
+    )
+    const candidate = buildCandidateTree(element, opts.pageId)
+    if (staleness === 'live' && prior !== undefined && prior.rootId === opts.pageId) {
+      const candidatePageByKey = indexCandidatePagesByKey(candidate.children)
+      const resolvedPending = yield* resolvePendingPages({
+        cached: prior.children,
+        candidates: candidate.children,
+        candidatePageByKey,
+      })
+      // Unlike sync(), the adopted tree is NOT saved — plan() never writes.
+      if (resolvedPending.changed) prior = { ...prior, children: resolvedPending.nodes }
+    }
+
+    const schemaMismatch = prior !== undefined && prior.schemaVersion !== CACHE_SCHEMA_VERSION
+    const pageIdDrift = prior !== undefined && prior.rootId !== opts.pageId
+    const useColdPath = prior === undefined || pageIdDrift
+
+    let drifted = false
+    let liveTopLevelIds: readonly string[] = []
+    const wantsLiveRetrieve =
+      staleness === 'live' &&
+      ((prior !== undefined && !schemaMismatch && !pageIdDrift) ||
+        (useColdPath && coldBaseline === 'clean'))
+    if (wantsLiveRetrieve) {
+      const liveChildren = yield* Stream.runCollect(
+        NotionBlocks.retrieveChildrenStream({ blockId: opts.pageId }),
+      ).pipe(
+        Effect.mapError((cause) => new NotionSyncError({ reason: 'notion-retrieve-failed', cause })),
+      )
+      const liveIds: string[] = []
+      for (const b of Array.from(liveChildren)) {
+        if (b.in_trash !== true) liveIds.push(b.id)
+      }
+      liveTopLevelIds = liveIds
+      if (prior !== undefined && !schemaMismatch && !pageIdDrift) {
+        drifted = topLevelDrifted(
+          prior.children.map((c) => c.blockId),
+          liveIds,
+        )
+      }
+    }
+
+    const { diffBase, fallbackReason } = selectDiffBase({
+      pageId: opts.pageId,
+      prior,
+      schemaMismatch,
+      pageIdDrift,
+      coldBaseline,
+      drifted,
+      liveTopLevelIds,
+    })
+
+    const rootUpdateOp = rootPageUpdateOpFor({ candidate, prior, pageId: opts.pageId })
+    const ops: DiffOp[] = [
+      ...(rootUpdateOp !== undefined ? [rootUpdateOp] : []),
+      ...diff(diffBase, candidate, {
+        reorderSiblings: opts.reorderSiblings !== undefined && opts.reorderSiblings !== false,
+      }),
+    ]
+    return {
+      ops,
+      blocks: tallyDiff(ops),
+      pages: tallyPageOps(ops),
+      fallbackReason,
+      empty: ops.length === 0,
+    }
+  })

--- a/packages/@overeng/notion-react/src/renderer/sync.ts
+++ b/packages/@overeng/notion-react/src/renderer/sync.ts
@@ -1187,10 +1187,7 @@ const resolvePendingPages = ({
  * block-id set intact but scramble order, and we must rebuild to converge —
  * so this is sequence equality, not set equality.
  */
-const topLevelDrifted = (
-  expectedIds: readonly string[],
-  liveIds: readonly string[],
-): boolean => {
+const topLevelDrifted = (expectedIds: readonly string[], liveIds: readonly string[]): boolean => {
   if (liveIds.length !== expectedIds.length) return true
   for (let k = 0; k < expectedIds.length; k++) {
     if (liveIds[k] !== expectedIds[k]) return true
@@ -2453,6 +2450,13 @@ export interface SyncPlan {
  *
  * The `empty` flag doubles as a post-publication fixpoint oracle: after a
  * successful `sync()`, `plan()` over the same element must return zero ops.
+ *
+ * `onEvent` mirrors `sync()`'s hook for the read-only prefix: the `'live'`
+ * children GET emits `OpIssued`/`OpSucceeded`/`OpFailed` with kind
+ * `'retrieve'` (it is real HTTP volume), and the computed plan emits one
+ * `PlanComputed`. No other events — in particular no `SyncStart`/`SyncEnd`
+ * (nothing is synced) and no `CacheOutcome` (so plan probes don't skew
+ * cache-efficiency metrics aggregated across real syncs).
  */
 export const plan = (
   element: ReactNode,
@@ -2462,10 +2466,12 @@ export const plan = (
     readonly coldBaseline?: ColdBaseline
     readonly reorderSiblings?: boolean | { readonly holdingParentId: string }
     readonly staleness?: PlanStaleness
+    readonly onEvent?: SyncEventHandler
   },
 ): Effect.Effect<SyncPlan, NotionSyncError, NotionConfig | HttpClient> =>
   Effect.gen(function* () {
     const staleness: PlanStaleness = opts.staleness ?? 'live'
+    const onEvent = opts.onEvent
     const coldBaseline: ColdBaseline = opts.coldBaseline ?? 'clean'
     let prior = yield* opts.cache.load.pipe(
       Effect.mapError((cause) => new NotionSyncError({ reason: 'cache-load-failed', cause })),
@@ -2493,11 +2499,44 @@ export const plan = (
       ((prior !== undefined && !schemaMismatch && !pageIdDrift) ||
         (useColdPath && coldBaseline === 'clean'))
     if (wantsLiveRetrieve) {
+      const retrieveOpId = 1
+      const t0 = onEvent !== undefined ? performance.now() : 0
+      if (onEvent !== undefined) {
+        onEvent(SyncEvent.OpIssued({ id: retrieveOpId, kind: 'retrieve', at: Date.now() }))
+      }
       const liveChildren = yield* Stream.runCollect(
         NotionBlocks.retrieveChildrenStream({ blockId: opts.pageId }),
       ).pipe(
-        Effect.mapError((cause) => new NotionSyncError({ reason: 'notion-retrieve-failed', cause })),
+        Effect.tapError((cause) =>
+          Effect.sync(() => {
+            if (onEvent !== undefined) {
+              onEvent(
+                SyncEvent.OpFailed({
+                  id: retrieveOpId,
+                  kind: 'retrieve',
+                  durationMs: performance.now() - t0,
+                  error: String(cause),
+                  at: Date.now(),
+                }),
+              )
+            }
+          }),
+        ),
+        Effect.mapError(
+          (cause) => new NotionSyncError({ reason: 'notion-retrieve-failed', cause }),
+        ),
       )
+      if (onEvent !== undefined) {
+        onEvent(
+          SyncEvent.OpSucceeded({
+            id: retrieveOpId,
+            kind: 'retrieve',
+            durationMs: performance.now() - t0,
+            resultCount: Chunk.size(liveChildren),
+            at: Date.now(),
+          }),
+        )
+      }
       const liveIds: string[] = []
       for (const b of Array.from(liveChildren)) {
         if (b.in_trash !== true) liveIds.push(b.id)
@@ -2528,9 +2567,22 @@ export const plan = (
         reorderSiblings: opts.reorderSiblings !== undefined && opts.reorderSiblings !== false,
       }),
     ]
+    const blocks = tallyDiff(ops)
+    if (onEvent !== undefined) {
+      onEvent(
+        SyncEvent.PlanComputed({
+          pageId: opts.pageId,
+          appends: blocks.appends,
+          inserts: blocks.inserts,
+          updates: blocks.updates,
+          removes: blocks.removes,
+          at: Date.now(),
+        }),
+      )
+    }
     return {
       ops,
-      blocks: tallyDiff(ops),
+      blocks,
       pages: tallyPageOps(ops),
       fallbackReason,
       empty: ops.length === 0,


### PR DESCRIPTION
> Recreated from #1127: rebased onto current main (effect@4.0.0-rc.111 cohort); head SHA 5087bb902da5e9c51058e49bd9bd9583fe2cbd2d. The original was a stacked-base PR that GitHub refused to merge on every surface (stack guard + async merge API 404). Diff vs main currently includes earlier train stages; it shrinks to this stage only as predecessors below merge.

## Outcome

Add `plan()`, a read-only companion to `sync()`: the exact op sequence a sync would apply — computed through the same pre-flight and diff code path, root-page metadata update included — with zero writes: no Notion mutation, no cache save.

Closes #1122. Stacked on #1126.

## Why

`sync()` computes a full plan internally before applying, but there was no read-only way to ask "what would sync do". Consumers need that for pre-apply gating/audit, for post-apply fixpoint verification (a fresh plan over the same element must be empty — the strongest cheap convergence oracle for a managed tree), and for previews in additive publication flows. The Blocky publication flow hand-rolled this from `buildCandidateTree` + `diff` and silently missed root metadata drift, because `sync()` applies the root `updatePage` outside its internal diff.

## Changes

- `sync()`'s pre-flight extracted into shared module-level helpers (`resolvePendingPages`, `topLevelDrifted`, `selectDiffBase`, `rootPageUpdateOpFor`); `sync()` and `plan()` both run through them — shared code path, not a reimplementation
- `plan(element, { pageId, cache, coldBaseline?, reorderSiblings?, staleness?, onEvent? })` → `SyncPlan { ops, blocks, pages, fallbackReason, empty }`
- `staleness: 'live'` (default) mirrors sync's shallow pre-flight (one children GET + in-memory pending-marker adoption, never persisted); detects out-of-band appends as `fallbackReason: 'cache-drift'`. `'cache-only'` is a zero-request pure cache×JSX function with documented blind spots (out-of-band drift, cold-`'clean'` baseline removes, pending markers)
- docs: api.md plan section, VRS R37/R38 + tradeoff T11 (TOCTOU stance: the plan can go stale, the applied result cannot — sync recomputes), spec plan() section, experiment 0003, changelog

## Open decision taken (from #1122)

`plan()` accepts `onEvent` and emits from the existing `SyncEvent` union: the `'live'` GET emits `OpIssued`/`OpSucceeded`/`OpFailed` with kind `'retrieve'` (it is real HTTP volume) plus one `PlanComputed` for the computed plan. Deliberately no `SyncStart`/`SyncEnd`/`CacheOutcome`, so plan probes don't skew cache-efficiency or sync-duration metrics aggregated across real syncs.

## Evidence

- `notion-react`: 373 passed, 1 skipped (baseline 364 + 2 from #1126 + 7 new)
- new tests: cold + warm plan ≡ sync applied tallies; post-sync empty plan (fixpoint), including a `<Page>` + `<ChildPage>` + icon scenario where an icon change plans as exactly one root `updatePage`; GET-only request log during `'live'`; zero requests during `'cache-only'`; out-of-band append detected as `'cache-drift'` by `'live'` and invisible to `'cache-only'`; event sequences for both staleness modes
- existing sync behavior unchanged (full suite green, zero regressions)
- TypeScript build passed (`tsc -b tsconfig.check.json`); lint + format green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | unknown |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.0.3 |
| `agent_runtime` | OMP 18.0.3 |
| `tooling_profile` | dotfiles@a80129b-dirty |
</details>
<!-- agent-footer:end -->