### PR TITLE
Scope pnpm FOD identity to owned workspace closures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
+- **Nix workspace tooling**: aggregate CLI dependency sources now prune shared
+  pnpm lockfiles to the selected importer's reachable closure, so unrelated
+  workspace lock changes no longer invalidate fixed-output dependencies.
 - **@overeng/utils, @overeng/tui-core, @overeng/tui-react**: Effect 4 idiom
   adoption. `base64` is now a thin facade over upstream `Encoding` (net -107
   lines; invalid input throws `Encoding.EncodingError` instead of `DOMException`

--- a/genie/external.ts
+++ b/genie/external.ts
@@ -343,6 +343,9 @@ export const catalog = defineCatalog({
   vitest: '4.1.9',
   '@vitejs/plugin-react': '6.0.2',
 
+  // pnpm workspace lock projection
+  '@pnpm/lockfile.fs': '1100.1.6',
+  '@pnpm/lockfile.pruner': '1100.0.11',
   // TanStack
   '@tanstack/react-router': '1.170.16',
   '@tanstack/react-start': '1.168.26',

--- a/nix/workspace-tools/lib/mk-pnpm-cli.nix
+++ b/nix/workspace-tools/lib/mk-pnpm-cli.nix
@@ -32,6 +32,7 @@ let
   lib = pkgs.lib;
   pnpmDepsHelper = import ./mk-pnpm-deps.nix { inherit pkgs pnpm; };
   dependencyProfile = import ./dependency-materialization-profile.nix { inherit lib; };
+  lockfileProjector = import ./mk-pnpm-cli/lockfile-projector { inherit pkgs; };
   # Closure-completeness guardrail (#807). Partially applied with the shared
   # native-optional-families detector source; each install root gets a check
   # derivation exposed via passthru.nativeBindingClosureChecks.<attrName>.
@@ -1158,10 +1159,8 @@ let
       ]
     );
 
-  # The aggregate root owns the top-level lockfile plus any workspace members
-  # not delegated to nested install roots. It still stages external install-root
-  # manifests so the aggregate lockfile can resolve linked workspace packages
-  # against the exact member set that will exist in the final composed build.
+  # Restrict the shared lock to the target importer's reachable dependency
+  # graph before it becomes fixed-output derivation input.
   rootDepsSrc = pkgs.runCommand "${name}-pnpm-deps-src" { } (
     ''
       set -euo pipefail
@@ -1180,6 +1179,12 @@ let
     }
     + builtins.concatStringsSep "\n" (map stageExternalInstallRootManifestOnlyCmd externalInstallRoots)
     + stageRootSourceInputManifestAliasesCmd
+    + ''
+      ${pkgs.nodejs}/bin/node \
+        ${lockfileProjector}/lib/pnpm-lock-projector/project-lockfile.mjs \
+        "$out" \
+        ${lib.escapeShellArgs (lib.unique ([ packageDir ] ++ aggregateOwnedWorkspaceClosureDirs))}
+    ''
   );
 
   # Each external install root gets its own manifest-only derivation and its

