### PR TITLE
fix(stylex): make Vite preset Node-executable

### DIFF
--- a/packages/@overeng/ci-tools/nix/build.nix
+++ b/packages/@overeng/ci-tools/nix/build.nix
@@ -19,7 +19,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-s/lGu1yy5OE7FYuJDEqS9yOQ4v002SgjYc09tdFw2cE=";
+      "." = mkSharedHash "sha256-FEfeZd5z4+OwR3J/o1FF1x4l5/5Y36SaCeAe+39zoKI=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/genie/nix/build.nix
+++ b/packages/@overeng/genie/nix/build.nix
@@ -26,7 +26,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-IOZ7woA7yOIyItVlY4NCL4fsggE5crVXvJRpiKUqLsY=";
+      "." = mkSharedHash "sha256-aE8WuoS69LUwZbL1rXNjx91Dgig+MMxA42LTOUa5cRs=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/megarepo/nix/build.nix
+++ b/packages/@overeng/megarepo/nix/build.nix
@@ -24,7 +24,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-JG1CU5+WRnW26cYSfwairVblwsSEIUHfxil3UR91pe4=";
+      "." = mkSharedHash "sha256-5aaVqfuvaZjB1lofKwPk8Xdy9V5NuHCR8FJLbj4fTHc=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     smokeTestArgs = [ "--help" ];

--- a/packages/@overeng/notion-cli/nix/build.nix
+++ b/packages/@overeng/notion-cli/nix/build.nix
@@ -33,7 +33,7 @@ let
     installRuntimeWorkspace = true;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-QvCa4gyncIlOm2apHCYOjIq/qP4pulG9zbz/Oh4K4Vs=";
