### PR TITLE
feat(notion-md): track remote page trees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -698,10 +698,14 @@ violations }` (the offending `DiffOp[]`); block ops and page content
 
 - **@overeng/notion-md**: `track <page> <existing-directory>` now materializes a
   remote-authoritative child-page tree as separate `.nmd` files plus an authority-tagged workspace
-  manifest. Ordinary directory sync refreshes content and reconciles recorded additions, moves,
-  and deletions while preserving unknown local files. Child placeholders become relative local
-  navigation links without entering the remote push baseline, and Unicode titles produce stable
-  ASCII paths with German umlaut transliteration. File and missing-path tracking is unchanged.
+  manifest. Non-recursive directory status plans the same tree engine; ordinary directory sync
+  refreshes content and reconciles recorded additions, page-ID moves, and deletions only across
+  manifest and frontmatter-proven ownership. Dry-run validates every remote node without writing,
+  and a different root cannot repurpose an established workspace. Child placeholders become
+  relative local navigation links without entering the remote push baseline, while local-authority
+  user links remain authored content. Hierarchical tree watch is rejected; `--recursive` remains
+  flat file watch. Unicode titles produce stable ASCII paths with German umlaut transliteration.
+  File and missing-path tracking is unchanged.
 - **genie semantic-conventions generator (M1) / @overeng/genie + @overeng/otel-contract**:
   First genie generator for OpenTelemetry semantic-convention registries.
   - Layer 1 (`@overeng/genie` `src/runtime/weaver`, dep-free): a faithful typed model of the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
+
 - **@overeng/utils, @overeng/tui-core, @overeng/tui-react**: Effect 4 idiom
   adoption. `base64` is now a thin facade over upstream `Encoding` (net -107
   lines; invalid input throws `Encoding.EncodingError` instead of `DOMException`
@@ -41,6 +42,7 @@ All notable changes to this project will be documented in this file.
   `resolveCliBuildIdentity` is unchanged.
 
 ### Removed
+
 - **context/effect-4/**: the flip-era migration docs (alignment register, idiom
   catalog, differential recipes, ops manuals). The executable
   baseline-collection gate moved to
@@ -694,6 +696,12 @@ violations }` (the offending `DiffOp[]`); block ops and page content
   success, not the child exit code. Pure passthrough stays silent (R04);
   `--trace-link off` / `OTEL_SCRAPE_TRACE_LINK=off` disables it.
 
+- **@overeng/notion-md**: `track <page> <existing-directory>` now materializes a
+  remote-authoritative child-page tree as separate `.nmd` files plus an authority-tagged workspace
+  manifest. Ordinary directory sync refreshes content and reconciles recorded additions, moves,
+  and deletions while preserving unknown local files. Child placeholders become relative local
+  navigation links without entering the remote push baseline, and Unicode titles produce stable
+  ASCII paths with German umlaut transliteration. File and missing-path tracking is unchanged.
 - **genie semantic-conventions generator (M1) / @overeng/genie + @overeng/otel-contract**:
   First genie generator for OpenTelemetry semantic-convention registries.
   - Layer 1 (`@overeng/genie` `src/runtime/weaver`, dep-free): a faithful typed model of the

--- a/packages/@overeng/notion-cli/src/__snapshots__/cli.contract.test.ts.snap
+++ b/packages/@overeng/notion-cli/src/__snapshots__/cli.contract.test.ts.snap
@@ -47,7 +47,7 @@ USAGE
   notion md status [flags] <path...>
 
 ARGUMENTS
-  path... string    Local .nmd file or directory (a directory means everything under it)
+  path... string    Local .nmd file or directory tree (--recursive selects flat batch mode)
 
 FLAGS
   --recursive, -r          Discover existing .nmd files recursively under a directory target
@@ -77,7 +77,7 @@ USAGE
   notion md status [flags] <path...>
 
 ARGUMENTS
-  path... string    Local .nmd file or directory (a directory means everything under it)
+  path... string    Local .nmd file or directory tree (--recursive selects flat batch mode)
 
 FLAGS
   --recursive, -r          Discover existing .nmd files recursively under a directory target

--- a/packages/@overeng/notion-md/README.md
+++ b/packages/@overeng/notion-md/README.md
@@ -40,14 +40,14 @@ The CLI reads `NOTION_API_TOKEN`.
 ## Safety Model
 
 - `track <page> <file.nmd>` writes a strict `.nmd` envelope for one existing page; `track <page> <existing-directory>` materializes its remote-authoritative child-page tree as separate `.nmd` files plus `.notion-md/workspace.json`.
-- `status <path...>` is read-only and reports `in-sync`, `local-ahead`, `remote-ahead`, `diverged`, or `unbound`.
-- `sync <path...>` dispatches per file from frontmatter `source`, not flags or argument shape.
+- `status <path...>` is read-only: files report `in-sync`, `local-ahead`, `remote-ahead`, `diverged`, or `unbound`; non-recursive directories report a tree plan.
+- File sync dispatches from frontmatter `source`; non-recursive directory sync dispatches from workspace authority.
 - `source: local` mirrors local state to Notion; `source: remote` mirrors Notion state to the local file; `source: shared` uses the guarded base/merge path.
 - Unbound `source: local` files with `page_id: null` create new Notion pages on `sync`.
-- Every write command supports `--dry-run`.
-- `sync <dir>` follows the workspace manifest's explicit authority; remote trees refresh content and reconcile recorded additions, moves, and deletions without deleting unknown local files.
+- Every write command supports `--dry-run`; remote tree plans validate every page and ownership boundary without writing.
+- `sync <dir>` follows the workspace manifest's explicit authority; remote trees refresh content and reconcile recorded additions, moves, and deletions only across manifest and frontmatter-proven ownership.
 - `sync <dir> --recursive` is flat batch mode for existing `.nmd` files only; it does not imply hierarchy, moves, trashing, or remote materialization.
-- `sync --watch` runs the same frontmatter-dispatched reconcile path after local file changes and on a remote polling interval.
+- `sync --watch` supports files and flat recursive batches; a hierarchical directory tree is rejected rather than entering one-file watch.
 - Multi-file and recursive folder sync are orchestration only: each `.nmd` still maps to one Notion page and duplicate page ids are rejected before mutation.
 - Sync refuses to update pages with unresolved unknown Notion blocks unless destructive deletion is explicit.
 - Shared sync writes a Roughdraft conflict artifact next to the `.nmd` file when local and remote body edits diverge.

--- a/packages/@overeng/notion-md/README.md
+++ b/packages/@overeng/notion-md/README.md
@@ -25,6 +25,7 @@ An `.nmd` file is:
 
 ```sh
 notion-md track <page-id-or-url> page.nmd
+notion-md track <page-id-or-url> ./existing-directory
 notion-md status page.nmd
 notion-md status docs --recursive
 notion-md sync page.nmd
@@ -38,12 +39,13 @@ The CLI reads `NOTION_API_TOKEN`.
 
 ## Safety Model
 
-- `track <page> <file.nmd>` writes a strict `.nmd` envelope for an existing Notion page and records explicit `source`.
+- `track <page> <file.nmd>` writes a strict `.nmd` envelope for one existing page; `track <page> <existing-directory>` materializes its remote-authoritative child-page tree as separate `.nmd` files plus `.notion-md/workspace.json`.
 - `status <path...>` is read-only and reports `in-sync`, `local-ahead`, `remote-ahead`, `diverged`, or `unbound`.
 - `sync <path...>` dispatches per file from frontmatter `source`, not flags or argument shape.
 - `source: local` mirrors local state to Notion; `source: remote` mirrors Notion state to the local file; `source: shared` uses the guarded base/merge path.
 - Unbound `source: local` files with `page_id: null` create new Notion pages on `sync`.
 - Every write command supports `--dry-run`.
+- `sync <dir>` follows the workspace manifest's explicit authority; remote trees refresh content and reconcile recorded additions, moves, and deletions without deleting unknown local files.
 - `sync <dir> --recursive` is flat batch mode for existing `.nmd` files only; it does not imply hierarchy, moves, trashing, or remote materialization.
 - `sync --watch` runs the same frontmatter-dispatched reconcile path after local file changes and on a remote polling interval.
 - Multi-file and recursive folder sync are orchestration only: each `.nmd` still maps to one Notion page and duplicate page ids are rejected before mutation.

--- a/packages/@overeng/notion-md/docs/cli.md
+++ b/packages/@overeng/notion-md/docs/cli.md
@@ -22,24 +22,42 @@ each file's required `source` frontmatter field.
 
 ## Commands
 
-| Command                                               | Meaning                                                                 |
-| ----------------------------------------------------- | ----------------------------------------------------------------------- |
-| `notion-md track <page-id-or-url> [file-or-dir]`      | Materialize an existing Notion page as tracked local `.nmd` state       |
-| `notion-md status <path...>`                          | Read-only live status for local `.nmd` files                            |
-| `notion-md status <dir> --recursive`                  | Read-only status for existing `.nmd` files discovered under a directory |
-| `notion-md sync <path...>`                            | Reconcile local paths toward in-sync according to each file's `source`  |
-| `notion-md sync <dir> --recursive --concurrency 4`    | Reconcile a flat batch of existing `.nmd` files                         |
-| `notion-md sync <path...> --watch --poll-interval-ms` | Keep reconciling after file events and remote polling                   |
+| Command                                               | Meaning                                                                             |
+| ----------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `notion-md track <page-id-or-url> [file-or-dir]`      | Materialize one page into a file, or its child-page tree into an existing directory |
+| `notion-md status <path...>`                          | Read-only live status for local `.nmd` files                                        |
+| `notion-md status <dir> --recursive`                  | Read-only status for existing `.nmd` files discovered under a directory             |
+| `notion-md sync <path...>`                            | Reconcile local paths toward in-sync according to each file's `source`              |
+| `notion-md sync <dir> --recursive --concurrency 4`    | Reconcile a flat batch of existing `.nmd` files                                     |
+| `notion-md sync <path...> --watch --poll-interval-ms` | Keep reconciling after file events and remote polling                               |
 
 ## `track`
 
 ```sh
 notion-md track <page-id-or-url> notes.nmd
+notion-md track <page-id-or-url> ./notes-directory
 ```
 
-`track` establishes a local tracked file for an existing Notion page. It writes
-strict frontmatter with the page identity, parent, page metadata, and explicit
-`source`.
+With a `.nmd` file or missing output path, `track` retains the single-page
+behavior: it writes strict frontmatter with the page identity, parent, page
+metadata, and explicit `source`.
+
+An existing directory is detected from its filesystem type and invokes the
+remote subtree materializer. The root becomes `index.nmd`, each child page gets
+its own remote-authoritative nested `.nmd` file, and `.notion-md/workspace.json`
+records remote authority plus the derived tree index. Later `sync <directory>`
+passes refresh content and reconcile additions, page-id moves, and remote
+deletions; deletion is limited to files recorded by the previous manifest, so
+unknown local files are preserved. Directory tracking supports `--as remote`
+only; `--as local` and `--as shared` remain single-file modes.
+
+Remote titles become stable lowercase ASCII paths; German umlauts use the
+conventional `ae` / `oe` / `ue` transliteration before general Unicode
+normalization. Notion child placeholders and id-bearing child anchors become
+relative Markdown links to the materialized child files. The stored remote
+baseline strips those local navigation links and retains the canonical Notion
+child anchors, so the guarded local tree composer remains a no-op at the
+materialization baseline.
 
 The default source is `remote`, because the first materialization starts from
 Notion:

--- a/packages/@overeng/notion-md/docs/cli.md
+++ b/packages/@overeng/notion-md/docs/cli.md
@@ -10,8 +10,8 @@ notion-md sync <path...> --watch [--poll-interval-ms <ms>]
 ```
 
 `track` is the only command that accepts a Notion page id or URL. `status` and
-`sync` accept local `.nmd` files or directories only. Sync direction lives in
-each file's required `source` frontmatter field.
+`sync` accept local `.nmd` files or directories only. Files take direction from
+required `source` frontmatter; Tracked Trees take it from workspace authority.
 
 ## Environment
 
@@ -26,10 +26,11 @@ each file's required `source` frontmatter field.
 | ----------------------------------------------------- | ----------------------------------------------------------------------------------- |
 | `notion-md track <page-id-or-url> [file-or-dir]`      | Materialize one page into a file, or its child-page tree into an existing directory |
 | `notion-md status <path...>`                          | Read-only live status for local `.nmd` files                                        |
-| `notion-md status <dir> --recursive`                  | Read-only status for existing `.nmd` files discovered under a directory             |
-| `notion-md sync <path...>`                            | Reconcile local paths toward in-sync according to each file's `source`              |
+| `notion-md status <dir>`                              | Read-only plan for a hierarchical Tracked Tree                                      |
+| `notion-md status <dir> --recursive`                  | Read-only status for a flat batch of existing `.nmd` files                          |
+| `notion-md sync <path...>`                            | Reconcile files by `source` or a Tracked Tree by workspace authority                |
 | `notion-md sync <dir> --recursive --concurrency 4`    | Reconcile a flat batch of existing `.nmd` files                                     |
-| `notion-md sync <path...> --watch --poll-interval-ms` | Keep reconciling after file events and remote polling                               |
+| `notion-md sync <path...> --watch --poll-interval-ms` | Keep files or flat recursive batches reconciling after local and remote cues        |
 
 ## `track`
 
@@ -47,9 +48,12 @@ remote subtree materializer. The root becomes `index.nmd`, each child page gets
 its own remote-authoritative nested `.nmd` file, and `.notion-md/workspace.json`
 records remote authority plus the derived tree index. Later `sync <directory>`
 passes refresh content and reconcile additions, page-id moves, and remote
-deletions; deletion is limited to files recorded by the previous manifest, so
-unknown local files are preserved. Directory tracking supports `--as remote`
-only; `--as local` and `--as shared` remain single-file modes.
+deletions; deletion is limited to files recorded by the previous manifest whose
+frontmatter still identifies the expected page. Unknown or rebound local files
+are preserved or refused. Directory tracking supports `--as remote` only,
+refuses a different root for an established workspace, and validates every
+remote node under `--dry-run`; `--as local` and `--as shared` remain single-file
+modes.
 
 Remote titles become stable lowercase ASCII paths; German umlauts use the
 conventional `ae` / `oe` / `ue` transliteration before general Unicode
