### PR TITLE
Stage Vercel production deployments before promotion

### DIFF
--- a/packages/@overeng/ci-tools/src/deploy-domain.ts
+++ b/packages/@overeng/ci-tools/src/deploy-domain.ts
@@ -159,6 +159,13 @@ export const CleanupResult = Schema.TaggedStruct('CleanupResult', {
 }).annotate({ identifier: 'CiTools.Deploy.CleanupResult' })
 export type CleanupResult = typeof CleanupResult.Type
 
+export const DeployPromotionResult = Schema.TaggedStruct('DeployPromotionResult', {
+  deploymentUrl: HttpsUrl,
+  previousProductionDeploymentId: Schema.optional(NonEmptyTrimmedString),
+  previousProductionDeploymentUrl: Schema.optional(HttpsUrl),
+}).annotate({ identifier: 'CiTools.Deploy.PromotionResult' })
+export type DeployPromotionResult = typeof DeployPromotionResult.Type
+
 export const DeployResultV1 = Schema.TaggedStruct('DeployResult', {
   schemaVersion: Schema.Literal(1),
   provider: DeployProvider,
@@ -173,6 +180,7 @@ export const DeployResultV1 = Schema.TaggedStruct('DeployResult', {
   endedAtUtc: Schema.DateTimeUtcFromString,
   attempts: PositiveInt,
   cleanup: Schema.optional(CleanupResult),
+  promotion: Schema.optional(DeployPromotionResult),
 }).annotate({ identifier: 'CiTools.Deploy.ResultV1' })
 export type DeployResultV1 = typeof DeployResultV1.Type
 
@@ -286,6 +294,7 @@ export class ProviderOperationFailed extends Schema.TaggedError<ProviderOperatio
     'alias',
     'verify',
     'cleanup',
+    'promote',
   ]),
   transient: Schema.Boolean,
 }) {
@@ -465,6 +474,23 @@ export const deploySuccessRecord = (
       finalUrl: opts.result.finalUrl.toString(),
       deployedAtUtc: encodeDateTimeUtc(opts.result.endedAtUtc),
       ...(opts.result.cleanup === undefined ? {} : { cleanup: opts.result.cleanup.status }),
+      ...(opts.result.promotion === undefined
+        ? {}
+        : {
+            promotedDeployUrl: opts.result.promotion.deploymentUrl.toString(),
+            ...(opts.result.promotion.previousProductionDeploymentId === undefined
+              ? {}
+              : {
+                  previousProductionDeploymentId:
+                    opts.result.promotion.previousProductionDeploymentId,
+                }),
+            ...(opts.result.promotion.previousProductionDeploymentUrl === undefined
+              ? {}
+              : {
+                  previousProductionDeploymentUrl:
+                    opts.result.promotion.previousProductionDeploymentUrl.toString(),
+                }),
+          }),
     },
   })
 

--- a/packages/@overeng/ci-tools/src/deploy-vercel.e2e.test.ts
+++ b/packages/@overeng/ci-tools/src/deploy-vercel.e2e.test.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'node:child_process'
 import {
+  appendFileSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -12,7 +13,12 @@ import { createServer, type Server } from 'node:http'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 
+import { Clock, Effect, Result } from 'effect'
+import * as HttpClient from 'effect/unstable/http/HttpClient'
+import * as HttpClientResponse from 'effect/unstable/http/HttpClientResponse'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { runVercelDeploy } from './deploy-vercel.ts'
 
 type ApiMode = 'ok' | 'unauthorized' | 'missing' | 'blank-project'
 
@@ -119,7 +125,18 @@ beforeAll(async () => {
     }
     response
       .writeHead(200, { 'content-type': 'application/json', connection: 'close' })
-      .end(JSON.stringify({ id: 'fake-project', name: 'fake-vercel-project' }))
+      .end(
+        JSON.stringify({
+          id: 'fake-project',
+          name: 'fake-vercel-project',
+          targets: {
+            production: {
+              id: 'dpl_previous',
+              url: 'prior-web.vercel.app',
+            },
+          },
+        }),
+      )
   })
   await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
   const address = server.address()
@@ -188,6 +205,14 @@ if [ "\${1:-}" = "deploy" ]; then
   printf 'https://deploy-web.vercel.app\\n'
   exit 0
 fi
+if [ "\${1:-}" = "promote" ]; then
+  if [ "\${FAKE_VERCEL_PROMOTE_FAIL:-0}" = "1" ]; then
+    echo 'Promotion failed' >&2
+    exit 1
+  fi
+  printf 'Promoted %s\\n' "\${2:-}"
+  exit 0
+fi
 if [ "\${1:-}" = "alias" ] && [ "\${2:-}" = "rm" ]; then
   printf 'Removed alias %s\\n' "\${3:-}"
   exit 0
@@ -202,6 +227,125 @@ exit 1
       { mode: 0o755 },
     )
     return { root, artifactDir, fakeVercelBin, logPath }
