### PR TITLE
feat(watch): embrace recursive FileSystem.watch per rc.111 design study

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
+- **@overeng/utils, @overeng/genie, @overeng/notion-md**: apply the watch-recursion
+  design study for effect@4.0.0-rc.111 (recursion is opt-in again). New
+  `watchScoped` helper in `@overeng/utils/node` wraps `FileSystem.watch` with an
+  explicit `{ recursive: true }`, resolves event paths against each root,
+  filters by absolute-path scope, coalesces bursts into deduped batches over a
+  250 ms window (configurable), and ties watcher cleanup to the stream scope;
+  watcher failures propagate through the stream. The utils file-system semaphore
+  backing's `onPermitsReleased` now watches via the helper (recursive, explicit)
+  with unchanged failure semantics. Genie `--watch` embraces recursion — closing
+  the latent blindness to nested `*.genie.ts` edits — and regenerates each
+  250 ms burst as a single TUI cycle instead of one cycle per event; watch-stream
+  errors are surfaced in the TUI. notion-md single-file watch pins
+  `{ recursive: false }` explicitly and keeps its exact-path filter; batch watch
+  collapses the per-parent-dir watchers into one recursive watch rooted at the
+  deepest common ancestor of the targets.
 
 - **Repository-wide**: atomic Effect 4 cohort flip to `effect@4.0.0-rc.111`
   (with `@effect/platform-node`, `@effect/vitest`, `@effect/opentelemetry`,

--- a/context/effect-4/alignment-register.md
+++ b/context/effect-4/alignment-register.md
@@ -251,18 +251,19 @@
   default non-recursive watch call site, where the proposed shared `watchScoped` helper would
   land. Unexpected nested events can trigger spurious rebuilds or watch loops and present as
   timing flakiness rather than a clear migration failure.
-- **Status:** OPEN DESIGN WORK; the beta.102 "REQUIRED COMPATIBILITY WORK" framing is retired.
-  At rc.111 the forced-recursion premise no longer holds: `WatchOptions.recursive` is opt-in
-  again (`effect/src/FileSystem.ts:1171-1176`) and the Node backend defaults it to false
-  (`@effect/platform-node-shared/src/NodeFileSystem.ts:557-558`), so call sites pass
-  `{ recursive: true }` explicitly where recursion is wanted. What remains open is applying the
-  design study in `watch-recursion-experiments.md`: megarepo has no watch usage; genie should
-  embrace recursion (fixes latent nested-genie-file blindness) with a 250ms coalescing window;
-  notion-md keeps an exact-path filter for single-file watch and collapses batch watch to one
-  recursive common-root watch; a shared `watchScoped` helper for @overeng/utils is proposed only
-  after both migrations land. Historical characterization record: allowlisted at the one stable
-  nested-path membership trace path; raw event ordering was deliberately not gated (five
-  same-major runs produced four unique v3 and three unique v4 traces); draft upstream report in
+- **Status:** APPLIED/RESOLVED — the design study in `watch-recursion-experiments.md` has been
+  implemented (branch `schickling-assistant/2026-08-26-effect4-watch-recursion`):
+  `@overeng/utils/node` gained the shared `watchScoped` helper (recursive roots, resolve +
+  scope filter, 250 ms coalescing batches, scoped cleanup, error propagation) and the
+  file-system-backing semaphore watcher now uses it with an explicit `{ recursive: true }`;
+  genie watch embraces recursion with a 250 ms coalescing window via `watchScoped`, closing
+  the latent nested-`.genie.ts` blindness, and surfaces watch-stream errors to the TUI;
+  notion-md single-file watch keeps its exact-path filter and pins `{ recursive: false }`
+  explicitly; notion-md batch watch collapsed its per-parent-dir fan-out into one recursive
+  watch rooted at the deepest common ancestor (`batch.ts commonAncestor`). Historical
+  characterization record: allowlisted at the one stable nested-path membership trace path;
+  raw event ordering was deliberately not gated (five same-major runs produced four unique v3
+  and three unique v4 traces); draft upstream report in
   `recipes/filesystem-watch-ordering.md`.
 
 ## prompt-pty-ansi-rendering

--- a/packages/@overeng/genie/src/build/mod.tsx
+++ b/packages/@overeng/genie/src/build/mod.tsx
@@ -2,9 +2,9 @@ import path from 'node:path'
 
 import { Effect, FileSystem, Fiber, Option, pipe, PubSub, Result, Stream } from 'effect'
 import type { Path } from 'effect'
+import type { PlatformError } from 'effect/PlatformError'
 import * as Cli from 'effect/unstable/cli'
 import * as CommandExecutor from 'effect/unstable/process/ChildProcessSpawner'
-import type { PlatformError } from 'effect/PlatformError'
 import React from 'react'
 
 import { run } from '@overeng/tui-react'

--- a/packages/@overeng/genie/src/build/mod.tsx
+++ b/packages/@overeng/genie/src/build/mod.tsx
@@ -1,13 +1,15 @@
 import path from 'node:path'
 
 import { Effect, FileSystem, Fiber, Option, pipe, PubSub, Result, Stream } from 'effect'
-import type { PlatformError } from 'effect/PlatformError'
+import type { Path } from 'effect'
 import * as Cli from 'effect/unstable/cli'
+import * as CommandExecutor from 'effect/unstable/process/ChildProcessSpawner'
+import type { PlatformError } from 'effect/PlatformError'
 import React from 'react'
 
 import { run } from '@overeng/tui-react'
 import { outputOption, outputModeLayer } from '@overeng/tui-react/node'
-import { CurrentWorkingDirectory } from '@overeng/utils/node'
+import { CurrentWorkingDirectory, watchCauseMessage, watchScoped } from '@overeng/utils/node'
 
 import {
   checkAll,
@@ -22,7 +24,12 @@ import { type GenieEvent, GenieEventBus } from '../core/events.ts'
 import { generateFile } from '../core/generation.ts'
 import { withCliModeSpan } from '../core/observability.ts'
 import { GENERATOR_PHASES, type GeneratorPhase } from '../core/phase.ts'
-import { createInitialGenieState, type GenieSummary, type GenieMode } from '../core/schema.ts'
+import {
+  createInitialGenieState,
+  type GenieAction,
+  type GenieSummary,
+  type GenieMode,
+} from '../core/schema.ts'
 import { GenieApp } from './app.ts'
 import { GenieView } from './view.tsx'
 
@@ -62,7 +69,101 @@ const dispatchEvent = (tui: { dispatch: (action: any) => void }, event: GenieEve
   }
 }
 
+/**
+ * One coalesced watch cycle: regenerate every changed file in the batch and
+ * drive the TUI exactly once per burst (one WatchReset, one Complete).
+ */
+export const runWatchCycle = (opts: {
+  /** Absolute paths of changed `*.genie.ts` files for this window. */
+  readonly changedPaths: ReadonlyArray<string>
+  readonly cwd: string
+  readonly readOnly: boolean
+  readonly oxfmtConfigPath: Option.Option<string>
+  readonly tui: { dispatch: (action: GenieAction) => void }
+}): Effect.Effect<
+  GenieSummary,
+  PlatformError,
+  FileSystem.FileSystem | CommandExecutor.ChildProcessSpawner | Path.Path
+> =>
+  Effect.gen(function* () {
+    const changedPaths = new Set(opts.changedPaths)
+
+    // Reset for a new watch cycle — one reset per coalesced burst.
+    opts.tui.dispatch({ _tag: 'WatchReset' })
+
+    // Re-discover files (in case new ones were added)
+    const newGenieFiles = (yield* findGenieFiles(opts.cwd)).map((file) =>
+      path.resolve(opts.cwd, file),
+    )
+
+    opts.tui.dispatch({
+      _tag: 'FilesDiscovered',
+      files: newGenieFiles.map((filePath) => ({
+        path: filePath,
+        relativePath: path.relative(opts.cwd, filePath.replace('.genie.ts', '')),
+      })),
+    })
+
+    let created = 0
+    let updated = 0
+    let unchangedCount = 0
+    let skipped = 0
+    let failed = 0
+
+    // Regenerate each changed file
+    for (const genieFilePath of opts.changedPaths) {
+      opts.tui.dispatch({ _tag: 'FileStarted', path: genieFilePath })
+
+      const result = yield* generateFile({
+        genieFilePath,
+        cwd: opts.cwd,
+        readOnly: opts.readOnly,
+        oxfmtConfigPath: opts.oxfmtConfigPath,
+      }).pipe(Effect.result)
+
+      if (result._tag === 'Success') {
+        if (result.success._tag === 'created') created += 1
+        else if (result.success._tag === 'updated') updated += 1
+        else if (result.success._tag === 'unchanged') unchangedCount += 1
+        else skipped += 1
+        opts.tui.dispatch({
+          _tag: 'FileCompleted',
+          path: genieFilePath,
+          status: mapResultToStatus(result.success),
+          message: result.success._tag === 'updated' ? result.success.diffSummary : undefined,
+        })
+      } else {
+        failed += 1
+        opts.tui.dispatch({
+          _tag: 'FileCompleted',
+          path: genieFilePath,
+          status: 'error',
+          message: result.failure.message,
+        })
+      }
+    }
+
+    // Mark all other files as unchanged
+    for (const otherFile of newGenieFiles) {
+      if (!changedPaths.has(otherFile)) {
+        unchangedCount += 1
+        opts.tui.dispatch({ _tag: 'FileCompleted', path: otherFile, status: 'unchanged' })
+      }
+    }
+
+    const summary: GenieSummary = {
+      created,
+      updated,
+      unchanged: unchangedCount,
+      skipped,
+      failed,
+    }
+    opts.tui.dispatch({ _tag: 'Complete', summary })
+    return summary
+  })
+
 /** Genie CLI command - generates files from .genie.ts source files */
+
 export const genieCommand = Cli.Command.make(
   'genie',
   {
@@ -197,97 +298,38 @@ export const genieCommand = Cli.Command.make(
                 }
 
                 if (watch && !check && !dryRun) {
-                  // Watch mode - uses low-level APIs directly (CLI-specific)
+                  // Watch mode — recursive scoped watch with a 250 ms
+                  // coalescing window (context/effect-4/
+                  // watch-recursion-experiments.md §3.2). Discovery is already
+                  // recursive, so the previous non-recursive watcher silently
+                  // never fired for nested *.genie.ts edits; the window
+                  // collapses editor write bursts into one regeneration pass.
                   yield* pipe(
-                    fs.watch(resolvedCwd),
-                    Stream.filter(({ path: p }) => p.endsWith('.genie.ts')),
-                    Stream.tap(({ path: p }) => {
-                      const genieFilePath = path.join(resolvedCwd, p)
-
-                      // Reset for new watch cycle
-                      tui.dispatch({ _tag: 'WatchReset' })
-
-                      return Effect.gen(function* () {
-                        // Re-discover files (in case new ones were added)
-                        const newGenieFiles = (yield* findGenieFiles(resolvedCwd)).map((file) =>
-                          path.resolve(resolvedCwd, file),
-                        )
-
-                        tui.dispatch({
-                          _tag: 'FilesDiscovered',
-                          files: newGenieFiles.map((filePath) => ({
-                            path: filePath,
-                            relativePath: path.relative(
-                              resolvedCwd,
-                              filePath.replace('.genie.ts', ''),
-                            ),
-                          })),
-                        })
-
-                        // Regenerate the changed file
-                        tui.dispatch({ _tag: 'FileStarted', path: genieFilePath })
-
-                        const result = yield* generateFile({
-                          genieFilePath,
-                          cwd: resolvedCwd,
-                          readOnly,
-                          oxfmtConfigPath,
-                        }).pipe(Effect.result)
-
-                        if (result._tag === 'Success') {
-                          const message =
-                            result.success._tag === 'updated'
-                              ? result.success.diffSummary
-                              : undefined
-                          tui.dispatch({
-                            _tag: 'FileCompleted',
-                            path: genieFilePath,
-                            status: mapResultToStatus(result.success),
-                            message,
-                          })
-                        } else {
-                          tui.dispatch({
-                            _tag: 'FileCompleted',
-                            path: genieFilePath,
-                            status: 'error',
-                            message: result.failure.message,
-                          })
-                        }
-
-                        // Mark all other files as unchanged
-                        for (const otherFile of newGenieFiles) {
-                          if (otherFile !== genieFilePath) {
-                            tui.dispatch({
-                              _tag: 'FileCompleted',
-                              path: otherFile,
-                              status: 'unchanged',
-                            })
-                          }
-                        }
-
-                        const watchSummary: GenieSummary =
-                          result._tag === 'Success'
-                            ? {
-                                created: result.success._tag === 'created' ? 1 : 0,
-                                updated: result.success._tag === 'updated' ? 1 : 0,
-                                unchanged:
-                                  newGenieFiles.length -
-                                  1 +
-                                  (result.success._tag === 'unchanged' ? 1 : 0),
-                                skipped: result.success._tag === 'skipped' ? 1 : 0,
-                                failed: 0,
-                              }
-                            : {
-                                created: 0,
-                                updated: 0,
-                                unchanged: newGenieFiles.length - 1,
-                                skipped: 0,
-                                failed: 1,
-                              }
-
-                        tui.dispatch({ _tag: 'Complete', summary: watchSummary })
-                      })
+                    watchScoped({
+                      roots: [resolvedCwd],
+                      scope: (absolutePath) => absolutePath.endsWith('.genie.ts'),
                     }),
+                    Stream.mapEffect((batch) =>
+                      runWatchCycle({
+                        changedPaths: batch.map((group) => group.path),
+                        cwd: resolvedCwd,
+                        readOnly,
+                        oxfmtConfigPath,
+                        tui,
+                      }),
+                    ),
+                    // Surface watch-stream failures instead of dying silently;
+                    // the stream ends after a fatal watcher error.
+                    Stream.catchCause((cause) =>
+                      Stream.fromEffect(
+                        Effect.sync(() => {
+                          tui.dispatch({
+                            _tag: 'Error',
+                            message: `watch error: ${watchCauseMessage(cause)}`,
+                          })
+                        }),
+                      ),
+                    ),
                     Stream.runDrain,
                   )
                 }

--- a/packages/@overeng/genie/src/build/watch-cycle.probe.ts
+++ b/packages/@overeng/genie/src/build/watch-cycle.probe.ts
@@ -1,0 +1,75 @@
+import * as fsSync from 'node:fs'
+import * as path from 'node:path'
+
+import { NodeServices } from '@effect/platform-node'
+import { Effect, FileSystem, Option } from 'effect'
+
+import { runWatchCycle } from './mod.tsx'
+
+const template = `export default {
+  data: { name: 'genie-watch-cycle-probe', private: true },
+  stringify: () => JSON.stringify({ name: 'genie-watch-cycle-probe', private: true }, null, 2),
+}`
+
+/**
+ * Probe for `watch-cycle.unit.test.ts`: exercises one coalesced watch cycle
+ * against a real temp workspace and prints the observed summary + TUI actions
+ * as whitespace-separated lines. Run under bun — genie's template loader
+ * requires the Bun global, which vitest workers do not provide.
+ */
+const prog = Effect.scoped(
+  Effect.gen(function* () {
+    const root = process.argv[2]
+    if (root === undefined || !fsSync.existsSync(root)) {
+      throw new Error(`usage: bun watch-cycle.probe.ts <existing-root>`)
+    }
+    const fs = yield* FileSystem.FileSystem
+
+    yield* fs.writeFileString(path.join(root, 'package.json.genie.ts'), template)
+    yield* fs.makeDirectory(path.join(root, 'members'), { recursive: true })
+    yield* fs.writeFileString(path.join(root, 'members', 'package.json.genie.ts'), template)
+
+    const actions: Array<{
+      readonly _tag: string
+      readonly path?: string
+      readonly status?: string
+    }> = []
+    const summary = yield* runWatchCycle({
+      changedPaths: [path.join(root, 'members', 'package.json.genie.ts')],
+      cwd: root,
+      readOnly: false,
+      oxfmtConfigPath: Option.none(),
+      tui: {
+        dispatch: (action) => {
+          if (action._tag === 'FileCompleted') {
+            actions.push({ _tag: action._tag, path: action.path, status: action.status })
+          } else if (action._tag === 'FileStarted') {
+            actions.push({ _tag: action._tag, path: action.path })
+          } else {
+            actions.push({ _tag: action._tag })
+          }
+        },
+      },
+    })
+
+    yield* Effect.sync(() => {
+      // Line protocol instead of ad-hoc JSON serialization: each record is one
+      // line, parsed by watch-cycle.unit.test.ts.
+      process.stdout.write(
+        `SUMMARY ${summary.created} ${summary.updated} ${summary.unchanged} ${summary.skipped} ${summary.failed}\n`,
+      )
+      for (const action of actions) {
+        const pathPart = action.path === undefined ? '' : ` path=${action.path}`
+        const statusPart = action.status === undefined ? '' : ` status=${action.status}`
+        process.stdout.write(`ACTION ${action._tag}${pathPart}${statusPart}\n`)
+      }
+    })
+  }).pipe(Effect.provide(NodeServices.layer)),
+)
+
+await Effect.runPromiseExit(prog).then((exit) => {
+  if (exit._tag === 'Failure') {
+    process.stderr.write('probe failed\n')
+    process.exitCode = 1
+  }
+})

--- a/packages/@overeng/genie/src/build/watch-cycle.unit.test.ts
+++ b/packages/@overeng/genie/src/build/watch-cycle.unit.test.ts
@@ -15,7 +15,10 @@ interface ParsedAction {
 }
 
 const parseProbeOutput = (stdout: string) => {
-  const lines = stdout.trim().split('\n').filter((line) => line.length > 0)
+  const lines = stdout
+    .trim()
+    .split('\n')
+    .filter((line) => line.length > 0)
   const summaryLine = lines.find((line) => line.startsWith('SUMMARY '))
   expect(summaryLine).toBeDefined()
   const [created, updated, unchanged, skipped, failed] = (summaryLine ?? '')

--- a/packages/@overeng/genie/src/build/watch-cycle.unit.test.ts
+++ b/packages/@overeng/genie/src/build/watch-cycle.unit.test.ts
@@ -1,0 +1,87 @@
+import { spawnSync } from 'node:child_process'
+import * as fsSync from 'node:fs'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+const probePath = new URL('./watch-cycle.probe.ts', import.meta.url).pathname
+
+interface ParsedAction {
+  readonly _tag: string
+  readonly path?: string
+  readonly status?: string
+}
+
+const parseProbeOutput = (stdout: string) => {
+  const lines = stdout.trim().split('\n').filter((line) => line.length > 0)
+  const summaryLine = lines.find((line) => line.startsWith('SUMMARY '))
+  expect(summaryLine).toBeDefined()
+  const [created, updated, unchanged, skipped, failed] = (summaryLine ?? '')
+    .slice('SUMMARY '.length)
+    .split(' ')
+    .map((value) => Number(value))
+  const summary = { created, updated, unchanged, skipped, failed }
+
+  const actions: Array<ParsedAction> = []
+  for (const line of lines.filter((line) => line.startsWith('ACTION '))) {
+    const rest = line.slice('ACTION '.length)
+    const tag = rest.split(' ')[0] ?? ''
+    const pathMatch = / path=(\S+)/.exec(rest)
+    const statusMatch = / status=(\S+)/.exec(rest)
+    actions.push({
+      _tag: tag,
+      ...(pathMatch === null ? {} : { path: pathMatch[1] }),
+      ...(statusMatch === null ? {} : { status: statusMatch[1] }),
+    })
+  }
+  return { summary, actions }
+}
+
+describe('genie watch cycle', () => {
+  it('regenerates a coalesced batch in one pass and marks untouched files unchanged', () => {
+    const root = mkdtempSync(join(tmpdir(), 'genie-watch-cycle-'))
+    try {
+      // Only the nested file changes — the previous non-recursive watcher never
+      // fired for nested *.genie.ts edits; recursive scope + coalescing delivers
+      // them as one batched pass.
+      fsSync.mkdirSync(join(root, 'members'), { recursive: true })
+
+      const probe = spawnSync('bun', [probePath, root], { encoding: 'utf8' })
+      expect(probe.status).toBe(0)
+
+      const changed = join(root, 'members', 'package.json.genie.ts')
+      const { summary, actions } = parseProbeOutput(probe.stdout)
+
+      console.log('PARSED', JSON.stringify({ summary, actions }))
+      // One burst → one TUI cycle over both discovered files.
+      expect(summary).toEqual({
+        created: 1,
+        updated: 0,
+        unchanged: 1,
+        skipped: 0,
+        failed: 0,
+      })
+      expect(actions.filter((action) => action._tag === 'WatchReset')).toHaveLength(1)
+      expect(actions.filter((action) => action._tag === 'FilesDiscovered')).toHaveLength(1)
+      expect(actions.filter((action) => action._tag === 'Complete')).toHaveLength(1)
+      expect(
+        actions.some((action) => action._tag === 'FileStarted' && action.path === changed),
+      ).toBe(true)
+
+      // The nested file was actually regenerated.
+      expect(fsSync.existsSync(join(root, 'members', 'package.json'))).toBe(true)
+
+      // The untouched discovered file is reported unchanged exactly once.
+      const unchangedActions = actions.filter(
+        (action) => action._tag === 'FileCompleted' && action.status === 'unchanged',
+      )
+      expect(unchangedActions.map((action) => action.path)).toEqual([
+        join(root, 'package.json.genie.ts'),
+      ])
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/@overeng/notion-md/src/batch-common-ancestor.unit.test.ts
+++ b/packages/@overeng/notion-md/src/batch-common-ancestor.unit.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+
+import { commonAncestor } from './batch.ts'
+
+describe('commonAncestor', () => {
+  it('returns the single parent directory for one path', () => {
+    expect(commonAncestor(['/tmp/docs'])).toBe('/tmp/docs')
+  })
+
+  it('returns the deepest shared directory for sibling trees', () => {
+    expect(commonAncestor(['/repo/a/b/pages', '/repo/a/c/pages'])).toBe('/repo/a')
+  })
+
+  it('falls back to the filesystem root for unrelated paths', () => {
+    expect(commonAncestor(['/x/y', '/z'])).toBe('/')
+  })
+
+  it('handles identical directories', () => {
+    expect(commonAncestor(['/repo/a', '/repo/a', '/repo/a'])).toBe('/repo/a')
+  })
+})

--- a/packages/@overeng/notion-md/src/batch.ts
+++ b/packages/@overeng/notion-md/src/batch.ts
@@ -489,26 +489,40 @@ export const runBatchWatch = <A, R>(
       const emit = opts.emit ?? writeJsonLine
       const paths = uniqueSorted(opts.paths.map((path) => resolve(path)))
       const watchedPaths = new Set(paths)
-      const watchRoot = commonAncestor(paths.map((path) => dirname(path)))
+      const parentDirs = uniqueSorted(paths.map((path) => dirname(path)))
+      // Collapse to ONE recursive watcher over the targets' common ancestor,
+      // unless that ancestor is so broad it approaches the filesystem root
+      // (e.g. '/' or '/home') — recursing there would watch unrelated trees.
+      // In the degenerate case, keep one recursive watcher per parent dir.
+      const ancestor = commonAncestor(parentDirs)
+      const watchRoots =
+        ancestor.split(sep).filter((segment) => segment !== '').length <= 1
+          ? parentDirs
+          : [ancestor]
 
       yield* Effect.forEach(paths, (path) => Queue.offer(queue, { path, reason: 'initial' }))
 
       yield* Effect.forkScoped(
-        fs.watch(watchRoot, { recursive: true }).pipe(
-          Stream.filter((event) => watchedPaths.has(resolve(watchRoot, event.path))),
-          Stream.runForEach((event) =>
-            Queue.offer(queue, {
-              path: resolve(watchRoot, event.path),
-              reason: 'file',
-            }),
-          ),
-          Effect.catch((error) =>
-            emit({
-              event: 'watch_error',
-              path: watchRoot,
-              error: watchErrorJson(error),
-            }),
-          ),
+        Effect.forEach(
+          watchRoots,
+          (watchRoot) =>
+            fs.watch(watchRoot, { recursive: true }).pipe(
+              Stream.filter((event) => watchedPaths.has(resolve(watchRoot, event.path))),
+              Stream.runForEach((event) =>
+                Queue.offer(queue, {
+                  path: resolve(watchRoot, event.path),
+                  reason: 'file',
+                }),
+              ),
+              Effect.catch((error) =>
+                emit({
+                  event: 'watch_error',
+                  path: watchRoot,
+                  error: watchErrorJson(error),
+                }),
+              ),
+            ),
+          { concurrency: 'unbounded', discard: true },
         ),
       )
 

--- a/packages/@overeng/notion-md/src/batch.ts
+++ b/packages/@overeng/notion-md/src/batch.ts
@@ -1,4 +1,4 @@
-import { basename, dirname, resolve } from 'node:path'
+import { basename, dirname, resolve, sep } from 'node:path'
 
 import { Duration, Effect, FileSystem, Path, Queue, Stream } from 'effect'
 
@@ -456,6 +456,28 @@ const watchErrorJson = (error: unknown): Record<string, unknown> => {
   return { message: String(error) }
 }
 
+/**
+ * Deepest directory that contains every given absolute directory.
+ *
+ * Collapses the N parent-directory watchers of a batch watch into one
+ * recursive watcher rooted at the common ancestor
+ * (context/effect-4/watch-recursion-experiments.md §3.4): the resolved-path
+ * Set filter is depth-independent, so extra events from sibling subtrees are
+ * rejected and the existing debounce/coalesce machinery absorbs the volume.
+ */
+export const commonAncestor = (dirs: ReadonlyArray<string>): string => {
+  const segmentLists = dirs.map((dir) => dir.split(sep))
+  const first = segmentLists[0] ?? []
+  const prefix: Array<string> = []
+  for (let index = 0; index < first.length; index++) {
+    const segment = first[index] ?? ''
+    if (!segmentLists.every((segments) => segments[index] === segment)) break
+    prefix.push(segment)
+  }
+  const joined = prefix.join(sep)
+  return joined === '' ? sep : joined
+}
+
 /** Watch a resolved set of `.nmd` files and run coalesced batch sync passes. */
 export const runBatchWatch = <A, R>(
   opts: BatchWatchOptions<A, R>,
@@ -467,30 +489,28 @@ export const runBatchWatch = <A, R>(
       const emit = opts.emit ?? writeJsonLine
       const paths = uniqueSorted(opts.paths.map((path) => resolve(path)))
       const watchedPaths = new Set(paths)
-      const watchedDirs = uniqueSorted(paths.map((path) => dirname(path)))
+      const watchRoot = commonAncestor(paths.map((path) => dirname(path)))
 
       yield* Effect.forEach(paths, (path) => Queue.offer(queue, { path, reason: 'initial' }))
 
-      for (const watchedDir of watchedDirs) {
-        yield* Effect.forkScoped(
-          fs.watch(watchedDir).pipe(
-            Stream.filter((event) => watchedPaths.has(resolve(watchedDir, event.path))),
-            Stream.runForEach((event) =>
-              Queue.offer(queue, {
-                path: resolve(watchedDir, event.path),
-                reason: 'file',
-              }),
-            ),
-            Effect.catch((error) =>
-              emit({
-                event: 'watch_error',
-                path: watchedDir,
-                error: watchErrorJson(error),
-              }),
-            ),
+      yield* Effect.forkScoped(
+        fs.watch(watchRoot, { recursive: true }).pipe(
+          Stream.filter((event) => watchedPaths.has(resolve(watchRoot, event.path))),
+          Stream.runForEach((event) =>
+            Queue.offer(queue, {
+              path: resolve(watchRoot, event.path),
+              reason: 'file',
+            }),
           ),
-        )
-      }
+          Effect.catch((error) =>
+            emit({
+              event: 'watch_error',
+              path: watchRoot,
+              error: watchErrorJson(error),
+            }),
+          ),
+        ),
+      )
 
       yield* Effect.forkScoped(
         Effect.forever(

--- a/packages/@overeng/notion-md/src/batch.ts
+++ b/packages/@overeng/notion-md/src/batch.ts
@@ -471,7 +471,7 @@ export const commonAncestor = (dirs: ReadonlyArray<string>): string => {
   const prefix: Array<string> = []
   for (let index = 0; index < first.length; index++) {
     const segment = first[index] ?? ''
-    if (!segmentLists.every((segments) => segments[index] === segment)) break
+    if (segmentLists.every((segments) => segments[index] === segment) === false) break
     prefix.push(segment)
   }
   const joined = prefix.join(sep)

--- a/packages/@overeng/notion-md/src/cli-program.ts
+++ b/packages/@overeng/notion-md/src/cli-program.ts
@@ -354,7 +354,11 @@ export const runWatch = (opts: {
         )
 
       const initialEvents = Stream.succeed<WatchTrigger>({ reason: 'initial' })
-      const fileEvents = fs.watch(watchedDir).pipe(
+      // Single-file scope: watch the parent directory NON-recursively and keep
+      // the exact-path filter (context/effect-4/watch-recursion-experiments.md
+      // §3.3) — recursion would only widen the event stream past a cheap
+      // equality check, and rc.111's default (false) is pinned explicitly.
+      const fileEvents = fs.watch(watchedDir, { recursive: false }).pipe(
         Stream.filter((event) => resolve(watchedDir, event.path) === watchedPath),
         Stream.map((): WatchTrigger => ({ reason: 'file' })),
         Stream.catchCause((cause) => {

--- a/packages/@overeng/utils/src/node/file-system-backing.ts
+++ b/packages/@overeng/utils/src/node/file-system-backing.ts
@@ -21,6 +21,7 @@ import {
   SemaphoreForceRevokeOperation as SemaphoreForceRevokeContract,
   SemaphoreKeyOperation as SemaphoreKeyContract,
 } from './semaphore.contract.ts'
+import { watchScoped } from './watch.ts'
 
 /** Information about a holder's lock state */
 export interface HolderInfo {
@@ -387,16 +388,23 @@ export const layer = (
   const onPermitsReleased = (key: string): Stream.Stream<void, never, FileSystem.FileSystem> => {
     const keyDir = getKeyDir({ lockDir, key })
 
-    return Stream.unwrap(
-      Effect.gen(function* () {
-        const fs = yield* FileSystem.FileSystem
-
-        return fs.watch(keyDir).pipe(
-          Stream.filter((event) => event._tag === 'Update' || event._tag === 'Remove'),
-          Stream.map((): void => undefined),
-          Stream.catch(() => Stream.empty),
-        )
-      }),
+    // Recursive scoped watch via the shared helper (rc.111 recursion is
+    // opt-in): holder locks live flat inside the key directory, so the
+    // recursive scope observes exactly the same files as before.
+    return watchScoped({
+      roots: [keyDir],
+      scope: (absolutePath) => absolutePath.endsWith('.lock'),
+      debounce: Duration.millis(0),
+    }).pipe(
+      Stream.filter((groups) =>
+        groups.some((group) =>
+          group.events.some((event) => event._tag === 'Update' || event._tag === 'Remove'),
+        ),
+      ),
+      Stream.map((): void => undefined),
+      // Preserve the previous failure semantics: a dead watcher (e.g. a deleted
+      // lock directory) must not fail consumers — they fall back to polling.
+      Stream.catchCause(() => Stream.empty),
     )
   }
 

--- a/packages/@overeng/utils/src/node/mod.ts
+++ b/packages/@overeng/utils/src/node/mod.ts
@@ -8,6 +8,9 @@ export * from './net.ts'
 /** File-system based backing for distributed semaphore */
 export * as FileSystemBacking from './file-system-backing.ts'
 
+/** Scoped recursive file-system watching with coalesced batches */
+export * from './watch.ts'
+
 /** Workspace helpers and command runner utilities */
 export * from './workspace.ts'
 

--- a/packages/@overeng/utils/src/node/watch.ts
+++ b/packages/@overeng/utils/src/node/watch.ts
@@ -1,6 +1,7 @@
+import { resolve } from 'node:path'
+
 import { Cause, Data, Deferred, Duration, Effect, FileSystem, Option, Queue, Stream } from 'effect'
 import type { PlatformError } from 'effect/PlatformError'
-import { resolve } from 'node:path'
 
 /**
  * One watched path grouped with every event observed for it inside the same
@@ -17,6 +18,10 @@ export interface WatchGroup {
   readonly events: ReadonlyArray<FileSystem.WatchEvent>
 }
 
+/**
+ * Policy for a scoped recursive watch: which roots, which paths count, and
+ * how events are coalesced into batches.
+ */
 export interface WatchScopedOptions {
   /**
    * Directories to watch. Every root is watched with an explicit
@@ -57,17 +62,20 @@ interface PendingEntry {
  * with `Queue.poll` — `Queue.takeAll` would block until a further event
  * arrives and stall single-change flushes.
  */
-const takeWindow = (
-  pending: Queue.Queue<PendingEntry>,
-  debounce: Duration.Duration,
-): Effect.Effect<ReadonlyArray<WatchGroup>> =>
+const takeWindow = ({
+  pending,
+  debounce,
+}: {
+  readonly pending: Queue.Queue<PendingEntry>
+  readonly debounce: Duration.Duration
+}): Effect.Effect<ReadonlyArray<WatchGroup>> =>
   Effect.gen(function* () {
     const first = yield* Queue.take(pending)
     yield* Effect.sleep(debounce)
 
     const entries: Array<PendingEntry> = [first]
     let next = yield* Queue.poll(pending)
-    while (Option.isSome(next)) {
+    while (Option.isSome(next) === true) {
       entries.push(next.value)
       next = yield* Queue.poll(pending)
     }
@@ -102,68 +110,68 @@ export const watchScoped = (
   Stream.scoped(
     Stream.unwrap(
       Effect.gen(function* () {
-      const fs = yield* FileSystem.FileSystem
+        const fs = yield* FileSystem.FileSystem
 
-      if (options.roots.length === 0) return Stream.empty
+        if (options.roots.length === 0) return Stream.empty
 
-      const debounce =
-        options.debounce === undefined
-          ? DEFAULT_WATCH_DEBOUNCE
-          : Duration.fromInputUnsafe(options.debounce)
-      const scope = options.scope
-      const inScope: (absolutePath: string) => boolean =
-        typeof scope === 'function' ? scope : (absolutePath) => scope.has(absolutePath)
+        const debounce =
+          options.debounce === undefined
+            ? DEFAULT_WATCH_DEBOUNCE
+            : Duration.fromInputUnsafe(options.debounce)
+        const scope = options.scope
+        const inScope: (absolutePath: string) => boolean =
+          typeof scope === 'function' ? scope : (absolutePath) => scope.has(absolutePath)
 
-      const pending = yield* Queue.sliding<PendingEntry>(WATCH_QUEUE_CAPACITY)
-      // Completed by the watcher fiber: failed with the sentinel when the
-      // watchers ended cleanly, with their PlatformError when they errored,
-      // died with the original cause on unexpected defects.
-      const halted = yield* Deferred.make<never, PlatformError | WatchSourceEnded>()
+        const pending = yield* Queue.sliding<PendingEntry>(WATCH_QUEUE_CAPACITY)
+        // Completed by the watcher fiber: failed with the sentinel when the
+        // watchers ended cleanly, with their PlatformError when they errored,
+        // died with the original cause on unexpected defects.
+        const halted = yield* Deferred.make<never, PlatformError | WatchSourceEnded>()
 
-      // One filler fiber per root; the supervisor waits for all of them and
-      // signals `halted` with the first watcher error, or with the sentinel
-      // once every watcher ended cleanly (e.g. a watched directory vanished).
-      yield* Effect.gen(function* () {
-        const results = yield* Effect.forEach(
-          options.roots,
-          (root) =>
-            fs.watch(root, { recursive: true }).pipe(
-              Stream.map((event) => ({ absolutePath: resolve(root, event.path), event })),
-              Stream.filter((entry) => inScope(entry.absolutePath)),
-              Stream.runForEach((entry) => Queue.offer(pending, entry)),
-              Effect.result,
+        // One filler fiber per root; the supervisor waits for all of them and
+        // signals `halted` with the first watcher error, or with the sentinel
+        // once every watcher ended cleanly (e.g. a watched directory vanished).
+        yield* Effect.gen(function* () {
+          const results = yield* Effect.forEach(
+            options.roots,
+            (root) =>
+              fs.watch(root, { recursive: true }).pipe(
+                Stream.map((event) => ({ absolutePath: resolve(root, event.path), event })),
+                Stream.filter((entry) => inScope(entry.absolutePath)),
+                Stream.runForEach((entry) => Queue.offer(pending, entry)),
+                Effect.result,
+              ),
+            { concurrency: 'unbounded' },
+          )
+
+          const failure = results.find((result) => result._tag === 'Failure')
+          if (failure !== undefined && failure._tag === 'Failure') {
+            yield* Deferred.fail(halted, failure.failure)
+          } else {
+            yield* Deferred.fail(halted, new WatchSourceEnded())
+          }
+        }).pipe(Effect.forkScoped)
+
+        // Windowed batch loop: each iteration blocks until a first scoped event
+        // opens a window, sleeps out the debounce, drains the queue, and emits
+        // one deduped batch. Ends cleanly on the sentinel, fails with the
+        // watchers' PlatformError otherwise.
+        return Stream.unfold(
+          undefined,
+          (): Effect.Effect<
+            readonly [ReadonlyArray<WatchGroup>, undefined] | undefined,
+            PlatformError
+          > =>
+            Effect.raceFirst(takeWindow({ pending, debounce }), Deferred.await(halted)).pipe(
+              Effect.map((batch) => [batch, undefined] as const),
+              Effect.catch((error) =>
+                error._tag === 'WatchSourceEnded'
+                  ? Effect.void.pipe(Effect.as(undefined))
+                  : Effect.fail(error),
+              ),
             ),
-          { concurrency: 'unbounded' },
         )
-
-        const failure = results.find((result) => result._tag === 'Failure')
-        if (failure !== undefined && failure._tag === 'Failure') {
-          yield* Deferred.fail(halted, failure.failure)
-        } else {
-          yield* Deferred.fail(halted, new WatchSourceEnded())
-        }
-      }).pipe(Effect.forkScoped)
-
-      // Windowed batch loop: each iteration blocks until a first scoped event
-      // opens a window, sleeps out the debounce, drains the queue, and emits
-      // one deduped batch. Ends cleanly on the sentinel, fails with the
-      // watchers' PlatformError otherwise.
-      return Stream.unfold(
-        undefined,
-        (): Effect.Effect<
-          readonly [ReadonlyArray<WatchGroup>, undefined] | undefined,
-          PlatformError
-        > =>
-          Effect.raceFirst(takeWindow(pending, debounce), Deferred.await(halted)).pipe(
-            Effect.map((batch) => [batch, undefined] as const),
-            Effect.catch((error) =>
-              error._tag === 'WatchSourceEnded'
-                ? Effect.void.pipe(Effect.as(undefined))
-                : Effect.fail(error),
-            ),
-          ),
-      )
-    }),
+      }),
     ),
   )
 

--- a/packages/@overeng/utils/src/node/watch.ts
+++ b/packages/@overeng/utils/src/node/watch.ts
@@ -1,6 +1,17 @@
 import { resolve } from 'node:path'
 
-import { Cause, Data, Deferred, Duration, Effect, FileSystem, Option, Queue, Stream } from 'effect'
+import {
+  Cause,
+  Data,
+  Deferred,
+  Duration,
+  Effect,
+  FileSystem,
+  Option,
+  Queue,
+  Ref,
+  Stream,
+} from 'effect'
 import type { PlatformError } from 'effect/PlatformError'
 
 /**
@@ -128,28 +139,41 @@ export const watchScoped = (
         // died with the original cause on unexpected defects.
         const halted = yield* Deferred.make<never, PlatformError | WatchSourceEnded>()
 
-        // One filler fiber per root; the supervisor waits for all of them and
-        // signals `halted` with the first watcher error, or with the sentinel
-        // once every watcher ended cleanly (e.g. a watched directory vanished).
+        // One filler fiber per root. Each fiber signals `halted` the moment IT
+        // exits — with its watcher error on failure (so one dead root fails the
+        // stream immediately instead of waiting for the others), and with the
+        // sentinel once every root has ended cleanly (e.g. a watched directory
+        // vanished).
         yield* Effect.gen(function* () {
-          const results = yield* Effect.forEach(
-            options.roots,
-            (root) =>
-              fs.watch(root, { recursive: true }).pipe(
-                Stream.map((event) => ({ absolutePath: resolve(root, event.path), event })),
-                Stream.filter((entry) => inScope(entry.absolutePath)),
-                Stream.runForEach((entry) => Queue.offer(pending, entry)),
-                Effect.result,
-              ),
-            { concurrency: 'unbounded' },
-          )
+          const remaining = yield* Ref.make(options.roots.length)
 
-          const failure = results.find((result) => result._tag === 'Failure')
-          if (failure !== undefined && failure._tag === 'Failure') {
-            yield* Deferred.fail(halted, failure.failure)
-          } else {
-            yield* Deferred.fail(halted, new WatchSourceEnded())
-          }
+          const watchRoot = (root: string) =>
+            fs.watch(root, { recursive: true }).pipe(
+              Stream.map((event) => ({ absolutePath: resolve(root, event.path), event })),
+              Stream.filter((entry) => inScope(entry.absolutePath)),
+              Stream.runForEach((entry) => Queue.offer(pending, entry)),
+              Effect.result,
+              Effect.tap((result) => {
+                if (result._tag === 'Failure') {
+                  return Deferred.fail(halted, result.failure).pipe(Effect.asVoid)
+                }
+                return Ref.modify(remaining, (count) => {
+                  const next = count - 1
+                  return [next, next]
+                }).pipe(
+                  Effect.flatMap((left) =>
+                    left === 0
+                      ? Deferred.fail(halted, new WatchSourceEnded()).pipe(Effect.asVoid)
+                      : Effect.void,
+                  ),
+                )
+              }),
+            )
+
+          yield* Effect.forEach(options.roots, watchRoot, {
+            concurrency: 'unbounded',
+            discard: true,
+          })
         }).pipe(Effect.forkScoped)
 
         // Windowed batch loop: each iteration blocks until a first scoped event

--- a/packages/@overeng/utils/src/node/watch.ts
+++ b/packages/@overeng/utils/src/node/watch.ts
@@ -1,0 +1,178 @@
+import { Cause, Data, Deferred, Duration, Effect, FileSystem, Option, Queue, Stream } from 'effect'
+import type { PlatformError } from 'effect/PlatformError'
+import { resolve } from 'node:path'
+
+/**
+ * One watched path grouped with every event observed for it inside the same
+ * coalescing window.
+ */
+export interface WatchGroup {
+  /** Absolute path of the changed entry, resolved against the watched root. */
+  readonly path: string
+  /**
+   * Raw events observed for this path within the window. Event `_tag`s are
+   * deliberately kept opaque to consumers: on Linux, writes frequently surface
+   * as `Create` (via rename→stat) instead of `Update`.
+   */
+  readonly events: ReadonlyArray<FileSystem.WatchEvent>
+}
+
+export interface WatchScopedOptions {
+  /**
+   * Directories to watch. Every root is watched with an explicit
+   * `{ recursive: true }` (rc.111 made recursion opt-in again), so one root
+   * covers its entire subtree.
+   */
+  readonly roots: ReadonlyArray<string>
+  /**
+   * Absolute paths to keep, as a set or predicate. Watch events arrive with
+   * paths relative to the watched root; they are resolved before this scope
+   * check, matching the resolve-and-compare idiom every consumer needs.
+   */
+  readonly scope: ReadonlySet<string> | ((absolutePath: string) => boolean)
+  /**
+   * Coalescing window: once the first scoped event arrives, further events are
+   * accumulated for this long before one deduped batch is emitted. Defaults to
+   * 250 milliseconds (the window already used by notion-md's watchers).
+   * Pass `0` for immediate, uncoalesced delivery.
+   */
+  readonly debounce?: Duration.Input | undefined
+}
+
+/** Internal marker: all watchers ended without a platform error. */
+class WatchSourceEnded extends Data.TaggedError('WatchSourceEnded') {}
+
+const DEFAULT_WATCH_DEBOUNCE = Duration.millis(250)
+const WATCH_QUEUE_CAPACITY = 4096
+
+interface PendingEntry {
+  readonly absolutePath: string
+  readonly event: FileSystem.WatchEvent
+}
+
+/**
+ * Collect scoped events from a sliding queue into one deduped batch after a
+ * debounce window: the first event opens the window (blocking), then
+ * everything that accumulated while it was open joins the same batch. Drains
+ * with `Queue.poll` — `Queue.takeAll` would block until a further event
+ * arrives and stall single-change flushes.
+ */
+const takeWindow = (
+  pending: Queue.Queue<PendingEntry>,
+  debounce: Duration.Duration,
+): Effect.Effect<ReadonlyArray<WatchGroup>> =>
+  Effect.gen(function* () {
+    const first = yield* Queue.take(pending)
+    yield* Effect.sleep(debounce)
+
+    const entries: Array<PendingEntry> = [first]
+    let next = yield* Queue.poll(pending)
+    while (Option.isSome(next)) {
+      entries.push(next.value)
+      next = yield* Queue.poll(pending)
+    }
+
+    const groups = new Map<string, { path: string; events: Array<FileSystem.WatchEvent> }>()
+    for (const entry of entries) {
+      const group = groups.get(entry.absolutePath)
+      if (group === undefined) {
+        groups.set(entry.absolutePath, { path: entry.absolutePath, events: [entry.event] })
+      } else {
+        group.events.push(entry.event)
+      }
+    }
+    return [...groups.values()]
+  })
+
+/**
+ * Watch directories recursively and emit deduped batches of scoped changes.
+ *
+ * Wraps Effect `FileSystem.watch` with an explicit `{ recursive: true }` option
+ * (the rc.111 default is non-recursive), resolves event paths against each
+ * watch root before applying the scope filter, coalesces bursts into per-window
+ * batches, and ties watcher cleanup to the consuming stream's scope.
+ *
+ * Failure semantics: a watcher error fails the returned stream (consumers can
+ * degrade to polling or swallow it); when all watchers end cleanly — e.g. the
+ * watched directory disappears — the stream ends instead of hanging.
+ */
+export const watchScoped = (
+  options: WatchScopedOptions,
+): Stream.Stream<ReadonlyArray<WatchGroup>, PlatformError, FileSystem.FileSystem> =>
+  Stream.scoped(
+    Stream.unwrap(
+      Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem
+
+      if (options.roots.length === 0) return Stream.empty
+
+      const debounce =
+        options.debounce === undefined
+          ? DEFAULT_WATCH_DEBOUNCE
+          : Duration.fromInputUnsafe(options.debounce)
+      const scope = options.scope
+      const inScope: (absolutePath: string) => boolean =
+        typeof scope === 'function' ? scope : (absolutePath) => scope.has(absolutePath)
+
+      const pending = yield* Queue.sliding<PendingEntry>(WATCH_QUEUE_CAPACITY)
+      // Completed by the watcher fiber: failed with the sentinel when the
+      // watchers ended cleanly, with their PlatformError when they errored,
+      // died with the original cause on unexpected defects.
+      const halted = yield* Deferred.make<never, PlatformError | WatchSourceEnded>()
+
+      // One filler fiber per root; the supervisor waits for all of them and
+      // signals `halted` with the first watcher error, or with the sentinel
+      // once every watcher ended cleanly (e.g. a watched directory vanished).
+      yield* Effect.gen(function* () {
+        const results = yield* Effect.forEach(
+          options.roots,
+          (root) =>
+            fs.watch(root, { recursive: true }).pipe(
+              Stream.map((event) => ({ absolutePath: resolve(root, event.path), event })),
+              Stream.filter((entry) => inScope(entry.absolutePath)),
+              Stream.runForEach((entry) => Queue.offer(pending, entry)),
+              Effect.result,
+            ),
+          { concurrency: 'unbounded' },
+        )
+
+        const failure = results.find((result) => result._tag === 'Failure')
+        if (failure !== undefined && failure._tag === 'Failure') {
+          yield* Deferred.fail(halted, failure.failure)
+        } else {
+          yield* Deferred.fail(halted, new WatchSourceEnded())
+        }
+      }).pipe(Effect.forkScoped)
+
+      // Windowed batch loop: each iteration blocks until a first scoped event
+      // opens a window, sleeps out the debounce, drains the queue, and emits
+      // one deduped batch. Ends cleanly on the sentinel, fails with the
+      // watchers' PlatformError otherwise.
+      return Stream.unfold(
+        undefined,
+        (): Effect.Effect<
+          readonly [ReadonlyArray<WatchGroup>, undefined] | undefined,
+          PlatformError
+        > =>
+          Effect.raceFirst(takeWindow(pending, debounce), Deferred.await(halted)).pipe(
+            Effect.map((batch) => [batch, undefined] as const),
+            Effect.catch((error) =>
+              error._tag === 'WatchSourceEnded'
+                ? Effect.succeed(undefined)
+                : Effect.fail(error),
+            ),
+          ),
+      )
+    }),
+    ),
+  )
+
+/**
+ * Extract the platform error from a failing watch-stream cause and render it
+ * as a single-line message, falling back to a generic note for defects.
+ */
+export const watchCauseMessage = (cause: Cause.Cause<PlatformError>): string => {
+  const fail = Cause.findFail(cause)
+  if (fail._tag !== 'Success') return 'unknown watch failure'
+  return fail.success.error.message
+}

--- a/packages/@overeng/utils/src/node/watch.ts
+++ b/packages/@overeng/utils/src/node/watch.ts
@@ -158,7 +158,7 @@ export const watchScoped = (
             Effect.map((batch) => [batch, undefined] as const),
             Effect.catch((error) =>
               error._tag === 'WatchSourceEnded'
-                ? Effect.succeed(undefined)
+                ? Effect.void.pipe(Effect.as(undefined))
                 : Effect.fail(error),
             ),
           ),

--- a/packages/@overeng/utils/src/node/watch.unit.test.ts
+++ b/packages/@overeng/utils/src/node/watch.unit.test.ts
@@ -1,0 +1,146 @@
+import * as path from 'node:path'
+
+import { NodeServices } from '@effect/platform-node'
+import { Cause, Deferred, Duration, Effect, Exit, FileSystem, Fiber, Option, Queue, Stream } from 'effect'
+import type { PlatformError } from 'effect/PlatformError'
+import { systemError } from 'effect/PlatformError'
+import { expect } from 'vitest'
+import { Vitest } from '@overeng/utils-dev/node-vitest'
+
+import { watchCauseMessage, watchScoped, type WatchGroup } from './watch.ts'
+
+const drainBatches = (batches: Queue.Queue<ReadonlyArray<WatchGroup>>) =>
+  Effect.gen(function* () {
+    const first = yield* Queue.take(batches)
+    // Grace period so stragglers from the same burst land in the assertion set.
+    yield* Effect.sleep(Duration.millis(200))
+    const rest: Array<ReadonlyArray<WatchGroup>> = []
+    let next = yield* Queue.poll(batches)
+    while (Option.isSome(next)) {
+      rest.push(next.value)
+      next = yield* Queue.poll(batches)
+    }
+    yield* Queue.shutdown(batches)
+    return [first, ...rest].flat()
+  })
+
+Vitest.describe('watchScoped', () => {
+  Vitest.it.live(
+    'watches nested paths recursively, filters scope, and dedupes bursts',
+    Effect.fnUntraced(
+      function* () {
+        const fs = yield* FileSystem.FileSystem
+        const root = yield* fs.makeTempDirectory()
+        yield* fs.makeDirectory(path.join(root, 'sub'))
+
+        const batches = yield* Queue.unbounded<ReadonlyArray<WatchGroup>>()
+        const watcher = yield* watchScoped({
+          roots: [root],
+          scope: (absolutePath) => absolutePath.endsWith('.txt'),
+          debounce: Duration.millis(100),
+        }).pipe(Stream.runForEach((batch) => Queue.offer(batches, batch)), Effect.forkChild)
+
+        // Let the watcher settle before writing (fs.watch registration is
+        // asynchronous; events fired before it lands are not delivered).
+        yield* Effect.sleep(Duration.millis(200))
+
+        const nestedFile = path.join(root, 'sub', 'deep.txt')
+        const ignoredFile = path.join(root, 'notes.log')
+        yield* fs.writeFileString(nestedFile, 'one')
+        yield* fs.writeFileString(nestedFile, 'two')
+        yield* fs.writeFileString(ignoredFile, 'ignored')
+
+        const groups = yield* drainBatches(batches).pipe(Effect.timeout(Duration.seconds(10)))
+        yield* Fiber.interrupt(watcher)
+        yield* fs.remove(root, { recursive: true })
+
+        const paths = groups.map((group) => group.path)
+        // Recursive: a change two levels deep is observed (the rc.111 default
+        // non-recursive watch would never fire for it).
+        expect(paths).toContain(nestedFile)
+        // Scope predicate rejects out-of-scope paths.
+        expect(paths).not.toContain(ignoredFile)
+        // Bursts collapse to one group per path within a window.
+        expect(paths.filter((entry) => entry === nestedFile)).toHaveLength(1)
+      },
+      Effect.provide(NodeServices.layer),
+      Effect.scoped,
+    ),
+  )
+
+  Vitest.it.live(
+    'supports set-based scopes across multiple roots',
+    Effect.fnUntraced(
+      function* () {
+        const fs = yield* FileSystem.FileSystem
+        const rootA = yield* fs.makeTempDirectory()
+        const rootB = yield* fs.makeTempDirectory()
+
+        const watchedFile = path.join(rootB, 'target.txt')
+        const batches = yield* Queue.unbounded<ReadonlyArray<WatchGroup>>()
+        const watcher = yield* watchScoped({
+          roots: [rootA, rootB],
+          scope: new Set([watchedFile]),
+          debounce: Duration.millis(100),
+        }).pipe(Stream.runForEach((batch) => Queue.offer(batches, batch)), Effect.forkChild)
+
+        yield* Effect.sleep(Duration.millis(200))
+
+        yield* fs.writeFileString(path.join(rootA, 'other.txt'), 'noise')
+        yield* fs.writeFileString(watchedFile, 'change')
+
+        const groups = yield* drainBatches(batches).pipe(Effect.timeout(Duration.seconds(10)))
+        yield* Fiber.interrupt(watcher)
+        yield* fs.remove(rootA, { recursive: true })
+        yield* fs.remove(rootB, { recursive: true })
+
+        expect(groups.map((group) => group.path)).toEqual([watchedFile])
+      },
+      Effect.provide(NodeServices.layer),
+      Effect.scoped,
+    ),
+  )
+
+  Vitest.it.live(
+    'propagates watcher failures through the stream',
+    Effect.fnUntraced(
+      function* () {
+        const real = yield* FileSystem.FileSystem
+        const root = yield* real.makeTempDirectory()
+
+        // Named override (repo cast rule): swap `watch` for a permanently
+        // failing stream to exercise error propagation deterministically — on
+        // Linux, deleting a watched directory just silences the watcher.
+        const watchError = systemError({
+          _tag: 'NotFound',
+          module: 'node',
+          method: 'watch',
+          description: 'synthetic watch failure',
+        })
+        const fsWithFailingWatch: FileSystem.FileSystem = {
+          ...real,
+          watch: () => Stream.fail(watchError),
+        }
+
+        const outcome = yield* watchScoped({
+          roots: [root],
+          scope: () => true,
+          debounce: Duration.millis(50),
+        }).pipe(
+          Stream.runDrain,
+          Effect.exit,
+          Effect.provideService(FileSystem.FileSystem, fsWithFailingWatch),
+        )
+
+        expect(outcome._tag).toBe('Failure')
+        if (outcome._tag === 'Failure') {
+          expect(watchCauseMessage(outcome.cause as Cause.Cause<PlatformError>)).toContain(
+            'synthetic watch failure',
+          )
+        }
+      },
+      Effect.provide(NodeServices.layer),
+      Effect.scoped,
+    ),
+  )
+})

--- a/packages/@overeng/utils/src/node/watch.unit.test.ts
+++ b/packages/@overeng/utils/src/node/watch.unit.test.ts
@@ -1,10 +1,12 @@
 import * as path from 'node:path'
 
 import { NodeServices } from '@effect/platform-node'
-import { Cause, Deferred, Duration, Effect, Exit, FileSystem, Fiber, Option, Queue, Stream } from 'effect'
+import type { Cause } from 'effect'
+import { Duration, Effect, FileSystem, Fiber, Option, Queue, Stream } from 'effect'
 import type { PlatformError } from 'effect/PlatformError'
 import { systemError } from 'effect/PlatformError'
 import { expect } from 'vitest'
+
 import { Vitest } from '@overeng/utils-dev/node-vitest'
 
 import { watchCauseMessage, watchScoped, type WatchGroup } from './watch.ts'
@@ -16,7 +18,7 @@ const drainBatches = (batches: Queue.Queue<ReadonlyArray<WatchGroup>>) =>
     yield* Effect.sleep(Duration.millis(200))
     const rest: Array<ReadonlyArray<WatchGroup>> = []
     let next = yield* Queue.poll(batches)
-    while (Option.isSome(next)) {
+    while (Option.isSome(next) === true) {
       rest.push(next.value)
       next = yield* Queue.poll(batches)
     }
@@ -38,7 +40,10 @@ Vitest.describe('watchScoped', () => {
           roots: [root],
           scope: (absolutePath) => absolutePath.endsWith('.txt'),
           debounce: Duration.millis(100),
-        }).pipe(Stream.runForEach((batch) => Queue.offer(batches, batch)), Effect.forkChild)
+        }).pipe(
+          Stream.runForEach((batch) => Queue.offer(batches, batch)),
+          Effect.forkChild,
+        )
 
         // Let the watcher settle before writing (fs.watch registration is
         // asynchronous; events fired before it lands are not delivered).
@@ -82,7 +87,10 @@ Vitest.describe('watchScoped', () => {
           roots: [rootA, rootB],
           scope: new Set([watchedFile]),
           debounce: Duration.millis(100),
-        }).pipe(Stream.runForEach((batch) => Queue.offer(batches, batch)), Effect.forkChild)
+        }).pipe(
+          Stream.runForEach((batch) => Queue.offer(batches, batch)),
+          Effect.forkChild,
+        )
 
         yield* Effect.sleep(Duration.millis(200))
 


### PR DESCRIPTION
Contraction of the last effect-4 migration design item (rc111-followups item 4; alignment-register `filesystem-watch-recursive-option-removed`). Applies `context/effect-4/watch-recursion-experiments.md`.

## Change
- **@overeng/utils**: new shared `watchScoped` helper (`src/node/watch.ts`) — scoped FileSystem watch with explicit `{ recursive }`, scope filtering, burst dedup, and deterministic error propagation.
- **genie**: watch mode embraces recursion via `watchScoped` — fixes latent nested-genie-file blindness, coalesces regeneration passes (~250ms window); watch-stream errors now surface through the TUI Error action instead of silently killing the stream.
- **notion-md**: batch watch collapses N per-directory watchers into ONE recursive common-root watcher; single-file watch pins `{ recursive: false }` with exact-path filter preserved. Debounce/coalesce untouched.
- Semaphore backing (`file-system-backing.ts`) migrated to the helper with error-swallow semantics preserved.

Failure semantics per consumer documented in the commit. Register entry moved OPEN DESIGN WORK → APPLIED/RESOLVED.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | unknown |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.0.3 |
| `agent_runtime` | OMP 18.0.3 |
| `tooling_profile` | dotfiles@929dc21 |
</details>
<!-- agent-footer:end -->