@@ -76,6 +80,7 @@ page to track yet.
 
 ```sh
 notion-md status notes.nmd
+notion-md status tracked-tree
 notion-md status docs --recursive --concurrency 4
 ```
 
@@ -100,8 +105,9 @@ notion-md sync notes.nmd
 notion-md sync docs --recursive --concurrency 4
 ```
 
-`sync` runs one reconciliation pass for local paths. The command does not accept
-Notion page ids. Each file's frontmatter decides the mechanism:
+`sync` runs one reconciliation pass for local paths and does not accept Notion
+page ids. A file's frontmatter decides its mechanism; a non-recursive directory
+uses its workspace manifest's `local` or `remote` authority:
 
 | `source` | Normal sync behavior                                                     |
 | -------- | ------------------------------------------------------------------------ |
@@ -138,10 +144,15 @@ notion-md sync notes.nmd --watch --poll-interval-ms 30000
 notion-md sync docs --recursive --watch --poll-interval-ms 30000
 ```
 
-Watch mode runs the same reconciliation pass after local file changes and on a
-remote polling interval. One file target emits one-file watch events. Multiple
-files or recursive directory targets use a batch watch envelope and reconcile
-affected files with bounded concurrency.
+Watch mode runs the same file reconciliation pass after local file changes and
+on a remote polling interval. One file target emits one-file watch events.
+Multiple files or recursive directory targets use a batch watch envelope and
+reconcile affected files with bounded concurrency.
+
+A hierarchical directory tree without `--recursive` is rejected: tree sync is
+currently one-shot, and must not fall through to one-file watch on the directory
+path. `--recursive` explicitly selects flat file watch rather than tree
+reconciliation.
 
 Options:
 
@@ -151,8 +162,8 @@ Options:
 | `--poll-interval-ms` | `30000` | Remote polling interval in milliseconds    |
 | `--dry-run`          | `false` | Keep watch live while each pass plans only |
 
-The watched file set is resolved at startup. Restart the watcher after adding a
-new `.nmd` file.
+The watched file set is resolved at startup. Restart the flat batch watcher after
+adding a new `.nmd` file.
 
 ## Output
 

--- a/packages/@overeng/notion-md/docs/vrs/02-file-sync/requirements.md
+++ b/packages/@overeng/notion-md/docs/vrs/02-file-sync/requirements.md
@@ -19,6 +19,12 @@ file/property-surface bits of R11/R13 are exercised here but defined there.
 
 - **R20 Bounded concurrency:** Watch mode must serialize or intentionally coordinate sync passes so local writes, remote writes, and state-store updates cannot overlap unsafely.
 
+### Must preserve tree authority and ownership
+
+- **R51 Tree authority dispatch:** Tracking an existing Notion page into an existing directory must materialize its complete child-page subtree and persist explicit `remote` authority in the tree manifest. Later non-recursive `status` and `sync` calls must dispatch from that manifest; file calls continue to dispatch from frontmatter `source`. New local tree manifests must persist `local`, while manifests without authority normalize to `local` at the read boundary. Tracking a different root into an established tree must refuse rather than repurpose the workspace.
+- **R53 Ownership-safe remote reconciliation:** A remote-authoritative tree must refresh page content and reconcile remote additions, page-ID-preserving path moves, and removals. The manifest is a derived routing and prior-ownership index, never page identity: an existing destination may be replaced only when its frontmatter identifies the incoming page or the manifest-recorded occupant, and a stale path may be removed only when both the prior manifest and current frontmatter identify the expected page. Unknown, rebound, identity-less, and unrelated local files must be preserved or refused, never overwritten or deleted. A dry run must perform every remote read, completeness check, child-anchor validation, and ownership check that apply would perform while writing nothing.
+- **R55 Derived child links:** Remote tree materialization must render direct child-page navigation as relative Markdown links in local files while keeping canonical Notion child anchors in the sync baseline. Those links are derived only inside a remote-authoritative tree; a local-authoritative tree must preserve a user-authored Markdown link even when its href matches a child path.
+
 ### Must verify watch behavior
 
 - **R28 Watch coverage:** Watch mode must be tested for debounce, coalescing, cancellation, overlapping events, remote polling, and shutdown.

--- a/packages/@overeng/notion-md/docs/vrs/02-file-sync/spec.md
+++ b/packages/@overeng/notion-md/docs/vrs/02-file-sync/spec.md
@@ -7,7 +7,7 @@ lifecycle. Builds on [../requirements.md](../requirements.md) +
 rationale in [../.decisions/](../.decisions/). See [../spec.md](../spec.md) for the
 architecture index.
 
-Traces: R20, R28. The guarded-push / three-way-merge / settle decisions invoked
+Traces: R20, R28, R51, R53, R55. The guarded-push / three-way-merge / settle decisions invoked
 by these flows are owned by [03-sync-engine](../03-sync-engine/spec.md) (R09, R11,
 R13, R15); the lossy-page refusal at the pull is owned by
 [04-fidelity](../04-fidelity/spec.md) (R30/R38); the `.nmd` envelope and object
@@ -84,72 +84,71 @@ Markdown through CommonMark can promote prose paragraphs to Setext/ATX headings.
 `notion-md` therefore treats endpoint Markdown as evidence and adopts the
 client block-tree renderer output as the clean body.
 
-## CLI
-
-Current commands:
+## CLI and Authority Dispatch
 
 ```bash
-notion-md sync <page-id-or-url> page.nmd
-notion-md sync docs --from-remote --root <page-id-or-url>
-notion-md plan docs
-notion-md status page.nmd
-notion-md sync page.nmd [--watch] [--poll-interval-ms 30000]
-notion-md sync docs
+notion-md track <page-id-or-url> [file-or-existing-directory] [--as local|remote|shared]
+notion-md status <path...> [--recursive] [--concurrency 4]
+notion-md sync <path...> [--recursive] [--concurrency 4] [--dry-run]
+notion-md sync <path...> --watch [--poll-interval-ms 30000]
 ```
 
-Environment:
+`track` is the only command that accepts a Notion page reference. A file or
+missing target establishes one Tracked Page and records its authority in
+frontmatter `source`. An existing directory establishes a remote-authoritative
+Tracked Tree: it walks the complete child-page hierarchy, materializes one
+`.nmd` file per page, and writes `.notion-md/workspace.json` with `remote`
+authority. Directory tracking refuses `local` and `shared`, and refuses a root
+page that differs from an established manifest's root.
 
-| Variable           | Meaning          |
-| ------------------ | ---------------- |
-| `NOTION_API_TOKEN` | Notion API token |
+Files dispatch from frontmatter `source`. A non-recursive directory dispatches
+from the Tree Manifest: `status` executes the tree engine as a read-only plan,
+and `sync` applies the declared `local` or `remote` authority. A legacy manifest
+without authority normalizes to `local` when read and is written back with
+explicit authority. `--recursive` deliberately selects flat batch discovery of
+existing `.nmd` files instead of hierarchical tree reconciliation.
 
-Output:
+Every `--dry-run` follows the apply read and validation path. In particular, a
+remote tree plan pulls every node and checks observation completeness, child
+anchors/placeholders, destination ownership, and root identity, but writes no
+files, sidecars, manifests, or Notion state. Hierarchical directory watch is not
+supported and is rejected before entering one-file watch; `--recursive` remains
+the explicit flat file-watch surface.
 