+  }
+
+  const runDirectProductionDeploy = async (opts: {
+    readonly workdir: string
+    readonly artifactDir: string
+    readonly artifactKind?: 'static' | 'prebuilt-output'
+    readonly fakeVercelBin: string
+    readonly logPath: string
+    readonly immutableResponseText: string
+    readonly immutableResponseStatus?: number
+    readonly productionResponseText?: string
+    readonly promoteFails?: boolean
+    readonly productionDomains?: readonly string[]
+    readonly buildPrebuiltOutput?: boolean
+    readonly vercelRootDirectory?: string
+    readonly buildEnv?: readonly string[]
+    readonly workflowReportOutputFile?: string
+  }) => {
+    const envNames = [
+      'CI_TOOLS_TEST_VERCEL_TOKEN',
+      'CI_TOOLS_TEST_VERCEL_ORG_ID',
+      'CI_TOOLS_TEST_VERCEL_PROJECT_ID',
+      'CI_TOOLS_TEST_VERCEL_SCOPE',
+      'DEVENV_TASK_OUTPUT_FILE',
+      'FAKE_VERCEL_REQUIRE_DOTFILE',
+      'FAKE_VERCEL_PROMOTE_FAIL',
+    ] as const
+    const previousEnv = {
+      CI_TOOLS_TEST_VERCEL_TOKEN: process.env.CI_TOOLS_TEST_VERCEL_TOKEN,
+      CI_TOOLS_TEST_VERCEL_ORG_ID: process.env.CI_TOOLS_TEST_VERCEL_ORG_ID,
+      CI_TOOLS_TEST_VERCEL_PROJECT_ID: process.env.CI_TOOLS_TEST_VERCEL_PROJECT_ID,
+      CI_TOOLS_TEST_VERCEL_SCOPE: process.env.CI_TOOLS_TEST_VERCEL_SCOPE,
+      DEVENV_TASK_OUTPUT_FILE: process.env.DEVENV_TASK_OUTPUT_FILE,
+      FAKE_VERCEL_REQUIRE_DOTFILE: process.env.FAKE_VERCEL_REQUIRE_DOTFILE,
+      FAKE_VERCEL_PROMOTE_FAIL: process.env.FAKE_VERCEL_PROMOTE_FAIL,
+    }
+    process.env.CI_TOOLS_TEST_VERCEL_TOKEN = 'fake-token'
+    process.env.CI_TOOLS_TEST_VERCEL_ORG_ID = 'fake-org'
+    process.env.CI_TOOLS_TEST_VERCEL_PROJECT_ID = 'fake-project'
+    process.env.CI_TOOLS_TEST_VERCEL_SCOPE = 'fake-scope'
+    delete process.env.DEVENV_TASK_OUTPUT_FILE
+    process.env.FAKE_VERCEL_REQUIRE_DOTFILE = '0'
+    const previousCwd = process.cwd()
+    process.env.FAKE_VERCEL_PROMOTE_FAIL = opts.promoteFails === true ? '1' : '0'
+    process.chdir(opts.workdir)
+
+    const httpClient = HttpClient.make((request, url) =>
+      Effect.sync(() => {
+        if (url.pathname.startsWith('/v9/projects/') === true) {
+          return HttpClientResponse.fromWeb(
+            request,
+            new Response(
+              '{"id":"fake-project","name":"fake-vercel-project","targets":{"production":{"id":"dpl_previous","url":"prior-web.vercel.app"}}}',
+              { status: 200 },
+            ),
+          )
+        }
+
+        appendFileSync(opts.logPath, `http=${url.host}${url.pathname}\n`)
+        const isImmutable = url.host === 'deploy-web.vercel.app'
+        const text = isImmutable
+          ? opts.immutableResponseText
+          : (opts.productionResponseText ?? 'production marker')
+        const status = isImmutable ? (opts.immutableResponseStatus ?? 200) : 200
+        return HttpClientResponse.fromWeb(request, new Response(text, { status }))
+      }),
+    )
+
+    try {
+      return await Effect.runPromise(
+        runVercelDeploy({
+          target: 'app',
+          artifactDir: opts.artifactDir,
+          artifactKind: opts.artifactKind ?? 'static',
+          mode: 'prod',
+          productionDomains: opts.productionDomains ?? [
+            'app.example.com',
+            'www.app.example.com',
+          ],
+          projectIdEnv: 'CI_TOOLS_TEST_VERCEL_PROJECT_ID',
+          orgIdEnv: 'CI_TOOLS_TEST_VERCEL_ORG_ID',
+          authTokenEnv: 'CI_TOOLS_TEST_VERCEL_TOKEN',
+          scopeEnv: 'CI_TOOLS_TEST_VERCEL_SCOPE',
+          buildPrebuiltOutput: opts.buildPrebuiltOutput ?? false,
+          vercelRootDirectory: opts.vercelRootDirectory,
+          buildEnv: opts.buildEnv ?? [],
+          vercelBin: opts.fakeVercelBin,
+          vercelApiBaseUrl: 'https://api.vercel.test',
+          createdAtUtc: '2026-09-01T08:00:00Z',
+          e2eAllowSharedProject: false,
+          e2eReservedAliasPrefix: 'ci-tools-e2e',
+          e2eVerifyPath: '/index.html',
+          e2eVerifyText: 'production marker',
+          workflowReportOutputFile: opts.workflowReportOutputFile,
+        }).pipe(
+          Effect.provideService(HttpClient.HttpClient, httpClient),
+          Effect.provideService(Clock.Clock, {
+            currentTimeMillisUnsafe: Date.now,
+            currentTimeMillis: Effect.sync(Date.now),
+            currentTimeNanosUnsafe: () => BigInt(Date.now()) * 1_000_000n,
+            currentTimeNanos: Effect.sync(() => BigInt(Date.now()) * 1_000_000n),
+            monotonicTimeNanosUnsafe: () => BigInt(Date.now()) * 1_000_000n,
+            monotonicTimeNanos: Effect.sync(() => BigInt(Date.now()) * 1_000_000n),
+            sleep: () => Effect.void,
+          }),
+          Effect.result,
+        ),
+      )
+    } finally {
+      process.chdir(previousCwd)
+      for (const name of envNames) {
+        const value = previousEnv[name]
+        if (value === undefined) {
+          delete process.env[name]
+        } else {
+          process.env[name] = value
+        }
+      }
+    }
   }
 
   it('deploys PR previews with Vercel prebuilt packaging, alias semantics, and records', async () => {
@@ -273,53 +417,38 @@ exit 1
     }
   })
 