--- a/nix/workspace-tools/lib/mk-pnpm-cli/lockfile-projector/default.nix
+++ b/nix/workspace-tools/lib/mk-pnpm-cli/lockfile-projector/default.nix
@@ -1,0 +1,31 @@
+{ pkgs }:
+
+pkgs.buildNpmPackage {
+  pname = "pnpm-lock-projector";
+  version = "0.1.0";
+
+  src = pkgs.lib.cleanSourceWith {
+    src = ./.;
+    filter =
+      path: _type:
+      builtins.elem (baseNameOf path) [
+        "package.json"
+        "package-lock.json"
+        "project-lockfile.mjs"
+      ];
+  };
+  npmDepsHash = "sha256-yUnILl80Yao/vmB9U4qPLQew0d3cBXHLiWHkfKvdxgc=";
+
+  dontNpmBuild = true;
+  npmRebuildFlags = [ "--ignore-scripts" ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/lib/pnpm-lock-projector"
+    cp -R node_modules package.json package-lock.json project-lockfile.mjs \
+      "$out/lib/pnpm-lock-projector/"
+
+    runHook postInstall
+  '';
+}

--- a/nix/workspace-tools/lib/mk-pnpm-cli/lockfile-projector/package-lock.json
+++ b/nix/workspace-tools/lib/mk-pnpm-cli/lockfile-projector/package-lock.json
@@ -1,0 +1,872 @@
+{
+  "name": "@overeng/pnpm-lock-projector",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@overeng/pnpm-lock-projector",
+      "version": "0.1.0",
+      "dependencies": {
+        "@pnpm/lockfile.fs": "1100.1.6",
+        "@pnpm/lockfile.pruner": "1100.0.11"
+      }
+    },
+    "node_modules/@pnpm/constants": {
+      "version": "1100.0.0",
+      "resolved": "https://registry.npmjs.org/@pnpm/constants/-/constants-1100.0.0.tgz",
+      "integrity": "sha512-CSJ5fKSUgqXrON5J2zQd1LwttU4gdqffJ3zYyHGAEhZ8u22fhQEVfCnc4+3aczDHbBNU0pNRX2ajiioPj46YtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.13"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@pnpm/crypto.hash": {
+      "version": "1100.0.1",
+      "resolved": "https://registry.npmjs.org/@pnpm/crypto.hash/-/crypto.hash-1100.0.1.tgz",
+      "integrity": "sha512-Zq7m0/2wT/9BgXtk0ue5OC6MeHk+KpbDICmSKybeSy7NQ7sWreiDXhRBnipRLDo21vY7nLuXRsRLopk+3cCmoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/fs.graceful-fs": "1100.1.0",
+        "ssri": "13.0.1"
+      },
+      "engines": {
+        "node": ">=22.13"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@pnpm/deps.path": {
+      "version": "1100.0.8",
+      "resolved": "https://registry.npmjs.org/@pnpm/deps.path/-/deps.path-1100.0.8.tgz",
+      "integrity": "sha512-rW5a0TPcITHS+DF/SsGmFGKnUvmuSimTjeUGVXWZb2zbJ1kllSa67HSarM+Kg9UHD08rGYLt2EShoiOPl3lfig==",
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/crypto.hash": "1100.0.1",
+        "@pnpm/types": "1101.3.2",
+        "semver": "^7.8.4"
+      },
+      "engines": {
+        "node": ">=22.13"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@pnpm/error": {
+      "version": "1100.0.0",
+      "resolved": "https://registry.npmjs.org/@pnpm/error/-/error-1100.0.0.tgz",
+      "integrity": "sha512-Pe+UcOhBwBBM38GPavnPJllik4/DZ8Fawt9+D2JLoWSo6FNZBJWQbaDMuwba3W0Ej0v43etKmyCT+MOvwt95Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/constants": "1100.0.0"
+      },
+      "engines": {
+        "node": ">=22.13"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@pnpm/fetching.fetcher-base": {
+      "version": "1100.1.9",
+      "resolved": "https://registry.npmjs.org/@pnpm/fetching.fetcher-base/-/fetching.fetcher-base-1100.1.9.tgz",
+      "integrity": "sha512-yhhzMBQCVYRWn/JDoK6QOxfmma0S8T332FTqmTFbCWgs84VmmfYLZPNumXNZkCls7TMGbLAglyuYozPD4188XA==",
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/resolving.resolver-base": "1100.4.2",
+        "@pnpm/types": "1101.3.2",
+        "@types/ssri": "^7.1.5"
+      },
+      "engines": {
+        "node": ">=22.13"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@pnpm/fs.graceful-fs": {
+      "version": "1100.1.0",
+      "resolved": "https://registry.npmjs.org/@pnpm/fs.graceful-fs/-/fs.graceful-fs-1100.1.0.tgz",
+      "integrity": "sha512-sqz/s9GmCpMdTL1CP7lteu6EzV2FpAB2xBTztWh7ZCZUoM2MFQZlQI1OuCqdkn6VI3WRnhkUgV0pIOlbqFTCSw==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.11"
+      },
+      "engines": {
+        "node": ">=22.13"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@pnpm/hooks.types": {
+      "version": "1100.0.12",
+      "resolved": "https://registry.npmjs.org/@pnpm/hooks.types/-/hooks.types-1100.0.12.tgz",
+      "integrity": "sha512-exdlDvPNdV7cbVvclzoZLGK72zBj+Z14orTkgIpDOy55/JNtx5bZ8vYAb51GdiWhcji90p+316YLiL5fE1/NUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/fetching.fetcher-base": "1100.1.9",
+        "@pnpm/lockfile.types": "1100.0.11",
+        "@pnpm/resolving.resolver-base": "1100.4.2",
+        "@pnpm/store.cafs-types": "1100.0.1",
+        "@pnpm/types": "1101.3.2"
+      },
+      "engines": {
+        "node": ">=22.13"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@pnpm/lockfile.fs": {
+      "version": "1100.1.6",
+      "resolved": "https://registry.npmjs.org/@pnpm/lockfile.fs/-/lockfile.fs-1100.1.6.tgz",
+      "integrity": "sha512-ooZXS/yMGcrcHGSb7MNXR1pLG4UaGTO/7m/NJ3+sr6ScwdbdWduilrF9JoOMyKjMIfiOhygXrazYIE8ChjELfg==",
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/constants": "1100.0.0",
+        "@pnpm/deps.path": "1100.0.8",
+        "@pnpm/error": "1100.0.0",
+        "@pnpm/lockfile.merger": "1100.0.11",
+        "@pnpm/lockfile.types": "1100.0.11",
+        "@pnpm/lockfile.utils": "1100.0.13",
+        "@pnpm/network.git-utils": "1100.0.2",
+        "@pnpm/object.key-sorting": "1100.0.1",
+        "@pnpm/types": "1101.3.2",
+        "@zkochan/rimraf": "^4.0.0",
+        "comver-to-semver": "^2.0.0",
+        "js-yaml": "npm:@zkochan/js-yaml@0.0.11",
+        "normalize-path": "^3.0.0",
+        "ramda": "npm:@pnpm/ramda@0.28.1",
+        "semver": "^7.8.4",
+        "strip-bom": "^5.0.0",
+        "write-file-atomic": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=22.13"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      },
+      "peerDependencies": {
+        "@pnpm/logger": "^1100.0.0"
+      }
+    },
+    "node_modules/@pnpm/lockfile.merger": {
+      "version": "1100.0.11",
+      "resolved": "https://registry.npmjs.org/@pnpm/lockfile.merger/-/lockfile.merger-1100.0.11.tgz",
+      "integrity": "sha512-P/OuZtsRv0/IFE0wq1XqDiEGz31AiNJzsBvDOq6eDl/upx5g01MYe1SHzGDCR0Yy91jopfeEocIyhSwSzoyiUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/lockfile.types": "1100.0.11",
+        "@pnpm/types": "1101.3.2",
+        "comver-to-semver": "^2.0.0",
+        "ramda": "npm:@pnpm/ramda@0.28.1",
+        "semver": "^7.8.4"
+      },
+      "engines": {
+        "node": ">=22.13"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@pnpm/lockfile.pruner": {
+      "version": "1100.0.11",
+      "resolved": "https://registry.npmjs.org/@pnpm/lockfile.pruner/-/lockfile.pruner-1100.0.11.tgz",
+      "integrity": "sha512-HoJ+8RqBLTgiOyKrHL1dExwSTcAS6mm8f+ryzMwgQPaQtuhhHkr8j3Gr3alLQ3Hz1LLBJHl3HqMRhoN1oEILvg==",
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/constants": "1100.0.0",
+        "@pnpm/deps.path": "1100.0.8",
+        "@pnpm/lockfile.types": "1100.0.11",
+        "@pnpm/types": "1101.3.2",
+        "ramda": "npm:@pnpm/ramda@0.28.1"
+      },
+      "engines": {
+        "node": ">=22.13"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@pnpm/lockfile.types": {
+      "version": "1100.0.11",
+      "resolved": "https://registry.npmjs.org/@pnpm/lockfile.types/-/lockfile.types-1100.0.11.tgz",
+      "integrity": "sha512-WiGzV9/q0rpyQzAxV9jnqra5cZ2JNGSKocC2rhzmKKfXuuVo8XAXW5o9BzVl8kCuIYqqR/ei11AH5WTuTaXcIw==",
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/patching.types": "1100.0.0",
+        "@pnpm/resolving.resolver-base": "1100.4.2",
+        "@pnpm/types": "1101.3.2"
+      },
+      "engines": {
+        "node": ">=22.13"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@pnpm/lockfile.utils": {
+      "version": "1100.0.13",
+      "resolved": "https://registry.npmjs.org/@pnpm/lockfile.utils/-/lockfile.utils-1100.0.13.tgz",
+      "integrity": "sha512-EMHJN+BZRDHLZV2Xl17f7qFtqS+UDgiz6k6EzuUdIsOARmLRS+rDEw7GmmTum2fkHQNosg3M84HeL1W+3a4OWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/deps.path": "1100.0.8",
+        "@pnpm/error": "1100.0.0",
+        "@pnpm/hooks.types": "1100.0.12",
+        "@pnpm/lockfile.types": "1100.0.11",
+        "@pnpm/resolving.resolver-base": "1100.4.2",
+        "@pnpm/types": "1101.3.2",
+        "get-npm-tarball-url": "^2.1.0",
+        "ramda": "npm:@pnpm/ramda@0.28.1"
+      },
+      "engines": {
+        "node": ">=22.13"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@pnpm/logger": {
+      "version": "1100.0.0",
+      "resolved": "https://registry.npmjs.org/@pnpm/logger/-/logger-1100.0.0.tgz",
+      "integrity": "sha512-A3bRMTIZ5ptDPAE/KsDeY1J5UqqOiyo66+k/mUvaVjx++OJdMbp9If5kisEq9ljAV5r5TRpkxsJbSdrdJ5WtzQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bole": "^5.0.17",
+        "split2": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=22.13"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@pnpm/network.git-utils": {
+      "version": "1100.0.2",
+      "resolved": "https://registry.npmjs.org/@pnpm/network.git-utils/-/network.git-utils-1100.0.2.tgz",
+      "integrity": "sha512-4YD6DSFp4OPjIwstIhKWt37ppkCL0wazkTQTkBMTUMKbxvFJgL4LNxFg3uR3SsZ/tHRT2L7rLvNr4I52+sMNUA==",
+      "license": "MIT",
+      "dependencies": {
+        "execa": "npm:safe-execa@0.3.0"
+      },
+      "engines": {
+        "node": ">=22.13"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@pnpm/object.key-sorting": {
+      "version": "1100.0.1",
+      "resolved": "https://registry.npmjs.org/@pnpm/object.key-sorting/-/object.key-sorting-1100.0.1.tgz",
+      "integrity": "sha512-93ZFWlQkQa/0Kqt6ApCIQdK5q1lzNqvb23Mlcr25GPixgQGv+nMoQJlMcRUGJWqLoiyhpYyKai4Pfwi5Su0wMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/util.lex-comparator": "^4.0.1",
+        "sort-keys": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=22.13"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@pnpm/patching.types": {
+      "version": "1100.0.0",
+      "resolved": "https://registry.npmjs.org/@pnpm/patching.types/-/patching.types-1100.0.0.tgz",
+      "integrity": "sha512-trrr0UIaIEIDagZhuxjO83z+/aCvyKib+g5zXQQ7d2H3bj8GN2sHPPi/5/i8C1eMiBGNZut/8cl8ipNRbFwIow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.13"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@pnpm/resolving.resolver-base": {
+      "version": "1100.4.2",
+      "resolved": "https://registry.npmjs.org/@pnpm/resolving.resolver-base/-/resolving.resolver-base-1100.4.2.tgz",
+      "integrity": "sha512-EJUOio/kQsDJGNCFj7jMjGdkCiz/NIOLu4H4ueosLMD5Wq1hLEvqCSTVCE8h68vShUlJ3XSkFdXSpihVdbzL8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/types": "1101.3.2"
+      },
+      "engines": {
+        "node": ">=22.13"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@pnpm/store.cafs-types": {
+      "version": "1100.0.1",
+      "resolved": "https://registry.npmjs.org/@pnpm/store.cafs-types/-/store.cafs-types-1100.0.1.tgz",
+      "integrity": "sha512-UeXt5uecNdvQl9fdhgpiFvcBm18CDDKFzWj686uiPyQ7cGvu77RpEGk2cd7CfXvvaY89AaMfmdER0O1+8UA51A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.13"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@pnpm/types": {
+      "version": "1101.3.2",
+      "resolved": "https://registry.npmjs.org/@pnpm/types/-/types-1101.3.2.tgz",
+      "integrity": "sha512-iYpRR/wY+FNnMEUT9LO4OPV256QRk3NhXIiAIVg9tZv1F4cX28Ka7yXE1oyT9zQ2yhkZZYZSgm0M9IHDEZ/62g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.13"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@pnpm/util.lex-comparator": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@pnpm/util.lex-comparator/-/util.lex-comparator-4.0.1.tgz",
+      "integrity": "sha512-EZ3aWU7ThppE3Xgq7/ftxq8J/nit6z8I2/wZbC/acea2Zw7KJ1k/fLkGBgyyVAE37CULFsOSmPl3EjYM18cB2Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.13"
+      }
+    },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.4.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.0.tgz",
+      "integrity": "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/ssri": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@types/ssri/-/ssri-7.1.5.tgz",
+      "integrity": "sha512-odD/56S3B51liILSk5aXJlnYt99S6Rt9EFDDqGtJM26rKHApHcwyU/UoYHrzKkdkHMAIquGWCuHtQTbes+FRQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@zkochan/rimraf": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@zkochan/rimraf/-/rimraf-4.0.0.tgz",
+      "integrity": "sha512-0EdBn93hMsbx4svJsKQCch+sNMuXvzWbVYqTCGdctQmxtuYK57uCURZPNiNdwS2Y31d96DMWI3BpJ9DLN2Jxfw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.13"
+      }
+    },
+    "node_modules/@zkochan/which": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@zkochan/which/-/which-2.0.3.tgz",
+      "integrity": "sha512-C1ReN7vt2/2O0fyTsx5xnbQuxBrmG5NMSbcIkPKCCfCTJgpZBsuRYzFXHj3nVq8vTfK7vxHUmzfCpSHgO7j4rg==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/bole": {
+      "version": "5.0.29",
+      "resolved": "https://registry.npmjs.org/bole/-/bole-5.0.29.tgz",
+      "integrity": "sha512-eYR9i2ubLv5/4TFGyZsQ1cVH4jF9+qLJA72Aow+E7ZZQfqHqQNUZeX3w+pVWF76PQyjl5eDKf2xylyOOX76ozA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-safe-stringify": "^2.0.7",
+        "individual": "^3.0.0"
+      }
+    },
+    "node_modules/comver-to-semver": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/comver-to-semver/-/comver-to-semver-2.0.0.tgz",
+      "integrity": "sha512-4pxiLt2bXHe5BDrolTJs9wfwwT0pPQPQxeUj+X6SKTCkpi8VwvOvgMzohTVVDLXHmAjrZuKEq+tyb0C5zzTSxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.13"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/execa": {
+      "name": "safe-execa",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/safe-execa/-/safe-execa-0.3.0.tgz",
+      "integrity": "sha512-LMzgcWXnnL60sDuAzlmGehx7OHa4ajy0R/3djFOfnZwj4aksZUcdHfZgIIWLNcqverOAQJ2qOe7BDFm7Qpxd6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@zkochan/which": "^2.0.3",
+        "execa": "^9.6.1",
+        "path-name": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=22.13"
+      }
+    },
+    "node_modules/execa/node_modules/execa": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-npm-tarball-url": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/get-npm-tarball-url/-/get-npm-tarball-url-2.1.0.tgz",
+      "integrity": "sha512-ro+DiMu5DXgRBabqXupW38h7WPZ9+Ad8UjwhvsmmN8w1sU7ab0nzAXvVZ4kqYg57OrqomRtJvepX5/xvFKNtjA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/individual": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/individual/-/individual-3.0.0.tgz",
+      "integrity": "sha512-rUY5vtT748NMRbEMrTNiFfy29BgGZwGXUi2NFUVMWQrogSLzlJvQV9eeMWi+g1aVaQ53tpyLAQtd5x/JH0Nh1g==",
+      "peer": true
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/js-yaml": {
+      "name": "@zkochan/js-yaml",
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/@zkochan/js-yaml/-/js-yaml-0.0.11.tgz",
+      "integrity": "sha512-SO+h5Jg079r2JvGle0jbdtk1EY7ppu6TGzmfWTp3Gy61IEb1OVKBocJ6ydTn4++nYFNfRKYenI2MniZQwsM9KQ==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-name": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/path-name/-/path-name-1.0.0.tgz",
+      "integrity": "sha512-/dcAb5vMXH0f51yvMuSUqFpxUcA8JelbRmE5mW/p4CUJxrNgK24IkstnV7ENtg2IDGBOu6izKTG6eilbnbNKWQ==",
+      "license": "MIT"
+    },
+    "node_modules/pretty-ms": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.1.tgz",
+      "integrity": "sha512-HzMy3Geq23nVALD/M2LliU+F+M+gVNsvkQWWqeBZ8HDiCgzo6YPJ/Omrmtq24EFrIsk0a3EkQGEd7bDOo+IhGA==",
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ramda": {
+      "name": "@pnpm/ramda",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@pnpm/ramda/-/ramda-0.28.1.tgz",
+      "integrity": "sha512-zcAG+lvU0fMziNeGXpPyCyCJYp5ZVrPElEE4t14jAmViaihohocZ+dDkcRIyAomox8pQsuZnv1EyHR+pOhmUWw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ramda"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sort-keys": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-6.0.1.tgz",
+      "integrity": "sha512-w7xWRu8U9MneKNna8ptG194jp9PLtbd/Rl6gwrmbK4yUeKbE66a64rHgl0iKTBBDr/hpanx7zMGP1Qo8MRkc/w==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/ssri": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.1.tgz",
+      "integrity": "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-5.0.0.tgz",
+      "integrity": "sha512-p+byADHF7SzEcVnLvc/r3uognM1hUhObuHXxJcgLCfD194XAkaLbjq3Wzb0N5G2tgIjH0dgT708Z51QxMeu60A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/write-file-atomic": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-7.0.1.tgz",
+      "integrity": "sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==",
+      "license": "ISC",
+      "dependencies": {
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
+      "integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/nix/workspace-tools/lib/mk-pnpm-cli/lockfile-projector/package.json
+++ b/nix/workspace-tools/lib/mk-pnpm-cli/lockfile-projector/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@overeng/pnpm-lock-projector",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@pnpm/lockfile.fs": "1100.1.6",
+    "@pnpm/lockfile.pruner": "1100.0.11"
+  },
+  "$genie": {
+    "source": "package.json.genie.ts",
+    "warning": "DO NOT EDIT - changes will be overwritten"
+  }
+}

