### PR TITLE
fix(nix): isolate pnpm builders from expected hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
+- **nix/workspace-tools**: keep declared pnpm fixed-output hashes exclusively in
+  derivation metadata instead of interpolating them into the prepared-deps
+  builder, and verify that changing only the expected hash leaves the staged
+  source, derivation name, and install program identical.
 - **@overeng/utils, @overeng/genie, @overeng/notion-md**: apply the watch-recursion
   design study for effect@4.0.0-rc.111 (recursion is opt-in again). New
   `watchScoped` helper in `@overeng/utils/node` wraps `FileSystem.watch` with an

--- a/nix/workspace-tools/lib/mk-pnpm-cli/tests/fixtures/downstream/flake.nix
+++ b/nix/workspace-tools/lib/mk-pnpm-cli/tests/fixtures/downstream/flake.nix
@@ -57,6 +57,25 @@
           };
           smokeTestArgs = [ ];
         };
+        pureEvalAlternateHashFixture = mkPnpmCli {
+          name = "mk-pnpm-cli-pure-eval-fixture";
+          binaryName = "mk-pnpm-cli-pure-eval-fixture";
+          entry = "app/src/mod.ts";
+          packageDir = "app";
+          workspaceRoot = ./fixture-workspace;
+          workspaceSources = {
+            "repos/effect-utils" = effectUtilsSource;
+          };
+          depsBuilds = {
+            "." = {
+              hash = "sha256-CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC=";
+            };
+            "repos/effect-utils" = {
+              hash = "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=";
+            };
+          };
+          smokeTestArgs = [ ];
+        };
         pureEvalDerivedWorkspaceFixture = mkPnpmCli {
           name = "mk-pnpm-cli-pure-eval-derived-workspace-fixture";
           binaryName = "mk-pnpm-cli-pure-eval-derived-workspace-fixture";
@@ -135,6 +154,20 @@
           fi
           printf '%s' "$actual" > "$out"
         '';
+        checks.pure-eval-declared-hash-isolation =
+          let
+            baseline = pureEvalFixture.passthru.depsBuildsByInstallRoot.root;
+            alternate = pureEvalAlternateHashFixture.passthru.depsBuildsByInstallRoot.root;
+          in
+          assert baseline.outputHash != alternate.outputHash;
+          assert baseline.src == alternate.src;
+          assert baseline.pname == alternate.pname;
+          assert baseline.installPhase == alternate.installPhase;
+          assert !(lib.hasInfix baseline.outputHash baseline.installPhase);
+          assert !(lib.hasInfix alternate.outputHash alternate.installPhase);
+          pkgs.runCommand "mk-pnpm-cli-declared-hash-isolation" { } ''
+            touch "$out"
+          '';
         checks.pure-eval-deps-build-metadata =
           pkgs.runCommand "mk-pnpm-cli-pure-eval-deps-build-metadata" { }
             ''

--- a/nix/workspace-tools/lib/mk-pnpm-cli/tests/run.sh
+++ b/nix/workspace-tools/lib/mk-pnpm-cli/tests/run.sh
@@ -239,6 +239,11 @@ run_downstream_pure_eval_regression() {
     --override-input effect-utils "path:$WORKSPACE_REAL/repos/effect-utils" \
     "path:$DOWNSTREAM_DIR#checks.$SYSTEM.pure-eval-external-install-roots"
 
+  echo "Build: declared expected hash stays out of the prepared-deps builder"
+  nix build --no-link --no-write-lock-file \
+    --override-input effect-utils "path:$WORKSPACE_REAL/repos/effect-utils" \
+    "path:$DOWNSTREAM_DIR#checks.$SYSTEM.pure-eval-declared-hash-isolation"
+
   echo "Build: downstream pure-eval derived-workspace-root regression (composed repos/effect-utils path)"
   nix build --no-link --no-write-lock-file \
     --override-input effect-utils "path:$WORKSPACE_REAL/repos/effect-utils" \

--- a/nix/workspace-tools/lib/mk-pnpm-deps.nix
+++ b/nix/workspace-tools/lib/mk-pnpm-deps.nix
@@ -888,8 +888,12 @@ in
                 log_prep_phase "archive" "duration=''${archiveDuration}s mode=tar-stream-tree"
                 log_prep_event "archive" "$archiveDuration" "mode=tar-stream-tree"
                 prepDuration=$(timer_elapsed "$prepStartedAt")
-                log_prep_phase "complete" "duration=''${prepDuration}s declared_output_hash=${pnpmDepsHash}"
-                log_prep_event "complete" "$prepDuration" "declared_output_hash=${pnpmDepsHash}"
+                # Keep the declared hash exclusively in the fixed-output metadata.
+                # Feeding it into the builder script makes otherwise-identical
+                # materializations have different builders and obscures whether a
+                # mismatch came from staged inputs or from the expected hash.
+                log_prep_phase "complete" "duration=''${prepDuration}s"
+                log_prep_event "complete" "$prepDuration" "kind=prepared-workspace"
 
                 runHook postInstall
       '';


### PR DESCRIPTION
## Problem
The pnpm prepared-deps builder interpolated the declared fixed-output hash into its install program for completion logging. That made otherwise-identical builder programs differ when only the expected hash changed, obscuring whether a mismatch came from staged source inputs or hash metadata.

## Goal
Keep the expected hash exclusively in Nix fixed-output metadata and make hash-only changes leave the staged source, derivation name, and install program identical.

## Decisions
Removed the expected hash from completion logs rather than adding normalization or cache workarounds. The output hash remains the single Nix-owned validation boundary. Added a pure-eval regression using two otherwise-identical consumers with distinct declared hashes.

## Verification
Focused regression passed:

```text
nix build --option min-free 0 --no-link --no-write-lock-file \
  --override-input effect-utils path:. \
  path:./nix/workspace-tools/lib/mk-pnpm-cli/tests/fixtures/downstream#checks.x86_64-linux.pure-eval-declared-hash-isolation

building '...-mk-pnpm-cli-declared-hash-isolation.drv'...
```

The check asserts that only `outputHash` differs; `src`, `pname`, and `installPhase` remain identical, and neither expected hash occurs in the builder program.

## Complexity
No new runtime abstraction or dependency; one focused pure-eval fixture/check.

## Concerns
Completion telemetry no longer includes the declared expected hash. Repair tooling already owns that metadata at evaluation time, so retaining it in builder logs was redundant.

## Friction & bottlenecks
A host-wide Nix auto-GC temporarily serialized the focused reproduction. No product bottleneck introduced by this PR.

## Follow-ups
None.

## References
No linked issue.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | unknown |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.0.3 |
| `agent_runtime` | OMP 18.0.3 |
| `tooling_profile` | dotfiles@e4789b0 |
</details>
<!-- agent-footer:end -->