### PR TITLE
Anchor StyleX semantic tokens to named scales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,11 @@ All notable changes to this project will be documented in this file.
   publication build emits that reset and compiled component rules together.
   Byte-identical markup baselines were regenerated with hashed StyleX class names.
 
+- **@overeng/effect-schema-form-aria**: anchor semantic color defaults to named
+  Tailwind-compatible palette steps (`neutral900`, the gray scale, and
+  `blue500`) instead of raw hex values. This intentionally updates rendered
+  colors while leaving component token usage unchanged.
+
 - **@overeng/effect-rpc-tanstack**: client request-id policy — `layerClient`
   now validates outgoing RPC request ids at the client boundary. Non-empty
   strings and non-negative, finite numbers/bigints are accepted (v4 interop);

--- a/packages/@overeng/effect-schema-form-aria/README.md
+++ b/packages/@overeng/effect-schema-form-aria/README.md
@@ -163,7 +163,7 @@ import { tokens } from '@overeng/effect-schema-form-aria'
 import '@overeng/effect-schema-form-aria/styles.css'
 ```
 
-The default semantic color values intentionally match the previous Tailwind implementation.
+The default semantic colors are anchored to named Tailwind-compatible palette steps. This intentionally changes some rendered colors from the previous Tailwind implementation while keeping palette choices behind the semantic `tokens` contract.
 
 ## Custom Renderers
 

--- a/packages/@overeng/effect-schema-form-aria/src/tokens.stylex.ts
+++ b/packages/@overeng/effect-schema-form-aria/src/tokens.stylex.ts
@@ -1,21 +1,21 @@
 import * as stylex from '@stylexjs/stylex'
+import { colors } from 'tailwind-stylex/tokens.stylex'
 
 /**
  * Semantic design tokens for effect-schema-form-aria.
  *
- * Components consume only these semantic names — never raw colors or sizes.
- * Raw scales (spacing, radii, fontSizes) come from tailwind-stylex; re-anchoring
- * these defaults onto named scale steps is a follow-up design decision that
- * must not require component changes.
+ * Components consume semantic names rather than palette steps. Defaults use
+ * named design-system scale values so unconstrained raw colors are not the
+ * easiest path.
  */
 export const tokens = stylex.defineVars({
-  ink: '#1a1a1a',
-  'subtle-ink': '#6b7280',
-  'muted-ink': '#9ca3af',
-  border: '#e5e7eb',
-  input: '#ffffff',
-  surface: '#f9fafb',
-  'surface-raised': '#f3f4f6',
-  primary: '#3b82f6',
-  accent: '#3b82f6',
+  ink: colors.neutral900,
+  'subtle-ink': colors.gray500,
+  'muted-ink': colors.gray400,
+  border: colors.gray200,
+  input: colors.white,
+  surface: colors.gray50,
+  'surface-raised': colors.gray100,
+  primary: colors.blue500,
+  accent: colors.blue500,
 })


### PR DESCRIPTION
## Problem

PR #1152 intentionally preserves the legacy arbitrary hex defaults so the migration can enforce pixel identity. The resulting semantic names are constrained, but their default values still do not derive from a design-system scale — the inconsistency-by-default problem Devon Govett called out.

## Goal

Anchor every semantic color default to a named Tailwind-compatible scale constant without changing component code.

## Decisions

- Use `neutral900` for primary ink; use the Tailwind gray scale for secondary ink, borders, and surfaces.
- Use `blue500` for primary and accent.
- Keep semantic names (`ink`, `surface`, `primary`, etc.) as the component contract; palette steps remain an implementation detail.
- Keep this intentional visual change separate from the pixel-identical migration in PR #1152.

## Verification

- `devenv tasks run check:all --no-tui` — exit 0.
- Package Vitest: 7/7 passed.
- Storybook production build: exit 0.
- Visual review artifact: https://effect-utils-stylex-anchor.scratch.schickling.dev
- 39/39 stories measured: 137,988 changed pixels total; all before/after root dimensions are identical (color-only change, no layout/root-geometry change).

## Complexity

No new abstraction. One token module replaces nine raw values with named scale constants.

## Concerns

This PR intentionally changes pixels. It must be judged against the visual review artifact rather than expected to match the legacy baseline.

## Friction & bottlenecks

None specific to this PR.

## Follow-ups

- Next stacked PR: extract `@overeng/stylex-preset`, vendor the MIT Tailwind token scales, and remove `tailwind-stylex`.

## References

- Depends on #1152.
- Devon Govett's design-system constraint argument: https://x.com/devongovett/status/2092278233899172112

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | unknown |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.0.3 |
| `agent_runtime` | OMP 18.0.3 |
| `tooling_profile` | dotfiles@38d88c4-dirty |
</details>
<!-- agent-footer:end -->