--- a/nix/workspace-tools/lib/mk-pnpm-cli/lockfile-projector/package.json.genie.ts
+++ b/nix/workspace-tools/lib/mk-pnpm-cli/lockfile-projector/package.json.genie.ts
@@ -1,0 +1,8 @@
+// @genie-bootstrap
+import { catalog, packageJson, privatePackageDefaults } from '../../../../../genie/internal.ts'
+
+export default packageJson({
+  name: '@overeng/pnpm-lock-projector',
+  ...privatePackageDefaults,
+  dependencies: catalog.pick('@pnpm/lockfile.fs', '@pnpm/lockfile.pruner'),
+})

--- a/nix/workspace-tools/lib/mk-pnpm-cli/lockfile-projector/project-lockfile.mjs
+++ b/nix/workspace-tools/lib/mk-pnpm-cli/lockfile-projector/project-lockfile.mjs
@@ -1,0 +1,36 @@
+import { readWantedLockfile, writeWantedLockfile } from '@pnpm/lockfile.fs'
+import { pruneSharedLockfile } from '@pnpm/lockfile.pruner'
+
+const [lockfileDir, ...importerIds] = process.argv.slice(2)
+if (lockfileDir === undefined || importerIds.length === 0) {
+  throw new Error('usage: project-lockfile.mjs <lockfile-dir> <importer-id>...')
+}
+
+const lockfile = await readWantedLockfile(lockfileDir, { ignoreIncompatible: false })
+if (lockfile === null) {
+  throw new Error(`lockfile is missing from ${lockfileDir}`)
+}
+
+const importers = Object.fromEntries(
+  importerIds.map((importerId) => {
+    const importer = lockfile.importers[importerId]
+    if (importer === undefined) {
+      throw new Error(`lockfile is missing importer ${importerId}`)
+    }
+    return [importerId, importer]
+  }),
+)
+
+const projectedLockfile = pruneSharedLockfile(
+  {
+    ...lockfile,
+    importers,
+  },
+  {
+    warn: (message) => {
+      throw new Error(`cannot project incomplete lockfile closure: ${message}`)
+    },
+  },
+)
+
+await writeWantedLockfile(lockfileDir, projectedLockfile)