-- One-shot commands emit pretty JSON results by default.
-- Watch emits compact NDJSON event lines by default.
-- Watch `sync_error` events include structured typed error fields.
-- The long-term stable contract is explicit `--output human|json|ndjson`, with `auto` allowed only as a convenience alias after envelope schemas are versioned.
+One-shot commands emit pretty JSON by default. Watch emits compact NDJSON.
+Write-path commands also surface the staged sync-progress indicator on TTY
+stderr ([01-editor](../01-editor/spec.md#sync-progress-indicator-write-path),
+R43–R45).
 
-The write-path commands also surface the staged sync-progress indicator on a TTY
-stderr ([01-editor](../01-editor/spec.md#sync-progress-indicator-write-path), R43–R45).
+## Remote-Authoritative Tree Reconciliation
 
-Future CLI contract:
+Remote tracking and each subsequent remote-authoritative directory pass walk
+the Notion subtree top-down. The root uses the manifest's root filename; a page
+with children anchors its directory through that same filename, and leaf pages
+use stable slugged `.nmd` paths. Page IDs, not titles or paths, preserve identity
+across remote renames and moves.
 
-```bash
-notion-md diff <file.nmd> [--surface body|properties|comments|files]
-notion-md comments pull|push <file.nmd>
-notion-md doctor <page-id-or-url|file.nmd>
-notion-md store verify|gc|export <file.nmd>
-```
+For each remote node:
 
-Batch commands:
+1. Pull and validate a complete remote body.
+2. Render direct child-page anchors or unambiguous title placeholders as
+   relative Derived Child Links in the local body.
+3. Render the canonical Notion child anchors into the clean sync baseline.
+4. Write the page with `source: remote` and establish its baseline unless the
+   pass is a plan.
 
-```bash
-notion-md status <target...> [--recursive] [--concurrency 4]
-notion-md sync <target> [--recursive] [--concurrency 4] [--watch]
-```
+The prior Tree Manifest is only routing and ownership evidence. Before writing
+an existing destination, reconciliation parses the file's frontmatter and
+accepts it only when it identifies the incoming page or the manifest-recorded
+occupant. This permits page-ID-preserving path swaps while refusing unknown,
+identity-less, or rebound files. After materialization, a stale path is removed
+only when the prior manifest recorded that page and the current file still
+identifies it; unrelated local files remain untouched.
 
-Rules:
-
-- A single file target emits a single-page JSON result.
-- Multiple status targets or flat recursive directory targets emit a batch envelope.
-- Directory tree targets read `.notion-md/workspace.json` as an internal tree
-  index when present. `plan` reports tree operations without writing files, and
-  `sync` applies the local tree unless `--from-remote` is explicit.
-- Recursive discovery includes existing `*.nmd` files and skips `.notion-md`,
-  `.git`, and `node_modules`.
-- Duplicate `page_id` values in the same batch are rejected before any Notion
-  mutation.
-- Missing or malformed files are reported as per-file errors when other valid
-  targets can still run.
-- Local file deletion, local rename, and remote page moves are not destructive
-  intent. Remote archive/delete remains explicit future behavior.
-
-Batch and folder support do not change the ownership unit: one `.nmd` file maps
-to one Notion page, and every mutation still passes through the same page-local
-guards ([03-sync-engine](../03-sync-engine/spec.md)). The batch layer only owns
-target discovery, duplicate page-id preflight, bounded concurrency, per-file
-result reporting, and multi-file watch scheduling.
+Derived Child Links are stripped only when composing a previously
+remote-authoritative tree back into canonical child anchors. Local-authoritative
+trees treat a Markdown link whose href happens to match a child path as authored
+content and preserve it through cross-reference resolution.
 
 ## Watch Lifecycle
 
@@ -172,8 +171,8 @@ Rules:
   adapters are thin stream producers; coalescing policy stays in the watch loop.
 - Multi-file watch resolves the target set at startup, watches the containing
   directories for those files, coalesces by path, and runs batch sync passes with
-  bounded concurrency. New files discovered after startup require restarting the
-  watcher until a tree manifest/daemon owns dynamic discovery.
+  bounded concurrency. New files require restarting the flat batch watcher.
+  Hierarchical Tracked Trees use one-shot `status` / `sync`; tree watch is refused.
 
 The watch core uses a sliding queue and debounce window. Future tests may inject
 source streams and `TestClock`, but production code must stay on Effect Platform

--- a/packages/@overeng/notion-md/docs/vrs/glossary.md
+++ b/packages/@overeng/notion-md/docs/vrs/glossary.md
@@ -16,6 +16,24 @@ A Notion page bound to a local `.nmd` file through explicit frontmatter identity
 and Source. Tracking is established by `track`.
 _Avoid_: cloned page, imported page
 
+**Tracked Tree**:
+A Notion root page and its child-page hierarchy bound to one local directory.
+Each page retains its own `.nmd` frontmatter identity; the Tree Manifest declares
+the hierarchy's authority and routes directory operations.
+_Avoid_: recursive batch, folder sync
+
+**Tree Manifest**:
+The regenerable `.notion-md/workspace.json` routing and prior-ownership index for
+a Tracked Tree. It records the root, layout, authority, and last materialized
+path-to-page mapping, but never supersedes `.nmd` frontmatter as page identity.
+_Avoid_: identity store, source of truth
+
+**Derived Child Link**:
+A relative local Markdown link rendered from a direct Notion child-page anchor
+inside a remote-authoritative Tracked Tree. It is local navigation, not authored
+body content; the sync baseline retains the canonical Notion child anchor.
+_Avoid_: user-authored child-file link
+
 **Mirror Sync**:
 The stateless mechanism for pages authored on exactly one side. `source: local`
 mirrors local content to Notion; `source: remote` mirrors Notion content to the
@@ -29,9 +47,10 @@ resolved.
 _Avoid_: bidirectional mode, two-way sync
 
 **Authority**:
-The side that wins under Mirror Sync when the local and remote Modeled Body
-differs. Local is authoritative for `source: local`; Notion is authoritative for
-`source: remote`.
+The side that wins when modeled content differs. A file derives authority from
+`source`; a Tracked Tree derives it from the Tree Manifest. Local authority
+mirrors local content to Notion, remote authority mirrors Notion into the local
+surface, and `shared` is available only through per-file Source.
 _Avoid_: winner flag, precedence
 
 **Modeled Body**:

--- a/packages/@overeng/notion-md/docs/vrs/spec.md
+++ b/packages/@overeng/notion-md/docs/vrs/spec.md
@@ -38,33 +38,36 @@ Traces requirements [R09](./requirements.md), [R11](./requirements.md), and
 
 Make notion-md frictionless: the common single-source path (author on one side,
 mirror to the other) pays _zero_ stored-state complexity; bidirectional power is
-opt-in and progressively disclosed. The engine dispatches on self-describing
-files, not on CLI flags.
+opt-in and progressively disclosed. The engine dispatches on a self-describing
+file's `source` or a Tracked Tree's manifest authority, not direction flags.
 
 ### Decided surface (bake-off outcome)
 
 The decided surface is three single-purpose, near-flagless verbs:
-`track` / `status` / `sync`. Direction
-and identity live in each file's frontmatter, not in flags (R34).
+`track` / `status` / `sync`. File direction and identity live in frontmatter;
+hierarchical directory authority and routing live in the derived Tree Manifest.
 
-| Verb                     | Argument             | Behavior                                                                                                                                                                               |
-| ------------------------ | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `track <id\|url> [path]` | a Notion page id/url | The ONLY command taking a page id. Establishes a local tracked file/subtree for an existing Notion page. Writes self-describing frontmatter (`page_id`, `parent`, `source`).           |
-| `status <path...>`       | local paths          | Read-only, **safe by construction** (no write path in its call graph). Reports the live in-sync decision per file in git-porcelain vocabulary; never mutates.                          |
-| `sync <path...>`         | local paths          | Reconciles self-describing files; dispatches per file on frontmatter `source`, never on flags/arity. Creates remote pages for unbound local files. Always moves a file toward in-sync. |
+| Verb                     | Argument             | Behavior                                                                                                                                                                                             |
+| ------------------------ | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `track <id\|url> [path]` | a Notion page id/url | The ONLY command taking a page id. Establishes a local Tracked Page, or a remote-authoritative Tracked Tree when `path` is an existing directory.                                                    |
+| `status <path...>`       | local paths          | Read-only, **safe by construction** (no write path in its call graph). Reports file status or a directory-tree plan; never mutates.                                                                  |
+| `sync <path...>`         | local paths          | Reconciles files by frontmatter `source` and non-recursive directory trees by manifest authority. Creates remote pages for unbound local files and always moves the selected surface toward in-sync. |
 
 #### `track <id|url> [path]`
 
-Establishes tracking for an existing Notion page by materializing a local
-file/subtree and writing self-describing frontmatter (`page_id`, `parent`,
-`source`).
+Establishes tracking for an existing Notion page. A file or missing path
+materializes one self-describing `.nmd` file (`page_id`, `parent`, `source`).
+An existing directory materializes the full remote child-page hierarchy and
+writes an explicit remote-authority Tree Manifest (R51).
 
-- `--as local|remote|shared` — default `remote` (you tracked existing Notion state).
-- `--dry-run` — read and validate the remote page, report the intended output,
-  and write nothing.
-- Fail-closed on lossy remote observation: no clean base from a truncated or
+- `--as local|remote|shared` — default `remote` for a file; directory tracking
+  accepts only `remote`.
+- `--dry-run` — read and validate the complete selected page or tree, report the
+  intended output, and write nothing.
+- Fail closed on lossy remote observation: no clean base from a truncated or
   lossy body.
-- Refuses to overwrite an existing file bound to a different page.
+- Refuse an existing file bound to a different page or an established tree
+  bound to a different root.
 
 #### `status <path...>`
 
@@ -87,12 +90,14 @@ manual preview.
 
 #### `sync <path...>`
 
-Reconciles self-describing files. Dispatch is per file on frontmatter `source`,
-never on flags or argument arity. Common-path flags: zero.
+Reconciles self-describing local paths. A file dispatches on frontmatter
+`source`; a non-recursive directory dispatches on manifest authority. A missing
+manifest authority normalizes to `local` for compatibility. `--recursive`
+selects flat batch discovery rather than hierarchical tree reconciliation.
 
-Local-first creation is part of `sync`: an unbound `source: local` file creates
-a new remote page and records the returned `page_id`. Existing remote pages are
-adopted with `track`, not with `sync`.
+Local-first creation is part of file sync: an unbound `source: local` file
+creates a new remote page and records the returned `page_id`. Existing remote
+pages are adopted with `track`, not with `sync`.
 
 | Flag                            | Effect                                                                                                                                                                             |
 | ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -124,12 +129,12 @@ alternate surface area.
 
 `track` / `status` / `sync` keep one target grammar: `track` takes Notion page
 ids or URLs, while `status` and `sync` take local paths. There is deliberately
-**no `push` / `pull` verb**: direction lives
-in each file's `source` — the per-file upstream-tracking config, analogous to
-git's `branch.<x>.remote`. `status` and `sync` surface the one-line explainer:
+**no `push` / `pull` verb**: direction lives in a file's `source` or a Tracked
+Tree's manifest authority, analogous to git upstream configuration. `status`
+and `sync` surface the one-line explainer:
 
-> no push/pull — direction is each file's `source`; `sync` always moves toward
-> in-sync, `source` decides which way.
+> no push/pull — direction is each file's `source` or tree workspace authority;
+> `sync` always moves toward in-sync.
 
 git's staging, commits, and branches are rejected entirely — there is no `add`,
 `commit`, `log`, or heuristic `sync <page-url>` form.

--- a/packages/@overeng/notion-md/src/cli-program.ts
+++ b/packages/@overeng/notion-md/src/cli-program.ts
@@ -56,7 +56,7 @@ import {
   withOperation,
   withRootOperation,
 } from './observability.ts'
-import { syncPath, targetKind, trackPath } from './path.ts'
+import { statusPath, syncPath, targetKind, trackPath } from './path.ts'
 import { ProgressReporterStderrLines } from './progress.ts'
 import { reconcileFile, reconcileTree, statusTree } from './reconcile.ts'
 import {
@@ -528,18 +528,30 @@ const statusCommand = Command.make(
       command: 'status',
       label: paths.length === 1 ? basename(paths[0] ?? 'target') : `${paths.length} targets`,
       effect: withNotion(
-        statusTree({ targets: paths, recursive, concurrency }).pipe(
-          Effect.flatMap((batch) =>
-            renderStatus({
-              json,
-              results: batch.items.flatMap((item) =>
-                item._tag === 'success'
-                  ? [{ path: item.result.path, status: item.result.status }]
-                  : [{ path: item.path, status: 'error' }],
-              ),
-            }),
-          ),
-        ),
+        Effect.gen(function* () {
+          const onlyPath = paths.length === 1 ? paths[0] : undefined
+          if (
+            onlyPath !== undefined &&
+            recursive === false &&
+            (yield* targetKind(onlyPath)) === 'directory'
+          ) {
+            const result = yield* statusPath({ path: onlyPath })
+            if (!('ops' in result)) {
+              return yield* Effect.die('Directory status did not return a tree result')
+            }
+            return yield* renderTreeSync({ json, result })
+          }
+
+          const batch = yield* statusTree({ targets: paths, recursive, concurrency })
+          return yield* renderStatus({
+            json,
+            results: batch.items.flatMap((item) =>
+              item._tag === 'success'
+                ? [{ path: item.result.path, status: item.result.status }]
+                : [{ path: item.path, status: 'error' }],
+            ),
+          })
+        }),
       ),
     }),
 ).pipe(
@@ -578,51 +590,65 @@ const syncCommand = Command.make(
     json,
   }) => {
     if (watch === true) {
-      const syncOptions: SyncOptions = {
-        path: paths[0] ?? '',
-        force,
-        dryRun,
-        allowDeletingUnknownBlocks: allowDeleteUnknownBlocks,
-        allowReviewMarkup,
-      }
-      return paths.length === 1
-        ? withNotion(
-            runWatch({
-              syncOptions: { ...syncOptions, gcObjects } as SyncOptions,
-              pollIntervalMs,
-            }),
-          )
-        : withNotion(
-            targetsFor({ paths, recursive }).pipe(
-              Effect.flatMap((resolved) =>
-                resolved.length === 0
-                  ? Effect.fail(
-                      new NmdCliError({
-                        message: 'No .nmd files matched the requested watch targets',
-                      }),
-                    )
-                  : runBatchWatch({
-                      paths: resolved,
-                      concurrency,
-                      pollIntervalMs,
-                      force,
-                      dryRun,
-                      runSyncMany: (batchOpts) =>
-                        reconcileTree({
-                          targets: batchOpts.targets,
-                          ...(batchOpts.concurrency === undefined
-                            ? {}
-                            : { concurrency: batchOpts.concurrency }),
-                          ...(batchOpts.force === undefined ? {} : { force: batchOpts.force }),
-                          ...(batchOpts.dryRun === undefined ? {} : { dryRun: batchOpts.dryRun }),
-                          allowDeletingUnknownBlocks: allowDeleteUnknownBlocks,
-                          allowReviewMarkup,
-                          gcObjects,
+      return Effect.gen(function* () {
+        const onlyPath = paths.length === 1 ? paths[0] : undefined
+        if (
+          onlyPath !== undefined &&
+          recursive === false &&
+          (yield* targetKind(onlyPath)) === 'directory'
+        ) {
+          return yield* new NmdCliError({
+            message:
+              'Directory tree watch is not supported; run one-shot `notion-md sync <directory>` or use `--recursive` for flat file watch.',
+          })
+        }
+
+        const syncOptions: SyncOptions = {
+          path: paths[0] ?? '',
+          force,
+          dryRun,
+          allowDeletingUnknownBlocks: allowDeleteUnknownBlocks,
+          allowReviewMarkup,
+        }
+        return yield* paths.length === 1
+          ? withNotion(
+              runWatch({
+                syncOptions: { ...syncOptions, gcObjects } as SyncOptions,
+                pollIntervalMs,
+              }),
+            )
+          : withNotion(
+              targetsFor({ paths, recursive }).pipe(
+                Effect.flatMap((resolved) =>
+                  resolved.length === 0
+                    ? Effect.fail(
+                        new NmdCliError({
+                          message: 'No .nmd files matched the requested watch targets',
                         }),
-                    }),
+                      )
+                    : runBatchWatch({
+                        paths: resolved,
+                        concurrency,
+                        pollIntervalMs,
+                        force,
+                        dryRun,
+                        runSyncMany: (batchOpts) =>
+                          reconcileTree({
+                            targets: batchOpts.targets,
+                            ...(batchOpts.concurrency === undefined
+                              ? {}
+                              : { concurrency: batchOpts.concurrency }),
+                            ...(batchOpts.force === undefined ? {} : { force: batchOpts.force }),
+                            ...(batchOpts.dryRun === undefined ? {} : { dryRun: batchOpts.dryRun }),
+                            allowDeletingUnknownBlocks: allowDeleteUnknownBlocks,
+                            allowReviewMarkup,
+                            gcObjects,
+                          }),
+                      }),
+                ),
               ),
-            ),
-          )
+            )
+      })
     }
 
     return commandSpan({

--- a/packages/@overeng/notion-md/src/cli-program.ts
+++ b/packages/@overeng/notion-md/src/cli-program.ts
@@ -56,8 +56,9 @@ import {
   withOperation,
   withRootOperation,
 } from './observability.ts'
+import { syncPath, targetKind, trackPath } from './path.ts'
 import { ProgressReporterStderrLines } from './progress.ts'
-import { reconcileFile, reconcileTree, statusTree, trackPage } from './reconcile.ts'
+import { reconcileFile, reconcileTree, statusTree } from './reconcile.ts'
 import {
   garbageCollectObjects,
   NmdStateStoreLive,
@@ -66,6 +67,7 @@ import {
   type NmdObjectGcResult,
 } from './state-store.ts'
 import type { SyncOptions } from './sync.ts'
+import type { TreeSyncResult } from './tree.ts'
 import { NOTION_MD_VERSION } from './version.ts'
 
 const NonEmptyCliText = Schema.NonEmptyString.pipe(Schema.check(Schema.isTrimmed())).annotate({
@@ -85,7 +87,7 @@ const PositiveInteger = Schema.Int.pipe(Schema.check(Schema.isGreaterThan(0))).a
 
 /** Local `.nmd` paths (file or directory). `status`/`sync` take only local paths. */
 const localTargetsArg = Args.string('path').pipe(
-  Args.withDescription('Local .nmd file or directory (a directory means everything under it)'),
+  Args.withDescription('Local .nmd file or directory tree (--recursive selects flat batch mode)'),
   Args.withSchema(NonEmptyCliText),
   Args.atLeast(1),
 )
@@ -97,7 +99,9 @@ const trackPageRefArg = Args.string('page-id-or-url').pipe(
 )
 
 const trackOutPathArg = Args.string('path').pipe(
-  Args.withDescription('Local .nmd file to write (default: <page-id>.nmd)'),
+  Args.withDescription(
+    'Local .nmd file, or an existing directory for the full child-page tree (default: <page-id>.nmd)',
+  ),
   Args.withSchema(NonEmptyCliText),
   Args.optional,
 )
@@ -436,11 +440,11 @@ const parseNotionPageRefOrFail = (value: string): Effect.Effect<string, NmdCliEr
 }
 
 /*
- * Direction is each file's `source`; there is deliberately no push/pull verb.
- * `status` and `sync` surface this one-line explainer (spec git-native framing).
+ * Direction is each file's `source`, or a tree manifest's explicit authority;
+ * there is deliberately no push/pull verb.
  */
 const directionExplainer =
-  "no push/pull — direction is each file's `source`; `sync` always moves toward in-sync, `source` decides which way."
+  "no push/pull — direction is each file's `source` or tree workspace authority; `sync` always moves toward in-sync."
 
 const porcelainLine = (status: { readonly path: string; readonly status: string }): string =>
   `${status.status.padEnd(12)} ${basename(status.path)}`
@@ -453,6 +457,20 @@ const renderStatus = (opts: {
     ? logJson(opts.results)
     : Effect.gen(function* () {
         for (const r of opts.results) yield* Console.log(porcelainLine(r))
+        yield* Console.log('')
+        yield* Console.log(directionExplainer)
+      })
+
+const renderTreeSync = (opts: {
+  readonly json: boolean
+  readonly result: TreeSyncResult
+}): Effect.Effect<void> =>
+  opts.json === true
+    ? logJson(opts.result)
+    : Effect.gen(function* () {
+        for (const op of opts.result.ops) {
+          yield* Console.log(`${op._tag.padEnd(16)} ${op.relPath}`)
+        }
         yield* Console.log('')
         yield* Console.log(directionExplainer)
       })
@@ -474,7 +492,7 @@ const trackCommand = Command.make(
         Effect.flatMap((pageId) => {
           const outPath = Option.isSome(out) === true ? out.value : `${pageId}.nmd`
           return withNotion(
-            trackPage({ pageId, outPath, source: as, dryRun }).pipe(
+            trackPath({ pageId, outPath, source: as, dryRun }).pipe(
               Effect.map((result): unknown => result),
             ),
           )
@@ -483,7 +501,7 @@ const trackCommand = Command.make(
     }).pipe(Effect.flatMap(logJson)),
 ).pipe(
   Command.withDescription(
-    'Track an existing Notion page as a local .nmd file (the only command taking a page id)',
+    'Track an existing Notion page as one local .nmd file or an existing directory tree (the only command taking a page id)',
   ),
 )
 
@@ -530,7 +548,7 @@ const statusCommand = Command.make(
   ),
 )
 
-/** `sync [path...]` — reconcile self-describing files; dispatch per file on `source`. */
+/** `sync [path...]` — reconcile files by `source`, or trees by manifest authority. */
 const syncCommand = Command.make(
   'sync',
   {
@@ -611,38 +629,53 @@ const syncCommand = Command.make(
       command: 'sync',
       label: paths.length === 1 ? basename(paths[0] ?? 'target') : `${paths.length} targets`,
       effect: withNotion(
-        reconcileTree({
-          targets: paths,
-          recursive,
-          concurrency,
-          force,
-          allowDeletingUnknownBlocks: allowDeleteUnknownBlocks,
-          allowReviewMarkup,
-          gcObjects,
-          dryRun,
-        }).pipe(
-          Effect.flatMap((batch) =>
-            json === true
-              ? logJson(batch)
-              : Effect.gen(function* () {
-                  for (const item of batch.items) {
-                    yield* Console.log(
-                      item._tag === 'success'
-                        ? `${item.result._tag.padEnd(16)} ${basename(item.result.path)}`
-                        : `error            ${basename(item.path)}${guardSuffix(item.error)}`,
-                    )
-                  }
-                  yield* Console.log('')
-                  yield* Console.log(directionExplainer)
-                }),
-          ),
-        ),
+        Effect.gen(function* () {
+          if (
+            paths.length === 1 &&
+            recursive === false &&
+            (yield* targetKind(paths[0] ?? '')) === 'directory'
+          ) {
+            const result = yield* syncPath({
+              path: paths[0] ?? '',
+              force,
+              dryRun,
+              allowDeletingUnknownBlocks: allowDeleteUnknownBlocks,
+              allowReviewMarkup,
+              gcObjects,
+            })
+            if (result._tag !== 'tree') {
+              return yield* Effect.die(new Error('Directory sync did not return a tree result'))
+            }
+            return yield* renderTreeSync({ json, result })
+          }
+
+          const batch = yield* reconcileTree({
+            targets: paths,
+            recursive,
+            concurrency,
+            force,
+            allowDeletingUnknownBlocks: allowDeleteUnknownBlocks,
+            allowReviewMarkup,
+            gcObjects,
+            dryRun,
+          })
+          if (json === true) return yield* logJson(batch)
+          for (const item of batch.items) {
+            yield* Console.log(
+              item._tag === 'success'
+                ? `${item.result._tag.padEnd(16)} ${basename(item.result.path)}`
+                : `error            ${basename(item.path)}${guardSuffix(item.error)}`,
+            )
+          }
+          yield* Console.log('')
+          yield* Console.log(directionExplainer)
+        }),
       ),
     })
   },
 ).pipe(
   Command.withDescription(
-    'Reconcile self-describing .nmd files toward in-sync; dispatch per file on frontmatter `source`',
+    'Reconcile .nmd files by frontmatter `source`, or a directory tree by workspace authority',
   ),
 )
 

--- a/packages/@overeng/notion-md/src/cli.e2e.test.ts
+++ b/packages/@overeng/notion-md/src/cli.e2e.test.ts
@@ -156,6 +156,18 @@ describe('notion-md CLI boundary', () => {
   )
 
   it(
+    'rejects directory tree watch instead of entering one-file watch mode',
+    async () => {
+      await withTempDir(async (dir) => {
+        await expect(runCli(['sync', dir, '--watch'])).rejects.toMatchObject({
+          stdout: expect.stringContaining('Directory tree watch is not supported'),
+        })
+      })
+    },
+    cliTestTimeoutMs,
+  )
+
+  it(
     'rejects a non-page-id track argument before resolving Notion credentials',
     async () => {
       await withTempDir(async (dir) => {

--- a/packages/@overeng/notion-md/src/path.ts
+++ b/packages/@overeng/notion-md/src/path.ts
@@ -17,6 +17,7 @@ import {
   type TrackResult,
 } from './reconcile.ts'
 import type { NmdStateStore } from './state-store.ts'
+import { readTreeIndexOptional } from './tree-index.ts'
 import { syncTree, type TreeSyncResult } from './tree.ts'
 
 /** Filesystem shape used to choose the appropriate notion-md reconcile engine. */
@@ -97,6 +98,12 @@ export const trackPath = (
       if (opts.source !== 'remote') {
         return yield* new NmdCliError({
           message: `Directory track targets only support --as remote; use a .nmd file target with --as ${opts.source}`,
+        })
+      }
+      const previous = yield* readTreeIndexOptional(opts.outPath)
+      if (previous !== undefined && previous.root_page_id !== opts.pageId) {
+        return yield* new NmdCliError({
+          message: `Refusing to track Notion root ${opts.pageId} into ${opts.outPath}: workspace already tracks root ${previous.root_page_id}`,
         })
       }
       return yield* syncTree({

--- a/packages/@overeng/notion-md/src/path.ts
+++ b/packages/@overeng/notion-md/src/path.ts
@@ -11,8 +11,10 @@ import {
   reconcileTree,
   statusFile,
   statusTree,
+  trackPage,
   type ReconcileResult,
   type ReconcileStatus,
+  type TrackResult,
 } from './reconcile.ts'
 import type { NmdStateStore } from './state-store.ts'
 import { syncTree, type TreeSyncResult } from './tree.ts'
@@ -26,6 +28,16 @@ export type StatusPathResult = ReconcileStatus | TreeSyncResult | BatchResult<Re
 export type SyncPathResult = ReconcileResult | TreeSyncResult | BatchResult<ReconcileResult>
 /** Result of a dry-run directory tree plan. */
 export type PlanPathResult = TreeSyncResult
+/** Result of tracking a remote page into one file or an existing directory tree. */
+export type TrackPathResult = TrackResult | TreeSyncResult
+
+/** Options for routing `track` by the explicit filesystem kind of its output path. */
+export interface TrackPathOptions {
+  readonly pageId: string
+  readonly outPath: string
+  readonly source: TrackResult['source']
+  readonly dryRun?: boolean
+}
 
 /** Options for status over the public path-oriented API. */
 export interface StatusPathOptions {
@@ -66,6 +78,40 @@ export const targetKind = (
     const info = yield* fs.stat(target).pipe(Effect.result)
     if (info._tag === 'Failure') return 'missing'
     return info.success.type === 'Directory' ? 'directory' : 'file'
+  })
+
+/**
+ * Track one remote page into a file, or its full child-page subtree into an
+ * existing directory. Missing targets retain the single-file `trackPage` behavior.
+ */
+export const trackPath = (
+  opts: TrackPathOptions,
+): Effect.Effect<
+  TrackPathResult,
+  NmdError,
+  FileSystem.FileSystem | NotionMdGateway | NmdStateStore
+> =>
+  Effect.gen(function* () {
+    const kind = yield* targetKind(opts.outPath)
+    if (kind === 'directory') {
+      if (opts.source !== 'remote') {
+        return yield* new NmdCliError({
+          message: `Directory track targets only support --as remote; use a .nmd file target with --as ${opts.source}`,
+        })
+      }
+      return yield* syncTree({
+        root: opts.outPath,
+        rootPageId: opts.pageId,
+        fromRemote: true,
+        ...(opts.dryRun === undefined ? {} : { plan: opts.dryRun }),
+      })
+    }
+    return yield* trackPage({
+      pageId: opts.pageId,
+      outPath: opts.outPath,
+      source: opts.source,
+      ...(opts.dryRun === undefined ? {} : { dryRun: opts.dryRun }),
+    })
   })
 
 /** Compare a local path with Notion, routing files, trees, and flat batches safely. */
@@ -160,7 +206,7 @@ export const syncPath = (
       return yield* syncTree({
         root: opts.path,
         fromRemote: true,
-        pushOptions: { path: opts.path, ...pushSafety(opts) },
+        ...(opts.dryRun === undefined ? {} : { plan: opts.dryRun }),
         ...(opts.rootPageId === undefined ? {} : { rootPageId: opts.rootPageId }),
         ...(opts.rootFile === undefined ? {} : { rootFile: opts.rootFile }),
       })
@@ -185,7 +231,7 @@ export const syncPath = (
       }
       return yield* syncTree({
         root: opts.path,
-        fromRemote: false,
+        ...(opts.dryRun === undefined ? {} : { plan: opts.dryRun }),
         pushOptions: { path: opts.path, ...pushSafety(opts) },
         ...(opts.rootPageId === undefined ? {} : { rootPageId: opts.rootPageId }),
         ...(opts.rootFile === undefined ? {} : { rootFile: opts.rootFile }),

--- a/packages/@overeng/notion-md/src/tree-index.ts
+++ b/packages/@overeng/notion-md/src/tree-index.ts
@@ -5,16 +5,32 @@ import { Effect, FileSystem, Schema } from 'effect'
 import { NmdCliError, NmdFileSystemError, type NmdError } from './errors.ts'
 
 /** Regenerable path↔id index for a synced tree (NOT the source of identity). */
-export const TreeIndex = Schema.Struct({
+const TreeAuthority = Schema.Literals(['local', 'remote'])
+
+const treeIndexPrefix = {
   version: Schema.Literal(1),
   root_page_id: Schema.String,
   /** Root-file basename, so a later run reconstructs the same layout. */
   root_file: Schema.String,
+}
+
+const treeIndexSuffix = {
   /** posix relativePath (from root) → page_id; derived from frontmatter each run. */
   pages: Schema.Record(Schema.String, Schema.String),
+}
+
+/** On-disk tree index; legacy manifests may omit `authority`. */
+export const TreeIndex = Schema.Struct({
+  ...treeIndexPrefix,
+  authority: Schema.optional(TreeAuthority),
+  ...treeIndexSuffix,
 }).annotate({ identifier: 'NotionMd.TreeIndex' })
 
 export type TreeIndex = typeof TreeIndex.Type
+/** Tree index after read-boundary authority normalization. */
+export type NormalizedTreeIndex = Omit<TreeIndex, 'authority'> & {
+  readonly authority: typeof TreeAuthority.Type
+}
 
 const encodeTreeIndexJson = Schema.encodeSync(Schema.fromJsonString(TreeIndex, { space: 2 }))
 const decodeTreeIndexJson = Schema.decodeUnknownEffect(Schema.fromJsonString(TreeIndex), {
@@ -42,7 +58,7 @@ export const treeIndexPath = (root: string): string => join(root, '.notion-md', 
 /** Read the internal tree index when present. */
 export const readTreeIndexOptional = (
   root: string,
-): Effect.Effect<TreeIndex | undefined, NmdError, FileSystem.FileSystem> =>
+): Effect.Effect<NormalizedTreeIndex | undefined, NmdError, FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem
     const path = treeIndexPath(root)
@@ -54,6 +70,12 @@ export const readTreeIndexOptional = (
       .readFileString(path)
       .pipe(Effect.mapError((cause) => makeFsError({ operation: 'read', path, cause })))
     return yield* decodeTreeIndexJson(content).pipe(
+      Effect.map(
+        (index): NormalizedTreeIndex => ({
+          ...index,
+          authority: index.authority ?? 'local',
+        }),
+      ),
       Effect.mapError(
         (cause) =>
           new NmdCliError({
@@ -66,7 +88,7 @@ export const readTreeIndexOptional = (
 /** Write the derived tree index under the tree root's `.notion-md` directory. */
 export const writeTreeIndex = (opts: {
   readonly root: string
-  readonly index: TreeIndex
+  readonly index: NormalizedTreeIndex
 }): Effect.Effect<void, NmdFileSystemError, FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem
@@ -85,7 +107,7 @@ export interface TreeMembership {
   readonly relPath: string
   readonly pageId: string
   readonly isRoot: boolean
-  readonly index: TreeIndex
+  readonly index: NormalizedTreeIndex
 }
 
 /**

--- a/packages/@overeng/notion-md/src/tree.ts
+++ b/packages/@overeng/notion-md/src/tree.ts
@@ -375,8 +375,7 @@ export const composePushBody = (opts: {
     readonly localHref?: string
   }[]
 }): string => {
-  const pushBody = stripMaterializedChildLinks({ body: opts.resolvedBody, children: opts.children })
-  const trimmed = pushBody.replace(/\n+$/u, '')
+  const trimmed = opts.resolvedBody.replace(/\n+$/u, '')
   if (opts.children.length === 0) return normalizeMarkdownLineEndings(`${trimmed}\n`)
   const anchors = opts.children
     .map((child) => `<page url="${pageUrl(child.pageId)}">${child.title}</page>`)
@@ -524,15 +523,11 @@ const composeTreePushBody = (opts: {
   readonly relPath: string
   readonly resolvedBody: string
   readonly children: readonly ChildIndexChild[]
-}): Effect.Effect<string, NmdError> => {
-  const resolvedBody = stripMaterializedChildLinks({
-    body: opts.resolvedBody,
-    children: opts.children,
-  })
-  return childAnchors(resolvedBody).length === 0
+}): Effect.Effect<string, NmdError> =>
+  childAnchors(opts.resolvedBody).length === 0
     ? Effect.succeed(
         composePushBody({
-          resolvedBody,
+          resolvedBody: opts.resolvedBody,
           children: opts.children.flatMap((child) =>
             child.pageId === undefined
               ? []
@@ -546,14 +541,13 @@ const composeTreePushBody = (opts: {
           ),
         }),
       )
-    : validateAndFillChildAnchors({ ...opts, resolvedBody }).pipe(
+    : validateAndFillChildAnchors(opts).pipe(
         Effect.map((body) =>
           normalizeMarkdownLineEndings(
             `${blankLineSeparateChildAnchors(body).replace(/\n+$/u, '')}\n`,
           ),
         ),
       )
-}
 
 /** Re-render a file with the real `page_id`/`url` bound in (keeps body + title). */
 const bindFrontmatter = (opts: {
@@ -746,6 +740,7 @@ const syncTreeLocal = (opts: {
     const store = yield* NmdStateStore
     const { root, rootFile, rootPageId, pages, previous, plan } = opts
     const stateAnchor = treeStateAnchor(root)
+    const stripMaterializedLinks = previous?.authority === 'remote'
     const rootRel = rootFile
     const rootPage = pages.find((page) => page.relPath === rootRel)
     if (rootPage === undefined) {
@@ -873,7 +868,7 @@ const syncTreeLocal = (opts: {
     }
 
     if (plan === true) {
-      yield* classifyPlan({ root, pages, idForRelPath, slugMap, ops })
+      yield* classifyPlan({ root, pages, idForRelPath, slugMap, ops, stripMaterializedLinks })
       const liveIds = new Set(idForRelPath.values())
       for (const [relPath, pageId] of Object.entries(previous?.pages ?? {})) {
         if (liveIds.has(pageId) === false) {
@@ -916,7 +911,10 @@ const syncTreeLocal = (opts: {
       const pageId = idForRelPath.get(page.relPath)
       if (pageId === undefined) continue
       const children = childrenOf.get(page.relPath) ?? []
-      const bodyForPush = stripMaterializedChildLinks({ body: page.body, children })
+      const bodyForPush =
+        stripMaterializedLinks === true
+          ? stripMaterializedChildLinks({ body: page.body, children })
+          : page.body
       const resolvedBody = yield* resolveCrossRefs({
         body: bodyForPush,
         relPath: page.relPath,
@@ -1086,6 +1084,7 @@ const classifyPlan = (opts: {
   readonly idForRelPath: ReadonlyMap<string, string>
   readonly slugMap: ReadonlyMap<string, string>
   readonly ops: TreeOp[]
+  readonly stripMaterializedLinks: boolean
 }): Effect.Effect<void, NmdError, NmdStateStore> =>
   Effect.gen(function* () {
     const childrenOf = childIndexChildrenByParent({
@@ -1098,7 +1097,10 @@ const classifyPlan = (opts: {
       if (opts.ops.some((op) => op.relPath === page.relPath && op._tag === 'move') === true)
         continue
       const children = childrenOf.get(page.relPath) ?? []
-      const bodyForPush = stripMaterializedChildLinks({ body: page.body, children })
+      const bodyForPush =
+        opts.stripMaterializedLinks === true
+          ? stripMaterializedChildLinks({ body: page.body, children })
+          : page.body
       const resolved = yield* resolveCrossRefs({
         body: bodyForPush,
         relPath: page.relPath,
@@ -1407,25 +1409,32 @@ const syncTreeFromRemote = (opts: {
         .exists(path)
         .pipe(Effect.mapError((cause) => makeFsError({ operation: 'exists', path, cause })))
       const previousRelPath = previousRelPathByPageId.get(node.pageId)
-      let unindexedSamePage = false
-      if (exists === true && previousPageIdByRelPath.has(node.relPath) === false) {
+      let samePageAtExistingPath = false
+      if (exists === true) {
         const existingFile = yield* store.readNmdFile({ path }).pipe(
           Effect.flatMap((content) => parseNmdFile({ path, content })),
           Effect.result,
         )
-        unindexedSamePage =
-          existingFile._tag === 'Success' &&
-          existingFile.success.frontmatter.notion_md.page_id === node.pageId
-        if (unindexedSamePage === false) {
+        const existingPageId =
+          existingFile._tag === 'Success'
+            ? existingFile.success.frontmatter.notion_md.page_id
+            : undefined
+        const trackedPageId = previousPageIdByRelPath.get(node.relPath)
+        samePageAtExistingPath = existingPageId === node.pageId
+        const isTrackedOccupant = trackedPageId !== undefined && existingPageId === trackedPageId
+        if (samePageAtExistingPath === false && isTrackedOccupant === false) {
           return yield* new NmdCliError({
-            message: `Refusing to overwrite untracked local file ${path} while mirroring page ${node.pageId}`,
+            message:
+              trackedPageId === undefined
+                ? `Refusing to overwrite untracked local file ${path} while mirroring page ${node.pageId}`
+                : `Refusing to overwrite tracked local file ${path}: expected page ${trackedPageId}, found ${existingPageId ?? 'no page identity'}`,
           })
         }
       }
       const op: TreeOp =
         previousRelPath !== undefined && previousRelPath !== node.relPath
           ? { _tag: 'move', relPath: node.relPath, pageId: node.pageId }
-          : exists === true && (previousRelPath === node.relPath || unindexedSamePage === true)
+          : exists === true && (previousRelPath === node.relPath || samePageAtExistingPath === true)
             ? { _tag: 'update', relPath: node.relPath, pageId: node.pageId }
             : { _tag: 'materialize', relPath: node.relPath, pageId: node.pageId }
       ops.push(op)

--- a/packages/@overeng/notion-md/src/tree.ts
+++ b/packages/@overeng/notion-md/src/tree.ts
@@ -1306,6 +1306,7 @@ const materializeRemoteTreeNode = (opts: {
   readonly rootFile: string
   readonly node: RemoteTreeNode
   readonly children: readonly RemoteTreeNode[]
+  readonly plan: boolean
 }): Effect.Effect<void, NmdError, FileSystem.FileSystem | NotionMdGateway | NmdStateStore> =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem
@@ -1335,6 +1336,7 @@ const materializeRemoteTreeNode = (opts: {
         }),
       })),
     })
+    if (opts.plan === true) return
 
     yield* fs
       .makeDirectory(dirname(path), { recursive: true })
@@ -1440,15 +1442,14 @@ const syncTreeFromRemote = (opts: {
       ops.push(op)
     }
 
-    if (plan === false) {
-      for (const node of remoteNodes) {
-        yield* materializeRemoteTreeNode({
-          root,
-          rootFile,
-          node,
-          children: remoteChildrenByParent.get(node.pageId) ?? [],
-        })
-      }
+    for (const node of remoteNodes) {
+      yield* materializeRemoteTreeNode({
+        root,
+        rootFile,
+        node,
+        children: remoteChildrenByParent.get(node.pageId) ?? [],
+        plan,
+      })
     }
 
     const previousEntries = [

--- a/packages/@overeng/notion-md/src/tree.ts
+++ b/packages/@overeng/notion-md/src/tree.ts
@@ -19,7 +19,7 @@ import {
   type NmdError,
 } from './errors.ts'
 import { parseNmdFile, renderNmdFile } from './frontmatter.ts'
-import { normalizeMarkdownLineEndings, sha256Digest, stripChildAnchors } from './hash.ts'
+import { normalizeMarkdownLineEndings, sha256Digest } from './hash.ts'
 import { NotionMdGateway, type RemoteMarkdownSnapshot, type RemotePageSnapshot } from './model.ts'
 import { SyncTreeSpan, withOperation } from './observability.ts'
 import {
@@ -29,17 +29,18 @@ import {
   writeSyncState,
 } from './state-store.ts'
 import { buildTreeNodeLocalState, pushGuarded, treeNodePersist, type PushOptions } from './sync.ts'
-import { readTreeIndexOptional, writeTreeIndex, type TreeIndex } from './tree-index.ts'
+import { readTreeIndexOptional, writeTreeIndex, type NormalizedTreeIndex } from './tree-index.ts'
 
 export { pageUrl, resolveCrossRefs, validateCrossRefTargets } from './cross-refs.ts'
 
 /**
  * Unified directory-tree ↔ Notion-subtree reconcile.
  *
- * The local directory tree is the source of truth for hierarchy: each `.nmd`
- * file is a page, directory nesting is page nesting. Binding/identity lives IN
- * the file (frontmatter `page_id`); an unbound file (`page_id: null`) is a
- * to-be-created page.
+ * The workspace manifest records which side is authoritative. In a local tree,
+ * each `.nmd` file is a page and directory nesting is page nesting;
+ * frontmatter `page_id` carries identity and `page_id: null` means
+ * to-be-created. In a remote tree, the Notion child-page graph is mirrored into
+ * that same layout.
  *
  * `tree.ts` is a pure ORCHESTRATOR: it computes hierarchy, the slug→id map, and
  * the composed body per node, then delegates every per-node create/update to
@@ -154,6 +155,7 @@ export type TreeOp =
   | { readonly _tag: 'trash_blocked'; readonly relPath: string; readonly pageId: string }
   | { readonly _tag: 'conflict'; readonly relPath: string; readonly pageId: string }
   | { readonly _tag: 'materialize'; readonly relPath: string; readonly pageId: string }
+  | { readonly _tag: 'delete'; readonly relPath: string; readonly pageId: string }
 
 /** Result envelope for a tree sync (or plan) pass. */
 export interface TreeSyncResult {
@@ -261,7 +263,7 @@ const walkNmdFiles = (
 const detectRootFile = (opts: {
   readonly root: string
   readonly explicit: string | undefined
-  readonly previous: TreeIndex | undefined
+  readonly previous: NormalizedTreeIndex | undefined
 }): Effect.Effect<string, NmdError, FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem
@@ -339,6 +341,27 @@ const scanLocalPages = (opts: {
     })
   })
 
+const materializedChildLink = /^(?<indent>\s*)\[(?<label>[^\]]+)\]\((?<href>[^)]+)\)\s*$/u
+
+const childHref = (opts: {
+  readonly parentRelPath: string
+  readonly childRelPath: string
+}): string => toPosix(relative(dirname(opts.parentRelPath), opts.childRelPath))
+
+const stripMaterializedChildLinks = (opts: {
+  readonly body: string
+  readonly children: readonly ChildIndexChild[]
+}): string =>
+  opts.body
+    .split('\n')
+    .map((line) => {
+      const link = materializedChildLink.exec(line)
+      if (link === null) return line
+      const isDerived = opts.children.some((child) => child.localHref === link.groups?.href)
+      return isDerived === true ? '' : line
+    })
+    .join('\n')
+
 /**
  * Compose the body to PUSH for a page: resolved cross-refs + DERIVED child
  * index. Re-emits one `<page url>` anchor per ordered child (blank-line
@@ -346,9 +369,14 @@ const scanLocalPages = (opts: {
  */
 export const composePushBody = (opts: {
   readonly resolvedBody: string
-  readonly children: readonly { readonly title: string; readonly pageId: string }[]
+  readonly children: readonly {
+    readonly title: string
+    readonly pageId: string
+    readonly localHref?: string
+  }[]
 }): string => {
-  const trimmed = opts.resolvedBody.replace(/\n+$/u, '')
+  const pushBody = stripMaterializedChildLinks({ body: opts.resolvedBody, children: opts.children })
+  const trimmed = pushBody.replace(/\n+$/u, '')
   if (opts.children.length === 0) return normalizeMarkdownLineEndings(`${trimmed}\n`)
   const anchors = opts.children
     .map((child) => `<page url="${pageUrl(child.pageId)}">${child.title}</page>`)
@@ -367,6 +395,7 @@ type ChildAnchor =
 interface ChildIndexChild {
   readonly title: string
   readonly pageId?: string
+  readonly localHref?: string
 }
 
 const childKey = (child: ChildIndexChild): string =>
@@ -495,24 +524,36 @@ const composeTreePushBody = (opts: {
   readonly relPath: string
   readonly resolvedBody: string
   readonly children: readonly ChildIndexChild[]
-}): Effect.Effect<string, NmdError> =>
-  childAnchors(opts.resolvedBody).length === 0
+}): Effect.Effect<string, NmdError> => {
+  const resolvedBody = stripMaterializedChildLinks({
+    body: opts.resolvedBody,
+    children: opts.children,
+  })
+  return childAnchors(resolvedBody).length === 0
     ? Effect.succeed(
         composePushBody({
-          resolvedBody: opts.resolvedBody,
-          children: opts.children.filter(
-            (child): child is { readonly title: string; readonly pageId: string } =>
-              child.pageId !== undefined,
+          resolvedBody,
+          children: opts.children.flatMap((child) =>
+            child.pageId === undefined
+              ? []
+              : [
+                  {
+                    title: child.title,
+                    pageId: child.pageId,
+                    ...(child.localHref === undefined ? {} : { localHref: child.localHref }),
+                  },
+                ],
           ),
         }),
       )
-    : validateAndFillChildAnchors(opts).pipe(
+    : validateAndFillChildAnchors({ ...opts, resolvedBody }).pipe(
         Effect.map((body) =>
           normalizeMarkdownLineEndings(
             `${blankLineSeparateChildAnchors(body).replace(/\n+$/u, '')}\n`,
           ),
         ),
       )
+}
 
 /** Re-render a file with the real `page_id`/`url` bound in (keeps body + title). */
 const bindFrontmatter = (opts: {
@@ -601,7 +642,7 @@ const frontmatterForRemotePage = (page: RemotePageSnapshot): NmdFrontmatterV2 =>
     version: 2,
     api_version: NOTION_API_VERSION,
     object: 'page',
-    source: 'local',
+    source: 'remote',
     page_id: page.id,
     url: page.url,
     parent: toParentRef(page),
@@ -637,15 +678,19 @@ const buildSlugMap = (
 const childrenByParent = (opts: {
   readonly pages: readonly LocalTreePage[]
   readonly idForRelPath: ReadonlyMap<string, string>
-}): Map<string, { readonly title: string; readonly pageId: string }[]> => {
-  const childrenOf = new Map<string, { readonly title: string; readonly pageId: string }[]>()
+}): Map<string, ChildIndexChild[]> => {
+  const childrenOf = new Map<string, ChildIndexChild[]>()
   for (const page of opts.pages) {
     const parentRel = page.parentRelPath
     if (parentRel === undefined) continue
     const id = opts.idForRelPath.get(page.relPath)
     if (id === undefined) continue
     const list = childrenOf.get(parentRel) ?? []
-    list.push({ title: page.title, pageId: id })
+    list.push({
+      title: page.title,
+      pageId: id,
+      localHref: childHref({ parentRelPath: parentRel, childRelPath: page.relPath }),
+    })
     childrenOf.set(parentRel, list)
   }
   return childrenOf
@@ -664,6 +709,7 @@ const childIndexChildrenByParent = (opts: {
     list.push({
       title: page.title,
       ...(pageId === undefined ? {} : { pageId }),
+      localHref: childHref({ parentRelPath: parentRel, childRelPath: page.relPath }),
     })
     childrenOf.set(parentRel, list)
   }
@@ -687,7 +733,7 @@ const syncTreeLocal = (opts: {
   readonly rootFile: string
   readonly rootPageId: string
   readonly pages: readonly LocalTreePage[]
-  readonly previous: TreeIndex | undefined
+  readonly previous: NormalizedTreeIndex | undefined
   readonly plan: boolean
   readonly pushOptions: PushOptions
 }): Effect.Effect<
@@ -748,7 +794,13 @@ const syncTreeLocal = (opts: {
       }
       yield* writeTreeIndex({
         root,
-        index: { version: 1, root_page_id: rootPageId, root_file: rootFile, pages: {} },
+        index: {
+          version: 1,
+          root_page_id: rootPageId,
+          root_file: rootFile,
+          authority: 'local',
+          pages: {},
+        },
       })
     }
 
@@ -863,8 +915,10 @@ const syncTreeLocal = (opts: {
     for (const page of pages) {
       const pageId = idForRelPath.get(page.relPath)
       if (pageId === undefined) continue
+      const children = childrenOf.get(page.relPath) ?? []
+      const bodyForPush = stripMaterializedChildLinks({ body: page.body, children })
       const resolvedBody = yield* resolveCrossRefs({
-        body: page.body,
+        body: bodyForPush,
         relPath: page.relPath,
         slugMap,
         idMap: idForRelPath,
@@ -872,7 +926,7 @@ const syncTreeLocal = (opts: {
       const composedBody = yield* composeTreePushBody({
         relPath: page.relPath,
         resolvedBody,
-        children: childrenOf.get(page.relPath) ?? [],
+        children,
       })
       const path = filePathFor({ root, relPath: page.relPath })
       const remoteForStatus = yield* gateway.pullPage({ pageId })
@@ -1009,7 +1063,13 @@ const syncTreeLocal = (opts: {
     }
     yield* writeTreeIndex({
       root,
-      index: { version: 1, root_page_id: rootPageId, root_file: rootFile, pages: indexPages },
+      index: {
+        version: 1,
+        root_page_id: rootPageId,
+        root_file: rootFile,
+        authority: 'local',
+        pages: indexPages,
+      },
     })
 
     return ops
@@ -1037,16 +1097,18 @@ const classifyPlan = (opts: {
       if (pageId === undefined) continue
       if (opts.ops.some((op) => op.relPath === page.relPath && op._tag === 'move') === true)
         continue
+      const children = childrenOf.get(page.relPath) ?? []
+      const bodyForPush = stripMaterializedChildLinks({ body: page.body, children })
       const resolved = yield* resolveCrossRefs({
-        body: page.body,
+        body: bodyForPush,
         relPath: page.relPath,
         slugMap: opts.slugMap,
         idMap: opts.idForRelPath,
-      }).pipe(Effect.orElseSucceed(() => page.body))
+      }).pipe(Effect.orElseSucceed(() => bodyForPush))
       const composed = yield* composeTreePushBody({
         relPath: page.relPath,
         resolvedBody: resolved,
-        children: childrenOf.get(page.relPath) ?? [],
+        children,
       })
       const prevState = yield* readSyncStateOptional({
         path: treeStateAnchor(opts.root),
@@ -1167,6 +1229,76 @@ const buildRemoteTree = (opts: {
     return nodes
   })
 
+const emptyChildLink = /^(?<indent>\s*)\[(?<label>[^\]]+)\]\(\)\s*$/u
+
+const materializeRemoteChildLinks = (opts: {
+  readonly body: string
+  readonly parentRelPath: string
+  readonly children: readonly RemoteTreeNode[]
+}): Effect.Effect<{ readonly localBody: string; readonly bareBody: string }, NmdCliError> =>
+  Effect.gen(function* () {
+    const localLines: string[] = []
+    const bareLines: string[] = []
+
+    for (const line of opts.body.split('\n')) {
+      const anchor = blockChildAnchor.exec(line)
+      const placeholder = emptyChildLink.exec(line)
+      if (anchor === null && placeholder === null) {
+        localLines.push(line)
+        bareLines.push(line)
+        continue
+      }
+
+      const label = anchor?.groups?.label ?? placeholder?.groups?.label ?? ''
+      const indent = anchor?.groups?.indent ?? placeholder?.groups?.indent ?? ''
+      const url = anchorUrlAttr.exec(anchor?.groups?.attrs ?? '')
+      const rawUrl = url?.groups?.double ?? url?.groups?.single
+      const linkedPageId = rawUrl === undefined ? undefined : parseNotionUuid(rawUrl)
+      let child: RemoteTreeNode | undefined
+
+      if (rawUrl !== undefined) {
+        if (linkedPageId === undefined) {
+          return yield* new NmdCliError({
+            message: `Invalid child page URL in ${opts.parentRelPath}: ${rawUrl}`,
+          })
+        }
+        child = opts.children.find((candidate) => candidate.pageId === linkedPageId)
+        if (child === undefined) {
+          return yield* new NmdCliError({
+            message: `Child page ${linkedPageId} in ${opts.parentRelPath} is not a direct child`,
+          })
+        }
+      } else {
+        const matches = opts.children.filter((candidate) => candidate.title === label)
+        if (matches.length === 0 && anchor === null) {
+          localLines.push(line)
+          bareLines.push(line)
+          continue
+        }
+        if (matches.length !== 1) {
+          return yield* new NmdCliError({
+            message: `Ambiguous child placeholder "${label}" in ${opts.parentRelPath}; use an id-bearing child anchor`,
+          })
+        }
+        child = matches[0]
+      }
+
+      if (child === undefined) continue
+      localLines.push(
+        `${indent}[${label}](${childHref({
+          parentRelPath: opts.parentRelPath,
+          childRelPath: child.relPath,
+        })})`,
+      )
+      bareLines.push('')
+    }
+
+    return {
+      localBody: normalizeMarkdownLineEndings(localLines.join('\n')),
+      bareBody: normalizeMarkdownLineEndings(bareLines.join('\n')),
+    }
+  })
+
 const materializeRemoteTreeNode = (opts: {
   readonly root: string
   readonly rootFile: string
@@ -1185,10 +1317,21 @@ const materializeRemoteTreeNode = (opts: {
       pageId: opts.node.pageId,
       markdown: pulled.markdown,
     })
-    const bareBody = stripChildAnchors(pulled.markdown.markdown)
+    const bodies = yield* materializeRemoteChildLinks({
+      body: pulled.markdown.markdown,
+      parentRelPath: opts.node.relPath,
+      children: opts.children,
+    })
     const baselineBody = composePushBody({
-      resolvedBody: bareBody,
-      children: opts.children.map((child) => ({ title: child.title, pageId: child.pageId })),
+      resolvedBody: bodies.bareBody,
+      children: opts.children.map((child) => ({
+        title: child.title,
+        pageId: child.pageId,
+        localHref: childHref({
+          parentRelPath: opts.node.relPath,
+          childRelPath: child.relPath,
+        }),
+      })),
     })
 
     yield* fs
@@ -1198,7 +1341,7 @@ const materializeRemoteTreeNode = (opts: {
       path,
       content: renderNmdFile({
         frontmatter: frontmatterForRemotePage(pulled.page),
-        body: bareBody,
+        body: bodies.localBody,
       }),
     })
     yield* establishBaseline({
@@ -1210,16 +1353,16 @@ const materializeRemoteTreeNode = (opts: {
 
 /**
  * Pull/mirror direction within the ONE tree engine: walk the remote subtree and
- * materialize/reconcile each page into the SAME `<root-file>` / `<dir>/<root-file>`
- * layout and the SAME index file the forward path uses, so pull→edit→push
- * round-trips. Missing files are materialized; existing ones are reconciled via
- * the single-page guarded `statusPage`/`pullPage` (remote-authoritative pull).
+ * materialize each page into the SAME `<root-file>` / `<dir>/<root-file>` layout.
+ * Page ids reconcile renamed/moved paths; only stale paths recorded by the prior
+ * manifest may be removed, so unrelated local files remain outside the mirror.
  */
 const syncTreeFromRemote = (opts: {
   readonly root: string
   readonly rootFile: string
   readonly rootPageId: string
   readonly plan: boolean
+  readonly previous: NormalizedTreeIndex | undefined
 }): Effect.Effect<
   readonly TreeOp[],
   NmdError,
@@ -1227,7 +1370,8 @@ const syncTreeFromRemote = (opts: {
 > =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem
-    const { root, rootFile, rootPageId, plan } = opts
+    const store = yield* NmdStateStore
+    const { root, rootFile, rootPageId, plan, previous } = opts
     yield* fs
       .makeDirectory(root, { recursive: true })
       .pipe(Effect.mapError((cause) => makeFsError({ operation: 'mkdir', path: root, cause })))
@@ -1236,6 +1380,19 @@ const syncTreeFromRemote = (opts: {
     const ops: TreeOp[] = []
     const indexPages: Record<string, string> = {}
     const remoteChildrenByParent = new Map<string, RemoteTreeNode[]>()
+    const previousPageIdByRelPath = new Map(Object.entries(previous?.pages ?? {}))
+    const previousRelPathByPageId = new Map(
+      [...previousPageIdByRelPath].map(([relPath, pageId]) => [pageId, relPath] as const),
+    )
+    if (previous !== undefined) {
+      previousPageIdByRelPath.set(previous.root_file, previous.root_page_id)
+      previousRelPathByPageId.set(previous.root_page_id, previous.root_file)
+    }
+    const currentRelPaths = new Set(remoteNodes.map((node) => node.relPath))
+    const currentRelPathByPageId = new Map(
+      remoteNodes.map((node) => [node.pageId, node.relPath] as const),
+    )
+
     for (const node of remoteNodes) {
       if (node.parentPageId === undefined) continue
       const list = remoteChildrenByParent.get(node.parentPageId) ?? []
@@ -1249,49 +1406,100 @@ const syncTreeFromRemote = (opts: {
       const exists = yield* fs
         .exists(path)
         .pipe(Effect.mapError((cause) => makeFsError({ operation: 'exists', path, cause })))
-      if (plan === true) {
-        ops.push(
-          exists === true
-            ? { _tag: 'update', relPath: node.relPath, pageId: node.pageId }
-            : { _tag: 'materialize', relPath: node.relPath, pageId: node.pageId },
+      const previousRelPath = previousRelPathByPageId.get(node.pageId)
+      let unindexedSamePage = false
+      if (exists === true && previousPageIdByRelPath.has(node.relPath) === false) {
+        const existingFile = yield* store.readNmdFile({ path }).pipe(
+          Effect.flatMap((content) => parseNmdFile({ path, content })),
+          Effect.result,
         )
-        continue
+        unindexedSamePage =
+          existingFile._tag === 'Success' &&
+          existingFile.success.frontmatter.notion_md.page_id === node.pageId
+        if (unindexedSamePage === false) {
+          return yield* new NmdCliError({
+            message: `Refusing to overwrite untracked local file ${path} while mirroring page ${node.pageId}`,
+          })
+        }
       }
-      yield* fs
-        .makeDirectory(dirname(path), { recursive: true })
-        .pipe(Effect.mapError((cause) => makeFsError({ operation: 'mkdir', path, cause })))
+      const op: TreeOp =
+        previousRelPath !== undefined && previousRelPath !== node.relPath
+          ? { _tag: 'move', relPath: node.relPath, pageId: node.pageId }
+          : exists === true && (previousRelPath === node.relPath || unindexedSamePage === true)
+            ? { _tag: 'update', relPath: node.relPath, pageId: node.pageId }
+            : { _tag: 'materialize', relPath: node.relPath, pageId: node.pageId }
+      ops.push(op)
+    }
+
+    if (plan === false) {
+      for (const node of remoteNodes) {
+        yield* materializeRemoteTreeNode({
+          root,
+          rootFile,
+          node,
+          children: remoteChildrenByParent.get(node.pageId) ?? [],
+        })
+      }
+    }
+
+    const previousEntries = [
+      ...(previous === undefined ? [] : [[previous.root_file, previous.root_page_id] as const]),
+      ...Object.entries(previous?.pages ?? {}),
+    ]
+    for (const [previousRelPath, pageId] of previousEntries) {
+      const currentRelPath = currentRelPathByPageId.get(pageId)
+      const moved = currentRelPath !== undefined && currentRelPath !== previousRelPath
+      const deleted = currentRelPath === undefined
+      if (moved === false && deleted === false) continue
+      if (deleted === true) {
+        ops.push({ _tag: 'delete', relPath: previousRelPath, pageId })
+      }
+      if (plan === true || currentRelPaths.has(previousRelPath) === true) continue
+      const stalePath = filePathFor({ root, relPath: previousRelPath })
+      const exists = yield* fs
+        .exists(stalePath)
+        .pipe(
+          Effect.mapError((cause) => makeFsError({ operation: 'exists', path: stalePath, cause })),
+        )
       if (exists === true) {
-        yield* materializeRemoteTreeNode({
-          root,
-          rootFile,
-          node,
-          children: remoteChildrenByParent.get(node.pageId) ?? [],
-        })
-        ops.push({ _tag: 'update', relPath: node.relPath, pageId: node.pageId })
-      } else {
-        yield* materializeRemoteTreeNode({
-          root,
-          rootFile,
-          node,
-          children: remoteChildrenByParent.get(node.pageId) ?? [],
-        })
-        ops.push({ _tag: 'materialize', relPath: node.relPath, pageId: node.pageId })
+        const trackedFile = yield* store.readNmdFile({ path: stalePath }).pipe(
+          Effect.flatMap((content) => parseNmdFile({ path: stalePath, content })),
+          Effect.result,
+        )
+        if (
+          trackedFile._tag === 'Success' &&
+          trackedFile.success.frontmatter.notion_md.page_id === pageId
+        ) {
+          yield* fs
+            .remove(stalePath)
+            .pipe(
+              Effect.mapError((cause) =>
+                makeFsError({ operation: 'remove', path: stalePath, cause }),
+              ),
+            )
+        }
       }
     }
 
     if (plan === false) {
       yield* writeTreeIndex({
         root,
-        index: { version: 1, root_page_id: rootPageId, root_file: rootFile, pages: indexPages },
+        index: {
+          version: 1,
+          root_page_id: rootPageId,
+          root_file: rootFile,
+          authority: 'remote',
+          pages: indexPages,
+        },
       })
     }
     return ops
   })
 
 /**
- * Reconcile a directory tree against a Notion subtree. Forward (local-as-desired)
- * by default; `fromRemote` mirrors Notion into the same layout/index. Both
- * directions are this one engine — there is no separate workspace materializer.
+ * Reconcile a directory tree against a Notion subtree. An existing manifest's
+ * authority selects local push or remote mirror; legacy/no-manifest trees default
+ * to local, while `fromRemote` explicitly selects the initial remote materialization.
  */
 export const syncTree = (opts: {
   readonly root: string
@@ -1308,18 +1516,18 @@ export const syncTree = (opts: {
   Effect.gen(function* () {
     const root = resolve(opts.root)
     const plan = opts.plan === true
-    const fromRemote = opts.fromRemote === true
     const previous = yield* readTreeIndexOptional(root)
+    const fromRemote = opts.fromRemote ?? previous?.authority === 'remote'
 
     if (fromRemote === true) {
       const rootFile = opts.rootFile ?? previous?.root_file ?? ROOT_FILE_CANDIDATES[0]
       const rootPageId = opts.rootPageId ?? previous?.root_page_id
       if (rootPageId === undefined) {
         return yield* new NmdCliError({
-          message: `--from-remote needs a Notion root page id; pass --root on first mirror`,
+          message: `Remote tree sync needs a Notion root page id; track the directory first`,
         })
       }
-      const ops = yield* syncTreeFromRemote({ root, rootFile, rootPageId, plan })
+      const ops = yield* syncTreeFromRemote({ root, rootFile, rootPageId, plan, previous })
       return {
         _tag: 'tree',
         root,

--- a/packages/@overeng/notion-md/src/tree.unit.test.ts
+++ b/packages/@overeng/notion-md/src/tree.unit.test.ts
@@ -1124,6 +1124,31 @@ describe('track path routing', () => {
     })
   })
 
+  it('validates every remote node during directory track dry-run without writing', async () => {
+    await withTempDir(async (dir) => {
+      const fake = new FakeTreeNotion()
+      const childId = fake.addRemotePage({
+        parentId: rootPageId,
+        title: 'Lossy',
+        markdown: 'Incomplete body.\n',
+      })
+      fake.setRemoteCompleteness(childId, {
+        _tag: 'lossy',
+        reasons: ['rendered_markdown_has_unobserved_suffix'],
+      })
+
+      await expect(
+        run(trackPath({ pageId: rootPageId, outPath: dir, source: 'remote', dryRun: true }), fake),
+      ).rejects.toThrow('Remote Markdown body')
+      await expect(readFile(join(dir, 'index.nmd'), 'utf8')).rejects.toMatchObject({
+        code: 'ENOENT',
+      })
+      await expect(
+        readFile(join(dir, '.notion-md', 'workspace.json'), 'utf8'),
+      ).rejects.toMatchObject({ code: 'ENOENT' })
+    })
+  })
+
   it('keeps a missing .nmd target on the single-page track path', async () => {
     await withTempDir(async (dir) => {
       const fake = new FakeTreeNotion()
@@ -1151,6 +1176,24 @@ describe('track path routing', () => {
     })
   })
 
+  it('refuses to re-track an existing workspace under a different root page', async () => {
+    await withTempDir(async (dir) => {
+      const fake = new FakeTreeNotion()
+      const otherRootId = fake.addRemotePage({
+        parentId: rootPageId,
+        title: 'Other root',
+        markdown: 'Other body.\n',
+      })
+      await run(trackPath({ pageId: rootPageId, outPath: dir, source: 'remote' }), fake)
+      const originalRoot = await readFile(join(dir, 'index.nmd'), 'utf8')
+
+      await expect(
+        run(trackPath({ pageId: otherRootId, outPath: dir, source: 'remote' }), fake),
+      ).rejects.toThrow(`workspace already tracks root ${rootPageId}`)
+      expect(await readFile(join(dir, 'index.nmd'), 'utf8')).toBe(originalRoot)
+    })
+  })
+
   it('refreshes remote content on ordinary directory sync', async () => {
     await withTempDir(async (dir) => {
       const fake = new FakeTreeNotion()
@@ -1166,6 +1209,29 @@ describe('track path routing', () => {
 
       expect(result).toMatchObject({ _tag: 'tree', direction: 'from-remote' })
       expect(await readFile(join(dir, 'alpha.nmd'), 'utf8')).toContain('Refreshed body.')
+    })
+  })
+
+  it('routes non-recursive directory status through the remote tree plan', async () => {
+    await withTempDir(async (dir) => {
+      const fake = new FakeTreeNotion()
+      const alphaId = fake.addRemotePage({
+        parentId: rootPageId,
+        title: 'Alpha',
+        markdown: 'Original body.\n',
+      })
+      await run(trackPath({ pageId: rootPageId, outPath: dir, source: 'remote' }), fake)
+      fake.mutateRemote(alphaId, 'Remote change.\n')
+
+      const result = await run(statusPath({ path: dir }), fake)
+
+      expect(result).toMatchObject({
+        _tag: 'tree',
+        direction: 'from-remote',
+        plan: true,
+        ops: expect.arrayContaining([{ _tag: 'update', relPath: 'alpha.nmd', pageId: alphaId }]),
+      })
+      expect(await readFile(join(dir, 'alpha.nmd'), 'utf8')).toContain('Original body.')
     })
   })
 

--- a/packages/@overeng/notion-md/src/tree.unit.test.ts
+++ b/packages/@overeng/notion-md/src/tree.unit.test.ts
@@ -16,7 +16,7 @@ import {
   type PullPageResult,
   type RemotePageSnapshot,
 } from './model.ts'
-import { statusPath, syncPath } from './path.ts'
+import { statusPath, syncPath, trackPath } from './path.ts'
 import { NmdStateStoreLive, type NmdStateStore } from './state-store.ts'
 import { statusPage } from './sync.ts'
 import {
@@ -61,6 +61,14 @@ class FakeTreeNotion {
   /** Simulate a concurrent remote edit (someone edited the page on Notion). */
   mutateRemote(id: string, markdown: string): void {
     this.require(id).markdown = markdown
+  }
+
+  renameRemote(id: string, title: string): void {
+    this.require(id).title = title
+  }
+
+  trashRemote(id: string): void {
+    this.require(id).inTrash = true
   }
 
   /** Simulate a write that succeeds but whose refreshed Markdown observation is lossy. */
@@ -962,6 +970,18 @@ describe('notion-md tree reconcile lifecycle', () => {
       })
       fake.addRemotePage({ parentId: subtreeId, title: 'Child', markdown: 'Child body.\n' })
 
+      fake.mutateRemote(
+        rootPageId,
+        [
+          `Root body.`,
+          '',
+          `<page url="${pageUrl(leafId)}">Same</page>`,
+          '',
+          `<page url="${pageUrl(subtreeId)}">Same</page>`,
+          '',
+        ].join('\n'),
+      )
+
       const result = await run(
         syncTree({ root: dir, rootPageId, fromRemote: true, rootFile: 'index.nmd' }),
         fake,
@@ -975,8 +995,28 @@ describe('notion-md tree reconcile lifecycle', () => {
         ),
       ).toContain(`"page_id": "${subtreeId}"`)
 
-      const plan = await run(syncTree({ root: dir, plan: true }), fake)
+      const plan = await run(syncTree({ root: dir, plan: true, fromRemote: false }), fake)
       expect(plan.ops.some((op) => op._tag === 'update')).toBe(false)
+      const rootFile = await readFile(join(dir, 'index.nmd'), 'utf8')
+      expect(rootFile).toContain('[Same](same.nmd)')
+      expect(rootFile).toContain(
+        `[Same](same-${subtreeId.replaceAll('-', '').slice(-6)}/index.nmd)`,
+      )
+    })
+  })
+
+  it('refuses an ambiguous title-only child placeholder', async () => {
+    await withTempDir(async (dir) => {
+      const fake = new FakeTreeNotion()
+      fake.addRemotePage({ parentId: rootPageId, title: 'Same', markdown: 'First.\n' })
+      fake.addRemotePage({ parentId: rootPageId, title: 'Same', markdown: 'Second.\n' })
+      fake.mutateRemote(rootPageId, 'Root body.\n\n[Same]()\n')
+
+      await expect(
+        run(syncTree({ root: dir, rootPageId, fromRemote: true }), fake),
+      ).rejects.toThrow(
+        'Ambiguous child placeholder "Same" in index.nmd; use an id-bearing child anchor',
+      )
     })
   })
 
@@ -998,9 +1038,222 @@ describe('notion-md tree reconcile lifecycle', () => {
       expect(rootFile).toContain('Root body.')
       expect(rootFile).not.toContain('<page url=')
 
-      const plan = await run(syncTree({ root: dir, plan: true }), fake)
+      const plan = await run(syncTree({ root: dir, plan: true, fromRemote: false }), fake)
       expect(opTags(plan.ops).noop).toBe(2)
+      expect(rootFile).toContain('[Alpha](alpha.nmd)')
       expect(opTags(plan.ops).update).toBeUndefined()
+    })
+  })
+})
+
+describe('track path routing', () => {
+  it('materializes an existing directory as a remote subtree with a workspace manifest', async () => {
+    await withTempDir(async (dir) => {
+      const fake = new FakeTreeNotion()
+      const guideId = fake.addRemotePage({
+        parentId: rootPageId,
+        title: 'Guide',
+        markdown: 'Guide body.\n\n[Setup]()\n',
+      })
+      const setupId = fake.addRemotePage({
+        parentId: guideId,
+        title: 'Setup',
+        markdown: 'Setup body.\n',
+      })
+      fake.mutateRemote(rootPageId, 'Root body.\n\n[Guide]()\n')
+
+      const result = await run(
+        trackPath({ pageId: rootPageId, outPath: dir, source: 'remote' }),
+        fake,
+      )
+
+      expect(result).toMatchObject({
+        _tag: 'tree',
+        root: dir,
+        rootPageId,
+        rootFile: 'index.nmd',
+        direction: 'from-remote',
+        plan: false,
+      })
+      expect(await readFile(join(dir, 'index.nmd'), 'utf8')).toContain(`"page_id": "${rootPageId}"`)
+      expect(await readFile(join(dir, 'guide', 'index.nmd'), 'utf8')).toContain(
+        `"page_id": "${guideId}"`,
+      )
+      expect(await readFile(join(dir, 'guide', 'setup.nmd'), 'utf8')).toContain(
+        `"page_id": "${setupId}"`,
+      )
+      expect(await readFile(join(dir, 'guide', 'setup.nmd'), 'utf8')).toContain(
+        '"source": "remote"',
+      )
+      const rootContent = await readFile(join(dir, 'index.nmd'), 'utf8')
+      expect(rootContent).toContain('[Guide](guide/index.nmd)')
+      expect(rootContent).not.toContain('[Guide]()')
+      const guideContent = await readFile(join(dir, 'guide', 'index.nmd'), 'utf8')
+      expect(guideContent).toContain('[Setup](setup.nmd)')
+      expect(guideContent).not.toContain('[Setup]()')
+      const forwardPlan = await run(syncTree({ root: dir, fromRemote: false, plan: true }), fake)
+      expect(opTags(forwardPlan.ops).noop).toBe(3)
+      expect(opTags(forwardPlan.ops).update).toBeUndefined()
+      expect(JSON.parse(await readFile(join(dir, '.notion-md', 'workspace.json'), 'utf8'))).toEqual(
+        {
+          version: 1,
+          root_page_id: rootPageId,
+          root_file: 'index.nmd',
+          authority: 'remote',
+          pages: {
+            'guide/index.nmd': guideId,
+            'guide/setup.nmd': setupId,
+          },
+        },
+      )
+    })
+  })
+
+  it('keeps a missing .nmd target on the single-page track path', async () => {
+    await withTempDir(async (dir) => {
+      const fake = new FakeTreeNotion()
+      const outPath = join(dir, 'root.nmd')
+
+      const result = await run(trackPath({ pageId: rootPageId, outPath, source: 'remote' }), fake)
+
+      expect(result).toEqual({ path: outPath, pageId: rootPageId, source: 'remote' })
+      expect(await readFile(outPath, 'utf8')).toContain('"source": "remote"')
+      await expect(
+        readFile(join(dir, '.notion-md', 'workspace.json'), 'utf8'),
+      ).rejects.toMatchObject({ code: 'ENOENT' })
+    })
+  })
+
+  it('rejects a non-remote source for a directory instead of silently ignoring it', async () => {
+    await withTempDir(async (dir) => {
+      const fake = new FakeTreeNotion()
+
+      await expect(
+        run(trackPath({ pageId: rootPageId, outPath: dir, source: 'shared' }), fake),
+      ).rejects.toThrow(
+        'Directory track targets only support --as remote; use a .nmd file target with --as shared',
+      )
+    })
+  })
+
+  it('refreshes remote content on ordinary directory sync', async () => {
+    await withTempDir(async (dir) => {
+      const fake = new FakeTreeNotion()
+      const alphaId = fake.addRemotePage({
+        parentId: rootPageId,
+        title: 'Alpha',
+        markdown: 'Original body.\n',
+      })
+      await run(trackPath({ pageId: rootPageId, outPath: dir, source: 'remote' }), fake)
+
+      fake.mutateRemote(alphaId, 'Refreshed body.\n')
+      const result = await run(syncPath({ path: dir }), fake)
+
+      expect(result).toMatchObject({ _tag: 'tree', direction: 'from-remote' })
+      expect(await readFile(join(dir, 'alpha.nmd'), 'utf8')).toContain('Refreshed body.')
+    })
+  })
+
+  it('moves a tracked page by page id when its remote title and path change', async () => {
+    await withTempDir(async (dir) => {
+      const fake = new FakeTreeNotion()
+      const alphaId = fake.addRemotePage({
+        parentId: rootPageId,
+        title: 'Alpha',
+        markdown: 'Alpha body.\n',
+      })
+      await run(trackPath({ pageId: rootPageId, outPath: dir, source: 'remote' }), fake)
+
+      fake.renameRemote(alphaId, 'Handbook')
+      const result = await run(syncPath({ path: dir }), fake)
+
+      expect(result._tag === 'tree' ? result.ops : []).toContainEqual({
+        _tag: 'move',
+        relPath: 'handbook.nmd',
+        pageId: alphaId,
+      })
+      await expect(readFile(join(dir, 'alpha.nmd'), 'utf8')).rejects.toMatchObject({
+        code: 'ENOENT',
+      })
+      expect(await readFile(join(dir, 'handbook.nmd'), 'utf8')).toContain(`"page_id": "${alphaId}"`)
+    })
+  })
+
+  it('adds and deletes recorded remote pages without deleting unknown local files', async () => {
+    await withTempDir(async (dir) => {
+      const fake = new FakeTreeNotion()
+      const alphaId = fake.addRemotePage({
+        parentId: rootPageId,
+        title: 'Alpha',
+        markdown: 'Alpha body.\n',
+      })
+      await run(trackPath({ pageId: rootPageId, outPath: dir, source: 'remote' }), fake)
+      await writeFile(join(dir, 'local-notes.nmd'), 'unknown local file\n')
+
+      fake.trashRemote(alphaId)
+      const betaId = fake.addRemotePage({
+        parentId: rootPageId,
+        title: 'Beta',
+        markdown: 'Beta body.\n',
+      })
+      const result = await run(syncPath({ path: dir }), fake)
+
+      expect(result._tag === 'tree' ? result.ops : []).toEqual(
+        expect.arrayContaining([
+          { _tag: 'delete', relPath: 'alpha.nmd', pageId: alphaId },
+          { _tag: 'materialize', relPath: 'beta.nmd', pageId: betaId },
+        ]),
+      )
+      await expect(readFile(join(dir, 'alpha.nmd'), 'utf8')).rejects.toMatchObject({
+        code: 'ENOENT',
+      })
+      expect(await readFile(join(dir, 'beta.nmd'), 'utf8')).toContain('Beta body.')
+      expect(await readFile(join(dir, 'local-notes.nmd'), 'utf8')).toBe('unknown local file\n')
+    })
+  })
+
+  it('refuses a remote addition that would overwrite an unknown local file', async () => {
+    await withTempDir(async (dir) => {
+      const fake = new FakeTreeNotion()
+      await run(trackPath({ pageId: rootPageId, outPath: dir, source: 'remote' }), fake)
+      const unknownPath = join(dir, 'local-notes.nmd')
+      await writeFile(unknownPath, 'unknown local file\n')
+      fake.addRemotePage({
+        parentId: rootPageId,
+        title: 'Local Notes',
+        markdown: 'Remote body.\n',
+      })
+
+      await expect(run(syncPath({ path: dir }), fake)).rejects.toThrow(
+        `Refusing to overwrite untracked local file ${unknownPath}`,
+      )
+      expect(await readFile(unknownPath, 'utf8')).toBe('unknown local file\n')
+    })
+  })
+
+  it('defaults a legacy workspace manifest without authority to local tree sync', async () => {
+    await withTempDir(async (dir) => {
+      const fake = new FakeTreeNotion()
+      await mkdir(join(dir, '.notion-md'), { recursive: true })
+      await writeFile(join(dir, 'index.nmd'), unbound({ title: 'Root', body: 'Root.' }))
+      await writeFile(join(dir, 'alpha.nmd'), unbound({ title: 'Alpha', body: 'Alpha.' }))
+      await writeFile(
+        join(dir, '.notion-md', 'workspace.json'),
+        `${JSON.stringify({
+          version: 1,
+          root_page_id: rootPageId,
+          root_file: 'index.nmd',
+          pages: {},
+        })}\n`,
+      )
+
+      const result = await run(syncPath({ path: dir }), fake)
+
+      expect(result).toMatchObject({ _tag: 'tree', direction: 'local' })
+      expect(fake.childTitles(rootPageId)).toEqual(['Alpha'])
+      expect(
+        JSON.parse(await readFile(join(dir, '.notion-md', 'workspace.json'), 'utf8')),
+      ).toMatchObject({ authority: 'local' })
     })
   })
 })

--- a/packages/@overeng/notion-md/src/tree.unit.test.ts
+++ b/packages/@overeng/notion-md/src/tree.unit.test.ts
@@ -1020,6 +1020,21 @@ describe('notion-md tree reconcile lifecycle', () => {
     })
   })
 
+  it('preserves user-authored links to child files in local-authoritative trees', async () => {
+    await withTempDir(async (dir) => {
+      const fake = new FakeTreeNotion()
+      await writeFile(
+        join(dir, 'index.nmd'),
+        unbound({ title: 'Root', body: 'Root.\n\n[Read the details](alpha.nmd)' }),
+      )
+      await writeFile(join(dir, 'alpha.nmd'), unbound({ title: 'Alpha', body: 'Alpha.' }))
+
+      await run(syncTree({ root: dir, rootPageId }), fake)
+
+      expect(fake.remoteBody(rootPageId)).toContain('[Read the details](https://app.notion.com/p/')
+    })
+  })
+
   it('strips derived child anchors from from-remote file bodies while keeping composed baselines', async () => {
     await withTempDir(async (dir) => {
       const fake = new FakeTreeNotion()
@@ -1228,6 +1243,57 @@ describe('track path routing', () => {
         `Refusing to overwrite untracked local file ${unknownPath}`,
       )
       expect(await readFile(unknownPath, 'utf8')).toBe('unknown local file\n')
+    })
+  })
+
+  it('refuses to overwrite a tracked path rebound to another page', async () => {
+    await withTempDir(async (dir) => {
+      const fake = new FakeTreeNotion()
+      const alphaId = fake.addRemotePage({
+        parentId: rootPageId,
+        title: 'Alpha',
+        markdown: 'Alpha body.\n',
+      })
+      await run(trackPath({ pageId: rootPageId, outPath: dir, source: 'remote' }), fake)
+      const alphaPath = join(dir, 'alpha.nmd')
+      const reboundId = '99999999-9999-4999-8999-999999999999'
+      const reboundFile = (await readFile(alphaPath, 'utf8')).replaceAll(alphaId, reboundId)
+      await writeFile(alphaPath, reboundFile)
+
+      await expect(run(syncPath({ path: dir }), fake)).rejects.toThrow(
+        `Refusing to overwrite tracked local file ${alphaPath}: expected page ${alphaId}, found ${reboundId}`,
+      )
+      expect(await readFile(alphaPath, 'utf8')).toBe(reboundFile)
+    })
+  })
+
+  it('allows remote page moves between paths occupied by their tracked predecessors', async () => {
+    await withTempDir(async (dir) => {
+      const fake = new FakeTreeNotion()
+      const alphaId = fake.addRemotePage({
+        parentId: rootPageId,
+        title: 'Alpha',
+        markdown: 'Alpha body.\n',
+      })
+      const betaId = fake.addRemotePage({
+        parentId: rootPageId,
+        title: 'Beta',
+        markdown: 'Beta body.\n',
+      })
+      await run(trackPath({ pageId: rootPageId, outPath: dir, source: 'remote' }), fake)
+
+      fake.renameRemote(alphaId, 'Beta')
+      fake.renameRemote(betaId, 'Alpha')
+      const result = await run(syncPath({ path: dir }), fake)
+
+      expect(result._tag === 'tree' ? result.ops : []).toEqual(
+        expect.arrayContaining([
+          { _tag: 'move', relPath: 'beta.nmd', pageId: alphaId },
+          { _tag: 'move', relPath: 'alpha.nmd', pageId: betaId },
+        ]),
+      )
+      expect(await readFile(join(dir, 'alpha.nmd'), 'utf8')).toContain(`"page_id": "${betaId}"`)
+      expect(await readFile(join(dir, 'beta.nmd'), 'utf8')).toContain(`"page_id": "${alphaId}"`)
     })
   })
 

--- a/packages/@overeng/utils/src/isomorphic/string.ts
+++ b/packages/@overeng/utils/src/isomorphic/string.ts
@@ -77,15 +77,30 @@ export const formatReasonMessage = (input: {
   return parts.join(' ')
 }
 
+const GERMAN_ASCII: Readonly<Record<string, string>> = {
+  ä: 'ae',
+  ö: 'oe',
+  ü: 'ue',
+  Ä: 'Ae',
+  Ö: 'Oe',
+  Ü: 'Ue',
+  ß: 'ss',
+  ẞ: 'Ss',
+}
+
 /**
- * Converts a title into a URL-safe lowercase slug (max 120 chars).
+ * Converts a title into a URL-safe lowercase ASCII slug (max 120 chars).
  *
+ * German letters are transliterated before NFKD decomposition so their
+ * conventional vowel survives; remaining combining marks are removed.
  * Non-alphanumeric runs become single hyphens; leading/trailing hyphens are trimmed.
  * Returns `"untitled"` for blank or all-punctuation titles.
  */
 export const titleSlug = (title: string): string => {
   const slug = title
-    .normalize('NFC')
+    .replace(/[äöüÄÖÜßẞ]/gu, (letter) => GERMAN_ASCII[letter] ?? letter)
+    .normalize('NFKD')
+    .replace(/\p{Mark}+/gu, '')
     .toLocaleLowerCase('en-US')
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')

--- a/packages/@overeng/utils/src/isomorphic/string.unit.test.ts
+++ b/packages/@overeng/utils/src/isomorphic/string.unit.test.ts
@@ -3,7 +3,7 @@ import { expect } from 'vitest'
 
 import { Vitest } from '@overeng/utils-dev/node-vitest'
 
-import { formatReasonMessage, nonEmptyTrimmedString } from './string.ts'
+import { formatReasonMessage, nonEmptyTrimmedString, titleSlug } from './string.ts'
 
 Vitest.describe('formatReasonMessage', () => {
   /* The cause segment is space-separated like the other parts, so it reads
@@ -69,6 +69,15 @@ Vitest.describe('formatReasonMessage', () => {
 
   Vitest.it('omits the cause segment when cause is undefined', () => {
     expect(formatReasonMessage({ reason: 'Timeout', method: 'waitFor' })).toBe('Timeout (waitFor)')
+  })
+})
+
+Vitest.describe('titleSlug', () => {
+  Vitest.it('transliterates German titles before general Unicode normalization', () => {
+    expect(titleSlug('Werk und künstlerische Themen')).toBe('werk-und-kuenstlerische-themen')
+    expect(titleSlug('Quellen und offene Prüfpunkte')).toBe('quellen-und-offene-pruefpunkte')
+    expect(titleSlug('ÄÖÜ äöü Straße ẞ')).toBe('aeoeue-aeoeue-strasse-ss')
+    expect(titleSlug('Crème brûlée')).toBe('creme-brulee')
   })
 })
 


### PR DESCRIPTION
## Problem

`notion-md track <page> <directory>` routed through single-page tracking, so pages with child pages were rejected as lossy instead of becoming a local tree. The existing remote materializer also behaved as local-authoritative and could not safely reconcile later remote structure changes.

## Goal

Make directory tracking and steady-state directory sync a safe remote-authoritative page-tree mirror while preserving single-file tracking and legacy local tree manifests.

## Decisions

- Persist explicit `local` or `remote` tree authority in new manifests; normalize missing legacy authority to `local` at the read boundary.
- Dispatch files from frontmatter `source` and non-recursive directories from manifest authority. Directory `status` uses the same tree engine as a read-only plan.
- Reconcile remote additions, page-ID-preserving moves, and recorded removals only across manifest and frontmatter-proven ownership. Refuse unknown, identity-less, rebound, and conflicting-root boundaries.
- Render remote child navigation as relative local links while retaining canonical Notion child anchors in the sync baseline. Local-authoritative user links remain authored content.
- Validate every remote node during dry-run without writing. Reject hierarchical directory watch rather than falling through to one-file watch; `--recursive` remains flat batch watch.
- Transliterate German characters before general Unicode slug normalization so generated paths remain meaningful.
- Record the durable contract in the notion-md VRS requirements, spec, glossary, and architecture index. The canonical cross-cutting datasource VRS remains unchanged because standalone notion-md tree ownership is outside that workspace contract.

## Verification

- `./node_modules/.bin/vitest run src/tree.unit.test.ts src/cli.e2e.test.ts` in `@overeng/notion-md` — 2 files, 57 tests passed.
- `./node_modules/.bin/tsc --noEmit -p tsconfig.json` — passed.
- `oxlint` over the five changed TypeScript files — 0 warnings, 0 errors.
- `oxfmt --check` over all 12 files in the review-fix commit — passed.
- `devenv tasks run check:all --no-tui` — attempted in observable PTY. The run reported `lint:check:format` for three changed files; those files were then formatted and the formatter check passed. Other lanes continued, but the run was interrupted after its terminal stopped advancing. The full gate was not rerun, so this is a pre-flip deviation and is not claimed as pristine-main-identical.

Before:

```text
track <page-with-children> <directory>
→ lossy child_page refusal
```

After:

```text
track <page-with-children> <directory> --as remote
→ remote-authoritative .nmd tree + workspace manifest
status <directory>
→ read-only tree plan
sync <directory>
→ refresh/add/move/safely remove identity-proven tracked pages
```

## Complexity

The change reuses the existing tree walker and reconciliation engine. New complexity is limited to persisted tree authority, ownership checks, remote-plan validation, and explicit CLI routing needed for safe steady-state mirrors.

## Concerns

- Hierarchical tree watch is intentionally unsupported; the CLI fails explicitly and directs callers to one-shot tree sync or flat `--recursive` watch.
- Draft PR #794 overlaps `cli-program.ts` and two VRS files for an output-system redesign. It should rebase after this PR and preserve the tree routing and authority contracts.

## Friction & bottlenecks

The full gate performs long concurrent Nix and test work with sparse terminal progress, which made a still-active run appear stalled. No product bottleneck was introduced by this change.

## Follow-ups

None.

## References

- Related draft output redesign: #794

<!-- agent-footer:begin v=2 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | dev3.direct.omp.56yv2w6x |
| `session` | dev3.56yv2w6x |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.0.11 |
| `agent_runtime` | OMP 18.0.11 |
| `tooling_profile` | dotfiles@5a8d579-dirty |
</details>
<!-- agent-footer:end -->