-  it('runs Vercel pull/build for build-mode prebuilt output before deploy', async () => {
-    apiMode = 'ok'
+  it('runs production pull/build before staged deploy and records promotion evidence', async () => {
     const workspace = makeWorkspace()
     const reportFile = join(workspace.root, 'report.jsonl')
     try {
-      const result = await runCiTools({
+      const result = await runDirectProductionDeploy({
         workdir: workspace.root,
+        artifactDir: join(workspace.root, '.vercel', 'output'),
+        artifactKind: 'prebuilt-output',
         fakeVercelBin: workspace.fakeVercelBin,
-        reportFile,
-        args: [
-          '--target',
-          'app',
-          '--artifact-dir',
-          join(workspace.root, '.vercel', 'output'),
-          '--artifact-kind',
-          'prebuilt-output',
-          '--mode',
-          'prod',
-          '--production-domain',
-          'app.example.com',
-          '--build-prebuilt-output',
-          '--vercel-root-directory',
-          'app',
-          '--build-env',
-          'BUILD_MARKER=ci-tools',
-          '--scope-env',
-          'VERCEL_SCOPE',
-        ],
-        env: { FAKE_VERCEL_REQUIRE_DOTFILE: '0' },
+        logPath: workspace.logPath,
+        immutableResponseText: 'production marker',
+        productionDomains: ['app.example.com'],
+        buildPrebuiltOutput: true,
+        vercelRootDirectory: 'app',
+        buildEnv: ['BUILD_MARKER=ci-tools'],
+        workflowReportOutputFile: reportFile,
       })
-      if (result.status !== 0) {
-        console.error({ stdout: result.stdout, stderr: result.stderr })
-      }
-      expect(result.status).toBe(0)
-      expect(result.stdout).toContain('Pulling Vercel project settings and env for app')
-      expect(result.stdout).toContain('Building app locally with vercel build')
+      expect(Result.isSuccess(result)).toBe(true)
+
       const log = readFileSync(workspace.logPath, 'utf8')
       expect(log).toContain(
         'args=pull --yes --environment production --scope fake-scope --token fake-token',
       )
       expect(log).toContain('args=build --yes --prod --scope fake-scope --token fake-token')
-      expect(log).toContain(
-        'args=deploy --prebuilt --yes --prod --scope fake-scope --token fake-token',
-      )
-      expect(log).toContain(
-        'args=alias https://deploy-web.vercel.app app.example.com --scope fake-scope',
-      )
+      const deployCommand =
+        'args=deploy --prebuilt --yes --prod --skip-domain --scope fake-scope --token fake-token'
+      const promoteCommand =
+        'args=promote https://deploy-web.vercel.app --yes --scope fake-scope --token fake-token'
+      expect(log).toContain(deployCommand)
+      expect(log).toContain(promoteCommand)
+      expect(log).not.toContain('args=alias')
+      expect(log.indexOf(deployCommand)).toBeLessThan(log.indexOf(promoteCommand))
       expect(log).toContain(`cwd=${realpathSync(workspace.root)} VERCEL_PROJECT_ID=fake-project`)
       expect(existsSync(join(workspace.root, 'app', 'vercel.json'))).toBe(false)
       expect(existsSync(join(workspace.root, '.vercel'))).toBe(false)
@@ -329,7 +458,152 @@ exit 1
         mode: 'prod',
         finalUrl: 'https://app.example.com/',
         productionDomains: ['app.example.com'],
+        rawDeployUrl: 'https://deploy-web.vercel.app/',
+        promotedDeployUrl: 'https://deploy-web.vercel.app/',
+        previousProductionDeploymentId: 'dpl_previous',
+        previousProductionDeploymentUrl: 'https://prior-web.vercel.app/',
       })
+      expect(readRecord(reportFile).data).not.toHaveProperty('alias')
+    } finally {
+      rmSync(workspace.root, { recursive: true, force: true })
+    }
+  })
+
+  it('verifies the immutable production deployment before promotion and domains after', async () => {
+    const workspace = makeWorkspace()
+    try {
+      const result = await runDirectProductionDeploy({
+        workdir: workspace.root,
+        artifactDir: workspace.artifactDir,
+        fakeVercelBin: workspace.fakeVercelBin,
+        logPath: workspace.logPath,
+        immutableResponseText: 'production marker',
+      })
+      expect(Result.isSuccess(result)).toBe(true)
+
+      const log = readFileSync(workspace.logPath, 'utf8')
+      const deployIndex = log.indexOf('args=deploy --prebuilt --yes --prod --skip-domain')
+      const immutableVerifyIndex = log.indexOf('http=deploy-web.vercel.app/index.html')
+      const promoteIndex = log.indexOf('args=promote https://deploy-web.vercel.app --yes')
+      const primaryDomainVerifyIndex = log.indexOf('http=app.example.com/index.html')
+      const secondaryDomainVerifyIndex = log.indexOf('http=www.app.example.com/index.html')
+      expect(deployIndex).toBeGreaterThanOrEqual(0)
+      expect(immutableVerifyIndex).toBeGreaterThan(deployIndex)
+      expect(promoteIndex).toBeGreaterThan(immutableVerifyIndex)
+      expect(primaryDomainVerifyIndex).toBeGreaterThan(promoteIndex)
+      expect(secondaryDomainVerifyIndex).toBeGreaterThan(primaryDomainVerifyIndex)
+    } finally {
+      rmSync(workspace.root, { recursive: true, force: true })
+    }
+  })
+
+  it('does not promote when immutable production verification fails', async () => {
+    const workspace = makeWorkspace()
+    try {
+      const result = await runDirectProductionDeploy({
+        workdir: workspace.root,
+        artifactDir: workspace.artifactDir,
+        fakeVercelBin: workspace.fakeVercelBin,
+        logPath: workspace.logPath,
+        immutableResponseText: 'wrong marker',
+      })
+      expect(Result.isFailure(result)).toBe(true)
+      if (Result.isFailure(result) === true) {
+        expect(result.failure._tag).toBe('VerificationFailed')
+      }
+
+      const log = readFileSync(workspace.logPath, 'utf8')
+      expect(log).toContain('http=deploy-web.vercel.app/index.html')
+      expect(log).not.toContain('args=promote')
+      expect(log).not.toContain('http=app.example.com/index.html')
+    } finally {
+      rmSync(workspace.root, { recursive: true, force: true })
+    }
+  })
+
+  it('reports a nonzero promote command and does not verify production domains', async () => {
+    const workspace = makeWorkspace()
+    try {
+      const result = await runDirectProductionDeploy({
+        workdir: workspace.root,
+        artifactDir: workspace.artifactDir,
+        fakeVercelBin: workspace.fakeVercelBin,
+        logPath: workspace.logPath,
+        immutableResponseText: 'production marker',
+        promoteFails: true,
+      })
+      expect(Result.isFailure(result)).toBe(true)
+      if (Result.isFailure(result) === true) {
+        expect(result.failure).toMatchObject({
+          _tag: 'ProviderOperationFailed',
+          operation: 'promote',
+        })
+      }
+
+      const log = readFileSync(workspace.logPath, 'utf8')
+      expect(log).toContain('args=promote https://deploy-web.vercel.app --yes')
+      expect(log).not.toContain('http=app.example.com/index.html')
+    } finally {
+      rmSync(workspace.root, { recursive: true, force: true })
+    }
+  })
+
+  it('records promoted and prior deployment evidence when production-domain verification fails', async () => {
+    const workspace = makeWorkspace()
+    const reportFile = join(workspace.root, 'report.jsonl')
+    try {
+      const result = await runDirectProductionDeploy({
+        workdir: workspace.root,
+        artifactDir: workspace.artifactDir,
+        fakeVercelBin: workspace.fakeVercelBin,
+        logPath: workspace.logPath,
+        immutableResponseText: 'production marker',
+        productionResponseText: 'stale marker',
+        workflowReportOutputFile: reportFile,
+      })
+      expect(Result.isFailure(result)).toBe(true)
+      expect(readRecord(reportFile).data).toMatchObject({
+        errorKind: 'VerificationFailed',
+        diagnostics: {
+          verificationStage: 'final',
+          stagedDeployUrl: 'https://deploy-web.vercel.app',
+          promotedDeployUrl: 'https://deploy-web.vercel.app',
+          previousProductionDeploymentId: 'dpl_previous',
+          previousProductionDeploymentUrl: 'https://prior-web.vercel.app',
+        },
+      })
+      expect(
+        readFileSync(workspace.logPath, 'utf8').match(/http=app\.example\.com\/index\.html/gu),
+      ).toHaveLength(10)
+    } finally {
+      rmSync(workspace.root, { recursive: true, force: true })
+    }
+  })
+
+  it('reports a staged-production protection hint for an unbypassed 401', async () => {
+    const workspace = makeWorkspace()
+    const reportFile = join(workspace.root, 'report.jsonl')
+    try {
+      const result = await runDirectProductionDeploy({
+        workdir: workspace.root,
+        artifactDir: workspace.artifactDir,
+        fakeVercelBin: workspace.fakeVercelBin,
+        logPath: workspace.logPath,
+        immutableResponseText: 'protected',
+        immutableResponseStatus: 401,
+        workflowReportOutputFile: reportFile,
+      })
+      expect(Result.isFailure(result)).toBe(true)
+      expect(readRecord(reportFile).data).toMatchObject({
+        errorKind: 'VerificationFailed',
+        diagnostics: {
+          httpStatus: '401',
+          verificationStage: 'staged-production',
+          protectionHint:
+            'Configure --protection-bypass-env with a Vercel protection bypass secret',
+        },
+      })
+      expect(readFileSync(workspace.logPath, 'utf8')).not.toContain('args=promote')
     } finally {
       rmSync(workspace.root, { recursive: true, force: true })
     }
@@ -362,7 +636,7 @@ exit 1
           '--artifact-kind',
           'prebuilt-output',
           '--mode',
-          'prod',
+          'preview',
           '--build-prebuilt-output',
           '--vercel-root-directory',
           'app',
@@ -405,7 +679,7 @@ exit 1
           '--artifact-kind',
           'prebuilt-output',
           '--mode',
-          'prod',
+          'preview',
           '--build-prebuilt-output',
           '--vercel-root-directory',
           'app',
@@ -467,10 +741,13 @@ exit 1
         workdir: workspace.root,
         fakeVercelBin: workspace.fakeVercelBin,
         reportFile,
-        args: ['--target', 'web', '--artifact-dir', workspace.artifactDir, '--mode', 'preview'],
+        args: ['--target', 'web', '--artifact-dir', workspace.artifactDir, '--mode', 'prod'],
         env: { FAKE_VERCEL_MODE: 'no-url' },
       })
       expect(result.status).not.toBe(0)
+      expect(readFileSync(workspace.logPath, 'utf8')).toContain(
+        'args=deploy --prebuilt --yes --prod --skip-domain',
+      )
       const record = readRecord(reportFile)
       expect(record.status).toBe('failure')
       expect(record.data).toMatchObject({

--- a/packages/@overeng/ci-tools/src/deploy-vercel.ts
+++ b/packages/@overeng/ci-tools/src/deploy-vercel.ts
@@ -80,9 +80,19 @@ export type VercelDeployCommandOptions = {
   readonly e2eVerifyText?: string | undefined
 }
 
+const VercelDeploymentTargetJson = Schema.Struct({
+  id: Schema.optional(NonEmptyTrimmedString),
+  url: Schema.optional(NonEmptyTrimmedString),
+}).annotate({ identifier: 'CiTools.Vercel.DeploymentTargetJson' })
+
 const VercelProjectJson = Schema.Struct({
   id: Schema.optional(NonEmptyTrimmedString),
   name: Schema.optional(NonEmptyTrimmedString),
+  targets: Schema.optional(
+    Schema.Struct({
+      production: Schema.optional(Schema.NullOr(VercelDeploymentTargetJson)),
+    }),
+  ),
 }).annotate({ identifier: 'CiTools.Vercel.ProjectJson' })
 
 const VercelProjectFileJson = Schema.fromJsonString(
@@ -109,7 +119,7 @@ const vercelAlias = Effect.fn('ci-tools.deploy.vercel.alias')(function* (opts: {
   const suffix = opts.aliasSuffix === undefined ? '' : `-${opts.aliasSuffix}`
   switch (opts.mode) {
     case 'prod':
-      return `${opts.target}${suffix}`
+      return undefined
     case 'pr':
       if (opts.pr === undefined) {
         return yield* new ProviderOperationFailed({
@@ -592,7 +602,7 @@ const classifyVercelFailure = (opts: {
   readonly stdout: string
   readonly stderr: string
   readonly authToken: string
-  readonly operation: 'prepare' | 'deploy' | 'alias' | 'cleanup'
+  readonly operation: 'prepare' | 'deploy' | 'alias' | 'promote' | 'cleanup'
 }) => {
   const sanitizedStderr = redactDeployDiagnosticText(opts.stderr, {
     secretValues: [opts.authToken],
@@ -640,9 +650,10 @@ const verifyFinalUrlOnce = Effect.fn('ci-tools.deploy.vercel.verify-once')(funct
   readonly target: string
   readonly finalUrl: URL
   readonly path: string
-  readonly expectedText: string
+  readonly expectedText: string | undefined
   readonly attempt: number
   readonly protectionBypass: string | undefined
+  readonly phase: 'staged-production' | 'final'
 }) {
   const verifyUrl = new URL(opts.path, opts.finalUrl)
   const client = yield* HttpClient.HttpClient
@@ -668,30 +679,54 @@ const verifyFinalUrlOnce = Effect.fn('ci-tools.deploy.vercel.verify-once')(funct
           finalUrl: opts.finalUrl,
           transient: true,
           message: cause.message,
-          diagnostics: { attempt: String(opts.attempt), verifyPath: opts.path },
+          diagnostics: {
+            attempt: String(opts.attempt),
+            verifyPath: opts.path,
+            verificationStage: opts.phase,
+          },
         }),
     ),
   )
 
   if (response.status < 200 || response.status >= 300) {
+    const stagedProtectionFailure =
+      opts.phase === 'staged-production' &&
+      opts.protectionBypass === undefined &&
+      (response.status === 401 || response.status === 403)
     return yield* new VerificationFailed({
       provider: 'vercel',
       target: opts.target,
       finalUrl: opts.finalUrl,
       transient: response.status >= 500,
-      message: `Vercel live E2E verification returned HTTP ${response.status}`,
-      diagnostics: { attempt: String(opts.attempt), httpStatus: String(response.status) },
+      message: stagedProtectionFailure
+        ? `Staged production verification returned HTTP ${response.status}; configure --protection-bypass-env with a Vercel protection bypass secret`
+        : `Vercel live E2E verification returned HTTP ${response.status}`,
+      diagnostics: {
+        attempt: String(opts.attempt),
+        httpStatus: String(response.status),
+        verificationStage: opts.phase,
+        ...(stagedProtectionFailure
+          ? {
+              protectionHint:
+                'Configure --protection-bypass-env with a Vercel protection bypass secret',
+            }
+          : {}),
+      },
     })
   }
 
-  if (response.text.includes(opts.expectedText) === false) {
+  if (opts.expectedText !== undefined && response.text.includes(opts.expectedText) === false) {
     return yield* new VerificationFailed({
       provider: 'vercel',
       target: opts.target,
       finalUrl: opts.finalUrl,
       transient: false,
       message: 'Vercel live E2E marker text was not served',
-      diagnostics: { attempt: String(opts.attempt), verifyPath: opts.path },
+      diagnostics: {
+        attempt: String(opts.attempt),
+        verifyPath: opts.path,
+        verificationStage: opts.phase,
+      },
     })
   }
 })
@@ -700,8 +735,9 @@ const verifyFinalUrl = Effect.fn('ci-tools.deploy.vercel.verify')(function* (opt
   readonly target: string
   readonly finalUrl: URL
   readonly path: string
-  readonly expectedText: string
+  readonly expectedText: string | undefined
   readonly protectionBypass: string | undefined
+  readonly phase: 'staged-production' | 'final'
 }) {
   let lastFailure: VerificationFailed | undefined
   for (let attempt = 1; attempt <= 10; attempt += 1) {
@@ -729,6 +765,9 @@ const verifyFinalUrl = Effect.fn('ci-tools.deploy.vercel.verify')(function* (opt
     )
     if (Result.isSuccess(result) === true) return
     lastFailure = result.failure
+    if (opts.phase === 'staged-production') {
+      return yield* lastFailure
+    }
     if (attempt < 10) {
       yield* Effect.sleep('2 seconds')
     }
@@ -937,7 +976,7 @@ export const runVercelDeploy = Effect.fn('ci-tools.deploy.vercel')(function* (
     )
   }
 
-  yield* resolveVercelProject({
+  const project = yield* resolveVercelProject({
     target: options.target,
     projectId,
     orgId,
@@ -945,6 +984,14 @@ export const runVercelDeploy = Effect.fn('ci-tools.deploy.vercel')(function* (
     authToken: authTokenValue,
     apiBaseUrl: options.vercelApiBaseUrl,
   }).pipe(Effect.catch(failWithRecord))
+  const previousProductionDeployment =
+    options.mode === 'prod' ? (project.targets?.production ?? undefined) : undefined
+  const previousProductionDeploymentUrl =
+    previousProductionDeployment?.url === undefined
+      ? undefined
+      : previousProductionDeployment.url.startsWith('https://')
+        ? previousProductionDeployment.url
+        : `https://${previousProductionDeployment.url}`
 
   let cleanupLocalVercel = false
   try {
@@ -1002,7 +1049,7 @@ export const runVercelDeploy = Effect.fn('ci-tools.deploy.vercel')(function* (
             'deploy',
             '--prebuilt',
             '--yes',
-            ...(options.mode === 'prod' ? ['--prod'] : []),
+            ...(options.mode === 'prod' ? ['--prod', '--skip-domain'] : []),
             ...vercelScopeArgs(scope),
             '--token',
             authTokenValue,
@@ -1044,8 +1091,69 @@ export const runVercelDeploy = Effect.fn('ci-tools.deploy.vercel')(function* (
         )
       }
 
+      const promotion =
+        options.mode === 'prod'
+          ? yield* Effect.gen(function* () {
+              yield* verifyFinalUrl({
+                target: input.target,
+                finalUrl: new URL(rawDeployUrl),
+                path: input.e2e?.verifyContent?.path ?? '/',
+                expectedText: input.e2e?.verifyContent?.expectedText,
+                protectionBypass,
+                phase: 'staged-production',
+              }).pipe(Effect.catch(failWithRecord))
+
+              const promoteResult = yield* DeployProviderOperation.with({
+                attributes: {
+                  provider: 'vercel',
+                  target: input.target,
+                },
+                effect: runVercelCommand({
+                  vercelBin: options.vercelBin,
+                  cwd: preparedOutput.workDir,
+                  args: [
+                    'promote',
+                    rawDeployUrl,
+                    '--yes',
+                    ...vercelScopeArgs(scope),
+                    '--token',
+                    authTokenValue,
+                  ],
+                  env: {
+                    VERCEL_PROJECT_ID: projectId,
+                    VERCEL_ORG_ID: orgId,
+                    ...(teamId === undefined ? {} : { VERCEL_TEAM_ID: teamId }),
+                  },
+                }),
+              })
+              if (promoteResult.status !== 0) {
+                return yield* failWithRecord(
+                  classifyVercelFailure({
+                    target: options.target,
+                    status: promoteResult.status,
+                    stdout: promoteResult.stdout,
+                    stderr: promoteResult.stderr,
+                    authToken: authTokenValue,
+                    operation: 'promote',
+                  }),
+                )
+              }
+
+              return {
+                _tag: 'DeployPromotionResult',
+                deploymentUrl: rawDeployUrl,
+                ...(previousProductionDeployment?.id === undefined
+                  ? {}
+                  : { previousProductionDeploymentId: previousProductionDeployment.id }),
+                ...(previousProductionDeploymentUrl === undefined
+                  ? {}
+                  : { previousProductionDeploymentUrl }),
+              } as const
+            })
+          : undefined
+
       let finalUrl = rawDeployUrl
-      if (alias !== undefined) {
+      if (options.mode !== 'prod' && alias !== undefined) {
         const aliasHost = `${alias}.vercel.app`
         const aliasResult = yield* DeployProviderOperation.with({
           attributes: {
@@ -1085,45 +1193,13 @@ export const runVercelDeploy = Effect.fn('ci-tools.deploy.vercel')(function* (
         finalUrl = `https://${aliasHost}`
       }
 
-      for (const productionDomain of productionDomains) {
-        const domainResult = yield* DeployProviderOperation.with({
-          attributes: {
-            provider: 'vercel',
-            target: input.target,
-          },
-          effect: runVercelCommand({
-            vercelBin: options.vercelBin,
-            cwd: preparedOutput.workDir,
-            args: [
-              'alias',
-              rawDeployUrl,
-              productionDomain,
-              ...vercelScopeArgs(scope),
-              '--token',
-              authTokenValue,
-            ],
-            env: {
-              VERCEL_PROJECT_ID: projectId,
-              VERCEL_ORG_ID: orgId,
-              ...(teamId === undefined ? {} : { VERCEL_TEAM_ID: teamId }),
-            },
-          }),
-        })
-        if (domainResult.status !== 0) {
-          return yield* failWithRecord(
-            classifyVercelFailure({
-              target: options.target,
-              status: domainResult.status,
-              stdout: domainResult.stdout,
-              stderr: domainResult.stderr,
-              authToken: authTokenValue,
-              operation: 'alias',
-            }),
-          )
-        }
-      }
-      if (productionDomains.length > 0) {
-        finalUrl = `https://${productionDomains[0]}`
+      if (options.mode === 'prod') {
+        finalUrl =
+          productionDomains.length > 0
+            ? `https://${productionDomains[0]}`
+            : project.name === undefined
+              ? rawDeployUrl
+              : `https://${project.name}.vercel.app`
       }
 
       const preliminary = decodeResultEither({
@@ -1139,6 +1215,7 @@ export const runVercelDeploy = Effect.fn('ci-tools.deploy.vercel')(function* (
         startedAtUtc: createdAtUtc,
         endedAtUtc: isoNow(),
         attempts: 1,
+        ...(promotion === undefined ? {} : { promotion }),
       })
 
       if (Result.isFailure(preliminary) === true) {
@@ -1153,14 +1230,55 @@ export const runVercelDeploy = Effect.fn('ci-tools.deploy.vercel')(function* (
         )
       }
 
-      if (input.e2e?.verifyContent !== undefined) {
-        yield* verifyFinalUrl({
-          target: input.target,
-          finalUrl: preliminary.success.finalUrl,
-          path: input.e2e.verifyContent.path,
-          expectedText: input.e2e.verifyContent.expectedText,
-          protectionBypass,
-        }).pipe(Effect.catch(failWithRecord))
+      if (options.mode === 'prod' || input.e2e?.verifyContent !== undefined) {
+        const postPromotionUrls =
+          options.mode !== 'prod'
+            ? [preliminary.success.finalUrl]
+            : productionDomains.length === 0
+              ? [preliminary.success.finalUrl]
+              : productionDomains.map((domain) => new URL(`https://${domain}`))
+        for (const url of postPromotionUrls) {
+          const verification = verifyFinalUrl({
+            target: input.target,
+            finalUrl: url,
+            path: input.e2e?.verifyContent?.path ?? '/',
+            expectedText: input.e2e?.verifyContent?.expectedText,
+            protectionBypass,
+            phase: 'final',
+          })
+          yield* (
+            options.mode !== 'prod'
+              ? verification.pipe(Effect.catch(failWithRecord))
+              : verification.pipe(
+                  Effect.catch((failure) =>
+                    failWithRecord(
+                      new VerificationFailed({
+                        provider: 'vercel',
+                        target: input.target,
+                        finalUrl: failure.finalUrl,
+                        transient: failure.transient,
+                        message: 'Vercel production domain verification failed after promotion',
+                        diagnostics: {
+                          ...(failure.diagnostics ?? {}),
+                          verificationMessage: failure.message,
+                          stagedDeployUrl: rawDeployUrl,
+                          promotedDeployUrl: rawDeployUrl,
+                          ...(previousProductionDeployment?.id === undefined
+                            ? {}
+                            : {
+                                previousProductionDeploymentId:
+                                  previousProductionDeployment.id,
+                              }),
+                          ...(previousProductionDeploymentUrl === undefined
+                            ? {}
+                            : { previousProductionDeploymentUrl }),
+                        },
+                      }),
+                    ),
+                  ),
+                )
+          )
+        }
       }
 
       const cleanup =
@@ -1193,6 +1311,7 @@ export const runVercelDeploy = Effect.fn('ci-tools.deploy.vercel')(function* (
         endedAtUtc: isoNow(),
         attempts: 1,
         ...(cleanup === undefined ? {} : { cleanup }),
+        ...(promotion === undefined ? {} : { promotion }),
       })
       if (Result.isFailure(decoded) === true) {
         return yield* failWithRecord(


### PR DESCRIPTION
## Problem

Production Vercel deploys used `vercel deploy --prod`, which can assign production domains before the immutable deployment has been verified. The former sequence was effectively:

```
deploy --prod -> assign aliases/domains -> verify final URL
```

A pre-merge production run could therefore move traffic before proving the staged deployment.

## Goal

Build for production, create an immutable production-targeted deployment without assigning domains, verify it, promote that exact deployment, and only then verify configured production domains.

## Decisions

- Use the documented staged flow: `vercel deploy --prod --skip-domain`, immutable HTTP verification, then `vercel promote <immutable-url>`.
- Keep Vercel's default promotion wait behavior; no sleeps, timeout override, or no-wait mode was added around promotion.
- Resolve scope and token once and reuse them for deploy and promote.
- Read the current production target during the existing project lookup and preserve its deployment ID/URL as operator evidence.
- Do not synthesize a production alias or manually alias configured domains; promotion is the single production-domain mutation.
- Retry final-domain verification for propagation, but fail the immutable staged check immediately.

## Verification

Parent validation after the final edits:

- Focused Vercel deploy and deploy-contract tests: **23 passed**.
- Focused `ci-tools` no-emit TypeScript check: **exit 0**.
- `git diff --check`: **exit 0**, no output.

The focused cases cover production flags and command order, failed immutable verification suppressing promotion, nonzero promotion failure, post-promotion domain verification and retry behavior, protection-bypass diagnostics, structured promotion/prior-target evidence, and production CLI subprocess wiring.

## Complexity

No new dependency or provider abstraction. The existing deploy result gains one optional promotion evidence object, and the existing Vercel orchestration owns the staged sequence.

## Concerns

Automatic rollback is intentionally not claimed. If domain verification fails after promotion, the failure record includes the staged/promoted URL and prior production deployment identity when Vercel exposed it, but an operator must decide whether the prior deployment is eligible for explicit rollback.

## Friction & bottlenecks

No implementation bottleneck. The focused validation remained package-scoped.

## Follow-ups

- Automatic rollback remains out of scope until eligibility and restoration can be modeled through stable provider APIs.

## References

- Vercel staged production workflow: production deploy with `--skip-domain`, followed by explicit promotion.

<!-- agent-footer:begin v=2 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | dev3.direct.omp.6mbkdtda |
| `session` | dev3.6mbkdtda |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.0.11 |
| `agent_runtime` | OMP 18.0.11 |
| `tooling_profile` | dotfiles@1defc60 |
</details>
<!-- agent-footer:end -->