--- a/nix/workspace-tools/lib/mk-pnpm-cli/tests/fixtures/downstream/fixture-workspace/app/package.json
+++ b/nix/workspace-tools/lib/mk-pnpm-cli/tests/fixtures/downstream/fixture-workspace/app/package.json
@@ -4,7 +4,8 @@
   "version": "0.0.0",
   "type": "module",
   "dependencies": {
-    "@overeng/utils": "workspace:^"
+    "@overeng/utils": "workspace:^",
+    "target-direct": "1.0.0"
   },
   "$genie": {
     "workspaceClosureDirs": [

--- a/nix/workspace-tools/lib/mk-pnpm-cli/tests/fixtures/downstream/fixture-workspace/patches/target-direct.patch
+++ b/nix/workspace-tools/lib/mk-pnpm-cli/tests/fixtures/downstream/fixture-workspace/patches/target-direct.patch
@@ -1,0 +1,3 @@
+diff --git a/fixture.txt b/fixture.txt
+new file mode 100644
+index 0000000..e69de29

--- a/nix/workspace-tools/lib/mk-pnpm-cli/tests/fixtures/downstream/fixture-workspace/pnpm-lock.yaml
+++ b/nix/workspace-tools/lib/mk-pnpm-cli/tests/fixtures/downstream/fixture-workspace/pnpm-lock.yaml
@@ -9,6 +9,9 @@ overrides:
 
 packageExtensionsChecksum: sha256-LU2/j/l3R+j7b1WqrjZQtPcw3ScrfwaVJrrAFedVGTs=
 
+patchedDependencies:
+  target-direct@1.0.0: hash-target-direct
+
 importers:
   .: {}
   app:
@@ -16,12 +19,40 @@ importers:
       '@overeng/utils':
         specifier: file:../.devenv/pnpm-source-inputs/current/repos/effect-utils/packages/@overeng/utils
         version: '@overeng/utils@file:.devenv/pnpm-source-inputs/current/repos/effect-utils/packages/@overeng/utils'
+      target-direct:
+        specifier: 1.0.0
+        version: 1.0.0(patch_hash=hash-target-direct)
+  excluded:
+    dependencies:
+      excluded-only:
+        specifier: 2.0.0
+        version: 2.0.0
 
 packages:
-
   '@overeng/utils@file:.devenv/pnpm-source-inputs/current/repos/effect-utils/packages/@overeng/utils':
     resolution: {directory: .devenv/pnpm-source-inputs/current/repos/effect-utils/packages/@overeng/utils, type: directory}
+  excluded-leaf@3.0.0:
+    resolution: {integrity: sha512-excluded-leaf-300}
+  excluded-leaf@3.0.1:
+    resolution: {integrity: sha512-excluded-leaf-301}
+  excluded-only@2.0.0:
+    resolution: {integrity: sha512-excluded-only}
+  target-direct@1.0.0:
+    resolution: {integrity: sha512-target-direct}
+  target-transitive@1.0.0:
+    resolution: {integrity: sha512-target-transitive-100}
+  target-transitive@1.0.1:
+    resolution: {integrity: sha512-target-transitive-101}
 
 snapshots:
-
   '@overeng/utils@file:.devenv/pnpm-source-inputs/current/repos/effect-utils/packages/@overeng/utils': {}
+  excluded-leaf@3.0.0: {}
+  excluded-leaf@3.0.1: {}
+  excluded-only@2.0.0:
+    dependencies:
+      excluded-leaf: 3.0.0
+  target-direct@1.0.0(patch_hash=hash-target-direct):
+    dependencies:
+      target-transitive: 1.0.0
+  target-transitive@1.0.0: {}
+  target-transitive@1.0.1: {}

--- a/nix/workspace-tools/lib/mk-pnpm-cli/tests/fixtures/downstream/fixture-workspace/pnpm-workspace.yaml
+++ b/nix/workspace-tools/lib/mk-pnpm-cli/tests/fixtures/downstream/fixture-workspace/pnpm-workspace.yaml
@@ -1,6 +1,9 @@
 packages:
   - app
 
+patchedDependencies:
+  target-direct@1.0.0: patches/target-direct.patch
+
 overrides:
   '@overeng/utils': file:.devenv/pnpm-source-inputs/current/repos/effect-utils/packages/@overeng/utils
 

--- a/nix/workspace-tools/lib/mk-pnpm-cli/tests/fixtures/downstream/flake.nix
+++ b/nix/workspace-tools/lib/mk-pnpm-cli/tests/fixtures/downstream/flake.nix
@@ -89,6 +89,52 @@
           };
           smokeTestArgs = [ ];
         };
