### PR TITLE
feat(effect-rpc-tanstack): conservative client request-id validation policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- **@overeng/effect-rpc-tanstack**: client request-id policy — `layerClient`
+  now validates outgoing RPC request ids at the client boundary. Non-empty
+  strings and non-negative, finite numbers/bigints are accepted (v4 interop);
+  malformed ids fail with the new typed `InvalidRequestIdError` instead of
+  reaching the wire (`validateRequestId` is exported for direct use). See
+  `rpc-request-id-policy` in `context/effect-4/alignment-register.md`.
 - **Repository-wide**: atomic Effect 4 cohort flip to `effect@4.0.0-rc.111`
   (with `@effect/platform-node`, `@effect/vitest`, `@effect/opentelemetry`,
   `@effect/atom-react`, all rc.111). Platform, CLI, RPC, Schema, AI, Cluster,

--- a/context/effect-4/alignment-register.md
+++ b/context/effect-4/alignment-register.md
@@ -212,6 +212,22 @@
   `patterns/rpc-payload-codecs/scenario.json`; payload bytes and decoded handler values are
   otherwise identical.
 
+## rpc-request-id-policy
+
+- **Difference:** v3 RPC request ids were BigInt-only; v4 accepts string or
+  numeric ids on the wire and echoes them back opaquely.
+- **Decision:** accept both shapes for v4 interop, but validate at the client
+  boundary: non-empty strings and non-negative, finite numbers or bigints are
+  accepted; anything else fails with `InvalidRequestIdError` instead of
+  passing through to the wire. Server-side handling stays permissive. Envelope
+  versioning for persisted ids remains under `rpc-failure-cause-wire-shape`.
+- **Blast radius:** outgoing client envelopes in `@overeng/effect-rpc-tanstack`
+  (`layerClient`); custom `generateRequestId` implementations that emit
+  malformed ids now fail loudly.
+- **Status:** DECIDED — enforced by the `layerClient` serialization wrapper
+  (`validateRequestId`); wire acceptance of both shapes characterized in
+  `rpc-wire-baseline.test.ts`.
+
 ## browser-testing-barrel
 
 - **Difference:** a static re-export from v4 `effect/testing` reaches

--- a/context/effect-4/rc111-followups.md
+++ b/context/effect-4/rc111-followups.md
@@ -24,8 +24,12 @@ owner decision or upstream movement before/with test-suite convergence.
 ## Wire/format decisions recorded during migration
 
 6. **RPC string request IDs accepted** — v3 rejected non-BigInt ids; wire
