### PR TITLE
feat(renderer): adopt() — fail-closed adoption of existing rendered pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,21 @@ All notable changes to this project will be documented in this file.
   into a `CacheTree` out-of-band can no longer drift from the scheme
   `buildCandidateTree` / `diff` actually produce.
 
+- **@overeng/notion-react**: add `adopt()`, fail-closed adoption of an
+  existing rendered page (#1093). A stateless consumer whose renderer cache
+  did not survive can rebuild the `CacheTree` a prior `sync()` would have
+  persisted from (candidate JSX, pageId, live observation) alone — zero
+  Notion mutations in every outcome, refusal paths included. Binding is
+  strictly positional (`blockKey` is never stored in Notion; keys flow
+  candidate-side only); every bound pair is verified — block content through
+  the readback oracle, `child_page`/root `<Page>` title/icon/cover claims
+  per field via `pages.retrieve` — and every divergence is collected into
+  one typed `AdoptionRefusedError` (`ChildCountMismatch`, `TypeMismatch`,
+  `ContentDrift`, `UnverifiableContent`, `PageMetaDrift`, `RootTrashed`).
+  `onContentDrift: 'adopt-live'` keeps structural checks fail-closed but
+  records a live marker at drifted nodes so the next ordinary `sync()`
+  emits exactly the minimal repairing updates, after which strict
+  re-adoption reaches the zero-op fixpoint.
 - **@overeng/notion-react**: add `pageLifecycle: 'managed' | 'append-only'` on
   `sync()`/`plan()` (#1124). `'append-only'` guarantees a sync never archives,
   moves, or reorders a page and never creates one out of tail position in its

--- a/packages/@overeng/notion-react/docs/api.md
+++ b/packages/@overeng/notion-react/docs/api.md
@@ -207,14 +207,14 @@ whenever either side expects children, so untracked nested live content
 surfaces instead of being ignored. All refusals in a pass are collected
 into one `AdoptionRefusedError`:
 
-| Refusal                | Meaning                                                                                                    |
-| ---------------------- | ---------------------------------------------------------------------------------------------------------- |
-| `ChildCountMismatch`   | Extra untracked live blocks or missing candidate content under a parent (ids/keys pinned).                 |
-| `TypeMismatch`         | Live block type differs from the candidate's at a position.                                                |
-| `ContentDrift`         | Bound block's content drifted (pins key, blockId, and both readback-space hashes).                         |
-| `UnverifiableContent`  | The readback oracle cannot normalize the node (`<Raw>` escape-hatch payloads) — fail closed, never trust.  |
-| `PageMetaDrift`        | A claimed page title/icon/cover drifted (field-level, cache-space claim hashes).                           |
-| `RootTrashed`          | The root page is in the trash while the JSX carries root `<Page>` claims.                                  |
+| Refusal               | Meaning                                                                                                   |
+| --------------------- | --------------------------------------------------------------------------------------------------------- |
+| `ChildCountMismatch`  | Extra untracked live blocks or missing candidate content under a parent (ids/keys pinned).                |
+| `TypeMismatch`        | Live block type differs from the candidate's at a position.                                               |
+| `ContentDrift`        | Bound block's content drifted (pins key, blockId, and both readback-space hashes).                        |
+| `UnverifiableContent` | The readback oracle cannot normalize the node (`<Raw>` escape-hatch payloads) — fail closed, never trust. |
+| `PageMetaDrift`       | A claimed page title/icon/cover drifted (field-level, cache-space claim hashes).                          |
+| `RootTrashed`         | The root page is in the trash while the JSX carries root `<Page>` claims.                                 |
 
 `onContentDrift: 'adopt-live'` keeps all structural checks fail-closed
 but adopts drifted nodes with a recorded live marker (blocks:

--- a/packages/@overeng/notion-react/docs/api.md
+++ b/packages/@overeng/notion-react/docs/api.md
@@ -16,6 +16,7 @@ import { renderToNotionMarkdown } from '@overeng/notion-react/markdown'
 | `renderToNotion`         | [`renderer/render-to-notion.ts`](../src/renderer/render-to-notion.ts)                   | Cold-start append; no cache. Returns `Effect<SyncResult, NotionSyncError, NotionConfig \| HttpClient>`.                                      |
 | `sync`                   | [`renderer/sync.ts`](../src/renderer/sync.ts)                                           | Incremental cache-backed sync. Same return type. See [sync options](#sync-options).                                                          |
 | `plan`                   | [`renderer/sync.ts`](../src/renderer/sync.ts)                                           | Read-only companion to `sync`: the ops a sync would apply, zero writes. Returns `Effect<SyncPlan, …>`. See [plan options](#plan-options).    |
+| `adopt`                  | [`renderer/adopt.ts`](../src/renderer/adopt.ts)                                         | Fail-closed adoption of an existing rendered page: rebuild the cache from live state, zero mutations. See [Adoption](#adoption-fail-closed). |
 | `collectOps`             | [`renderer/render-to-notion.ts`](../src/renderer/render-to-notion.ts)                   | Collect an `OpBuffer` from a one-shot render. Exposed for tests.                                                                             |
 | `SyncResult`             | [`renderer/render-to-notion.ts`](../src/renderer/render-to-notion.ts)                   | `{ appends, updates, removes, inserts, fallbackReason? }`                                                                                    |
 | `SyncPlan`               | [`renderer/sync.ts`](../src/renderer/sync.ts)                                           | `{ ops, blocks, pages, fallbackReason, empty }` — `empty` is the fixpoint oracle.                                                            |
@@ -168,6 +169,67 @@ own content with its own `compareReadback`/`compareReadbackPage` pass
 (same per-page boundary as sync itself). Raw escape-hatch blocks
 (`<Raw>`, `SyncedBlock`, …) are unsupported and throw.
 
+## Adoption (fail-closed)
+
+```ts
+import { adopt, AdoptionRefusedError } from '@overeng/notion-react'
+
+const cacheTree = yield * adopt(element, {
+  pageId,
+  onContentDrift?, // 'refuse' (default) | 'adopt-live'
+})
+// → Effect<CacheTree, AdoptionRefusedError | NotionSyncError, NotionConfig | HttpClient>
+```
+
+For stateless consumers whose renderer cache did not survive a redeploy:
+`adopt()` rebuilds the exact `CacheTree` a prior `sync()` of the same
+element would have persisted, from live observation alone — with **zero
+Notion mutations** in every outcome, refusal paths included (GET-only).
+The default cold-cache path (`coldBaseline: 'clean'`) archives and
+re-appends everything; a successful adoption feeds the normal
+incremental diff and `plan()` over the adopted tree is immediately
+empty. The returned tree is not persisted — save it through your
+`NotionCache`.
+
+Binding is strictly **positional**: `blockKey` is never stored in
+Notion, so keys and hashes flow exclusively from the candidate side and
+candidate child _i_ binds to live child _i_ (in-trash blocks excluded).
+Identical siblings bind deterministically (index order is the unique
+binding up to observational equivalence); reordered _distinct_ siblings
+refuse at both positions — adoption never re-matches by content search.
+
+Every bound pair is verified before the mapping is trusted: block
+content through the [readback oracle](#readback-verification) (one node
+at a time, so a drifted child pins the child, not its ancestors);
+`child_page` and root `<Page>` title/icon/cover claims per field against
+`pages.retrieve`; recursion crosses page boundaries and descends
+whenever either side expects children, so untracked nested live content
+surfaces instead of being ignored. All refusals in a pass are collected
+into one `AdoptionRefusedError`:
+
+| Refusal                | Meaning                                                                                                    |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `ChildCountMismatch`   | Extra untracked live blocks or missing candidate content under a parent (ids/keys pinned).                 |
+| `TypeMismatch`         | Live block type differs from the candidate's at a position.                                                |
+| `ContentDrift`         | Bound block's content drifted (pins key, blockId, and both readback-space hashes).                         |
+| `UnverifiableContent`  | The readback oracle cannot normalize the node (`<Raw>` escape-hatch payloads) — fail closed, never trust.  |
+| `PageMetaDrift`        | A claimed page title/icon/cover drifted (field-level, cache-space claim hashes).                           |
+| `RootTrashed`          | The root page is in the trash while the JSX carries root `<Page>` claims.                                  |
+
+`onContentDrift: 'adopt-live'` keeps all structural checks fail-closed
+but adopts drifted nodes with a recorded live marker (blocks:
+`adopt-live:<observedReadbackHash>` in `CacheNode.hash`; page fields:
+the live claim's cache-space hash). The next ordinary `sync()` then
+emits exactly the minimal repairing updates, after which strict
+re-adoption succeeds and reaches the zero-op fixpoint.
+
+Adoption inherits the readback oracle's masked dimensions (T12):
+uploaded media bytes and unclaimed provider-owned fields are
+presence-verified, not content-verified. Like a plan, an adoption is
+advisory for the observed window — there is no snapshot isolation
+against a concurrent writer (T11); the post-adoption empty-`plan()`
+check is the proof of convergence.
+
 ## Block components
 
 From `@overeng/notion-react` (Notion host) and
@@ -309,7 +371,7 @@ import {
 ## Errors
 
 ```ts
-import { NotionSyncError, CacheError } from '@overeng/notion-react'
+import { NotionSyncError, CacheError, AdoptionRefusedError } from '@overeng/notion-react'
 ```
 
 | Error             | Reasons (so far)                                                                                                                                                                                               |
@@ -321,6 +383,10 @@ Both are `Data.TaggedError` classes with `reason: string` and optional
 `cause: unknown`. For `"page-lifecycle-violation"` (#1124),
 `NotionSyncError.violations` carries the offending `DiffOp[]` the
 `'append-only'` predicate rejected — before any op was applied.
+
+`AdoptionRefusedError` (#1093) is the typed failure of
+[`adopt()`](#adoption-fail-closed): `refusals` carries every
+`AdoptionRefusal` found in the pass, not just the first.
 
 ## Uploads
 

--- a/packages/@overeng/notion-react/docs/limitations.md
+++ b/packages/@overeng/notion-react/docs/limitations.md
@@ -207,6 +207,32 @@ writer can produce an observation no single instant exhibited. Treat
 readback equality as advisory for the observed window, exactly like a
 `plan()` (T11).
 
+## Adoption scope (R42–R44)
+
+### Verification inherits readback's masked dimensions
+
+`adopt()` uses the readback oracle as its content gate, so everything
+masked there (T12, above) is presence-verified, not content-verified,
+during adoption too: uploaded media bytes, built-in icon identity, and
+unclaimed provider-owned defaults are trusted from the candidate side.
+`<Raw>` escape-hatch content cannot be verified at all and refuses with
+`UnverifiableContent` — a tree containing raw blocks is not adoptable.
+
+### Positional binding is the only binding
+
+Adoption never re-matches by content search: a live page whose sibling
+order differs from the candidate refuses rather than guessing a
+permutation, even when a unique content-based matching "obviously"
+exists. Fix the JSX order (or the live page) and re-adopt.
+
+### No snapshot isolation
+
+Like `plan()` and readback (T11), adoption observes without a lock. A
+writer racing the walk can invalidate the binding; the adopted tree is
+advisory for the observed window. The post-adoption empty-`plan()`
+check — and ultimately the next `sync()`, which recomputes from
+scratch — is the proof that matters.
+
 ## Web renderer (Storybook preview)
 
 ### Not API-stable (T05)

--- a/packages/@overeng/notion-react/docs/vrs/requirements.md
+++ b/packages/@overeng/notion-react/docs/vrs/requirements.md
@@ -118,6 +118,16 @@ host-config, or cache are implemented (see [spec.md](./spec.md) for that).
   comparison that flaps on server-owned noise. Like T11, an observation
   has no snapshot isolation: equality is advisory for the observed
   window.
+- **T13 Adoption trusts the candidate where readback masks:** Fail-closed
+  adoption verifies content through the readback oracle, so readback's
+  masked dimensions (T12) are presence-verified, not content-verified,
+  during adoption: uploaded bytes, built-in icon identity, and unclaimed
+  provider-owned defaults are recorded from the candidate's claims. Raw
+  escape-hatch content is not verifiable at all and refuses. Accepted
+  because the alternative is either a best-effort comparison that flaps
+  (rejected by R40) or refusing every tree containing an upload. Like
+  T11/T12, an adoption has no snapshot isolation — it is advisory for
+  the observed window, and the next `sync()` recomputes from scratch.
 
 ## Requirements
 
@@ -324,6 +334,41 @@ host-config, or cache are implemented (see [spec.md](./spec.md) for that).
   title/icon/cover) remain fully managed; `plan()` reports the same
   violations without failing; #1100 pending-adoption (read + cache-save)
   remains legal under the mode.
+
+### Must adopt existing rendered pages fail-closed
+
+- **R42 Zero-mutation adoption or typed refusal:** A public API must
+  accept a JSX candidate plus a live page id and either return the exact
+  `CacheTree` a prior `sync()` of the same element would have persisted
+  (so the next sync diffs incrementally and `plan()` is immediately
+  empty, root-metadata hashes included) or fail with a typed error
+  collecting EVERY divergence found in the pass — count, type, content,
+  page-metadata (field-level), unverifiable content, trashed root — not
+  just the first. Adoption must perform zero Notion mutations in every
+  outcome, refusal paths included, and must handle nested blocks and
+  `child_page` page boundaries, not only flat top-level blocks. The
+  documented cold-cache default stays unchanged when no adoption is
+  requested.
+- **R43 Positional binding is canonical, never inferred:** `blockKey` is
+  not stored in Notion, so keys and hashes must flow exclusively from
+  the candidate side; candidate child _i_ binds to live child _i_ under
+  every parent (in-trash blocks excluded). Identical siblings bind
+  deterministically — index order is the unique binding up to
+  observational equivalence, not a guess. Reordered DISTINCT siblings
+  must refuse at both positions; adoption must never re-match by content
+  search. Content verification goes through the readback oracle
+  (R39/R40) — never a forked normalizer — and descends whenever either
+  side expects children, so untracked nested live content surfaces as a
+  refusal.
+- **R44 Drift recovery composes with ordinary sync:** An explicit
+  opt-in (`onContentDrift: 'adopt-live'`) must keep every structural
+  check fail-closed while adopting content-drifted nodes with a recorded
+  live marker at exactly those nodes, such that the next ordinary
+  `sync()` emits exactly the minimal repairing updates and strict
+  re-adoption then reaches the zero-op fixpoint. A recorded block marker
+  must never be confusable with a cache-space hash (R39): it must be
+  deterministic and guaranteed unequal to the candidate's request-shape
+  hash, without pretending to be one.
 
 ### Must project authored JSX to readable Markdown (experimental)
 

--- a/packages/@overeng/notion-react/docs/vrs/spec.md
+++ b/packages/@overeng/notion-react/docs/vrs/spec.md
@@ -653,6 +653,68 @@ so crash recovery stays legal: a checkpointed page that _moved_ in the
 retry JSX is adopted first (harmless) and its implied `movePage` then
 rejected by the predicate.
 
+## Fail-closed adoption (R42–R44)
+
+`adopt(element, { pageId, onContentDrift? })` (`adopt.ts`) rebuilds the
+cache a stateless consumer lost, from live observation alone:
+
+```
+buildCandidateTree ──► keys + hashes (candidate side ONLY — blockKey is
+                       never stored in Notion, so there is no recovery
+                       problem to solve)
+observeBlockTree   ──► live children per parent, in-trash excluded
+positional walk    ──► candidate i ↔ live i, per parent, collecting
+                       refusals; recursion crosses child_page boundaries
+                       (fresh observation per page) and descends whenever
+                       EITHER side expects children
+candidateToCache   ──► the clean-path snapshot + root metadata hashes
+```
+
+Verification per bound pair, in order:
+
+1. **type** — live block type must equal the candidate's;
+2. **content** — through `compareReadback`, one node at a time with
+   children stripped on both sides, so a drifted descendant pins the
+   descendant, not its ancestors. Reusing the readback oracle (rather
+   than hashing a hand-projected live payload) is what makes adoption
+   correct against the real API's response decoration; any
+   adopt-specific tolerance belongs in readback's masking table, never
+   in a forked normalizer. Nodes readback cannot normalize (`<Raw>`
+   payloads) refuse as `UnverifiableContent` — fail closed, never
+   trust;
+3. **page claims** — for `child_page` nodes and the root `<Page>`,
+   title/icon/cover claims verify per field via `compareReadbackPage`
+   against `pages.retrieve` (field-level `PageMetaDrift`), so the A07
+   icon rewrite and uploaded-cover envelopes are absorbed by the
+   shipped page masking; a trashed root refuses (`RootTrashed`). Root
+   metadata is only checked when the JSX carried root claims —
+   mirroring `sync()`'s own contract.
+
+All refusals collect into one `AdoptionRefusedError` (never first-fail),
+and every outcome — success or refusal — performs zero mutations.
+
+Recovery (R44): `'adopt-live'` records, at content-drifted block nodes
+only, `adopt-live:<observedReadbackHash>` in `CacheNode.hash`. The
+marker is deliberately NOT a cache-space hash (R39 forbids cross-space
+comparison; the response→request projection needed to compute the true
+live cache hash does not exist) — its contract is deterministic
+inequality with the candidate's hash, which makes the next `sync()`
+emit exactly one `update` per drifted node. Drifted page-metadata
+fields record the live claim's cache-space hash (computable via the
+shared `normalizeTitle`/`normalizeIcon`/`normalizeCover`), or drop the
+field when the live side is unset — either way the next sync emits one
+repairing `updatePage`. After the repair, strict re-adoption succeeds
+and `plan()` is empty.
+
+Relation to #1100: `adoptInlineChildren` (crash recovery for inline
+creates) is the positional prior art — same binding rule, but it trusts
+the persisted create-time hashes because the same process wrote them
+moments earlier. `adopt()` is its strict strengthening for trees the
+adopter did not write: every hash is re-derived candidate-side and
+every binding content-verified. The walkers stay separate because their
+inputs differ (`PendingInlineNode` intent vs full candidate tree) and
+the recovery path must not destabilize.
+
 ## Upload coordination
 
 See `src/renderer/upload-registry.ts`.

--- a/packages/@overeng/notion-react/src/renderer/adopt.ts
+++ b/packages/@overeng/notion-react/src/renderer/adopt.ts
@@ -1,0 +1,439 @@
+/**
+ * Fail-closed adoption of an existing rendered page (#1093).
+ *
+ * `adopt()` reconstructs the `CacheTree` a prior `sync()` of the same JSX
+ * would have persisted, from (candidate JSX, root pageId, live observation)
+ * alone — with zero Notion mutations (GET-only). It exists for stateless
+ * consumers whose renderer cache did not survive a redeploy: the documented
+ * cold-cache default (`coldBaseline: 'clean'`) archives and re-appends the
+ * whole page, while a successful adoption feeds the normal incremental diff
+ * and reaches the zero-op fixpoint immediately.
+ *
+ * ## Binding is strictly positional
+ *
+ * `blockKey` is intentionally not stored in Notion, so no key recovery
+ * problem exists: keys and hashes flow exclusively from the candidate side
+ * (`buildCandidateTree`), and candidate child *i* binds to live child *i*
+ * under every parent (in-trash blocks excluded). Identical siblings are
+ * observationally indistinguishable, which makes index-order assignment the
+ * unique binding up to observational equivalence — a canon, not a guess.
+ * Reordered *distinct* siblings refuse at both positions; adoption never
+ * re-matches by content search.
+ *
+ * ## Verification is fail-closed
+ *
+ * Every bound pair is verified before the mapping is trusted:
+ *
+ * - block content through the readback oracle (`compareReadback`), one node
+ *   at a time with children stripped — so a drifted child pins the child,
+ *   not its ancestors. Readback's canonicalization and candidate-contextual
+ *   masking (R39/R40) absorb the response-shape deltas of the real API;
+ *   adoption inherits readback's masked dimensions (T12): uploaded bytes and
+ *   provider-owned defaults are presence-verified, not content-verified.
+ * - `child_page` / root `<Page>` metadata claims (title/icon/cover) through
+ *   `compareReadbackPage` per field against `pages.retrieve`, giving
+ *   field-level `PageMetaDrift` refusals; a trashed root refuses outright.
+ * - recursion crosses page boundaries and descends whenever EITHER side
+ *   expects children, so untracked nested live content surfaces as a
+ *   `ChildCountMismatch` instead of being silently ignored.
+ *
+ * All refusals are collected (not first-fail) and returned in one typed
+ * `AdoptionRefusedError`; refusal paths perform zero mutations too.
+ *
+ * ## Recovery: `onContentDrift: 'adopt-live'`
+ *
+ * The default refuses on any content drift. `'adopt-live'` keeps every
+ * STRUCTURAL check fail-closed (count/type/shape) but adopts drifted nodes
+ * with a recorded live marker instead of the candidate hash:
+ *
+ * - block nodes record `adopt-live:<observedReadbackHash>` in
+ *   `CacheNode.hash`. The marker is deliberately not a cache-space hash
+ *   (readback hashes and cache hashes are separate spaces, R39) — its only
+ *   contract is to be deterministic and never equal the candidate's
+ *   request-shape hash, so the next ordinary `sync()` emits exactly one
+ *   `update` per drifted node and repairs the live content;
+ * - page-metadata fields record the live claim's cache-space hash (computed
+ *   through the same `normalizeTitle`/`normalizeIcon`/`normalizeCover` the
+ *   sync diff uses), or drop the field when the live side is unset — either
+ *   way the next `sync()` emits one `updatePage` for the drifted fields.
+ *
+ * After that repair sync, strict re-adoption succeeds and `plan()` is empty.
+ */
+import type { HttpClient } from '@effect/platform'
+import { Data, Effect } from 'effect'
+import type { ReactNode } from 'react'
+
+import { NotionPages, type NotionConfig } from '@overeng/notion-effect-client'
+
+import { CACHE_SCHEMA_VERSION, type CacheNode, type CacheTree } from '../cache/types.ts'
+import { NotionSyncError } from './errors.ts'
+import { normalizeCover, normalizeIcon, normalizeTitle } from './icons.ts'
+import { observeBlockTree } from './readback-observe.ts'
+import {
+  compareReadback,
+  compareReadbackPage,
+  type ObservedBlockTree,
+  type ReadbackPageCandidate,
+} from './readback.ts'
+import {
+  buildCandidateTree,
+  candidateToCache,
+  hashStable,
+  type CandidateNode,
+  type CandidateRootPage,
+} from './sync-diff.ts'
+
+type Json = Record<string, unknown>
+
+/**
+ * One reason adoption refused to bind the candidate to the live page. All
+ * refusals found in a single pass are collected into
+ * {@link AdoptionRefusedError} — adoption never stops at the first one.
+ *
+ * Hash spaces: `ContentDrift` pins READBACK-space hashes (both sides
+ * normalized through the readback oracle — never compare them against
+ * `CacheNode.hash`). `PageMetaDrift` pins CACHE-space claim hashes (the
+ * same per-field hashes `sync()` diffs on).
+ */
+export type AdoptionRefusal =
+  | {
+      readonly _tag: 'ChildCountMismatch'
+      readonly parentId: string
+      readonly expected: number
+      readonly actual: number
+      /** Live block ids beyond the candidate's children (untracked content). */
+      readonly untrackedLiveIds: readonly string[]
+      /** Candidate keys with no live block at their position (missing content). */
+      readonly missingCandidateKeys: readonly string[]
+    }
+  | {
+      readonly _tag: 'TypeMismatch'
+      readonly parentId: string
+      readonly position: number
+      readonly key: string
+      readonly expectedType: string
+      readonly actualType: string
+      readonly blockId: string
+    }
+  | {
+      readonly _tag: 'ContentDrift'
+      readonly parentId: string
+      readonly position: number
+      readonly key: string
+      readonly blockId: string
+      /** Readback-space hash of the candidate node (children excluded). */
+      readonly candidateHash: string
+      /** Readback-space hash of the observed live block (children excluded). */
+      readonly observedHash: string
+    }
+  | {
+      /**
+       * The readback oracle cannot normalize this node — raw escape-hatch
+       * payloads (`<Raw>`, `template`, `synced_block`, ...) have no generic
+       * response-shape normalization, so their live content is unverifiable
+       * and adoption fails closed rather than trusting it.
+       */
+      readonly _tag: 'UnverifiableContent'
+      readonly parentId: string
+      readonly position: number
+      readonly key: string
+      readonly blockId: string
+      readonly reason: string
+    }
+  | {
+      readonly _tag: 'PageMetaDrift'
+      readonly pageId: string
+      readonly key: string
+      readonly field: 'title' | 'icon' | 'cover'
+      /** Cache-space hash of the candidate's claim for this field. */
+      readonly expectedHash: string
+      /** Cache-space hash of the live value, or `undefined` when unset live. */
+      readonly actualHash: string | undefined
+    }
+  | { readonly _tag: 'RootTrashed'; readonly pageId: string }
+
+/** Typed failure carrying every refusal found in one adoption pass. */
+export class AdoptionRefusedError extends Data.TaggedError('AdoptionRefusedError')<{
+  readonly refusals: readonly AdoptionRefusal[]
+}> {}
+
+/**
+ * What to do when a bound block or page-metadata field verifies structurally
+ * but its content drifted from the candidate. `'refuse'` (default) fails the
+ * adoption; `'adopt-live'` records a live marker at exactly the drifted nodes
+ * so the next ordinary `sync()` repairs them — see the module docs.
+ */
+export type ContentDriftPolicy = 'refuse' | 'adopt-live'
+
+/**
+ * Tri-state page-metadata override produced by verification under
+ * `'adopt-live'`: `string` = record this live cache-space hash instead of
+ * the candidate's; `null` = record NO hash (live side unset) so the next
+ * sync repairs by setting the field; key absent = claim verified, keep the
+ * candidate hash.
+ */
+type PageMetaOverride = Partial<Record<'titleHash' | 'iconHash' | 'coverHash', string | null>>
+
+/** Page-metadata claims common to `CandidateRootPage` and page-kind nodes. */
+type PageMetaCandidate = Pick<
+  CandidateRootPage,
+  'title' | 'icon' | 'cover' | 'titleHash' | 'iconHash' | 'coverHash'
+>
+
+const retrievePage = (pageId: string) =>
+  NotionPages.retrieve({ pageId }).pipe(
+    Effect.mapError((cause) => new NotionSyncError({ reason: 'notion-retrieve-failed', cause })),
+  )
+
+/**
+ * Adopt an existing rendered page: bind the candidate's keys and hashes to
+ * the live block/page ids and return the `CacheTree` a prior `sync()` of the
+ * same element would have persisted — or fail with every refusal found.
+ * Performs zero Notion mutations in all outcomes (GET-only).
+ *
+ * The returned tree is not persisted; save it through your `NotionCache`
+ * (or pass it to `InMemoryCache.make(tree)`) and the next `sync()` diffs
+ * incrementally against it.
+ */
+export const adopt = (
+  element: ReactNode,
+  opts: {
+    readonly pageId: string
+    /** See {@link ContentDriftPolicy}. Defaults to `'refuse'`. */
+    readonly onContentDrift?: ContentDriftPolicy
+  },
+): Effect.Effect<
+  CacheTree,
+  AdoptionRefusedError | NotionSyncError,
+  NotionConfig | HttpClient.HttpClient
+> =>
+  Effect.gen(function* () {
+    const policy: ContentDriftPolicy = opts.onContentDrift ?? 'refuse'
+    const candidate = buildCandidateTree(element, opts.pageId)
+    const refusals: AdoptionRefusal[] = []
+    const hashOverrides = new Map<CandidateNode, string>()
+    const pageMetaOverrides = new Map<CandidateNode, PageMetaOverride>()
+
+    /**
+     * Verify one page's title/icon/cover claims against its `pages.retrieve`
+     * response. Equality per field goes through `compareReadbackPage` so the
+     * response-shape deltas the real API introduces (decorated title spans,
+     * the A07 built-in-icon rewrite, uploaded-cover signed URLs) are absorbed
+     * by the shipped masking instead of a hand-rolled comparison.
+     */
+    const verifyPageMeta = (
+      cand: PageMetaCandidate,
+      livePage: Json,
+      pageId: string,
+      key: string,
+    ): PageMetaOverride => {
+      const out: PageMetaOverride = {}
+      const liveTitle = (livePage.properties as Json | undefined)?.title as
+        | { title?: unknown }
+        | undefined
+      const liveOf = {
+        title: liveTitle?.title,
+        icon: livePage.icon,
+        cover: livePage.cover,
+      } as const
+      const liveCacheHash = {
+        title: (): string | undefined =>
+          liveOf.title == null ? undefined : hashStable(normalizeTitle(liveOf.title)),
+        icon: (): string | undefined =>
+          liveOf.icon == null ? undefined : hashStable(normalizeIcon(liveOf.icon)),
+        cover: (): string | undefined =>
+          liveOf.cover == null ? undefined : hashStable(normalizeCover(liveOf.cover)),
+      } as const
+      const check = (
+        field: 'title' | 'icon' | 'cover',
+        candHash: string | undefined,
+        claim: ReadbackPageCandidate,
+      ): void => {
+        if (candHash === undefined) return
+        const cmp = compareReadbackPage({ candidate: claim, observed: livePage })
+        if (cmp.equal) return
+        if (policy === 'adopt-live') out[`${field}Hash`] = liveCacheHash[field]() ?? null
+        else {
+          refusals.push({
+            _tag: 'PageMetaDrift',
+            pageId,
+            key,
+            field,
+            expectedHash: candHash,
+            actualHash: liveCacheHash[field](),
+          })
+        }
+      }
+      check('title', cand.titleHash, { title: cand.title })
+      check('icon', cand.iconHash, { icon: cand.icon })
+      check('cover', cand.coverHash, { cover: cand.cover })
+      return out
+    }
+
+    /**
+     * Bind and verify one parent's candidate children against the observed
+     * live children, positionally. `observed` comes from `observeBlockTree`,
+     * so in-trash blocks are already excluded and nested children are only
+     * populated where the live side has them.
+     */
+    const walkChildren = (
+      parentId: string,
+      cands: readonly CandidateNode[],
+      observed: readonly ObservedBlockTree[],
+    ): Effect.Effect<void, NotionSyncError, NotionConfig | HttpClient.HttpClient> =>
+      Effect.gen(function* () {
+        if (observed.length !== cands.length) {
+          refusals.push({
+            _tag: 'ChildCountMismatch',
+            parentId,
+            expected: cands.length,
+            actual: observed.length,
+            untrackedLiveIds: observed.slice(cands.length).map((o) => o.block.id as string),
+            missingCandidateKeys: cands.slice(observed.length).map((c) => c.key),
+          })
+        }
+        const n = Math.min(observed.length, cands.length)
+        for (let i = 0; i < n; i++) {
+          const cand = cands[i]!
+          const obs = observed[i]!
+          const blockId = obs.block.id as string
+          const liveType = obs.block.type as string
+          if (liveType !== cand.type) {
+            refusals.push({
+              _tag: 'TypeMismatch',
+              parentId,
+              position: i,
+              key: cand.key,
+              expectedType: cand.type,
+              actualType: liveType,
+              blockId,
+            })
+            continue
+          }
+          cand.blockId = blockId
+          if (cand.nodeKind === 'page') {
+            const page = (yield* retrievePage(blockId)) as unknown as Json
+            const override = verifyPageMeta(cand, page, blockId, cand.key)
+            if (Object.keys(override).length > 0) pageMetaOverrides.set(cand, override)
+            // Page boundary: the sub-page's blocks are their own observation
+            // scope (observeBlockTree stops at child_page).
+            const subObserved = yield* observeBlockTree({ blockId })
+            yield* walkChildren(blockId, cand.children, subObserved)
+            continue
+          }
+          // Content gate: one node at a time with children stripped on both
+          // sides, so a drifted descendant pins the descendant (below), not
+          // this node. compareReadback carries the masking context (R40).
+          try {
+            const cmp = compareReadback({
+              candidate: { rootId: parentId, children: [{ ...cand, children: [] }] },
+              observed: [{ block: obs.block, children: [] }],
+            })
+            if (!cmp.equal) {
+              if (policy === 'adopt-live') {
+                hashOverrides.set(cand, `adopt-live:${cmp.observedHash}`)
+              } else {
+                refusals.push({
+                  _tag: 'ContentDrift',
+                  parentId,
+                  position: i,
+                  key: cand.key,
+                  blockId,
+                  candidateHash: cmp.candidateHash,
+                  observedHash: cmp.observedHash,
+                })
+              }
+            }
+          } catch (cause) {
+            refusals.push({
+              _tag: 'UnverifiableContent',
+              parentId,
+              position: i,
+              key: cand.key,
+              blockId,
+              reason: cause instanceof Error ? cause.message : String(cause),
+            })
+          }
+          // Recurse when EITHER side expects nested blocks — an expected-empty
+          // candidate against a live parent with children must surface the
+          // untracked nested content as a ChildCountMismatch (and vice versa).
+          if (cand.children.length > 0 || obs.children.length > 0) {
+            yield* walkChildren(blockId, cand.children, obs.children)
+          }
+        }
+      })
+
+    const rootObserved = yield* observeBlockTree({ blockId: opts.pageId })
+    yield* walkChildren(opts.pageId, candidate.children, rootObserved)
+
+    // Root-page metadata: only observable when the JSX carried a <Page>
+    // wrapper with actual claims — otherwise root metadata is out of scope,
+    // mirroring sync()'s own contract.
+    let rootMeta: Pick<CacheTree, 'rootTitleHash' | 'rootIconHash' | 'rootCoverHash'> = {}
+    const rootPage = candidate.rootPage
+    if (
+      rootPage !== undefined &&
+      (rootPage.titleHash !== undefined ||
+        rootPage.iconHash !== undefined ||
+        rootPage.coverHash !== undefined)
+    ) {
+      const livePage = (yield* retrievePage(opts.pageId)) as unknown as Json
+      if (livePage.in_trash === true) {
+        refusals.push({ _tag: 'RootTrashed', pageId: opts.pageId })
+      } else {
+        const override = verifyPageMeta(rootPage, livePage, opts.pageId, '<root>')
+        const pick = (
+          candHash: string | undefined,
+          o: string | null | undefined,
+        ): string | undefined => {
+          if (o === null) return undefined
+          if (o !== undefined) return o
+          return candHash
+        }
+        const rootTitleHash = pick(rootPage.titleHash, override.titleHash)
+        const rootIconHash = pick(rootPage.iconHash, override.iconHash)
+        const rootCoverHash = pick(rootPage.coverHash, override.coverHash)
+        rootMeta = {
+          ...(rootTitleHash !== undefined ? { rootTitleHash } : {}),
+          ...(rootIconHash !== undefined ? { rootIconHash } : {}),
+          ...(rootCoverHash !== undefined ? { rootCoverHash } : {}),
+        }
+      }
+    }
+
+    if (refusals.length > 0) {
+      return yield* new AdoptionRefusedError({ refusals })
+    }
+
+    // Every position is bound — the public primitive turns the candidate into
+    // a cache snapshot; then patch in the adopt-live overrides in lockstep.
+    const base = candidateToCache(candidate, CACHE_SCHEMA_VERSION)
+    const patch = (
+      candNodes: readonly CandidateNode[],
+      cacheNodes: readonly CacheNode[],
+    ): readonly CacheNode[] =>
+      cacheNodes.map((node, i) => {
+        const cand = candNodes[i]!
+        const meta = pageMetaOverrides.get(cand)
+        const withChildren: CacheNode = {
+          ...node,
+          hash: hashOverrides.get(cand) ?? node.hash,
+          children: patch(cand.children, node.children),
+        }
+        if (meta === undefined) return withChildren
+        const applied: Json = { ...withChildren }
+        for (const field of ['titleHash', 'iconHash', 'coverHash'] as const) {
+          const value = meta[field]
+          if (value === undefined) continue
+          if (value === null) delete applied[field]
+          else applied[field] = value
+        }
+        return applied as unknown as CacheNode
+      })
+
+    return {
+      ...base,
+      children: patch(candidate.children, base.children),
+      ...rootMeta,
+    }
+  })

--- a/packages/@overeng/notion-react/src/renderer/adopt.ts
+++ b/packages/@overeng/notion-react/src/renderer/adopt.ts
@@ -180,6 +180,21 @@ type PageMetaCandidate = Pick<
   'title' | 'icon' | 'cover' | 'titleHash' | 'iconHash' | 'coverHash'
 >
 
+/**
+ * Resolve one root-metadata hash from the candidate claim plus its
+ * `'adopt-live'` override: `null` = live side unset (record no hash),
+ * `string` = record the live hash, `undefined` = claim verified (keep the
+ * candidate's).
+ */
+const pickRootHash = (
+  candHash: string | undefined,
+  override: string | null | undefined,
+): string | undefined => {
+  if (override === null) return undefined
+  if (override !== undefined) return override
+  return candHash
+}
+
 const retrievePage = (pageId: string) =>
   NotionPages.retrieve({ pageId }).pipe(
     Effect.mapError((cause) => new NotionSyncError({ reason: 'notion-retrieve-failed', cause })),
@@ -382,17 +397,9 @@ export const adopt = (
         refusals.push({ _tag: 'RootTrashed', pageId: opts.pageId })
       } else {
         const override = verifyPageMeta(rootPage, livePage, opts.pageId, '<root>')
-        const pick = (
-          candHash: string | undefined,
-          o: string | null | undefined,
-        ): string | undefined => {
-          if (o === null) return undefined
-          if (o !== undefined) return o
-          return candHash
-        }
-        const rootTitleHash = pick(rootPage.titleHash, override.titleHash)
-        const rootIconHash = pick(rootPage.iconHash, override.iconHash)
-        const rootCoverHash = pick(rootPage.coverHash, override.coverHash)
+        const rootTitleHash = pickRootHash(rootPage.titleHash, override.titleHash)
+        const rootIconHash = pickRootHash(rootPage.iconHash, override.iconHash)
+        const rootCoverHash = pickRootHash(rootPage.coverHash, override.coverHash)
         rootMeta = {
           ...(rootTitleHash !== undefined ? { rootTitleHash } : {}),
           ...(rootIconHash !== undefined ? { rootIconHash } : {}),

--- a/packages/@overeng/notion-react/src/renderer/adopt.ts
+++ b/packages/@overeng/notion-react/src/renderer/adopt.ts
@@ -60,7 +60,7 @@
  * After that repair sync, strict re-adoption succeeds and `plan()` is empty.
  */
 import type { HttpClient } from '@effect/platform'
-import { Data, Effect } from 'effect'
+import { Data, Effect, Either } from 'effect'
 import type { ReactNode } from 'react'
 
 import { NotionPages, type NotionConfig } from '@overeng/notion-effect-client'
@@ -155,6 +155,11 @@ export type AdoptionRefusal =
 /** Typed failure carrying every refusal found in one adoption pass. */
 export class AdoptionRefusedError extends Data.TaggedError('AdoptionRefusedError')<{
   readonly refusals: readonly AdoptionRefusal[]
+}> {}
+
+/** Thrown by `compareReadback` when the oracle cannot verify a node. */
+class ReadbackUnverifiableError extends Data.TaggedError('ReadbackUnverifiableError')<{
+  readonly cause: unknown
 }> {}
 
 /**
@@ -339,27 +344,18 @@ export const adopt = (
           // Content gate: one node at a time with children stripped on both
           // sides, so a drifted descendant pins the descendant (below), not
           // this node. compareReadback carries the masking context (R40).
-          try {
-            const cmp = compareReadback({
-              candidate: { rootId: parentId, children: [{ ...cand, children: [] }] },
-              observed: [{ block: obs.block, children: [] }],
-            })
-            if (!cmp.equal) {
-              if (policy === 'adopt-live') {
-                hashOverrides.set(cand, `adopt-live:${cmp.observedHash}`)
-              } else {
-                refusals.push({
-                  _tag: 'ContentDrift',
-                  parentId,
-                  position: i,
-                  key: cand.key,
-                  blockId,
-                  candidateHash: cmp.candidateHash,
-                  observedHash: cmp.observedHash,
-                })
-              }
-            }
-          } catch (cause) {
+          const verified = yield* Effect.either(
+            Effect.try({
+              try: () =>
+                compareReadback({
+                  candidate: { rootId: parentId, children: [{ ...cand, children: [] }] },
+                  observed: [{ block: obs.block, children: [] }],
+                }),
+              catch: (cause) => new ReadbackUnverifiableError({ cause }),
+            }),
+          )
+          if (Either.isLeft(verified)) {
+            const { cause } = verified.left
             refusals.push({
               _tag: 'UnverifiableContent',
               parentId,
@@ -368,6 +364,21 @@ export const adopt = (
               blockId,
               reason: cause instanceof Error ? cause.message : String(cause),
             })
+          } else if (!verified.right.equal) {
+            const cmp = verified.right
+            if (policy === 'adopt-live') {
+              hashOverrides.set(cand, `adopt-live:${cmp.observedHash}`)
+            } else {
+              refusals.push({
+                _tag: 'ContentDrift',
+                parentId,
+                position: i,
+                key: cand.key,
+                blockId,
+                candidateHash: cmp.candidateHash,
+                observedHash: cmp.observedHash,
+              })
+            }
           }
           // Recurse when EITHER side expects nested blocks — an expected-empty
           // candidate against a live parent with children must surface the

--- a/packages/@overeng/notion-react/src/renderer/adopt.ts
+++ b/packages/@overeng/notion-react/src/renderer/adopt.ts
@@ -222,11 +222,7 @@ export const adopt = (
     /** See {@link ContentDriftPolicy}. Defaults to `'refuse'`. */
     readonly onContentDrift?: ContentDriftPolicy
   },
-): Effect.Effect<
-  CacheTree,
-  AdoptionRefusedError | NotionSyncError,
-  NotionConfig | HttpClient
-> =>
+): Effect.Effect<CacheTree, AdoptionRefusedError | NotionSyncError, NotionConfig | HttpClient> =>
   Effect.gen(function* () {
     const policy: ContentDriftPolicy = opts.onContentDrift ?? 'refuse'
     const candidate = buildCandidateTree(element, opts.pageId)

--- a/packages/@overeng/notion-react/src/renderer/adopt.ts
+++ b/packages/@overeng/notion-react/src/renderer/adopt.ts
@@ -59,8 +59,8 @@
  *
  * After that repair sync, strict re-adoption succeeds and `plan()` is empty.
  */
-import type { HttpClient } from '@effect/platform'
-import { Data, Effect, Either } from 'effect'
+import { Data, Effect } from 'effect'
+import type { HttpClient } from 'effect/unstable/http/HttpClient'
 import type { ReactNode } from 'react'
 
 import { NotionPages, type NotionConfig } from '@overeng/notion-effect-client'
@@ -225,7 +225,7 @@ export const adopt = (
 ): Effect.Effect<
   CacheTree,
   AdoptionRefusedError | NotionSyncError,
-  NotionConfig | HttpClient.HttpClient
+  NotionConfig | HttpClient
 > =>
   Effect.gen(function* () {
     const policy: ContentDriftPolicy = opts.onContentDrift ?? 'refuse'
@@ -300,7 +300,7 @@ export const adopt = (
       parentId: string,
       cands: readonly CandidateNode[],
       observed: readonly ObservedBlockTree[],
-    ): Effect.Effect<void, NotionSyncError, NotionConfig | HttpClient.HttpClient> =>
+    ): Effect.Effect<void, NotionSyncError, NotionConfig | HttpClient> =>
       Effect.gen(function* () {
         if (observed.length !== cands.length) {
           refusals.push({
@@ -344,7 +344,7 @@ export const adopt = (
           // Content gate: one node at a time with children stripped on both
           // sides, so a drifted descendant pins the descendant (below), not
           // this node. compareReadback carries the masking context (R40).
-          const verified = yield* Effect.either(
+          const verified = yield* Effect.result(
             Effect.try({
               try: () =>
                 compareReadback({
@@ -354,8 +354,8 @@ export const adopt = (
               catch: (cause) => new ReadbackUnverifiableError({ cause }),
             }),
           )
-          if (Either.isLeft(verified)) {
-            const { cause } = verified.left
+          if (verified._tag === 'Failure') {
+            const cause: unknown = verified.failure
             refusals.push({
               _tag: 'UnverifiableContent',
               parentId,
@@ -364,8 +364,8 @@ export const adopt = (
               blockId,
               reason: cause instanceof Error ? cause.message : String(cause),
             })
-          } else if (!verified.right.equal) {
-            const cmp = verified.right
+          } else if (!verified.success.equal) {
+            const cmp = verified.success
             if (policy === 'adopt-live') {
               hashOverrides.set(cand, `adopt-live:${cmp.observedHash}`)
             } else {

--- a/packages/@overeng/notion-react/src/renderer/adopt.ts
+++ b/packages/@overeng/notion-react/src/renderer/adopt.ts
@@ -389,6 +389,17 @@ export const adopt = (
         }
       })
 
+    // Retrieve the root page BEFORE walking its blocks: per A09,
+    // `blocks.children.list` 404s for archived pages, so observing first
+    // would exit with NotionSyncError('notion-retrieve-failed') and the
+    // typed RootTrashed refusal below could never fire. A trashed root
+    // fails closed immediately.
+    const liveRootPage = (yield* retrievePage(opts.pageId)) as unknown as Json
+    if (liveRootPage.in_trash === true) {
+      return yield* new AdoptionRefusedError({
+        refusals: [{ _tag: 'RootTrashed', pageId: opts.pageId }],
+      })
+    }
     const rootObserved = yield* observeBlockTree({ blockId: opts.pageId })
     yield* walkChildren(opts.pageId, candidate.children, rootObserved)
 
@@ -403,19 +414,14 @@ export const adopt = (
         rootPage.iconHash !== undefined ||
         rootPage.coverHash !== undefined)
     ) {
-      const livePage = (yield* retrievePage(opts.pageId)) as unknown as Json
-      if (livePage.in_trash === true) {
-        refusals.push({ _tag: 'RootTrashed', pageId: opts.pageId })
-      } else {
-        const override = verifyPageMeta(rootPage, livePage, opts.pageId, '<root>')
-        const rootTitleHash = pickRootHash(rootPage.titleHash, override.titleHash)
-        const rootIconHash = pickRootHash(rootPage.iconHash, override.iconHash)
-        const rootCoverHash = pickRootHash(rootPage.coverHash, override.coverHash)
-        rootMeta = {
-          ...(rootTitleHash !== undefined ? { rootTitleHash } : {}),
-          ...(rootIconHash !== undefined ? { rootIconHash } : {}),
-          ...(rootCoverHash !== undefined ? { rootCoverHash } : {}),
-        }
+      const override = verifyPageMeta(rootPage, liveRootPage, opts.pageId, '<root>')
+      const rootTitleHash = pickRootHash(rootPage.titleHash, override.titleHash)
+      const rootIconHash = pickRootHash(rootPage.iconHash, override.iconHash)
+      const rootCoverHash = pickRootHash(rootPage.coverHash, override.coverHash)
+      rootMeta = {
+        ...(rootTitleHash !== undefined ? { rootTitleHash } : {}),
+        ...(rootIconHash !== undefined ? { rootIconHash } : {}),
+        ...(rootCoverHash !== undefined ? { rootCoverHash } : {}),
       }
     }
 

--- a/packages/@overeng/notion-react/src/renderer/adopt.unit.test.tsx
+++ b/packages/@overeng/notion-react/src/renderer/adopt.unit.test.tsx
@@ -434,14 +434,9 @@ describe('adopt(): fail-closed adoption of an existing rendered page (#1093)', (
     // AdoptionTree carries <Page title=...> claims — the pre-flight must
     // surface the typed refusal, not NotionSyncError from a 404 on
     // blocks.children.list against an archived page.
-    const err = await runWith(
-      fake,
-      adopt(<AdoptionTree />, { pageId: ROOT }).pipe(Effect.flip),
-    )
+    const err = await runWith(fake, adopt(<AdoptionTree />, { pageId: ROOT }).pipe(Effect.flip))
     expect(err).toBeInstanceOf(AdoptionRefusedError)
-    expect((err as AdoptionRefusedError).refusals).toEqual([
-      { _tag: 'RootTrashed', pageId: ROOT },
-    ])
+    expect((err as AdoptionRefusedError).refusals).toEqual([{ _tag: 'RootTrashed', pageId: ROOT }])
     expect(mutatingRequestsSince(fake, marker)).toEqual([])
   })
 })

--- a/packages/@overeng/notion-react/src/renderer/adopt.unit.test.tsx
+++ b/packages/@overeng/notion-react/src/renderer/adopt.unit.test.tsx
@@ -1,10 +1,10 @@
+import { Effect } from 'effect'
 /**
  * Fail-closed adoption (#1093). Every test — including every refusal path —
  * asserts zero mutating requests on the mock's request log: adoption is
  * GET-only by contract, in all outcomes.
  */
 import type { HttpClient } from 'effect/unstable/http/HttpClient'
-import { Effect } from 'effect'
 import type { ReactNode } from 'react'
 import { describe, expect, it } from 'vitest'
 

--- a/packages/@overeng/notion-react/src/renderer/adopt.unit.test.tsx
+++ b/packages/@overeng/notion-react/src/renderer/adopt.unit.test.tsx
@@ -1,0 +1,446 @@
+/**
+ * Fail-closed adoption (#1093). Every test — including every refusal path —
+ * asserts zero mutating requests on the mock's request log: adoption is
+ * GET-only by contract, in all outcomes.
+ */
+import type { HttpClient } from '@effect/platform'
+import { Effect } from 'effect'
+import type { ReactNode } from 'react'
+import { describe, expect, it } from 'vitest'
+
+import { NotionBlocks, NotionPages, type NotionConfig } from '@overeng/notion-effect-client'
+
+import { InMemoryCache } from '../cache/in-memory-cache.ts'
+import type { CacheTree } from '../cache/types.ts'
+import {
+  BulletedListItem,
+  ChildPage,
+  Code,
+  Heading2,
+  Page,
+  Paragraph,
+  Raw,
+  Toggle,
+} from '../components/blocks.ts'
+import { createFakeNotion, type FakeNotion } from '../test/mock-client.ts'
+import { adopt, AdoptionRefusedError, type AdoptionRefusal } from './adopt.ts'
+import { buildCandidateTree, diff } from './sync-diff.ts'
+import { plan, sync } from './sync.ts'
+
+const ROOT = '00000000-0000-4000-8000-000000000001'
+
+const runWith = <A, E>(
+  fake: FakeNotion,
+  eff: Effect.Effect<A, E, HttpClient.HttpClient | NotionConfig>,
+): Promise<A> => Effect.runPromise(eff.pipe(Effect.provide(fake.layer)))
+
+/**
+ * Nontrivial tree: root-page metadata, keyed and unkeyed blocks, nested
+ * blocks under a toggle, sibling list items, a child page with icon holding a
+ * nested child page, and an unkeyed tail paragraph.
+ */
+const AdoptionTree = ({ intro = 'intro text' }: { readonly intro?: string }): ReactNode => (
+  <Page title="Adoption Root">
+    <Heading2>Stats</Heading2>
+    <Paragraph blockKey="intro">{intro}</Paragraph>
+    <Toggle blockKey="t1" title="Details">
+      <Paragraph>nested body</Paragraph>
+      <Code language="typescript">{'const x = 1'}</Code>
+    </Toggle>
+    <BulletedListItem>alpha</BulletedListItem>
+    <BulletedListItem>beta</BulletedListItem>
+    <ChildPage blockKey="sub" title="Sub Page" icon={{ type: 'emoji', emoji: '📄' }}>
+      <Paragraph blockKey="p1">sub content</Paragraph>
+      <ChildPage blockKey="subsub" title="Deep Page">
+        <Paragraph>deep body</Paragraph>
+      </ChildPage>
+    </ChildPage>
+    <Paragraph>outro</Paragraph>
+  </Page>
+)
+
+/** Render live state via a normal cold sync, then discard the cache (loss simulation). */
+const renderAndDiscardCache = async (element: ReactNode): Promise<FakeNotion> => {
+  const fake = createFakeNotion()
+  await runWith(fake, sync(element, { pageId: ROOT, cache: InMemoryCache.make() }))
+  return fake
+}
+
+const mutatingRequestsSince = (fake: FakeNotion, marker: number) =>
+  fake.requests.slice(marker).filter((r) => r.method !== 'GET')
+
+const adoptRefusals = async (
+  fake: FakeNotion,
+  element: ReactNode,
+): Promise<readonly AdoptionRefusal[]> => {
+  const marker = fake.requests.length
+  const err = await runWith(fake, adopt(element, { pageId: ROOT }).pipe(Effect.flip))
+  // Fail-closed refusals must also be mutation-free.
+  expect(mutatingRequestsSince(fake, marker)).toEqual([])
+  expect(err).toBeInstanceOf(AdoptionRefusedError)
+  return (err as AdoptionRefusedError).refusals
+}
+
+describe('adopt(): fail-closed adoption of an existing rendered page (#1093)', () => {
+  it('clean adoption: reconstructed cache equals the organically saved cache, with zero mutations', async () => {
+    const fake = createFakeNotion()
+    const organic = InMemoryCache.make()
+    await runWith(fake, sync(<AdoptionTree />, { pageId: ROOT, cache: organic }))
+    const organicTree = await Effect.runPromise(organic.load)
+    expect(organicTree).toBeDefined()
+
+    const marker = fake.requests.length
+    const adopted = await runWith(fake, adopt(<AdoptionTree />, { pageId: ROOT }))
+    expect(mutatingRequestsSince(fake, marker)).toEqual([])
+    // The adopted cache is byte-equivalent to the cache sync itself persisted.
+    expect(adopted).toEqual(organicTree)
+  })
+
+  it('adoption fixpoint: plan() over the adopted cache is empty, and sync applies zero ops', async () => {
+    const fake = await renderAndDiscardCache(<AdoptionTree />)
+    const adopted = await runWith(fake, adopt(<AdoptionTree />, { pageId: ROOT }))
+
+    const marker = fake.requests.length
+    const p = await runWith(
+      fake,
+      plan(<AdoptionTree />, { pageId: ROOT, cache: InMemoryCache.make(adopted) }),
+    )
+    expect(p.empty).toBe(true)
+    expect(p.fallbackReason).toBeUndefined()
+
+    const res = await runWith(
+      fake,
+      sync(<AdoptionTree />, { pageId: ROOT, cache: InMemoryCache.make(adopted) }),
+    )
+    expect({
+      appends: res.appends,
+      inserts: res.inserts,
+      updates: res.updates,
+      removes: res.removes,
+    }).toEqual({ appends: 0, inserts: 0, updates: 0, removes: 0 })
+    expect(res.pages).toMatchObject({ creates: 0, updates: 0, archives: 0, moves: 0 })
+    expect(res.fallbackReason).toBeUndefined()
+    expect(mutatingRequestsSince(fake, marker)).toEqual([])
+  })
+
+  it('pure-diff proof: diff(adoptedCache, candidate) is empty', async () => {
+    const fake = await renderAndDiscardCache(<AdoptionTree />)
+    const adopted = await runWith(fake, adopt(<AdoptionTree />, { pageId: ROOT }))
+    const ops = diff(adopted, buildCandidateTree(<AdoptionTree />, ROOT))
+    expect(ops).toEqual([])
+  })
+
+  it('refuses (a): untracked extra live block → ChildCountMismatch, zero mutations', async () => {
+    const fake = await renderAndDiscardCache(<AdoptionTree />)
+    await runWith(
+      fake,
+      NotionBlocks.append({
+        blockId: ROOT,
+        children: [
+          {
+            object: 'block',
+            type: 'paragraph',
+            paragraph: { rich_text: [{ type: 'text', text: { content: 'intruder' } }] },
+          },
+        ],
+      }),
+    )
+    const refusals = await adoptRefusals(fake, <AdoptionTree />)
+    const count = refusals.find((r) => r._tag === 'ChildCountMismatch')
+    expect(count).toMatchObject({ parentId: ROOT, expected: 7, actual: 8 })
+    expect(count && count._tag === 'ChildCountMismatch' && count.untrackedLiveIds).toHaveLength(1)
+  })
+
+  it('refuses (a2): untracked NESTED live content under a leaf-expected block → ChildCountMismatch at that parent', async () => {
+    const fake = await renderAndDiscardCache(<AdoptionTree />)
+    // Out-of-band nested append under the tail paragraph (candidate expects a leaf).
+    const tail = fake.childrenOf(ROOT).at(-1)!
+    await runWith(
+      fake,
+      NotionBlocks.append({
+        blockId: tail.id,
+        children: [
+          {
+            object: 'block',
+            type: 'paragraph',
+            paragraph: { rich_text: [{ type: 'text', text: { content: 'stowaway' } }] },
+          },
+        ],
+      }),
+    )
+    const refusals = await adoptRefusals(fake, <AdoptionTree />)
+    expect(refusals).toHaveLength(1)
+    expect(refusals[0]).toMatchObject({
+      _tag: 'ChildCountMismatch',
+      parentId: tail.id,
+      expected: 0,
+      actual: 1,
+    })
+  })
+
+  it('refuses (b): live type mismatch at a position → TypeMismatch, no content-based rebinding', async () => {
+    const fake = await renderAndDiscardCache(<AdoptionTree />)
+    // Replace the tail paragraph ("outro") with a divider, preserving count.
+    const tail = fake.childrenOf(ROOT).at(-1)!
+    expect(tail.type).toBe('paragraph')
+    await runWith(fake, NotionBlocks.delete({ blockId: tail.id }))
+    await runWith(
+      fake,
+      NotionBlocks.append({
+        blockId: ROOT,
+        children: [{ object: 'block', type: 'divider', divider: {} }],
+      }),
+    )
+    const refusals = await adoptRefusals(fake, <AdoptionTree />)
+    expect(refusals).toHaveLength(1)
+    expect(refusals[0]).toMatchObject({
+      _tag: 'TypeMismatch',
+      parentId: ROOT,
+      position: 6,
+      expectedType: 'paragraph',
+      actualType: 'divider',
+    })
+  })
+
+  it('refuses (c): out-of-band content edit → ContentDrift pinning key, blockId, and both readback hashes', async () => {
+    const fake = await renderAndDiscardCache(<AdoptionTree />)
+    const intro = fake.childrenOf(ROOT)[1]!
+    fake.blocks.get(intro.id)!.payload = {
+      rich_text: [{ type: 'text', text: { content: 'tampered' } }],
+    }
+    const refusals = await adoptRefusals(fake, <AdoptionTree />)
+    expect(refusals).toHaveLength(1)
+    expect(refusals[0]).toMatchObject({
+      _tag: 'ContentDrift',
+      parentId: ROOT,
+      position: 1,
+      key: 'k:intro',
+      blockId: intro.id,
+    })
+    const drift = refusals[0]!
+    if (drift._tag === 'ContentDrift') {
+      expect(drift.candidateHash).not.toBe(drift.observedHash)
+    }
+  })
+
+  it('refuses (c2): NESTED content drift pins the nested block, not its ancestors', async () => {
+    const fake = await renderAndDiscardCache(<AdoptionTree />)
+    const toggle = fake.childrenOf(ROOT)[2]!
+    expect(toggle.type).toBe('toggle')
+    const nested = fake.childrenOf(toggle.id)[0]!
+    fake.blocks.get(nested.id)!.payload = {
+      rich_text: [{ type: 'text', text: { content: 'tampered nested' } }],
+    }
+    const refusals = await adoptRefusals(fake, <AdoptionTree />)
+    expect(refusals).toHaveLength(1)
+    expect(refusals[0]).toMatchObject({
+      _tag: 'ContentDrift',
+      parentId: toggle.id,
+      position: 0,
+      blockId: nested.id,
+    })
+  })
+
+  it('rule (d1): identical unkeyed siblings bind positionally — deterministic, not a guess', async () => {
+    const twins = (
+      <>
+        <Paragraph>same text</Paragraph>
+        <Paragraph>same text</Paragraph>
+      </>
+    )
+    const fake = await renderAndDiscardCache(twins)
+    const adopted = await runWith(fake, adopt(twins, { pageId: ROOT }))
+    const live = fake.childrenOf(ROOT)
+    // Position i in the candidate binds to position i live. Identical siblings
+    // are observationally indistinguishable, so the positional binding is the
+    // canonical one (any permutation is equivalent); keys stay positional too.
+    expect(adopted.children.map((c) => ({ key: c.key, blockId: c.blockId }))).toEqual([
+      { key: 'p:0', blockId: live[0]!.id },
+      { key: 'p:1', blockId: live[1]!.id },
+    ])
+  })
+
+  it('refuses (d2): live order swapped against candidate → refusal at both positions, no re-matching by content', async () => {
+    const pair = (
+      <>
+        <Paragraph>alpha body</Paragraph>
+        <Heading2>beta title</Heading2>
+      </>
+    )
+    const fake = await renderAndDiscardCache(pair)
+    // Out-of-band swap: delete the leading paragraph, re-append it at the
+    // tail → live order [heading_2, paragraph] vs candidate [paragraph, heading_2].
+    const first = fake.childrenOf(ROOT)[0]!
+    await runWith(fake, NotionBlocks.delete({ blockId: first.id }))
+    await runWith(
+      fake,
+      NotionBlocks.append({
+        blockId: ROOT,
+        children: [
+          {
+            object: 'block',
+            type: 'paragraph',
+            paragraph: { rich_text: [{ type: 'text', text: { content: 'alpha body' } }] },
+          },
+        ],
+      }),
+    )
+    const refusals = await adoptRefusals(fake, pair)
+    // A content-searching matcher would "find" both blocks; positional
+    // fail-closed adoption refuses instead.
+    expect(refusals.map((r) => r._tag)).toEqual(['TypeMismatch', 'TypeMismatch'])
+  })
+
+  it('refuses (e): live child page missing → ChildCountMismatch (and positional fallout), zero mutations', async () => {
+    const fake = await renderAndDiscardCache(<AdoptionTree />)
+    const subBlock = fake.childrenOf(ROOT).find((b) => b.type === 'child_page')!
+    await runWith(fake, NotionPages.archive({ pageId: subBlock.id }))
+    const refusals = await adoptRefusals(fake, <AdoptionTree />)
+    const count = refusals.find((r) => r._tag === 'ChildCountMismatch')
+    expect(count).toMatchObject({ parentId: ROOT, expected: 7, actual: 6 })
+  })
+
+  it('refuses: child-page title renamed out-of-band → PageMetaDrift(title)', async () => {
+    const fake = await renderAndDiscardCache(<AdoptionTree />)
+    const subBlock = fake.childrenOf(ROOT).find((b) => b.type === 'child_page')!
+    fake.pages.get(subBlock.id)!.properties = {
+      title: { title: [{ type: 'text', text: { content: 'Renamed Out Of Band' } }] },
+    }
+    const refusals = await adoptRefusals(fake, <AdoptionTree />)
+    expect(refusals).toHaveLength(1)
+    expect(refusals[0]).toMatchObject({
+      _tag: 'PageMetaDrift',
+      pageId: subBlock.id,
+      key: 'k:sub',
+      field: 'title',
+    })
+  })
+
+  it('refuses: <Raw> content is unverifiable through the readback oracle → UnverifiableContent', async () => {
+    const withRaw = (
+      <>
+        <Paragraph>lead</Paragraph>
+        <Raw type="breadcrumb" content={{}} />
+      </>
+    )
+    const fake = await renderAndDiscardCache(withRaw)
+    const refusals = await adoptRefusals(fake, withRaw)
+    expect(refusals).toHaveLength(1)
+    expect(refusals[0]).toMatchObject({ _tag: 'UnverifiableContent', parentId: ROOT, position: 1 })
+  })
+
+  it('recovery: adopt-live on content drift, then one sync repairs with exactly one update, then fail-closed adoption succeeds', async () => {
+    const fake = await renderAndDiscardCache(<AdoptionTree />)
+    const intro = fake.childrenOf(ROOT)[1]!
+    fake.blocks.get(intro.id)!.payload = {
+      rich_text: [{ type: 'text', text: { content: 'tampered' } }],
+    }
+
+    // Step 1: default adoption refuses (fail-closed baseline).
+    await adoptRefusals(fake, <AdoptionTree />)
+
+    // Step 2: explicit opt-in adopts STRUCTURE, records the live marker at
+    // the drifted node, still performs zero mutations.
+    const marker = fake.requests.length
+    const adopted = await runWith(
+      fake,
+      adopt(<AdoptionTree />, { pageId: ROOT, onContentDrift: 'adopt-live' }),
+    )
+    expect(mutatingRequestsSince(fake, marker)).toEqual([])
+
+    // Step 3: a normal sync against the adopted cache emits exactly the one
+    // update needed to repair the drifted paragraph — no removes, no appends.
+    const res = await runWith(
+      fake,
+      sync(<AdoptionTree />, { pageId: ROOT, cache: InMemoryCache.make(adopted) }),
+    )
+    expect({
+      appends: res.appends,
+      inserts: res.inserts,
+      updates: res.updates,
+      removes: res.removes,
+    }).toEqual({ appends: 0, inserts: 0, updates: 1, removes: 0 })
+    expect(JSON.stringify(fake.blocks.get(intro.id)!.payload)).toContain('intro text')
+
+    // Step 4: the repaired page now passes strict fail-closed adoption and
+    // reaches the zero-op fixpoint.
+    const readopted = await runWith(fake, adopt(<AdoptionTree />, { pageId: ROOT }))
+    const res2 = await runWith(
+      fake,
+      sync(<AdoptionTree />, { pageId: ROOT, cache: InMemoryCache.make(readopted) }),
+    )
+    expect({
+      appends: res2.appends,
+      inserts: res2.inserts,
+      updates: res2.updates,
+      removes: res2.removes,
+    }).toEqual({ appends: 0, inserts: 0, updates: 0, removes: 0 })
+  })
+
+  it('recovery: adopt-live on root-title drift, then one sync repairs with exactly one pages.update', async () => {
+    const fake = await renderAndDiscardCache(<AdoptionTree />)
+    fake.pages.get(ROOT)!.properties = {
+      title: { title: [{ type: 'text', text: { content: 'Renamed Root' } }] },
+    }
+
+    // Structural checks stay fail-closed; only the drifted root title records
+    // the live hash. Still zero mutations.
+    const marker = fake.requests.length
+    const adopted = await runWith(
+      fake,
+      adopt(<AdoptionTree />, { pageId: ROOT, onContentDrift: 'adopt-live' }),
+    )
+    expect(mutatingRequestsSince(fake, marker)).toEqual([])
+
+    const res = await runWith(
+      fake,
+      sync(<AdoptionTree />, { pageId: ROOT, cache: InMemoryCache.make(adopted) }),
+    )
+    expect({
+      appends: res.appends,
+      inserts: res.inserts,
+      updates: res.updates,
+      removes: res.removes,
+    }).toEqual({ appends: 0, inserts: 0, updates: 0, removes: 0 })
+    expect(res.pages).toMatchObject({ creates: 0, updates: 1, archives: 0, moves: 0 })
+    expect(JSON.stringify(fake.pages.get(ROOT)!.properties)).toContain('Adoption Root')
+
+    // Repaired root now passes strict re-adoption.
+    const readopted = await runWith(fake, adopt(<AdoptionTree />, { pageId: ROOT }))
+    const p = await runWith(
+      fake,
+      plan(<AdoptionTree />, { pageId: ROOT, cache: InMemoryCache.make(readopted) }),
+    )
+    expect(p.empty).toBe(true)
+  })
+
+  it('contrast: the documented cold path re-renders everything where adoption is a noop', async () => {
+    const fake = await renderAndDiscardCache(<AdoptionTree />)
+    // The issue's repro: same live page, fresh cache, default coldBaseline
+    // 'clean' → full remove + append churn.
+    const cold = await runWith(
+      fake,
+      sync(<AdoptionTree />, { pageId: ROOT, cache: InMemoryCache.make() }),
+    )
+    expect(cold.fallbackReason).toBe('cold-cache')
+    expect(cold.removes).toBeGreaterThan(0)
+    expect(cold.appends).toBeGreaterThan(0)
+  })
+})
+
+/** Adopted-cache shape sanity: nested pages carry nodeKind 'page' and verified meta hashes. */
+describe('adopt(): adopted cache shape', () => {
+  it('binds nested page identities recursively with verified title/icon hashes', async () => {
+    const fake = await renderAndDiscardCache(<AdoptionTree />)
+    const adopted: CacheTree = await runWith(fake, adopt(<AdoptionTree />, { pageId: ROOT }))
+    expect(adopted.rootTitleHash).toBeDefined()
+    const sub = adopted.children.find((c) => c.key === 'k:sub')!
+    expect(sub.nodeKind).toBe('page')
+    expect(sub.titleHash).toBeDefined()
+    expect(sub.iconHash).toBeDefined()
+    expect(fake.pages.has(sub.blockId)).toBe(true)
+    const subsub = sub.children.find((c) => c.key === 'k:subsub')!
+    expect(subsub.nodeKind).toBe('page')
+    expect(fake.pages.has(subsub.blockId)).toBe(true)
+  })
+})

--- a/packages/@overeng/notion-react/src/renderer/adopt.unit.test.tsx
+++ b/packages/@overeng/notion-react/src/renderer/adopt.unit.test.tsx
@@ -426,6 +426,24 @@ describe('adopt(): fail-closed adoption of an existing rendered page (#1093)', (
     expect(cold.removes).toBeGreaterThan(0)
     expect(cold.appends).toBeGreaterThan(0)
   })
+
+  it('refuses: archived root → typed RootTrashed, checked BEFORE the block walk (A09)', async () => {
+    const fake = await renderAndDiscardCache(<AdoptionTree />)
+    await runWith(fake, NotionPages.archive({ pageId: ROOT }))
+    const marker = fake.requests.length
+    // AdoptionTree carries <Page title=...> claims — the pre-flight must
+    // surface the typed refusal, not NotionSyncError from a 404 on
+    // blocks.children.list against an archived page.
+    const err = await runWith(
+      fake,
+      adopt(<AdoptionTree />, { pageId: ROOT }).pipe(Effect.flip),
+    )
+    expect(err).toBeInstanceOf(AdoptionRefusedError)
+    expect((err as AdoptionRefusedError).refusals).toEqual([
+      { _tag: 'RootTrashed', pageId: ROOT },
+    ])
+    expect(mutatingRequestsSince(fake, marker)).toEqual([])
+  })
 })
 
 /** Adopted-cache shape sanity: nested pages carry nodeKind 'page' and verified meta hashes. */

--- a/packages/@overeng/notion-react/src/renderer/adopt.unit.test.tsx
+++ b/packages/@overeng/notion-react/src/renderer/adopt.unit.test.tsx
@@ -3,7 +3,7 @@
  * asserts zero mutating requests on the mock's request log: adoption is
  * GET-only by contract, in all outcomes.
  */
-import type { HttpClient } from '@effect/platform'
+import type { HttpClient } from 'effect/unstable/http/HttpClient'
 import { Effect } from 'effect'
 import type { ReactNode } from 'react'
 import { describe, expect, it } from 'vitest'
@@ -31,7 +31,7 @@ const ROOT = '00000000-0000-4000-8000-000000000001'
 
 const runWith = <A, E>(
   fake: FakeNotion,
-  eff: Effect.Effect<A, E, HttpClient.HttpClient | NotionConfig>,
+  eff: Effect.Effect<A, E, HttpClient | NotionConfig>,
 ): Promise<A> => Effect.runPromise(eff.pipe(Effect.provide(fake.layer)))
 
 /**

--- a/packages/@overeng/notion-react/src/renderer/mod.ts
+++ b/packages/@overeng/notion-react/src/renderer/mod.ts
@@ -69,6 +69,12 @@ export {
 } from './readback.ts'
 export { observeBlockTree } from './readback-observe.ts'
 export {
+  adopt,
+  AdoptionRefusedError,
+  type AdoptionRefusal,
+  type ContentDriftPolicy,
+} from './adopt.ts'
+export {
   UploadRegistryProvider,
   useNotionUpload,
   type UploadRecord,

--- a/packages/@overeng/notion-react/src/test/integration/e2e/adopt.e2e.test.tsx
+++ b/packages/@overeng/notion-react/src/test/integration/e2e/adopt.e2e.test.tsx
@@ -1,0 +1,121 @@
+import { Effect } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import { NotionBlocks } from '@overeng/notion-effect-client'
+
+import { InMemoryCache } from '../../../cache/in-memory-cache.ts'
+import {
+  BulletedListItem,
+  Callout,
+  ChildPage,
+  Code,
+  Heading2,
+  Page,
+  Paragraph,
+  Toggle,
+} from '../../../components/blocks.ts'
+import { Bold, Link } from '../../../components/inline.ts'
+import { adopt, AdoptionRefusedError } from '../../../renderer/adopt.ts'
+import { plan, sync } from '../../../renderer/sync.ts'
+import { SKIP_E2E, withScratchPage } from './helpers.ts'
+
+/**
+ * Live-API coverage for `adopt()` (#1093). The mock stores request-shape
+ * payloads, so mock roundtrips cannot exercise the response-shape deltas the
+ * readback content gate absorbs (decorated rich text, explicit defaults,
+ * provider-injected callout icons/code language, decorated title spans) —
+ * only the real API produces those. This is the load-bearing case for
+ * adoption: a stateless redeploy must adopt a page the REAL API rendered.
+ */
+
+const DEFAULT_TIMEOUT = 60_000
+
+describe.skipIf(SKIP_E2E)('adopt() against the live API (e2e)', () => {
+  it(
+    'stateless adoption: sync → discard cache → adopt → plan is empty, zero mutations',
+    async () => {
+      const element = (pageId: string) => (
+        <Page title={`adopt probe ${pageId.slice(0, 8)}`} icon={{ type: 'emoji', emoji: '🧬' }}>
+          <Heading2>Section</Heading2>
+          <Paragraph blockKey="intro">
+            Hello <Bold>world</Bold> with <Link href="https://example.com/x">a link</Link>
+          </Paragraph>
+          <Toggle blockKey="t1" title="Details">
+            <Paragraph>nested body</Paragraph>
+            <Code language="typescript">const x = 1</Code>
+          </Toggle>
+          <Callout>no icon claimed — server injects a default</Callout>
+          <BulletedListItem>alpha</BulletedListItem>
+          <ChildPage blockKey="sub" title="Sub Page" icon={{ type: 'emoji', emoji: '📄' }}>
+            <Paragraph blockKey="p1">sub content</Paragraph>
+          </ChildPage>
+        </Page>
+      )
+      await withScratchPage('adopt-stateless', (pageId) =>
+        Effect.gen(function* () {
+          // Render live state, then simulate a stateless redeploy by
+          // discarding the cache entirely.
+          yield* sync(element(pageId), { pageId, cache: InMemoryCache.make() })
+
+          const adopted = yield* adopt(element(pageId), { pageId })
+
+          // The adopted cache reaches the zero-op fixpoint immediately.
+          const p = yield* plan(element(pageId), {
+            pageId,
+            cache: InMemoryCache.make(adopted),
+          })
+          expect(p.empty).toBe(true)
+          expect(p.fallbackReason).toBeUndefined()
+        }),
+      )
+    },
+    DEFAULT_TIMEOUT * 3,
+  )
+
+  it(
+    'drift recovery: out-of-band edit refuses strictly, adopt-live + one sync repairs, strict re-adoption succeeds',
+    async () => {
+      const element = (
+        <>
+          <Paragraph blockKey="a">alpha body</Paragraph>
+          <Paragraph blockKey="b">beta body</Paragraph>
+        </>
+      )
+      await withScratchPage('adopt-drift-recovery', (pageId) =>
+        Effect.gen(function* () {
+          yield* sync(element, { pageId, cache: InMemoryCache.make() })
+
+          // Out-of-band tamper: edit the first paragraph directly.
+          const live = yield* NotionBlocks.retrieveChildren({ blockId: pageId })
+          const first = live.results[0] as { id: string }
+          yield* NotionBlocks.update({
+            blockId: first.id,
+            paragraph: { rich_text: [{ type: 'text', text: { content: 'tampered' } }] },
+          })
+
+          // Strict adoption refuses with ContentDrift pinned to the block.
+          const err = yield* adopt(element, { pageId }).pipe(Effect.flip)
+          expect(err).toBeInstanceOf(AdoptionRefusedError)
+          const refusals = (err as AdoptionRefusedError).refusals
+          expect(refusals.map((r) => r._tag)).toEqual(['ContentDrift'])
+
+          // adopt-live records the live marker; the next sync emits exactly
+          // one repairing update; strict re-adoption then succeeds.
+          const adopted = yield* adopt(element, { pageId, onContentDrift: 'adopt-live' })
+          const res = yield* sync(element, { pageId, cache: InMemoryCache.make(adopted) })
+          expect({
+            appends: res.appends,
+            inserts: res.inserts,
+            updates: res.updates,
+            removes: res.removes,
+          }).toEqual({ appends: 0, inserts: 0, updates: 1, removes: 0 })
+
+          const readopted = yield* adopt(element, { pageId })
+          const p = yield* plan(element, { pageId, cache: InMemoryCache.make(readopted) })
+          expect(p.empty).toBe(true)
+        }),
+      )
+    },
+    DEFAULT_TIMEOUT * 3,
+  )
+})

--- a/packages/@overeng/notion-react/src/test/mock-client.ts
+++ b/packages/@overeng/notion-react/src/test/mock-client.ts
@@ -451,9 +451,24 @@ export const createFakeNotion = (): FakeNotion => {
     // 404 on list.
     if (pageOpMatch !== null && req.method === 'GET') {
       const id = pageOpMatch[1]!
-      const p = pages.get(id)
-      if (p === undefined) respErr(404, 'object_not_found', `Could not find page with ID: ${id}.`)
-      return toPageResponse(p!)
+      let p = pages.get(id)
+      if (p === undefined) {
+        // Same backward-compat path as PATCH below: tests address the ROOT
+        // page id without ever POSTing it (fragment roots carry no <Page>
+        // claims, so no PATCH ever synthesized it). Synthesize on first
+        // touch — adopt()'s pre-flight root retrieve now GETs the root.
+        p = {
+          id,
+          parent: { type: 'workspace', workspace: true },
+          properties: { title: { title: [] } },
+          icon: null,
+          cover: null,
+          archived: false,
+          in_trash: false,
+        }
+        pages.set(id, p)
+      }
+      return toPageResponse(p)
     }
 
     // PATCH /v1/pages/{id} — merge title / icon / cover and toggle


### PR DESCRIPTION
> Recreated from #1139: rebased onto current main (effect@4.0.0-rc.111 cohort); head SHA f22d96aa030ad177c309dc8bc4190ceed8006a65. The original was a stacked-base PR that GitHub refused to merge on every surface (stack guard + async merge API 404). Diff vs main currently includes earlier train stages; it shrinks to this stage only as predecessors below merge.

Closes #1093

5th PR on the #1128 train, stacked on #1132 (append-only). Implements the design proven by the #1093 spike report (13-green-test throwaway at the pre-readback pin), consolidated onto the shipped exports the train landed since.

## What

`adopt(element, { pageId, onContentDrift? }) → Effect<CacheTree, AdoptionRefusedError | NotionSyncError, NotionConfig | HttpClient>`

A stateless consumer whose renderer cache did not survive a redeploy can rebuild the exact `CacheTree` a prior `sync()` of the same element would have persisted — from live observation alone, with **zero Notion mutations in every outcome** (GET-only, asserted on the mock request log in every test including all refusal paths). A successful adoption feeds the normal incremental diff: `plan()` over the adopted tree is immediately empty.

- **Binding is strictly positional** (candidate child *i* ↔ live child *i*, in-trash excluded). `blockKey` is never stored in Notion, so keys/hashes flow candidate-side only; identical siblings bind deterministically (index order is the unique binding up to observational equivalence), reordered *distinct* siblings refuse at both positions — never content-search rematching.
- **Every bound pair is verified**: block content through the readback oracle (#1123), one node at a time with children stripped so a drifted descendant pins the descendant; `child_page`/root `<Page>` title/icon/cover claims per field via `compareReadbackPage` against `pages.retrieve`; recursion crosses page boundaries and descends whenever *either* side expects children (untracked nested live content surfaces as `ChildCountMismatch`).
- **All refusals collect** (never first-fail) into one typed `AdoptionRefusedError`: `ChildCountMismatch`, `TypeMismatch`, `ContentDrift`, `UnverifiableContent`, `PageMetaDrift` (field-level), `RootTrashed`.
- **Recovery**: `onContentDrift: 'adopt-live'` keeps every structural check fail-closed, records a live marker at exactly the drifted nodes → the next ordinary `sync()` emits exactly the minimal repairing updates → strict re-adoption succeeds → zero-op fixpoint. Proven end-to-end for both block content and root-page metadata.

Division of labor: **readback owns content** — canonicalization, response-shape absorption, candidate-contextual masking, and hash equality all live in `readback.ts` (any adopt-specific tolerance would belong in its masking tables, not a fork); **adopt owns structure** — positional binding, count/type checks, page-boundary recursion, refusal collection, and cache reconstruction (`candidateToCache` + root hashes + adopt-live patching).

## Deviations from the spike design

1. **Content gate = the shipped readback oracle**, not the spike's hand-projected live-payload hash. The spike flagged the response→request projection as its load-bearing gap; #1123 is that component, so `adopt` calls `compareReadback` per node (children stripped both sides) and gets the real API's response-shape deltas absorbed for free. Consequence: `ContentDrift` pins readback-space `candidateHash`/`observedHash` (renamed from the spike's `expectedHash`/`actualHash` to make the hash space explicit; `PageMetaDrift` keeps `expectedHash`/`actualHash` because those are cache-space claim hashes).
2. **`adopt-live` block marker is `adopt-live:<observedReadbackHash>`**, not the spike's projected live cache-space hash. The true live cache hash is not computable without the projection the spike faked, and R39 forbids treating a readback hash as a cache hash — the marker's contract is deterministic inequality with the candidate's request-shape hash (which is all the one-update repair needs), spelled so it can never masquerade as either space. Page-meta overrides do record genuine live cache-space hashes (computable via the shared `normalizeTitle`/`normalizeIcon`/`normalizeCover`).
3. **New refusal `UnverifiableContent`** for `<Raw>` escape-hatch payloads. Forced by the shipped oracle: readback normalization throws on raw blocks by design, and the spike's projection-based hash had verified them only vacuously against the mock. Fail closed with a typed refusal beats a defect.
4. **Page-meta verification goes through `compareReadbackPage` per field** (three single-claim calls), so the A07 built-in-icon rewrite and uploaded-cover signed-URL envelopes are absorbed by the shipped page masking instead of the spike's raw normalize+hash equality (which would false-refuse both against the real API). Recorded hashes stay cache-space.
5. **Error channel is `NotionSyncError`** (reason `notion-retrieve-failed`), not the raw client `NotionApiError` the spike surfaced — consistent with `sync()`/`plan()`/`observeBlockTree`.
6. **Observation reuses `observeBlockTree`** (one GET-only walk per page boundary) instead of the spike's per-parent `retrieveChildrenStream` calls — same request pattern, shared code, and the exact shape `compareReadback` consumes.
7. **#1100 alignment**: `adoptInlineChildren` stays a separate walker (documented in the spec section) — same positional rule, but it trusts persisted create-time hashes from the same process, takes `PendingInlineNode` intent rather than a full candidate tree, and is a crash-recovery path this PR must not destabilize. `adopt()` is its strict strengthening: every hash re-derived candidate-side, every binding content-verified.

## Tests

17 new unit tests in `adopt.unit.test.tsx` (mock-driven, every one asserting the GET-only contract):

- clean adoption `toEqual` the organically persisted cache; `plan()` empty + zero-op `sync` fixpoint; pure `diff()` empty;
- refusal classes: extra untracked live block, untracked *nested* live content under a leaf-expected block, type mismatch at position, content drift (top-level and nested-pins-the-child), archived child page, renamed child-page title (field-level), `<Raw>` unverifiable;
- positional-binding canon: identical siblings bind deterministically; swapped distinct siblings refuse at both positions;
- recovery chains: adopt-live on content drift → exactly one block `update` → strict re-adoption → fixpoint; adopt-live on root-title drift → exactly one `pages.update` → strict re-adoption → empty plan;
- the issue's cold-path contrast (full remove+append churn where adoption is a no-op).

Verification: full notion-react unit suite **414 passed | 1 skipped** (top-of-stack baseline 397 | 1 + these 17), `tsc -b tsconfig.check.json` exit 0, `devenv tasks run lint:check` exit 0.

A gated live e2e (`adopt.e2e.test.tsx`, `describe.skipIf(SKIP_E2E)` following the existing pattern) was **written but not run** here — it covers the load-bearing real-API case the mock cannot (response-shape deltas through the content gate: stateless adopt → empty plan, and the out-of-band-edit refuse → adopt-live → one-update repair → strict re-adopt chain).

## Docs

R42–R44 + T13 (requirements), "Fail-closed adoption" spec section (algorithm, verification order, marker semantics, #1100 relation), api.md Adoption section + entry-point/errors rows, limitations "Adoption scope", CHANGELOG.

## Notes for the downstream consumer rebase (Blocky Stage-3)

- Import surface: `adopt`, `AdoptionRefusedError`, `AdoptionRefusal`, `ContentDriftPolicy` from `@overeng/notion-react`. The returned tree is not persisted — save it through your `NotionCache` / `InMemoryCache.make(tree)`.
- The hand-rolled response normalization downstream (the spike's "blocky-normalized-ast" inventory item) is superseded on this path: the readback oracle is the content gate.
- Trees containing `<Raw>` blocks are not adoptable (typed `UnverifiableContent` refusal) — plan accordingly.
- `CacheNode.hash` may now carry an `adopt-live:` marker after an opt-in drift adoption; treat cache hashes as opaque equality tokens (which the diff already does).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | unknown |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.0.3 |
| `agent_runtime` | OMP 18.0.3 |
| `tooling_profile` | dotfiles@a80129b-dirty |
</details>
<!-- agent-footer:end -->