### PR TITLE
fix(notion): widen response schemas to decoders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ All notable changes to this project will be documented in this file.
   notion-datasource-sync, ci-tools, and notion-effect-client;
   content-address stays dependency-free to avoid a utils ->
   otel-contract -> content-address -> utils cycle.
+- **@overeng/notion-effect-client, @overeng/notion-effect-schema,
+  @overeng/notion-cli**: response-only page and database APIs now accept
+  `Schema.Decoder`; generated schemas import the package's re-exported `Schema`
+  namespace and use the explicit Effect 4 async decode/encode helpers.
 - **@overeng/notion-effect-client**: the request throttle reads
   `RateLimiter.ConsumeResult.delay` directly (the double-Clock measurement and
   the `isRateLimiterError` catch-to-die workaround are gone; e2e wait assertions

--- a/packages/@overeng/notion-cli/src/codegen.ts
+++ b/packages/@overeng/notion-cli/src/codegen.ts
@@ -790,8 +790,7 @@ export function generateSchemaCode(opts: GenerateSchemaCodeOptions): string {
     `// URL: ${dbInfo.url}`,
     ...(configComment !== '' ? [configComment] : []),
     ``,
-    `import { NotionSchema${schemaMeta === true ? ', notionPropertyMeta' : ''} } from '@overeng/notion-effect-schema'`,
-    `import { Schema } from 'effect'`,
+    `import { NotionSchema${schemaMeta === true ? ', notionPropertyMeta' : ''}, Schema } from '@overeng/notion-effect-schema'`,
   ]
 
   // Add typed options definitions
@@ -839,7 +838,7 @@ export function generateSchemaCode(opts: GenerateSchemaCodeOptions): string {
   lines.push(` * Decode properties from unknown data (returns Effect).`)
   lines.push(` */`)
   lines.push(
-    `export const decode${pascalName}PropertiesEffect = Schema.decodeUnknown(${pascalName}PageProperties)`,
+    `export const decode${pascalName}PropertiesEffect = Schema.decodeUnknownEffect(${pascalName}PageProperties)`,
   )
 
   // Write schema (if enabled)
@@ -875,7 +874,7 @@ export function generateSchemaCode(opts: GenerateSchemaCodeOptions): string {
     lines.push(` * Decode write data from simple types (returns Effect).`)
     lines.push(` */`)
     lines.push(
-      `export const decode${pascalName}WriteEffect = Schema.decodeUnknown(${pascalName}PageWrite)`,
+      `export const decode${pascalName}WriteEffect = Schema.decodeUnknownEffect(${pascalName}PageWrite)`,
     )
     lines.push(``)
     lines.push(`/**`)
@@ -887,7 +886,7 @@ export function generateSchemaCode(opts: GenerateSchemaCodeOptions): string {
     lines.push(` * Encode write data back to simple types (returns Effect).`)
     lines.push(` */`)
     lines.push(
-      `export const encode${pascalName}WriteEffect = Schema.encode(${pascalName}PageWrite)`,
+      `export const encode${pascalName}WriteEffect = Schema.encodeEffect(${pascalName}PageWrite)`,
     )
   }
 

--- a/packages/@overeng/notion-cli/src/codegen.unit.test.ts
+++ b/packages/@overeng/notion-cli/src/codegen.unit.test.ts
@@ -146,8 +146,7 @@ describe('codegen', () => {
         // ID: test-db-id
         // URL: https://notion.so/test-db
 
-        import { NotionSchema, notionPropertyMeta } from '@overeng/notion-effect-schema'
-        import { Schema } from 'effect'
+        import { NotionSchema, notionPropertyMeta, Schema } from '@overeng/notion-effect-schema'
 
         // -----------------------------------------------------------------------------
         // Read Schema
@@ -176,7 +175,7 @@ describe('codegen', () => {
         /**
          * Decode properties from unknown data (returns Effect).
          */
-        export const decodeTestDatabasePropertiesEffect = Schema.decodeUnknown(TestDatabasePageProperties)
+        export const decodeTestDatabasePropertiesEffect = Schema.decodeUnknownEffect(TestDatabasePageProperties)
         "
       `)
     })
@@ -206,8 +205,7 @@ describe('codegen', () => {
         // ID: test-db-id
         // URL: https://notion.so/test-db
 
-        import { NotionSchema, notionPropertyMeta } from '@overeng/notion-effect-schema'
-        import { Schema } from 'effect'
+        import { NotionSchema, notionPropertyMeta, Schema } from '@overeng/notion-effect-schema'
 
         // -----------------------------------------------------------------------------
         // Read Schema
@@ -233,7 +231,7 @@ describe('codegen', () => {
         /**
          * Decode properties from unknown data (returns Effect).
          */
-        export const decodeTestDatabasePropertiesEffect = Schema.decodeUnknown(TestDatabasePageProperties)
+        export const decodeTestDatabasePropertiesEffect = Schema.decodeUnknownEffect(TestDatabasePageProperties)
         "
       `)
     })
@@ -261,8 +259,7 @@ describe('codegen', () => {
         // ID: test-db-id
         // URL: https://notion.so/test
 
-        import { NotionSchema, notionPropertyMeta } from '@overeng/notion-effect-schema'
-        import { Schema } from 'effect'
+        import { NotionSchema, notionPropertyMeta, Schema } from '@overeng/notion-effect-schema'
 
         // -----------------------------------------------------------------------------
         // Read Schema
@@ -290,7 +287,7 @@ describe('codegen', () => {
         /**
          * Decode properties from unknown data (returns Effect).
          */
-        export const decodeTestPropertiesEffect = Schema.decodeUnknown(TestPageProperties)
+        export const decodeTestPropertiesEffect = Schema.decodeUnknownEffect(TestPageProperties)
         "
       `)
     })
@@ -325,8 +322,7 @@ describe('codegen', () => {
         // URL: https://notion.so/test
         // @config { transforms: { Status: raw, Tags: raw, Website: asString } }
 
-        import { NotionSchema, notionPropertyMeta } from '@overeng/notion-effect-schema'
-        import { Schema } from 'effect'
+        import { NotionSchema, notionPropertyMeta, Schema } from '@overeng/notion-effect-schema'
 
         // -----------------------------------------------------------------------------
         // Read Schema
@@ -354,7 +350,7 @@ describe('codegen', () => {
         /**
          * Decode properties from unknown data (returns Effect).
          */
-        export const decodeTestPropertiesEffect = Schema.decodeUnknown(TestPageProperties)
+        export const decodeTestPropertiesEffect = Schema.decodeUnknownEffect(TestPageProperties)
         "
       `)
     })
@@ -429,8 +425,7 @@ describe('codegen', () => {
         // ID: test-db-id
         // URL: https://notion.so/test
 
-        import { NotionSchema, notionPropertyMeta } from '@overeng/notion-effect-schema'
-        import { Schema } from 'effect'
+        import { NotionSchema, notionPropertyMeta, Schema } from '@overeng/notion-effect-schema'
 
         // -----------------------------------------------------------------------------
         // Read Schema
@@ -457,7 +452,7 @@ describe('codegen', () => {
         /**
          * Decode properties from unknown data (returns Effect).
          */
-        export const decodeTestPropertiesEffect = Schema.decodeUnknown(TestPageProperties)
+        export const decodeTestPropertiesEffect = Schema.decodeUnknownEffect(TestPageProperties)
         "
       `)
     })
@@ -684,8 +679,7 @@ describe('codegen', () => {
         // URL: https://notion.so/test
         // @config { includeWrite: true }
 
-        import { NotionSchema, notionPropertyMeta } from '@overeng/notion-effect-schema'
-        import { Schema } from 'effect'
+        import { NotionSchema, notionPropertyMeta, Schema } from '@overeng/notion-effect-schema'
 
         // -----------------------------------------------------------------------------
         // Read Schema
@@ -713,7 +707,7 @@ describe('codegen', () => {
         /**
          * Decode properties from unknown data (returns Effect).
          */
-        export const decodeTestPropertiesEffect = Schema.decodeUnknown(TestPageProperties)
+        export const decodeTestPropertiesEffect = Schema.decodeUnknownEffect(TestPageProperties)
 
         // -----------------------------------------------------------------------------
         // Write Schema
@@ -741,7 +735,7 @@ describe('codegen', () => {
         /**
          * Decode write data from simple types (returns Effect).
          */
-        export const decodeTestWriteEffect = Schema.decodeUnknown(TestPageWrite)
+        export const decodeTestWriteEffect = Schema.decodeUnknownEffect(TestPageWrite)
 
         /**
          * Encode write data back to simple types (throws on failure).
@@ -751,7 +745,7 @@ describe('codegen', () => {
         /**
          * Encode write data back to simple types (returns Effect).
          */
-        export const encodeTestWriteEffect = Schema.encode(TestPageWrite)
+        export const encodeTestWriteEffect = Schema.encodeEffect(TestPageWrite)
         "
       `)
     })
@@ -804,8 +798,7 @@ describe('codegen', () => {
         // URL: https://notion.so/test
         // @config { typedOptions: true }
 
-        import { NotionSchema, notionPropertyMeta } from '@overeng/notion-effect-schema'
-        import { Schema } from 'effect'
+        import { NotionSchema, notionPropertyMeta, Schema } from '@overeng/notion-effect-schema'
 
         // -----------------------------------------------------------------------------
         // Typed Options
@@ -849,7 +842,7 @@ describe('codegen', () => {
         /**
          * Decode properties from unknown data (returns Effect).
          */
-        export const decodeTestPropertiesEffect = Schema.decodeUnknown(TestPageProperties)
+        export const decodeTestPropertiesEffect = Schema.decodeUnknownEffect(TestPageProperties)
         "
       `)
     })
@@ -924,8 +917,7 @@ describe('codegen', () => {
         // URL: https://notion.so/test
         // @config { name: MyCustomName, includeWrite: true, typedOptions: true, includeApi: true, transforms: { Status: asOption, Priority: asName } }
 
-        import { NotionSchema, notionPropertyMeta } from '@overeng/notion-effect-schema'
-        import { Schema } from 'effect'
+        import { NotionSchema, notionPropertyMeta, Schema } from '@overeng/notion-effect-schema'
 
         // -----------------------------------------------------------------------------
         // Read Schema
@@ -951,7 +943,7 @@ describe('codegen', () => {
         /**
          * Decode properties from unknown data (returns Effect).
          */
-        export const decodeTestPropertiesEffect = Schema.decodeUnknown(TestPageProperties)
+        export const decodeTestPropertiesEffect = Schema.decodeUnknownEffect(TestPageProperties)
 
         // -----------------------------------------------------------------------------
         // Write Schema
@@ -978,7 +970,7 @@ describe('codegen', () => {
         /**
          * Decode write data from simple types (returns Effect).
          */
-        export const decodeTestWriteEffect = Schema.decodeUnknown(TestPageWrite)
+        export const decodeTestWriteEffect = Schema.decodeUnknownEffect(TestPageWrite)
 
         /**
          * Encode write data back to simple types (throws on failure).
@@ -988,7 +980,7 @@ describe('codegen', () => {
         /**
          * Encode write data back to simple types (returns Effect).
          */
-        export const encodeTestWriteEffect = Schema.encode(TestPageWrite)
+        export const encodeTestWriteEffect = Schema.encodeEffect(TestPageWrite)
         "
       `)
     })

--- a/packages/@overeng/notion-cli/src/integration.integration.test.ts
+++ b/packages/@overeng/notion-cli/src/integration.integration.test.ts
@@ -101,14 +101,11 @@ describe('integration', () => {
     const code = generateSchemaCode({ dbInfo, schemaName: 'TestDatabase' })
 
     // Verify it's valid TypeScript (basic smoke test)
-    expect(code).toContain("import { Schema } from 'effect'")
+    expect(code).toContain(
+      "import { NotionSchema, notionPropertyMeta, Schema } from '@overeng/notion-effect-schema'",
+    )
     expect(code).toContain('export const TestDatabasePageProperties')
     expect(code).toContain('export type TestDatabasePageProperties')
-
-    // Verify imports are correct
-    expect(code).toContain(
-      "import { NotionSchema, notionPropertyMeta } from '@overeng/notion-effect-schema'",
-    )
 
     // Verify usage is correct
     expect(code).toContain('Name: NotionSchema.title.annotate({ [notionPropertyMeta]')

--- a/packages/@overeng/notion-effect-client/src/databases.ts
+++ b/packages/@overeng/notion-effect-client/src/databases.ts
@@ -61,13 +61,9 @@ export interface QueryDatabaseOptions extends QueryDatabaseOptionsBase {
 }
 
 /** Options for querying a database with schema-based decoding */
-export interface QueryDatabaseWithSchemaOptions<
-  TProperties,
-  I,
-  R,
-> extends QueryDatabaseOptionsBase {
-  /** Schema to decode page properties */
-  readonly schema: Schema.Codec<TProperties, I, R>
+export interface QueryDatabaseWithSchemaOptions<TProperties, R> extends QueryDatabaseOptionsBase {
+  /** Decoder for page properties */
+  readonly schema: Schema.Decoder<TProperties, R>
 }
 
 /** Options for retrieving a database */
@@ -337,16 +333,16 @@ const queryRaw = (
 export function query(
   opts: QueryDatabaseOptions,
 ): Effect.Effect<PaginatedResult<Page>, NotionApiError, NotionConfig | HttpClient>
-export function query<TProperties, I, R>(
-  opts: QueryDatabaseWithSchemaOptions<TProperties, I, R>,
+export function query<TProperties, R>(
+  opts: QueryDatabaseWithSchemaOptions<TProperties, R>,
 ): Effect.Effect<
   TypedPaginatedResult<TProperties>,
   NotionApiError | PageDecodeError,
   NotionConfig | HttpClient | R
 >
 // oxlint-disable-next-line overeng/jsdoc-require-exports -- JSDoc is on first overload signature
-export function query<TProperties, I, R>(
-  opts: QueryDatabaseOptions | QueryDatabaseWithSchemaOptions<TProperties, I, R>,
+export function query<TProperties, R>(
+  opts: QueryDatabaseOptions | QueryDatabaseWithSchemaOptions<TProperties, R>,
 ): Effect.Effect<
   PaginatedResult<Page> | TypedPaginatedResult<TProperties>,
   NotionApiError | PageDecodeError,
@@ -398,18 +394,18 @@ export function query<TProperties, I, R>(
 export function queryStream(
   opts: Omit<QueryDatabaseOptions, 'startCursor'>,
 ): Stream.Stream<Page, NotionApiError, NotionConfig | HttpClient>
-export function queryStream<TProperties, I, R>(
-  opts: Omit<QueryDatabaseWithSchemaOptions<TProperties, I, R>, 'startCursor'>,
+export function queryStream<TProperties, R>(
+  opts: Omit<QueryDatabaseWithSchemaOptions<TProperties, R>, 'startCursor'>,
 ): Stream.Stream<
   TypedPage<TProperties>,
   NotionApiError | PageDecodeError,
   NotionConfig | HttpClient | R
 >
 // oxlint-disable-next-line overeng/jsdoc-require-exports -- JSDoc is on first overload signature
-export function queryStream<TProperties, I, R>(
+export function queryStream<TProperties, R>(
   opts:
     | Omit<QueryDatabaseOptions, 'startCursor'>
-    | Omit<QueryDatabaseWithSchemaOptions<TProperties, I, R>, 'startCursor'>,
+    | Omit<QueryDatabaseWithSchemaOptions<TProperties, R>, 'startCursor'>,
 ): Stream.Stream<
   Page | TypedPage<TProperties>,
   NotionApiError | PageDecodeError,

--- a/packages/@overeng/notion-effect-client/src/pages.ts
+++ b/packages/@overeng/notion-effect-client/src/pages.ts
@@ -53,9 +53,9 @@ export interface RetrievePageOptions extends RetrievePageOptionsBase {
 }
 
 /** Options for retrieving a page with schema-based decoding */
-export interface RetrievePageWithSchemaOptions<TProperties, I, R> extends RetrievePageOptionsBase {
-  /** Schema to decode page properties */
-  readonly schema: Schema.Codec<TProperties, I, R>
+export interface RetrievePageWithSchemaOptions<TProperties, R> extends RetrievePageOptionsBase {
+  /** Decoder for page properties */
+  readonly schema: Schema.Decoder<TProperties, R>
 }
 
 /** Options for creating a page */
@@ -204,16 +204,16 @@ export interface MovePageOptions {
 export function retrieve(
   opts: RetrievePageOptions,
 ): Effect.Effect<Page, NotionApiError, NotionConfig | HttpClient>
-export function retrieve<TProperties, I, R>(
-  opts: RetrievePageWithSchemaOptions<TProperties, I, R>,
+export function retrieve<TProperties, R>(
+  opts: RetrievePageWithSchemaOptions<TProperties, R>,
 ): Effect.Effect<
   TypedPage<TProperties>,
   NotionApiError | PageDecodeError,
   NotionConfig | HttpClient | R
 >
 // oxlint-disable-next-line overeng/jsdoc-require-exports -- JSDoc is on first overload signature
-export function retrieve<TProperties, I, R>(
-  opts: RetrievePageOptions | RetrievePageWithSchemaOptions<TProperties, I, R>,
+export function retrieve<TProperties, R>(
+  opts: RetrievePageOptions | RetrievePageWithSchemaOptions<TProperties, R>,
 ): Effect.Effect<
   Page | TypedPage<TProperties>,
   NotionApiError | PageDecodeError,

--- a/packages/@overeng/notion-effect-client/src/typed-page.ts
+++ b/packages/@overeng/notion-effect-client/src/typed-page.ts
@@ -44,9 +44,9 @@ export class PageDecodeError extends Schema.TaggedError<PageDecodeError>()('Page
  *
  * @returns Typed page with decoded properties
  */
-export const decodePage = Effect.fnUntraced(function* <TProperties, I, R>(opts: {
+export const decodePage = Effect.fnUntraced(function* <TProperties, R>(opts: {
   page: Page
-  schema: Schema.Codec<TProperties, I, R>
+  schema: Schema.Decoder<TProperties, R>
 }) {
   const { page, schema } = opts
   const decode = Schema.decodeUnknownEffect(schema)
@@ -78,8 +78,8 @@ export const decodePage = Effect.fnUntraced(function* <TProperties, I, R>(opts: 
  *
  * Fails fast on first decode error.
  */
-export const decodePages = <TProperties, I, R>(opts: {
+export const decodePages = <TProperties, R>(opts: {
   pages: readonly Page[]
-  schema: Schema.Codec<TProperties, I, R>
+  schema: Schema.Decoder<TProperties, R>
 }): Effect.Effect<readonly TypedPage<TProperties>[], PageDecodeError, R> =>
   Effect.forEach(opts.pages, (page) => decodePage({ page, schema: opts.schema }))

--- a/packages/@overeng/notion-effect-schema/src/mod.ts
+++ b/packages/@overeng/notion-effect-schema/src/mod.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Schema } from 'effect'
+export { Schema } from 'effect'
 
 import { Required, asName, asNames, asNullable } from './common.ts'
 import {


### PR DESCRIPTION
## Problem

Notion response paths accepted only full `Schema.Codec` values even though they only decode page properties. Effect 4 can expose valid read schemas through the narrower `Schema.Decoder` view, so those schemas were rejected at compile time. Generated schema modules also imported `Schema` directly and emitted the pre-Effect-4 async helper names.

## Goal

Allow decoder-only Notion property schemas across page retrieval and database query APIs, while keeping decoding behavior and wire/runtime semantics unchanged. Keep generated modules on the same Effect schema surface as `@overeng/notion-effect-schema`.

## Decisions

- Widen only response-decoding inputs from `Schema.Codec` to `Schema.Decoder`; no encoder, cast, or compatibility shim is introduced.
- Re-export `Schema` from `@overeng/notion-effect-schema` and have generated modules import it there, so generated schemas and helper calls share one package boundary.
- Emit the explicit Effect 4 `decodeUnknownEffect` and `encodeEffect` helpers. Inline generator snapshots cover each generated shape.

## Verification

- `DEVENV_TASK_PASSTHROUGH=1 devenv tasks run check:all` — passed on implementation commit `8138554d8`; the environment override lets the repository's pnpm fixture self-test invoke pnpm under managed-agent policy.
- `devenv tasks run test:notion-cli` — passed on review-fix commit `688d5bba9`.
- `DEVENV_TASK_PASSTHROUGH=1 devenv tasks run check:quick` — passed on review-fix commit `688d5bba9`.

## Complexity

No new abstraction or runtime branch; this is a type-boundary widening plus canonical generated output updates.

## Concerns

`Schema` becomes an intentional public re-export of the package's Effect peer dependency. Runtime behavior is otherwise unchanged.

## Friction & bottlenecks

The full gate exposed two unrelated Restate integration flakes before a focused rerun and the final committed-tree run passed. The managed agent's pnpm policy also required `DEVENV_TASK_PASSTHROUGH=1` for the repository's direct-pnpm self-test.

## Follow-ups

None.

## References

None.

<!-- agent-footer:begin v=2 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | dev3.direct.omp.kun3a8mg |
| `session` | dev3.kun3a8mg |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.0.11 |
| `agent_runtime` | OMP 18.0.11 |
| `tooling_profile` | dotfiles@847c617 |
</details>
<!-- agent-footer:end -->