### PR TITLE
feat(renderer): readback verification oracle — compare observed blocks against candidate intent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,19 @@ All notable changes to this project will be documented in this file.
   into a `CacheTree` out-of-band can no longer drift from the scheme
   `buildCandidateTree` / `diff` actually produce.
 
+- **@overeng/notion-react**: add the readback verification oracle (#1123).
+  `compareReadback({candidate, observed})` folds server-observed block JSON
+  and rendered candidate trees into one canonical form and compares them by
+  hash, absorbing Notion's response-shape deltas (decorated/re-segmented rich
+  text, explicit defaults, provider-injected fields). Ships with
+  `compareReadbackPage` for the page title/icon/cover envelope and
+  `observeBlockTree`, a GET-only walk producing the observed tree. Readback
+  hashes are a **separate hash space** from `CacheNode.hash` — never compare
+  across the two. Masking is candidate-contextual (no context-free observed
+  hash exists): unclaimed provider-owned fields, uploaded-media signed URLs,
+  and built-in-icon rewrites are masked and documented rather than compared
+  best-effort. `child_page` blocks compare by title identity; sub-pages get
+  their own per-page readback pass.
 - **@overeng/notion-react**: add `plan()`, a read-only companion to `sync()`
   (#1122). It computes the exact op sequence a sync would apply — through the
   same pre-flight and diff code path, root-page metadata update included —

--- a/packages/@overeng/notion-react/docs/api.md
+++ b/packages/@overeng/notion-react/docs/api.md
@@ -120,11 +120,11 @@ canonical form and compare by hash:
 
 ```ts
 const candidate = buildCandidateTree(element, pageId)
-const observed = yield* observeBlockTree({ blockId: pageId }) // GET-only walk
+const observed = yield * observeBlockTree({ blockId: pageId }) // GET-only walk
 const { equal, candidateHash, observedHash } = compareReadback({ candidate, observed })
 
 // Page envelope (title/icon/cover) — root or any sub-page:
-const page = yield* NotionPages.retrieve({ pageId })
+const page = yield * NotionPages.retrieve({ pageId })
 compareReadbackPage({ candidate: candidate.rootPage ?? {}, observed: page })
 ```
 

--- a/packages/@overeng/notion-react/docs/api.md
+++ b/packages/@overeng/notion-react/docs/api.md
@@ -116,7 +116,8 @@ import {
 The readback oracle certifies **server × intent** equality — the
 complement of `plan()`'s cache × intent fixpoint. Both the observed
 block JSON and the rendered `CandidateTree` normalize into one
-canonical form and compare by hash:
+canonical form; `equal` is decided by full stable-serialization equality
+of that form, with the reported hashes as diagnostics only.
 
 ```ts
 const candidate = buildCandidateTree(element, pageId)

--- a/packages/@overeng/notion-react/docs/api.md
+++ b/packages/@overeng/notion-react/docs/api.md
@@ -101,6 +101,51 @@ so the _plan_ can go stale — the applied result cannot, because `sync()`
 recomputes from scratch. Treat a plan as advisory for the observed
 instant; use the post-apply empty-plan check for proof of convergence.
 
+## Readback verification
+
+```ts
+import {
+  compareReadback,
+  compareReadbackPage,
+  observeBlockTree,
+  type ObservedBlockTree,
+  type ReadbackComparison,
+} from '@overeng/notion-react'
+```
+
+The readback oracle certifies **server × intent** equality — the
+complement of `plan()`'s cache × intent fixpoint. Both the observed
+block JSON and the rendered `CandidateTree` normalize into one
+canonical form and compare by hash:
+
+```ts
+const candidate = buildCandidateTree(element, pageId)
+const observed = yield* observeBlockTree({ blockId: pageId }) // GET-only walk
+const { equal, candidateHash, observedHash } = compareReadback({ candidate, observed })
+
+// Page envelope (title/icon/cover) — root or any sub-page:
+const page = yield* NotionPages.retrieve({ pageId })
+compareReadbackPage({ candidate: candidate.rootPage ?? {}, observed: page })
+```
+
+**Readback hashes are a separate hash space from `CacheNode.hash`.**
+The cache hashes request-shape projected props; readback hashes a
+response-normalized canonical form. Both build on the exported
+`hashStable`, but a cache hash never equals a readback hash for the
+same content — comparing across the two spaces is always a bug.
+
+**There is no context-free observed hash.** Masking is
+candidate-contextual: fields the JSX never claimed (callout `icon`,
+code `language`, column `widthRatio`, table `tableWidth`) are
+provider-owned and excluded; claimed fields compare exactly. Uploaded
+media sources and built-in-icon rewrites are masked as unverifiable —
+see [Limitations → Readback](./limitations.md#readback-verification-scope).
+
+`child_page` blocks compare by title identity only; verify a sub-page's
+own content with its own `compareReadback`/`compareReadbackPage` pass
+(same per-page boundary as sync itself). Raw escape-hatch blocks
+(`<Raw>`, `SyncedBlock`, …) are unsupported and throw.
+
 ## Block components
 
 From `@overeng/notion-react` (Notion host) and

--- a/packages/@overeng/notion-react/docs/limitations.md
+++ b/packages/@overeng/notion-react/docs/limitations.md
@@ -145,6 +145,45 @@ Our `@overeng/notion-effect-client` handles this transparently under
 `retryEnabled: true`, but if you layer your own retry on top, don't rely
 on headers.
 
+## Readback verification scope
+
+### Masked dimensions (T12)
+
+`compareReadback` / `compareReadbackPage` certify managed content, not
+byte-total equality. Explicitly outside the comparison:
+
+- **Uploaded media content.** A `fileUploadId` request comes back as a
+  `file` envelope with an expiring signed URL; the bytes are not
+  verifiable through block JSON. Uploaded sources mask to an `uploaded`
+  sentinel — position, type, and caption still compare exactly.
+- **Built-in icon identity (A07).** An external icon URL under
+  `notion.so/icons/` resolves server-side to the undocumented
+  `{type:'icon', icon:{name,color}}` envelope with no public name↔URL
+  mapping. That pairing masks to `builtin-unverified`: presence is
+  verified, the exact glyph is not.
+- **Provider-owned defaults.** Fields the JSX never claimed — callout
+  `icon`, code `language`, column `widthRatio`, table `tableWidth` —
+  are server-injected and excluded. Claim the prop to make it exact
+  managed content.
+- **Sub-page content.** `child_page` blocks compare by title identity
+  only and are never recursed into. Run a per-page readback for each
+  sub-page (mirrors the R26 per-page sync boundary).
+
+### Unsupported: raw escape-hatch blocks
+
+`<Raw>` and its passthrough wrappers (`Template`, `LinkPreview`,
+`SyncedBlock`, `ChildDatabase`, `Breadcrumb`) forward opaque
+request-shape payloads; their response-shape delta cannot be normalized
+generically. Readback normalization throws on them rather than
+comparing best-effort.
+
+### No snapshot isolation
+
+`observeBlockTree` is a paginated multi-request walk; a concurrent
+writer can produce an observation no single instant exhibited. Treat
+readback equality as advisory for the observed window, exactly like a
+`plan()` (T11).
+
 ## Web renderer (Storybook preview)
 
 ### Not API-stable (T05)

--- a/packages/@overeng/notion-react/docs/vrs/.experiments/0004-readback-normalization.md
+++ b/packages/@overeng/notion-react/docs/vrs/.experiments/0004-readback-normalization.md
@@ -1,0 +1,65 @@
+# Experiment: readback normalization into one comparable hash space
+
+- **Date:** 2026-08-25
+- **Related:** R39, R40, T12
+
+## Question
+
+Can server-observed block JSON and rendered candidate trees normalize into a
+single canonical form whose hash equality certifies "the live page matches the
+render" — without reusing (and thereby invalidating) the deployed
+`CacheNode.hash` space, and without a context-free observed hash?
+
+## Method
+
+A spike normalized four block types (paragraph, heading_2,
+bulleted_list_item, callout) into a shared `NormalizedReadbackNode` form:
+rich-text run coalescing, explicit annotation frames, empty-run dropping,
+default folding, callout-icon envelopes. It was then extended to the full
+first-class component surface (25 block types incl. table/table_row cells,
+code captions, media sources, mention/equation leaves, child_page identity)
+plus page-metadata comparison. Probes: (a) mock roundtrips
+(render → sync → observe → compare) per block type; (b) hand-written
+realistic response-shape fixtures carrying the deltas the mock cannot produce
+(`plain_text`/`href` decoration, re-segmented runs, provider-injected
+defaults, expanded mention objects, signed-URL file envelopes); (c) negatives
+(text/cell/expression/icon/checked/language tampering); (d) a gated live-API
+e2e lane replaying (a) against real Notion.
+
+## Result
+
+All sides hash-equal through the canonical form; every tamper probe breaks
+equality. Three structural findings:
+
+1. **Separate hash space is forced.** `CacheNode.hash` is djb2 over
+   request-shape projected props; the readback form must differ (defaults
+   explicit, runs coalesced, derived fields dropped). Rebasing the cache hash
+   onto the readback form would invalidate every deployed cache, so the two
+   spaces share only the `hashStable` primitive.
+2. **No context-free observed hash.** Unclaimed callout icons, unclaimed code
+   language, unclaimed column ratios and table widths are provider-injected —
+   whether an observed value is noise or drift depends on the candidate's
+   claim. `compareReadback` therefore takes both sides.
+3. **Some dimensions are unverifiable in principle** through block JSON:
+   uploaded-asset content (expiring signed URLs) and built-in icon identity
+   (undocumented `{type:'icon'}` rewrite, no public name↔URL mapping). These
+   mask to explicit sentinels rather than comparing flaky values.
+
+Latent sync finding (out of readback scope, reported upstream): the
+root-scope interleaved apply flushes buffered block ops at each `createPage`
+boundary, but the diff defers an atomic container's descendant appends until
+after the sibling run — a `<Table>`/`<ColumnList>` rendered before a root
+`<ChildPage>` is flushed without its inlined children and fails Notion's
+atomic-create validation.
+
+## Conclusion
+
+One canonical form with candidate-contextual masking satisfies R39/R40; the
+masked dimensions become the T12 tradeoff instead of silent flakiness.
+`child_page` stays an identity boundary — per-page readback composes the same
+way per-page sync does (R26).
+
+## VRS Impact
+
+R39, R40, T12 added; spec gains the readback-oracle section. Limitations
+document the masked dimensions and the unsupported raw escape-hatch types.

--- a/packages/@overeng/notion-react/docs/vrs/requirements.md
+++ b/packages/@overeng/notion-react/docs/vrs/requirements.md
@@ -106,6 +106,18 @@ host-config, or cache are implemented (see [spec.md](./spec.md) for that).
   Callers gating on a plan (pre-apply audit) must treat it as advisory
   for the observed instant, and use the post-apply empty-plan fixpoint
   check for proof.
+- **T12 Readback equality is scoped, not total:** The readback oracle
+  certifies managed content only. Deliberately outside its equality:
+  uploaded-asset bytes (signed URLs expire; masked to an `uploaded`
+  sentinel), built-in icon identity behind Notion's undocumented
+  `{type:'icon'}` rewrite (masked to `builtin-unverified`),
+  provider-owned defaults the JSX never claimed, and sub-page content
+  behind a `child_page` boundary (title-only identity; the sub-page gets
+  its own readback pass). A readback-equal page can therefore differ in
+  those masked dimensions — accepted, because the alternative is a
+  comparison that flaps on server-owned noise. Like T11, an observation
+  has no snapshot isolation: equality is advisory for the observed
+  window.
 
 ## Requirements
 
@@ -276,6 +288,27 @@ host-config, or cache are implemented (see [spec.md](./spec.md) for that).
   is a pure function of cache + JSX. The blind spots of `'cache-only'`
   (out-of-band drift, cold-`'clean'` baseline removes, pending-marker
   resolution) must be documented, not silently approximated.
+
+### Must verify server state against intent
+
+- **R39 Readback oracle in a dedicated hash space:** The library must
+  offer a normalization oracle that folds server-observed block JSON and
+  rendered candidate trees into one canonical form and compares them by
+  hash, absorbing every response-shape delta the API introduces
+  (decorated/re-segmented rich text, explicit defaults, provider-injected
+  fields, A07 envelope rewrites). Readback hashes are a separate hash
+  space from `CacheNode.hash` (which hashes request-shape projected
+  props); the two must never be compared against each other, and the
+  cache hash function must not change to accommodate readback — doing so
+  would invalidate every deployed cache.
+- **R40 Masking is candidate-contextual:** Whether an observed field is
+  managed content or provider-owned noise depends on whether the JSX
+  claimed it (e.g. an unclaimed callout icon is server-injected; a claimed
+  one is exact content). The comparison must therefore take both sides —
+  a context-free "hash of observed blocks" cannot exist in the public
+  API. Fields that are unverifiable through block JSON in principle
+  (uploaded-asset signed URLs, built-in-icon name↔URL mapping) must be
+  masked explicitly and documented, never compared best-effort.
 
 ### Must project authored JSX to readable Markdown (experimental)
 

--- a/packages/@overeng/notion-react/docs/vrs/spec.md
+++ b/packages/@overeng/notion-react/docs/vrs/spec.md
@@ -571,8 +571,8 @@ shared `hashStable`:
 ```ts
 compareReadback({ candidate, observed })
 // → { candidateHash, observedHash, equal, candidate, observed }
-compareReadbackPage({ candidate, observed })  // page title/icon/cover envelope
-observeBlockTree({ blockId })                  // effectful ObservedBlockTree walk
+compareReadbackPage({ candidate, observed }) // page title/icon/cover envelope
+observeBlockTree({ blockId }) // effectful ObservedBlockTree walk
 ```
 
 **Separate hash space (R39).** `CacheNode.hash` hashes request-shape

--- a/packages/@overeng/notion-react/docs/vrs/spec.md
+++ b/packages/@overeng/notion-react/docs/vrs/spec.md
@@ -560,6 +560,59 @@ Staleness (R38, T11):
 `SyncStart`/`SyncEnd`/`CacheOutcome` — plan probes must not skew
 cache-efficiency or sync-duration metrics aggregated across real syncs.
 
+## Readback oracle (R39–R40)
+
+`readback.ts` answers "does the live page equal what this JSX renders?"
+in one dedicated hash space. Both sides — server-observed block JSON
+(response shape) and the rendered `CandidateTree` (request-shape props)
+— normalize into `NormalizedReadbackNode` trees and hash through the
+shared `hashStable`:
+
+```ts
+compareReadback({ candidate, observed })
+// → { candidateHash, observedHash, equal, candidate, observed }
+compareReadbackPage({ candidate, observed })  // page title/icon/cover envelope
+observeBlockTree({ blockId })                  // effectful ObservedBlockTree walk
+```
+
+**Separate hash space (R39).** `CacheNode.hash` hashes request-shape
+projected props; readback hashes hash the canonical readback form. Both
+use `hashStable` (djb2 over stable-stringify) but are never comparable
+against each other. Unifying them would change the cache hash function
+and invalidate every deployed cache, so the two spaces are permanent.
+
+**Canonicalization.** Rich-text runs get fully explicit annotation
+frames, empty text runs drop, adjacent identical-frame text runs
+coalesce (Notion re-segments), mention envelopes reduce to
+`{type, ref}` (the response expands referenced objects), and
+`plain_text` / `href` are dropped as derived. Per-type props fold
+explicit API defaults (`color`, `is_toggleable`, `checked`, table
+header flags, empty captions).
+
+**Candidate-contextual masking (R40).** `maskProviderOwned` blanks
+fields on the observed side only where the candidate made no claim:
+callout `icon`, code `language`, column `width_ratio`, table
+`table_width`. Claimed values compare exactly. Two things are masked
+unconditionally because block JSON cannot verify them: uploaded media
+sources (`file_upload` request / expiring signed-URL `file` response →
+`uploaded` sentinel) and, on page metadata, the A07 built-in-icon
+rewrite (external notion.so/icons URL ↔ undocumented `{type:'icon'}`
+envelope → `builtin-unverified` sentinel).
+
+**Boundaries.** `child_page` blocks compare by title identity only and
+are never recursed into — a sub-page is its own reconciliation unit
+(R26) and gets its own `compareReadback` (blocks) +
+`compareReadbackPage` (envelope) pass; `observeBlockTree` stops at the
+same boundary. Raw escape-hatch payloads (`<Raw>`, `synced_block`, …)
+throw: their response shape is not normalizable generically.
+
+**Relation to plan().** `plan().empty` proves cache×intent convergence;
+`compareReadback` proves server×intent equality. The pair brackets the
+cache: a page can be plan-empty yet readback-unequal (cache poisoned or
+server edited out of band) and vice versa. Like a plan, an observation
+is advisory for the observed window (T11/T12) — there is no snapshot
+isolation across the paginated children walk.
+
 ## Upload coordination
 
 See `src/renderer/upload-registry.ts`.

--- a/packages/@overeng/notion-react/src/renderer/mod.ts
+++ b/packages/@overeng/notion-react/src/renderer/mod.ts
@@ -44,12 +44,25 @@ export {
   buildCandidateTree,
   candidateToCache,
   diff,
+  hashStable,
   stableStringify,
   tallyDiff,
+  tallyPageOps,
   type CandidateNode,
   type CandidateTree,
   type DiffOp,
 } from './sync-diff.ts'
+export {
+  compareReadback,
+  normalizeCandidate,
+  normalizeObserved,
+  readbackHash,
+  type NormalizedReadbackNode,
+  type ObservedBlockTree,
+  type ReadbackAnnotations,
+  type ReadbackComparison,
+  type ReadbackRun,
+} from './readback.ts'
 export {
   UploadRegistryProvider,
   useNotionUpload,

--- a/packages/@overeng/notion-react/src/renderer/mod.ts
+++ b/packages/@overeng/notion-react/src/renderer/mod.ts
@@ -54,6 +54,7 @@ export {
 } from './sync-diff.ts'
 export {
   compareReadback,
+  compareReadbackPage,
   normalizeCandidate,
   normalizeObserved,
   readbackHash,
@@ -61,8 +62,11 @@ export {
   type ObservedBlockTree,
   type ReadbackAnnotations,
   type ReadbackComparison,
+  type ReadbackPageCandidate,
+  type ReadbackPageComparison,
   type ReadbackRun,
 } from './readback.ts'
+export { observeBlockTree } from './readback-observe.ts'
 export {
   UploadRegistryProvider,
   useNotionUpload,

--- a/packages/@overeng/notion-react/src/renderer/readback-observe.ts
+++ b/packages/@overeng/notion-react/src/renderer/readback-observe.ts
@@ -27,11 +27,7 @@ import type { ObservedBlockTree } from './readback.ts'
  */
 export const observeBlockTree = (input: {
   readonly blockId: string
-}): Effect.Effect<
-  readonly ObservedBlockTree[],
-  NotionSyncError,
-  NotionConfig | HttpClient
-> =>
+}): Effect.Effect<readonly ObservedBlockTree[], NotionSyncError, NotionConfig | HttpClient> =>
   Effect.gen(function* () {
     const children = yield* Stream.runCollect(
       NotionBlocks.retrieveChildrenStream({ blockId: input.blockId }),

--- a/packages/@overeng/notion-react/src/renderer/readback-observe.ts
+++ b/packages/@overeng/notion-react/src/renderer/readback-observe.ts
@@ -1,5 +1,5 @@
-import type { HttpClient } from '@effect/platform'
-import { Chunk, Effect, Stream } from 'effect'
+import { Effect, Stream } from 'effect'
+import type { HttpClient } from 'effect/unstable/http/HttpClient'
 
 import { NotionBlocks, type NotionConfig } from '@overeng/notion-effect-client'
 
@@ -30,7 +30,7 @@ export const observeBlockTree = (input: {
 }): Effect.Effect<
   readonly ObservedBlockTree[],
   NotionSyncError,
-  NotionConfig | HttpClient.HttpClient
+  NotionConfig | HttpClient
 > =>
   Effect.gen(function* () {
     const children = yield* Stream.runCollect(
@@ -39,7 +39,7 @@ export const observeBlockTree = (input: {
       Effect.mapError((cause) => new NotionSyncError({ reason: 'notion-retrieve-failed', cause })),
     )
     const out: ObservedBlockTree[] = []
-    for (const block of Chunk.toReadonlyArray(children)) {
+    for (const block of Array.from(children)) {
       if (block.in_trash === true) continue
       const nested =
         block.has_children === true && block.type !== 'child_page'

--- a/packages/@overeng/notion-react/src/renderer/readback-observe.ts
+++ b/packages/@overeng/notion-react/src/renderer/readback-observe.ts
@@ -1,0 +1,51 @@
+import type { HttpClient } from '@effect/platform'
+import { Chunk, Effect, Stream } from 'effect'
+
+import { NotionBlocks, type NotionConfig } from '@overeng/notion-effect-client'
+
+import { NotionSyncError } from './errors.ts'
+import type { ObservedBlockTree } from './readback.ts'
+
+/**
+ * Observe a page's (or any block's) live subtree as the `ObservedBlockTree`
+ * shape `compareReadback` consumes: one `blocks.children` list per node with
+ * `has_children`, recursively, with in-trash blocks dropped.
+ *
+ * Effectful companion to the pure readback oracle — kept in its own module so
+ * `readback.ts` stays a pure function of its inputs (usable against
+ * hand-written fixtures and non-client observations without pulling the
+ * Notion client into the import graph).
+ *
+ * `child_page` blocks are NOT recursed into: their children belong to
+ * another page, which the readback oracle treats as an identity boundary
+ * (see readback.ts) — observe the sub-page separately with its own id.
+ *
+ * Cost: one paginated GET per block that has children, sequentially. There is
+ * no snapshot isolation — a writer racing the walk can produce a tree no
+ * single instant ever exhibited; treat the observation (and any comparison
+ * built on it) as advisory for the observed window, exactly like `plan()`.
+ */
+export const observeBlockTree = (input: {
+  readonly blockId: string
+}): Effect.Effect<
+  readonly ObservedBlockTree[],
+  NotionSyncError,
+  NotionConfig | HttpClient.HttpClient
+> =>
+  Effect.gen(function* () {
+    const children = yield* Stream.runCollect(
+      NotionBlocks.retrieveChildrenStream({ blockId: input.blockId }),
+    ).pipe(
+      Effect.mapError((cause) => new NotionSyncError({ reason: 'notion-retrieve-failed', cause })),
+    )
+    const out: ObservedBlockTree[] = []
+    for (const block of Chunk.toReadonlyArray(children)) {
+      if (block.in_trash === true) continue
+      const nested =
+        block.has_children === true && block.type !== 'child_page'
+          ? yield* observeBlockTree({ blockId: block.id })
+          : []
+      out.push({ block: block as unknown as Record<string, unknown>, children: nested })
+    }
+    return out
+  })

--- a/packages/@overeng/notion-react/src/renderer/readback.ts
+++ b/packages/@overeng/notion-react/src/renderer/readback.ts
@@ -2,11 +2,13 @@
  * Readback-normalization oracle.
  *
  * Answers one question: does the server-observed state of a page match what a
- * JSX element renders to, in the same hash space? Both sides are folded into a
- * canonical `NormalizedReadbackNode` tree and hashed with the package's shared
- * `hashStable` (djb2 over stable-stringify), so
- * `observed.hash === candidate.hash` iff the page content is semantically
- * identical to the render.
+ * JSX element renders to? Both sides are folded into a canonical
+ * `NormalizedReadbackNode` tree and compared by their full stable
+ * serializations, so the comparison is equal iff the page content is
+ * semantically identical to the render. The reported `candidateHash` /
+ * `observedHash` (package-shared `hashStable`, djb2 over stable-stringify)
+ * are fingerprints for reporting only — 32-bit collisions must never decide
+ * equality, so `equal` is always computed from the serializations.
  *
  * ## Readback hashes are a SEPARATE hash space from `CacheNode.hash`
  *
@@ -52,9 +54,18 @@
  * `synced_block`, `child_database`, `breadcrumb`, ...) are not supported:
  * their payloads are opaque request-shape passthroughs, so the response-shape
  * delta cannot be normalized generically. Normalization throws on them.
+ *
+ * Root-page metadata (title/icon/cover from `<Page>`) is out of scope here —
+ * pair with {@link compareReadbackPage} for the full page.
+ *
+ * `equal` is decided by full stable-serialization equality of the canonical
+ * trees — the 32-bit hashes are reported for diagnostics but never decide
+ * the verdict, so a hash collision cannot certify drifted content as
+ * matching.
  */
+
 import type { CandidateNode, CandidateTree } from './sync-diff.ts'
-import { hashStable } from './sync-diff.ts'
+import { hashStable, stableStringify } from './sync-diff.ts'
 
 type Json = Record<string, unknown>
 
@@ -433,9 +444,11 @@ export interface ReadbackComparison {
 
 /**
  * Compare a rendered candidate against a server observation of the same page.
- * `equal` (equivalently `candidateHash === observedHash`) certifies the page's
- * managed block content matches the render — the readback half of a
- * publication verification, complementing `plan()`'s cache-side fixpoint.
+ * `equal` certifies the page's managed block content matches the render —
+ * the readback half of a publication verification, complementing `plan()`'s
+ * cache-side fixpoint. It is decided by full stable-serialization equality;
+ * the reported hashes are diagnostics and never decide the verdict (a 32-bit
+ * collision must not certify drift as a match).
  *
  * Root-page metadata (title/icon/cover from `<Page>`) is out of scope here —
  * pair with {@link compareReadbackPage} for the full page.
@@ -449,12 +462,12 @@ export const compareReadback = ({
 }): ReadbackComparison => {
   const cand = normalizeCandidate(candidate.children)
   const obs = maskProviderOwned(cand, normalizeObserved(observed))
-  const candidateHash = readbackHash(cand)
-  const observedHash = readbackHash(obs)
+  const candJson = stableStringify(cand)
+  const obsJson = stableStringify(obs)
   return {
-    candidateHash,
-    observedHash,
-    equal: candidateHash === observedHash,
+    candidateHash: readbackHash(cand),
+    observedHash: readbackHash(obs),
+    equal: candJson === obsJson,
     candidate: cand,
     observed: obs,
   }
@@ -556,12 +569,12 @@ export const compareReadbackPage = ({
         : normalizeMediaSource(observed.cover as Json, 'page/cover(observed)')
   }
 
-  const candidateHash = hashStable(cand)
-  const observedHash = hashStable(obs)
+  const candJson = stableStringify(cand)
+  const obsJson = stableStringify(obs)
   return {
-    candidateHash,
-    observedHash,
-    equal: candidateHash === observedHash,
+    candidateHash: hashStable(cand),
+    observedHash: hashStable(obs),
+    equal: candJson === obsJson,
     candidate: cand,
     observed: obs,
   }

--- a/packages/@overeng/notion-react/src/renderer/readback.ts
+++ b/packages/@overeng/notion-react/src/renderer/readback.ts
@@ -410,12 +410,12 @@ const maskProviderOwned = (
     const children = maskProviderOwned(authored?.children ?? [], node.children)
     const maskable = PROVIDER_OWNED_WHEN_UNCLAIMED[node.type]
     if (maskable === undefined || authored?.type !== node.type) return { ...node, children }
-    let props = node.props
-    for (const field of maskable) {
-      if (authored.props[field] === null && props[field] !== null) {
-        props = { ...props, [field]: null }
-      }
-    }
+    const masked = maskable.filter(
+      (field) => authored.props[field] === null && node.props[field] !== null,
+    )
+    if (masked.length === 0) return { ...node, children }
+    const props: Json = { ...node.props }
+    for (const field of masked) props[field] = null
     return { ...node, props, children }
   })
 

--- a/packages/@overeng/notion-react/src/renderer/readback.ts
+++ b/packages/@overeng/notion-react/src/renderer/readback.ts
@@ -1,29 +1,57 @@
 /**
- * Readback-normalization oracle (spike).
+ * Readback-normalization oracle.
  *
- * Answers one question: does the server-observed block tree of a page match
- * what a JSX element renders to, in the same hash space? Both sides are folded
- * into a canonical `NormalizedReadbackNode` tree and hashed with the package's
- * shared `hashStable` (djb2 over stable-stringify), so
+ * Answers one question: does the server-observed state of a page match what a
+ * JSX element renders to, in the same hash space? Both sides are folded into a
+ * canonical `NormalizedReadbackNode` tree and hashed with the package's shared
+ * `hashStable` (djb2 over stable-stringify), so
  * `observed.hash === candidate.hash` iff the page content is semantically
  * identical to the render.
  *
- * Why a canonicalization layer is required (and why the raw candidate
- * `CandidateNode.hash` cannot be compared against readback directly): the
- * cache hash is computed over the REQUEST-shape projected props, while the
- * API returns RESPONSE-shape blocks — extra `plain_text` / `href` fields,
- * always-explicit `color` / `is_toggleable` defaults, and rich-text runs that
- * Notion may re-segment (merge adjacent identical frames, drop empty spans).
- * Both sides therefore map into one canonical form:
- *   - rich-text runs get fully explicit annotation frames, empty runs are
- *     dropped, and adjacent runs with identical (link, annotations) coalesce;
- *   - omitted-with-default fields (`color`, `is_toggleable`) become explicit;
- *   - callout icons are compared exactly when the JSX claimed one, and are
- *     provider-owned (masked to `null` on both sides) when the JSX omitted
- *     the `icon` prop — Notion injects a default icon the author never wrote.
+ * ## Readback hashes are a SEPARATE hash space from `CacheNode.hash`
  *
- * Spike scope: paragraph, heading_2, bulleted_list_item, callout. Text-only
- * rich text (no mention/equation leaves).
+ * The cache hash (`CandidateNode.hash` / `CacheNode.hash`) is computed over
+ * the REQUEST-shape projected props, while the API returns RESPONSE-shape
+ * blocks — extra `plain_text` / `href` fields, always-explicit
+ * `color` / `is_toggleable` defaults, and rich-text runs that Notion may
+ * re-segment (merge adjacent identical frames, drop empty spans). The two
+ * spaces share `hashStable` as the underlying hash function but hash
+ * DIFFERENT canonical forms: a readback hash never equals a cache hash for
+ * the same content, and unifying them would change the cache hash function
+ * and invalidate every deployed cache. Never compare a `CacheNode.hash`
+ * against a readback hash — compare readback hashes against readback hashes.
+ *
+ * ## No context-free observed hash
+ *
+ * Provider-owned masking (below) requires the candidate side: whether a
+ * field on the observed block is managed content or server noise depends on
+ * whether the JSX claimed it. A standalone `hashObserved(blocks)` therefore
+ * cannot exist — the public API takes both sides.
+ *
+ * ## Canonicalization rules
+ *
+ * - rich-text runs get fully explicit annotation frames, empty text runs are
+ *   dropped, and adjacent text runs with identical (link, annotations)
+ *   coalesce; mention / equation leaves normalize their envelopes (derived
+ *   `plain_text` / `href` / expanded user objects are dropped);
+ * - omitted-with-default fields (`color`, `is_toggleable`, `checked`,
+ *   `has_column_header`, `has_row_header`, captions) become explicit;
+ * - provider-owned-when-unclaimed fields (callout `icon`, code `language`,
+ *   column `width_ratio`, table `table_width`) are compared exactly when the
+ *   JSX claimed them and masked to `null` on both sides when it did not —
+ *   Notion injects defaults the author never wrote;
+ * - uploaded media sources (`file_upload` on the request, `file` with an
+ *   expiring signed URL on the response) are masked to an `uploaded`
+ *   sentinel — the bytes are not verifiable through block JSON, so uploaded
+ *   media compare by position, type, and caption only;
+ * - `child_page` blocks are an identity boundary: only the title is compared
+ *   and children are NOT recursed into — a sub-page's content is its own
+ *   page and gets its own `compareReadback` / `compareReadbackPage` pass.
+ *
+ * Raw escape-hatch blocks (`<Raw>`, `template`, `link_preview`,
+ * `synced_block`, `child_database`, `breadcrumb`, ...) are not supported:
+ * their payloads are opaque request-shape passthroughs, so the response-shape
+ * delta cannot be normalized generically. Normalization throws on them.
  */
 import type { CandidateNode, CandidateTree } from './sync-diff.ts'
 import { hashStable } from './sync-diff.ts'
@@ -40,12 +68,27 @@ export interface ReadbackAnnotations {
   readonly color: string
 }
 
-/** One canonical rich-text run: adjacent identical frames are coalesced. */
-export interface ReadbackRun {
-  readonly text: string
-  readonly link: string | null
-  readonly annotations: ReadbackAnnotations
-}
+/**
+ * One canonical rich-text run. Text runs coalesce with adjacent
+ * identical-frame text runs; mention and equation leaves never coalesce.
+ */
+export type ReadbackRun =
+  | {
+      readonly kind: 'text'
+      readonly text: string
+      readonly link: string | null
+      readonly annotations: ReadbackAnnotations
+    }
+  | {
+      readonly kind: 'mention'
+      readonly mention: Json
+      readonly annotations: ReadbackAnnotations
+    }
+  | {
+      readonly kind: 'equation'
+      readonly expression: string
+      readonly annotations: ReadbackAnnotations
+    }
 
 /** One canonical block node — the unit both hash sides agree on. */
 export interface NormalizedReadbackNode {
@@ -57,13 +100,13 @@ export interface NormalizedReadbackNode {
 /**
  * Server-observed block plus its (separately retrieved) children. The block
  * JSON is the public API response shape: `{ type, [type]: body, ... }`.
+ * Produced by `observeBlockTree` (readback-observe.ts) or any equivalent
+ * `blocks.children` walk.
  */
 export interface ObservedBlockTree {
   readonly block: Json
   readonly children: readonly ObservedBlockTree[]
 }
-
-const READBACK_SUPPORTED = new Set(['paragraph', 'heading_2', 'bulleted_list_item', 'callout'])
 
 const defaultAnnotations: ReadbackAnnotations = {
   bold: false,
@@ -74,11 +117,40 @@ const defaultAnnotations: ReadbackAnnotations = {
   color: 'default',
 }
 
+/** Case/dash-insensitive canonical form for Notion ids (page/block UUIDs). */
+const normalizeUuid = (id: string): string => id.toLowerCase().replaceAll('-', '')
+
+/**
+ * Canonicalize a mention envelope from either side. Notion expands referenced
+ * objects on the response (`user` mentions come back with name/avatar, `date`
+ * mentions with explicit `null` fields), while the request carries minimal
+ * refs — reduce both to the mention type plus a minimal reference: `{ id }`
+ * when the inner object carries one, otherwise the inner object with
+ * `null`-valued keys dropped.
+ */
+const normalizeMention = (mention: unknown, path: string): Json => {
+  if (typeof mention !== 'object' || mention === null) {
+    throw new Error(`${path}: malformed mention envelope`)
+  }
+  const env = mention as Json
+  const type = env.type
+  if (typeof type !== 'string') throw new Error(`${path}: mention lacks a type`)
+  const inner = env[type]
+  if (typeof inner !== 'object' || inner === null) return { type }
+  const rec = inner as Json
+  if (typeof rec.id === 'string') return { type, [type]: { id: normalizeUuid(rec.id) } }
+  const compact: Json = {}
+  for (const [k, v] of Object.entries(rec)) {
+    if (v !== null && v !== undefined) compact[k] = v
+  }
+  return { type, [type]: compact }
+}
+
 /**
  * Canonicalize a `rich_text` array from EITHER side. Request-shape items
- * (candidate props) and response-shape items (readback) both carry
- * `{ type: 'text', text: { content, link }, annotations }`; response items
- * additionally carry `plain_text` / `href`, which are derived and dropped.
+ * (candidate props) and response-shape items (readback) share
+ * `{ type, [type]: body, annotations }`; response items additionally carry
+ * `plain_text` / `href`, which are derived and dropped.
  */
 const normalizeRichText = (value: unknown, path: string): readonly ReadbackRun[] => {
   if (value === undefined) return []
@@ -87,11 +159,32 @@ const normalizeRichText = (value: unknown, path: string): readonly ReadbackRun[]
   for (const [index, raw] of value.entries()) {
     const item = raw as {
       readonly type?: unknown
-      readonly text?: { readonly content?: unknown; readonly link?: { readonly url?: unknown } | null }
+      readonly text?: {
+        readonly content?: unknown
+        readonly link?: { readonly url?: unknown } | null
+      }
+      readonly mention?: unknown
+      readonly equation?: { readonly expression?: unknown }
       readonly annotations?: Partial<ReadbackAnnotations>
     }
+    const annotations: ReadbackAnnotations = { ...defaultAnnotations, ...item.annotations }
+    if (item.type === 'mention') {
+      out.push({
+        kind: 'mention',
+        mention: normalizeMention(item.mention, `${path}/rich_text[${index}]`),
+        annotations,
+      })
+      continue
+    }
+    if (item.type === 'equation') {
+      if (typeof item.equation?.expression !== 'string') {
+        throw new Error(`${path}/rich_text[${index}]: malformed equation leaf`)
+      }
+      out.push({ kind: 'equation', expression: item.equation.expression, annotations })
+      continue
+    }
     if (item.type !== 'text' || typeof item.text?.content !== 'string') {
-      throw new Error(`${path}/rich_text[${index}]: unsupported non-text rich text`)
+      throw new Error(`${path}/rich_text[${index}]: unsupported rich text leaf`)
     }
     // Zero-length runs carry no semantics: the reconciler can emit them at
     // inline-component boundaries and Notion omits them on readback.
@@ -100,23 +193,23 @@ const normalizeRichText = (value: unknown, path: string): readonly ReadbackRun[]
     if (link !== null && typeof link !== 'string') {
       throw new Error(`${path}/rich_text[${index}]: malformed link`)
     }
-    const annotations: ReadbackAnnotations = { ...defaultAnnotations, ...item.annotations }
     const previous = out.at(-1)
     if (
       previous !== undefined &&
+      previous.kind === 'text' &&
       previous.link === link &&
       JSON.stringify(previous.annotations) === JSON.stringify(annotations)
     ) {
       out[out.length - 1] = { ...previous, text: `${previous.text}${item.text.content}` }
     } else {
-      out.push({ text: item.text.content, link, annotations })
+      out.push({ kind: 'text', text: item.text.content, link, annotations })
     }
   }
   return out
 }
 
-/** Canonical callout icon: the two request/response envelopes the spike supports. */
-const normalizeCalloutIcon = (icon: unknown, path: string): Json | null => {
+/** Canonical icon envelope: the request/response shapes both sides can carry. */
+const normalizeIconEnvelope = (icon: unknown, path: string): Json | null => {
   if (icon == null) return null
   const env = icon as Json
   if (env.type === 'emoji' && typeof env.emoji === 'string') {
@@ -125,26 +218,138 @@ const normalizeCalloutIcon = (icon: unknown, path: string): Json | null => {
   if (env.type === 'external' && typeof (env.external as Json | undefined)?.url === 'string') {
     return { type: 'external', external: { url: (env.external as Json).url } }
   }
-  throw new Error(`${path}: unsupported callout icon`)
+  if (
+    env.type === 'custom_emoji' &&
+    typeof (env.custom_emoji as Json | undefined)?.id === 'string'
+  ) {
+    return { type: 'custom_emoji', custom_emoji: { id: (env.custom_emoji as Json).id } }
+  }
+  if (env.type === 'icon' && typeof (env.icon as Json | undefined)?.name === 'string') {
+    // Notion's built-in-SVG rewrite envelope (A07): an `external` request URL
+    // under notion.so/icons resolves to `{type:'icon', icon:{name, color}}`.
+    const inner = env.icon as Json
+    const out: Json = { type: 'icon', name: inner.name }
+    if (typeof inner.color === 'string') out.color = inner.color
+    return out
+  }
+  throw new Error(`${path}: unsupported icon envelope`)
 }
 
 /**
+ * Canonical media source. Uploaded assets are masked to an `uploaded`
+ * sentinel: the request references a `file_upload` id (never echoed by the
+ * API) and the response serves a `file` envelope with an expiring signed URL
+ * — neither is stable, so uploaded content is not verifiable through block
+ * JSON. External sources compare by URL.
+ */
+const normalizeMediaSource = (body: Json, path: string): Json => {
+  if (body.type === 'external' || (body.type === undefined && body.external !== undefined)) {
+    const url = (body.external as Json | undefined)?.url
+    if (typeof url !== 'string') throw new Error(`${path}: malformed external media envelope`)
+    return { kind: 'external', url }
+  }
+  if (body.type === 'file_upload' || body.type === 'file') {
+    return { kind: 'uploaded' }
+  }
+  throw new Error(`${path}: unsupported media source '${String(body.type)}'`)
+}
+
+/**
+ * Plain-text projection of a page title for `child_page` identity: the block
+ * API only surfaces a sub-page's title as a bare string, so the candidate's
+ * title spans reduce to their concatenated text content for this comparison.
+ */
+const titlePlainText = (title: unknown): string => {
+  if (typeof title === 'string') return title
+  if (!Array.isArray(title)) return ''
+  return title
+    .map((span) => {
+      const text = (span as { text?: { content?: unknown } }).text
+      return typeof text?.content === 'string' ? text.content : ''
+    })
+    .join('')
+}
+
+const HEADINGS = new Set(['heading_1', 'heading_2', 'heading_3', 'heading_4'])
+const MEDIA = new Set(['image', 'video', 'audio', 'file', 'pdf'])
+
+/**
  * Fold one block body (request- or response-shape — they share the fields the
- * canonical form keeps) into canonical props for its type.
+ * canonical form keeps) into canonical props for its type. Fields whose
+ * ownership depends on whether the JSX claimed them come out as `null` when
+ * absent; `maskProviderOwned` equalizes them using the candidate side.
  */
 const normalizeBody = (type: string, body: Json, path: string): Json => {
-  if (!READBACK_SUPPORTED.has(type)) {
-    throw new Error(`${path}: readback normalization not implemented for ${type}`)
-  }
-  const richText = normalizeRichText(body.rich_text, path)
+  const richText = (): readonly ReadbackRun[] => normalizeRichText(body.rich_text, path)
+  const caption = (): readonly ReadbackRun[] => normalizeRichText(body.caption, path)
   const color = typeof body.color === 'string' ? body.color : 'default'
-  if (type === 'heading_2') {
-    return { rich_text: richText, color, is_toggleable: body.is_toggleable === true }
+  if (type === 'paragraph' || type === 'quote') {
+    return { rich_text: richText(), color }
+  }
+  if (type === 'bulleted_list_item' || type === 'numbered_list_item' || type === 'toggle') {
+    return { rich_text: richText(), color }
+  }
+  if (HEADINGS.has(type)) {
+    return { rich_text: richText(), color, is_toggleable: body.is_toggleable === true }
+  }
+  if (type === 'to_do') {
+    return { rich_text: richText(), color, checked: body.checked === true }
   }
   if (type === 'callout') {
-    return { rich_text: richText, color, icon: normalizeCalloutIcon(body.icon, path) }
+    return { rich_text: richText(), color, icon: normalizeIconEnvelope(body.icon, path) }
   }
-  return { rich_text: richText, color }
+  if (type === 'code') {
+    return {
+      rich_text: richText(),
+      caption: caption(),
+      language: typeof body.language === 'string' ? body.language : null,
+    }
+  }
+  if (type === 'divider' || type === 'column_list') {
+    return {}
+  }
+  if (type === 'table_of_contents') {
+    return { color }
+  }
+  if (type === 'equation') {
+    if (typeof body.expression !== 'string') throw new Error(`${path}: equation lacks expression`)
+    return { expression: body.expression }
+  }
+  if (type === 'bookmark' || type === 'embed') {
+    if (typeof body.url !== 'string') throw new Error(`${path}: ${type} lacks url`)
+    return { url: body.url, caption: caption() }
+  }
+  if (MEDIA.has(type)) {
+    return { source: normalizeMediaSource(body, path), caption: caption() }
+  }
+  if (type === 'table') {
+    return {
+      table_width: typeof body.table_width === 'number' ? body.table_width : null,
+      has_column_header: body.has_column_header === true,
+      has_row_header: body.has_row_header === true,
+    }
+  }
+  if (type === 'table_row') {
+    const cells = body.cells
+    if (!Array.isArray(cells)) throw new Error(`${path}: table_row lacks cells`)
+    return {
+      cells: cells.map((cell, i) => normalizeRichText(cell, `${path}/cells[${i}]`)),
+    }
+  }
+  if (type === 'column') {
+    return { width_ratio: typeof body.width_ratio === 'number' ? body.width_ratio : null }
+  }
+  if (type === 'link_to_page') {
+    const pageId = body.page_id
+    if (typeof pageId !== 'string') throw new Error(`${path}: link_to_page lacks page_id`)
+    return { page_id: normalizeUuid(pageId) }
+  }
+  if (type === 'child_page') {
+    // Identity boundary — see module docs. The block API surfaces only the
+    // title; icon/cover/content verify through their own page-level pass.
+    return { title: titlePlainText(body.title) }
+  }
+  throw new Error(`${path}: readback normalization not implemented for ${type}`)
 }
 
 /** Normalize a server-observed block tree into canonical nodes. */
@@ -163,7 +368,8 @@ export const normalizeObserved = (
     return {
       type,
       props: normalizeBody(type, body as Json, nodePath),
-      children: normalizeObserved(children, nodePath),
+      // child_page children live in another page — never compared here.
+      children: type === 'child_page' ? [] : normalizeObserved(children, nodePath),
     }
   })
 
@@ -177,17 +383,24 @@ export const normalizeCandidate = (
     return {
       type: node.type,
       props: normalizeBody(node.type, node.props, nodePath),
-      children: normalizeCandidate(node.children, nodePath),
+      children: node.type === 'child_page' ? [] : normalizeCandidate(node.children, nodePath),
     }
   })
 
 /**
- * Blank provider-owned fields on the observed side. Today that is exactly one
- * field: a callout icon the JSX never claimed (candidate `icon` prop omitted
- * → canonical `icon: null`) is supplied by Notion with a default the author
- * does not manage — mask it back to `null` so it cannot fail the comparison.
- * Explicit JSX icons stay exact managed content.
+ * Fields Notion supplies a default for when the author made no claim. When
+ * the candidate's canonical value is `null` (prop omitted in JSX), the
+ * observed value is provider-owned noise — masked back to `null` so it cannot
+ * fail the comparison. Explicit JSX claims stay exact managed content.
  */
+const PROVIDER_OWNED_WHEN_UNCLAIMED: Readonly<Record<string, readonly string[]>> = {
+  callout: ['icon'],
+  code: ['language'],
+  column: ['width_ratio'],
+  table: ['table_width'],
+}
+
+/** Blank provider-owned fields on the observed side using candidate context. */
 const maskProviderOwned = (
   candidate: readonly NormalizedReadbackNode[],
   observed: readonly NormalizedReadbackNode[],
@@ -195,14 +408,19 @@ const maskProviderOwned = (
   observed.map((node, index) => {
     const authored = candidate[index]
     const children = maskProviderOwned(authored?.children ?? [], node.children)
-    const providerOwnedIcon =
-      node.type === 'callout' && authored?.type === 'callout' && authored.props.icon === null
-    return providerOwnedIcon
-      ? { ...node, props: { ...node.props, icon: null }, children }
-      : { ...node, children }
+    const maskable = PROVIDER_OWNED_WHEN_UNCLAIMED[node.type]
+    if (maskable === undefined || authored?.type !== node.type) return { ...node, children }
+    let props = node.props
+    for (const field of maskable) {
+      if (authored.props[field] === null && props[field] !== null) {
+        props = { ...props, [field]: null }
+      }
+    }
+    return { ...node, props, children }
   })
 
-/** Hash a canonical tree — shares `hashStable` with the candidate/cache hashes. */
+/** Hash a canonical tree. Shares `hashStable` with the cache hashes but is a
+ * DIFFERENT hash space — see module docs. */
 export const readbackHash = (nodes: readonly NormalizedReadbackNode[]): string => hashStable(nodes)
 
 export interface ReadbackComparison {
@@ -216,8 +434,11 @@ export interface ReadbackComparison {
 /**
  * Compare a rendered candidate against a server observation of the same page.
  * `equal` (equivalently `candidateHash === observedHash`) certifies the page's
- * managed content matches the render — the readback half of a publication
- * verification, complementing `plan()`'s cache-side fixpoint.
+ * managed block content matches the render — the readback half of a
+ * publication verification, complementing `plan()`'s cache-side fixpoint.
+ *
+ * Root-page metadata (title/icon/cover from `<Page>`) is out of scope here —
+ * pair with {@link compareReadbackPage} for the full page.
  */
 export const compareReadback = ({
   candidate,
@@ -230,5 +451,118 @@ export const compareReadback = ({
   const obs = maskProviderOwned(cand, normalizeObserved(observed))
   const candidateHash = readbackHash(cand)
   const observedHash = readbackHash(obs)
-  return { candidateHash, observedHash, equal: candidateHash === observedHash, candidate: cand, observed: obs }
+  return {
+    candidateHash,
+    observedHash,
+    equal: candidateHash === observedHash,
+    candidate: cand,
+    observed: obs,
+  }
+}
+
+/**
+ * Candidate-side page metadata claims, mirroring `CandidateRootPage` and the
+ * page fields of a page-kind `CandidateNode` (both are structurally
+ * assignable). Field semantics follow the cache-side sentinel contract:
+ *
+ * - `undefined` (prop omitted) = no claim — the field is masked out of the
+ *   comparison entirely;
+ * - `null` on icon/cover = "clear on server" — the observed field must be
+ *   unset for the comparison to hold;
+ * - a set value compares exactly (modulo A07 normalization).
+ */
+export interface ReadbackPageCandidate {
+  readonly title?: readonly Json[] | undefined
+  readonly icon?: Json | null | undefined
+  readonly cover?: Json | null | undefined
+}
+
+export interface ReadbackPageComparison {
+  readonly candidateHash: string
+  readonly observedHash: string
+  readonly equal: boolean
+  readonly candidate: Json
+  readonly observed: Json
+}
+
+/** Sentinel for fields the JSX made no claim about (masked on both sides). */
+const UNCLAIMED = '(unclaimed)'
+
+const BUILTIN_ICON_URL_PREFIX = 'https://www.notion.so/icons/'
+
+/**
+ * Compare authored page metadata (title/icon/cover) against a
+ * `pages.retrieve` response. Complements {@link compareReadback}: block
+ * readback covers a page's children, this covers the page envelope itself —
+ * for the sync root (candidate side: `CandidateTree.rootPage`) and for
+ * sub-pages (candidate side: the page-kind `CandidateNode`'s
+ * title/icon/cover, observed side: the sub-page's own `pages.retrieve`).
+ *
+ * A07 wrinkle: an external icon URL under notion.so/icons resolves
+ * server-side to an undocumented `{type:'icon', icon:{name,color}}` envelope
+ * whose name↔URL mapping is not public. That pairing is masked to a shared
+ * `builtin-unverified` sentinel — presence is verified, the exact glyph is
+ * not. Uploaded covers (`file_upload` request / `file` signed-URL response)
+ * mask to `uploaded` like media block sources.
+ */
+export const compareReadbackPage = ({
+  candidate,
+  observed,
+}: {
+  readonly candidate: ReadbackPageCandidate
+  readonly observed: Json
+}): ReadbackPageComparison => {
+  const cand: Json = {}
+  const obs: Json = {}
+
+  if (candidate.title === undefined) {
+    cand.title = UNCLAIMED
+    obs.title = UNCLAIMED
+  } else {
+    cand.title = normalizeRichText(candidate.title, 'page/title')
+    const properties = observed.properties as Json | undefined
+    const titleProp = properties?.title as { title?: unknown } | undefined
+    obs.title = normalizeRichText(titleProp?.title ?? [], 'page/title(observed)')
+  }
+
+  if (candidate.icon === undefined) {
+    cand.icon = UNCLAIMED
+    obs.icon = UNCLAIMED
+  } else {
+    let candIcon =
+      candidate.icon === null ? null : normalizeIconEnvelope(candidate.icon, 'page/icon')
+    let obsIcon = normalizeIconEnvelope(observed.icon, 'page/icon(observed)')
+    const candUrl =
+      candIcon !== null && candIcon.type === 'external'
+        ? ((candIcon.external as Json).url as string)
+        : undefined
+    if (candUrl?.startsWith(BUILTIN_ICON_URL_PREFIX) === true && obsIcon?.type === 'icon') {
+      candIcon = { type: 'builtin-unverified' }
+      obsIcon = { type: 'builtin-unverified' }
+    }
+    cand.icon = candIcon
+    obs.icon = obsIcon
+  }
+
+  if (candidate.cover === undefined) {
+    cand.cover = UNCLAIMED
+    obs.cover = UNCLAIMED
+  } else {
+    cand.cover =
+      candidate.cover === null ? null : normalizeMediaSource(candidate.cover, 'page/cover')
+    obs.cover =
+      observed.cover == null
+        ? null
+        : normalizeMediaSource(observed.cover as Json, 'page/cover(observed)')
+  }
+
+  const candidateHash = hashStable(cand)
+  const observedHash = hashStable(obs)
+  return {
+    candidateHash,
+    observedHash,
+    equal: candidateHash === observedHash,
+    candidate: cand,
+    observed: obs,
+  }
 }

--- a/packages/@overeng/notion-react/src/renderer/readback.ts
+++ b/packages/@overeng/notion-react/src/renderer/readback.ts
@@ -1,0 +1,234 @@
+/**
+ * Readback-normalization oracle (spike).
+ *
+ * Answers one question: does the server-observed block tree of a page match
+ * what a JSX element renders to, in the same hash space? Both sides are folded
+ * into a canonical `NormalizedReadbackNode` tree and hashed with the package's
+ * shared `hashStable` (djb2 over stable-stringify), so
+ * `observed.hash === candidate.hash` iff the page content is semantically
+ * identical to the render.
+ *
+ * Why a canonicalization layer is required (and why the raw candidate
+ * `CandidateNode.hash` cannot be compared against readback directly): the
+ * cache hash is computed over the REQUEST-shape projected props, while the
+ * API returns RESPONSE-shape blocks — extra `plain_text` / `href` fields,
+ * always-explicit `color` / `is_toggleable` defaults, and rich-text runs that
+ * Notion may re-segment (merge adjacent identical frames, drop empty spans).
+ * Both sides therefore map into one canonical form:
+ *   - rich-text runs get fully explicit annotation frames, empty runs are
+ *     dropped, and adjacent runs with identical (link, annotations) coalesce;
+ *   - omitted-with-default fields (`color`, `is_toggleable`) become explicit;
+ *   - callout icons are compared exactly when the JSX claimed one, and are
+ *     provider-owned (masked to `null` on both sides) when the JSX omitted
+ *     the `icon` prop — Notion injects a default icon the author never wrote.
+ *
+ * Spike scope: paragraph, heading_2, bulleted_list_item, callout. Text-only
+ * rich text (no mention/equation leaves).
+ */
+import type { CandidateNode, CandidateTree } from './sync-diff.ts'
+import { hashStable } from './sync-diff.ts'
+
+type Json = Record<string, unknown>
+
+/** Fully explicit annotation frame used for canonical comparison. */
+export interface ReadbackAnnotations {
+  readonly bold: boolean
+  readonly italic: boolean
+  readonly strikethrough: boolean
+  readonly underline: boolean
+  readonly code: boolean
+  readonly color: string
+}
+
+/** One canonical rich-text run: adjacent identical frames are coalesced. */
+export interface ReadbackRun {
+  readonly text: string
+  readonly link: string | null
+  readonly annotations: ReadbackAnnotations
+}
+
+/** One canonical block node — the unit both hash sides agree on. */
+export interface NormalizedReadbackNode {
+  readonly type: string
+  readonly props: Json
+  readonly children: readonly NormalizedReadbackNode[]
+}
+
+/**
+ * Server-observed block plus its (separately retrieved) children. The block
+ * JSON is the public API response shape: `{ type, [type]: body, ... }`.
+ */
+export interface ObservedBlockTree {
+  readonly block: Json
+  readonly children: readonly ObservedBlockTree[]
+}
+
+const READBACK_SUPPORTED = new Set(['paragraph', 'heading_2', 'bulleted_list_item', 'callout'])
+
+const defaultAnnotations: ReadbackAnnotations = {
+  bold: false,
+  italic: false,
+  strikethrough: false,
+  underline: false,
+  code: false,
+  color: 'default',
+}
+
+/**
+ * Canonicalize a `rich_text` array from EITHER side. Request-shape items
+ * (candidate props) and response-shape items (readback) both carry
+ * `{ type: 'text', text: { content, link }, annotations }`; response items
+ * additionally carry `plain_text` / `href`, which are derived and dropped.
+ */
+const normalizeRichText = (value: unknown, path: string): readonly ReadbackRun[] => {
+  if (value === undefined) return []
+  if (!Array.isArray(value)) throw new Error(`${path}: rich_text must be an array`)
+  const out: ReadbackRun[] = []
+  for (const [index, raw] of value.entries()) {
+    const item = raw as {
+      readonly type?: unknown
+      readonly text?: { readonly content?: unknown; readonly link?: { readonly url?: unknown } | null }
+      readonly annotations?: Partial<ReadbackAnnotations>
+    }
+    if (item.type !== 'text' || typeof item.text?.content !== 'string') {
+      throw new Error(`${path}/rich_text[${index}]: unsupported non-text rich text`)
+    }
+    // Zero-length runs carry no semantics: the reconciler can emit them at
+    // inline-component boundaries and Notion omits them on readback.
+    if (item.text.content === '') continue
+    const link = item.text.link == null ? null : item.text.link.url
+    if (link !== null && typeof link !== 'string') {
+      throw new Error(`${path}/rich_text[${index}]: malformed link`)
+    }
+    const annotations: ReadbackAnnotations = { ...defaultAnnotations, ...item.annotations }
+    const previous = out.at(-1)
+    if (
+      previous !== undefined &&
+      previous.link === link &&
+      JSON.stringify(previous.annotations) === JSON.stringify(annotations)
+    ) {
+      out[out.length - 1] = { ...previous, text: `${previous.text}${item.text.content}` }
+    } else {
+      out.push({ text: item.text.content, link, annotations })
+    }
+  }
+  return out
+}
+
+/** Canonical callout icon: the two request/response envelopes the spike supports. */
+const normalizeCalloutIcon = (icon: unknown, path: string): Json | null => {
+  if (icon == null) return null
+  const env = icon as Json
+  if (env.type === 'emoji' && typeof env.emoji === 'string') {
+    return { type: 'emoji', emoji: env.emoji }
+  }
+  if (env.type === 'external' && typeof (env.external as Json | undefined)?.url === 'string') {
+    return { type: 'external', external: { url: (env.external as Json).url } }
+  }
+  throw new Error(`${path}: unsupported callout icon`)
+}
+
+/**
+ * Fold one block body (request- or response-shape — they share the fields the
+ * canonical form keeps) into canonical props for its type.
+ */
+const normalizeBody = (type: string, body: Json, path: string): Json => {
+  if (!READBACK_SUPPORTED.has(type)) {
+    throw new Error(`${path}: readback normalization not implemented for ${type}`)
+  }
+  const richText = normalizeRichText(body.rich_text, path)
+  const color = typeof body.color === 'string' ? body.color : 'default'
+  if (type === 'heading_2') {
+    return { rich_text: richText, color, is_toggleable: body.is_toggleable === true }
+  }
+  if (type === 'callout') {
+    return { rich_text: richText, color, icon: normalizeCalloutIcon(body.icon, path) }
+  }
+  return { rich_text: richText, color }
+}
+
+/** Normalize a server-observed block tree into canonical nodes. */
+export const normalizeObserved = (
+  observed: readonly ObservedBlockTree[],
+  path = 'page',
+): readonly NormalizedReadbackNode[] =>
+  observed.map(({ block, children }, index) => {
+    const type = block.type
+    if (typeof type !== 'string') throw new Error(`${path}[${index}]: block lacks a type`)
+    const body = block[type]
+    if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+      throw new Error(`${path}[${index}]: missing ${type} payload`)
+    }
+    const nodePath = `${path}/${type}[${index}]`
+    return {
+      type,
+      props: normalizeBody(type, body as Json, nodePath),
+      children: normalizeObserved(children, nodePath),
+    }
+  })
+
+/** Normalize a rendered candidate tree into the same canonical nodes. */
+export const normalizeCandidate = (
+  nodes: readonly CandidateNode[],
+  path = 'page',
+): readonly NormalizedReadbackNode[] =>
+  nodes.map((node, index) => {
+    const nodePath = `${path}/${node.type}[${index}]`
+    return {
+      type: node.type,
+      props: normalizeBody(node.type, node.props, nodePath),
+      children: normalizeCandidate(node.children, nodePath),
+    }
+  })
+
+/**
+ * Blank provider-owned fields on the observed side. Today that is exactly one
+ * field: a callout icon the JSX never claimed (candidate `icon` prop omitted
+ * → canonical `icon: null`) is supplied by Notion with a default the author
+ * does not manage — mask it back to `null` so it cannot fail the comparison.
+ * Explicit JSX icons stay exact managed content.
+ */
+const maskProviderOwned = (
+  candidate: readonly NormalizedReadbackNode[],
+  observed: readonly NormalizedReadbackNode[],
+): readonly NormalizedReadbackNode[] =>
+  observed.map((node, index) => {
+    const authored = candidate[index]
+    const children = maskProviderOwned(authored?.children ?? [], node.children)
+    const providerOwnedIcon =
+      node.type === 'callout' && authored?.type === 'callout' && authored.props.icon === null
+    return providerOwnedIcon
+      ? { ...node, props: { ...node.props, icon: null }, children }
+      : { ...node, children }
+  })
+
+/** Hash a canonical tree — shares `hashStable` with the candidate/cache hashes. */
+export const readbackHash = (nodes: readonly NormalizedReadbackNode[]): string => hashStable(nodes)
+
+export interface ReadbackComparison {
+  readonly candidateHash: string
+  readonly observedHash: string
+  readonly equal: boolean
+  readonly candidate: readonly NormalizedReadbackNode[]
+  readonly observed: readonly NormalizedReadbackNode[]
+}
+
+/**
+ * Compare a rendered candidate against a server observation of the same page.
+ * `equal` (equivalently `candidateHash === observedHash`) certifies the page's
+ * managed content matches the render — the readback half of a publication
+ * verification, complementing `plan()`'s cache-side fixpoint.
+ */
+export const compareReadback = ({
+  candidate,
+  observed,
+}: {
+  readonly candidate: CandidateTree
+  readonly observed: readonly ObservedBlockTree[]
+}): ReadbackComparison => {
+  const cand = normalizeCandidate(candidate.children)
+  const obs = maskProviderOwned(cand, normalizeObserved(observed))
+  const candidateHash = readbackHash(cand)
+  const observedHash = readbackHash(obs)
+  return { candidateHash, observedHash, equal: candidateHash === observedHash, candidate: cand, observed: obs }
+}

--- a/packages/@overeng/notion-react/src/renderer/readback.unit.test.tsx
+++ b/packages/@overeng/notion-react/src/renderer/readback.unit.test.tsx
@@ -1,0 +1,165 @@
+import type { HttpClient } from '@effect/platform'
+import { Effect } from 'effect'
+import type { ReactNode } from 'react'
+import { describe, expect, it } from 'vitest'
+
+import type { NotionConfig } from '@overeng/notion-effect-client'
+
+import { InMemoryCache } from '../cache/in-memory-cache.ts'
+import { BulletedListItem, Callout, Heading2, Paragraph } from '../components/blocks.ts'
+import { Bold, Link } from '../components/inline.ts'
+import { createFakeNotion, type FakeBlock, type FakeNotion } from '../test/mock-client.ts'
+import { compareReadback, type ObservedBlockTree } from './readback.ts'
+import { buildCandidateTree } from './sync-diff.ts'
+import { sync } from './sync.ts'
+
+const ROOT = '00000000-0000-4000-8000-000000000001'
+
+const runWith = <A, E>(
+  fake: FakeNotion,
+  eff: Effect.Effect<A, E, HttpClient.HttpClient | NotionConfig>,
+): Promise<A> => Effect.runPromise(eff.pipe(Effect.provide(fake.layer)))
+
+/** Read the fake server's live tree back as public-API-shaped block JSON. */
+const observeFake = (fake: FakeNotion, parentId: string): readonly ObservedBlockTree[] =>
+  fake.childrenOf(parentId).map(
+    (b: FakeBlock): ObservedBlockTree => ({
+      block: { object: 'block', id: b.id, type: b.type, [b.type]: b.payload },
+      children: observeFake(fake, b.id),
+    }),
+  )
+
+const element: ReactNode = (
+  <>
+    <Paragraph>
+      Hello <Bold>world</Bold> and <Link href="https://overeng.dev">a link</Link>
+    </Paragraph>
+    <Heading2>Section</Heading2>
+    <BulletedListItem>
+      item one
+      <Paragraph>nested detail</Paragraph>
+    </BulletedListItem>
+    <Callout icon="⚠️" color="red_background">
+      warning text
+    </Callout>
+    <Callout>plain callout without icon claim</Callout>
+  </>
+)
+
+/** Response-shape text run with the derived fields real Notion adds. */
+const run = (
+  text: string,
+  overrides?: { readonly bold?: boolean; readonly link?: string },
+): Record<string, unknown> => ({
+  type: 'text',
+  text: { content: text, link: overrides?.link !== undefined ? { url: overrides.link } : null },
+  plain_text: text,
+  href: overrides?.link ?? null,
+  annotations: {
+    bold: overrides?.bold ?? false,
+    italic: false,
+    strikethrough: false,
+    underline: false,
+    code: false,
+    color: 'default',
+  },
+})
+
+describe('readback normalization oracle', () => {
+  it('mock roundtrip: render → sync → observe → hash equality', async () => {
+    const fake = createFakeNotion()
+    const cache = InMemoryCache.make()
+    await runWith(fake, sync(element, { pageId: ROOT, cache }))
+    const candidate = buildCandidateTree(element, ROOT)
+    const observed = observeFake(fake, ROOT)
+    const cmp = compareReadback({ candidate, observed })
+    expect(cmp.equal).toBe(true)
+    expect(cmp.observedHash).toBe(cmp.candidateHash)
+    // The hash is a pure function of the element: a fresh render agrees.
+    expect(compareReadback({ candidate: buildCandidateTree(element, ROOT), observed }).candidateHash).toBe(
+      cmp.candidateHash,
+    )
+  })
+
+  it('normalizes realistic response-shape readback into the candidate hash space', () => {
+    const candidate = buildCandidateTree(
+      <>
+        <Paragraph>
+          Hello <Bold>world</Bold>
+        </Paragraph>
+        <Callout>no icon</Callout>
+      </>,
+      ROOT,
+    )
+    const observed: ObservedBlockTree[] = [
+      {
+        block: {
+          object: 'block',
+          id: 'b1',
+          type: 'paragraph',
+          paragraph: {
+            color: 'default', // response always carries the default explicitly
+            rich_text: [
+              run('Hel'), // Notion re-segmented the default-frame text —
+              run('lo '), // adjacent identical frames must coalesce
+              run('world', { bold: true }),
+            ],
+          },
+        },
+        children: [],
+      },
+      {
+        block: {
+          object: 'block',
+          id: 'b2',
+          type: 'callout',
+          callout: {
+            color: 'default',
+            // Provider-injected default icon for an authored-null icon: the
+            // JSX never claimed one, so this field is provider-owned.
+            icon: { type: 'external', external: { url: 'https://www.notion.so/icons/star.svg' } },
+            rich_text: [run('no icon')],
+          },
+        },
+        children: [],
+      },
+    ]
+    const cmp = compareReadback({ candidate, observed })
+    expect(cmp.equal).toBe(true)
+  })
+
+  it('detects real content drift: text change and explicit-icon change both break equality', () => {
+    const candidate = buildCandidateTree(
+      <Callout icon="⚠️">exact warning</Callout>,
+      ROOT,
+    )
+    const observedOk: ObservedBlockTree[] = [
+      {
+        block: {
+          id: 'b1',
+          type: 'callout',
+          callout: {
+            color: 'default',
+            icon: { type: 'emoji', emoji: '⚠️' },
+            rich_text: [run('exact warning')],
+          },
+        },
+        children: [],
+      },
+    ]
+    expect(compareReadback({ candidate, observed: observedOk }).equal).toBe(true)
+
+    const changedText = structuredClone(observedOk) as typeof observedOk
+    ;((changedText[0]!.block.callout as Record<string, unknown>).rich_text as unknown[])[0] =
+      run('tampered warning')
+    expect(compareReadback({ candidate, observed: changedText }).equal).toBe(false)
+
+    const changedIcon = structuredClone(observedOk) as typeof observedOk
+    ;(changedIcon[0]!.block.callout as Record<string, unknown>).icon = {
+      type: 'emoji',
+      emoji: '🎯',
+    }
+    // Explicit JSX icons are exact managed content — no provider tolerance.
+    expect(compareReadback({ candidate, observed: changedIcon }).equal).toBe(false)
+  })
+})

--- a/packages/@overeng/notion-react/src/renderer/readback.unit.test.tsx
+++ b/packages/@overeng/notion-react/src/renderer/readback.unit.test.tsx
@@ -6,14 +6,44 @@ import { describe, expect, it } from 'vitest'
 import type { NotionConfig } from '@overeng/notion-effect-client'
 
 import { InMemoryCache } from '../cache/in-memory-cache.ts'
-import { BulletedListItem, Callout, Heading2, Paragraph } from '../components/blocks.ts'
-import { Bold, Link } from '../components/inline.ts'
+import {
+  Bookmark,
+  BulletedListItem,
+  Callout,
+  ChildPage,
+  Code,
+  Column,
+  ColumnList,
+  Divider,
+  Embed,
+  Equation,
+  Heading2,
+  Image,
+  LinkToPage,
+  NumberedListItem,
+  Paragraph,
+  Quote,
+  Raw,
+  Table,
+  TableOfContents,
+  TableRow,
+  ToDo,
+  Toggle,
+} from '../components/blocks.ts'
+import { Bold, InlineEquation, Link, Mention } from '../components/inline.ts'
 import { createFakeNotion, type FakeBlock, type FakeNotion } from '../test/mock-client.ts'
-import { compareReadback, type ObservedBlockTree } from './readback.ts'
+import { observeBlockTree } from './readback-observe.ts'
+import {
+  compareReadback,
+  compareReadbackPage,
+  normalizeCandidate,
+  type ObservedBlockTree,
+} from './readback.ts'
 import { buildCandidateTree } from './sync-diff.ts'
 import { sync } from './sync.ts'
 
 const ROOT = '00000000-0000-4000-8000-000000000001'
+const LINKED = '00000000-0000-4000-8000-00000000abcd'
 
 const runWith = <A, E>(
   fake: FakeNotion,
@@ -46,6 +76,54 @@ const element: ReactNode = (
   </>
 )
 
+/**
+ * One block per supported type (beyond the original spike four), rendered
+ * through the real reconciler and synced against the Notion-shaped fake.
+ *
+ * The `<ChildPage>` deliberately comes first: sync's root-scope interleaved
+ * apply flushes buffered block ops at each `createPage` boundary, but the
+ * diff defers an atomic container's descendant appends until after the
+ * sibling run — a `<Table>`/`<ColumnList>` BEFORE a root `<ChildPage>` gets
+ * flushed without its inlined children and trips Notion's atomic-create
+ * validation. Pre-existing sync behavior, unrelated to readback.
+ */
+const fullSurfaceElement: ReactNode = (
+  <>
+    <ChildPage title="Sub page" blockKey="sub" />
+    <Quote>quoted wisdom</Quote>
+    <NumberedListItem>first</NumberedListItem>
+    <ToDo checked>done item</ToDo>
+    <ToDo>open item</ToDo>
+    <Toggle title="More">
+      <Paragraph>hidden</Paragraph>
+    </Toggle>
+    <Code language="typescript">const x = 1</Code>
+    <Divider />
+    <TableOfContents />
+    <Equation expression="e = mc^2" />
+    <Bookmark url="https://overeng.dev" />
+    <Embed url="https://overeng.dev/embed" />
+    <Image url="https://overeng.dev/pic.png" caption="a picture" />
+    <LinkToPage pageId={LINKED} />
+    <Table tableWidth={2} hasColumnHeader>
+      <TableRow cells={['a', 'b']} />
+      <TableRow cells={[<Bold key="c">c</Bold>, 'd']} />
+    </Table>
+    <ColumnList>
+      <Column>
+        <Paragraph>left</Paragraph>
+      </Column>
+      <Column>
+        <Paragraph>right</Paragraph>
+      </Column>
+    </ColumnList>
+    <Paragraph>
+      see <Mention mention={{ type: 'page', page: { id: LINKED } }} plainText="the page" /> at{' '}
+      <InlineEquation expression="x^2" />
+    </Paragraph>
+  </>
+)
+
 /** Response-shape text run with the derived fields real Notion adds. */
 const run = (
   text: string,
@@ -65,6 +143,11 @@ const run = (
   },
 })
 
+const leaf = (type: string, body: Record<string, unknown>): ObservedBlockTree => ({
+  block: { object: 'block', id: `b-${type}`, type, [type]: body },
+  children: [],
+})
+
 describe('readback normalization oracle', () => {
   it('mock roundtrip: render → sync → observe → hash equality', async () => {
     const fake = createFakeNotion()
@@ -76,9 +159,33 @@ describe('readback normalization oracle', () => {
     expect(cmp.equal).toBe(true)
     expect(cmp.observedHash).toBe(cmp.candidateHash)
     // The hash is a pure function of the element: a fresh render agrees.
-    expect(compareReadback({ candidate: buildCandidateTree(element, ROOT), observed }).candidateHash).toBe(
-      cmp.candidateHash,
-    )
+    expect(
+      compareReadback({ candidate: buildCandidateTree(element, ROOT), observed }).candidateHash,
+    ).toBe(cmp.candidateHash)
+  })
+
+  it('mock roundtrip covers the full supported block surface', async () => {
+    const fake = createFakeNotion()
+    const cache = InMemoryCache.make()
+    await runWith(fake, sync(fullSurfaceElement, { pageId: ROOT, cache }))
+    const candidate = buildCandidateTree(fullSurfaceElement, ROOT)
+    const cmp = compareReadback({ candidate, observed: observeFake(fake, ROOT) })
+    expect(cmp.equal).toBe(true)
+  })
+
+  it('observeBlockTree walks the children endpoint into the observed shape', async () => {
+    const fake = createFakeNotion()
+    const cache = InMemoryCache.make()
+    await runWith(fake, sync(fullSurfaceElement, { pageId: ROOT, cache }))
+    const observed = await runWith(fake, observeBlockTree({ blockId: ROOT }))
+    const candidate = buildCandidateTree(fullSurfaceElement, ROOT)
+    expect(compareReadback({ candidate, observed }).equal).toBe(true)
+    // The walk recurses into nested block children (toggle body)…
+    const toggle = observed.find((n) => n.block.type === 'toggle')
+    expect(toggle?.children).toHaveLength(1)
+    // …but never across the child_page identity boundary.
+    const childPage = observed.find((n) => n.block.type === 'child_page')
+    expect(childPage?.children).toHaveLength(0)
   })
 
   it('normalizes realistic response-shape readback into the candidate hash space', () => {
@@ -128,11 +235,129 @@ describe('readback normalization oracle', () => {
     expect(cmp.equal).toBe(true)
   })
 
-  it('detects real content drift: text change and explicit-icon change both break equality', () => {
+  it('folds provider-injected defaults across the extended surface', () => {
     const candidate = buildCandidateTree(
-      <Callout icon="⚠️">exact warning</Callout>,
+      <>
+        <Code>plain snippet</Code>
+        <ToDo>open</ToDo>
+        <Table>
+          <TableRow cells={['x']} />
+        </Table>
+        <ColumnList>
+          <Column>
+            <Paragraph>left</Paragraph>
+          </Column>
+          <Column>
+            <Paragraph>right</Paragraph>
+          </Column>
+        </ColumnList>
+      </>,
       ROOT,
     )
+    const observed: ObservedBlockTree[] = [
+      // Unclaimed language: Notion injects its default — provider-owned.
+      leaf('code', { rich_text: [run('plain snippet')], caption: [], language: 'plain text' }),
+      // Explicit default `checked` / `color` on the response side.
+      leaf('to_do', { rich_text: [run('open')], checked: false, color: 'default' }),
+      {
+        // Unclaimed table_width: the server derives it from the rows.
+        block: {
+          id: 'b-table',
+          type: 'table',
+          table: { table_width: 1, has_column_header: false, has_row_header: false },
+        },
+        children: [leaf('table_row', { cells: [[run('x')]] })],
+      },
+      {
+        block: { id: 'b-cl', type: 'column_list', column_list: {} },
+        children: [
+          {
+            // Unclaimed width_ratio: Notion computes and returns one.
+            block: { id: 'b-c1', type: 'column', column: { width_ratio: 0.5 } },
+            children: [leaf('paragraph', { rich_text: [run('left')], color: 'default' })],
+          },
+          {
+            block: { id: 'b-c2', type: 'column', column: { width_ratio: 0.5 } },
+            children: [leaf('paragraph', { rich_text: [run('right')], color: 'default' })],
+          },
+        ],
+      },
+    ]
+    expect(compareReadback({ candidate, observed }).equal).toBe(true)
+  })
+
+  it('masks uploaded media sources but keeps captions exact', () => {
+    const candidate = buildCandidateTree(
+      <Image fileUploadId="upload-123" caption="diagram" />,
+      ROOT,
+    )
+    // Response for an uploaded asset: `file` envelope with an expiring signed
+    // URL — not comparable content, masked to the `uploaded` sentinel.
+    const observed = [
+      leaf('image', {
+        type: 'file',
+        file: { url: 'https://s3.amazonaws.com/signed?X-Amz-Expires=3600', expiry_time: 'soon' },
+        caption: [run('diagram')],
+      }),
+    ]
+    expect(compareReadback({ candidate, observed }).equal).toBe(true)
+    const tampered = [
+      leaf('image', {
+        type: 'file',
+        file: { url: 'https://s3.amazonaws.com/other-signed' },
+        caption: [run('not the diagram')],
+      }),
+    ]
+    expect(compareReadback({ candidate, observed: tampered }).equal).toBe(false)
+  })
+
+  it('normalizes mention and equation leaves from the expanded response shape', () => {
+    const candidate = buildCandidateTree(
+      <Paragraph>
+        ping <Mention mention={{ type: 'user', user: { object: 'user', id: LINKED } }} /> re{' '}
+        <InlineEquation expression="x^2" />
+      </Paragraph>,
+      ROOT,
+    )
+    const observed = [
+      leaf('paragraph', {
+        color: 'default',
+        rich_text: [
+          run('ping '),
+          {
+            type: 'mention',
+            // The response expands the referenced user object …
+            mention: {
+              type: 'user',
+              user: { object: 'user', id: LINKED, name: 'Someone', avatar_url: null },
+            },
+            plain_text: '@Someone',
+            href: null,
+            annotations: run('x').annotations,
+          },
+          run(' re '),
+          {
+            type: 'equation',
+            equation: { expression: 'x^2' },
+            plain_text: 'x^2',
+            href: null,
+            annotations: run('x').annotations,
+          },
+        ],
+      }),
+    ]
+    expect(compareReadback({ candidate, observed }).equal).toBe(true)
+    const changed = structuredClone(observed) as typeof observed
+    ;(
+      (changed[0]!.block.paragraph as Record<string, unknown>).rich_text as {
+        equation?: { expression: string }
+      }[]
+    )[3]!.equation = { expression: 'x^3' }
+    expect(compareReadback({ candidate, observed: changed }).equal).toBe(false)
+  })
+
+  it('detects real content drift: text change and explicit-icon change both break equality', () => {
+    const candidate = buildCandidateTree(<Callout icon="⚠️">exact warning</Callout>, ROOT)
     const observedOk: ObservedBlockTree[] = [
       {
         block: {
@@ -161,5 +386,179 @@ describe('readback normalization oracle', () => {
     }
     // Explicit JSX icons are exact managed content — no provider tolerance.
     expect(compareReadback({ candidate, observed: changedIcon }).equal).toBe(false)
+  })
+
+  it('detects drift in claimed provider-maskable fields and structured props', () => {
+    const candidate = buildCandidateTree(
+      <>
+        <Code language="typescript">const x = 1</Code>
+        <ToDo checked>done</ToDo>
+        <Table tableWidth={2}>
+          <TableRow cells={['a', 'b']} />
+        </Table>
+      </>,
+      ROOT,
+    )
+    const observed = (overrides: {
+      readonly language?: string
+      readonly checked?: boolean
+      readonly cellB?: string
+    }): ObservedBlockTree[] => [
+      leaf('code', {
+        rich_text: [run('const x = 1')],
+        caption: [],
+        language: overrides.language ?? 'typescript',
+      }),
+      leaf('to_do', {
+        rich_text: [run('done')],
+        checked: overrides.checked ?? true,
+        color: 'default',
+      }),
+      {
+        block: {
+          id: 'b-table',
+          type: 'table',
+          table: { table_width: 2, has_column_header: false, has_row_header: false },
+        },
+        children: [leaf('table_row', { cells: [[run('a')], [run(overrides.cellB ?? 'b')]] })],
+      },
+    ]
+    expect(compareReadback({ candidate, observed: observed({}) }).equal).toBe(true)
+    expect(compareReadback({ candidate, observed: observed({ language: 'rust' }) }).equal).toBe(
+      false,
+    )
+    expect(compareReadback({ candidate, observed: observed({ checked: false }) }).equal).toBe(false)
+    expect(compareReadback({ candidate, observed: observed({ cellB: 'tampered' }) }).equal).toBe(
+      false,
+    )
+  })
+
+  it('compares child_page blocks by title identity without crossing the page boundary', () => {
+    const candidate = buildCandidateTree(<ChildPage title="Sub page" blockKey="sub" />, ROOT)
+    const withChildren: ObservedBlockTree[] = [
+      {
+        block: { id: 'p1', type: 'child_page', child_page: { title: 'Sub page' } },
+        // Live sub-page content is out of scope — its own readback pass owns it.
+        children: [leaf('paragraph', { rich_text: [run('sub content')], color: 'default' })],
+      },
+    ]
+    expect(compareReadback({ candidate, observed: withChildren }).equal).toBe(true)
+    const renamed: ObservedBlockTree[] = [
+      { block: { id: 'p1', type: 'child_page', child_page: { title: 'Renamed' } }, children: [] },
+    ]
+    expect(compareReadback({ candidate, observed: renamed }).equal).toBe(false)
+  })
+
+  it('throws on raw escape-hatch blocks instead of guessing their response shape', () => {
+    const candidate = buildCandidateTree(
+      <Raw type="synced_block" content={{ synced_from: null }} />,
+      ROOT,
+    )
+    expect(() => normalizeCandidate(candidate.children)).toThrow(
+      /readback normalization not implemented for synced_block/,
+    )
+  })
+})
+
+describe('readback page-metadata comparison', () => {
+  const pageJson = (overrides?: {
+    readonly title?: readonly Record<string, unknown>[]
+    readonly icon?: Record<string, unknown> | null
+    readonly cover?: Record<string, unknown> | null
+  }): Record<string, unknown> => ({
+    object: 'page',
+    id: ROOT,
+    icon: overrides?.icon ?? null,
+    cover: overrides?.cover ?? null,
+    properties: {
+      title: { id: 'title', type: 'title', title: overrides?.title ?? [run('My page')] },
+    },
+  })
+
+  it('claimed title compares through response decoration and re-segmentation', () => {
+    const candidate = { title: [{ type: 'text', text: { content: 'My page' } }] }
+    expect(
+      compareReadbackPage({
+        candidate,
+        observed: pageJson({ title: [run('My '), run('page')] }),
+      }).equal,
+    ).toBe(true)
+    expect(
+      compareReadbackPage({ candidate, observed: pageJson({ title: [run('Renamed')] }) }).equal,
+    ).toBe(false)
+  })
+
+  it('unclaimed fields are masked; null claims a server-side clear', () => {
+    // No claims at all: any observed metadata is fine.
+    expect(
+      compareReadbackPage({
+        candidate: {},
+        observed: pageJson({ icon: { type: 'emoji', emoji: '🎯' } }),
+      }).equal,
+    ).toBe(true)
+    // Claimed clear: observed must be unset.
+    expect(compareReadbackPage({ candidate: { icon: null }, observed: pageJson() }).equal).toBe(
+      true,
+    )
+    expect(
+      compareReadbackPage({
+        candidate: { icon: null },
+        observed: pageJson({ icon: { type: 'emoji', emoji: '🎯' } }),
+      }).equal,
+    ).toBe(false)
+  })
+
+  it('claimed icons compare exactly; builtin-URL icons mask to unverified (A07)', () => {
+    const emoji = { type: 'emoji', emoji: '🚀' }
+    expect(
+      compareReadbackPage({ candidate: { icon: emoji }, observed: pageJson({ icon: emoji }) })
+        .equal,
+    ).toBe(true)
+    expect(
+      compareReadbackPage({
+        candidate: { icon: emoji },
+        observed: pageJson({ icon: { type: 'emoji', emoji: '🎯' } }),
+      }).equal,
+    ).toBe(false)
+    // Built-in icon URL resolves server-side to the undocumented `icon`
+    // envelope; the name↔URL mapping is not public, so presence is verified
+    // but the exact glyph is masked.
+    expect(
+      compareReadbackPage({
+        candidate: {
+          icon: { type: 'external', external: { url: 'https://www.notion.so/icons/star.svg' } },
+        },
+        observed: pageJson({ icon: { type: 'icon', icon: { name: 'star', color: 'gray' } } }),
+      }).equal,
+    ).toBe(true)
+  })
+
+  it('covers compare by URL for external and mask for uploaded assets', () => {
+    const external = { type: 'external', external: { url: 'https://overeng.dev/cover.png' } }
+    expect(
+      compareReadbackPage({
+        candidate: { cover: external },
+        observed: pageJson({ cover: external }),
+      }).equal,
+    ).toBe(true)
+    expect(
+      compareReadbackPage({
+        candidate: { cover: external },
+        observed: pageJson({
+          cover: { type: 'external', external: { url: 'https://overeng.dev/other.png' } },
+        }),
+      }).equal,
+    ).toBe(false)
+    expect(
+      compareReadbackPage({
+        candidate: { cover: { type: 'file_upload', file_upload: { id: 'up-1' } } },
+        observed: pageJson({
+          cover: {
+            type: 'file',
+            file: { url: 'https://s3.amazonaws.com/signed', expiry_time: 't' },
+          },
+        }),
+      }).equal,
+    ).toBe(true)
   })
 })

--- a/packages/@overeng/notion-react/src/renderer/readback.unit.test.tsx
+++ b/packages/@overeng/notion-react/src/renderer/readback.unit.test.tsx
@@ -1,4 +1,4 @@
-import type { HttpClient } from '@effect/platform'
+import type { HttpClient } from 'effect/unstable/http/HttpClient'
 import { Effect } from 'effect'
 import type { ReactNode } from 'react'
 import { describe, expect, it } from 'vitest'
@@ -47,7 +47,7 @@ const LINKED = '00000000-0000-4000-8000-00000000abcd'
 
 const runWith = <A, E>(
   fake: FakeNotion,
-  eff: Effect.Effect<A, E, HttpClient.HttpClient | NotionConfig>,
+  eff: Effect.Effect<A, E, HttpClient | NotionConfig>,
 ): Promise<A> => Effect.runPromise(eff.pipe(Effect.provide(fake.layer)))
 
 /** Read the fake server's live tree back as public-API-shaped block JSON. */

--- a/packages/@overeng/notion-react/src/renderer/readback.unit.test.tsx
+++ b/packages/@overeng/notion-react/src/renderer/readback.unit.test.tsx
@@ -1,5 +1,5 @@
-import type { HttpClient } from 'effect/unstable/http/HttpClient'
 import { Effect } from 'effect'
+import type { HttpClient } from 'effect/unstable/http/HttpClient'
 import type { ReactNode } from 'react'
 import { describe, expect, it } from 'vitest'
 

--- a/packages/@overeng/notion-react/src/renderer/sync-diff.ts
+++ b/packages/@overeng/notion-react/src/renderer/sync-diff.ts
@@ -111,6 +111,15 @@ const hashAny = (value: unknown): string => {
 }
 
 /**
+ * djb2 hash over the stable-stringified value — the single hash space shared
+ * by candidate block hashes, page-metadata hashes, and the readback oracle
+ * (`readback.ts`). Exported so consumers comparing server-observed state
+ * against candidates hash through the identical function instead of
+ * reimplementing it.
+ */
+export const hashStable = (value: unknown): string => hashAny(value)
+
+/**
  * Hash helper for icon/cover candidate values (phase 4b, #618).
  *
  * - `null` (author asked to clear via `icon={null}` / `cover={null}`) hashes

--- a/packages/@overeng/notion-react/src/test/integration/e2e/readback.e2e.test.tsx
+++ b/packages/@overeng/notion-react/src/test/integration/e2e/readback.e2e.test.tsx
@@ -1,0 +1,150 @@
+import { Effect } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import { NotionPages } from '@overeng/notion-effect-client'
+
+import { InMemoryCache } from '../../../cache/in-memory-cache.ts'
+import {
+  Bookmark,
+  BulletedListItem,
+  Callout,
+  Code,
+  Column,
+  ColumnList,
+  Divider,
+  Embed,
+  Equation,
+  Heading2,
+  Heading3,
+  Image,
+  NumberedListItem,
+  Page,
+  Paragraph,
+  Quote,
+  Table,
+  TableOfContents,
+  TableRow,
+  ToDo,
+  Toggle,
+} from '../../../components/blocks.ts'
+import { Bold, InlineEquation, Italic, Link } from '../../../components/inline.ts'
+import { observeBlockTree } from '../../../renderer/readback-observe.ts'
+import { compareReadback, compareReadbackPage } from '../../../renderer/readback.ts'
+import { buildCandidateTree } from '../../../renderer/sync-diff.ts'
+import { sync } from '../../../renderer/sync.ts'
+import { SKIP_E2E, withScratchPage } from './helpers.ts'
+
+/**
+ * Live-API coverage for the readback oracle. The mock stores request-shape
+ * payloads, so mock roundtrips cannot exercise the response-shape deltas the
+ * oracle exists to absorb (decorated rich text, re-segmented runs, explicit
+ * defaults, provider-injected callout icons, `plain_text`/`href` extras) —
+ * only the real API produces those. Each test syncs a JSX tree to a scratch
+ * page, observes the live block tree back, and asserts hash equality plus a
+ * tamper-detection negative.
+ */
+
+const DEFAULT_TIMEOUT = 60_000
+
+describe.skipIf(SKIP_E2E)('readback oracle against the live API (e2e)', () => {
+  it(
+    'full-surface roundtrip: sync → observe → compareReadback equal',
+    async () => {
+      const element = (
+        <>
+          <Paragraph>
+            Hello <Bold>world</Bold> and <Italic>emphasis</Italic> plus{' '}
+            <Link href="https://example.com/x">a link</Link>
+          </Paragraph>
+          <Heading2 toggleable color="blue">
+            Section
+          </Heading2>
+          <Heading3>Plain section</Heading3>
+          <BulletedListItem>
+            item one
+            <Paragraph>nested detail</Paragraph>
+          </BulletedListItem>
+          <NumberedListItem>first</NumberedListItem>
+          <ToDo checked>done</ToDo>
+          <Quote>quoted</Quote>
+          <Callout icon="⚠️" color="red_background">
+            warning
+          </Callout>
+          <Callout>no icon claimed — server injects a default</Callout>
+          <Toggle title="More">
+            <Paragraph>hidden</Paragraph>
+          </Toggle>
+          <Code language="typescript">const x = 1</Code>
+          <Divider />
+          <TableOfContents />
+          <Equation expression="e = mc^2" />
+          <Bookmark url="https://example.com" />
+          <Embed url="https://example.com/embed" />
+          <Image url="https://picsum.photos/64" caption="a picture" />
+          <Table tableWidth={2} hasColumnHeader>
+            <TableRow cells={['a', 'b']} />
+            <TableRow cells={[<Bold key="c">c</Bold>, 'd']} />
+          </Table>
+          <ColumnList>
+            <Column>
+              <Paragraph>left</Paragraph>
+            </Column>
+            <Column>
+              <Paragraph>right</Paragraph>
+            </Column>
+          </ColumnList>
+          <Paragraph>
+            inline <InlineEquation expression="x^2" /> equation
+          </Paragraph>
+        </>
+      )
+      await withScratchPage('readback-full-surface', (pageId) =>
+        Effect.gen(function* () {
+          yield* sync(element, { pageId, cache: InMemoryCache.make() })
+          const observed = yield* observeBlockTree({ blockId: pageId })
+          const cmp = compareReadback({ candidate: buildCandidateTree(element, pageId), observed })
+          if (!cmp.equal) {
+            // Surface the normalized trees on failure — the diff IS the finding.
+            console.error('candidate', JSON.stringify(cmp.candidate, null, 2))
+            console.error('observed', JSON.stringify(cmp.observed, null, 2))
+          }
+          expect(cmp.equal).toBe(true)
+
+          // Negative: a drifted element must not hash-collide with the page.
+          const tampered = buildCandidateTree(<Paragraph>something else</Paragraph>, pageId)
+          expect(compareReadback({ candidate: tampered, observed }).equal).toBe(false)
+        }),
+      )
+    },
+    DEFAULT_TIMEOUT * 3,
+  )
+
+  it(
+    'page metadata roundtrip: title + icon claims verify via pages.retrieve',
+    async () => {
+      const title = 'readback metadata probe'
+      const icon = { type: 'emoji', emoji: '🎯' } as const
+      const element = (
+        <Page title={title} icon={icon}>
+          <Paragraph>body</Paragraph>
+        </Page>
+      )
+      await withScratchPage('readback-page-metadata', (pageId) =>
+        Effect.gen(function* () {
+          yield* sync(element, { pageId, cache: InMemoryCache.make() })
+          const page = (yield* NotionPages.retrieve({ pageId })) as Record<string, unknown>
+          const candidate = buildCandidateTree(element, pageId)
+          const cmp = compareReadbackPage({ candidate: candidate.rootPage ?? {}, observed: page })
+          expect(cmp.equal).toBe(true)
+          expect(
+            compareReadbackPage({
+              candidate: { title: [{ type: 'text', text: { content: 'other title' } }] },
+              observed: page,
+            }).equal,
+          ).toBe(false)
+        }),
+      )
+    },
+    DEFAULT_TIMEOUT * 2,
+  )
+})

--- a/packages/@overeng/notion-react/src/test/integration/e2e/readback.e2e.test.tsx
+++ b/packages/@overeng/notion-react/src/test/integration/e2e/readback.e2e.test.tsx
@@ -1,4 +1,4 @@
-import { Effect } from 'effect'
+import { Effect, Schema } from 'effect'
 import { describe, expect, it } from 'vitest'
 
 import { NotionPages } from '@overeng/notion-effect-client'
@@ -33,6 +33,7 @@ import { compareReadback, compareReadbackPage } from '../../../renderer/readback
 import { buildCandidateTree } from '../../../renderer/sync-diff.ts'
 import { sync } from '../../../renderer/sync.ts'
 import { SKIP_E2E, withScratchPage } from './helpers.ts'
+const encodeJson = Schema.encodeSync(Schema.parseJson())
 
 /**
  * Live-API coverage for the readback oracle. The mock stores request-shape
@@ -105,8 +106,8 @@ describe.skipIf(SKIP_E2E)('readback oracle against the live API (e2e)', () => {
           const cmp = compareReadback({ candidate: buildCandidateTree(element, pageId), observed })
           if (!cmp.equal) {
             // Surface the normalized trees on failure — the diff IS the finding.
-            console.error('candidate', JSON.stringify(cmp.candidate, null, 2))
-            console.error('observed', JSON.stringify(cmp.observed, null, 2))
+            console.error('candidate', encodeJson(cmp.candidate))
+            console.error('observed', encodeJson(cmp.observed))
           }
           expect(cmp.equal).toBe(true)
 

--- a/packages/@overeng/notion-react/src/test/integration/e2e/readback.e2e.test.tsx
+++ b/packages/@overeng/notion-react/src/test/integration/e2e/readback.e2e.test.tsx
@@ -33,7 +33,7 @@ import { compareReadback, compareReadbackPage } from '../../../renderer/readback
 import { buildCandidateTree } from '../../../renderer/sync-diff.ts'
 import { sync } from '../../../renderer/sync.ts'
 import { SKIP_E2E, withScratchPage } from './helpers.ts'
-const encodeJson = Schema.encodeSync(Schema.parseJson())
+const encodeJson = Schema.encodeSync(Schema.fromJsonString(Schema.Unknown))
 
 /**
  * Live-API coverage for the readback oracle. The mock stores request-shape


### PR DESCRIPTION
> Recreated from #1131: rebased onto current main (effect@4.0.0-rc.111 cohort); head SHA 14310bce228808bf29dde7cd7d360468d6b5374f. The original was a stacked-base PR that GitHub refused to merge on every surface (stack guard + async merge API 404). Diff vs main currently includes earlier train stages; it shrinks to this stage only as predecessors below merge.

## Outcome

Add the readback verification oracle: `compareReadback({ candidate, observed })` folds server-observed block JSON and rendered candidate trees into one canonical form and compares them by hash — certifying **server × intent** equality, the complement of `plan()`'s cache × intent fixpoint (#1127). Ships with `compareReadbackPage` for the page title/icon/cover envelope and `observeBlockTree`, a GET-only recursive children walk producing the observed tree.

Closes #1123. Stacked on #1127.

## Why

notion-react never verifies its own output: it trusts its cache. Consumers that need "does the live page equal what this JSX renders" — deploy verification gates, drift audits, content checks for fail-closed adoption (#1093) — must normalize Notion's *response* shapes (decorated `plain_text`/`href`, re-segmented rich-text runs, always-explicit defaults, provider-injected fields) into something comparable with candidate *intent*. The Blocky downstream consumer maintains ~340 lines doing exactly this, and the #1093 spike independently identified the same response→request projection as the single component the library must own.

## Two findings the design preserves (from the spike)

1. **Separate hash space.** `CacheNode.hash` is djb2 over request-shape projected props; the readback form must differ (defaults explicit, runs coalesced, derived fields dropped). Unifying would change the cache hash function and invalidate every deployed cache. Both spaces share only the `hashStable` primitive; comparing across them is always a bug — stated loudly in module docs, api.md, and R39.
2. **No context-free observed hash.** Whether an observed field is managed content or provider noise depends on whether the JSX claimed it, so the public API takes both sides; a standalone `hashObserved(blocks)` cannot exist (R40).

## Changes

- `readback.ts` extended from the 4-type spike to the full first-class component surface — 25 block types: paragraph, heading_1–4 (color/toggleable), quote, bulleted/numbered list items, to_do (checked), toggle, code (language + caption), callout (icon/color), divider, table_of_contents, equation, bookmark/embed (url + caption), image/video/audio/file/pdf (source + caption), table (width/header flags) + table_row cells, column_list/column, link_to_page (UUID-normalized), child_page identity
- rich text now covers mention and equation leaves (response-expanded mention objects reduce to minimal refs); text runs coalesce, empty runs drop, annotation frames are fully explicit
- candidate-contextual masking via one table: callout `icon`, code `language`, column `widthRatio`, table `tableWidth` are provider-owned when unclaimed, exact when claimed
- unverifiable-in-principle dimensions mask to explicit sentinels: uploaded media (`file_upload` request / expiring signed-URL `file` response → `uploaded`), built-in icon rewrite (external notion.so/icons URL ↔ undocumented `{type:'icon'}` envelope → `builtin-unverified`, A07)
- `child_page` is an identity boundary: title-only comparison, no recursion — a sub-page gets its own per-page readback pass, mirroring the R26 per-page sync unit; `observeBlockTree` stops at the same boundary
- `compareReadbackPage({ candidate, observed })`: title/icon/cover vs a `pages.retrieve` response, honoring the null-clear sentinel semantics (`null` = observed must be unset; `undefined` = no claim, masked)
- raw escape-hatch blocks (`<Raw>`, `SyncedBlock`, …) throw — opaque request-shape passthroughs have no generically normalizable response shape
- docs: R39/R40 + tradeoff T12, spec readback section, experiment 0004, api.md readback section, limitations (masked dimensions), changelog

## Coverage shipped vs deferred

Shipped: every block type with a first-class component (list above). Deferred (throws with a clear message, documented in limitations): `Raw` passthrough types — `template`, `link_preview`, `synced_block`, `child_database`, `breadcrumb`. Deep sub-page content comparison is deliberately out of scope by design (per-page boundary), not deferred.

## What was run vs written

- **Run:** full unit suite — 15 readback tests: mock roundtrips over the full surface (render → sync → observe → hash equality, incl. `observeBlockTree` against the mock transport), hand-written realistic response-shape fixtures (decoration, re-segmentation, provider-injected defaults, expanded mentions, signed-URL file envelopes — the deltas the request-shape mock cannot produce), and negatives (text/cell/icon/checked/language/expression tampering, child_page rename), plus page-metadata claim/clear/mask/builtin-fold cases.
- **Written but NOT run:** `readback.e2e.test.tsx` — gated live-API coverage following the repo's existing `*.e2e.test.tsx` pattern (skips without `NOTION_API_TOKEN`). This lane had no live credentials; the e2e file replays the full-surface roundtrip and page-metadata probes against real Notion and should be exercised before promoting readback claims about live response shapes beyond what the hand-written fixtures encode.

## Latent sync finding (out of scope here, worth an issue)

The root-scope interleaved apply flushes buffered block ops at each `createPage` boundary, but the diff defers an atomic container's descendant appends until after the sibling run — so a `<Table>`/`<ColumnList>` rendered *before* a root-level `<ChildPage>` is flushed without its inlined children and fails Notion's atomic-create validation (`table.children should be defined`). Reproduced via the fake in this PR's full-surface test (worked around by ordering; see the comment on `fullSurfaceElement`). Pre-existing `sync()` behavior, unrelated to readback.

## Evidence

- `notion-react`: 388 passed, 1 skipped (baseline 373 from #1127 + 15 new)
- existing sync/plan behavior unchanged (full suite green, zero regressions)
- TypeScript build passed (`tsc -b tsconfig.check.json`); lint + format green (`lint:check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | unknown |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.0.3 |
| `agent_runtime` | OMP 18.0.3 |
| `tooling_profile` | dotfiles@a80129b-dirty |
</details>
<!-- agent-footer:end -->