### PR TITLE
feat(devenv): add exact flake lock duplicate policy

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -281,6 +281,7 @@
           gh-labels = import ./nix/devenv-modules/gh-labels.nix;
           pnpm = import ./nix/devenv-modules/tasks/shared/pnpm.nix;
           nix-cli = import ./nix/devenv-modules/tasks/shared/nix-cli.nix;
+          flake-lock-duplicates = import ./nix/devenv-modules/tasks/shared/flake-lock-duplicates.nix;
           secretspec = import ./nix/devenv-modules/tasks/shared/secretspec.nix;
           # Prevent commits on default branch and optionally enforce worktree-only workflow
           worktree-guard = import ./nix/devenv-modules/tasks/shared/worktree-guard.nix;

--- a/nix/devenv-modules/tasks/README.md
+++ b/nix/devenv-modules/tasks/README.md
@@ -67,10 +67,14 @@ the packages and project attribution are needed.
 - `megarepo.nix` - Megarepo workspace tasks
 - `flake-lock-duplicates.nix` - Exact duplicate flake lock-node policy
   - `(taskModules.flake-lock-duplicates { lockfiles = [ "flake.lock" ... ]; })`
-    provides `nix:flake-lock:check-duplicates`.
-  - The task compares complete `.locked` objects within each lockfile, reports
-    every duplicate group in deterministic order, and fails for missing or
-    invalid lockfiles. Similar but non-identical identities are allowed.
+    selects the lockfiles and only defines `nix:flake-lock:check-duplicates`.
+    Each consumer explicitly attaches that task to its authoritative aggregate
+    gate.
+  - Lockfile paths are resolved relative to the task working directory.
+  - Each lockfile is checked independently. Complete `.locked` identities are
+    never compared across files. The task reports every within-file duplicate
+    group in deterministic order and fails for missing or invalid lockfiles;
+    similar but non-identical identities are allowed.
 - `nix-cli.nix` - Nix CLI build/check tasks
 - `pnpm.nix` - pnpm install tasks
   - Local development shares one complete pnpm Store Cache between trusted

--- a/nix/devenv-modules/tasks/README.md
+++ b/nix/devenv-modules/tasks/README.md
@@ -16,6 +16,9 @@ imports = [
     geniePatterns = [ "*.genie.ts" ];
     genieCoverageDirs = [ "." ];
   })
