### PR TITLE
fix(notion-react): reconcile recursive cache identities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -249,10 +249,14 @@ violations }` (the offending `DiffOp[]`); block ops and page content
 
 ### Fixed
 
-- **@overeng/notion-react**: verify warm-cache block identities recursively,
-  including nested blocks and child-page scopes. A stale nested cache now
-  reconciles untracked live descendants instead of appending duplicates, and
-  the persisted `CacheTree` exactly reflects the identities left live.
+- **@overeng/notion-react**: verify warm-cache block identities recursively
+  through renderer-owned nested blocks and child-page scopes. A stale nested
+  cache now reconciles untracked live descendants instead of appending
+  duplicates, while opaque synced-block children remain untouched. Promised
+  but transiently empty child lists retry and fail closed on exhaustion;
+  recursive and retry requests are reflected exactly in retrieve metrics and
+  `SyncEnd.opCount`. The persisted `CacheTree` exactly reflects the identities
+  left live and an immediate identical sync emits zero mutations.
 - **Nix prepared dependencies**: normalize ordinary, non-injected local
   `file:` packages through pnpm's exact package-map locator before removing
   transient Source Input aliases. Restored CLI workspaces now resolve the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -255,8 +255,10 @@ violations }` (the offending `DiffOp[]`); block ops and page content
   duplicates, while opaque synced-block children remain untouched. Promised
   but transiently empty child lists retry and fail closed on exhaustion;
   recursive and retry requests are reflected exactly in retrieve metrics and
-  `SyncEnd.opCount`. The persisted `CacheTree` exactly reflects the identities
-  left live and an immediate identical sync emits zero mutations.
+  `SyncEnd.opCount`. Cached child pages moved out of band between renderer-owned
+  parents retain their durable page ID, key, and subtree instead of being
+  archived and recreated. The persisted `CacheTree` exactly reflects the
+  identities left live and an immediate identical sync emits zero mutations.
 - **Nix prepared dependencies**: normalize ordinary, non-injected local
   `file:` packages through pnpm's exact package-map locator before removing
   transient Source Input aliases. Restored CLI workspaces now resolve the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
+
 - **@overeng/utils, @overeng/genie, @overeng/notion-md**: apply the watch-recursion
   design study for effect@4.0.0-rc.111 (recursion is opt-in again). New
   `watchScoped` helper in `@overeng/utils/node` wraps `FileSystem.watch` with an
@@ -133,6 +134,7 @@ All notable changes to this project will be documented in this file.
   `NotionThrottleShape`) instead of the tag name.
 
 ### Added
+
 - **@overeng/utils-dev**: add a shared `normalizeCliOutput` helper at the
   `./cli-contract` export for CLI contract baselines. Each masking policy
   (ANSI, log timestamps, checkout root, local-source suffix) is an explicit
@@ -247,6 +249,10 @@ violations }` (the offending `DiffOp[]`); block ops and page content
 
 ### Fixed
 
+- **@overeng/notion-react**: verify warm-cache block identities recursively,
+  including nested blocks and child-page scopes. A stale nested cache now
+  reconciles untracked live descendants instead of appending duplicates, and
+  the persisted `CacheTree` exactly reflects the identities left live.
 - **Nix prepared dependencies**: normalize ordinary, non-injected local
   `file:` packages through pnpm's exact package-map locator before removing
   transient Source Input aliases. Restored CLI workspaces now resolve the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -255,10 +255,12 @@ violations }` (the offending `DiffOp[]`); block ops and page content
   duplicates, while opaque synced-block children remain untouched. Promised
   but transiently empty child lists retry and fail closed on exhaustion;
   recursive and retry requests are reflected exactly in retrieve metrics and