+      "." = mkSharedHash "sha256-eEoWq2JlyscnWoURUunbkAcRPXU4JeevHw34lzXhEcM=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/notion-md/nix/build.nix
+++ b/packages/@overeng/notion-md/nix/build.nix
@@ -20,7 +20,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-A9b8ZLflR5S9q9EWr1lyUvm4I2vmFfo89lkDPqkDtjE=";
+      "." = mkSharedHash "sha256-hxyNHi2rf8tkPtbRnAo3BBzkJ98SnkhuW9kyvTjvrfw=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/stylex-preset/package.json
+++ b/packages/@overeng/stylex-preset/package.json
@@ -7,7 +7,10 @@
   "exports": {
     "./preflight.css": "./src/preflight.css",
     "./tokens.stylex": "./src/tokens.stylex.ts",
-    "./vite": "./src/vite.ts"
+    "./vite": {
+      "types": "./src/vite-types.d.ts",
+      "default": "./src/vite.js"
+    }
   },
   "publishConfig": {
     "access": "public",

--- a/packages/@overeng/stylex-preset/package.json.genie.ts
+++ b/packages/@overeng/stylex-preset/package.json.genie.ts
@@ -30,7 +30,13 @@ export default packageJson(
     exports: {
       './tokens.stylex': exportEntry('./src/tokens.stylex.ts', { environment: 'browser' }),
       './preflight.css': exportEntry('./src/preflight.css', { environment: 'browser' }),
-      './vite': exportEntry('./src/vite.ts', { environment: 'node' }),
+      './vite': exportEntry(
+        {
+          types: './src/vite-types.d.ts',
+          default: './src/vite.js',
+        },
+        { environment: 'node' },
+      ),
     },
     publishConfig: {
       access: 'public',

--- a/packages/@overeng/stylex-preset/src/vite-types.d.ts
+++ b/packages/@overeng/stylex-preset/src/vite-types.d.ts
@@ -1,0 +1,9 @@
+import type { Plugin } from 'vite'
+
+/**
+ * Creates the StyleX Vite plugin configured to compile this preset and any
+ * additional external packages that ship uncompiled StyleX source.
+ */
+export declare const createStylexVitePlugin: (options?: {
+  externalPackages?: readonly string[]
+}) => Plugin

--- a/packages/@overeng/stylex-preset/src/vite.integration.test.ts
+++ b/packages/@overeng/stylex-preset/src/vite.integration.test.ts
@@ -1,0 +1,74 @@
+import { spawnSync } from 'node:child_process'
+import { cpSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { expect, it } from 'vitest'
+
+it('loads the Vite entry point from a node_modules-installed consumer', () => {
+  const consumerRoot = mkdtempSync(join(tmpdir(), 'stylex-preset-vite-consumer-'))
+  const packageRoot = fileURLToPath(new URL('..', import.meta.url))
+  const installedPackage = join(consumerRoot, 'node_modules', '@overeng', 'stylex-preset')
+  const configPath = join(consumerRoot, 'vite.config.mjs')
+  const loaderPath = join(consumerRoot, 'load-config.mjs')
+
+  try {
+    mkdirSync(installedPackage, { recursive: true })
+    cpSync(join(packageRoot, 'package.json'), join(installedPackage, 'package.json'))
+    cpSync(join(packageRoot, 'src'), join(installedPackage, 'src'), { recursive: true })
+    mkdirSync(join(consumerRoot, 'node_modules', '@stylexjs'), { recursive: true })
+    symlinkSync(
+      join(packageRoot, 'node_modules', '@stylexjs', 'unplugin'),
+      join(consumerRoot, 'node_modules', '@stylexjs', 'unplugin'),
+      'dir',
+    )
+    symlinkSync(
+      join(packageRoot, 'node_modules', 'unplugin'),
+      join(consumerRoot, 'node_modules', 'unplugin'),
+      'dir',
+    )
+    writeFileSync(
+      configPath,
+      [
+        "import { createStylexVitePlugin } from '@overeng/stylex-preset/vite'",
+        '',
+        'export default { plugins: [createStylexVitePlugin()] }',
+        '',
+      ].join('\n'),
+    )
+    writeFileSync(
+      loaderPath,
+      [
+        `import { loadConfigFromFile } from ${JSON.stringify(import.meta.resolve('vite'))}`,
+        '',
+        `const loaded = await loadConfigFromFile(`,
+        `  { command: 'serve', mode: 'test', isSsrBuild: false, isPreview: false },`,
+        `  ${JSON.stringify(configPath)},`,
+        `  ${JSON.stringify(consumerRoot)},`,
+        `  'silent',`,
+        `  false,`,
+        `  'bundle',`,
+        `)`,
+        `if (loaded === null || loaded.config.plugins?.length !== 1) {`,
+        `  throw new Error('Vite config did not load the StyleX plugin')`,
+        `}`,
+        '',
+      ].join('\n'),
+    )
+
+    const result = spawnSync(process.execPath, [loaderPath], {
+      cwd: consumerRoot,
+      encoding: 'utf8',
+    })
+
+    expect({
+      status: result.status,
+      signal: result.signal,
+      stdout: result.stdout,
+      stderr: result.stderr,
+    }).toEqual({ status: 0, signal: null, stdout: '', stderr: '' })
+  } finally {
+    rmSync(consumerRoot, { recursive: true, force: true })
+  }
+})

--- a/packages/@overeng/stylex-preset/src/vite.js
+++ b/packages/@overeng/stylex-preset/src/vite.js
@@ -1,19 +1,20 @@
 import { unplugin as stylex } from '@stylexjs/unplugin'
-import type { Plugin } from 'vite'
+/** @import { Plugin } from 'vite' */
 
 /**
  * Creates the StyleX Vite plugin configured to compile this preset and any
  * additional external packages that ship uncompiled StyleX source.
+ *
+ * @param {{ externalPackages?: readonly string[] }} [options]
+ * @returns {Plugin}
  */
-export const createStylexVitePlugin = ({
-  externalPackages = [],
-}: { externalPackages?: readonly string[] } = {}): Plugin => {
+export const createStylexVitePlugin = ({ externalPackages = [] } = {}) => {
   const deduplicatedExternalPackages = [...new Set(['@overeng/stylex-preset', ...externalPackages])]
   // `externalPackages` is supported at runtime (unplugin core destructures it)
   // but missing from @stylexjs/unplugin@0.19 UserOptions typings.
-  const stylexOptions = {
+  const stylexOptions = /** @type {Parameters<typeof stylex.vite>[0]} */ ({
     externalPackages: deduplicatedExternalPackages,
-  } as Parameters<typeof stylex.vite>[0]
+  })
 
   return stylex.vite(stylexOptions)
 }

--- a/packages/@overeng/stylex-preset/tsconfig.json
+++ b/packages/@overeng/stylex-preset/tsconfig.json
@@ -10,7 +10,7 @@
     "rewriteRelativeImportExtensions": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "allowJs": false,
+    "allowJs": true,
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
@@ -43,7 +43,8 @@
     ],
     "composite": true,
     "rootDir": ".",
-    "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo"
+    "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
+    "checkJs": true
   },
   "include": ["src/**/*"]
 }

--- a/packages/@overeng/stylex-preset/tsconfig.json.genie.ts
+++ b/packages/@overeng/stylex-preset/tsconfig.json.genie.ts
@@ -9,6 +9,8 @@ export default tsconfigJson({
   compilerOptions: {
     ...baseTsconfigCompilerOptions,
     ...packageTsconfigCompilerOptions,
+    allowJs: true,
+    checkJs: true,
     lib: [...domLib],
   },
   include: ['src/**/*'],

--- a/packages/@overeng/stylex-preset/vitest.config.ts
+++ b/packages/@overeng/stylex-preset/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+})

--- a/packages/@overeng/tui-stories/nix/build.nix
+++ b/packages/@overeng/tui-stories/nix/build.nix
@@ -21,7 +21,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-CD94O5hrjhPYfJTlcD+UaTfuOw7qrXRXWI3nnY4USeM=";
+      "." = mkSharedHash "sha256-mAKUslj8S2JmLJ2P/c+Jkku8JZChBNjH9AoJWe3pfWE=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;


### PR DESCRIPTION
## Problem
`@overeng/stylex-preset/vite` exported a TypeScript source file. Vite loads configuration through Node, which rejects TypeScript stripping for packages under `node_modules`.

## Goal
Keep the public `@overeng/stylex-preset/vite` import while making it executable from installed and workspace-linked consumers.

## Decisions
Use checked JavaScript for the runtime entry and a separate declaration target. This avoids runtime transpilation and preserves TypeScript types.

## Verification
- Installed-consumer Vite configuration reproduction: passed.
- Downstream TypeScript build using the public import: passed.
- `devenv tasks run check:quick --no-tui`: passed.

## Complexity
Adds one declaration file and one installed-consumer integration test; no new dependency.

## Concerns
None.

## Friction & bottlenecks
The failure only appeared in an actual downstream Vite consumer because the package-local tests did not cross the `node_modules` Node-loading boundary.

## Follow-ups
None.

## References
Follow-up to #1156.

<!-- agent-footer:begin v=2 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | dev3.direct.omp.fck28pkm |
| `session` | dev3.fck28pkm |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.0.11 |
| `agent_runtime` | OMP 18.0.11 |
| `tooling_profile` | dotfiles@000f2b3 |
</details>
<!-- agent-footer:end -->