+        mkIdentityWorkspace =
+          suffix: mutation:
+          pkgs.runCommand "mk-pnpm-cli-lock-identity-${suffix}" { } ''
+            mkdir -p "$out"
+            cp -R ${./fixture-workspace}/. "$out/"
+            chmod -R +w "$out"
+            ${mutation}
+          '';
+        excludedIdentityWorkspace = mkIdentityWorkspace "excluded" ''
+          substituteInPlace "$out/pnpm-lock.yaml" \
+            --replace-fail "specifier: 2.0.0" "specifier: ^2.0.0" \
+            --replace-fail "excluded-leaf: 3.0.0" "excluded-leaf: 3.0.1"
+        '';
+        targetIdentityWorkspace = mkIdentityWorkspace "target" ''
+          substituteInPlace "$out/pnpm-lock.yaml" \
+            --replace-fail "specifier: 1.0.0" "specifier: ^1.0.0"
+        '';
+        transitiveIdentityWorkspace = mkIdentityWorkspace "transitive" ''
+          substituteInPlace "$out/pnpm-lock.yaml" \
+            --replace-fail "target-transitive: 1.0.0" "target-transitive: 1.0.1"
+        '';
+        mkIdentityFixture =
+          fixtureName: fixtureWorkspace:
+          mkPnpmCli {
+            name = "mk-pnpm-cli-lock-identity-${fixtureName}";
+            binaryName = "mk-pnpm-cli-lock-identity-${fixtureName}";
+            entry = "app/src/mod.ts";
+            packageDir = "app";
+            workspaceRoot = fixtureWorkspace;
+            evalWorkspaceRoot = ./fixture-workspace;
+            workspaceSources = {
+              "repos/effect-utils" = effectUtilsSource;
+            };
+            depsBuilds = {
+              "." = {
+                hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+              };
+              "repos/effect-utils" = {
+                hash = "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=";
+              };
+            };
+            smokeTestArgs = [ ];
+          };
+        excludedIdentityFixture = mkIdentityFixture "excluded" excludedIdentityWorkspace;
+        targetIdentityFixture = mkIdentityFixture "target" targetIdentityWorkspace;
+        transitiveIdentityFixture = mkIdentityFixture "transitive" transitiveIdentityWorkspace;
         # Two consumers that differ ONLY in `name` but share the same external
         # install-root profile. Their prepared deps for that shared root must
         # collapse to one in-store derivation (profileKey dedup), while their