-  `SyncEnd.opCount`. Cached child pages moved out of band between renderer-owned
-  parents retain their durable page ID, key, and subtree instead of being
-  archived and recreated. The persisted `CacheTree` exactly reflects the
-  identities left live and an immediate identical sync emits zero mutations.
+  `SyncEnd.opCount`. Unambiguously keyed child pages moved out of band between
+  renderer-owned parents retain their durable page ID, key, and subtree instead
+  of being archived and recreated; destination-scope key collisions take the
+  safe rebuild fallback instead of producing an invalid cache. The persisted
+  `CacheTree` exactly reflects the identities left live and an immediate
+  identical sync emits zero mutations.
 - **Nix prepared dependencies**: normalize ordinary, non-injected local
   `file:` packages through pnpm's exact package-map locator before removing
   transient Source Input aliases. Restored CLI workspaces now resolve the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -258,7 +258,9 @@ violations }` (the offending `DiffOp[]`); block ops and page content
   `SyncEnd.opCount`. Unambiguously keyed child pages moved out of band between
   renderer-owned parents retain their durable page ID, key, and subtree instead
   of being archived and recreated; destination-scope key collisions take the
-  safe rebuild fallback instead of producing an invalid cache. The persisted
+  safe rebuild fallback instead of producing an invalid cache. Independent
+  page-order retention is likewise limited to child-page scopes; root and
+  ordinary-block child scopes keep full mixed-kind ordering. The persisted
   `CacheTree` exactly reflects the identities left live and an immediate
   identical sync emits zero mutations.
 - **Nix prepared dependencies**: normalize ordinary, non-injected local

--- a/packages/@overeng/notion-react/docs/vrs/.experiments/0005-recursive-cache-drift-recovery.md
+++ b/packages/@overeng/notion-react/docs/vrs/.experiments/0005-recursive-cache-drift-recovery.md
@@ -1,0 +1,74 @@
+# Experiment: recursive cache-drift recovery
+
+- **Date:** 2026-08-28
+- **Related:** R04, R16, R18, R38, T14
+
+## Question
+
+Can recursive renderer-owned identity observation recover an interrupted
+nested sync without duplicate appends while remaining safe at opaque and
+temporarily unreadable child scopes?
+
+## Hypothesis
+
+A warm preflight that observes only root identities cannot safely recover after
+nested mutations land but their checkpoint does not. Recursively observing
+renderer-owned identity scopes, then merging live and cached metadata by block
+id, should reconcile the already-live descendants without duplicate appends,
+return an exact CacheTree, and reach the zero-mutation fixpoint immediately.
+Opaque provider-owned scopes and ambiguous promised-empty reads must remain
+outside drift classification.
+
+## Method
+
+A captured interrupted-sync shape was replayed with a stale CacheTree containing
+17 identities against a live renderer-owned tree containing 22. The candidate
+also contained the 22 intended identities. The old root-only preflight and the
+recursive recovery path were each run through the ordinary diff, mutation, and
+checkpoint pipeline; live and cached identity counts were recorded after the
+run and after one identical follow-up sync.
+
+Focused mock probes exercised two boundary cases:
+
+1. a `<SyncedBlock>` reporting `has_children: true` with inherited source
+   content, while its renderer cache node intentionally had no descendants;
+2. a renderer-owned `column_list` reporting `has_children: true` whose first
+   child-list response was transiently empty, followed by the complete list.
+   Request events, metrics, and final `SyncEnd.opCount` were compared with the
+   fake HTTP request log.
+
+## Result
+
+The stale input was cache 17 / live 22. The old shallow path appended five
+already-live descendants, producing live 27 while returning cache 22; the
+returned cache therefore looked complete but did not describe the server. The
+recursive path represented untracked live identities as temporary drift ghosts,
+removed or reconciled those ghosts through the normal diff, stripped them from
+all checkpoints, and returned an exact cache 22 matching live 22. An immediate
+identical sync emitted zero mutations.
+
+The opaque-scope probe performed no nested read, classified no drift, emitted
+no mutation, and left inherited synchronized content untouched. The
+promised-empty probe retried the list, consumed the later complete response,
+and also emitted zero mutations. Every root, nested, retry, and pagination
+request produced its own retrieve event pair and contributed one to metrics and
+`SyncEnd.opCount`.
+
+## Conclusion
+
+Recursive identity observation is required for safe warm recovery, but only
+inside renderer-owned scopes. A positive traversal boundary prevents inherited
+synced content from becoming destructive drift, and bounded retry with
+fail-closed exhaustion prevents an ambiguous empty response from becoming
+replacement appends. Exact per-request accounting makes T14's added read cost
+observable rather than hidden.
+
+## VRS Impact
+
+R04 now requires complete returned and persisted identity coverage at every
+renderer-owned depth and an immediate zero-mutation resync. R38 replaces the
+shallow live-plan contract with recursive owned-scope observation while keeping
+`cache-only` blind. T14 accepts the additional recursive and retry reads. The
+spec defines `identityTreeDrifted`, `driftedBase`, the internal drift-ghost
+lifecycle, opaque traversal boundaries, promised-nonempty settle behavior, and
+per-request telemetry. Vision and ontology are unchanged.

--- a/packages/@overeng/notion-react/docs/vrs/requirements.md
+++ b/packages/@overeng/notion-react/docs/vrs/requirements.md
@@ -45,8 +45,7 @@ host-config, or cache are implemented (see [spec.md](./spec.md) for that).
   `NotionConfig` + `HttpClient` in their runtime.
 - **A03 React 19 + react-reconciler:** Rendering uses `react@19` and
   `react-reconciler` as the host-config target. The library pins both
-  versions and manages upgrades explicitly per
-  [react-derisk-report](../../../../../context/pixeltrail/notion-page-sync/react-derisk-report.md).
+  versions and manages upgrades explicitly as scheduled compatibility work.
 - **A04 Single-writer page region:** The portion of the page reconciled by
   this library is treated as solely owned by the renderer. Human edits
   inside that region may be overwritten.
@@ -128,6 +127,12 @@ host-config, or cache are implemented (see [spec.md](./spec.md) for that).
   (rejected by R40) or refusing every tree containing an upload. Like
   T11/T12, an adoption has no snapshot isolation — it is advisory for
   the observed window, and the next `sync()` recomputes from scratch.
+- **T14 Recursive warm preflight reads:** Live warm-cache preflight may issue
+  one children-list request per renderer-owned nested block or child-page
+  scope, plus pagination and bounded settle retries. The additional reads are
+  accepted because shallow observation can duplicate nested appends and
+  persist poisoned checkpoints after interrupted syncs; telemetry must account
+  for every request exactly.
 
 ## Requirements
 
@@ -150,8 +155,11 @@ host-config, or cache are implemented (see [spec.md](./spec.md) for that).
 
 ### Must sync op-minimally
 
-- **R04 Idempotent resync:** Re-rendering the identical JSX tree against
-  the same cache must emit zero Notion API mutations.
+- **R04 Idempotent resync:** After every successful sync, the returned and
+  persisted `CacheTree` must contain every identity created or adopted at every
+  renderer-owned depth and child-page scope. Re-rendering the identical JSX
+  tree against that cache must emit zero Notion API mutations immediately,
+  without requiring a repair sync.
 - **R05 Single-prop change → single update:** A change to exactly one
   block's projected payload must produce exactly one `update` op.
 - **R06 Single sibling insert/remove → single op:** A single sibling
@@ -293,11 +301,12 @@ host-config, or cache are implemented (see [spec.md](./spec.md) for that).
   oracle: immediately after a successful `sync()` of the same element,
   `plan()` must return zero ops.
 - **R38 Plan staleness is explicit:** The default `'live'` staleness
-  mirrors sync's shallow pre-flight with read-only calls and detects
-  out-of-band top-level drift; `'cache-only'` issues zero requests and
-  is a pure function of cache + JSX. The blind spots of `'cache-only'`
-  (out-of-band drift, cold-`'clean'` baseline removes, pending-marker
-  resolution) must be documented, not silently approximated.
+  recursively observes identity through renderer-owned nested block scopes and
+  child-page scopes and detects out-of-band drift at every observed depth;
+  opaque provider-owned scopes are traversal boundaries. `'cache-only'` issues
+  zero requests and is a pure function of cache + JSX. Its blind spots
+  (out-of-band drift at every depth, cold-`'clean'` baseline removes, and
+  pending-marker resolution) must be documented, not silently approximated.
 
 ### Must verify server state against intent
 

--- a/packages/@overeng/notion-react/docs/vrs/spec.md
+++ b/packages/@overeng/notion-react/docs/vrs/spec.md
@@ -499,33 +499,80 @@ Third-party backends (SQLite, Redis, …) implement `NotionCache` directly
 
 ## Fallback decision table (R16)
 
-| Trigger                                             | Behaviour                                                      | `fallbackReason`     |
-| --------------------------------------------------- | -------------------------------------------------------------- | -------------------- |
-| No cache file                                       | Cold diff against empty tree                                   | `"cold-cache"`       |
-| `FsCache` persisted schema mismatch                 | `FsCache.load` returns `undefined`; sync runs cold diff        | `"cold-cache"`       |
-| Prior tree `schemaVersion !== CACHE_SCHEMA_VERSION` | Abort stale-tree diff from backends that return old trees      | `"schema-mismatch"`  |
-| Cache `rootId !== opts.pageId`                      | Cold diff against empty tree                                   | `"page-id-drift"`    |
-| `NotionBlocks.update` returns 404/archived          | Emit structural rebuild of that subtree                        | `"block-missing"`    |
-| Cached page id → `pages.retrieve` 404               | Drop cached subtree, recreate if JSX has it, else no-op        | `"page-missing"`     |
-| Cached page id is archived on server                | Treat as removed; if JSX still has `<ChildPage>`, create fresh | `"page-archived"`    |
-| Post-create inline retrieval or later work fails    | Preserve identity checkpoint; retry adopts live inline ids     | n/a (original error) |
-| Diff produces malformed op-plan (invariant break)   | Abort; propagate `NotionSyncError`                             | n/a (error)          |
+| Trigger                                             | Behaviour                                                                   | `fallbackReason`     |
+| --------------------------------------------------- | --------------------------------------------------------------------------- | -------------------- |
+| No cache file                                       | Cold diff; `'clean'` first represents live roots as removable ghosts        | `"cold-cache"`       |
+| `FsCache` persisted schema mismatch                 | `FsCache.load` returns `undefined`; sync runs the no-cache path             | `"cold-cache"`       |
+| Prior tree `schemaVersion !== CACHE_SCHEMA_VERSION` | Diff against the prior identity-bearing tree without recursive preflight    | `"schema-mismatch"`  |
+| Cache `rootId !== opts.pageId`                      | Use the no-cache path for the requested page                                | `"page-id-drift"`    |
+| Warm recursive identity tree differs from cache     | Diff against `driftedBase(live, prior)` at every observed owned scope       | `"cache-drift"`      |
+| Promised-nonempty children stay empty after retries | Abort before drift classification or mutation; preserve the prior cache     | n/a (typed error)    |
+| Opaque block reports inherited children             | Stop traversal at the opaque block; inherited content is not renderer-owned | n/a                  |
+| `NotionBlocks.update` returns 404/archived          | Emit structural rebuild of that subtree                                     | `"block-missing"`    |
+| Cached page id → `pages.retrieve` 404               | Drop cached subtree, recreate if JSX has it, else no-op                     | `"page-missing"`     |
+| Cached page id is archived on server                | Treat as removed; if JSX still has `<ChildPage>`, create fresh              | `"page-archived"`    |
+| Post-create inline retrieval or later work fails    | Preserve identity checkpoint; retry adopts live inline ids                  | n/a (original error) |
+| Diff produces malformed op-plan (invariant break)   | Abort; propagate `NotionSyncError`                                          | n/a (error)          |
 
-v0.1 implements `cold-cache`, `schema-mismatch`, and `page-id-drift`
-(via a pre-flight `NotionBlocks.retrieve(cache.rootId)`). `block-missing`
-is a v0.2 addition — under v0.1, a 404 on a cache-referenced block
-propagates as a `NotionSyncError`. Callers receive the reason on the
-`SyncResult`.
+`block-missing` remains a later apply-time refinement; a 404 on a
+cache-referenced block currently propagates as `NotionSyncError`. Every
+implemented fallback reason is returned on `SyncResult`.
+
+## Recursive identity preflight (R04, R16, R18, R38, T14)
+
+```text
+children list (root)
+  → renderer-owned block/page scopes
+      → identityTreeDrifted(prior, live)
+          ├─ equal   → diff(prior, candidate)
+          └─ drifted → diff(driftedBase(live, prior), candidate)
+                         → strip drift ghosts before every checkpoint
+```
+
+`sync()` and live `plan()` share `retrieveLiveIdentities`,
+`identityTreeDrifted`, `driftedBase`, and `selectDiffBase`.
+`retrieveLiveIdentities` builds an ordered tree of `{ blockId, type,
+children }`. Root and ordinary block children compare in server order.
+Children under a `child_page` scope compare by block id because page-scoped
+application may interleave block and page work.
+Traversal uses a positive ownership boundary. It descends through the
+renderer-owned child-bearing wire types (paragraph, toggleable headings, list
+items, to-do, toggle, quote, callout, table, column-list, and column) when the
+response reports children, and always opens a `child_page` scope. It does not
+descend through opaque passthrough wire types such as `synced_block`,
+`template`, `link_preview`, `child_database`, or `breadcrumb`. In particular,
+a `<SyncedBlock>` may report `has_children: true` for content inherited from
+its synchronization source; those descendants are source-owned and must never
+become removals or cache entries in this renderer's tree.
+
+Each children-list pagination page is one physical request. If a parent
+response promised `has_children: true` but the complete child list is empty,
+the whole list is retried on the bounded settle schedule (500 ms exponential
+backoff at factor 1.5, up to four retries). Exhaustion fails closed with
+`NotionSyncError { reason: 'children-not-yet-visible' }`; neither
+`identityTreeDrifted` nor `diff` runs against the ambiguous empty observation.
+
+When identities drift, `driftedBase` recursively indexes prior siblings by
+`blockId`. A still-live node keeps all known cache metadata (`key`, hashes,
+node kind, page metadata, and pending state) while its children are merged by
+the same rule. An untracked live node becomes an in-memory **drift ghost**:
+it carries the live block id/type but a synthetic `drift:<blockId>` key and
+empty hash, so the ordinary diff can reconcile or remove it. Drift ghosts are
+stripped recursively when initializing the working cache and before every
+checkpoint; only identities confirmed by successful operations can repopulate
+the persisted and returned `CacheTree`.
+
+Telemetry is accounted at the physical-request boundary. Every pagination
+page and every settle retry increments `opCount` once and emits its own
+`OpIssued` followed by `OpSucceeded` or `OpFailed`, all with kind
+`'retrieve'`. `SyncMetrics.actualOps.retrieve`, aggregate OER, and
+`SyncEnd.opCount` therefore include the full recursive read volume rather than
+one synthetic count for the tree walk.
 
 ## plan() — read-only companion (R37–R38)
 
-`sync()`'s pre-flight is factored into shared module-level helpers —
-`resolvePendingPages` (pending-marker adoption), `topLevelDrifted`
-(shallow drift detection), `selectDiffBase` (cold/warm/drift base
-selection incl. the fallback decision table above), and
-`rootPageUpdateOpFor` (the root title/icon/cover `updatePage` that
-`sync()` applies _outside_ its internal diff). `plan()` composes the
-same helpers with `diff()` and returns without applying:
+`plan()` composes the same preflight helpers with `diff()` and
+`rootPageUpdateOpFor` and returns without applying:
 
 ```ts
 interface SyncPlan {
@@ -537,28 +584,23 @@ interface SyncPlan {
 }
 ```
 
-Including the root `updatePage` in `ops` is load-bearing: without it
-the empty-plan fixpoint oracle would miss root metadata drift (an icon
-change plans as exactly one `pages.update`, matching what `sync()`
-applies).
+Including the root `updatePage` in `ops` is load-bearing: without it the
+empty-plan fixpoint oracle would miss root metadata drift.
 
-Staleness (R38, T11):
+Staleness (R38, T11, T14):
 
-- **`'live'` (default):** mirrors sync's shallow pre-flight — one
-  top-level children GET plus in-memory pending-marker adoption (never
-  persisted; plan() writes nothing). Detects out-of-band appends as
-  `fallbackReason: 'cache-drift'`. The plan can still go stale before a
-  later `sync()` (T11) — sync recomputes, so the applied result cannot.
-- **`'cache-only'`:** a pure function of cache + JSX, zero requests.
-  Blind to anything only the server knows: out-of-band drift, the
-  cold-`'clean'` baseline sweep (needs the live child list to plan its
-  removes), and pending-marker resolution.
+- **`'live'` (default):** performs the recursive renderer-owned identity
+  preflight above plus in-memory pending-marker adoption (never persisted by
+  `plan()`). It detects nested and child-page drift and reports
+  `fallbackReason: 'cache-drift'`. It remains an observation without snapshot
+  isolation; `sync()` recomputes before applying.
+- **`'cache-only'`:** is a pure function of cache + JSX and issues zero
+  requests. It is blind to server-only state at every depth, the
+  cold-`'clean'` baseline sweep, and pending-marker resolution.
 
-`onEvent` reuses the `SyncEvent` union for the read-only prefix: the
-`'live'` GET emits `OpIssued`/`OpSucceeded`/`OpFailed` with kind
-`'retrieve'`, and the computed plan emits one `PlanComputed`. No
-`SyncStart`/`SyncEnd`/`CacheOutcome` — plan probes must not skew
-cache-efficiency or sync-duration metrics aggregated across real syncs.
+Live plan requests emit the same per-request retrieve events as sync, followed
+by one `PlanComputed`. Plan emits no `SyncStart`, `SyncEnd`, or `CacheOutcome`,
+so plan probes do not skew sync-duration or cache-efficiency aggregates.
 
 ## Readback oracle (R39–R40)
 

--- a/packages/@overeng/notion-react/src/renderer/page-lifecycle.unit.test.tsx
+++ b/packages/@overeng/notion-react/src/renderer/page-lifecycle.unit.test.tsx
@@ -246,9 +246,15 @@ describe("pageLifecycle: 'append-only' (#1124)", () => {
         { pageId: ROOT, cache },
       ),
     )
+    const pagesBeforeCrash = fake.pages.size
     let tripped = false
     fake.failOn((request) => {
-      if (!tripped && request.method === 'GET' && request.path !== `/v1/blocks/${ROOT}/children`) {
+      if (
+        !tripped &&
+        fake.pages.size > pagesBeforeCrash &&
+        request.method === 'GET' &&
+        request.path !== `/v1/blocks/${ROOT}/children`
+      ) {
         tripped = true
         return new FakeNotionResponseError(500, 'internal_server_error', 'simulated process death')
       }

--- a/packages/@overeng/notion-react/src/renderer/plan.unit.test.tsx
+++ b/packages/@overeng/notion-react/src/renderer/plan.unit.test.tsx
@@ -151,11 +151,16 @@ describe('plan() — read-only companion to sync()', () => {
 
     const live: SyncEvent[] = []
     await runWith(fake, plan(doc(2), { pageId: ROOT, cache, onEvent: (e) => live.push(e) }))
-    expect(live.map((e) => e._tag)).toEqual(['OpIssued', 'OpSucceeded', 'PlanComputed'])
-    expect(live[0]).toMatchObject({ kind: 'retrieve' })
-    expect(live[1]).toMatchObject({ kind: 'retrieve' })
+    expect(live.map((e) => e._tag)).toEqual([
+      'OpIssued',
+      'OpSucceeded',
+      'OpIssued',
+      'OpSucceeded',
+      'PlanComputed',
+    ])
+    expect(live.slice(0, 4).every((e) => 'kind' in e && e.kind === 'retrieve')).toBe(true)
     // PlanComputed carries the block tallies of the computed plan.
-    expect(live[2]).toMatchObject({ pageId: ROOT, appends: 0, updates: 2, inserts: 1, removes: 0 })
+    expect(live[4]).toMatchObject({ pageId: ROOT, appends: 0, updates: 2, inserts: 1, removes: 0 })
 
     const offline: SyncEvent[] = []
     await runWith(

--- a/packages/@overeng/notion-react/src/renderer/sync-diff.ts
+++ b/packages/@overeng/notion-react/src/renderer/sync-diff.ts
@@ -430,6 +430,8 @@ interface DiffCtx {
    * `tmp/notion-618/options-ordering.md` experiment 9.
    */
   readonly reorderSiblings: boolean
+  /** The current parent is a child page whose block/page interleaving is non-authoritative. */
+  readonly independentPageOrder: boolean
 }
 
 const diffChildren = (
@@ -448,13 +450,15 @@ const diffChildren = (
   const cacheByKey = new Map<string, CacheNode>()
   for (const c of cacheChildren) cacheByKey.set(c.key, c)
 
-  // Block/page interleaving can differ in page scopes even when neither
-  // kind's relative order changed. Retain the page-kind LCS independently so
-  // an ordinary-block reorder cannot demote an unchanged page into a move.
-  const cachePages = cacheChildren.filter((node) => node.nodeKind === 'page')
-  const candidatePages = candidateChildren.filter((node) => node.nodeKind === 'page')
-  for (const index of retainedCacheIndices(cachePages, candidatePages)) {
-    retainedKeys.add(cachePages[index]!.key)
+  // Block/page interleaving can differ inside child pages even when neither
+  // kind's relative order changed. Only those scopes retain the page-kind LCS
+  // independently; root and ordinary-block child scopes remain fully ordered.
+  if (ctx.independentPageOrder) {
+    const cachePages = cacheChildren.filter((node) => node.nodeKind === 'page')
+    const candidatePages = candidateChildren.filter((node) => node.nodeKind === 'page')
+    for (const index of retainedCacheIndices(cachePages, candidatePages)) {
+      retainedKeys.add(cachePages[index]!.key)
+    }
   }
 
   // Demote retained candidates whose type demands full-rebuild on any
@@ -564,7 +568,11 @@ const diffChildren = (
         // (keeping blockKey namespaces isolated per R26). Nested page
         // descendants emit their own createPage/updatePage/… ops which the
         // driver routes in the same pass.
-        const subCtx: DiffCtx = { ...ctx, scopePageId: prior.blockId }
+        const subCtx: DiffCtx = {
+          ...ctx,
+          scopePageId: prior.blockId,
+          independentPageOrder: true,
+        }
         diffChildren(prior.blockId, prior.children, cand.children, ops, subCtx)
         prevRef = prior.blockId
         continue
@@ -597,7 +605,11 @@ const diffChildren = (
         // tmp ids and `candidateToCache` later throws `unresolved blockId`;
         // edits inside the moved page would also be silently skipped in the
         // same sync. Mirrors the retained-page branch above.
-        const moveSubCtx: DiffCtx = { ...ctx, scopePageId: moveSource.blockId }
+        const moveSubCtx: DiffCtx = {
+          ...ctx,
+          scopePageId: moveSource.blockId,
+          independentPageOrder: true,
+        }
         diffChildren(moveSource.blockId, moveSource.children, cand.children, ops, moveSubCtx)
         prevRef = moveSource.blockId
       } else {
@@ -684,7 +696,10 @@ const diffChildren = (
     if (d.kind === 'new-subtree') {
       emitAppendsForNew(d.parent, d.children, ops, ctx)
     } else {
-      diffChildren(d.blockId, d.cache, d.candidate, ops, ctx)
+      diffChildren(d.blockId, d.cache, d.candidate, ops, {
+        ...ctx,
+        independentPageOrder: false,
+      })
     }
   }
 
@@ -1016,6 +1031,7 @@ export const diff = (
     claimedMoves: new Set<string>(),
     preClaimedMoves,
     reorderSiblings: opts?.reorderSiblings ?? false,
+    independentPageOrder: false,
   }
   diffChildren(candidate.rootId, cache.children, candidate.children, ops, ctx)
   return ops

--- a/packages/@overeng/notion-react/src/renderer/sync-diff.ts
+++ b/packages/@overeng/notion-react/src/renderer/sync-diff.ts
@@ -448,6 +448,15 @@ const diffChildren = (
   const cacheByKey = new Map<string, CacheNode>()
   for (const c of cacheChildren) cacheByKey.set(c.key, c)
 
+  // Block/page interleaving can differ in page scopes even when neither
+  // kind's relative order changed. Retain the page-kind LCS independently so
+  // an ordinary-block reorder cannot demote an unchanged page into a move.
+  const cachePages = cacheChildren.filter((node) => node.nodeKind === 'page')
+  const candidatePages = candidateChildren.filter((node) => node.nodeKind === 'page')
+  for (const index of retainedCacheIndices(cachePages, candidatePages)) {
+    retainedKeys.add(cachePages[index]!.key)
+  }
+
   // Demote retained candidates whose type demands full-rebuild on any
   // subtree shape change (e.g. column_list — Notion rejects per-column
   // mutation). Unretaining here flows through the normal insert/append +

--- a/packages/@overeng/notion-react/src/renderer/sync-diff.unit.test.tsx
+++ b/packages/@overeng/notion-react/src/renderer/sync-diff.unit.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { CACHE_SCHEMA_VERSION, type CacheTree } from '../cache/types.ts'
-import { Heading2, Paragraph, Toggle } from '../components/blocks.ts'
+import { ChildPage, Heading2, Paragraph, Toggle } from '../components/blocks.ts'
 import { h } from '../components/h.ts'
 import {
   buildCandidateTree,
@@ -462,5 +462,74 @@ describe('sync-diff', () => {
       // child paragraph with its parent.
       expect(tallyDiff(ops)).toEqual({ appends: 0, updates: 0, inserts: 0, removes: 1 })
     })
+  })
+
+  it('retains page-kind order independently only inside child-page scopes', () => {
+    const rootWarm = buildCandidateTree(
+      <>
+        <Paragraph blockKey="a">A</Paragraph>
+        <ChildPage blockKey="p" title="P" />
+      </>,
+      ROOT,
+    )
+    rootWarm.children[0]!.blockId = 'block-a'
+    rootWarm.children[1]!.blockId = 'page-p'
+    const rootCache = candidateToCache(rootWarm, CACHE_SCHEMA_VERSION)
+    const rootSwapped = buildCandidateTree(
+      <>
+        <ChildPage blockKey="p" title="P" />
+        <Paragraph blockKey="a">A</Paragraph>
+      </>,
+      ROOT,
+    )
+    expect(diff(rootCache, rootSwapped)).toContainEqual({
+      kind: 'movePage',
+      pageId: 'page-p',
+      parent: { pageId: ROOT },
+    })
+
+    const blockWarm = buildCandidateTree(
+      <Toggle blockKey="outer" title="Outer">
+        <Paragraph blockKey="a">A</Paragraph>
+        <ChildPage blockKey="p" title="P" />
+      </Toggle>,
+      ROOT,
+    )
+    blockWarm.children[0]!.blockId = 'block-outer'
+    blockWarm.children[0]!.children[0]!.blockId = 'block-a'
+    blockWarm.children[0]!.children[1]!.blockId = 'page-p'
+    const blockCache = candidateToCache(blockWarm, CACHE_SCHEMA_VERSION)
+    const blockSwapped = buildCandidateTree(
+      <Toggle blockKey="outer" title="Outer">
+        <ChildPage blockKey="p" title="P" />
+        <Paragraph blockKey="a">A</Paragraph>
+      </Toggle>,
+      ROOT,
+    )
+    expect(diff(blockCache, blockSwapped)).toContainEqual({
+      kind: 'movePage',
+      pageId: 'page-p',
+      parent: { pageId: 'block-outer' },
+    })
+
+    const nestedWarm = buildCandidateTree(
+      <ChildPage blockKey="outer" title="Outer">
+        <Paragraph blockKey="a">A</Paragraph>
+        <ChildPage blockKey="p" title="P" />
+      </ChildPage>,
+      ROOT,
+    )
+    nestedWarm.children[0]!.blockId = 'page-outer'
+    nestedWarm.children[0]!.children[0]!.blockId = 'block-a'
+    nestedWarm.children[0]!.children[1]!.blockId = 'page-p'
+    const nestedCache = candidateToCache(nestedWarm, CACHE_SCHEMA_VERSION)
+    const nestedSwapped = buildCandidateTree(
+      <ChildPage blockKey="outer" title="Outer">
+        <ChildPage blockKey="p" title="P" />
+        <Paragraph blockKey="a">A</Paragraph>
+      </ChildPage>,
+      ROOT,
+    )
+    expect(diff(nestedCache, nestedSwapped)).toEqual([])
   })
 })

--- a/packages/@overeng/notion-react/src/renderer/sync-metrics.shape.unit.test.tsx
+++ b/packages/@overeng/notion-react/src/renderer/sync-metrics.shape.unit.test.tsx
@@ -204,7 +204,7 @@ describe('SyncMetrics — realistic daily-page shape', () => {
     expect(m.ok).toBe(true)
   })
 
-  it('[shape-warm-no-change] warm no-change: 0 mutations, drift probe only', async () => {
+  it('[shape-warm-no-change] warm no-change: 0 mutations, recursive drift probes only', async () => {
     const fake = createFakeNotion()
     const cache = InMemoryCache.make()
     await collect(fake, <RealisticPage spec={baseSpec()} />, cache)
@@ -212,7 +212,8 @@ describe('SyncMetrics — realistic daily-page shape', () => {
     expect(m.actualOps.append).toBe(0)
     expect(m.actualOps.update).toBe(0)
     expect(m.actualOps.delete).toBe(0)
-    expect(m.actualOps.retrieve).toBe(1)
+    // root + 2 tables + 10 column lists + 20 columns
+    expect(m.actualOps.retrieve).toBe(33)
     expect(m.cacheOutcome).toBe('hit')
     expect(m.updateNoopCount).toBe(0)
   })

--- a/packages/@overeng/notion-react/src/renderer/sync-mock.unit.test.tsx
+++ b/packages/@overeng/notion-react/src/renderer/sync-mock.unit.test.tsx
@@ -16,6 +16,7 @@ import {
   Paragraph,
   Table,
   TableRow,
+  SyncedBlock,
 } from '../components/blocks.ts'
 import { h } from '../components/h.ts'
 import {
@@ -26,6 +27,7 @@ import {
   type FakeRequest,
 } from '../test/mock-client.ts'
 import type { SyncEvent } from './sync-events.ts'
+import type { SyncMetrics } from './sync-metrics.ts'
 import { sync } from './sync.ts'
 
 /**
@@ -360,6 +362,82 @@ describe('sync() against in-memory fake Notion', () => {
     const methods = fake.requests.slice(after).map((r) => r.method)
     expect(methods.length).toBeGreaterThan(3)
     expect(methods.every((method) => method === 'GET')).toBe(true)
+  })
+
+  it('warm sync treats inherited synced-block children as opaque', async () => {
+    const fake = createFakeNotion()
+    const cache = InMemoryCache.make()
+    const tree = (
+      <>
+        <SyncedBlock content={{ synced_from: { block_id: 'source-block' } }} />
+        <Paragraph>renderer-owned sibling</Paragraph>
+      </>
+    )
+    await runWith(fake, sync(tree, { pageId: ROOT, cache }))
+    const synced = fake.childrenOf(ROOT).find((block) => block.type === 'synced_block')!
+    const inherited = fake.childrenOf(ROOT).find((block) => block.type === 'paragraph')!
+
+    // Notion exposes source-owned synchronized content through the synced
+    // block's children listing. It is not part of this renderer's CacheTree.
+    synced.children.push(inherited.id)
+    const before = fake.requests.length
+    const result = await runWith(fake, sync(tree, { pageId: ROOT, cache }))
+
+    expect(result).toMatchObject({ appends: 0, updates: 0, inserts: 0, removes: 0 })
+    expect(result.fallbackReason).toBeUndefined()
+    expect(inherited.archived).toBe(false)
+    expect(fake.requests.slice(before).filter((request) => request.method !== 'GET')).toEqual([])
+  })
+
+  it('recursive preflight retries promised-empty children and accounts for every request', async () => {
+    const fake = createFakeNotion()
+    const cache = InMemoryCache.make()
+    const tree = (
+      <ColumnList blockKey="columns">
+        <Column blockKey="left">
+          <Paragraph>left</Paragraph>
+        </Column>
+        <Column blockKey="right">
+          <Paragraph>right</Paragraph>
+        </Column>
+      </ColumnList>
+    )
+    await runWith(fake, sync(tree, { pageId: ROOT, cache }))
+    const columnList = fake.childrenOf(ROOT).find((block) => block.type === 'column_list')!
+    fake.delayChildrenVisibility(columnList.id, 1)
+
+    const events: SyncEvent[] = []
+    let metrics: SyncMetrics | undefined
+    const before = fake.requests.length
+    const result = await runWith(
+      fake,
+      sync(tree, {
+        pageId: ROOT,
+        cache,
+        onEvent: (event) => events.push(event),
+        onMetrics: (value) => {
+          metrics = value
+        },
+      }),
+    )
+    const requests = fake.requests.slice(before)
+    const retrieves = requests.filter((request) => request.method === 'GET')
+    const issuedRetrieves = events.filter(
+      (event) => event._tag === 'OpIssued' && event.kind === 'retrieve',
+    )
+    const successfulRetrieves = events.filter(
+      (event) => event._tag === 'OpSucceeded' && event.kind === 'retrieve',
+    )
+    const syncEnd = events.find((event) => event._tag === 'SyncEnd')
+
+    expect(result).toMatchObject({ appends: 0, updates: 0, inserts: 0, removes: 0 })
+    expect(result.fallbackReason).toBeUndefined()
+    expect(requests.every((request) => request.method === 'GET')).toBe(true)
+    expect(retrieves).toHaveLength(5)
+    expect(issuedRetrieves).toHaveLength(retrieves.length)
+    expect(successfulRetrieves).toHaveLength(retrieves.length)
+    expect(metrics?.actualOps.retrieve).toBe(retrieves.length)
+    expect(syncEnd).toMatchObject({ opCount: retrieves.length, ok: true })
   })
 
   it('drift detection: out-of-band archive on a tracked block forces cache-drift rebuild', async () => {

--- a/packages/@overeng/notion-react/src/renderer/sync-mock.unit.test.tsx
+++ b/packages/@overeng/notion-react/src/renderer/sync-mock.unit.test.tsx
@@ -146,7 +146,7 @@ describe('sync() against in-memory fake Notion', () => {
     }
   })
 
-  it('same-tree resync → {0,0,0,0}, no fallback, only the drift-check GET', async () => {
+  it('same-tree resync → {0,0,0,0}, no fallback, recursive drift reads only', async () => {
     const fake = createFakeNotion()
     const cache = InMemoryCache.make()
     const tree = <DailyPage screenTime="4h 12m" apps={7} sessions={v1} />
@@ -155,9 +155,11 @@ describe('sync() against in-memory fake Notion', () => {
     const res = await runWith(fake, sync(tree, { pageId: ROOT, cache }))
     expect(res).toMatchObject({ appends: 0, updates: 0, inserts: 0, removes: 0 })
     expect(res.fallbackReason).toBeUndefined()
-    // Pre-flight drift check (#105) issues exactly one GET; no mutating ops.
+    // Recursive pre-flight drift detection reads every nested identity scope
+    // and emits no mutations.
     const newReqs = fake.requests.slice(before)
-    expect(newReqs.map((r) => r.method)).toEqual(['GET'])
+    expect(newReqs.length).toBeGreaterThan(0)
+    expect(newReqs.every((request) => request.method === 'GET')).toBe(true)
   })
 
   it('body change → exactly one PATCH to the nested paragraph', async () => {
@@ -185,9 +187,10 @@ describe('sync() against in-memory fake Notion', () => {
       }),
     )
     expect(res).toMatchObject({ appends: 0, updates: 1, inserts: 0, removes: 0 })
-    // Pre-flight drift GET + one PATCH for the body change.
+    // Recursive pre-flight reads followed by the one PATCH for the body change.
     const newReqs = fake.requests.slice(before)
-    expect(newReqs.map((r) => r.method)).toEqual(['GET', 'PATCH'])
+    expect(newReqs.at(-1)?.method).toBe('PATCH')
+    expect(newReqs.slice(0, -1).every((request) => request.method === 'GET')).toBe(true)
   })
 
   it('append session → 2 new-block ops (toggle + nested paragraph)', async () => {
@@ -311,7 +314,8 @@ describe('sync() against in-memory fake Notion', () => {
     )
     expect(rerun).toMatchObject({ appends: 0, updates: 0, inserts: 0, removes: 0 })
     const rerunReqs = fake.requests.slice(before)
-    expect(rerunReqs.map((r) => r.method)).toEqual(['GET'])
+    expect(rerunReqs.length).toBeGreaterThan(0)
+    expect(rerunReqs.every((request) => request.method === 'GET')).toBe(true)
   })
 
   it('delete session → one DELETE', async () => {
@@ -352,9 +356,10 @@ describe('sync() against in-memory fake Notion', () => {
       expect(r).toMatchObject({ appends: 0, updates: 0, inserts: 0, removes: 0 })
       expect(r.fallbackReason).toBeUndefined()
     }
-    // Exactly one drift-check GET per hot-cache resync, no mutations.
+    // Recursive identity reads only; no mutations across hot-cache resyncs.
     const methods = fake.requests.slice(after).map((r) => r.method)
-    expect(methods).toEqual(['GET', 'GET', 'GET'])
+    expect(methods.length).toBeGreaterThan(3)
+    expect(methods.every((method) => method === 'GET')).toBe(true)
   })
 
   it('drift detection: out-of-band archive on a tracked block forces cache-drift rebuild', async () => {
@@ -505,7 +510,8 @@ describe('sync() against in-memory fake Notion', () => {
     expect(rerun).toMatchObject({ appends: 0, updates: 0, inserts: 0, removes: 0 })
     expect(rerun.fallbackReason).toBeUndefined()
     const newReqs = fake.requests.slice(before)
-    expect(newReqs.map((r) => r.method)).toEqual(['GET'])
+    expect(newReqs.length).toBeGreaterThan(0)
+    expect(newReqs.every((request) => request.method === 'GET')).toBe(true)
   })
 
   // Warm-sync regression: any structural change inside a retained
@@ -641,7 +647,8 @@ describe('sync() against in-memory fake Notion', () => {
     expect(rerun).toMatchObject({ appends: 0, updates: 0, inserts: 0, removes: 0 })
     expect(rerun.fallbackReason).toBeUndefined()
     const newReqs = fake.requests.slice(before)
-    expect(newReqs.map((r) => r.method)).toEqual(['GET'])
+    expect(newReqs.length).toBeGreaterThan(0)
+    expect(newReqs.every((request) => request.method === 'GET')).toBe(true)
   })
 
   it('mixed atomic nesting: ColumnList with a table inside a column', async () => {
@@ -782,7 +789,8 @@ describe('sync() against in-memory fake Notion', () => {
     expect(rerun).toMatchObject({ appends: 0, updates: 0, inserts: 0, removes: 0 })
     expect(rerun.fallbackReason).toBeUndefined()
     const newReqs = fake.requests.slice(before)
-    expect(newReqs.map((r) => r.method)).toEqual(['GET'])
+    expect(newReqs.length).toBeGreaterThan(0)
+    expect(newReqs.every((request) => request.method === 'GET')).toBe(true)
   })
 
   it('nested atomic overflow (table with 150 rows inside column_list > column) — throws clearly', async () => {
@@ -829,8 +837,9 @@ describe('sync() against in-memory fake Notion', () => {
     const warm = await runWith(fake, sync(tree, { pageId: ROOT, cache }))
     expect(warm).toMatchObject({ appends: 0, updates: 0, inserts: 0, removes: 0 })
     const warmReqs = fake.requests.slice(before)
-    // Only the drift-check GET; no PATCH / DELETE / POST.
-    expect(warmReqs.map((r) => r.method)).toEqual(['GET'])
+    // Recursive drift verification performs reads only.
+    expect(warmReqs.length).toBeGreaterThan(0)
+    expect(warmReqs.every((request) => request.method === 'GET')).toBe(true)
   })
 
   it('cold-cache: persisted cache has zero ghost entries', async () => {

--- a/packages/@overeng/notion-react/src/renderer/sync-mock.unit.test.tsx
+++ b/packages/@overeng/notion-react/src/renderer/sync-mock.unit.test.tsx
@@ -585,6 +585,48 @@ describe('sync() against in-memory fake Notion', () => {
     expect(stable).toMatchObject({ appends: 0, inserts: 0, updates: 0, removes: 0 })
   })
 
+  it('drift detection rebuilds pages whose recovered keys collide at one parent', async () => {
+    const fake = createFakeNotion()
+    const cache = InMemoryCache.make()
+    const tree = (
+      <>
+        <ChildPage blockKey="parent-a" title="Parent A">
+          <ChildPage blockKey="shared" title="Page A">
+            <Paragraph blockKey="body">A</Paragraph>
+          </ChildPage>
+        </ChildPage>
+        <ChildPage blockKey="parent-b" title="Parent B">
+          <ChildPage blockKey="shared" title="Page B">
+            <Paragraph blockKey="body">B</Paragraph>
+          </ChildPage>
+        </ChildPage>
+      </>
+    )
+    await runWith(fake, sync(tree, { pageId: ROOT, cache }))
+    const [parentA, parentB] = fake.childrenOf(ROOT)
+    const moved = fake.childrenOf(parentA!.id)[0]!
+
+    // The same key is valid in separate scopes. Once an out-of-band move puts
+    // both pages under one live parent, neither identity can safely claim that
+    // key there; the ambiguous pair must take the existing rebuild fallback.
+    await runWith(
+      fake,
+      NotionPages.move({
+        pageId: moved.id,
+        parent: { type: 'page_id', page_id: parentB!.id },
+      }),
+    )
+
+    const repaired = await runWith(fake, sync(tree, { pageId: ROOT, cache }))
+    expect(repaired.fallbackReason).toBe('cache-drift')
+    expect(repaired.pages).toEqual({ creates: 2, updates: 0, archives: 2, moves: 0, reorders: 0 })
+
+    const stable = await runWith(fake, sync(tree, { pageId: ROOT, cache }))
+    expect(stable.fallbackReason).toBeUndefined()
+    expect(stable.pages).toEqual({ creates: 0, updates: 0, archives: 0, moves: 0, reorders: 0 })
+    expect(stable).toMatchObject({ appends: 0, inserts: 0, updates: 0, removes: 0 })
+  })
+
   it('propagates a nested caller holding-page exclusion through recursive reads', async () => {
     const fake = createFakeNotion()
     const cache = InMemoryCache.make()

--- a/packages/@overeng/notion-react/src/renderer/sync-mock.unit.test.tsx
+++ b/packages/@overeng/notion-react/src/renderer/sync-mock.unit.test.tsx
@@ -541,6 +541,50 @@ describe('sync() against in-memory fake Notion', () => {
     expect(stable).toMatchObject({ appends: 0, inserts: 0, updates: 0, removes: 0 })
   })
 
+  it('drift detection preserves a keyed child page moved between owned parents', async () => {
+    const fake = createFakeNotion()
+    const cache = InMemoryCache.make()
+    const tree = (
+      <>
+        <ChildPage blockKey="parent-a" title="Parent A">
+          <ChildPage blockKey="moved" title="Moved">
+            <Paragraph blockKey="body">Body</Paragraph>
+          </ChildPage>
+        </ChildPage>
+        <ChildPage blockKey="parent-b" title="Parent B" />
+      </>
+    )
+    await runWith(fake, sync(tree, { pageId: ROOT, cache }))
+    const [parentA, parentB] = fake.childrenOf(ROOT)
+    const moved = fake.childrenOf(parentA!.id).find((block) => block.type === 'child_page')!
+
+    // Another client reparents the tracked page while this renderer still
+    // owns both possible parents. Drift recovery must find the cached page by
+    // its durable ID across the whole tree, then move that same page back.
+    await runWith(
+      fake,
+      NotionPages.move({
+        pageId: moved.id,
+        parent: { type: 'page_id', page_id: parentB!.id },
+      }),
+    )
+
+    const repaired = await runWith(fake, sync(tree, { pageId: ROOT, cache }))
+    expect(repaired.fallbackReason).toBe('cache-drift')
+    expect(repaired.pages).toEqual({ creates: 0, updates: 0, archives: 0, moves: 1, reorders: 0 })
+    expect(repaired).toMatchObject({ appends: 0, inserts: 0, updates: 0, removes: 0 })
+    expect(fake.childrenOf(parentA!.id).some((block) => block.id === moved.id)).toBe(true)
+    const persisted = await Effect.runPromise(cache.load)
+    expect(
+      persisted && flattenCache(persisted).find((node) => node.blockId === moved.id)?.key,
+    ).toBe('k:moved')
+
+    const stable = await runWith(fake, sync(tree, { pageId: ROOT, cache }))
+    expect(stable.fallbackReason).toBeUndefined()
+    expect(stable.pages).toEqual({ creates: 0, updates: 0, archives: 0, moves: 0, reorders: 0 })
+    expect(stable).toMatchObject({ appends: 0, inserts: 0, updates: 0, removes: 0 })
+  })
+
   it('propagates a nested caller holding-page exclusion through recursive reads', async () => {
     const fake = createFakeNotion()
     const cache = InMemoryCache.make()

--- a/packages/@overeng/notion-react/src/renderer/sync-mock.unit.test.tsx
+++ b/packages/@overeng/notion-react/src/renderer/sync-mock.unit.test.tsx
@@ -476,6 +476,41 @@ describe('sync() against in-memory fake Notion', () => {
     expect(res.appends + res.inserts).toBeGreaterThanOrEqual(1)
   })
 
+  it('drift detection preserves ordinary block order inside a child page', async () => {
+    const fake = createFakeNotion()
+    const cache = InMemoryCache.make()
+    const tree = (
+      <ChildPage blockKey="outer" title="Outer">
+        <Paragraph blockKey="a">A</Paragraph>
+        <Paragraph blockKey="b">B</Paragraph>
+      </ChildPage>
+    )
+    await runWith(fake, sync(tree, { pageId: ROOT, cache }))
+    const outer = fake.childrenOf(ROOT).find((block) => block.type === 'child_page')!
+    const expectedOrder = fake.childrenOf(outer.id).map((block) => block.id)
+    expect(expectedOrder).toHaveLength(2)
+
+    // Simulate another client reordering the two ordinary block siblings.
+    outer.children.reverse()
+    expect(fake.childrenOf(outer.id).map((block) => block.id)).toEqual(
+      [...expectedOrder].toReversed(),
+    )
+
+    const result = await runWith(fake, sync(tree, { pageId: ROOT, cache }))
+    expect(result.fallbackReason).toBe('cache-drift')
+    const repairedText = fake.childrenOf(outer.id).map((block) => {
+      const richText = (block.payload.rich_text ?? []) as readonly {
+        text?: { content?: string }
+      }[]
+      return richText[0]?.text?.content
+    })
+    expect(repairedText).toEqual(['A', 'B'])
+
+    const stable = await runWith(fake, sync(tree, { pageId: ROOT, cache }))
+    expect(stable.fallbackReason).toBeUndefined()
+    expect(stable).toMatchObject({ appends: 0, inserts: 0, updates: 0, removes: 0 })
+  })
+
   it('drift detection: LARGE warm page with 1-block drift → minimal ops (regression: #warm-sync-slow)', async () => {
     // Regression test for: warm sync on 500+ block page hung >5 minutes
     // because any ordered-sequence mismatch triggered a full rebuild

--- a/packages/@overeng/notion-react/src/renderer/sync-mock.unit.test.tsx
+++ b/packages/@overeng/notion-react/src/renderer/sync-mock.unit.test.tsx
@@ -3,7 +3,7 @@ import { HttpClient, HttpClientRequest } from 'effect/unstable/http'
 import { Fragment, type ReactNode } from 'react'
 import { describe, expect, it } from 'vitest'
 
-import type { NotionConfig } from '@overeng/notion-effect-client'
+import { NotionPages, type NotionConfig } from '@overeng/notion-effect-client'
 
 import { InMemoryCache } from '../cache/in-memory-cache.ts'
 import type { CacheNode, CacheTree, NotionCache } from '../cache/types.ts'
@@ -505,6 +505,74 @@ describe('sync() against in-memory fake Notion', () => {
       return richText[0]?.text?.content
     })
     expect(repairedText).toEqual(['A', 'B'])
+
+    const stable = await runWith(fake, sync(tree, { pageId: ROOT, cache }))
+    expect(stable.fallbackReason).toBeUndefined()
+    expect(stable).toMatchObject({ appends: 0, inserts: 0, updates: 0, removes: 0 })
+  })
+
+  it('propagates a nested caller holding-page exclusion through recursive reads', async () => {
+    const fake = createFakeNotion()
+    const cache = InMemoryCache.make()
+    const tree = (
+      <ChildPage blockKey="outer" title="Outer">
+        <Paragraph blockKey="body">Body</Paragraph>
+      </ChildPage>
+    )
+    await runWith(fake, sync(tree, { pageId: ROOT, cache }))
+    const outer = fake.childrenOf(ROOT).find((block) => block.type === 'child_page')!
+    const holdingParentId = await runWith(
+      fake,
+      NotionPages.create({
+        parent: { type: 'page_id', page_id: outer.id },
+        properties: {
+          title: { title: [{ type: 'text', text: { content: 'nested-holding' } }] },
+        },
+      }).pipe(Effect.map((page) => page.id)),
+    )
+    const holdingReadPath = `/v1/blocks/${holdingParentId}/children`
+    fake.failOn((request) =>
+      request.method === 'GET' && request.path === holdingReadPath
+        ? new FakeNotionResponseError(500, 'internal_server_error', 'must not read holding page')
+        : undefined,
+    )
+
+    const before = fake.requests.length
+    const result = await runWith(
+      fake,
+      sync(tree, { pageId: ROOT, cache, reorderSiblings: { holdingParentId } }),
+    )
+    expect(result.fallbackReason).toBeUndefined()
+    expect(result).toMatchObject({ appends: 0, inserts: 0, updates: 0, removes: 0 })
+    expect(fake.requests.slice(before).some((request) => request.path === holdingReadPath)).toBe(
+      false,
+    )
+    expect(fake.pages.get(holdingParentId)?.in_trash).toBe(false)
+  })
+
+  it('keeps tolerated block/page interleaving out of a nested drift base', async () => {
+    const fake = createFakeNotion()
+    const cache = InMemoryCache.make()
+    const tree = (
+      <ChildPage blockKey="outer" title="Outer">
+        <Paragraph blockKey="a">A</Paragraph>
+        <ChildPage blockKey="nested" title="Nested" />
+        <Paragraph blockKey="b">B</Paragraph>
+      </ChildPage>
+    )
+    await runWith(fake, sync(tree, { pageId: ROOT, cache }))
+    const outer = fake.childrenOf(ROOT).find((block) => block.type === 'child_page')!
+    const children = fake.childrenOf(outer.id)
+    const nestedPage = children.find((block) => block.type === 'child_page')!
+    const [blockA, blockB] = children.filter((block) => block.type === 'paragraph')
+    expect([blockA, blockB]).not.toContain(undefined)
+    outer.children.splice(0, outer.children.length, nestedPage.id, blockA!.id, blockB!.id)
+    blockB!.archived = true
+
+    const result = await runWith(fake, sync(tree, { pageId: ROOT, cache }))
+    expect(result.fallbackReason).toBe('cache-drift')
+    expect(result.pages).toMatchObject({ creates: 0, archives: 0, moves: 0 })
+    expect(result.appends + result.inserts).toBe(1)
 
     const stable = await runWith(fake, sync(tree, { pageId: ROOT, cache }))
     expect(stable.fallbackReason).toBeUndefined()

--- a/packages/@overeng/notion-react/src/renderer/sync-mock.unit.test.tsx
+++ b/packages/@overeng/notion-react/src/renderer/sync-mock.unit.test.tsx
@@ -440,6 +440,36 @@ describe('sync() against in-memory fake Notion', () => {
     expect(syncEnd).toMatchObject({ opCount: retrieves.length, ok: true })
   })
 
+  it('recursive preflight does not settle-retry permanent retrieve failures', async () => {
+    const fake = createFakeNotion()
+    const cache = InMemoryCache.make()
+    const tree = (
+      <ColumnList blockKey="columns">
+        <Column blockKey="left">
+          <Paragraph>left</Paragraph>
+        </Column>
+        <Column blockKey="right">
+          <Paragraph>right</Paragraph>
+        </Column>
+      </ColumnList>
+    )
+    await runWith(fake, sync(tree, { pageId: ROOT, cache }))
+    const columnList = fake.childrenOf(ROOT).find((block) => block.type === 'column_list')!
+    const failedPath = `/v1/blocks/${columnList.id}/children`
+    let attempts = 0
+    fake.failOn((request) => {
+      if (request.method !== 'GET' || request.path !== failedPath) return undefined
+      attempts += 1
+      return new FakeNotionResponseError(403, 'restricted_resource', 'permanent denial')
+    })
+
+    const exit = await Effect.runPromiseExit(
+      sync(tree, { pageId: ROOT, cache }).pipe(Effect.provide(fake.layer)),
+    )
+    expect(exit._tag).toBe('Failure')
+    expect(attempts).toBe(1)
+  })
+
   it('drift detection: out-of-band archive on a tracked block forces cache-drift rebuild', async () => {
     const fake = createFakeNotion()
     const cache = InMemoryCache.make()
@@ -569,7 +599,10 @@ describe('sync() against in-memory fake Notion', () => {
     outer.children.splice(0, outer.children.length, nestedPage.id, blockA!.id, blockB!.id)
     blockB!.archived = true
 
-    const result = await runWith(fake, sync(tree, { pageId: ROOT, cache }))
+    const result = await runWith(
+      fake,
+      sync(tree, { pageId: ROOT, cache, pageLifecycle: 'append-only' }),
+    )
     expect(result.fallbackReason).toBe('cache-drift')
     expect(result.pages).toMatchObject({ creates: 0, archives: 0, moves: 0 })
     expect(result.appends + result.inserts).toBe(1)

--- a/packages/@overeng/notion-react/src/renderer/sync-page-ops.unit.test.tsx
+++ b/packages/@overeng/notion-react/src/renderer/sync-page-ops.unit.test.tsx
@@ -7,7 +7,7 @@ import { NotionPages, type NotionConfig } from '@overeng/notion-effect-client'
 
 import { InMemoryCache } from '../cache/in-memory-cache.ts'
 import { CACHE_SCHEMA_VERSION, type CacheTree } from '../cache/types.ts'
-import { ChildPage, Page, Paragraph, Toggle } from '../components/blocks.ts'
+import { ChildPage, Page, Paragraph, Table, TableRow, Toggle } from '../components/blocks.ts'
 import {
   createFakeNotion,
   FakeNotionResponseError,
@@ -55,9 +55,15 @@ const crashMidCreate = async (preamble?: ReactNode) => {
   const fake = createFakeNotion()
   const cache = InMemoryCache.make()
   if (preamble !== undefined) await runSync(fake, preamble, cache)
+  const pagesBeforeCrash = fake.pages.size
   let tripped = false
   fake.failOn((request) => {
-    if (!tripped && request.method === 'GET' && request.path !== `/v1/blocks/${ROOT}/children`) {
+    if (
+      !tripped &&
+      fake.pages.size > pagesBeforeCrash &&
+      request.method === 'GET' &&
+      request.path !== `/v1/blocks/${ROOT}/children`
+    ) {
       tripped = true
       return new FakeNotionResponseError(500, 'internal_server_error', 'simulated process death')
     }
@@ -489,6 +495,53 @@ describe('sync() page ops (issue #618 phase 3b)', () => {
     }).toEqual({ appends: 0, inserts: 0, updates: 0, removes: 0 })
     const after = fake.requests.slice(before)
     expect(after.filter((r) => r.method !== 'GET')).toEqual([])
+  })
+
+  it('recovers a stale cache after rows were appended under a retained nested table', async () => {
+    const fake = createFakeNotion()
+    const cache = InMemoryCache.make()
+    const page = (count: number) => (
+      <Page>
+        <ChildPage blockKey="domain:tools" title="Tools">
+          <Table tableWidth={1}>
+            {Array.from({ length: count }, (_, index) => (
+              <TableRow key={String(index)} cells={[`command-${String(index)}`]} />
+            ))}
+          </Table>
+        </ChildPage>
+      </Page>
+    )
+
+    await runSync(fake, page(17), cache)
+    const stale = await Effect.runPromise(cache.load)
+    expect(stale).toBeDefined()
+    const appended = await runSync(fake, page(22), cache)
+    expect(appended.appends).toBe(5)
+    const liveTable = fake.childrenOf([...fake.pages.values()][0]!.id)[0]!
+    expect(fake.childrenOf(liveTable.id)).toHaveLength(22)
+
+    // Model a caller retaining the pre-append snapshot after the successful
+    // live append. Recovery must inspect nested identities instead of blindly
+    // appending the five rows again from the stale cache.
+    const recoveredCache = InMemoryCache.make(stale)
+    const recovered = await runSync(fake, page(22), recoveredCache)
+    const persisted = await Effect.runPromise(recoveredCache.load)
+    const persistedTable = persisted?.children[0]?.children[0]
+    expect(persistedTable?.children.map(({ blockId }) => blockId)).toEqual(
+      fake.childrenOf(liveTable.id).map(({ id }) => id),
+    )
+    expect(fake.childrenOf(liveTable.id)).toHaveLength(22)
+    expect(recovered).toMatchObject({
+      appends: 5,
+      inserts: 0,
+      updates: 0,
+      removes: 5,
+      fallbackReason: 'cache-drift',
+    })
+
+    const second = await runSync(fake, page(22), recoveredCache)
+    expect(second.pages).toMatchObject({ creates: 0, updates: 0, archives: 0, moves: 0 })
+    expect(second.appends + second.inserts + second.updates + second.removes).toBe(0)
   })
 
   it('phase 3c: nested-page mutation → 1 scoped block update, 0 page ops', async () => {

--- a/packages/@overeng/notion-react/src/renderer/sync-page-ops.unit.test.tsx
+++ b/packages/@overeng/notion-react/src/renderer/sync-page-ops.unit.test.tsx
@@ -3,7 +3,7 @@ import type { HttpClient } from 'effect/unstable/http/HttpClient'
 import type { ReactNode } from 'react'
 import { describe, expect, it } from 'vitest'
 
-import { NotionPages, type NotionConfig } from '@overeng/notion-effect-client'
+import { NotionBlocks, NotionPages, type NotionConfig } from '@overeng/notion-effect-client'
 
 import { InMemoryCache } from '../cache/in-memory-cache.ts'
 import { CACHE_SCHEMA_VERSION, type CacheTree } from '../cache/types.ts'
@@ -1266,6 +1266,7 @@ describe('sync() page ops (issue #618 phase 3b)', () => {
         </Page>,
         cache,
       )
+      const [idA, idB] = pageOrderUnderRoot(fake)
       // Pre-create a caller-owned holding parent under ROOT.
       const holdingParent = await runWith(
         fake,
@@ -1279,6 +1280,51 @@ describe('sync() page ops (issue #618 phase 3b)', () => {
           Effect.mapError(
             (cause) => new NotionSyncError({ reason: 'holding-parent-create-failed', cause }),
           ),
+        ),
+      )
+      // The holding page deliberately owns a large recursive subtree. One
+      // descendant is promised-but-empty and another would fail if read:
+      // neither condition belongs to the rendered root's drift boundary.
+      await runWith(
+        fake,
+        NotionBlocks.append({
+          blockId: holdingParent,
+          children: Array.from({ length: 100 }, (_, index) => ({
+            object: 'block' as const,
+            type: 'toggle' as const,
+            toggle: {
+              rich_text: [{ type: 'text' as const, text: { content: `holding-${index}` } }],
+              children: [
+                {
+                  object: 'block' as const,
+                  type: 'paragraph' as const,
+                  paragraph: { rich_text: [] },
+                },
+              ],
+            },
+          })),
+        }).pipe(
+          Effect.mapError(
+            (cause) => new NotionSyncError({ reason: 'holding-subtree-create-failed', cause }),
+          ),
+        ),
+      )
+      const holdingChildren = fake.childrenOf(holdingParent)
+      expect(holdingChildren).toHaveLength(100)
+      fake.delayChildrenVisibility(holdingChildren[0]!.id, 100)
+      const failingDescendantPath = `/v1/blocks/${holdingChildren[1]!.id}/children`
+      fake.failOn((request) =>
+        request.method === 'GET' && request.path === failingDescendantPath
+          ? new FakeNotionResponseError(
+              500,
+              'internal_server_error',
+              'holding subtree must not affect root sync',
+            )
+          : undefined,
+      )
+      const holdingReadPaths = new Set(
+        [holdingParent, ...holdingChildren.map((block) => block.id)].map(
+          (id) => `/v1/blocks/${id}/children`,
         ),
       )
       const before = fake.requests.length
@@ -1295,6 +1341,10 @@ describe('sync() page ops (issue #618 phase 3b)', () => {
       const after = fake.requests.slice(before)
       const moves = after.filter((r) => r.method === 'POST' && r.path.endsWith('/move'))
       expect(moves).toHaveLength(4) // 2 pages × 2 roundtrips each
+      expect(pageOrderUnderRoot(fake).filter((id) => id !== holdingParent)).toEqual([idB, idA])
+      expect(
+        after.filter((request) => request.method === 'GET' && holdingReadPaths.has(request.path)),
+      ).toEqual([])
       // Library did NOT create a holding page in this sync (caller supplied).
       const newPages = after.filter((r) => r.method === 'POST' && r.path === '/v1/pages')
       expect(newPages).toHaveLength(0)

--- a/packages/@overeng/notion-react/src/renderer/sync.ts
+++ b/packages/@overeng/notion-react/src/renderer/sync.ts
@@ -1110,7 +1110,12 @@ const retrieveLiveIdentityChildren = (
       })
     }
     return blocks
-  }).pipe(Effect.retry(childrenSettleSchedule))
+  }).pipe(
+    Effect.retry({
+      schedule: childrenSettleSchedule,
+      while: (error) => error.reason === 'children-not-yet-visible',
+    }),
+  )
 
 /**
  * Observe the ordered live identity tree below a page or block. Warm-cache

--- a/packages/@overeng/notion-react/src/renderer/sync.ts
+++ b/packages/@overeng/notion-react/src/renderer/sync.ts
@@ -1000,50 +1000,89 @@ const emptyCache = (rootId: string): CacheTree => ({
   children: [],
 })
 
+interface LiveIdentityNode {
+  readonly blockId: string
+  readonly type: string
+  readonly children: readonly LiveIdentityNode[]
+}
+
 /**
- * Build a cache-shaped base from the live top-level block ids on drift.
- *
- * When a prior cache is available, this preserves entries whose blockIds are
- * still live — their meaningful key/hash/children let `diff()` retain them
- * against matching candidate keys. Live blockIds that are NOT in the prior
- * cache get synthetic `drift:<blockId>` keys so `diff()` emits a `remove` for
- * each (they're unowned leftovers).
- *
- * Without a prior (cold-clean path), every live id becomes a ghost entry so
- * every live top-level block converts into an idempotent remove.
- *
- * Why this matters: the naive "all-ghost" base turns a 1-block out-of-band
- * drift into a full page rebuild — N removes + N appends — which is O(minutes)
- * on 500+ block pages. The hybrid base preserves locality: only the actual
- * drift (blocks added/removed out-of-band) drives ops; the stable majority is
- * retained via the normal LCS path.
+ * Observe the ordered live identity tree below a page or block. Warm-cache
+ * drift detection recurses through blocks with children and through every
+ * child-page boundary; cold cleanup only needs the root children.
  */
+const retrieveLiveIdentities: (
+  parentId: string,
+  recursive: boolean,
+) => Effect.Effect<readonly LiveIdentityNode[], NotionSyncError, NotionConfig | HttpClient> =
+  Effect.fn('notion-react.retrieve-live-identities')(function* (
+    parentId: string,
+    recursive: boolean,
+  ) {
+    const live = yield* Stream.runCollect(
+      NotionBlocks.retrieveChildrenStream({ blockId: parentId }),
+    ).pipe(
+      Effect.mapError((cause) => new NotionSyncError({ reason: 'notion-retrieve-failed', cause })),
+    )
+    const identities: LiveIdentityNode[] = []
+    for (const block of Array.from(live)) {
+      if (block.in_trash === true) continue
+      const children =
+        recursive && (block.has_children === true || block.type === 'child_page')
+          ? yield* retrieveLiveIdentities(block.id, true)
+          : []
+      identities.push({ blockId: block.id, type: block.type, children })
+    }
+    return identities
+  })
+
+/**
+ * Build a cache-shaped base from the recursive live identity tree on drift.
+ *
+ * Prior entries whose identities are still live retain their key/hash data,
+ * while untracked live entries become synthetic ghosts that the diff removes.
+ * The same rule is applied at every nested block and child-page scope, so a
+ * stale cache cannot blindly re-append descendants that already landed.
+ */
+const mergeLiveIdentityBase = (
+  liveNodes: readonly LiveIdentityNode[],
+  priorNodes: readonly CacheNode[],
+): readonly CacheNode[] => {
+  const priorByBlockId = new Map(priorNodes.map((node) => [node.blockId, node]))
+  return liveNodes.map((liveNode) => {
+    const priorNode = priorByBlockId.get(liveNode.blockId)
+    if (priorNode !== undefined) {
+      return {
+        ...priorNode,
+        children: mergeLiveIdentityBase(liveNode.children, priorNode.children),
+      }
+    }
+    return {
+      key: `drift:${liveNode.blockId}`,
+      blockId: liveNode.blockId,
+      type: liveNode.type,
+      hash: '',
+      children: mergeLiveIdentityBase(liveNode.children, []),
+      nodeKind: liveNode.type === 'child_page' ? 'page' : 'block',
+    }
+  })
+}
+
 const driftedBase = (
   rootId: string,
-  liveIds: readonly string[],
+  live: readonly LiveIdentityNode[],
   prior: CacheTree | undefined,
-): CacheTree => {
-  const priorByBlockId = new Map<string, CacheNode>()
-  if (prior !== undefined) {
-    for (const c of prior.children) priorByBlockId.set(c.blockId, c)
-  }
-  return {
-    schemaVersion: CACHE_SCHEMA_VERSION,
-    rootId,
-    children: liveIds.map((blockId) => {
-      const priorNode = priorByBlockId.get(blockId)
-      if (priorNode !== undefined) return priorNode
-      return {
-        key: `drift:${blockId}`,
-        blockId,
-        type: 'unknown',
-        hash: '',
-        children: [],
-        nodeKind: 'block',
-      }
-    }),
-  }
-}
+): CacheTree => ({
+  schemaVersion: CACHE_SCHEMA_VERSION,
+  rootId,
+  children: mergeLiveIdentityBase(live, prior?.children ?? []),
+})
+
+/** Remove synthetic drift entries before a working cache can be checkpointed. */
+const withoutDriftGhosts = (nodes: readonly CacheNode[]): readonly CacheNode[] =>
+  nodes.flatMap((node) =>
+    node.key.startsWith('drift:') ? [] : [{ ...node, children: withoutDriftGhosts(node.children) }],
+  )
 
 /**
  * Adopt the inline descendants of a page that was created with inline
@@ -1184,14 +1223,44 @@ const resolvePendingPages = ({
   })
 
 /**
- * Ordered top-level drift predicate (#105). Out-of-band reorders leave the
- * block-id set intact but scramble order, and we must rebuild to converge —
- * so this is sequence equality, not set equality.
+ * Compare recursive identities. Root and ordinary block children are ordered;
+ * child-page content is matched by identity because existing page-scope
+ * application can interleave nested pages and blocks in server order.
  */
-const topLevelDrifted = (expectedIds: readonly string[], liveIds: readonly string[]): boolean => {
-  if (liveIds.length !== expectedIds.length) return true
-  for (let k = 0; k < expectedIds.length; k++) {
-    if (liveIds[k] !== expectedIds[k]) return true
+const identityTreeDrifted = (
+  expected: readonly CacheNode[],
+  live: readonly LiveIdentityNode[],
+  ordered = true,
+): boolean => {
+  if (live.length !== expected.length) return true
+  if (ordered) {
+    for (let index = 0; index < expected.length; index++) {
+      const expectedNode = expected[index]!
+      const liveNode = live[index]!
+      if (liveNode.blockId !== expectedNode.blockId) return true
+      if (
+        identityTreeDrifted(
+          expectedNode.children,
+          liveNode.children,
+          expectedNode.nodeKind !== 'page',
+        )
+      )
+        return true
+    }
+    return false
+  }
+  const liveById = new Map(live.map((node) => [node.blockId, node]))
+  for (const expectedNode of expected) {
+    const liveNode = liveById.get(expectedNode.blockId)
+    if (liveNode === undefined) return true
+    if (
+      identityTreeDrifted(
+        expectedNode.children,
+        liveNode.children,
+        expectedNode.nodeKind !== 'page',
+      )
+    )
+      return true
   }
   return false
 }
@@ -1208,7 +1277,7 @@ const selectDiffBase = ({
   pageIdDrift,
   coldBaseline,
   drifted,
-  liveTopLevelIds,
+  liveIdentities,
 }: {
   readonly pageId: string
   readonly prior: CacheTree | undefined
@@ -1216,7 +1285,7 @@ const selectDiffBase = ({
   readonly pageIdDrift: boolean
   readonly coldBaseline: ColdBaseline
   readonly drifted: boolean
-  readonly liveTopLevelIds: readonly string[]
+  readonly liveIdentities: readonly LiveIdentityNode[]
 }): {
   readonly useCold: boolean
   readonly coldClean: boolean
@@ -1224,13 +1293,13 @@ const selectDiffBase = ({
   readonly fallbackReason: SyncFallbackReason | undefined
 } => {
   const useCold = prior === undefined || pageIdDrift
-  const coldClean = useCold && coldBaseline === 'clean' && liveTopLevelIds.length > 0
+  const coldClean = useCold && coldBaseline === 'clean' && liveIdentities.length > 0
   const diffBase: CacheTree = useCold
     ? coldClean
-      ? driftedBase(pageId, liveTopLevelIds, undefined)
+      ? driftedBase(pageId, liveIdentities, undefined)
       : emptyCache(pageId)
     : drifted
-      ? driftedBase(pageId, liveTopLevelIds, prior)
+      ? driftedBase(pageId, liveIdentities, prior)
       : (prior ?? emptyCache(pageId))
   const fallbackReason: SyncFallbackReason | undefined = pageIdDrift
     ? 'page-id-drift'
@@ -1466,29 +1535,19 @@ export const sync = (
     // that require a hard rebuild should bump the schema explicitly and
     // clear the cache out-of-band.
 
-    // Pre-flight drift detection (#105). When we have a usable prior cache,
-    // fetch the page's current top-level children and compare against the
-    // cache's expected block-id set. Any divergence (block archived out of
-    // band, added by another client, cache bitrot) means the diff would
-    // target stale ids — patching ghosts and leaving live content orphaned.
-    // Treat drift as a cold start: rebuild from scratch so server state
-    // converges on the rendered tree.
-    //
-    // Cost: one GET per sync in the hot-cache path. Kept shallow — nested
-    // children are verified lazily through the checkpoint round-trip since
-    // every mutation resolves to a real server id.
-    // Pre-computed so the retrieve decision below can see it. `useCold` also
-    // covers `schemaMismatch` implicitly — we diff against the stale tree in
-    // that case, so the cold-baseline sweep doesn't apply there (see below).
+    // Pre-flight drift detection (#105). A usable warm cache is compared with
+    // the ordered live identity tree recursively, including child-page scopes.
+    // A stale nested cache is unsafe for the same reason as a stale root: the
+    // diff would append already-live descendants and then persist a snapshot
+    // that omits those duplicate identities. Cold-clean only needs root ids,
+    // because removing a root subtree removes all of its descendants.
     const useColdPath = prior === undefined || pageIdDrift
 
     let drifted = false
-    let liveTopLevelIds: readonly string[] = []
-    // Retrieve live top-level ids when either (a) we have a warm cache and
-    // want drift detection, or (b) we're taking the cold path with
-    // `coldBaseline === 'clean'` and need the live ids to synthesize a
-    // drift-style base so every leftover block converts into an idempotent
-    // remove (Fix B — pixeltrail dogfood v5).
+    let liveIdentities: readonly LiveIdentityNode[] = []
+    // Retrieve live identities when either (a) we have a warm cache and want
+    // recursive drift detection, or (b) the cold-clean path needs root ids to
+    // synthesize removals for existing content.
     const wantsLiveRetrieve =
       (prior !== undefined && !schemaMismatch && !pageIdDrift) ||
       (useColdPath && coldBaseline === 'clean')
@@ -1498,9 +1557,8 @@ export const sync = (
       if (onEvent !== undefined) {
         onEvent(SyncEvent.OpIssued({ id: retrieveOpId, kind: 'retrieve', at: Date.now() }))
       }
-      const liveChildren = yield* Stream.runCollect(
-        NotionBlocks.retrieveChildrenStream({ blockId: opts.pageId }),
-      ).pipe(
+      const recursive = prior !== undefined && !schemaMismatch && !pageIdDrift
+      const observed = yield* retrieveLiveIdentities(opts.pageId, recursive).pipe(
         Effect.tapError((cause) =>
           Effect.sync(() => {
             if (onEvent !== undefined) {
@@ -1516,9 +1574,6 @@ export const sync = (
             }
           }),
         ),
-        Effect.mapError(
-          (cause) => new NotionSyncError({ reason: 'notion-retrieve-failed', cause }),
-        ),
       )
       o11y.opCount.n += 1
       if (onEvent !== undefined) {
@@ -1527,43 +1582,29 @@ export const sync = (
             id: retrieveOpId,
             kind: 'retrieve',
             durationMs: performance.now() - t0,
-            resultCount: liveChildren.length,
+            resultCount: observed.length,
             at: Date.now(),
           }),
         )
       }
-      const liveIds: string[] = []
-      for (const b of Array.from(liveChildren)) {
-        if (b.in_trash !== true) liveIds.push(b.id)
-      }
-      liveTopLevelIds = liveIds
+      const holdingParentId =
+        typeof opts.reorderSiblings === 'object' ? opts.reorderSiblings.holdingParentId : undefined
+      liveIdentities =
+        holdingParentId === undefined
+          ? observed
+          : observed.filter((node) => node.blockId !== holdingParentId)
       // Drift detection only applies to the warm-cache path; the cold path
       // always cleans pre-existing children when `coldBaseline === 'clean'`.
       if (prior !== undefined && !schemaMismatch && !pageIdDrift) {
-        drifted = topLevelDrifted(
-          prior.children.map((c) => c.blockId),
-          liveIds,
-        )
+        drifted = identityTreeDrifted(prior.children, liveIdentities)
       }
     }
 
-    // Cold start when either there's no prior cache or the prior cache is
-    // for a different page (pageIdDrift). On `drifted` we keep a synthesized
-    // base built from the *actual* live top-level ids so the diff emits
-    // removes for the orphaned blocks and appends for the candidate tree —
-    // otherwise a drifted page would get duplicated content (old blocks
-    // remain, new copies append) and never converge.
-    // `diffBase` feeds the diff algorithm; on drift (or cold-clean with
-    // pre-existing live blocks) it carries synthetic `drift:*` ghost entries
-    // so every live top-level block becomes a remove op. `workingBase` seeds
-    // the in-memory working cache that is checkpointed to disk — it must
-    // NEVER contain ghost entries, or a mid-sync failure will leak them
-    // into the persisted cache and poison the next warm sync (dogfood v4:
-    // ghosts drove 111 deletes against already-archived blocks). For
-    // drift / cold-clean, start the working cache empty: ops confirmed
-    // against Notion populate it via `workingAppend`; pending removes
-    // target ghost blockIds that are absent from `working.byId`, which is
-    // a safe no-op.
+    // `diffBase` carries the recursive live identity shape on warm drift:
+    // retained cache nodes keep their keys and hashes while untracked live
+    // nodes become `drift:*` ghosts that the normal diff removes. The working
+    // cache strips those ghosts at every depth so a mid-sync checkpoint can
+    // never persist them; successful operations repopulate confirmed nodes.
     const { useCold, diffBase, fallbackReason } = selectDiffBase({
       pageId: opts.pageId,
       prior,
@@ -1571,18 +1612,15 @@ export const sync = (
       pageIdDrift,
       coldBaseline,
       drifted,
-      liveTopLevelIds,
+      liveIdentities,
     })
-    /* Working base mirrors diffBase for warm drift (no ghost leakage risk —
-       we only copy prior entries whose blockIds are still live server-side,
-       so they're real confirmed entries). For cold paths we stay empty. */
     const workingBase: CacheTree = useCold
       ? emptyCache(opts.pageId)
       : drifted
         ? {
             schemaVersion: CACHE_SCHEMA_VERSION,
             rootId: opts.pageId,
-            children: diffBase.children.filter((c) => !c.key.startsWith('drift:')),
+            children: withoutDriftGhosts(diffBase.children),
           }
         : (prior ?? emptyCache(opts.pageId))
 
@@ -2423,7 +2461,7 @@ export const sync = (
  *
  * `'live'` (default): mirror `sync()`'s pre-flight exactly — resolve pending
  * inline markers (in memory; nothing is persisted) and fetch the page's live
- * top-level children for shallow drift detection. The returned plan is what
+ * recursive identity tree for drift detection. The returned plan is what
  * `sync()` would compute if invoked now, at the cost of read-only API calls.
  * There is still no lock: a writer racing between `plan()` and a later
  * `sync()` can invalidate the plan (sync re-computes, so it stays correct —
@@ -2479,7 +2517,7 @@ export interface SyncPlan {
  * Read-only companion to {@link sync}: compute the plan `sync()` would apply
  * for `element` against the current cache WITHOUT performing any write — no
  * Notion mutation, no cache save. Composed from the same building blocks as
- * `sync()`'s own pre-flight (`resolvePendingPages`, `topLevelDrifted`,
+ * `sync()`'s own pre-flight (`resolvePendingPages`, `identityTreeDrifted`,
  * `selectDiffBase`, `diff`, `rootPageUpdateOpFor`), so the two cannot
  * disagree about what a sync would do for a given observed state.
  *
@@ -2541,7 +2579,7 @@ export const plan = (
     const useColdPath = prior === undefined || pageIdDrift
 
     let drifted = false
-    let liveTopLevelIds: readonly string[] = []
+    let liveIdentities: readonly LiveIdentityNode[] = []
     const wantsLiveRetrieve =
       staleness === 'live' &&
       ((prior !== undefined && !schemaMismatch && !pageIdDrift) ||
@@ -2552,9 +2590,8 @@ export const plan = (
       if (onEvent !== undefined) {
         onEvent(SyncEvent.OpIssued({ id: retrieveOpId, kind: 'retrieve', at: Date.now() }))
       }
-      const liveChildren = yield* Stream.runCollect(
-        NotionBlocks.retrieveChildrenStream({ blockId: opts.pageId }),
-      ).pipe(
+      const recursive = prior !== undefined && !schemaMismatch && !pageIdDrift
+      const observed = yield* retrieveLiveIdentities(opts.pageId, recursive).pipe(
         Effect.tapError((cause) =>
           Effect.sync(() => {
             if (onEvent !== undefined) {
@@ -2570,9 +2607,6 @@ export const plan = (
             }
           }),
         ),
-        Effect.mapError(
-          (cause) => new NotionSyncError({ reason: 'notion-retrieve-failed', cause }),
-        ),
       )
       if (onEvent !== undefined) {
         onEvent(
@@ -2580,21 +2614,19 @@ export const plan = (
             id: retrieveOpId,
             kind: 'retrieve',
             durationMs: performance.now() - t0,
-            resultCount: Array.from(liveChildren).length,
+            resultCount: observed.length,
             at: Date.now(),
           }),
         )
       }
-      const liveIds: string[] = []
-      for (const b of Array.from(liveChildren)) {
-        if (b.in_trash !== true) liveIds.push(b.id)
-      }
-      liveTopLevelIds = liveIds
+      const holdingParentId =
+        typeof opts.reorderSiblings === 'object' ? opts.reorderSiblings.holdingParentId : undefined
+      liveIdentities =
+        holdingParentId === undefined
+          ? observed
+          : observed.filter((node) => node.blockId !== holdingParentId)
       if (prior !== undefined && !schemaMismatch && !pageIdDrift) {
-        drifted = topLevelDrifted(
-          prior.children.map((c) => c.blockId),
-          liveIds,
-        )
+        drifted = identityTreeDrifted(prior.children, liveIdentities)
       }
     }
 
@@ -2605,7 +2637,7 @@ export const plan = (
       pageIdDrift,
       coldBaseline,
       drifted,
-      liveTopLevelIds,
+      liveIdentities,
     })
 
     const rootUpdateOp = rootPageUpdateOpFor({ candidate, prior, pageId: opts.pageId })

--- a/packages/@overeng/notion-react/src/renderer/sync.ts
+++ b/packages/@overeng/notion-react/src/renderer/sync.ts
@@ -1,4 +1,4 @@
-import { Effect, Stream } from 'effect'
+import { Duration, Effect, Option, Schedule, Stream } from 'effect'
 import type { HttpClient } from 'effect/unstable/http/HttpClient'
 import type { ReactNode } from 'react'
 
@@ -1007,29 +1007,136 @@ interface LiveIdentityNode {
 }
 
 /**
+ * Block scopes whose descendants are created and reconciled by the renderer.
+ *
+ * This is intentionally a positive list. Opaque passthrough blocks such as
+ * `synced_block` can report inherited children that belong to their source;
+ * traversing those children would misclassify them as renderer drift and
+ * archive content the renderer does not own.
+ */
+const RENDERER_OWNED_CHILD_SCOPES: Readonly<Record<string, true>> = {
+  paragraph: true,
+  heading_1: true,
+  heading_2: true,
+  heading_3: true,
+  heading_4: true,
+  bulleted_list_item: true,
+  numbered_list_item: true,
+  to_do: true,
+  toggle: true,
+  quote: true,
+  callout: true,
+  table: true,
+  column_list: true,
+  column: true,
+}
+
+type RetrieveO11yCtx = Pick<O11yCtx, 'onEvent' | 'nextOpId' | 'opCount'>
+
+const childrenSettleSchedule = Schedule.exponential(Duration.millis(500), 1.5).pipe(
+  Schedule.upTo({ times: 4 }),
+)
+
+/**
+ * Issue one physical children-list request and account for it exactly once.
+ * Pagination and settled-read retries both pass through this boundary.
+ */
+const retrieveLiveIdentityPage = (
+  parentId: string,
+  startCursor: string | undefined,
+  o11y: RetrieveO11yCtx,
+) =>
+  Effect.gen(function* () {
+    const opId = o11y.nextOpId()
+    const t0 = o11y.onEvent !== undefined ? performance.now() : 0
+    o11y.opCount.n += 1
+    o11y.onEvent?.(SyncEvent.OpIssued({ id: opId, kind: 'retrieve', at: Date.now() }))
+    const page = yield* NotionBlocks.retrieveChildren({
+      blockId: parentId,
+      ...(startCursor !== undefined ? { startCursor } : {}),
+    }).pipe(
+      Effect.mapError((cause) => new NotionSyncError({ reason: 'notion-retrieve-failed', cause })),
+      Effect.tapError((cause) =>
+        Effect.sync(() => {
+          o11y.onEvent?.(
+            SyncEvent.OpFailed({
+              id: opId,
+              kind: 'retrieve',
+              durationMs: performance.now() - t0,
+              error: String(cause),
+              at: Date.now(),
+            }),
+          )
+        }),
+      ),
+    )
+    o11y.onEvent?.(
+      SyncEvent.OpSucceeded({
+        id: opId,
+        kind: 'retrieve',
+        durationMs: performance.now() - t0,
+        resultCount: page.results.length,
+        at: Date.now(),
+      }),
+    )
+    return page
+  })
+
+/**
+ * Retrieve every page of direct children. When the parent explicitly promised
+ * children, a transiently empty aggregate is retried with the repository's
+ * bounded settle schedule; exhausting that budget fails closed.
+ */
+const retrieveLiveIdentityChildren = (
+  parentId: string,
+  expectChildren: boolean,
+  o11y: RetrieveO11yCtx,
+) =>
+  Effect.gen(function* () {
+    const blocks = []
+    let startCursor: string | undefined
+    do {
+      const page = yield* retrieveLiveIdentityPage(parentId, startCursor, o11y)
+      blocks.push(...page.results)
+      startCursor =
+        page.hasMore === true && Option.isSome(page.nextCursor) === true
+          ? page.nextCursor.value
+          : undefined
+    } while (startCursor !== undefined)
+    if (expectChildren && blocks.length === 0) {
+      return yield* Effect.fail(
+        new NotionSyncError({ reason: 'children-not-yet-visible', cause: parentId }),
+      )
+    }
+    return blocks
+  }).pipe(Effect.retry(childrenSettleSchedule))
+
+/**
  * Observe the ordered live identity tree below a page or block. Warm-cache
- * drift detection recurses through blocks with children and through every
- * child-page boundary; cold cleanup only needs the root children.
+ * drift detection recurses only through renderer-owned block scopes and
+ * through every child-page boundary; cold cleanup only needs root children.
  */
 const retrieveLiveIdentities: (
   parentId: string,
   recursive: boolean,
+  o11y: RetrieveO11yCtx,
+  expectChildren?: boolean,
 ) => Effect.Effect<readonly LiveIdentityNode[], NotionSyncError, NotionConfig | HttpClient> =
   Effect.fn('notion-react.retrieve-live-identities')(function* (
     parentId: string,
     recursive: boolean,
+    o11y: RetrieveO11yCtx,
+    expectChildren = false,
   ) {
-    const live = yield* Stream.runCollect(
-      NotionBlocks.retrieveChildrenStream({ blockId: parentId }),
-    ).pipe(
-      Effect.mapError((cause) => new NotionSyncError({ reason: 'notion-retrieve-failed', cause })),
-    )
+    const live = yield* retrieveLiveIdentityChildren(parentId, expectChildren, o11y)
     const identities: LiveIdentityNode[] = []
-    for (const block of Array.from(live)) {
+    for (const block of live) {
       if (block.in_trash === true) continue
+      const ownsChildScope =
+        block.type === 'child_page' || RENDERER_OWNED_CHILD_SCOPES[block.type] === true
       const children =
-        recursive && (block.has_children === true || block.type === 'child_page')
-          ? yield* retrieveLiveIdentities(block.id, true)
+        recursive && ownsChildScope && (block.has_children === true || block.type === 'child_page')
+          ? yield* retrieveLiveIdentities(block.id, true, o11y, block.has_children === true)
           : []
       identities.push({ blockId: block.id, type: block.type, children })
     }
@@ -1552,41 +1659,8 @@ export const sync = (
       (prior !== undefined && !schemaMismatch && !pageIdDrift) ||
       (useColdPath && coldBaseline === 'clean')
     if (wantsLiveRetrieve) {
-      const retrieveOpId = o11y.nextOpId()
-      const t0 = onEvent !== undefined ? performance.now() : 0
-      if (onEvent !== undefined) {
-        onEvent(SyncEvent.OpIssued({ id: retrieveOpId, kind: 'retrieve', at: Date.now() }))
-      }
       const recursive = prior !== undefined && !schemaMismatch && !pageIdDrift
-      const observed = yield* retrieveLiveIdentities(opts.pageId, recursive).pipe(
-        Effect.tapError((cause) =>
-          Effect.sync(() => {
-            if (onEvent !== undefined) {
-              onEvent(
-                SyncEvent.OpFailed({
-                  id: retrieveOpId,
-                  kind: 'retrieve',
-                  durationMs: performance.now() - t0,
-                  error: String(cause),
-                  at: Date.now(),
-                }),
-              )
-            }
-          }),
-        ),
-      )
-      o11y.opCount.n += 1
-      if (onEvent !== undefined) {
-        onEvent(
-          SyncEvent.OpSucceeded({
-            id: retrieveOpId,
-            kind: 'retrieve',
-            durationMs: performance.now() - t0,
-            resultCount: observed.length,
-            at: Date.now(),
-          }),
-        )
-      }
+      const observed = yield* retrieveLiveIdentities(opts.pageId, recursive, o11y)
       const holdingParentId =
         typeof opts.reorderSiblings === 'object' ? opts.reorderSiblings.holdingParentId : undefined
       liveIdentities =
@@ -2558,6 +2632,15 @@ export const plan = (
   Effect.gen(function* () {
     const staleness: PlanStaleness = opts.staleness ?? 'live'
     const onEvent = opts.onEvent
+    let retrieveOpId = 0
+    const retrieveO11y: RetrieveO11yCtx = {
+      onEvent,
+      nextOpId: () => {
+        retrieveOpId += 1
+        return retrieveOpId
+      },
+      opCount: { n: 0 },
+    }
     const coldBaseline: ColdBaseline = opts.coldBaseline ?? 'clean'
     let prior = yield* opts.cache.load.pipe(
       Effect.mapError((cause) => new NotionSyncError({ reason: 'cache-load-failed', cause })),
@@ -2585,40 +2668,8 @@ export const plan = (
       ((prior !== undefined && !schemaMismatch && !pageIdDrift) ||
         (useColdPath && coldBaseline === 'clean'))
     if (wantsLiveRetrieve) {
-      const retrieveOpId = 1
-      const t0 = onEvent !== undefined ? performance.now() : 0
-      if (onEvent !== undefined) {
-        onEvent(SyncEvent.OpIssued({ id: retrieveOpId, kind: 'retrieve', at: Date.now() }))
-      }
       const recursive = prior !== undefined && !schemaMismatch && !pageIdDrift
-      const observed = yield* retrieveLiveIdentities(opts.pageId, recursive).pipe(
-        Effect.tapError((cause) =>
-          Effect.sync(() => {
-            if (onEvent !== undefined) {
-              onEvent(
-                SyncEvent.OpFailed({
-                  id: retrieveOpId,
-                  kind: 'retrieve',
-                  durationMs: performance.now() - t0,
-                  error: String(cause),
-                  at: Date.now(),
-                }),
-              )
-            }
-          }),
-        ),
-      )
-      if (onEvent !== undefined) {
-        onEvent(
-          SyncEvent.OpSucceeded({
-            id: retrieveOpId,
-            kind: 'retrieve',
-            durationMs: performance.now() - t0,
-            resultCount: observed.length,
-            at: Date.now(),
-          }),
-        )
-      }
+      const observed = yield* retrieveLiveIdentities(opts.pageId, recursive, retrieveO11y)
       const holdingParentId =
         typeof opts.reorderSiblings === 'object' ? opts.reorderSiblings.holdingParentId : undefined
       liveIdentities =

--- a/packages/@overeng/notion-react/src/renderer/sync.ts
+++ b/packages/@overeng/notion-react/src/renderer/sync.ts
@@ -1185,10 +1185,15 @@ const mergeLiveIdentityBase = (
   preserveKindInterleaving = false,
 ): readonly CacheNode[] => {
   const priorByBlockId = new Map(priorNodes.map((node) => [node.blockId, node]))
-  const merged = liveNodes.map((liveNode): CacheNode => {
-    const priorNode =
-      priorByBlockId.get(liveNode.blockId) ??
-      (liveNode.type === 'child_page' ? priorPageByBlockId.get(liveNode.blockId) : undefined)
+  const globallyRecoveredPageIds = new Set<string>()
+  const mergedWithRecoveredPages = liveNodes.map((liveNode): CacheNode => {
+    const localPriorNode = priorByBlockId.get(liveNode.blockId)
+    const globalPriorPage =
+      liveNode.type === 'child_page' ? priorPageByBlockId.get(liveNode.blockId) : undefined
+    const priorNode = localPriorNode ?? globalPriorPage
+    if (localPriorNode === undefined && globalPriorPage !== undefined) {
+      globallyRecoveredPageIds.add(liveNode.blockId)
+    }
     if (priorNode !== undefined) {
       return {
         ...priorNode,
@@ -1207,6 +1212,34 @@ const mergeLiveIdentityBase = (
       hash: '',
       children: mergeLiveIdentityBase(liveNode.children, [], priorPageByBlockId),
       nodeKind: liveNode.type === 'child_page' ? 'page' : 'block',
+    }
+  })
+
+  // A blockKey is only unique within its original parent. If global recovery
+  // relocates a page beside another page with the same key, retaining either
+  // key would make the sibling cache invalid or let the global move index pick
+  // the wrong identity. Demote every member of the colliding set to a ghost so
+  // the existing ambiguous-key policy safely rebuilds them all.
+  const pageCountByKey = new Map<string, number>()
+  for (const node of mergedWithRecoveredPages) {
+    if (node.nodeKind !== 'page' || node.key.startsWith('drift:')) continue
+    pageCountByKey.set(node.key, (pageCountByKey.get(node.key) ?? 0) + 1)
+  }
+  const collidedRecoveredKeys = new Set<string>()
+  for (const node of mergedWithRecoveredPages) {
+    if (globallyRecoveredPageIds.has(node.blockId) && (pageCountByKey.get(node.key) ?? 0) > 1) {
+      collidedRecoveredKeys.add(node.key)
+    }
+  }
+  const merged = mergedWithRecoveredPages.map((node): CacheNode => {
+    if (node.nodeKind !== 'page' || !collidedRecoveredKeys.has(node.key)) return node
+    return {
+      key: `drift:${node.blockId}`,
+      blockId: node.blockId,
+      type: node.type,
+      hash: '',
+      children: node.children,
+      nodeKind: 'page',
     }
   })
   if (!preserveKindInterleaving) return merged

--- a/packages/@overeng/notion-react/src/renderer/sync.ts
+++ b/packages/@overeng/notion-react/src/renderer/sync.ts
@@ -1104,9 +1104,10 @@ const retrieveLiveIdentityChildren = (
           : undefined
     } while (startCursor !== undefined)
     if (expectChildren && blocks.length === 0) {
-      return yield* Effect.fail(
-        new NotionSyncError({ reason: 'children-not-yet-visible', cause: parentId }),
-      )
+      return yield* new NotionSyncError({
+        reason: 'children-not-yet-visible',
+        cause: parentId,
+      })
     }
     return blocks
   }).pipe(Effect.retry(childrenSettleSchedule))
@@ -1121,17 +1122,19 @@ const retrieveLiveIdentities: (
   recursive: boolean,
   o11y: RetrieveO11yCtx,
   expectChildren?: boolean,
+  excludedChildId?: string,
 ) => Effect.Effect<readonly LiveIdentityNode[], NotionSyncError, NotionConfig | HttpClient> =
   Effect.fn('notion-react.retrieve-live-identities')(function* (
     parentId: string,
     recursive: boolean,
     o11y: RetrieveO11yCtx,
     expectChildren = false,
+    excludedChildId?: string,
   ) {
     const live = yield* retrieveLiveIdentityChildren(parentId, expectChildren, o11y)
     const identities: LiveIdentityNode[] = []
     for (const block of live) {
-      if (block.in_trash === true) continue
+      if (block.in_trash === true || block.id === excludedChildId) continue
       const ownsChildScope =
         block.type === 'child_page' || RENDERER_OWNED_CHILD_SCOPES[block.type] === true
       const children =
@@ -1660,13 +1663,15 @@ export const sync = (
       (useColdPath && coldBaseline === 'clean')
     if (wantsLiveRetrieve) {
       const recursive = prior !== undefined && !schemaMismatch && !pageIdDrift
-      const observed = yield* retrieveLiveIdentities(opts.pageId, recursive, o11y)
       const holdingParentId =
         typeof opts.reorderSiblings === 'object' ? opts.reorderSiblings.holdingParentId : undefined
-      liveIdentities =
-        holdingParentId === undefined
-          ? observed
-          : observed.filter((node) => node.blockId !== holdingParentId)
+      liveIdentities = yield* retrieveLiveIdentities(
+        opts.pageId,
+        recursive,
+        o11y,
+        false,
+        holdingParentId,
+      )
       // Drift detection only applies to the warm-cache path; the cold path
       // always cleans pre-existing children when `coldBaseline === 'clean'`.
       if (prior !== undefined && !schemaMismatch && !pageIdDrift) {
@@ -2669,13 +2674,15 @@ export const plan = (
         (useColdPath && coldBaseline === 'clean'))
     if (wantsLiveRetrieve) {
       const recursive = prior !== undefined && !schemaMismatch && !pageIdDrift
-      const observed = yield* retrieveLiveIdentities(opts.pageId, recursive, retrieveO11y)
       const holdingParentId =
         typeof opts.reorderSiblings === 'object' ? opts.reorderSiblings.holdingParentId : undefined
-      liveIdentities =
-        holdingParentId === undefined
-          ? observed
-          : observed.filter((node) => node.blockId !== holdingParentId)
+      liveIdentities = yield* retrieveLiveIdentities(
+        opts.pageId,
+        recursive,
+        retrieveO11y,
+        false,
+        holdingParentId,
+      )
       if (prior !== undefined && !schemaMismatch && !pageIdDrift) {
         drifted = identityTreeDrifted(prior.children, liveIdentities)
       }

--- a/packages/@overeng/notion-react/src/renderer/sync.ts
+++ b/packages/@overeng/notion-react/src/renderer/sync.ts
@@ -1157,6 +1157,19 @@ const retrieveLiveIdentities: (
     return identities
   })
 
+/** Index page nodes globally by durable ID; ordinary blocks remain scope-local. */
+const indexCachedPagesByBlockId = (nodes: readonly CacheNode[]): Map<string, CacheNode> => {
+  const pages = new Map<string, CacheNode>()
+  const walk = (children: readonly CacheNode[]): void => {
+    for (const child of children) {
+      if (child.nodeKind === 'page') pages.set(child.blockId, child)
+      walk(child.children)
+    }
+  }
+  walk(nodes)
+  return pages
+}
+
 /**
  * Build a cache-shaped base from the recursive live identity tree on drift.
  *
@@ -1168,17 +1181,21 @@ const retrieveLiveIdentities: (
 const mergeLiveIdentityBase = (
   liveNodes: readonly LiveIdentityNode[],
   priorNodes: readonly CacheNode[],
+  priorPageByBlockId: ReadonlyMap<string, CacheNode>,
   preserveKindInterleaving = false,
 ): readonly CacheNode[] => {
   const priorByBlockId = new Map(priorNodes.map((node) => [node.blockId, node]))
   const merged = liveNodes.map((liveNode): CacheNode => {
-    const priorNode = priorByBlockId.get(liveNode.blockId)
+    const priorNode =
+      priorByBlockId.get(liveNode.blockId) ??
+      (liveNode.type === 'child_page' ? priorPageByBlockId.get(liveNode.blockId) : undefined)
     if (priorNode !== undefined) {
       return {
         ...priorNode,
         children: mergeLiveIdentityBase(
           liveNode.children,
           priorNode.children,
+          priorPageByBlockId,
           priorNode.nodeKind === 'page',
         ),
       }
@@ -1188,7 +1205,7 @@ const mergeLiveIdentityBase = (
       blockId: liveNode.blockId,
       type: liveNode.type,
       hash: '',
-      children: mergeLiveIdentityBase(liveNode.children, []),
+      children: mergeLiveIdentityBase(liveNode.children, [], priorPageByBlockId),
       nodeKind: liveNode.type === 'child_page' ? 'page' : 'block',
     }
   })
@@ -1220,11 +1237,14 @@ const driftedBase = (
   rootId: string,
   live: readonly LiveIdentityNode[],
   prior: CacheTree | undefined,
-): CacheTree => ({
-  schemaVersion: CACHE_SCHEMA_VERSION,
-  rootId,
-  children: mergeLiveIdentityBase(live, prior?.children ?? []),
-})
+): CacheTree => {
+  const priorChildren = prior?.children ?? []
+  return {
+    schemaVersion: CACHE_SCHEMA_VERSION,
+    rootId,
+    children: mergeLiveIdentityBase(live, priorChildren, indexCachedPagesByBlockId(priorChildren)),
+  }
+}
 
 /** Remove synthetic drift entries before a working cache can be checkpointed. */
 const withoutDriftGhosts = (nodes: readonly CacheNode[]): readonly CacheNode[] =>

--- a/packages/@overeng/notion-react/src/renderer/sync.ts
+++ b/packages/@overeng/notion-react/src/renderer/sync.ts
@@ -1139,7 +1139,13 @@ const retrieveLiveIdentities: (
         block.type === 'child_page' || RENDERER_OWNED_CHILD_SCOPES[block.type] === true
       const children =
         recursive && ownsChildScope && (block.has_children === true || block.type === 'child_page')
-          ? yield* retrieveLiveIdentities(block.id, true, o11y, block.has_children === true)
+          ? yield* retrieveLiveIdentities(
+              block.id,
+              true,
+              o11y,
+              block.has_children === true,
+              excludedChildId,
+            )
           : []
       identities.push({ blockId: block.id, type: block.type, children })
     }
@@ -1157,14 +1163,19 @@ const retrieveLiveIdentities: (
 const mergeLiveIdentityBase = (
   liveNodes: readonly LiveIdentityNode[],
   priorNodes: readonly CacheNode[],
+  preserveKindInterleaving = false,
 ): readonly CacheNode[] => {
   const priorByBlockId = new Map(priorNodes.map((node) => [node.blockId, node]))
-  return liveNodes.map((liveNode) => {
+  const merged = liveNodes.map((liveNode): CacheNode => {
     const priorNode = priorByBlockId.get(liveNode.blockId)
     if (priorNode !== undefined) {
       return {
         ...priorNode,
-        children: mergeLiveIdentityBase(liveNode.children, priorNode.children),
+        children: mergeLiveIdentityBase(
+          liveNode.children,
+          priorNode.children,
+          priorNode.nodeKind === 'page',
+        ),
       }
     }
     return {
@@ -1176,6 +1187,28 @@ const mergeLiveIdentityBase = (
       nodeKind: liveNode.type === 'child_page' ? 'page' : 'block',
     }
   })
+  if (!preserveKindInterleaving) return merged
+
+  const retainedBlocks = merged.filter(
+    (node) => !node.key.startsWith('drift:') && node.nodeKind === 'block',
+  )
+  const retainedPages = merged.filter(
+    (node) => !node.key.startsWith('drift:') && node.nodeKind === 'page',
+  )
+  const ordered: CacheNode[] = []
+  let blockIndex = 0
+  let pageIndex = 0
+  for (const priorNode of priorNodes) {
+    const node =
+      priorNode.nodeKind === 'page' ? retainedPages[pageIndex++] : retainedBlocks[blockIndex++]
+    if (node !== undefined) ordered.push(node)
+  }
+  ordered.push(
+    ...retainedBlocks.slice(blockIndex),
+    ...retainedPages.slice(pageIndex),
+    ...merged.filter((node) => node.key.startsWith('drift:')),
+  )
+  return ordered
 }
 
 const driftedBase = (

--- a/packages/@overeng/notion-react/src/renderer/sync.ts
+++ b/packages/@overeng/notion-react/src/renderer/sync.ts
@@ -1333,9 +1333,9 @@ const resolvePendingPages = ({
   })
 
 /**
- * Compare recursive identities. Root and ordinary block children are ordered;
- * child-page content is matched by identity because existing page-scope
- * application can interleave nested pages and blocks in server order.
+ * Compare recursive identities. Root and ordinary block children are ordered.
+ * Child-page content ignores unstable block/page interleaving while preserving
+ * relative order within the block siblings and page siblings.
  */
 const identityTreeDrifted = (
   expected: readonly CacheNode[],
@@ -1359,18 +1359,12 @@ const identityTreeDrifted = (
     }
     return false
   }
-  const liveById = new Map(live.map((node) => [node.blockId, node]))
-  for (const expectedNode of expected) {
-    const liveNode = liveById.get(expectedNode.blockId)
-    if (liveNode === undefined) return true
-    if (
-      identityTreeDrifted(
-        expectedNode.children,
-        liveNode.children,
-        expectedNode.nodeKind !== 'page',
-      )
+  for (const nodeKind of ['block', 'page'] as const) {
+    const expectedOfKind = expected.filter((node) => node.nodeKind === nodeKind)
+    const liveOfKind = live.filter(
+      (node) => (node.type === 'child_page' ? 'page' : 'block') === nodeKind,
     )
-      return true
+    if (identityTreeDrifted(expectedOfKind, liveOfKind)) return true
   }
   return false
 }

--- a/packages/@overeng/notion-react/src/test/mock-client.ts
+++ b/packages/@overeng/notion-react/src/test/mock-client.ts
@@ -51,6 +51,12 @@ export interface FakeNotion {
    */
   readonly failOn: (hook: (req: FakeRequest) => Error | undefined) => void
   /**
+   * Make the next `emptyReads` children-list requests for `blockId` return an
+   * empty list while the parent envelope still reports its real
+   * `has_children` value. Models Notion's transient indexing paradox.
+   */
+  readonly delayChildrenVisibility: (blockId: string, emptyReads: number) => void
+  /**
    * Install a file_upload_id rejection predicate. Any append/update request
    * whose payload references a matching id surfaces as a Notion-shaped
    * `validation_error` with HTTP 400, matching the production API's
@@ -217,6 +223,7 @@ export const createFakeNotion = (): FakeNotion => {
 
   let failureHook: ((req: FakeRequest) => Error | undefined) | undefined
   let uploadIdPredicate: ((fileUploadId: string) => boolean) | undefined
+  const delayedChildrenReads = new Map<string, number>()
 
   /** Walk a nested block body collecting every `file_upload.id`. */
   const collectFileUploadIds = (body: unknown): string[] => {
@@ -650,6 +657,16 @@ export const createFakeNotion = (): FakeNotion => {
       if (pageParent !== undefined && pageParent.archived) {
         respErr(404, 'object_not_found', `Could not find block with ID: ${parent}.`)
       }
+      const delayedReads = delayedChildrenReads.get(parent) ?? 0
+      if (delayedReads > 0) {
+        delayedChildrenReads.set(parent, delayedReads - 1)
+        return {
+          object: 'list',
+          results: [],
+          has_more: false,
+          next_cursor: null,
+        }
+      }
       return {
         object: 'list',
         results: childrenOf(parent).map((b) => toBlockResponse(b, parent)),
@@ -795,6 +812,9 @@ export const createFakeNotion = (): FakeNotion => {
     childrenOf: (id) => childrenOf(id),
     failOn: (hook) => {
       failureHook = hook
+    },
+    delayChildrenVisibility: (blockId, emptyReads) => {
+      delayedChildrenReads.set(blockId, emptyReads)
     },
     rejectUploadIds: (predicate) => {
       uploadIdPredicate = predicate


### PR DESCRIPTION
## Problem

A warm `@overeng/notion-react` cache validated only root child IDs. If a nested append landed but the caller retained the pre-append cache, the next sync could not see that those descendants were already live: it appended them again and then returned a cache whose recursive identities differed from the server.

## Goal

Warm sync and live `plan()` detect identity drift recursively across renderer-owned block and child-page scopes, reconcile safely, and persist a `CacheTree` matching the identities left live without touching provider-owned content.

## Decisions

- Observe recursive identities only for usable warm caches; cold-clean still reads root children because deleting a root subtree removes its descendants.
- Traverse a positive set of renderer-owned child-bearing wire types and child-page scopes. Opaque passthrough types, especially inherited `<SyncedBlock>` children, are traversal boundaries.
- Retry `has_children: true` plus an empty complete child list with the repository's bounded settle schedule; exhaust the budget as a typed fail-closed error before drift classification or mutation.
- Preserve known cache metadata by block ID and represent only untracked live identities as removable drift ghosts; strip drift ghosts recursively before checkpoint writes.
- Account for every pagination page and retry as one retrieve request in events, `SyncMetrics.actualOps.retrieve`, OER, and `SyncEnd.opCount`.
- Keep child-page content identity matching order-insensitive because existing mixed page/block application can produce a different server order; ordinary block children, including table rows, remain order-sensitive.

## Verification

- Focused review regressions: 2 passed — opaque synced-block children remain untouched; transient promised-empty nested reads retry and every request is accounted.
- `@overeng/notion-react` suite: 30 files passed; 418 tests passed, 1 skipped.
- Full repository suite: 355 files passed, 4 skipped; 4,864 tests passed, 31 skipped.
- `tsc -b tsconfig.json --pretty false --force`: passed for the notion-react project-reference closure.
- Scoped `oxlint --deny-warnings`: 0 warnings, 0 errors.
- Scoped `oxfmt --check`: passed.
- `axe vrs check --profile strict packages/@overeng/notion-react/docs/vrs`: passed.
- Recovery evidence: stale cache 17 / live 22; the old path appended 5 duplicates and produced live 27 while returning cache 22. Recursive recovery returns exact live/cache 22 and the immediate identical sync emits zero mutations.

## Complexity

One recursive identity observer, a positive ownership boundary, one bounded settle schedule, and two pure tree helpers; no new dependency or public API.

## Concerns

Usable warm syncs now issue one paginated children read per renderer-owned nested container/page scope, plus bounded retries for ambiguous empty reads. T14 accepts this correctness cost; exact telemetry keeps it visible.

## Friction & bottlenecks

The managed task wrapper's local environment evaluation stalled, so validation used the same pinned workspace binaries and materialized dependency/native projection directly. No product behavior depends on that workaround.

## Follow-ups

None.

## References

- VRS experiment: `packages/@overeng/notion-react/docs/vrs/.experiments/0005-recursive-cache-drift-recovery.md`
- Review fixes: `996ca0f4f`
- VRS coverage: `7c7977bd4`

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | unknown |
| `agent_persona` | unknown |
| `agent_supervisor` | unavailable |
| `agent_tool` | unknown |
| `agent_tool_version` | unknown |
| `agent_runtime` | unknown |
| `tooling_profile` | dotfiles@e4789b0 |
</details>
<!-- agent-footer:end -->