-   baseline updated. Client-side id validation policy remains open. Envelope
-   versioning is now governed by the recorded mixed-major contract decision on
+   baseline updated. Client-side id validation policy RESOLVED: conservative
+   policy implemented in `@overeng/effect-rpc-tanstack` — non-empty strings and
+   non-negative numbers/bigints are accepted at the client boundary; anything
+   else fails with `InvalidRequestIdError` instead of reaching the wire
+   (`rpc-request-id-policy` in alignment-register.md). Envelope versioning
+   remains governed by the recorded mixed-major contract decision on
    `rpc-failure-cause-wire-shape` (alignment-register.md, issue #1115): the
    runtime versioned gate is deferred and mixed-major `effect-rpc-tanstack`
    deployment is out of contract until it lands.

--- a/packages/@overeng/effect-rpc-tanstack/src/client.test.ts
+++ b/packages/@overeng/effect-rpc-tanstack/src/client.test.ts
@@ -1,8 +1,13 @@
-import { Effect, Schema, Stream } from 'effect'
-import { Rpc, RpcGroup, RpcClient } from 'effect/unstable/rpc'
+import { Cause, Effect, Exit, Schema, Stream } from 'effect'
+import { type RpcMessage, Rpc, RpcGroup, RpcClient } from 'effect/unstable/rpc'
 import { describe, expect, it, vi } from 'vitest'
 
-import { layerClient, fetchFromWebHandler } from './client.ts'
+import {
+  fetchFromWebHandler,
+  InvalidRequestIdError,
+  layerClient,
+  validateRequestId,
+} from './client.ts'
 import { makeHandler } from './server.ts'
 
 describe('effect-rpc-tanstack client', () => {
@@ -90,6 +95,83 @@ describe('effect-rpc-tanstack client', () => {
       )
 
       expect(numbers).toEqual([1, 2, 3])
+    } finally {
+      await dispose()
+    }
+  })
+})
+
+describe('client request-id policy', () => {
+  it('accepts non-empty string ids', () => {
+    expect(validateRequestId('req-1')).toBe('req-1')
+  })
+
+  it('accepts non-negative number and bigint ids', () => {
+    expect(validateRequestId(1)).toBe(1)
+    expect(validateRequestId(1n)).toBe(1n)
+    expect(validateRequestId(0n)).toBe(0n)
+  })
+
+  it('rejects empty string ids with a typed error', () => {
+    try {
+      validateRequestId('')
+      throw new Error('expected validateRequestId to throw')
+    } catch (error) {
+      expect(error).toBeInstanceOf(InvalidRequestIdError)
+      expect((error as InvalidRequestIdError)._tag).toBe('InvalidRequestIdError')
+      expect((error as InvalidRequestIdError).id).toBe('')
+    }
+  })
+
+  it('rejects negative bigint ids with a typed error', () => {
+    try {
+      validateRequestId(-1n)
+      throw new Error('expected validateRequestId to throw')
+    } catch (error) {
+      expect(error).toBeInstanceOf(InvalidRequestIdError)
+      expect((error as InvalidRequestIdError).id).toBe(-1n)
+    }
+  })
+
+  it('fails requests whose generated id violates the policy instead of sending them', async () => {
+    const GetGreeting = Rpc.make('GetGreeting', {
+      payload: {},
+      success: Schema.String,
+      error: Schema.Never,
+    })
+
+    const Api = RpcGroup.make(GetGreeting)
+    const handlers = Api.toLayer(
+      Effect.succeed(
+        Api.of({
+          GetGreeting: () => Effect.succeed('hello'),
+        }),
+      ),
+    )
+
+    const { handler, dispose } = makeHandler({
+      group: Api,
+      handlerLayer: handlers,
+    })
+
+    const fetch = vi.fn(fetchFromWebHandler(handler))
+
+    try {
+      const exit = await Effect.gen(function* () {
+        const client = yield* RpcClient.make(Api, {
+          generateRequestId: () => '' as RpcMessage.RequestId,
+        })
+        return yield* client.GetGreeting({})
+      }).pipe(
+        Effect.provide(layerClient({ url: 'http://localhost/api/rpc', fetch })),
+        Effect.scoped,
+        Effect.exit,
+        Effect.runPromise,
+      )
+
+      expect(fetch).not.toHaveBeenCalled()
+      const defect = Exit.isFailure(exit) === true ? Cause.squash(exit.cause) : undefined
+      expect(defect).toBeInstanceOf(InvalidRequestIdError)
     } finally {
       await dispose()
     }

--- a/packages/@overeng/effect-rpc-tanstack/src/client.ts
+++ b/packages/@overeng/effect-rpc-tanstack/src/client.ts
@@ -4,10 +4,13 @@
  * @since 0.1.0
  */
 
-import { Layer } from 'effect'
+import { Data, Layer } from 'effect'
+import * as Context from 'effect/Context'
 import * as FetchHttpClient from 'effect/unstable/http/FetchHttpClient'
 import type * as HttpClient from 'effect/unstable/http/HttpClient'
-import { RpcClient, RpcSerialization } from 'effect/unstable/rpc'
+import { type RpcMessage, RpcClient, RpcSerialization } from 'effect/unstable/rpc'
+
+type SerializationService = Context.Service.Shape<typeof RpcSerialization.RpcSerialization>
 
 type FetchLike = typeof globalThis.fetch
 
@@ -47,12 +50,80 @@ export const fetchFromWebHandler = (
 }
 
 /**
+ * Typed error raised when an outgoing RPC request id violates the client id
+ * policy (see `validateRequestId`).
+ */
+export class InvalidRequestIdError extends Data.TaggedError('InvalidRequestIdError')<{
+  readonly id: unknown
+}> {
+  override get message(): string {
+    return `Invalid RPC request id: ${String(this.id)}`
+  }
+}
+
+/**
+ * Client request-id policy. v3 required BigInt request ids; v4 accepts
+ * string or numeric ids and echoes them back opaquely, so both shapes are
+ * accepted for interop. Valid ids are non-empty strings and non-negative,
+ * finite numbers or bigints; anything else raises `InvalidRequestIdError`
+ * instead of reaching the wire.
+ */
+export const validateRequestId = (id: unknown): RpcMessage.RequestId => {
+  if (
+    (typeof id === 'string' && id.length > 0) ||
+    (typeof id === 'number' && Number.isFinite(id) === true && id >= 0) ||
+    (typeof id === 'bigint' && id >= 0)
+  ) {
+    return id as RpcMessage.RequestId
+  }
+  throw new InvalidRequestIdError({ id })
+}
+
+const isRequestEncoded = (
+  message: unknown,
+): message is { readonly _tag: 'Request'; readonly id: unknown } =>
+  typeof message === 'object' && message !== null && '_tag' in message && message._tag === 'Request'
+
+const withRequestIdPolicy = (serialization: SerializationService): SerializationService =>
+  // `RpcSerialization.of` exists only in the rc.111 sources, not the compiled
+  // package, so the wrapped plain object is asserted to the nominal Service
+  // shape; its members are checked against the parameter above.
+  ({
+    contentType: serialization.contentType,
+    includesFraming: serialization.includesFraming,
+    makeUnsafe: () => {
+      const parser = serialization.makeUnsafe()
+      return {
+        decode: parser.decode,
+        encode: (message: unknown) => {
+          if (isRequestEncoded(message) === true) {
+            validateRequestId(message.id)
+          }
+          return parser.encode(message)
+        },
+      }
+    },
+  }) as unknown as SerializationService
+
+const requestIdPolicyLayer = (
+  base: Layer.Layer<RpcSerialization.RpcSerialization, never, never>,
+): Layer.Layer<RpcSerialization.RpcSerialization, never, never> =>
+  Layer.flatMap(base, (context) =>
+    Layer.succeed(
+      RpcSerialization.RpcSerialization,
+      withRequestIdPolicy(Context.get(context, RpcSerialization.RpcSerialization)),
+    ),
+  )
+
+/**
  * Creates an RpcClient.Protocol layer that uses the Effect HTTP RPC protocol.
  */
 export const layerClient: (
   options: ClientLayerOptions,
 ) => Layer.Layer<RpcClient.Protocol, never, never> = (options) => {
-  const serializationLayer = options.serializationLayer ?? RpcSerialization.layerNdjson
+  const serializationLayer = requestIdPolicyLayer(
+    options.serializationLayer ?? RpcSerialization.layerNdjson,
+  )
   const httpClientLayer =
     options.httpClientLayer ??
     FetchHttpClient.layer.pipe(


### PR DESCRIPTION
Records and enforces the client-side request-id validation policy left open by the rc.111 wire-format migration (rc111-followups item 6).

## Policy (now decided)
Request ids: non-empty strings and non-negative finite numbers/bigints are accepted (v3 BigInt interop + v4 string ids). Anything else throws a typed `InvalidRequestIdError` at the client boundary instead of reaching the wire.

## Change
- `validateRequestId` exported from client.ts; `layerClient` wraps the configured RpcSerialization parser to validate every outgoing request envelope before encoding.
- Server side untouched; wire-baseline snapshots unchanged.
- 5 new client tests; docs record the decision in rc111-followups + alignment register.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | unknown |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.0.3 |
| `agent_runtime` | OMP 18.0.3 |
| `tooling_profile` | dotfiles@929dc21 |
</details>
<!-- agent-footer:end -->