@@ -180,9 +226,6 @@
 
               grep -Fq "file:$stage_prefix/$logical_path" "$deps_src/pnpm-lock.yaml"
               grep -Fq "directory: $stage_prefix/$logical_path" "$deps_src/pnpm-lock.yaml"
-              grep -Fq "file:$stage_prefix/$logical_path" "$deps_src/pnpm-workspace.yaml"
-              grep -Fq "packageExtensionsChecksum: sha256-LU2/j/l3R+j7b1WqrjZQtPcw3ScrfwaVJrrAFedVGTs=" \
-                "$deps_src/pnpm-lock.yaml"
               test -d "$alias_path"
               test "$(find "$alias_path" -mindepth 1 -maxdepth 1 -printf '%f\n')" = package.json
               test -L "$alias_path/package.json"
@@ -202,6 +245,46 @@
           pkgs.runCommand "mk-pnpm-cli-invalid-source-input-stage-path" { } ''
             touch "$out"
           '';
+        checks.aggregate-lock-closure-identity =
+          pkgs.runCommand "mk-pnpm-cli-aggregate-lock-closure-identity" { }
+            ''
+              baseline=${pureEvalFixture.passthru.depsSrcByInstallRoot.root}
+              excluded=${excludedIdentityFixture.passthru.depsSrcByInstallRoot.root}
+              target=${targetIdentityFixture.passthru.depsSrcByInstallRoot.root}
+              transitive=${transitiveIdentityFixture.passthru.depsSrcByInstallRoot.root}
+
+              diff --recursive --brief "$baseline" "$excluded"
+              if cmp --silent "$baseline/pnpm-lock.yaml" "$target/pnpm-lock.yaml"; then
+                echo "target importer perturbation did not change projected dependency identity" >&2
+                exit 1
+              fi
+              if cmp --silent "$baseline/pnpm-lock.yaml" "$transitive/pnpm-lock.yaml"; then
+                echo "reachable transitive perturbation did not change projected dependency identity" >&2
+                exit 1
+              fi
+
+              grep -Fq "target-direct@1.0.0" "$baseline/pnpm-lock.yaml"
+              grep -Fq "target-transitive@1.0.0" "$baseline/pnpm-lock.yaml"
+              grep -Fq "target-direct@1.0.0: hash-target-direct" "$baseline/pnpm-lock.yaml"
+              grep -Fq "target-direct@1.0.0: patches/target-direct.patch" \
+                "$baseline/pnpm-workspace.yaml"
+              if grep -Fq "excluded-only" "$baseline/pnpm-lock.yaml"; then
+                echo "excluded importer closure leaked into projected lockfile" >&2
+                exit 1
+              fi
+              if grep -Fq "excluded-leaf" "$baseline/pnpm-lock.yaml"; then
+                echo "excluded snapshot closure leaked into projected lockfile" >&2
+                exit 1
+              fi
+              for deps_src in "$baseline" "$excluded" "$target" "$transitive"; do
+                if find "$deps_src" -name node_modules -print -quit | grep -q .; then
+                  echo "lock projection materialized node_modules: $deps_src" >&2
+                  exit 1
+                fi
+              done
+
+              touch "$out"
+            '';
         checks.pure-eval-profile-dedup = pkgs.runCommand "mk-pnpm-cli-pure-eval-profile-dedup" { } ''
           actual='${
             builtins.toJSON {

--- a/nix/workspace-tools/lib/mk-pnpm-cli/tests/run.sh
+++ b/nix/workspace-tools/lib/mk-pnpm-cli/tests/run.sh
@@ -249,6 +249,11 @@ run_downstream_pure_eval_regression() {
     --override-input effect-utils "path:$WORKSPACE_REAL/repos/effect-utils" \
     "path:$DOWNSTREAM_DIR#checks.$SYSTEM.prepared-source-input-manifest-aliases"
 
+  echo "Check: aggregate lock projection tracks only the target dependency closure"
+  nix build --no-link --no-write-lock-file \
+    --override-input effect-utils "path:$WORKSPACE_REAL/repos/effect-utils" \
+    "path:$DOWNSTREAM_DIR#checks.$SYSTEM.aggregate-lock-closure-identity"
+
   echo "Check: non-canonical source-input stage paths fail evaluation"
   nix build --no-link --no-write-lock-file \
     --override-input effect-utils "path:$WORKSPACE_REAL/repos/effect-utils" \

--- a/packages/@overeng/ci-tools/nix/build.nix
+++ b/packages/@overeng/ci-tools/nix/build.nix
@@ -19,7 +19,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-5lXB8UByHOdKM2lfYdfV3KfFdLTCShUGRZVjcSne3u8=";
+      "." = mkSharedHash "sha256-uJnIIs+LIu3SMu95gfvUFfL2gc0+xH5UeJVGQ0L3i/E=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/genie/nix/build.nix
+++ b/packages/@overeng/genie/nix/build.nix
@@ -26,7 +26,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-J0yUHnU6yMx4qPOvmJUdI18dfF8BBJ3nJqcGw/4lH54=";
+      "." = mkSharedHash "sha256-094tka4bCE/0jwdikJXmnQZiilVvrQExKbHAD6DeThY=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/megarepo/nix/build.nix
+++ b/packages/@overeng/megarepo/nix/build.nix
@@ -24,7 +24,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-JJJ+hhyzFMNd5wKyALJQBVXngk2Ylfy6DLlBvmCyE2o=";
+      "." = mkSharedHash "sha256-Qo/fhq7zfwGKMLiXYhcogrLgE4moF6dXjDJANJY6XqA=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     smokeTestArgs = [ "--help" ];

--- a/packages/@overeng/notion-cli/nix/build.nix
+++ b/packages/@overeng/notion-cli/nix/build.nix
@@ -33,7 +33,7 @@ let
     installRuntimeWorkspace = true;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-aAe1XrnUtBQ2nHwkyHQP4NtMGTot3zPnCw+pWMA6VXw=";
+      "." = mkSharedHash "sha256-T8Z9mFJCibd0u7AAX17Ry41ufpGwclNsfDMsnDoHZeI=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;


### PR DESCRIPTION
## Problem

`mkPnpmCli` staged the complete root `pnpm-lock.yaml` into every aggregate dependency source. An unrelated importer or package snapshot therefore changed a CLI fixed-output derivation (FOD), even when that importer was outside the CLI's owned workspace closure.

## Goal

Make aggregate pnpm dependency-source identity depend only on the target package and its owned workspace closure.

## Decisions

- Prune the shared lock with pnpm's public `pruneSharedLockfile` API instead of maintaining a second dependency graph implementation.
- Preserve every importer in the aggregate-owned workspace closure, not only the target importer. This keeps frozen installs valid for workspace dependencies.
- Package the projector as an isolated Nix-built Node helper because pnpm does not export the required lockfile APIs from its CLI package.
- Keep patch metadata behavior unchanged. Unrelated top-level patch declarations can still affect identity; pruning those safely is separate from the importer/snapshot defect.

## Verification

Passed locally:

- `nix build .#checks.x86_64-linux.aggregate-lock-closure-identity`
- `CI=1 bash nix/workspace-tools/lib/mk-pnpm-cli/tests/run.sh --skip-genie --skip-megarepo --skip-oxlint --skip-devenv-shell --skip-downstream-megarepo`
- `devenv tasks run check:quick --no-tui`

The new oracle proves both directions: excluded importer/package changes keep the staged source identical, while direct and transitive closure changes alter it. The oracle also verifies that relevant patch metadata remains and no `node_modules` enters the staged source.

Pre-flip deviation: `devenv tasks run check:all --no-tui` reaches the existing `pnpm-source-input-refresh.integration.test.sh`, where the local agent policy rejects the test's direct `pnpm install`. Running that test directly at the exact merge-base (`5f90869ee`) fails with the same policy rejection. All preceding full-suite tests passed. The first full run also hit a pre-existing Cargo-target/Nix source-snapshot race; the repeated run did not reproduce that race.

## Complexity

This adds one small isolated projector plus its locked build dependencies. The isolation is necessary because the pinned pnpm CLI package does not expose the public lockfile APIs.

## Concerns

- `pruneSharedLockfile` retains the top-level `patchedDependencies` map. Existing workspace YAML and patch-copy behavior therefore remain conservative rather than minimally projected.
- The fixture covers direct, transitive, workspace-owned, excluded, and patched dependencies. It does not independently exercise every peer/optional/dev edge handled by the upstream pnpm pruner.

## Friction & bottlenecks

- Full validation takes about 20 minutes because the Weaver lanes dominate the critical path.
- The direct-pnpm policy rejection in the source-refresh integration test prevents a fully green local `check:all` under the agent environment.
- One full run raced Nix source evaluation against a disappearing Cargo temporary file. This was recorded as agent feedback.

## Follow-ups

None required for this correction.

## References

Downstream adoption will be the sixth PR above dotfiles PR #2178.

<!-- agent-footer:begin v=2 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | dev3.direct.omp.5wtg9j4p |
| `session` | dev3.5wtg9j4p |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.0.11 |
| `agent_runtime` | OMP 18.0.11 |
| `tooling_profile` | dotfiles@2161b9c |
</details>
<!-- agent-footer:end -->