+  (inputs.effect-utils.devenvModules.tasks.flake-lock-duplicates {
+    lockfiles = [ "flake.lock" ];
+  })
 ];
 ```
 
@@ -62,6 +65,12 @@ the packages and project attribution are needed.
     non-ignored files through `git ls-files` before calling oxlint/oxfmt, and do
     not use devenv's `execIfModified` glob walker.
 - `megarepo.nix` - Megarepo workspace tasks
+- `flake-lock-duplicates.nix` - Exact duplicate flake lock-node policy
+  - `(taskModules.flake-lock-duplicates { lockfiles = [ "flake.lock" ... ]; })`
+    provides `nix:flake-lock:check-duplicates`.
+  - The task compares complete `.locked` objects within each lockfile, reports
+    every duplicate group in deterministic order, and fails for missing or
+    invalid lockfiles. Similar but non-identical identities are allowed.
 - `nix-cli.nix` - Nix CLI build/check tasks
 - `pnpm.nix` - pnpm install tasks
   - Local development shares one complete pnpm Store Cache between trusted

--- a/nix/devenv-modules/tasks/shared/flake-lock-duplicates.nix
+++ b/nix/devenv-modules/tasks/shared/flake-lock-duplicates.nix
@@ -1,0 +1,74 @@
+# Reject exact duplicate locked identities within each configured flake lockfile.
+#
+# Usage in devenv.nix:
+#   imports = [
+#     (inputs.effect-utils.devenvModules.tasks.flake-lock-duplicates {
+#       lockfiles = [ "flake.lock" ];
+#     })
+#   ];
+#
+# Provides:
+#   - nix:flake-lock:check-duplicates
+{ lockfiles }:
+{ pkgs, lib, ... }:
+let
+  trace = import ../lib/trace.nix { inherit lib; };
+  checkDuplicatesScript = pkgs.writeShellScript "flake-lock-duplicates" ''
+    set -euo pipefail
+
+    diagnostics_file="$(${pkgs.coreutils}/bin/mktemp)"
+    trap '${pkgs.coreutils}/bin/rm -f "$diagnostics_file"' EXIT
+
+    for lockfile in ${lib.escapeShellArgs lockfiles}; do
+      if [ ! -f "$lockfile" ]; then
+        printf '%s: missing or not a regular file\n' "$lockfile" >> "$diagnostics_file"
+        continue
+      fi
+
+      if duplicates="$(${pkgs.jq}/bin/jq -r --arg lockfile "$lockfile" '
+        def valid_node:
+          if type != "object" then false
+          elif has("locked") then ((.locked | type) == "object")
+          else true
+          end;
+
+        if type != "object" or ((.nodes | type) != "object") then
+          error("invalid flake lock file")
+        elif (([.nodes[] | valid_node] | all) | not) then
+          error("invalid flake lock file")
+        else
+          [
+            .nodes
+            | to_entries[]
+            | select(.value | has("locked"))
+            | { name: .key, locked: .value.locked }
+          ]
+          | group_by(.locked)
+          | map(select(length > 1) | map(.name) | sort)
+          | sort_by(join("\u0000"))
+          | .[]
+          | "\($lockfile): exact duplicate locked identity in nodes: \(join(", "))"
+        end
+      ' "$lockfile" 2>/dev/null)"; then
+        if [ -n "$duplicates" ]; then
+          printf '%s\n' "$duplicates" >> "$diagnostics_file"
+        fi
+      else
+        printf '%s: invalid flake lock file\n' "$lockfile" >> "$diagnostics_file"
+      fi
+    done
+
+    if [ -s "$diagnostics_file" ]; then
+      LC_ALL=C ${pkgs.coreutils}/bin/sort "$diagnostics_file"
+      exit 1
+    fi
+
+    echo "No exact duplicate flake lock nodes found."
+  '';
+in
+{
+  tasks."nix:flake-lock:check-duplicates" = {
+    description = "Reject exact duplicate locked identities within each flake lockfile";
+    exec = trace.exec "nix:flake-lock:check-duplicates" "${checkDuplicatesScript}";
+  };
+}

--- a/nix/devenv-modules/tasks/shared/tests/flake-lock-duplicates.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/flake-lock-duplicates.test.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$TESTS_DIR/../../../../.." && pwd)"
+MODULE="$ROOT/nix/devenv-modules/tasks/shared/flake-lock-duplicates.nix"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+workspace="$tmpdir/workspace"
+mkdir -p "$workspace"
+
+fail() {
+  echo "FAIL: $1"
+  exit 1
+}
+
+assert_status() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+
+  if [ "$actual" -ne "$expected" ]; then
+    echo "FAIL: $label"
+    echo "  expected status: $expected"
+    echo "  actual status:   $actual"
+    echo "  actual output:"
+    printf '%s\n' "$output" | sed 's/^/    /'
+    exit 1
+  fi
+}
+
+assert_contains() {
+  local output="$1"
+  local expected="$2"
+  local label="$3"
+
+  if ! printf '%s\n' "$output" | grep -qF -- "$expected"; then
+    echo "FAIL: $label"
+    echo "  expected output to contain: $expected"
+    echo "  actual output:"
+    printf '%s\n' "$output" | sed 's/^/    /'
+    exit 1
+  fi
+}
+
+assert_equals() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+
+  if [ "$actual" != "$expected" ]; then
+    echo "FAIL: $label"
+    echo "  expected:"
+    printf '%s\n' "$expected" | sed 's/^/    /'
+    echo "  actual:"
+    printf '%s\n' "$actual" | sed 's/^/    /'
+    exit 1
+  fi
+}
+
+write_lock() {
+  local path="$1"
+  local nodes="$2"
+
+  mkdir -p "$(dirname "$path")"
+  cat > "$path" <<JSON
+{
+  "nodes": $nodes,
+  "root": "root",
+  "version": 7
+}
+JSON
+}
+
+build_task_script() {
+  local lockfiles_json
+  lockfiles_json="$(printf '%s\n' "$@" | jq -Rsc 'split("\n")[:-1]')"
+
+  LOCKFILES_JSON="$lockfiles_json" nix-build --no-out-link --impure --expr "
+    let
+      flake = builtins.getFlake (toString $ROOT);
+      pkgs = import flake.inputs.nixpkgs { system = builtins.currentSystem; };
+      module = (import $MODULE {
+        lockfiles = builtins.fromJSON (builtins.getEnv \"LOCKFILES_JSON\");
+      }) {
+        inherit pkgs;
+        lib = pkgs.lib;
+      };
+    in pkgs.writeShellScript \"flake-lock-duplicates-test-task\"
+      module.tasks.\"nix:flake-lock:check-duplicates\".exec
+  "
+}
+
+run_check() {
+  local task_script
+  task_script="$(build_task_script "$@")"
+  [ -x "$task_script" ] || fail "Nix did not build the generated task script"
+
+  set +e
+  output="$(
+    cd "$workspace"
+    OTELITE_HTTP_ENDPOINT= \
+      OTEL_EXPORTER_OTLP_ENDPOINT= \
+      OTEL_SPAN_SPOOL_DIR= \
+      "$task_script" 2>&1
+  )"
+  status=$?
+  set -e
+}
+
+clean_nodes='{
+  "root": { "inputs": { "one": "one", "two": "two" } },
+  "one": { "locked": { "type": "github", "owner": "example", "repo": "one", "rev": "111", "narHash": "sha256-one" } },
+  "two": { "locked": { "type": "github", "owner": "example", "repo": "two", "rev": "222", "narHash": "sha256-two" } }
+}'
+duplicate_nodes='{
+  "root": { "inputs": { "beta": "beta", "alpha": "alpha" } },
+  "beta": { "locked": { "rev": "same", "repo": "shared", "owner": "example", "type": "github", "narHash": "sha256-same" } },
+  "alpha": { "locked": { "type": "github", "owner": "example", "repo": "shared", "rev": "same", "narHash": "sha256-same" } }
+}'
+similar_nodes='{
+  "root": { "inputs": { "one": "one", "two": "two" } },
+  "one": { "locked": { "type": "github", "owner": "example", "repo": "shared", "rev": "same", "narHash": "sha256-one" } },
+  "two": { "locked": { "type": "github", "owner": "example", "repo": "shared", "rev": "same", "narHash": "sha256-two" } }
+}'
+multiple_groups_nodes='{
+  "zeta": { "locked": { "type": "github", "owner": "example", "repo": "z", "rev": "z", "narHash": "sha256-z" } },
+  "gamma": { "locked": { "type": "github", "owner": "example", "repo": "g", "rev": "g", "narHash": "sha256-g" } },
+  "root": { "inputs": {} },
+  "delta": { "locked": { "narHash": "sha256-g", "rev": "g", "repo": "g", "owner": "example", "type": "github" } },
+  "alpha": { "locked": { "narHash": "sha256-z", "rev": "z", "repo": "z", "owner": "example", "type": "github" } }
+}'
+
+echo "Test 1: clean lockfile passes"
+write_lock "$workspace/clean.lock" "$clean_nodes"
+run_check clean.lock
+assert_status 0 "$status" "clean lockfile"
+assert_contains "$output" "No exact duplicate flake lock nodes found." "clean success diagnostic"
+
+echo "Test 2: exact duplicate complete locked objects fail"
+write_lock "$workspace/duplicate.lock" "$duplicate_nodes"
+run_check duplicate.lock
+assert_status 1 "$status" "exact duplicate"
+assert_contains "$output" "duplicate.lock: exact duplicate locked identity in nodes: alpha, beta" "duplicate diagnostic"
+
+echo "Test 3: similar but different complete identities pass"
+write_lock "$workspace/similar.lock" "$similar_nodes"
+run_check similar.lock
+assert_status 0 "$status" "similar identities"
+
+echo "Test 4: multiple duplicate groups across files are aggregated"
+write_lock "$workspace/one.lock" "$duplicate_nodes"
+write_lock "$workspace/two.lock" "$multiple_groups_nodes"
+run_check two.lock one.lock
+assert_status 1 "$status" "multiple duplicates"
+assert_contains "$output" "one.lock: exact duplicate locked identity in nodes: alpha, beta" "first lockfile duplicate"
+assert_contains "$output" "two.lock: exact duplicate locked identity in nodes: alpha, zeta" "first group in second lockfile"
+assert_contains "$output" "two.lock: exact duplicate locked identity in nodes: delta, gamma" "second group in second lockfile"
+
+
+echo "Test 5: missing lockfile fails without hiding other files"
+rm -f "$workspace/missing.lock"
+run_check duplicate.lock missing.lock
+assert_status 1 "$status" "missing lockfile"
+assert_contains "$output" "duplicate.lock: exact duplicate locked identity in nodes: alpha, beta" "duplicate remains visible with missing file"
+assert_contains "$output" "missing.lock: missing or not a regular file" "missing file diagnostic"
+
+echo "Test 6: malformed lockfile fails without hiding other files"
+printf '{ malformed\n' > "$workspace/malformed.lock"
+run_check malformed.lock duplicate.lock
+assert_status 1 "$status" "malformed lockfile"
+assert_contains "$output" "duplicate.lock: exact duplicate locked identity in nodes: alpha, beta" "duplicate remains visible with malformed file"
+assert_contains "$output" "malformed.lock: invalid flake lock file" "malformed file diagnostic"
+
+echo "Test 7: diagnostics have deterministic lexical ordering"
+write_lock "$workspace/z.lock" "$duplicate_nodes"
+write_lock "$workspace/a.lock" "$multiple_groups_nodes"
+run_check z.lock a.lock
+assert_status 1 "$status" "deterministic ordering"
+assert_equals "a.lock: exact duplicate locked identity in nodes: alpha, zeta
+a.lock: exact duplicate locked identity in nodes: delta, gamma
+z.lock: exact duplicate locked identity in nodes: alpha, beta" "$output" "sorted diagnostics"
+
+echo "Test 8: flake exports the parameterized module"
+exported="$(nix-instantiate --eval --strict --json --expr "
+  let flake = builtins.getFlake (toString $ROOT);
+  in builtins.hasAttr \"flake-lock-duplicates\" flake.devenvModules.tasks
+" | jq -r .)"
+assert_equals "true" "$exported" "flake module export"
+
+echo "flake lock duplicate task module tests passed"


### PR DESCRIPTION
## Problem

Repositories can accumulate multiple flake lock nodes with the same complete `.locked` identity. Existing checks do not provide a small reusable policy for rejecting only those exact within-file duplicates.

## Goal

Expose an opt-in shared devenv task module that checks one or more flake lockfiles, aggregates deterministic diagnostics, and fails closed for missing or invalid inputs.

## Decisions

- Compare complete `.locked` objects with jq rather than guessing identity from selected fields; similar identities remain valid when any field differs.
- Resolve configured paths relative to the task working directory and check each lockfile independently; identities are never compared across files.
- Keep the public configuration surface to `{ lockfiles = [ ... ]; }` and use Nix-pinned jq/coreutils in the generated shell script.
- Importing the module only defines `nix:flake-lock:check-duplicates`; each consumer explicitly attaches it to that consumer's authoritative aggregate gate.
- Sort all diagnostics lexically after processing every configured file.

## Verification

- `bash nix/devenv-modules/tasks/shared/tests/flake-lock-duplicates.test.sh` — passed all 8 fixture cases after the contract clarification: clean, exact duplicate, similar-but-different, multiple groups/files, missing, malformed, deterministic ordering, and flake export.
- `devenv tasks run lint:check:format` — passed for the documentation refinement.
- `devenv tasks run check:quick` — passed after the documentation refinement.
- `devenv tasks run check:all` — pre-flip deviation: the existing `devenv-modules:test` lane fails because the managed command policy rejects the lane's direct `pnpm` invocation. The same `devenv tasks run devenv-modules:test` failure was reproduced at pristine main `c7d966cb9906f07bdc15048fa5050fa79c053adb`. The new fixture itself passed inside the branch's full module-test run. Remaining independent full-gate work was stopped after it blocked on shared Nix GC under disk pressure.

## Complexity

One parameterized Nix module and one generated shell script; no package, CLI, dependency, or general lint framework is added.

## Concerns

The module only defines `nix:flake-lock:check-duplicates`. Consumers must select their lockfiles and explicitly attach the task to their authoritative aggregate check graph. This PR intentionally changes no consumer.

## Friction & bottlenecks

- Friction: the existing module-test lane directly invokes `pnpm`, which conflicts with the managed command policy on both this branch and pristine main.
- Bottleneck: the full gate encountered shared Nix-store disk pressure and waited on the global GC lock after unrelated lanes had already failed.

## Follow-ups

None in this PR. Consumer rollout remains intentionally out of scope.

## References

- Open PR overlap was reviewed. PR #1034 also touches `flake.nix` and the task README, but in separate observability-only hunks; no semantic or direct hunk conflict was found.

<!-- agent-footer:begin v=2 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | dev3.direct.omp.be9hj659 |
| `session` | dev3.be9hj659 |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.0.11 |
| `agent_runtime` | OMP 18.0.11 |
| `tooling_profile` | dotfiles@000f2b3 |
</details>
<!-- agent-footer:end -->