### PR TITLE
feat(renderer): pageLifecycle 'append-only' mode for sync()/plan()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,16 @@ All notable changes to this project will be documented in this file.
   into a `CacheTree` out-of-band can no longer drift from the scheme
   `buildCandidateTree` / `diff` actually produce.
 
+- **@overeng/notion-react**: add `pageLifecycle: 'managed' | 'append-only'` on
+  `sync()`/`plan()` (#1124). `'append-only'` guarantees a sync never archives,
+  moves, or reorders a page and never creates one out of tail position in its
+  parent's page-sibling run — for irreplaceable live trees whose page identity
+  carries grants. One pure post-diff predicate fails the whole sync before any
+  op applies with `NotionSyncError { reason: 'page-lifecycle-violation',
+violations }` (the offending `DiffOp[]`); block ops and page content
+  (`updatePage`) stay fully managed. `plan()` reports the same violations in
+  `SyncPlan.lifecycleViolations` without failing, and #1100 crash-recovery
+  adoption (read + cache-save) stays legal under the mode.
 - **@overeng/notion-react**: add the readback verification oracle (#1123).
   `compareReadback({candidate, observed})` folds server-observed block JSON
   and rendered candidate trees into one canonical form and compares them by

--- a/packages/@overeng/notion-react/docs/api.md
+++ b/packages/@overeng/notion-react/docs/api.md
@@ -44,8 +44,23 @@ sync(element, {
   coldBaseline?,       // 'clean' (default) | 'merge' — how to treat pre-existing live children on cold sync
   onUploadIdRejected?, // retry hook for evicted file_upload_ids
   reorderSiblings?,    // opt-in intra-parent <ChildPage> reorder (phase 4d, #618)
+  pageLifecycle?,      // 'managed' (default) | 'append-only' (#1124)
 })
 ```
+
+`pageLifecycle: 'append-only'` — for irreplaceable live trees (page
+identity carries grants; recreation is impossible through the public
+API). Block ops and page content (`updatePage` title/icon/cover) stay
+fully managed, but the sync guarantees it never archives, moves, or
+reorders a page and never creates one out of tail position: a single
+post-diff predicate fails the WHOLE sync before any op applies with
+`NotionSyncError { reason: 'page-lifecycle-violation', violations }`
+(the offending `DiffOp[]`). Fail, not skip — JSX implying page
+destruction under this mode is a caller bug. Notion creates children at
+the tail, so new pages must be appended after the retained run; wanting
+a fixed order means accepting tail placement, not reordering. #1100
+crash recovery (pending-adoption) stays legal. See
+[Limitations → Append-only page lifecycle](./limitations.md#append-only-page-lifecycle-r41).
 
 `reorderSiblings` values:
 
@@ -68,6 +83,7 @@ plan(element, {
   reorderSiblings?, // same semantics as sync()
   staleness?,       // 'live' (default) | 'cache-only'
   onEvent?,         // retrieve op events + one PlanComputed; nothing else
+  pageLifecycle?,   // same semantics as sync(); plan() reports, never fails
 })
 // → Effect<SyncPlan, NotionSyncError, NotionConfig | HttpClient>
 ```
@@ -88,6 +104,11 @@ siblings emits a same-parent `movePage` that Notion rejects and `sync()`
 deliberately swallows (a documented no-op), so server sibling order
 never converges and subsequent live plans keep reporting that move — opt
 into `reorderSiblings: true` for a true fixpoint.
+
+Under `pageLifecycle: 'append-only'`, `SyncPlan.lifecycleViolations`
+carries the ops the sync-side guard would reject (same predicate — the
+preview and the guard cannot disagree); `plan()` itself never fails on
+violations. The field is present only when the option was passed.
 
 `staleness`:
 
@@ -291,13 +312,15 @@ import {
 import { NotionSyncError, CacheError } from '@overeng/notion-react'
 ```
 
-| Error             | Reasons (so far)                                                                                                                                                                 |
-| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `NotionSyncError` | `"notion-append-failed"`, `"notion-insert-failed"`, `"notion-update-failed"`, `"notion-delete-failed"`, `"notion-retrieve-failed"`, `"cache-load-failed"`, `"cache-save-failed"` |
-| `CacheError`      | `"fs-cache-read-failed"`, `"fs-cache-parse-failed"`, `"fs-cache-write-failed"`                                                                                                   |
+| Error             | Reasons (so far)                                                                                                                                                                                               |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `NotionSyncError` | `"notion-append-failed"`, `"notion-insert-failed"`, `"notion-update-failed"`, `"notion-delete-failed"`, `"notion-retrieve-failed"`, `"cache-load-failed"`, `"cache-save-failed"`, `"page-lifecycle-violation"` |
+| `CacheError`      | `"fs-cache-read-failed"`, `"fs-cache-parse-failed"`, `"fs-cache-write-failed"`                                                                                                                                 |
 
 Both are `Data.TaggedError` classes with `reason: string` and optional
-`cause: unknown`.
+`cause: unknown`. For `"page-lifecycle-violation"` (#1124),
+`NotionSyncError.violations` carries the offending `DiffOp[]` the
+`'append-only'` predicate rejected — before any op was applied.
 
 ## Uploads
 

--- a/packages/@overeng/notion-react/docs/limitations.md
+++ b/packages/@overeng/notion-react/docs/limitations.md
@@ -145,6 +145,29 @@ Our `@overeng/notion-effect-client` handles this transparently under
 `retryEnabled: true`, but if you layer your own retry on top, don't rely
 on headers.
 
+## Append-only page lifecycle (R41)
+
+### Tail placement, not order preservation
+
+Under `pageLifecycle: 'append-only'`, new `<ChildPage>`s are legal only
+at the tail of their parent's page-sibling run — Notion creates
+children at the tail, and reordering is a second, non-atomic lifecycle
+op the mode exists to forbid. JSX that inserts a page mid-run fails the
+whole sync (`page-lifecycle-violation`) rather than silently landing at
+the tail and diverging server order from JSX order. Wanting a fixed
+presentation order under this mode means authoring pages append-last.
+
+### The guard is per-sync, not a server-side lock
+
+The predicate constrains what THIS library will do in the guarded sync.
+It cannot prevent out-of-band writers (or the same consumer running in
+`'managed'` mode) from archiving or moving pages. Note the interaction
+with cold syncs: the cold-`'clean'` baseline sweep emits block removes
+for pre-existing live children — a live `child_page` under a
+cold-`'clean'` root still surfaces as a lifecycle-legal block `remove`
+targeting the mirrored block. For irreplaceable trees, pair
+`'append-only'` with `coldBaseline: 'merge'` and a persistent cache.
+
 ## Readback verification scope
 
 ### Masked dimensions (T12)

--- a/packages/@overeng/notion-react/docs/vrs/requirements.md
+++ b/packages/@overeng/notion-react/docs/vrs/requirements.md
@@ -310,6 +310,21 @@ host-config, or cache are implemented (see [spec.md](./spec.md) for that).
   (uploaded-asset signed URLs, built-in-icon name↔URL mapping) must be
   masked explicitly and documented, never compared best-effort.
 
+### Must guarantee page survival on demand
+
+- **R41 Append-only page lifecycle:** With `pageLifecycle: 'append-only'`
+  on `sync()`/`plan()`, the library must guarantee it never archives,
+  moves, or reorders a page and never creates one out of tail position in
+  its parent's page-sibling run — enforced by a single pure predicate
+  over the computed plan, evaluated immediately after `diff()` and before
+  any op applies. A violation fails the WHOLE sync (fail, not skip —
+  dropping ops would silently diverge server from cache) with
+  `NotionSyncError { reason: 'page-lifecycle-violation' }` carrying the
+  offending `DiffOp[]`. Block ops and page content (`updatePage`
+  title/icon/cover) remain fully managed; `plan()` reports the same
+  violations without failing; #1100 pending-adoption (read + cache-save)
+  remains legal under the mode.
+
 ### Must project authored JSX to readable Markdown (experimental)
 
 - **R31 Read-only offline projection:** Rendering JSX through the Markdown

--- a/packages/@overeng/notion-react/docs/vrs/spec.md
+++ b/packages/@overeng/notion-react/docs/vrs/spec.md
@@ -613,6 +613,46 @@ server edited out of band) and vice versa. Like a plan, an observation
 is advisory for the observed window (T11/T12) — there is no snapshot
 isolation across the paginated children walk.
 
+## Page-lifecycle enforcement (R41)
+
+`pageLifecycle: 'managed' | 'append-only'` on `sync()`/`plan()`
+(default `'managed'`, the full existing contract). `'append-only'`
+exists for consumers managing an irreplaceable live tree — pages whose
+identity carries grants and cannot be recreated through the public API
+— where a JSX bug (or diff edge case) implying page destruction must
+fail before mutation, not execute.
+
+The enforcement point is `pageLifecycleViolations({ ops, candidate })`
+(`page-lifecycle.ts`): one pure predicate over the computed plan plus
+the diffed candidate tree, evaluated immediately after `diff()` — the
+first point where the full op set exists and before anything applies.
+Violations, in plan order:
+
+- every `archivePage` / `movePage` / `reorderPages`;
+- every `createPage` whose page sits before a retained page sibling in
+  candidate order. Notion creates children at the tail, so additive page
+  publication is append-last by nature; a consumer wanting a fixed
+  presentation order must accept tail placement rather than reorder (a
+  reorder is a second, non-atomic lifecycle op on an irreplaceable
+  tree). The tail test needs the candidate tree — the ops alone cannot
+  tell a tail create from a mid-run create.
+
+`sync()` fails the whole sync with
+`NotionSyncError { reason: 'page-lifecycle-violation', violations }`
+before any op applies — fail, not skip: dropping the offending ops
+would silently diverge server from cache. This is a plan predicate,
+not a mid-apply guard ("a late counter guard is not an apply
+boundary"). `plan()` evaluates the same predicate into
+`SyncPlan.lifecycleViolations` without failing — a free preview, and
+present only when the option was passed.
+
+Under the mode, block ops and page content (`updatePage`, including
+the root-metadata update) remain fully managed. #1100
+pending-adoption runs before the diff and is read + cache-save only,
+so crash recovery stays legal: a checkpointed page that _moved_ in the
+retry JSX is adopted first (harmless) and its implied `movePage` then
+rejected by the predicate.
+
 ## Upload coordination
 
 See `src/renderer/upload-registry.ts`.

--- a/packages/@overeng/notion-react/src/renderer/errors.ts
+++ b/packages/@overeng/notion-react/src/renderer/errors.ts
@@ -1,9 +1,18 @@
 import { Data } from 'effect'
 
-/** Error produced during a Notion sync/render */
+import type { DiffOp } from './sync-diff.ts'
+
+/**
+ * Error produced during a Notion sync/render.
+ *
+ * `violations` is populated only for `reason: 'page-lifecycle-violation'`
+ * (#1124): the offending `DiffOp[]` the `'append-only'` page-lifecycle
+ * predicate rejected, in plan order, before any op was applied.
+ */
 export class NotionSyncError extends Data.TaggedError('NotionSyncError')<{
   readonly reason: string
   readonly cause?: unknown
+  readonly violations?: readonly DiffOp[]
 }> {}
 
 /** Error produced by a NotionCache backend */

--- a/packages/@overeng/notion-react/src/renderer/mod.ts
+++ b/packages/@overeng/notion-react/src/renderer/mod.ts
@@ -25,6 +25,7 @@ export {
   type SyncFallbackReason,
 } from './render-to-notion.ts'
 export { sync, plan, type SyncPlan, type PlanStaleness } from './sync.ts'
+export { pageLifecycleViolations, type PageLifecycle } from './page-lifecycle.ts'
 export { SyncEvent, type SyncEventHandler } from './sync-events.ts'
 export {
   extractFileUploadId,

--- a/packages/@overeng/notion-react/src/renderer/page-lifecycle.ts
+++ b/packages/@overeng/notion-react/src/renderer/page-lifecycle.ts
@@ -1,0 +1,88 @@
+import type { CandidateNode, CandidateTree, DiffOp } from './sync-diff.ts'
+
+/**
+ * Page-lifecycle mode for `sync()` / `plan()` (#1124).
+ *
+ * - `'managed'` (default): the full existing contract — JSX drives page
+ *   create/update/archive/move/reorder.
+ * - `'append-only'`: for consumers managing an IRREPLACEABLE live tree
+ *   (e.g. agent-parented pages whose grants bind to page identity and which
+ *   cannot be recreated through the public API). Block ops stay fully
+ *   managed and page *content* (`updatePage` title/icon/cover) stays
+ *   allowed, but page *lifecycle* is constrained: `createPage` is legal
+ *   only at the tail of its parent's page-sibling run; any `archivePage`,
+ *   `movePage`, `reorderPages`, or out-of-tail `createPage` fails the whole
+ *   sync BEFORE any op applies.
+ *
+ * Fail, not skip: JSX implying page destruction under `'append-only'` is a
+ * caller bug — skipping the op would silently diverge server from cache.
+ */
+export type PageLifecycle = 'managed' | 'append-only'
+
+/**
+ * A candidate page is a create when the diff left it holding a placeholder
+ * id (retained / moved pages get their server id bound during `diff()`).
+ */
+const isCreatedPage = (node: CandidateNode): boolean =>
+  node.blockId === undefined || node.blockId.startsWith('tmp-')
+
+/**
+ * Collect the `tmpPageId`s of page candidates that sit BEFORE a retained page
+ * in their parent's page-sibling run — i.e. creates that cannot land in JSX
+ * order, because Notion only creates children at the tail. Walks every
+ * sibling scope (root and nested) of the diffed candidate tree.
+ */
+const collectOutOfTailCreates = (nodes: readonly CandidateNode[], out: Set<string>): void => {
+  const pages = nodes.filter((n) => n.nodeKind === 'page')
+  let lastRetained = -1
+  for (const [i, page] of pages.entries()) {
+    if (!isCreatedPage(page)) lastRetained = i
+  }
+  for (const [i, page] of pages.entries()) {
+    if (i < lastRetained && isCreatedPage(page) && page.blockId !== undefined) {
+      out.add(page.blockId)
+    }
+  }
+  for (const node of nodes) collectOutOfTailCreates(node.children, out)
+}
+
+/**
+ * The single `'append-only'` enforcement predicate: a pure function of the
+ * computed plan plus the diffed candidate tree (needed for tail-position
+ * context — the ops alone cannot tell a tail create from a mid-run create).
+ *
+ * Returns the offending ops, in plan order:
+ *
+ * - every `archivePage` / `movePage` / `reorderPages` — page destruction,
+ *   reparenting, and reordering are categorically illegal;
+ * - every `createPage` whose page sits before a retained page sibling in
+ *   candidate order (an out-of-tail create would silently land at the tail,
+ *   diverging server order from JSX order — see #1124: a reorder is a
+ *   second, non-atomic lifecycle op on an irreplaceable tree, so tail
+ *   placement must be accepted or the sync must fail).
+ *
+ * Both `sync()` (which fails on a non-empty result before applying anything)
+ * and `plan()` (which reports it without failing) evaluate this immediately
+ * after `diff()`, so the two cannot disagree. Block ops and `updatePage`
+ * (page content) are never violations. #1100 pending-adoption runs before
+ * the diff and is read + cache-save only, so crash recovery stays legal — a
+ * checkpointed page that *moved* in the retry JSX is adopted first
+ * (harmless) and its move then correctly rejected here.
+ */
+export const pageLifecycleViolations = ({
+  ops,
+  candidate,
+}: {
+  readonly ops: readonly DiffOp[]
+  readonly candidate: CandidateTree
+}): readonly DiffOp[] => {
+  const outOfTail = new Set<string>()
+  collectOutOfTailCreates(candidate.children, outOfTail)
+  return ops.filter(
+    (op) =>
+      op.kind === 'archivePage' ||
+      op.kind === 'movePage' ||
+      op.kind === 'reorderPages' ||
+      (op.kind === 'createPage' && outOfTail.has(op.tmpPageId)),
+  )
+}

--- a/packages/@overeng/notion-react/src/renderer/page-lifecycle.unit.test.tsx
+++ b/packages/@overeng/notion-react/src/renderer/page-lifecycle.unit.test.tsx
@@ -1,0 +1,294 @@
+import type { HttpClient } from '@effect/platform'
+import { Effect } from 'effect'
+import type { ReactNode } from 'react'
+import { describe, expect, it } from 'vitest'
+
+import type { NotionConfig } from '@overeng/notion-effect-client'
+
+import { InMemoryCache } from '../cache/in-memory-cache.ts'
+import { ChildPage, Page, Paragraph } from '../components/blocks.ts'
+import { createFakeNotion, FakeNotionResponseError, type FakeNotion } from '../test/mock-client.ts'
+import { NotionSyncError } from './errors.ts'
+import { plan, sync } from './sync.ts'
+
+/**
+ * #1124: `pageLifecycle: 'append-only'` — the sync must fail BEFORE any op
+ * applies whenever the computed plan implies page destruction, reparenting,
+ * reordering, or an out-of-tail create. Every violation-class test asserts
+ * zero writes on the mock request log: the enforcement point is a plan
+ * predicate, not a mid-apply guard (the downstream lesson this issue
+ * absorbs: "a late counter guard is not an apply boundary").
+ */
+const ROOT = '00000000-0000-4000-8000-000000000001'
+
+const runWith = <A, E>(
+  fake: FakeNotion,
+  eff: Effect.Effect<A, E, HttpClient.HttpClient | NotionConfig>,
+): Promise<A> => Effect.runPromise(eff.pipe(Effect.provide(fake.layer)))
+
+/** Mutating request count — GETs (pre-flight, adoption reads) are allowed. */
+const writeCount = (fake: FakeNotion): number =>
+  fake.requests.filter((r) => r.method !== 'GET').length
+
+const failingSync = (
+  fake: FakeNotion,
+  element: ReactNode,
+  cache: ReturnType<typeof InMemoryCache.make>,
+): Promise<NotionSyncError> =>
+  runWith(
+    fake,
+    Effect.flip(sync(element, { pageId: ROOT, cache, pageLifecycle: 'append-only' })),
+  ) as Promise<NotionSyncError>
+
+const TWO_PAGES = (
+  <Page>
+    <ChildPage blockKey="a" title="A" />
+    <ChildPage blockKey="b" title="B" />
+  </Page>
+)
+
+/** Warm state: two child pages (A, B) synced under the root in managed mode. */
+const warmTwoPages = async () => {
+  const fake = createFakeNotion()
+  const cache = InMemoryCache.make()
+  await runWith(fake, sync(TWO_PAGES, { pageId: ROOT, cache }))
+  return { fake, cache }
+}
+
+describe("pageLifecycle: 'append-only' (#1124)", () => {
+  it('tail create is legal: a new page after the retained run is created', async () => {
+    const { fake, cache } = await warmTwoPages()
+    const res = await runWith(
+      fake,
+      sync(
+        <Page>
+          <ChildPage blockKey="a" title="A" />
+          <ChildPage blockKey="b" title="B" />
+          <ChildPage blockKey="c" title="C" />
+        </Page>,
+        { pageId: ROOT, cache, pageLifecycle: 'append-only' },
+      ),
+    )
+    expect(res.pages).toMatchObject({ creates: 1, archives: 0, moves: 0 })
+    expect([...fake.pages.values()].filter((p) => !p.archived)).toHaveLength(3)
+  })
+
+  it('block ops and page content stay fully managed', async () => {
+    const fake = createFakeNotion()
+    const cache = InMemoryCache.make()
+    await runWith(
+      fake,
+      sync(
+        <Page title="v1">
+          <Paragraph blockKey="p">one</Paragraph>
+          <ChildPage blockKey="a" title="A" />
+        </Page>,
+        { pageId: ROOT, cache },
+      ),
+    )
+    const res = await runWith(
+      fake,
+      sync(
+        <Page title="v2" icon={{ type: 'emoji', emoji: '📎' }}>
+          <Paragraph blockKey="p">two</Paragraph>
+          <ChildPage blockKey="a" title="A renamed" />
+        </Page>,
+        { pageId: ROOT, cache, pageLifecycle: 'append-only' },
+      ),
+    )
+    // Root metadata + sub-page metadata updates and the block update all
+    // applied; no lifecycle op was needed or blocked.
+    expect(res.updates).toBe(1)
+    expect(res.pages).toMatchObject({ updates: 2, creates: 0, archives: 0, moves: 0 })
+  })
+
+  it('archive: removing a page from the JSX fails the whole sync with zero writes', async () => {
+    const { fake, cache } = await warmTwoPages()
+    const before = writeCount(fake)
+    const err = await failingSync(
+      fake,
+      <Page>
+        <ChildPage blockKey="a" title="A" />
+      </Page>,
+      cache,
+    )
+    expect(err).toBeInstanceOf(NotionSyncError)
+    expect(err.reason).toBe('page-lifecycle-violation')
+    expect(err.violations?.map((v) => v.kind)).toEqual(['archivePage'])
+    expect(writeCount(fake)).toBe(before)
+    expect([...fake.pages.values()].filter((p) => !p.archived)).toHaveLength(2)
+  })
+
+  it('move: reparenting a page fails pre-mutation with the movePage op attached', async () => {
+    const { fake, cache } = await warmTwoPages()
+    const before = writeCount(fake)
+    const err = await failingSync(
+      fake,
+      <Page>
+        <ChildPage blockKey="a" title="A">
+          <ChildPage blockKey="b" title="B" />
+        </ChildPage>
+      </Page>,
+      cache,
+    )
+    expect(err.reason).toBe('page-lifecycle-violation')
+    expect(err.violations?.map((v) => v.kind)).toContain('movePage')
+    expect(writeCount(fake)).toBe(before)
+  })
+
+  it('reorder: reshuffled retained siblings fail pre-mutation', async () => {
+    const { fake, cache } = await warmTwoPages()
+    const before = writeCount(fake)
+    const err = await runWith(
+      fake,
+      Effect.flip(
+        sync(
+          <Page>
+            <ChildPage blockKey="b" title="B" />
+            <ChildPage blockKey="a" title="A" />
+          </Page>,
+          { pageId: ROOT, cache, pageLifecycle: 'append-only', reorderSiblings: true },
+        ),
+      ),
+    )
+    expect((err as NotionSyncError).reason).toBe('page-lifecycle-violation')
+    expect((err as NotionSyncError).violations?.map((v) => v.kind)).toEqual(['reorderPages'])
+    expect(writeCount(fake)).toBe(before)
+  })
+
+  it('mid-list create: a new page before a retained sibling fails pre-mutation', async () => {
+    const { fake, cache } = await warmTwoPages()
+    const before = writeCount(fake)
+    const err = await failingSync(
+      fake,
+      <Page>
+        <ChildPage blockKey="new" title="New first" />
+        <ChildPage blockKey="a" title="A" />
+        <ChildPage blockKey="b" title="B" />
+      </Page>,
+      cache,
+    )
+    expect(err.reason).toBe('page-lifecycle-violation')
+    expect(err.violations?.map((v) => v.kind)).toEqual(['createPage'])
+    expect(writeCount(fake)).toBe(before)
+    expect(fake.pages.size).toBe(2)
+  })
+
+  it("plan() reports the same violations without failing; 'managed' omits the field", async () => {
+    const { fake, cache } = await warmTwoPages()
+    const removal = (
+      <Page>
+        <ChildPage blockKey="a" title="A" />
+      </Page>
+    )
+    const preview = await runWith(
+      fake,
+      plan(removal, { pageId: ROOT, cache, pageLifecycle: 'append-only' }),
+    )
+    expect(preview.lifecycleViolations?.map((v) => v.kind)).toEqual(['archivePage'])
+    // plan() never fails on violations and never writes.
+    expect(preview.pages.archives).toBe(1)
+    const managed = await runWith(fake, plan(removal, { pageId: ROOT, cache }))
+    expect(managed.lifecycleViolations).toBeUndefined()
+    // Default mode is unaffected: the same element syncs fine under 'managed'.
+    const res = await runWith(fake, sync(removal, { pageId: ROOT, cache }))
+    expect(res.pages.archives).toBe(1)
+  })
+
+  it('#1100 crash recovery stays legal: pending adoption is not a lifecycle op', async () => {
+    const CRASH_TREE = (
+      <Page>
+        <ChildPage blockKey="child" title="child">
+          <Paragraph blockKey="body">body</Paragraph>
+        </ChildPage>
+      </Page>
+    )
+    const fake = createFakeNotion()
+    const cache = InMemoryCache.make()
+    let tripped = false
+    fake.failOn((request) => {
+      if (!tripped && request.method === 'GET' && request.path !== `/v1/blocks/${ROOT}/children`) {
+        tripped = true
+        return new FakeNotionResponseError(500, 'internal_server_error', 'simulated process death')
+      }
+      return undefined
+    })
+    const first = await Effect.runPromiseExit(
+      sync(CRASH_TREE, { pageId: ROOT, cache, pageLifecycle: 'append-only' }).pipe(
+        Effect.provide(fake.layer),
+      ),
+    )
+    expect(first._tag).toBe('Failure')
+    const checkpoint = await Effect.runPromise(cache.load)
+    expect(checkpoint?.children.find((n) => n.pendingInlineResolution !== undefined)).toBeDefined()
+    // Retry with the SAME tree: adoption (read + cache-save) resolves the
+    // pending marker and the sync converges without a page mutation.
+    const retry = await runWith(
+      fake,
+      sync(CRASH_TREE, { pageId: ROOT, cache, pageLifecycle: 'append-only' }),
+    )
+    expect(retry.pages).toMatchObject({ creates: 0, archives: 0, moves: 0 })
+    const resolved = await Effect.runPromise(cache.load)
+    expect(resolved?.children.find((n) => n.pendingInlineResolution !== undefined)).toBeUndefined()
+  })
+
+  it('#1100 checkpointed page that MOVED in the retry JSX: adopted first, then rejected', async () => {
+    const fake = createFakeNotion()
+    const cache = InMemoryCache.make()
+    // Warm state: 'host' exists (so the retry's relocation diffs as a
+    // movePage into a RETAINED parent, not archive + re-create).
+    await runWith(
+      fake,
+      sync(
+        <Page>
+          <ChildPage blockKey="host" title="host" />
+        </Page>,
+        { pageId: ROOT, cache },
+      ),
+    )
+    let tripped = false
+    fake.failOn((request) => {
+      if (!tripped && request.method === 'GET' && request.path !== `/v1/blocks/${ROOT}/children`) {
+        tripped = true
+        return new FakeNotionResponseError(500, 'internal_server_error', 'simulated process death')
+      }
+      return undefined
+    })
+    // Tail-legal create of 'child' crashes after pages.create checkpointed
+    // its identity but before the inline-descendant retrieval landed.
+    const first = await Effect.runPromiseExit(
+      sync(
+        <Page>
+          <ChildPage blockKey="host" title="host" />
+          <ChildPage blockKey="child" title="child">
+            <Paragraph blockKey="body">body</Paragraph>
+          </ChildPage>
+        </Page>,
+        { pageId: ROOT, cache, pageLifecycle: 'append-only' },
+      ).pipe(Effect.provide(fake.layer)),
+    )
+    expect(first._tag).toBe('Failure')
+    const before = writeCount(fake)
+    // Retry JSX relocated the checkpointed page under the retained host. The
+    // cross-parent adoption binds the created identity (harmless: read +
+    // cache-save), then the post-diff predicate rejects the implied move.
+    const err = await failingSync(
+      fake,
+      <Page>
+        <ChildPage blockKey="host" title="host">
+          <ChildPage blockKey="child" title="child">
+            <Paragraph blockKey="body">body</Paragraph>
+          </ChildPage>
+        </ChildPage>
+      </Page>,
+      cache,
+    )
+    expect(err.reason).toBe('page-lifecycle-violation')
+    expect(err.violations?.map((v) => v.kind)).toContain('movePage')
+    // Adoption resolved the pending marker in the cache…
+    const resolved = await Effect.runPromise(cache.load)
+    expect(resolved?.children.find((n) => n.pendingInlineResolution !== undefined)).toBeUndefined()
+    // …but no server write happened on the retry.
+    expect(writeCount(fake)).toBe(before)
+  })
+})

--- a/packages/@overeng/notion-react/src/renderer/page-lifecycle.unit.test.tsx
+++ b/packages/@overeng/notion-react/src/renderer/page-lifecycle.unit.test.tsx
@@ -1,4 +1,4 @@
-import type { HttpClient } from '@effect/platform'
+import type { HttpClient } from 'effect/unstable/http/HttpClient'
 import { Effect } from 'effect'
 import type { ReactNode } from 'react'
 import { describe, expect, it } from 'vitest'
@@ -23,7 +23,7 @@ const ROOT = '00000000-0000-4000-8000-000000000001'
 
 const runWith = <A, E>(
   fake: FakeNotion,
-  eff: Effect.Effect<A, E, HttpClient.HttpClient | NotionConfig>,
+  eff: Effect.Effect<A, E, HttpClient | NotionConfig>,
 ): Promise<A> => Effect.runPromise(eff.pipe(Effect.provide(fake.layer)))
 
 /** Mutating request count — GETs (pre-flight, adoption reads) are allowed. */

--- a/packages/@overeng/notion-react/src/renderer/page-lifecycle.unit.test.tsx
+++ b/packages/@overeng/notion-react/src/renderer/page-lifecycle.unit.test.tsx
@@ -1,5 +1,5 @@
-import type { HttpClient } from 'effect/unstable/http/HttpClient'
 import { Effect } from 'effect'
+import type { HttpClient } from 'effect/unstable/http/HttpClient'
 import type { ReactNode } from 'react'
 import { describe, expect, it } from 'vitest'
 

--- a/packages/@overeng/notion-react/src/renderer/sync.ts
+++ b/packages/@overeng/notion-react/src/renderer/sync.ts
@@ -13,6 +13,7 @@ import type { CacheNode, CacheTree, NotionCache, PendingInlineNode } from '../ca
 import { CACHE_SCHEMA_VERSION } from '../cache/types.ts'
 import { NotionSyncError } from './errors.ts'
 import type { PageOp } from './op-buffer.ts'
+import { pageLifecycleViolations, type PageLifecycle } from './page-lifecycle.ts'
 import {
   ATOMIC_CONTAINERS,
   emptyPageCounts,
@@ -1371,6 +1372,18 @@ export const sync = (
      *   id. The library never archives caller-supplied holding parents.
      */
     readonly reorderSiblings?: boolean | { readonly holdingParentId: string }
+    /**
+     * Page-lifecycle mode (#1124). `'managed'` (default) keeps the full
+     * existing contract. `'append-only'` guarantees the sync never
+     * archives, moves, or reorders a page and never creates one out of
+     * tail position: a single post-diff predicate
+     * ({@link pageLifecycleViolations}) rejects the WHOLE sync — no op
+     * applied — with `NotionSyncError { reason:
+     * 'page-lifecycle-violation', violations }`. Block ops and page
+     * content (`updatePage`) stay fully managed. #1100 pending-adoption
+     * (read + cache-save) still runs — crash recovery stays legal.
+     */
+    readonly pageLifecycle?: PageLifecycle
   },
 ): Effect.Effect<SyncResult, NotionSyncError, NotionConfig | HttpClient> => {
   /* Compose the user `onEvent` with an internal metrics aggregator iff
@@ -1602,6 +1615,17 @@ export const sync = (
           at: Date.now(),
         }),
       )
+    }
+    // #1124: the single append-only enforcement point — a pure predicate over
+    // the computed plan, evaluated before ANY op applies. Everything below
+    // this line mutates (root updatePage, interleaved block/page apply), so
+    // the check must sit exactly here. Fail, not skip: dropping the
+    // offending ops would silently diverge server from cache.
+    if (opts.pageLifecycle === 'append-only') {
+      const violations = pageLifecycleViolations({ ops: plan, candidate })
+      if (violations.length > 0) {
+        return yield* new NotionSyncError({ reason: 'page-lifecycle-violation', violations })
+      }
     }
     // Prior hashes indexed by server block id — for UpdateNoop detection
     // when diff emits an update whose hash already matches the cached one
@@ -2441,6 +2465,14 @@ export interface SyncPlan {
   readonly fallbackReason: SyncFallbackReason | undefined
   /** `true` iff the page is already at the fixpoint: a sync now would write nothing. */
   readonly empty: boolean
+  /**
+   * Present iff `pageLifecycle: 'append-only'` was passed (#1124): the ops
+   * a sync under that mode would reject — same predicate, so `plan()` is a
+   * free preview: an empty array proves the sync would not trip the
+   * lifecycle guard for this observed state. `plan()` itself never fails on
+   * violations.
+   */
+  readonly lifecycleViolations?: readonly DiffOp[]
 }
 
 /**
@@ -2477,6 +2509,12 @@ export const plan = (
     readonly reorderSiblings?: boolean | { readonly holdingParentId: string }
     readonly staleness?: PlanStaleness
     readonly onEvent?: SyncEventHandler
+    /**
+     * See {@link sync}'s `pageLifecycle`. Under `'append-only'`, `plan()`
+     * reports the offending ops in `SyncPlan.lifecycleViolations` WITHOUT
+     * failing — a free preview of what the sync-side guard would reject.
+     */
+    readonly pageLifecycle?: PageLifecycle
   },
 ): Effect.Effect<SyncPlan, NotionSyncError, NotionConfig | HttpClient> =>
   Effect.gen(function* () {
@@ -2596,5 +2634,10 @@ export const plan = (
       pages: tallyPageOps(ops),
       fallbackReason,
       empty: ops.length === 0,
+      // Same predicate as sync()'s enforcement point, so the preview and the
+      // guard cannot disagree for a given observed state (#1124).
+      ...(opts.pageLifecycle === 'append-only'
+        ? { lifecycleViolations: pageLifecycleViolations({ ops, candidate }) }
+        : {}),
     }
   })


### PR DESCRIPTION
> Recreated from #1132: rebased onto current main (effect@4.0.0-rc.111 cohort); head SHA e0da82430b67cd6166b5a8293f285baa043ddb40. The original was a stacked-base PR that GitHub refused to merge on every surface (stack guard + async merge API 404). Diff vs main currently includes earlier train stages; it shrinks to this stage only as predecessors below merge.

## Outcome

Add `pageLifecycle: 'managed' | 'append-only'` to `sync()` and `plan()`. Under `'append-only'`, the library **guarantees** it never archives, moves, or reorders a page and never creates one out of tail position in its parent's page-sibling run — enforced by a single pure post-diff predicate that fails the whole sync before any op applies. Block ops and page content (`updatePage` title/icon/cover) stay fully managed.

Closes #1124. Stacked on #1131.

## Why

Some consumers manage an **irreplaceable** live tree: pages whose grants bind to page identity and which cannot be recreated through the public API. For such trees a sync must be able to guarantee it will never destroy a page — a bug in the JSX (or a diff edge case) that implies page destruction must fail *before* mutation, not execute. The Blocky downstream consumer currently enforces this with a post-apply counter guard plus a bespoke ~160-line append-only convergence loop; its own experiment log records the lesson this PR absorbs: "a late counter guard is not an apply boundary."

## Semantics

- `createPage` is legal only at the tail of its parent's page-sibling run. Notion creates children at the tail, so additive page publication is append-last by nature; a consumer wanting a fixed presentation order must accept tail placement rather than reorder (a reorder is a second, non-atomic lifecycle op on an irreplaceable tree). An out-of-tail create would silently land at the tail and diverge server order from JSX order — so it fails instead.
- Any `archivePage`, `movePage`, `reorderPages`, or out-of-tail `createPage` fails the WHOLE sync with `NotionSyncError { reason: 'page-lifecycle-violation', violations }` — `violations` carries the offending `DiffOp[]` in plan order. **Fail, not skip**: dropping the ops would silently diverge server from cache.
- `plan()` evaluates the same predicate into `SyncPlan.lifecycleViolations` without failing — a free preview; the field is present only when the option was passed, so the preview and the guard cannot disagree.
- #1100 pending-adoption stays legal: it runs before the diff and is read + cache-save, never a page mutation. A checkpointed page that *moved* in the retry JSX is adopted first (harmless) and its implied `movePage` then correctly rejected by the predicate — covered by a test.

## Changes

- new `page-lifecycle.ts`: `PageLifecycle` + `pageLifecycleViolations({ ops, candidate })` — the tail test needs the diffed candidate tree (ops alone cannot tell a tail create from a mid-run create; retained/moved pages hold server ids after `diff()`, creates hold placeholders)
- `sync()`: enforcement immediately after `diff()` — the first point the full op set exists, before the root `updatePage` and the interleaved block/page apply
- `plan()`: same predicate into `SyncPlan.lifecycleViolations`
- `NotionSyncError` gains optional `violations?: readonly DiffOp[]` (populated only for this reason)
- docs: R41, spec enforcement section, api.md (sync/plan options + errors), limitations, changelog

## Decisions taken

- `lifecycleViolations` is present **iff** the option was passed (rather than always computed): its meaning is "what `'append-only'` would reject", so surfacing it unconditionally under `'managed'` would read as a warning that isn't one.
- Documented limitation rather than extra machinery: the guard is per-sync, not a server-side lock, and the cold-`'clean'` baseline sweep's ghost removes are block ops (`nodeKind: 'block'` placeholders), so a live `child_page` under a cold-`'clean'` root bypasses the page-op classification. Limitations recommend pairing `'append-only'` with `coldBaseline: 'merge'` and a persistent cache; making the predicate consult the pre-flight child list's block types would close this and is a reasonable follow-up if a consumer needs it.

## Evidence

- `notion-react`: 397 passed, 1 skipped (388 from #1131 + 9 new)
- new tests: tail create allowed; each violation class — archive / move / reorder (`reorderSiblings: true`) / mid-list create — fails pre-mutation with **zero writes on the mock request log** (GET-only pre-flight allowed); block ops + root/sub-page `updatePage` still applied under the mode; `plan()` reports violations without failing and `'managed'` omits the field; #1100 crash-recovery retry converges under the mode, and the moved-in-retry variant is adopted (cache marker resolved) then rejected with zero writes
- existing behavior unchanged under `'managed'` (full suite green, zero regressions)
- TypeScript build passed (`tsc -b tsconfig.check.json`); lint + format green (`lint:check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | unknown |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.0.3 |
| `agent_runtime` | OMP 18.0.3 |
| `tooling_profile` | dotfiles@a80129b-dirty |
</details>
<!-- agent-footer:end -->