### PR TITLE
Fix the oxlint plugin seam, then enforce the StyleX token constraint in two layers

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,7 +1,10 @@
 {
   "$schema": "https://raw.githubusercontent.com/oxc-project/oxc/main/npm/oxlint/configuration_schema.json",
   "plugins": ["import", "typescript", "unicorn", "oxc", "react"],
-  "jsPlugins": ["./packages/@overeng/oxc-config/src/mod.ts"],
+  "jsPlugins": [
+    "./packages/@overeng/oxc-config/src/mod.ts",
+    "./packages/@overeng/oxc-config/src/stylex-upstream-plugin.ts"
+  ],
   "ignorePatterns": [
     "**/node_modules/**",
     "**/.pnpm/**",
@@ -83,7 +86,101 @@
     "typescript/no-unnecessary-template-expression": "off",
     "react/react-in-jsx-scope": "off",
     "react/rules-of-hooks": "error",
-    "react/exhaustive-deps": "warn"
+    "react/exhaustive-deps": "warn",
+    "overeng/stylex-no-raw-color": "error",
+    "overeng/stylex-outline-focus-visible-only": "error",
+    "@stylexjs/valid-styles": [
+      "error",
+      {
+        "propLimits": {
+          "accentColor": {
+            "limit": ["transparent", "currentColor", "currentcolor"],
+            "reason": "Read colours from a semantic token exported by a `*.stylex.ts` module."
+          },
+          "backgroundColor": {
+            "limit": ["transparent", "currentColor", "currentcolor"],
+            "reason": "Read colours from a semantic token exported by a `*.stylex.ts` module."
+          },
+          "borderBlockColor": {
+            "limit": ["transparent", "currentColor", "currentcolor"],
+            "reason": "Read colours from a semantic token exported by a `*.stylex.ts` module."
+          },
+          "borderBlockEndColor": {
+            "limit": ["transparent", "currentColor", "currentcolor"],
+            "reason": "Read colours from a semantic token exported by a `*.stylex.ts` module."
+          },
+          "borderBlockStartColor": {
+            "limit": ["transparent", "currentColor", "currentcolor"],
+            "reason": "Read colours from a semantic token exported by a `*.stylex.ts` module."
+          },
+          "borderBottomColor": {
+            "limit": ["transparent", "currentColor", "currentcolor"],
+            "reason": "Read colours from a semantic token exported by a `*.stylex.ts` module."
+          },
+          "borderColor": {
+            "limit": ["transparent", "currentColor", "currentcolor"],
+            "reason": "Read colours from a semantic token exported by a `*.stylex.ts` module."
+          },
+          "borderInlineColor": {
+            "limit": ["transparent", "currentColor", "currentcolor"],
+            "reason": "Read colours from a semantic token exported by a `*.stylex.ts` module."
+          },
+          "borderInlineEndColor": {
+            "limit": ["transparent", "currentColor", "currentcolor"],
+            "reason": "Read colours from a semantic token exported by a `*.stylex.ts` module."
+          },
+          "borderInlineStartColor": {
+            "limit": ["transparent", "currentColor", "currentcolor"],
+            "reason": "Read colours from a semantic token exported by a `*.stylex.ts` module."
+          },
+          "borderLeftColor": {
+            "limit": ["transparent", "currentColor", "currentcolor"],
+            "reason": "Read colours from a semantic token exported by a `*.stylex.ts` module."
+          },
+          "borderRightColor": {
+            "limit": ["transparent", "currentColor", "currentcolor"],
+            "reason": "Read colours from a semantic token exported by a `*.stylex.ts` module."
+          },
+          "borderTopColor": {
+            "limit": ["transparent", "currentColor", "currentcolor"],
+            "reason": "Read colours from a semantic token exported by a `*.stylex.ts` module."
+          },
+          "caretColor": {
+            "limit": ["transparent", "currentColor", "currentcolor"],
+            "reason": "Read colours from a semantic token exported by a `*.stylex.ts` module."
+          },
+          "color": {
+            "limit": ["transparent", "currentColor", "currentcolor"],
+            "reason": "Read colours from a semantic token exported by a `*.stylex.ts` module."
+          },
+          "columnRuleColor": {
+            "limit": ["transparent", "currentColor", "currentcolor"],
+            "reason": "Read colours from a semantic token exported by a `*.stylex.ts` module."
+          },
+          "outlineColor": {
+            "limit": ["transparent", "currentColor", "currentcolor"],
+            "reason": "Read colours from a semantic token exported by a `*.stylex.ts` module."
+          },
+          "textDecorationColor": {
+            "limit": ["transparent", "currentColor", "currentcolor"],
+            "reason": "Read colours from a semantic token exported by a `*.stylex.ts` module."
+          },
+          "textEmphasisColor": {
+            "limit": ["transparent", "currentColor", "currentcolor"],
+            "reason": "Read colours from a semantic token exported by a `*.stylex.ts` module."
+          },
+          "WebkitTapHighlightColor": {
+            "limit": ["transparent", "currentColor", "currentcolor"],
+            "reason": "Read colours from a semantic token exported by a `*.stylex.ts` module."
+          }
+        }
+      }
+    ],
+    "@stylexjs/valid-shorthands": "error",
+    "@stylexjs/no-unused": "error",
+    "@stylexjs/no-legacy-contextual-styles": "error",
+    "@stylexjs/no-lookahead-selectors": "error",
+    "@stylexjs/enforce-extension": "error"
   },
   "overrides": [
     {

--- a/.oxlintrc.json.genie.ts
+++ b/.oxlintrc.json.genie.ts
@@ -5,17 +5,34 @@ import {
   baseOxlintPlugins,
   baseOxlintRules,
   otelOxlintRules,
+  stylexOxlintRules,
 } from './genie/oxlint-base.ts'
 import { oxlintConfig, type OxlintConfigArgs } from './packages/@overeng/genie/src/runtime/mod.ts'
 
 /** Path to custom oxlint rules plugin */
 const OXC_PLUGIN_PATH = './packages/@overeng/oxc-config/src/mod.ts'
 
+/**
+ * Path to the `@stylexjs` namespace shim, which re-exports the upstream
+ * `@stylexjs/eslint-plugin` rules. A second plugin entry rather than the bare
+ * package specifier, because upstream ships no `meta.name` and a bare specifier
+ * only resolves from the root `node_modules`, which this aggregate root cannot
+ * carry a dependency in. See that file's header.
+ */
+const STYLEX_UPSTREAM_PLUGIN_PATH =
+  './packages/@overeng/oxc-config/src/stylex-upstream-plugin.ts'
+
 export default oxlintConfig({
   plugins: baseOxlintPlugins,
-  jsPlugins: [OXC_PLUGIN_PATH],
+  jsPlugins: [OXC_PLUGIN_PATH, STYLEX_UPSTREAM_PLUGIN_PATH],
   categories: baseOxlintCategories,
-  rules: baseOxlintRules,
+  rules: {
+    ...baseOxlintRules,
+    // StyleX enforcement, both layers (decision 0005 Amendment 2). Repo-wide
+    // rather than scoped, so a target becomes gated the moment it starts using
+    // StyleX — the rules are inert in files that never call the StyleX API.
+    ...stylexOxlintRules(),
+  },
   ignorePatterns: [
     ...baseOxlintIgnorePatterns,
     // The emitted Weaver registry directory: generated YAML/TS bindings + thin codegen glue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,40 @@ All notable changes to this project will be documented in this file.
   incidental as `PluginContextMeta.rolldownVersion`. Since every plugin member
   except `name` is optional in both majors, one required `name` stays assignable
   to `PluginOption` everywhere while imposing nothing.
+- **@overeng/oxc-config**: StyleX enforcement, as two deliberately complementary
+  layers. New first-party rules `overeng/stylex-no-raw-color` (bans raw colour
+  literals as values inside `stylex.create`, including colours embedded in
+  composite values such as `boxShadow` and gradients, while leaving the token
+  layer — `defineConsts`/`defineVars`/`createTheme` — alone) and
+  `overeng/stylex-outline-focus-visible-only` (reserves `outline`,
+  `outlineOffset` and `outlineColor` for the focus-visible state, so a selection
+  or pressed state cannot silently outrank the focus ring). The upstream
+  `@stylexjs/eslint-plugin` rules are adopted alongside them under their
+  documented `@stylexjs/*` names via a new namespace-shim plugin entry;
+  `stylexOxlintRules` in `genie/oxlint-base.ts` is the shared policy, and it
+  enumerates colour properties explicitly because a `*olor*` glob also matches
+  five keyword-valued properties. Upstream value limits are per-property and
+  cannot see inside a composite value, which is why both layers ship.
+  The pilot package `effect-schema-form-aria` — the reference implementation the
+  pattern was derived from — fails the enforcement the pattern produced, in 17
+  places. Each site carries a per-line `oxlint-disable-next-line` with a reason
+  rather than a file-scoped override, so new code there is still gated
+  (issue #1171).
+
+### Fixed
+
+- **nix/oxlint-with-plugins.nix**: three fixes to the oxlint wrapper.
+  `jsPlugins` entries other than ours are no longer discarded, so third-party JS
+  plugins can load beside `@overeng/oxc-config` (previously any such plugin
+  failed to resolve, and consumers grew local workarounds). `oxlint --config X`
+  with the config flag FIRST no longer exits 1 with no output at all — the
+  argument-rewrite loop used `((i++))`, which returns status 1 when `i` is 0 and
+  aborted the wrapper under `set -o errexit`, indistinguishable from a lint
+  failure in CI. And `OVERENG_OXC_CONFIG_PLUGIN` now overrides the injected
+  plugin path, so rule development can lint against live plugin source instead of
+  the Nix build-time snapshot (a newly added rule previously reported "not found
+  in plugin 'overeng'"). Covered by
+  `nix/devenv-modules/tasks/shared/tests/oxlint-plugin-injection.test.sh`.
 
 ### Changed
 

--- a/genie/oxlint-base.ts
+++ b/genie/oxlint-base.ts
@@ -27,6 +27,11 @@ type OtelOxlintRulesArgs = {
   readonly unsafeContract?: OxlintRuleSeverity
 }
 
+type StylexOxlintRulesArgs = {
+  /** Severity for the whole StyleX enforcement set. Defaults to `error`. */
+  readonly severity?: OxlintRuleSeverity
+}
+
 /** Standard ignore patterns for oxlint across all repos */
 export const baseOxlintIgnorePatterns = [
   '**/node_modules/**',
@@ -79,6 +84,97 @@ export const otelOxlintRules = ({
   ({
     'overeng/no-raw-otel-primitives': rawOtel,
     'overeng/otel-contract-in-seam-file': contractSeam,
+  }) satisfies OxlintOverride['rules']
+
+/**
+ * CSS properties whose value IS a colour, enumerated explicitly.
+ *
+ * A colour-shaped glob (`*olor*`) is NOT usable here, measured: it also matches
+ * `colorScheme`, `colorAdjust`, `forcedColorAdjust`, `printColorAdjust` and
+ * `colorInterpolation`, which take keywords and would be wrongly banned.
+ *
+ * Deliberately excluded even though they do take colours: `fill`, `stroke`,
+ * `floodColor`, `stopColor` and `scrollbarColor`. Each legitimately accepts a
+ * value an allowlist would reject — `none`, an `url(#fragment)` paint reference,
+ * or a pair — so limiting them would produce false positives.
+ * `overeng/stylex-no-raw-color` still covers colour literals in those values.
+ */
+export const stylexColorProperties = [
+  'accentColor',
+  'backgroundColor',
+  'borderBlockColor',
+  'borderBlockEndColor',
+  'borderBlockStartColor',
+  'borderBottomColor',
+  'borderColor',
+  'borderInlineColor',
+  'borderInlineEndColor',
+  'borderInlineStartColor',
+  'borderLeftColor',
+  'borderRightColor',
+  'borderTopColor',
+  'caretColor',
+  'color',
+  'columnRuleColor',
+  'outlineColor',
+  'textDecorationColor',
+  'textEmphasisColor',
+  'WebkitTapHighlightColor',
+] as const
+
+/**
+ * Shared StyleX lint policy: two complementary enforcement layers.
+ *
+ * **Upstream** (`@stylexjs/*`, loaded via the namespace shim in
+ * `@overeng/oxc-config`) owns general style validation. Its per-property value
+ * limits are what close the core hazard: with a colour property limited to an
+ * allowlist, a literal colour errors while a semantic token reference from a
+ * `*.stylex.ts` module passes untouched. `sort-keys` is deliberately NOT enabled
+ * — it fights the `property-specificity` resolution the design relies on.
+ *
+ * **First-party** (`overeng/stylex-*`) owns what per-property limits structurally
+ * cannot reach. A value limit is keyed on one property, so it cannot see a colour
+ * embedded in a composite value; measured, a colour inside a `boxShadow` and
+ * inside a gradient both passed upstream validation. Banning composite properties
+ * outright is not viable because they need literal offsets.
+ *
+ * The overlap on plain colour properties is kept on purpose: an array `limit`
+ * drops its custom `reason` from the diagnostic, so only the first-party message
+ * names the remedy.
+ *
+ * See the stylex spec's "Enforcement" section and decision 0005 Amendment 2.
+ */
+export const stylexOxlintRules = ({
+  severity = 'error',
+}: StylexOxlintRulesArgs = {}): OxlintOverride['rules'] =>
+  ({
+    'overeng/stylex-no-raw-color': severity,
+    'overeng/stylex-outline-focus-visible-only': severity,
+
+    '@stylexjs/valid-styles': [
+      severity,
+      {
+        propLimits: Object.fromEntries(
+          stylexColorProperties.map((property) => [
+            property,
+            {
+              // Unioned by upstream with the CSS-wide keywords and `null`, so
+              // unsetting a colour still works. Everything else — including a
+              // hand-written `var()` — must come through a token reference.
+              limit: ['transparent', 'currentColor', 'currentcolor'],
+              // Currently dropped from the diagnostic for array limits; kept so
+              // it appears if upstream starts rendering it.
+              reason: 'Read colours from a semantic token exported by a `*.stylex.ts` module.',
+            },
+          ]),
+        ),
+      },
+    ] as const,
+    '@stylexjs/valid-shorthands': severity,
+    '@stylexjs/no-unused': severity,
+    '@stylexjs/no-legacy-contextual-styles': severity,
+    '@stylexjs/no-lookahead-selectors': severity,
+    '@stylexjs/enforce-extension': severity,
   }) satisfies OxlintOverride['rules']
 
 /** Standard rules shared across all repos */

--- a/nix/devenv-modules/tasks/shared/tests/oxlint-plugin-injection.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/oxlint-plugin-injection.test.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# Regression tests for nix/oxlint-with-plugins.nix.
+#
+# The wrapper rewrites a project's oxlint config so the `@overeng/oxc-config` JS
+# plugin resolves. Three defects it used to have, each reproduced here against the
+# REAL built wrapper and the real oxlint binary rather than a stub, because all
+# three were failures of plugin RESOLUTION — the one thing a stub cannot model:
+#
+#   1. it replaced `jsPlugins` wholesale, so no third-party JS plugin could load
+#      beside ours ("Plugin 'x' not found");
+#   2. `oxlint --config X ...` with the config flag FIRST exited 1 with no output
+#      at all, which in a pipeline is indistinguishable from a lint failure;
+#   3. the injected plugin is a build-time snapshot, so a newly added rule
+#      reported "not found in plugin 'overeng'" and could not be exercised.
+set -euo pipefail
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$TESTS_DIR/../../../../.." && pwd)"
+
+fail() {
+  echo "FAIL: $1"
+  shift
+  for line in "$@"; do echo "  $line"; done
+  exit 1
+}
+
+assert_contains() {
+  local needle="$1" haystack="$2" label="$3"
+  if ! printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    fail "$label" "expected output to contain: $needle" "actual output:" "$haystack"
+  fi
+  echo "  ok: $label"
+}
+
+assert_not_contains() {
+  local needle="$1" haystack="$2" label="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    fail "$label" "expected output NOT to contain: $needle" "actual output:" "$haystack"
+  fi
+  echo "  ok: $label"
+}
+
+assert_equals() {
+  local expected="$1" actual="$2" label="$3"
+  if [ "$expected" != "$actual" ]; then
+    fail "$label" "expected: $expected" "actual:   $actual"
+  fi
+  echo "  ok: $label"
+}
+
+echo "Running oxlint plugin injection tests..."
+echo ""
+
+# Prefer the wrapper the developer/CI actually runs: inside the devenv shell it is
+# already on PATH and realised, so the test needs no build at all. Fall back to
+# building it only when running outside the shell.
+resolve_wrapper() {
+  if [ -n "${OXLINT_WRAPPER_BIN:-}" ]; then
+    printf '%s' "$OXLINT_WRAPPER_BIN"
+    return
+  fi
+
+  local on_path
+  on_path="$(command -v oxlint || true)"
+  if [ -n "$on_path" ] && grep -q 'OVERENG_OXC_CONFIG_PLUGIN' "$(readlink -f "$on_path")" 2>/dev/null; then
+    printf '%s' "$on_path"
+    return
+  fi
+
+  printf '%s' "$(nix build --no-link --print-out-paths "$ROOT#oxlint-with-plugins")/bin/oxlint"
+}
+
+wrapper="$(resolve_wrapper)"
+echo "Using oxlint wrapper: $wrapper"
+[ -x "$wrapper" ] || fail "wrapper resolution" "not executable: $wrapper"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+workspace="$tmpdir/workspace"
+mkdir -p "$workspace/oxc-config/src" "$workspace/live/oxc-config/src"
+cd "$workspace"
+
+# A third-party JS plugin, standing in for @stylexjs/eslint-plugin. Namespace
+# comes from `meta.name`, so the assertions can name it.
+cat > probe-plugin.js <<'EOF'
+module.exports = {
+  meta: { name: 'probe', version: '0.0.1' },
+  rules: {
+    'always-report': {
+      meta: { messages: { hit: 'probe plugin fired' } },
+      create(context) {
+        return {
+          DebuggerStatement(node) {
+            context.report({ node, messageId: 'hit' })
+          },
+        }
+      },
+    },
+  },
+}
+EOF
+
+# A SIBLING plugin entry inside the oxc-config package directory — the shape the
+# `@stylexjs` namespace shim has. Substituting this one would silently swap a
+# third-party plugin for ours, so the wrapper must match our ENTRY POINT
+# (`oxc-config/src/mod.ts`), not merely the package directory.
+cat > oxc-config/src/sibling-plugin.js <<'EOF'
+module.exports = {
+  meta: { name: 'sibling', version: '0.0.1' },
+  rules: {
+    'always-report': {
+      meta: { messages: { hit: 'sibling plugin fired' } },
+      create(context) {
+        return {
+          DebuggerStatement(node) {
+            context.report({ node, messageId: 'hit' })
+          },
+        }
+      },
+    },
+  },
+}
+EOF
+
+# Live plugin source under the `overeng` namespace, carrying a rule that does NOT
+# exist in the Nix-built snapshot. That is exactly the rule-development case:
+# without an opt-out the new rule is unreachable through the wrapper.
+cat > live/oxc-config/src/mod.ts <<'EOF'
+export default {
+  meta: { name: 'overeng', version: '0.0.1' },
+  rules: {
+    'live-source-only': {
+      meta: { messages: { hit: 'live plugin source fired' } },
+      create(context: { report: (d: unknown) => void }) {
+        return {
+          DebuggerStatement(node: unknown) {
+            context.report({ node, messageId: 'hit' })
+          },
+        }
+      },
+    },
+  },
+}
+EOF
+
+cat > fixture.ts <<'EOF'
+debugger
+export const now = Date.now()
+EOF
+
+# `overeng/no-raw-nondeterminism` is a rule of the real built plugin, so it proves
+# our own namespace still resolves after the rewrite.
+write_config() {
+  cat > .oxlintrc.json
+}
+
+echo "Test 1: a third-party plugin declared beside ours still resolves (bug 1)"
+write_config <<'EOF'
+{
+  "jsPlugins": ["./probe-plugin.js", "./oxc-config/src/mod.ts"],
+  "rules": {
+    "overeng/no-raw-nondeterminism": "error",
+    "probe/always-report": "error"
+  }
+}
+EOF
+out="$("$wrapper" fixture.ts --config .oxlintrc.json 2>&1 || true)"
+assert_not_contains "Plugin 'probe' not found" "$out" "third-party plugin is not clobbered"
+assert_contains "probe(always-report)" "$out" "third-party rule fires"
+assert_contains "overeng(no-raw-nondeterminism)" "$out" "our own rule still fires"
+
+echo ""
+echo "Test 2: a sibling entry in our own package directory is not substituted (bug 1)"
+write_config <<'EOF'
+{
+  "jsPlugins": ["./oxc-config/src/mod.ts", "./oxc-config/src/sibling-plugin.js"],
+  "rules": {
+    "overeng/no-raw-nondeterminism": "error",
+    "sibling/always-report": "error"
+  }
+}
+EOF
+out="$("$wrapper" fixture.ts --config .oxlintrc.json 2>&1 || true)"
+assert_contains "sibling(always-report)" "$out" "sibling plugin entry survives the rewrite"
+assert_contains "overeng(no-raw-nondeterminism)" "$out" "our entry point is the one substituted"
+
+echo ""
+echo "Test 3: the config flag may come first (bug 2)"
+write_config <<'EOF'
+{
+  "jsPlugins": ["./oxc-config/src/mod.ts"],
+  "rules": { "overeng/no-raw-nondeterminism": "error" }
+}
+EOF
+status_last=0
+out_last="$("$wrapper" fixture.ts --config .oxlintrc.json 2>&1)" || status_last=$?
+status_first=0
+out_first="$("$wrapper" --config .oxlintrc.json fixture.ts 2>&1)" || status_first=$?
+
+assert_equals "$status_last" "$status_first" "exit code does not depend on argument order"
+assert_contains "overeng(no-raw-nondeterminism)" "$out_first" "config-flag-first run still reports diagnostics"
+assert_contains "overeng(no-raw-nondeterminism)" "$out_last" "config-flag-last run reports diagnostics"
+
+echo ""
+echo "Test 4: a leaked temp config would break the repo tree; none is left behind"
+leaked="$(find . -maxdepth 1 -name '.oxlint-with-plugins.*' -print)"
+assert_equals "" "$leaked" "injected temp config is cleaned up on exit"
+
+echo ""
+echo "Test 5: OVERENG_OXC_CONFIG_PLUGIN lints live plugin source (bug 3)"
+write_config <<'EOF'
+{
+  "jsPlugins": ["./oxc-config/src/mod.ts"],
+  "rules": { "overeng/live-source-only": "error" }
+}
+EOF
+status_snapshot=0
+out_snapshot="$("$wrapper" fixture.ts --config .oxlintrc.json 2>&1)" || status_snapshot=$?
+assert_contains "not found in plugin 'overeng'" "$out_snapshot" \
+  "the built snapshot does not know a rule that only exists in source"
+
+status_live=0
+out_live="$(OVERENG_OXC_CONFIG_PLUGIN="$workspace/live/oxc-config/src/mod.ts" \
+  "$wrapper" fixture.ts --config .oxlintrc.json 2>&1)" || status_live=$?
+assert_contains "overeng(live-source-only)" "$out_live" "live plugin source is linted without a Nix rebuild"
+assert_equals "1" "$status_live" "a violation from live source still fails the run"
+
+echo ""
+echo "All oxlint plugin injection tests passed"

--- a/nix/oxc-config-plugin.nix
+++ b/nix/oxc-config-plugin.nix
@@ -29,7 +29,7 @@ let
     pnpm = pinnedPnpm;
   };
   packageDir = "packages/@overeng/oxc-config";
-  pnpmDepsHash = "sha256-07CI8FzwRTiv5reVg4NNxRPhRHXU9CLOjjFR6jiaQF8=";
+  pnpmDepsHash = "sha256-u6EdKIQX0zyJUfV3rMS5c9n+vkJPC0Zht3b3xypCeoY=";
 
   srcPath =
     if builtins.isAttrs src && builtins.hasAttr "outPath" src then

--- a/nix/oxlint-with-plugins.nix
+++ b/nix/oxlint-with-plugins.nix
@@ -1,8 +1,21 @@
-# Wrapper around oxlint-npm that auto-injects the @overeng/oxc-config JS plugin.
+# Wrapper around oxlint-npm that points the @overeng/oxc-config JS plugin entry at
+# a resolvable implementation.
 #
 # When the project's .oxlintrc.json (or an explicit -c config) contains overeng/*
-# rules, this wrapper transparently injects (or replaces) the plugin path
-# via a temporary config copy. Projects without overeng rules get plain pass-through.
+# rules, this wrapper rewrites that config's `jsPlugins` entry for our plugin to a
+# concrete path, via a temporary config copy. Projects without overeng rules get
+# plain pass-through.
+#
+# The rewrite SUBSTITUTES our entry and leaves every other `jsPlugins` entry
+# alone, so third-party JS plugins (e.g. `@stylexjs/eslint-plugin`) declared next
+# to ours still resolve.
+#
+# Plugin source selection:
+#   default                        the Nix-built plugin snapshot (hermetic)
+#   OVERENG_OXC_CONFIG_PLUGIN=<p>  use <p> instead — point it at
+#                                  packages/@overeng/oxc-config/src/mod.ts to lint
+#                                  against live plugin source (rule development;
+#                                  no Nix rebuild between edits)
 #
 # Usage:
 #   oxlintWithPlugins = import ./oxlint-with-plugins.nix { inherit pkgs; oxlintNpm = ...; };
@@ -16,15 +29,20 @@ pkgs.writeShellApplication {
   name = "oxlint";
   runtimeInputs = [ pkgs.jq ];
   text = ''
-    pluginPath="${oxlintNpm.pluginPath}"
+    # Rule development escape hatch: the default plugin is a Nix build-time
+    # snapshot, so edits to packages/@overeng/oxc-config/src/*.ts are invisible and
+    # a newly added rule reports "not found in plugin 'overeng'". Overriding this
+    # with the plugin's TypeScript entry point makes the wrapper lint against live
+    # source (the host runtime is Bun, which imports .ts directly).
+    pluginPath="''${OVERENG_OXC_CONFIG_PLUGIN:-${oxlintNpm.pluginPath}}"
 
     # Find the config file: explicit -c/--config arg, or default .oxlintrc.json
     config_file=""
     args=("$@")
-    for ((i=0; i<''${#args[@]}; i++)); do
+    for ((i = 0; i < ''${#args[@]}; i++)); do
       case "''${args[$i]}" in
         -c|--config)
-          config_file="''${args[$((i+1))]}"
+          config_file="''${args[$((i + 1))]}"
           break
           ;;
       esac
@@ -33,7 +51,7 @@ pkgs.writeShellApplication {
       config_file=".oxlintrc.json"
     fi
 
-    # If config has overeng rules, inject the Nix-built plugin path (replaces any existing jsPlugins)
+    # If config has overeng rules, point our jsPlugins entry at $pluginPath
     if [ -n "$config_file" ] && grep -q '"overeng/' "$config_file" 2>/dev/null; then
       # oxlint 1.39.0's experimental JS-plugin rules only apply to files located
       # UNDER the (injected) config file's directory. Writing the merged config to
@@ -46,16 +64,48 @@ pkgs.writeShellApplication {
       config_dir=$(dirname "$config_file")
       tmpconfig=$(mktemp "$config_dir/.oxlint-with-plugins.XXXXXX.json")
       trap 'rm -f "$tmpconfig"' EXIT
-      jq --argjson plugins "[\"$pluginPath\"]" '.jsPlugins = $plugins' "$config_file" > "$tmpconfig"
+
+      # Substitute OUR entry in place rather than replacing the whole list.
+      # Replacing it wholesale made every third-party plugin declared beside ours
+      # unresolvable ("Plugin 'x' not found"), which is why consumers grew local
+      # workarounds. Entries are either a path string or an ["alias", path] tuple;
+      # a tuple keeps its alias. When no entry of ours is present (consumer configs
+      # that rely purely on injection) ours is appended.
+      #
+      # The match is the plugin's ENTRY POINT, not merely the package directory:
+      # `@overeng/oxc-config` also ships sibling plugin entries (the `@stylexjs`
+      # namespace shim), and substituting one of those would silently replace a
+      # third-party plugin with ours — the very failure this fix removes.
+      jq --arg p "$pluginPath" '
+        def is_ours:
+          if type == "string" then test("oxc-config/src/mod\\.ts$") or test("oxc-config-plugin[^/]*/plugin\\.js$")
+          elif type == "array" then (.[1] | type == "string" and (test("oxc-config/src/mod\\.ts$") or test("oxc-config-plugin[^/]*/plugin\\.js$")))
+          else false
+          end;
+        def substituted:
+          if type == "array" then [.[0], $p] else $p end;
+        .jsPlugins = (
+          (.jsPlugins // []) as $existing
+          | if any($existing[]; is_ours)
+            then $existing | map(if is_ours then substituted else . end)
+            else $existing + [$p]
+            end
+        )
+      ' "$config_file" > "$tmpconfig"
 
       # Replace the config arg, or prepend -c if using default
       new_args=()
       replaced=false
-      for ((i=0; i<''${#args[@]}; i++)); do
+      for ((i = 0; i < ''${#args[@]}; i++)); do
         case "''${args[$i]}" in
           -c|--config)
             new_args+=("''${args[$i]}" "$tmpconfig")
-            ((i++))
+            # NOTE: `i=$((i+1))`, never `((i++))`. Post-increment evaluates to the
+            # OLD value of i, so `((i++))` exits 1 when i is 0 — and under
+            # `set -o errexit` that aborted the wrapper with no output and exit 1,
+            # indistinguishable from a lint failure. Reproduced by passing
+            # `--config` as the first argument.
+            i=$((i + 1))
             replaced=true
             ;;
           *)

--- a/packages/@overeng/ci-tools/nix/build.nix
+++ b/packages/@overeng/ci-tools/nix/build.nix
@@ -19,7 +19,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-VO4m9fyyz50Avm9bxmnLauXDVMoFvL9P2sz4YzMaXow=";
+      "." = mkSharedHash "sha256-aYanMLOwu20gAtLzznzUude2SisenNmUUWPCoXk0+fM=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/effect-schema-form-aria/src/components/BooleanField.tsx
+++ b/packages/@overeng/effect-schema-form-aria/src/components/BooleanField.tsx
@@ -60,6 +60,7 @@ const styles = stylex.create({
   check: {
     width: '0.75rem',
     height: '0.75rem',
+    // oxlint-disable-next-line overeng/stylex-no-raw-color, @stylexjs/valid-styles -- needs a semantic `onPrimary` token; see #1171
     color: '#ffffff',
     opacity: 0,
     transitionProperty: 'opacity',

--- a/packages/@overeng/effect-schema-form-aria/src/components/LiteralField.tsx
+++ b/packages/@overeng/effect-schema-form-aria/src/components/LiteralField.tsx
@@ -74,17 +74,20 @@ const styles = stylex.create({
     borderRightColor: tokens.border,
     transitionProperty: 'background-color, color',
     transitionDuration: '150ms',
+    // oxlint-disable-next-line @stylexjs/no-legacy-contextual-styles, @stylexjs/valid-styles -- deprecated top-level pseudo-class; nesting it changes condition precedence, so it needs the visual gate. See #1171
     ':last-child': {
       borderRightWidth: 0,
     },
   },
   segmentUnselected: {
+    // oxlint-disable-next-line @stylexjs/no-legacy-contextual-styles, @stylexjs/valid-styles -- deprecated top-level pseudo-class; nesting it changes condition precedence, so it needs the visual gate. See #1171
     ':hover': {
       backgroundColor: tokens['surface-raised'],
     },
   },
   segmentSelected: {
     backgroundColor: tokens.primary,
+    // oxlint-disable-next-line overeng/stylex-no-raw-color, @stylexjs/valid-styles -- needs a semantic `onPrimary` token; see #1171
     color: '#ffffff',
   },
   root: {
@@ -108,9 +111,11 @@ const styles = stylex.create({
     backgroundColor: tokens.input,
     color: tokens.ink,
     outline: 'none',
+    // oxlint-disable-next-line @stylexjs/no-legacy-contextual-styles, @stylexjs/valid-styles -- deprecated top-level pseudo-class; nesting it changes condition precedence, so it needs the visual gate. See #1171
     ':focus': {
       boxShadow: `0 0 0 1px ${tokens.primary}`,
     },
+    // oxlint-disable-next-line @stylexjs/no-legacy-contextual-styles, @stylexjs/valid-styles -- deprecated top-level pseudo-class; nesting it changes condition precedence, so it needs the visual gate. See #1171
     ':disabled': {
       opacity: 0.5,
     },
@@ -131,6 +136,7 @@ const styles = stylex.create({
     borderStyle: 'solid',
     borderColor: tokens.border,
     backgroundColor: tokens.surface,
+    // oxlint-disable-next-line overeng/stylex-no-raw-color -- needs a scheme-varying elevation-shadow token; see #1171
     boxShadow: '0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)',
   },
   listBox: {
@@ -148,6 +154,7 @@ const styles = stylex.create({
     borderRadius: radii.default,
   },
   optionUnselected: {
+    // oxlint-disable-next-line @stylexjs/no-legacy-contextual-styles, @stylexjs/valid-styles -- deprecated top-level pseudo-class; nesting it changes condition precedence, so it needs the visual gate. See #1171
     ':hover': {
       backgroundColor: tokens['surface-raised'],
     },
@@ -160,6 +167,7 @@ const styles = stylex.create({
   },
   optionSelected: {
     backgroundColor: tokens.primary,
+    // oxlint-disable-next-line overeng/stylex-no-raw-color, @stylexjs/valid-styles -- needs a semantic `onPrimary` token; see #1171
     color: '#ffffff',
   },
   hint: {

--- a/packages/@overeng/effect-schema-form-aria/src/components/NumberField.tsx
+++ b/packages/@overeng/effect-schema-form-aria/src/components/NumberField.tsx
@@ -50,9 +50,11 @@ const styles = stylex.create({
     backgroundColor: tokens.input,
     color: tokens.ink,
     outline: 'none',
+    // oxlint-disable-next-line @stylexjs/no-legacy-contextual-styles, @stylexjs/valid-styles -- deprecated top-level pseudo-class; nesting it changes condition precedence, so it needs the visual gate. See #1171
     ':focus': {
       boxShadow: `0 0 0 1px ${tokens.primary}`,
     },
+    // oxlint-disable-next-line @stylexjs/no-legacy-contextual-styles, @stylexjs/valid-styles -- deprecated top-level pseudo-class; nesting it changes condition precedence, so it needs the visual gate. See #1171
     ':disabled': {
       opacity: 0.5,
     },
@@ -68,9 +70,11 @@ const styles = stylex.create({
     borderWidth: 1,
     borderStyle: 'solid',
     borderColor: tokens.border,
+    // oxlint-disable-next-line @stylexjs/no-legacy-contextual-styles, @stylexjs/valid-styles -- deprecated top-level pseudo-class; nesting it changes condition precedence, so it needs the visual gate. See #1171
     ':hover': {
       backgroundColor: tokens['surface-raised'],
     },
+    // oxlint-disable-next-line @stylexjs/no-legacy-contextual-styles, @stylexjs/valid-styles -- deprecated top-level pseudo-class; nesting it changes condition precedence, so it needs the visual gate. See #1171
     ':disabled': {
       opacity: 0.5,
     },
@@ -92,9 +96,11 @@ const styles = stylex.create({
     backgroundColor: tokens.input,
     color: tokens.ink,
     outline: 'none',
+    // oxlint-disable-next-line @stylexjs/no-legacy-contextual-styles, @stylexjs/valid-styles -- deprecated top-level pseudo-class; nesting it changes condition precedence, so it needs the visual gate. See #1171
     ':focus': {
       boxShadow: `0 0 0 1px ${tokens.primary}`,
     },
+    // oxlint-disable-next-line @stylexjs/no-legacy-contextual-styles, @stylexjs/valid-styles -- deprecated top-level pseudo-class; nesting it changes condition precedence, so it needs the visual gate. See #1171
     ':disabled': {
       opacity: 0.5,
       cursor: 'not-allowed',

--- a/packages/@overeng/effect-schema-form-aria/src/components/TextField.tsx
+++ b/packages/@overeng/effect-schema-form-aria/src/components/TextField.tsx
@@ -49,12 +49,14 @@ const styles = stylex.create({
     backgroundColor: tokens.input,
     color: tokens.ink,
     outline: 'none',
+    // oxlint-disable-next-line @stylexjs/no-legacy-contextual-styles, @stylexjs/valid-styles -- deprecated top-level pseudo-class; nesting it changes condition precedence, so it needs the visual gate. See #1171
     ':focus': {
       boxShadow: `0 0 0 1px ${tokens.primary}`,
     },
     '::placeholder': {
       color: tokens['subtle-ink'],
     },
+    // oxlint-disable-next-line @stylexjs/no-legacy-contextual-styles, @stylexjs/valid-styles -- deprecated top-level pseudo-class; nesting it changes condition precedence, so it needs the visual gate. See #1171
     ':disabled': {
       opacity: 0.5,
       cursor: 'not-allowed',

--- a/packages/@overeng/notion-cli/nix/build.nix
+++ b/packages/@overeng/notion-cli/nix/build.nix
@@ -33,7 +33,7 @@ let
     installRuntimeWorkspace = true;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-bWRTuIny77tnyxrBFrWyIWmF3Iujg0f4I227kQfmK+A=";
+      "." = mkSharedHash "sha256-RKCPKM8MIDATSGLdYSO3HaLcVEE5ZpUjH/KxYUcM+x4=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/oxc-config/package.json
+++ b/packages/@overeng/oxc-config/package.json
@@ -4,9 +4,11 @@
   "private": true,
   "type": "module",
   "exports": {
-    "./plugin": "./src/mod.ts"
+    "./plugin": "./src/mod.ts",
+    "./stylex-upstream-plugin": "./src/stylex-upstream-plugin.ts"
   },
   "devDependencies": {
+    "@stylexjs/eslint-plugin": "0.19.0",
     "@types/eslint": "9.6.1",
     "@typescript-eslint/parser": "8.61.1",
     "@typescript-eslint/rule-tester": "8.61.1",

--- a/packages/@overeng/oxc-config/package.json.genie.ts
+++ b/packages/@overeng/oxc-config/package.json.genie.ts
@@ -23,6 +23,7 @@ const deps = catalog.compose({
   devDependencies: {
     external: {
       ...catalog.pick(
+        '@stylexjs/eslint-plugin',
         '@types/eslint',
         '@typescript-eslint/parser',
         '@typescript-eslint/rule-tester',
@@ -42,6 +43,9 @@ export default packageJson(
     ...privatePackageDefaults,
     exports: {
       './plugin': exportEntry('./src/mod.ts', { environment: 'node' }),
+      './stylex-upstream-plugin': exportEntry('./src/stylex-upstream-plugin.ts', {
+        environment: 'node',
+      }),
     },
   } satisfies PackageJsonInputData,
   deps,

--- a/packages/@overeng/oxc-config/src/mod.ts
+++ b/packages/@overeng/oxc-config/src/mod.ts
@@ -10,6 +10,8 @@
  * - no-raw-nondeterminism: Ban raw nondeterminism outside a journaled Restate.run closure
  * - no-non-durable-wait: Ban non-durable Effect.sleep/Effect.timeout outside a journaled Restate.run closure
  * - no-raw-otel-primitives: Ban raw Effect/Stream OTEL span primitives outside contract boundaries
+ * - stylex-no-raw-color: Ban raw colour literals as values inside stylex.create
+ * - stylex-outline-focus-visible-only: Reserve the outline properties for the focus-visible state
  *
  * It also provides native reimplementations of selected Storybook CSF best-practice
  * rules under the `overeng/storybook/*` namespace (reimplemented from
@@ -45,6 +47,8 @@ import { metaSatisfiesTypeRule } from './storybook/meta-satisfies-type.ts'
 import { noRedundantStoryNameRule } from './storybook/no-redundant-story-name.ts'
 import { preferPascalCaseRule } from './storybook/prefer-pascal-case.ts'
 import { storyExportsRule } from './storybook/story-exports.ts'
+import { stylexNoRawColorRule } from './stylex-no-raw-color.ts'
+import { stylexOutlineFocusVisibleOnlyRule } from './stylex-outline-focus-visible-only.ts'
 
 type Rules = {
   'explicit-boolean-compare': typeof explicitBooleanCompareRule
@@ -56,6 +60,8 @@ type Rules = {
   'no-raw-nondeterminism': typeof noRawNondeterminismRule
   'no-raw-otel-primitives': typeof noRawOtelPrimitivesRule
   'otel-contract-in-seam-file': typeof otelContractInSeamFileRule
+  'stylex-no-raw-color': typeof stylexNoRawColorRule
+  'stylex-outline-focus-visible-only': typeof stylexOutlineFocusVisibleOnlyRule
   'storybook/meta-satisfies-type': typeof metaSatisfiesTypeRule
   'storybook/default-exports': typeof defaultExportsRule
   'storybook/story-exports': typeof storyExportsRule
@@ -76,6 +82,8 @@ const rules: Rules = {
   'no-raw-nondeterminism': noRawNondeterminismRule,
   'no-raw-otel-primitives': noRawOtelPrimitivesRule,
   'otel-contract-in-seam-file': otelContractInSeamFileRule,
+  'stylex-no-raw-color': stylexNoRawColorRule,
+  'stylex-outline-focus-visible-only': stylexOutlineFocusVisibleOnlyRule,
 
   // Native storybook rules (use as overeng/storybook/*)
   'storybook/meta-satisfies-type': metaSatisfiesTypeRule,

--- a/packages/@overeng/oxc-config/src/stylex-no-raw-color.ts
+++ b/packages/@overeng/oxc-config/src/stylex-no-raw-color.ts
@@ -1,0 +1,264 @@
+/**
+ * stylex-no-raw-color oxlint rule.
+ *
+ * Bans raw colour literals as values inside `stylex.create(...)`. Colour values in
+ * component styles must come from a semantic token exported by a `*.stylex.ts`
+ * token module, because raw scale steps are inlined constants that cannot vary by
+ * colour scheme: a component reading one compiles cleanly and silently ignores
+ * dark mode.
+ *
+ * Deliberately complementary to `@stylexjs/valid-styles`' `propLimits`, which is
+ * the source of truth for pure colour properties. A value limit is keyed on one
+ * property, so it structurally cannot see a colour *embedded in a composite
+ * value* — measured: a colour inside a `boxShadow` and inside a gradient both
+ * passed upstream validation untouched. Hence the pattern here is NOT anchored.
+ * The overlap on plain colour properties is kept on purpose, because an upstream
+ * allowlist limit drops its custom `reason` text and only this message can name
+ * the remedy.
+ *
+ * The token layer is untouched by construction: only `create` is visited, never
+ * `defineConsts`, `defineVars` or `createTheme`, which is where literal colours
+ * belong.
+ *
+ * See stylex spec "Enforcement" and decision 0005 Amendment 2.
+ *
+ * @example
+ * // ✅ Good - semantic token from a *.stylex.ts module
+ * import { colors } from './tokens.stylex.ts'
+ * stylex.create({ box: { color: colors.textPrimary } })
+ *
+ * // ✅ Good - literals belong in the token layer
+ * stylex.defineConsts({ red500: 'oklch(63.7% .237 25.331)' })
+ *
+ * // ✅ Good - an SVG fragment reference is not a colour
+ * stylex.create({ icon: { fill: 'url(#brandGradient)' } })
+ *
+ * // ❌ Bad - colour literal in a component style
+ * stylex.create({ box: { color: '#fff' } })
+ *
+ * // ❌ Bad - colour embedded in a composite value (upstream limits cannot see this)
+ * stylex.create({ box: { boxShadow: '0 1px 2px #00000014' } })
+ */
+
+import type { TSESTree } from '@typescript-eslint/utils'
+
+import {
+  createStylexImports,
+  isConditionKey,
+  staticKeyName,
+  stylexCreateArgument,
+  trackStylexImport,
+  type StylexRuleContext,
+} from './stylex-shared.ts'
+
+/**
+ * `url(...)` is erased before matching so an SVG fragment reference such as
+ * `url(#abc)` — which is shaped exactly like a 3-digit hex colour — cannot be
+ * mistaken for one.
+ */
+const URL_FUNCTION_PATTERN = /url\([^)]*\)/gi
+
+/**
+ * Hex colours in all four legal lengths, longest first so `#00000014` reports as
+ * one 8-digit colour rather than a 6-digit prefix. The trailing lookahead rejects
+ * longer hex runs, which are not colours.
+ */
+const HEX_COLOR_PATTERN = /#(?:[\da-f]{8}|[\da-f]{6}|[\da-f]{4}|[\da-f]{3})(?![\da-f])/i
+
+/**
+ * Functional notations that CONSTRUCT a colour from raw channel values. `\b`
+ * before the name keeps `forcedColorAdjust` and `--color-brand` out, and the
+ * required `(` keeps `background-color 200ms` out.
+ *
+ * Two families of *derivations* are deliberately absent, because their colour
+ * comes from their arguments rather than from raw channels — and a derivation
+ * over a token still follows the colour scheme, which is the whole hazard this
+ * rule exists for:
+ * - `color-mix(...)`, and
+ * - relative-colour syntax, `<fn>(from <colour> ...)`, hence the lookahead.
+ *
+ * Neither is a loophole: a raw colour among their arguments is still matched,
+ * because the patterns here are not anchored to the start of the value.
+ */
+const COLOR_FUNCTION_PATTERN =
+  /\b(?:rgba?|hsla?|hwb|lab|lch|oklab|oklch|color|device-cmyk)\((?!\s*from\b)/i
+
+/**
+ * `content` holds text, never a colour, so a quoted hash such as `content: '"#"'`
+ * or `content: '"#fff"'` is legal.
+ */
+const TEXT_VALUED_PROPERTIES: Readonly<Record<string, true>> = { content: true }
+
+/** The colour literal inside `value`, or `undefined` when there is none. */
+const rawColorIn = (value: string): string | undefined => {
+  const scrubbed = value.replaceAll(URL_FUNCTION_PATTERN, 'url()')
+
+  const hex = HEX_COLOR_PATTERN.exec(scrubbed)
+  if (hex !== null) return hex[0]
+
+  const fn = COLOR_FUNCTION_PATTERN.exec(scrubbed)
+  if (fn === null) return undefined
+
+  // Report the whole colour function call, not just its name, by scanning to the
+  // balanced closing paren.
+  let depth = 0
+  for (let index = fn.index; index < scrubbed.length; index++) {
+    const char = scrubbed[index]
+    if (char === '(') depth = depth + 1
+    else if (char === ')') {
+      depth = depth - 1
+      if (depth === 0) return scrubbed.slice(fn.index, index + 1)
+    }
+  }
+  return scrubbed.slice(fn.index)
+}
+
+type ValueWalk = {
+  readonly context: StylexRuleContext
+  readonly node: TSESTree.Node
+  /** Innermost CSS property name on the path, used for the message and exemptions. */
+  readonly property: string | undefined
+}
+
+/**
+ * Walk a style value, reporting every string or template literal that contains a
+ * colour. Handles the shapes StyleX actually produces: nested condition objects,
+ * pseudo-element blocks, fallback arrays, dynamic-style arrow functions, and both
+ * arms of a conditional.
+ */
+const walkValue = ({ context, node, property }: ValueWalk): void => {
+  switch (node.type) {
+    case 'ObjectExpression': {
+      for (const member of node.properties) {
+        if (member.type !== 'Property') continue
+        const key = staticKeyName(member)
+        const nextProperty =
+          key !== undefined && isConditionKey(key) === false ? key : property
+        walkValue({ context, node: member.value, property: nextProperty })
+      }
+      return
+    }
+
+    case 'Literal': {
+      if (typeof node.value !== 'string') return
+      if (property !== undefined && TEXT_VALUED_PROPERTIES[property] === true) return
+      const color = rawColorIn(node.value)
+      if (color === undefined) return
+      context.report({
+        node,
+        messageId: 'rawColor',
+        data: { color, property: property ?? 'a style value' },
+      })
+      return
+    }
+
+    case 'TemplateLiteral': {
+      if (property === undefined || TEXT_VALUED_PROPERTIES[property] !== true) {
+        // Join with a space so a colour cannot be forged across an interpolation
+        // boundary (`` `#${a}bc` `` must not read as `#abc`).
+        const text = node.quasis.map((quasi) => quasi.value.cooked).join(' ')
+        const color = rawColorIn(text)
+        if (color !== undefined) {
+          context.report({
+            node,
+            messageId: 'rawColor',
+            data: { color, property: property ?? 'a style value' },
+          })
+        }
+      }
+      for (const expression of node.expressions) {
+        walkValue({ context, node: expression, property })
+      }
+      return
+    }
+
+    case 'ConditionalExpression': {
+      walkValue({ context, node: node.consequent, property })
+      walkValue({ context, node: node.alternate, property })
+      return
+    }
+
+    case 'LogicalExpression':
+    case 'BinaryExpression': {
+      if (node.left.type !== 'PrivateIdentifier') {
+        walkValue({ context, node: node.left, property })
+      }
+      walkValue({ context, node: node.right, property })
+      return
+    }
+
+    case 'ArrayExpression': {
+      for (const element of node.elements) {
+        if (element === null) continue
+        walkValue({ context, node: element, property })
+      }
+      return
+    }
+
+    case 'ArrowFunctionExpression':
+    case 'FunctionExpression': {
+      walkValue({ context, node: node.body, property })
+      return
+    }
+
+    case 'BlockStatement': {
+      for (const statement of node.body) {
+        walkValue({ context, node: statement, property })
+      }
+      return
+    }
+
+    case 'ReturnStatement': {
+      if (node.argument !== null) walkValue({ context, node: node.argument, property })
+      return
+    }
+
+    case 'IfStatement': {
+      walkValue({ context, node: node.consequent, property })
+      if (node.alternate !== null) walkValue({ context, node: node.alternate, property })
+      return
+    }
+
+    case 'TSAsExpression':
+    case 'TSSatisfiesExpression':
+    case 'TSNonNullExpression': {
+      walkValue({ context, node: node.expression, property })
+      return
+    }
+
+    default:
+      return
+  }
+}
+
+/** ESLint rule banning raw colour literals as values inside `stylex.create`. */
+export const stylexNoRawColorRule = {
+  meta: {
+    type: 'problem' as const,
+    docs: {
+      description: 'Ban raw colour literals as values inside stylex.create',
+      recommended: false,
+    },
+    messages: {
+      rawColor:
+        'Raw colour `{{color}}` in `{{property}}`. Component styles must read colours from a semantic token exported by a `*.stylex.ts` module — a raw colour is an inlined constant and silently ignores the colour scheme. Move the value into the token layer and reference the token here.',
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context: StylexRuleContext) {
+    const imports = createStylexImports()
+
+    return {
+      ImportDeclaration(node: TSESTree.ImportDeclaration) {
+        trackStylexImport({ imports, node })
+      },
+
+      CallExpression(node: TSESTree.CallExpression) {
+        const styleMap = stylexCreateArgument({ imports, node })
+        if (styleMap === undefined) return
+        walkValue({ context, node: styleMap, property: undefined })
+      },
+    }
+  },
+}

--- a/packages/@overeng/oxc-config/src/stylex-no-raw-color.ts
+++ b/packages/@overeng/oxc-config/src/stylex-no-raw-color.ts
@@ -132,8 +132,7 @@ const walkValue = ({ context, node, property }: ValueWalk): void => {
       for (const member of node.properties) {
         if (member.type !== 'Property') continue
         const key = staticKeyName(member)
-        const nextProperty =
-          key !== undefined && isConditionKey(key) === false ? key : property
+        const nextProperty = key !== undefined && isConditionKey(key) === false ? key : property
         walkValue({ context, node: member.value, property: nextProperty })
       }
       return

--- a/packages/@overeng/oxc-config/src/stylex-no-raw-color.unit.test.ts
+++ b/packages/@overeng/oxc-config/src/stylex-no-raw-color.unit.test.ts
@@ -1,0 +1,244 @@
+import tsParser from '@typescript-eslint/parser'
+import { RuleTester } from '@typescript-eslint/rule-tester'
+import { RuleTester as ESLintRuleTester } from 'eslint'
+import { afterAll, describe, it } from 'vitest'
+
+import plugin from './mod.ts'
+
+RuleTester.afterAll = afterAll
+RuleTester.describe = describe
+RuleTester.it = it
+ESLintRuleTester.describe = describe
+ESLintRuleTester.it = it
+
+const ruleTester = new ESLintRuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+  },
+})
+
+const tsRuleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+    parser: tsParser,
+  },
+})
+
+const rule = plugin.rules['stylex-no-raw-color']
+
+const IMPORT = `import * as stylex from '@stylexjs/stylex'\n`
+
+/** The exact rendered message for a flagged 6-digit hex in `color`. */
+const hexColorMessage =
+  'Raw colour `#ff0000` in `color`. Component styles must read colours from a semantic token exported by a `*.stylex.ts` module — a raw colour is an inlined constant and silently ignores the colour scheme. Move the value into the token layer and reference the token here.'
+
+ruleTester.run('stylex-no-raw-color: the token layer is where colours belong', rule, {
+  valid: [
+    // Raw scale, semantic tokens and themes are all definitions, not usages.
+    {
+      code: `${IMPORT}export const colors = stylex.defineConsts({ red500: 'oklch(63.7% .237 25.331)', hex: '#ff0000' })`,
+    },
+    {
+      code: `${IMPORT}export const tokens = stylex.defineVars({ textPrimary: '#111827', surface: 'rgb(255 255 255)' })`,
+    },
+    {
+      code: `${IMPORT}export const dark = stylex.createTheme(tokens, { textPrimary: '#f9fafb' })`,
+    },
+    // A token reference is the whole point of the rule.
+    {
+      code: `${IMPORT}const styles = stylex.create({ box: { color: tokens.textPrimary, backgroundColor: tokens.surface } })`,
+    },
+  ],
+  invalid: [],
+})
+
+ruleTester.run('stylex-no-raw-color: legal lookalikes stay silent', rule, {
+  valid: [
+    // An SVG fragment reference is shaped exactly like a 3-digit hex colour.
+    {
+      code: `${IMPORT}const styles = stylex.create({ icon: { fill: 'url(#abc)', clipPath: 'url(#fff)' } })`,
+    },
+    // Non-colour literals, including composite ones with literal offsets.
+    {
+      code: `${IMPORT}const styles = stylex.create({ box: { padding: '1px 2px', border: '1px solid', transition: 'background-color 200ms', boxShadow: 'inset 0 1px 2px' } })`,
+    },
+    // Keyword-valued members of the colour-adjust family take no colour.
+    {
+      code: `${IMPORT}const styles = stylex.create({ box: { colorScheme: 'light dark', forcedColorAdjust: 'none' } })`,
+    },
+    // Generated content is text, so a quoted hash is not a colour.
+    {
+      code: `${IMPORT}const styles = stylex.create({ box: { '::before': { content: '"#"' } } })`,
+    },
+    {
+      code: `${IMPORT}const styles = stylex.create({ box: { '::before': { content: '"#fff"' } } })`,
+    },
+    // A longer hex run is not a colour.
+    {
+      code: `${IMPORT}const styles = stylex.create({ box: { gridArea: '#abcdefabcdef' } })`,
+    },
+    // Colour-shaped strings outside stylex.create are none of this rule's business.
+    {
+      code: `${IMPORT}const brand = '#ff0000'\nconst theme = { color: 'rgb(1 2 3)' }`,
+    },
+    // A same-named method on a different object is not a style declaration.
+    {
+      code: `${IMPORT}const row = db.create({ color: '#ff0000' })`,
+    },
+    // A colour cannot be forged across an interpolation boundary.
+    {
+      code: `${IMPORT}const styles = stylex.create({ box: { color: \`#\${suffix}bc\` } })`,
+    },
+    // A derivation over a TOKEN still follows the colour scheme, so it is legal.
+    // This is the shape real code uses for a translucent border.
+    {
+      code: `${IMPORT}const styles = stylex.create({ box: { borderColor: \`color-mix(in oklab, \${tokens.border} 50%, transparent)\` } })`,
+    },
+    // Relative-colour syntax is a derivation too.
+    {
+      code: `${IMPORT}const styles = stylex.create({ box: { color: \`oklch(from \${tokens.text} l c h / 0.6)\` } })`,
+    },
+  ],
+  invalid: [],
+})
+
+ruleTester.run('stylex-no-raw-color: pure colour values', rule, {
+  valid: [],
+  invalid: [
+    // Assert the exact rendered message once (RuleTester forbids combining
+    // `message` and `messageId` on the same error).
+    {
+      code: `${IMPORT}const styles = stylex.create({ box: { color: '#ff0000' } })`,
+      errors: [{ message: hexColorMessage }],
+    },
+    // Hex in all four legal lengths.
+    {
+      code: `${IMPORT}const styles = stylex.create({ box: { color: '#fff' } })`,
+      errors: [{ messageId: 'rawColor' }],
+    },
+    {
+      code: `${IMPORT}const styles = stylex.create({ box: { color: '#fff8' } })`,
+      errors: [{ messageId: 'rawColor' }],
+    },
+    {
+      code: `${IMPORT}const styles = stylex.create({ box: { color: '#00000014' } })`,
+      errors: [{ messageId: 'rawColor' }],
+    },
+    // Functional notations.
+    {
+      code: `${IMPORT}const styles = stylex.create({ box: { color: 'rgb(255 0 0)' } })`,
+      errors: [{ messageId: 'rawColor' }],
+    },
+    {
+      code: `${IMPORT}const styles = stylex.create({ box: { color: 'rgba(255, 0, 0, 0.5)' } })`,
+      errors: [{ messageId: 'rawColor' }],
+    },
+    {
+      code: `${IMPORT}const styles = stylex.create({ box: { color: 'hsl(0 100% 50%)' } })`,
+      errors: [{ messageId: 'rawColor' }],
+    },
+    {
+      code: `${IMPORT}const styles = stylex.create({ box: { color: 'oklch(63.7% .237 25.331)' } })`,
+      errors: [{ messageId: 'rawColor' }],
+    },
+    // A derivation is not a loophole: a raw argument is still caught.
+    {
+      code: `${IMPORT}const styles = stylex.create({ box: { color: 'color-mix(in oklab, #ff0000 50%, transparent)' } })`,
+      errors: [{ messageId: 'rawColor' }],
+    },
+    {
+      code: `${IMPORT}const styles = stylex.create({ box: { color: 'color-mix(in srgb, rgb(255 0 0) 50%, transparent)' } })`,
+      errors: [{ messageId: 'rawColor' }],
+    },
+    {
+      code: `${IMPORT}const styles = stylex.create({ box: { color: 'oklch(from #ff0000 l c h / 0.5)' } })`,
+      errors: [{ messageId: 'rawColor' }],
+    },
+  ],
+})
+
+ruleTester.run('stylex-no-raw-color: colours embedded in composite values', rule, {
+  valid: [],
+  invalid: [
+    // The decisive cases: per-property upstream limits structurally cannot reach
+    // a colour inside a composite value, so an anchored pattern would miss these.
+    {
+      code: `${IMPORT}const styles = stylex.create({ box: { boxShadow: '0 1px 2px #00000014' } })`,
+      errors: [{ messageId: 'rawColor' }],
+    },
+    {
+      code: `${IMPORT}const styles = stylex.create({ box: { backgroundImage: 'linear-gradient(to right, #fff, rgba(0,0,0,0.5))' } })`,
+      errors: [{ messageId: 'rawColor' }],
+    },
+    {
+      code: `${IMPORT}const styles = stylex.create({ box: { border: '1px solid #e5e7eb' } })`,
+      errors: [{ messageId: 'rawColor' }],
+    },
+    {
+      code: `${IMPORT}const styles = stylex.create({ box: { filter: 'drop-shadow(0 0 2px rgb(0 0 0 / 0.5))' } })`,
+      errors: [{ messageId: 'rawColor' }],
+    },
+  ],
+})
+
+ruleTester.run('stylex-no-raw-color: nested and dynamic positions', rule, {
+  valid: [],
+  invalid: [
+    // Inside a pseudo-class condition.
+    {
+      code: `${IMPORT}const styles = stylex.create({ box: { color: { default: tokens.text, ':hover': '#ff0000' } } })`,
+      errors: [{ messageId: 'rawColor' }],
+    },
+    // Inside a media query.
+    {
+      code: `${IMPORT}const styles = stylex.create({ box: { '@media (prefers-color-scheme: dark)': { color: '#fff' } } })`,
+      errors: [{ messageId: 'rawColor' }],
+    },
+    // Inside a pseudo-element block.
+    {
+      code: `${IMPORT}const styles = stylex.create({ box: { '::before': { backgroundColor: '#fff' } } })`,
+      errors: [{ messageId: 'rawColor' }],
+    },
+    // Template literal.
+    {
+      code: `${IMPORT}const styles = stylex.create({ box: { boxShadow: \`0 0 0 1px #00000014\` } })`,
+      errors: [{ messageId: 'rawColor' }],
+    },
+    // Both arms of a conditional in a dynamic style.
+    {
+      code: `${IMPORT}const styles = stylex.create({ box: (on) => ({ color: on ? '#fff' : '#000' }) })`,
+      errors: [{ messageId: 'rawColor' }, { messageId: 'rawColor' }],
+    },
+    // Fallback stack array.
+    {
+      code: `${IMPORT}const styles = stylex.create({ box: { color: ['#ff0000', 'oklch(63.7% .237 25.331)'] } })`,
+      errors: [{ messageId: 'rawColor' }, { messageId: 'rawColor' }],
+    },
+    // Named `create` import, and a dynamic style with a block body.
+    {
+      code: `import { create } from '@stylexjs/stylex'\nconst styles = create({ box: (on) => { return { color: '#fff' } } })`,
+      errors: [{ messageId: 'rawColor' }],
+    },
+  ],
+})
+
+tsRuleTester.run('stylex-no-raw-color: TypeScript', rule, {
+  valid: [
+    {
+      code: `${IMPORT}const styles = stylex.create({ box: { color: tokens.textPrimary } } as const)`,
+    },
+  ],
+  invalid: [
+    {
+      code: `${IMPORT}const styles = stylex.create({ box: { color: '#ff0000' as string } })`,
+      errors: [{ messageId: 'rawColor' }],
+    },
+    // `as const` around the style map must not become a bypass.
+    {
+      code: `${IMPORT}const styles = stylex.create({ box: { color: '#ff0000' } } as const)`,
+      errors: [{ messageId: 'rawColor' }],
+    },
+  ],
+})

--- a/packages/@overeng/oxc-config/src/stylex-outline-focus-visible-only.ts
+++ b/packages/@overeng/oxc-config/src/stylex-outline-focus-visible-only.ts
@@ -1,0 +1,221 @@
+/**
+ * stylex-outline-focus-visible-only oxlint rule.
+ *
+ * `outline`, `outlineOffset` and `outlineColor` are reserved, design-system-wide,
+ * for the focus-visible state. Any *other* state condition setting them is a
+ * defect.
+ *
+ * This is the lintable half of the focus-ring invariant. StyleX assigns a fixed
+ * numeric priority per condition *kind*, not per authoring position, so an
+ * attribute-state condition outranks a pseudo-class condition on the same
+ * property no matter how they are written. Measured: a selected-state shadow beat
+ * a focus-visible shadow, so an element that was both selected and
+ * keyboard-focused silently lost its focus ring — an accessibility regression
+ * neither the type checker nor value validation can see. Partitioning the
+ * properties makes the collision impossible rather than merely managed: focus
+ * owns `outline*`, selection and pressed states restyle `boxShadow` and
+ * background.
+ *
+ * Allowed alongside focus-visible:
+ * - the unconditional base value, so `outline: 'none'` can suppress the
+ *   user-agent ring;
+ * - `default` inside a condition object, same reason;
+ * - at-rule conditions (`@media`, `@container`, `@supports`), which are not
+ *   states — a forced-colours or reduced-motion override of the ring is fine;
+ * - pseudo-elements (`::before`), which draw a different box entirely.
+ *
+ * Any condition key containing `focus-visible` counts as the focus-visible state,
+ * which covers both the native `:focus-visible` pseudo-class and the accessible-
+ * component library's `[data-focus-visible]` attribute state. Plain `:focus` does
+ * NOT count: that is the mistake this rule exists to catch.
+ *
+ * See stylex spec "State styling" and requirement R06.
+ *
+ * @example
+ * // ✅ Good - base suppression plus the focus-visible ring
+ * stylex.create({
+ *   button: {
+ *     outline: { default: 'none', ':focus-visible': '2px solid' },
+ *     boxShadow: { default: null, '[data-selected]': 'inset 0 0 0 1px' },
+ *   },
+ * })
+ *
+ * // ❌ Bad - a selection state claims the focus-ring property
+ * stylex.create({ button: { outline: { default: 'none', '[data-selected]': '2px solid' } } })
+ *
+ * // ❌ Bad - same defect written the other way round
+ * stylex.create({ button: { ':hover': { outlineColor: 'red' } } })
+ */
+
+import type { TSESTree } from '@typescript-eslint/utils'
+
+import {
+  createStylexImports,
+  isConditionKey,
+  staticKeyName,
+  stylexCreateArgument,
+  trackStylexImport,
+  type StylexRuleContext,
+} from './stylex-shared.ts'
+
+/** The focus-ring properties, reserved for the focus-visible state. */
+const FOCUS_RING_PROPERTIES: Readonly<Record<string, true>> = {
+  outline: true,
+  outlineOffset: true,
+  outlineColor: true,
+}
+
+/**
+ * A condition key that is a *state* — a pseudo-class or an attribute condition —
+ * as opposed to `default`, an at-rule, or a pseudo-element. Only states can
+ * collide with the focus ring, because only states describe the same element in
+ * the same layout.
+ */
+const isStateCondition = (name: string): boolean => {
+  if (name === 'default') return false
+  if (name.startsWith('@') === true) return false
+  if (name.startsWith('::') === true) return false
+  if (name.includes('focus-visible') === true) return false
+  return isConditionKey(name) === true
+}
+
+type ConditionWalk = {
+  readonly context: StylexRuleContext
+  readonly node: TSESTree.Node
+  /** Focus-ring property already on the path, if any. */
+  readonly focusRingProperty: string | undefined
+  /** Non-focus-visible state condition already on the path, if any. */
+  readonly stateCondition: string | undefined
+}
+
+/**
+ * Walk a style object reporting where a focus-ring property and a
+ * non-focus-visible state condition meet.
+ *
+ * StyleX allows either nesting order — property outside condition, or condition
+ * outside property — so the report fires at whichever of the two is encountered
+ * second. That yields exactly one diagnostic per offending pair, at the node that
+ * introduced the conflict.
+ */
+const walkConditions = ({
+  context,
+  node,
+  focusRingProperty,
+  stateCondition,
+}: ConditionWalk): void => {
+  // A dynamic style is an arrow returning the style object; unwrap to reach it.
+  if (node.type === 'ArrowFunctionExpression' || node.type === 'FunctionExpression') {
+    walkConditions({ context, node: node.body, focusRingProperty, stateCondition })
+    return
+  }
+  if (
+    node.type === 'TSAsExpression' ||
+    node.type === 'TSSatisfiesExpression' ||
+    node.type === 'TSNonNullExpression'
+  ) {
+    walkConditions({ context, node: node.expression, focusRingProperty, stateCondition })
+    return
+  }
+  if (node.type !== 'ObjectExpression') return
+
+  for (const member of node.properties) {
+    if (member.type !== 'Property') continue
+
+    const key = staticKeyName(member)
+    if (key === undefined) {
+      // A computed key is a `when.*` observed condition: a state, and never
+      // focus-visible.
+      if (focusRingProperty !== undefined) {
+        context.report({
+          node: member,
+          messageId: 'outlineOutsideFocusVisible',
+          data: { property: focusRingProperty, condition: 'an observed `when.*` condition' },
+        })
+      }
+      walkConditions({
+        context,
+        node: member.value,
+        focusRingProperty,
+        stateCondition: stateCondition ?? 'an observed `when.*` condition',
+      })
+      continue
+    }
+
+    if (isConditionKey(key) === true) {
+      const isState = isStateCondition(key)
+      if (isState === true && focusRingProperty !== undefined) {
+        context.report({
+          node: member,
+          messageId: 'outlineOutsideFocusVisible',
+          data: { property: focusRingProperty, condition: key },
+        })
+      }
+      walkConditions({
+        context,
+        node: member.value,
+        focusRingProperty,
+        stateCondition: isState === true ? (stateCondition ?? key) : stateCondition,
+      })
+      continue
+    }
+
+    const isFocusRing = FOCUS_RING_PROPERTIES[key] === true
+    if (isFocusRing === true && stateCondition !== undefined) {
+      context.report({
+        node: member,
+        messageId: 'outlineOutsideFocusVisible',
+        data: { property: key, condition: stateCondition },
+      })
+    }
+    walkConditions({
+      context,
+      node: member.value,
+      focusRingProperty: isFocusRing === true ? key : focusRingProperty,
+      stateCondition,
+    })
+  }
+}
+
+/** ESLint rule reserving the outline properties for the focus-visible state. */
+export const stylexOutlineFocusVisibleOnlyRule = {
+  meta: {
+    type: 'problem' as const,
+    docs: {
+      description:
+        'Reserve outline, outlineOffset and outlineColor for the focus-visible state',
+      recommended: false,
+    },
+    messages: {
+      outlineOutsideFocusVisible:
+        '`{{property}}` is reserved for the focus-visible state but is set under `{{condition}}`. StyleX orders conditions by kind, not by authoring position, so this state can silently outrank the focus ring on the same property. Restyle `boxShadow` or a background property for `{{condition}}` instead — partitioning the properties is what makes the focus ring collision-proof.',
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context: StylexRuleContext) {
+    const imports = createStylexImports()
+
+    return {
+      ImportDeclaration(node: TSESTree.ImportDeclaration) {
+        trackStylexImport({ imports, node })
+      },
+
+      CallExpression(node: TSESTree.CallExpression) {
+        const styleMap = stylexCreateArgument({ imports, node })
+        if (styleMap === undefined) return
+
+        // The style-map level names style objects, not properties or conditions,
+        // so descend one level before tracking anything.
+        for (const member of styleMap.properties) {
+          if (member.type !== 'Property') continue
+          walkConditions({
+            context,
+            node: member.value,
+            focusRingProperty: undefined,
+            stateCondition: undefined,
+          })
+        }
+      },
+    }
+  },
+}

--- a/packages/@overeng/oxc-config/src/stylex-outline-focus-visible-only.ts
+++ b/packages/@overeng/oxc-config/src/stylex-outline-focus-visible-only.ts
@@ -181,8 +181,7 @@ export const stylexOutlineFocusVisibleOnlyRule = {
   meta: {
     type: 'problem' as const,
     docs: {
-      description:
-        'Reserve outline, outlineOffset and outlineColor for the focus-visible state',
+      description: 'Reserve outline, outlineOffset and outlineColor for the focus-visible state',
       recommended: false,
     },
     messages: {

--- a/packages/@overeng/oxc-config/src/stylex-outline-focus-visible-only.unit.test.ts
+++ b/packages/@overeng/oxc-config/src/stylex-outline-focus-visible-only.unit.test.ts
@@ -1,0 +1,116 @@
+import { RuleTester as ESLintRuleTester } from 'eslint'
+import { describe, it } from 'vitest'
+
+import plugin from './mod.ts'
+
+ESLintRuleTester.describe = describe
+ESLintRuleTester.it = it
+
+const ruleTester = new ESLintRuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+  },
+})
+
+const rule = plugin.rules['stylex-outline-focus-visible-only']
+
+const IMPORT = `import * as stylex from '@stylexjs/stylex'\n`
+
+/** The exact rendered message for `outline` claimed by a selection state. */
+const selectedOutlineMessage =
+  '`outline` is reserved for the focus-visible state but is set under `[data-selected]`. StyleX orders conditions by kind, not by authoring position, so this state can silently outrank the focus ring on the same property. Restyle `boxShadow` or a background property for `[data-selected]` instead — partitioning the properties is what makes the focus ring collision-proof.'
+
+ruleTester.run('stylex-outline-focus-visible-only: focus-visible owns the ring', rule, {
+  valid: [
+    // The prescribed shape: base suppression plus the focus-visible ring, with
+    // selection restyling a disjoint property.
+    {
+      code: `${IMPORT}const styles = stylex.create({
+        button: {
+          outline: { default: 'none', ':focus-visible': '2px solid' },
+          outlineOffset: { default: 0, ':focus-visible': '2px' },
+          boxShadow: { default: null, '[data-selected]': 'inset 0 0 0 1px' },
+        },
+      })`,
+    },
+    // The accessible-component library's attribute state counts as focus-visible.
+    {
+      code: `${IMPORT}const styles = stylex.create({ button: { outline: { default: 'none', '[data-focus-visible]': '2px solid' } } })`,
+    },
+    // Condition-outside-property nesting, still focus-visible.
+    {
+      code: `${IMPORT}const styles = stylex.create({ button: { ':focus-visible': { outline: '2px solid', outlineColor: 'red' } } })`,
+    },
+    // An unconditional base value is how the user-agent ring gets suppressed.
+    {
+      code: `${IMPORT}const styles = stylex.create({ button: { outline: 'none' } })`,
+    },
+    // At-rules are not states: a forced-colours override of the ring is fine.
+    {
+      code: `${IMPORT}const styles = stylex.create({ button: { outline: { default: 'none', '@media (forced-colors: active)': { default: '1px solid', ':focus-visible': '3px solid' } } } })`,
+    },
+    // A pseudo-element draws a different box entirely.
+    {
+      code: `${IMPORT}const styles = stylex.create({ button: { '::before': { outline: '1px dashed' } } })`,
+    },
+    // Non-outline properties are free to use any state.
+    {
+      code: `${IMPORT}const styles = stylex.create({ button: { boxShadow: { default: null, ':hover': '0 0 0 1px', '[data-pressed]': 'inset 0 0 0 1px' } } })`,
+    },
+    // A same-named method on a different object is not a style declaration.
+    {
+      code: `${IMPORT}const row = db.create({ ':hover': { outline: '2px solid' } })`,
+    },
+  ],
+  invalid: [],
+})
+
+ruleTester.run('stylex-outline-focus-visible-only: competing states are defects', rule, {
+  valid: [],
+  invalid: [
+    // Assert the exact rendered message once.
+    {
+      code: `${IMPORT}const styles = stylex.create({ button: { outline: { default: 'none', '[data-selected]': '2px solid' } } })`,
+      errors: [{ message: selectedOutlineMessage }],
+    },
+    // The other nesting order is the same defect.
+    {
+      code: `${IMPORT}const styles = stylex.create({ button: { ':hover': { outlineColor: 'red' } } })`,
+      errors: [{ messageId: 'outlineOutsideFocusVisible' }],
+    },
+    // Plain `:focus` is exactly the mistake this rule exists to catch.
+    {
+      code: `${IMPORT}const styles = stylex.create({ button: { outline: { default: 'none', ':focus': '2px solid' } } })`,
+      errors: [{ messageId: 'outlineOutsideFocusVisible' }],
+    },
+    // outlineOffset is partitioned too.
+    {
+      code: `${IMPORT}const styles = stylex.create({ button: { outlineOffset: { default: 0, '[data-pressed]': '4px' } } })`,
+      errors: [{ messageId: 'outlineOutsideFocusVisible' }],
+    },
+    // One diagnostic per offending pair, not per nesting level.
+    {
+      code: `${IMPORT}const styles = stylex.create({ button: { outline: { default: 'none', ':focus-visible': '2px solid', '[data-selected]': '2px dotted', ':active': 'none' } } })`,
+      errors: [
+        { messageId: 'outlineOutsideFocusVisible' },
+        { messageId: 'outlineOutsideFocusVisible' },
+      ],
+    },
+    // A state nested inside a media query still competes.
+    {
+      code: `${IMPORT}const styles = stylex.create({ button: { outline: { default: 'none', '@media (hover: hover)': { ':hover': '2px solid' } } } })`,
+      errors: [{ messageId: 'outlineOutsideFocusVisible' }],
+    },
+    // An observed `when.*` condition is a state and never focus-visible.
+    {
+      code: `${IMPORT}const styles = stylex.create({ button: { outline: { default: 'none', [stylex.when.ancestor(':hover')]: '2px solid' } } })`,
+      errors: [{ messageId: 'outlineOutsideFocusVisible' }],
+    },
+    // Dynamic styles are not an escape hatch.
+    {
+      code: `${IMPORT}const styles = stylex.create({ button: (w) => ({ outline: { default: 'none', '[data-selected]': w } }) })`,
+      errors: [{ messageId: 'outlineOutsideFocusVisible' }],
+    },
+  ],
+})

--- a/packages/@overeng/oxc-config/src/stylex-shared.ts
+++ b/packages/@overeng/oxc-config/src/stylex-shared.ts
@@ -1,0 +1,142 @@
+/**
+ * Shared AST helpers for the `overeng/stylex-*` rules.
+ *
+ * Both StyleX rules need the same two things: recognise a `stylex.create(...)`
+ * call — and *only* that call, because the token-layer APIs `defineConsts`,
+ * `defineVars` and `createTheme` are exactly where literal colours legitimately
+ * live — and tell a CSS property key apart from a condition key inside a style
+ * object.
+ *
+ * Source of truth for the call-shape detection is `@stylexjs/eslint-plugin`'s
+ * `stylex-valid-styles` (`isStylexCallee` plus its import tracking),
+ * reimplemented here because an oxlint JS plugin cannot reuse the upstream
+ * rule's internals.
+ *
+ * NOTE on typing: the oxlint JS-plugin API ships no TypeScript definitions, and
+ * every older rule in this plugin annotates it `any`. These rules instead use
+ * `TSESTree` from `@typescript-eslint/utils` (already a devDependency, and the
+ * type-only import is erased before bundling) because the host presents
+ * ESLint-v8-compatible ESTree nodes, and because `any` is prohibited.
+ */
+
+import type { TSESTree } from '@typescript-eslint/utils'
+
+/** The subset of the ESLint/oxlint rule context these rules use. */
+export type StylexRuleContext = {
+  readonly report: (descriptor: {
+    readonly node: TSESTree.Node
+    readonly messageId: string
+    readonly data?: Readonly<Record<string, string>>
+  }) => void
+}
+
+/** Mutable per-file record of which local bindings refer to the StyleX API. */
+export type StylexImports = {
+  /** Locals bound to the whole namespace, e.g. `import * as stylex from '@stylexjs/stylex'`. */
+  readonly namespaces: Set<string>
+  /** Locals bound to `create` directly, e.g. `import { create } from '@stylexjs/stylex'`. */
+  readonly creates: Set<string>
+}
+
+/** Fresh, empty import record for one linted file. */
+export const createStylexImports = (): StylexImports => ({
+  namespaces: new Set<string>(),
+  creates: new Set<string>(),
+})
+
+/**
+ * Record the StyleX bindings introduced by one `ImportDeclaration`.
+ *
+ * Only the runtime module counts. A `*.stylex.ts` token module is deliberately
+ * NOT treated as the StyleX namespace: its exports are token objects, and
+ * mistaking one for the API would make `tokens.create` look like a style
+ * declaration.
+ */
+export const trackStylexImport = ({
+  imports,
+  node,
+}: {
+  readonly imports: StylexImports
+  readonly node: TSESTree.ImportDeclaration
+}): void => {
+  const source = node.source.value
+  if (source !== '@stylexjs/stylex' && source !== 'stylex') return
+
+  for (const specifier of node.specifiers) {
+    if (
+      specifier.type === 'ImportNamespaceSpecifier' ||
+      specifier.type === 'ImportDefaultSpecifier'
+    ) {
+      imports.namespaces.add(specifier.local.name)
+    }
+    if (
+      specifier.type === 'ImportSpecifier' &&
+      specifier.imported.type === 'Identifier' &&
+      specifier.imported.name === 'create'
+    ) {
+      imports.creates.add(specifier.local.name)
+    }
+  }
+}
+
+/**
+ * The single style-map argument of a `stylex.create({ ... })` call, or
+ * `undefined` when `node` is not such a call.
+ *
+ * The bare name `stylex` is accepted even without a tracked import, because that
+ * is the fleet-wide convention and it keeps the rule working when the namespace
+ * arrives through a re-export. A same-named method on any other object (say
+ * `db.create({ ... })`) is not a match.
+ */
+export const stylexCreateArgument = ({
+  imports,
+  node,
+}: {
+  readonly imports: StylexImports
+  readonly node: TSESTree.CallExpression
+}): TSESTree.ObjectExpression | undefined => {
+  if (node.arguments.length !== 1) return undefined
+
+  // `as const` / `satisfies` around the style map must not silently bypass the rule.
+  let argument = node.arguments[0]
+  while (
+    argument !== undefined &&
+    (argument.type === 'TSAsExpression' || argument.type === 'TSSatisfiesExpression')
+  ) {
+    argument = argument.expression
+  }
+  if (argument === undefined || argument.type !== 'ObjectExpression') return undefined
+
+  const callee = node.callee
+  if (callee.type === 'Identifier') {
+    return imports.creates.has(callee.name) === true ? argument : undefined
+  }
+
+  const isCreateMember =
+    callee.type === 'MemberExpression' &&
+    callee.computed === false &&
+    callee.property.type === 'Identifier' &&
+    callee.property.name === 'create' &&
+    callee.object.type === 'Identifier' &&
+    (imports.namespaces.has(callee.object.name) === true || callee.object.name === 'stylex')
+
+  return isCreateMember === true ? argument : undefined
+}
+
+/** Static name of a non-computed object-property key, if it has one. */
+export const staticKeyName = (property: TSESTree.Property): string | undefined => {
+  if (property.computed === true) return undefined
+  const key = property.key
+  if (key.type === 'Identifier') return key.name
+  if (key.type === 'Literal' && typeof key.value === 'string') return key.value
+  return undefined
+}
+
+/**
+ * Whether a static style-object key selects a *condition* rather than naming a
+ * CSS property: `default`, a pseudo-class or pseudo-element (`:hover`,
+ * `::before`), an at-rule (`@media`, `@container`), or an attribute state
+ * (`[data-selected]`).
+ */
+export const isConditionKey = (name: string): boolean =>
+  name === 'default' || /^[:@[&>~+*]/.test(name)

--- a/packages/@overeng/oxc-config/src/stylex-upstream-plugin.ts
+++ b/packages/@overeng/oxc-config/src/stylex-upstream-plugin.ts
@@ -1,0 +1,36 @@
+/**
+ * `@stylexjs` oxlint JS-plugin entry point.
+ *
+ * A second `jsPlugins` entry alongside `./mod.ts`, exposing the upstream
+ * `@stylexjs/eslint-plugin` rules under their documented `@stylexjs/*` names.
+ * The upstream plugin loads through oxlint's JS-plugin seam and its rules fire —
+ * verified against the real binary — so we adopt its general style validation
+ * rather than reimplementing it.
+ *
+ * Why this file exists rather than naming the package directly in `jsPlugins`:
+ * upstream ships no `meta.name`, so oxlint would derive the namespace from the
+ * bare specifier `@stylexjs/eslint-plugin`, and a bare specifier only resolves
+ * from the *root* `node_modules`. This repo's root `package.json` is a pure
+ * workspace aggregate and cannot carry a dependency, so the plugin lives where it
+ * belongs — a devDependency of this package, the one that owns lint config — and
+ * this module supplies the namespace explicitly. `jsPlugins` then references a
+ * path inside the workspace, exactly like `./mod.ts` does.
+ *
+ * Which rules are enabled, and the two measured configuration constraints, live
+ * in `genie/oxlint-base.ts` (`stylexOxlintRules`).
+ *
+ * See stylex spec "Enforcement" and decision 0005 Amendment 2.
+ */
+
+import { rules } from '@stylexjs/eslint-plugin'
+
+/** The upstream StyleX rules, namespaced `@stylexjs` for oxlint. */
+const plugin = {
+  meta: {
+    name: '@stylexjs',
+    version: '0.19.0',
+  },
+  rules,
+}
+
+export default plugin

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1235,6 +1235,9 @@ importers:
 
   packages/@overeng/oxc-config:
     devDependencies:
+      '@stylexjs/eslint-plugin':
+        specifier: 0.19.0
+        version: 0.19.0
       '@types/eslint':
         specifier: 9.6.1
         version: 9.6.1
@@ -1832,6 +1835,10 @@ packages:
 
   '@blazediff/core@1.9.1':
     resolution: {integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==}
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@dual-bundle/import-meta-resolve@4.2.1':
     resolution: {integrity: sha512-id+7YRUgoUX6CgV0DtuhirQWodeeA7Lf4i2x71JS/vtA5pRb/hIGWlw+G6MeXvsM+MXrz0VAydTGElX1rAfgPg==}
@@ -2909,6 +2916,9 @@ packages:
   '@stylexjs/babel-plugin@0.19.0':
     resolution: {integrity: sha512-2SnVZIl047TtqKW0nRTn7Irz0kmoot1bxdGDE/HwfwfF7dJYHqwkIFg92s87v3hj7zxJobrHWwDx1p3qvQXW4g==}
 
+  '@stylexjs/eslint-plugin@0.19.0':
+    resolution: {integrity: sha512-zZ6bCYcciaj2YYO0cG2nyCfjX5rclmW+WkcW/84gx4wCtpLvfr9+zYd3oqESr48suFlr8p6hrxGwnjYSLTDD4g==}
+
   '@stylexjs/shared@0.19.0':
     resolution: {integrity: sha512-7Yym70cQH5sPzJHgzJX3FkL9ZCptbC3IbiRijN9YLYU/5OywB/3c519Xv1DOzvxqjv8urSxh98/9HxLaPG7sDg==}
 
@@ -3389,6 +3399,10 @@ packages:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
 
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -3671,6 +3685,10 @@ packages:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
 
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -3781,6 +3799,10 @@ packages:
     resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
     engines: {node: '>=14.16'}
     hasBin: true
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
 
   is-object@1.0.2:
     resolution: {integrity: sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==}
@@ -4056,6 +4078,10 @@ packages:
   micromark@4.0.2:
     resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
   mime@4.1.0:
     resolution: {integrity: sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw==}
     engines: {node: '>=16'}
@@ -4172,6 +4198,10 @@ packages:
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
 
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
@@ -4473,6 +4503,10 @@ packages:
   tinyspy@4.0.4:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
 
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
@@ -4870,6 +4904,8 @@ snapshots:
       '@babel/helper-validator-identifier': 7.28.5
 
   '@blazediff/core@1.9.1': {}
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@dual-bundle/import-meta-resolve@4.2.1': {}
 
@@ -5707,6 +5743,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@stylexjs/eslint-plugin@0.19.0':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+      '@stylexjs/shared': 0.19.0
+      micromatch: 4.0.8
+      postcss-value-parser: 4.2.0
+
   '@stylexjs/shared@0.19.0': {}
 
   '@stylexjs/stylex@0.19.0':
@@ -6303,6 +6346,10 @@ snapshots:
     dependencies:
       balanced-match: 4.0.4
 
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
   browserslist@4.28.2:
     dependencies:
       baseline-browser-mapping: 2.10.21
@@ -6576,6 +6623,10 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
   find-up@5.0.0:
     dependencies:
       locate-path: 6.0.0
@@ -6686,6 +6737,8 @@ snapshots:
   is-inside-container@1.0.0:
     dependencies:
       is-docker: 3.0.0
+
+  is-number@7.0.0: {}
 
   is-object@1.0.2: {}
 
@@ -7048,6 +7101,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.2
+
   mime@4.1.0: {}
 
   min-indent@1.0.1: {}
@@ -7203,6 +7261,8 @@ snapshots:
   pathval@2.0.1: {}
 
   picocolors@1.1.1: {}
+
+  picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
 
@@ -7546,6 +7606,10 @@ snapshots:
   tinyrainbow@3.1.0: {}
 
   tinyspy@4.0.4: {}
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
 
   totalist@3.0.1: {}
 


### PR DESCRIPTION
Fixes the oxlint wrapper so third-party JS plugins can load at all, then uses that to ship StyleX enforcement as two complementary layers. Second half depends on the first: without the wrapper fix a config naming both `overeng/*` and `@stylexjs/*` rules fails to resolve, so neither could be tested.

Implements the StyleX spec's "Enforcement" section and decision 0005 Amendment 2.

## Base and merge order — read before merging

Rebased onto `schickling-assistant/2026-09-01-stylex-catalog-pins` (PR #1173, tip `6003e7dd5`), which supplies the `@stylexjs/eslint-plugin` catalog pin this needs. Merge that first.

**The `nix/oxc-config-plugin.nix` `pnpmDepsHash` is contested by construction, not by accident.** Its inputs include the root `pnpm-lock.yaml`, so it moves for any branch that touches dependencies — and this PR adds a devDependency to the very package it covers. #1170 moves it too, for its own reasons. The value here is correct for *this* tree; it is not correct for the merged tree, and neither is #1170's.

So when the second of those two merges: **re-measure from your own `nix build` `got:` line. Do not resolve the conflict by keeping a side, and do not carry a hash across from #1170 or #1173.** A carried-forward hash looks plausible, passes review, and fails after merge, which is the worst time to find out. `evergreen fod refresh` cannot address this attr — it is hand-written, not a CLI-shaped one (tooling gap filed separately); just write what nix reports.

The lockfile move also invalidated two CLI-shaped FODs (`ci-tools`, `notion-cli`), refreshed in the last commit via `evergreen fod refresh --name <pkg> --linux-system x86_64-linux`. Note evergreen writes the correct value even though its post-write verification step fails to evaluate these attrs — the warning is not a failure.

`devenv tasks run check:quick` is **green** on this tree.

## 1. Three wrapper defects (`nix/oxlint-with-plugins.nix`)

### Plugin list replaced instead of substituted — this was the blocker

The wrapper wrote `.jsPlugins = [ourPath]`, discarding every other entry, so a config naming a third-party plugin failed with `Plugin 'x' not found`. Two consumers already carry local workarounds with comments describing exactly this. Now only our entry is substituted.

```
before  $ oxlint fixture.ts --config .oxlintrc.json
        × Plugin 'probe' not found          (exit 1)

after   $ oxlint fixture.ts --config .oxlintrc.json
        × probe(always-report): probe plugin fired
        × overeng(no-raw-nondeterminism): ...   (exit 1, both namespaces)
```

Reproduced in situ, with this PR's real generated `.oxlintrc.json` and the pre-fix wrapper — this is what the blocker actually looked like:

```
$ oxlint packages/@overeng/oxc-config/lt-violation.tsx     # pre-fix wrapper
× Plugin '@stylexjs' not found
```

The match is our **entry point** (`oxc-config/src/mod.ts`), not the package directory, because this PR adds a second plugin entry from that same directory — matching the directory would swap a third-party plugin for ours one level down, reintroducing the same silent failure.

### `--config` first exited 1 with no output

The argument-rewrite loop used `((i++))`. Post-increment evaluates to the *old* value, so it returns status 1 when `i` is 0, and `writeShellApplication`'s `set -o errexit` aborted the wrapper silently. In CI that is indistinguishable from a lint failure.

```
before  $ oxlint --config .oxlintrc.json fixture.ts
        (no output)                          exit 1
        $ oxlint fixture.ts --config .oxlintrc.json
        × probe(always-report): ...           exit 1

after   both orders produce identical output and exit code
```

### A newly added rule was unreachable

The injected plugin is a Nix build-time snapshot, so editing `packages/@overeng/oxc-config/src/*.ts` had no effect and adding a rule reported `not found in plugin 'overeng'`. `OVERENG_OXC_CONFIG_PLUGIN` now overrides the path.

```
before  $ oxlint --config .oxlintrc.json f.ts
        × Rule 'stylex-no-raw-color' not found in plugin 'overeng'

after   $ OVERENG_OXC_CONFIG_PLUGIN=./packages/@overeng/oxc-config/src/mod.ts oxlint ...
        × overeng(stylex-no-raw-color): Raw colour `#00000014` in `boxShadow`. ...
```

### Regression test

`nix/devenv-modules/tasks/shared/tests/oxlint-plugin-injection.test.sh`, 13 assertions, picked up automatically by `devenv tasks run devenv-modules:test`. It drives the **real** built wrapper against the **real** oxlint, because all three defects were failures of plugin *resolution* — the one thing a stub cannot model. It prefers the already-realised wrapper on PATH, so inside the devenv shell it costs nothing and only falls back to `nix build` outside it.

Confirmed to fail against the old wrapper (`Plugin 'probe' not found`) and against an intermediate that matched the package directory rather than the entry point (`Plugin 'sibling' not found`) — it is a regression test, not a tautology.

The two consumer workarounds this unblocks (`devenv.nix` in dotfiles, `flakes/vista/nix/r59-oxc-plugin.js`) are outside this repo; reporting them rather than touching them.

## 2. StyleX enforcement, both layers

### Why both

Upstream per-property value limits are strictly better than anything we would hand-roll for pure colour properties — they distinguish a literal from a token reference. But a limit is keyed on one property and **structurally cannot see a colour embedded in a composite value**. Measured on this repo's own code:

```
× overeng(stylex-no-raw-color): Raw colour `rgb(0 0 0 / 0.1)` in `boxShadow`.
  LiteralField.tsx:134  boxShadow: '0 10px 15px -3px rgb(0 0 0 / 0.1), ...'
                        ^ upstream valid-styles reports nothing here
```

Banning composite properties outright is not viable — they need literal offsets. The overlap on plain colour properties is kept deliberately: an array `limit` drops its custom `reason` text, so only the first-party message names the remedy.

### Upstream loads through a namespace shim, NOT the bare specifier

`packages/@overeng/oxc-config/src/stylex-upstream-plugin.ts` re-exports the upstream rules with `meta: { name: '@stylexjs' }`.

**Please do not "simplify" this to `jsPlugins: ['@stylexjs/eslint-plugin']`.** It cannot work here, and the reason is structural rather than incidental. Upstream ships no `meta.name`, so oxlint derives the namespace from the specifier — which means the specifier must be the bare package name. A bare specifier resolves only from the **root** `node_modules`, and this repo's root `package.json` is a pure genie workspace aggregate (`{name, private, packageManager, workspaces}`) that cannot carry a dependency at all. Earlier prototyping suggested the bare specifier was required because it ran in an isolated temp project where a root `node_modules` happened to exist.

The shim keeps the dependency on the package that owns lint config, references a path inside the workspace exactly like `./mod.ts` does, and still yields rule names that read exactly as upstream documents them.

### Rules enabled

`valid-styles` (with `propLimits`), `valid-shorthands`, `no-unused`, `no-legacy-contextual-styles`, `no-lookahead-selectors`, `enforce-extension`. `sort-keys` is deliberately skipped — it fights the `property-specificity` resolution the design relies on. Policy lives in `stylexOxlintRules` in `genie/oxlint-base.ts`, repo-wide rather than scoped, so a target is gated the moment it starts using StyleX; the rules are inert in files that never call the API.

`no-lookahead-selectors` is in the set because the spec names it; `no-legacy-contextual-styles` because the brief named it. Shipping the union — both are cheap and neither is a "skip" in either document. It is a good thing: `no-legacy-contextual-styles` is what found the 13 pilot sites.

### Colour properties are enumerated, not globbed

Measured: `*olor*` also matches `colorScheme`, `colorAdjust`, `forcedColorAdjust`, `printColorAdjust` and `colorInterpolation`, all keyword-valued, all of which would be wrongly banned. `fill`, `stroke`, `floodColor`, `stopColor` and `scrollbarColor` are also excluded despite taking colours, because each accepts a value an allowlist would reject (`none`, a `url(#fragment)` paint reference, a pair). The first-party rule still covers colour literals in those.

### `overeng/stylex-no-raw-color`

Bans colour literals as values inside `stylex.create`. The pattern is deliberately **not** anchored, which is what reaches inside composites. The token layer is untouched by construction: only `create` is visited, never `defineConsts`/`defineVars`/`createTheme`.

One refinement beyond the brief, found by running against real code. `color-mix()` and relative-colour syntax (`oklch(from <colour> ...)`) are **derivations**, not constructors — a derivation over a token still follows the colour scheme, so flagging it contradicts the rule's own purpose. Treating them as constructors produced 4 false positives on `FieldGroup.tsx`'s `color-mix(in oklab, ${tokens.border} 50%, transparent)`. They are not a loophole: a raw argument inside them is still caught, because the patterns are not anchored.

Silent on: the token layer, non-colour literals, `colorScheme`/`forcedColorAdjust` keywords, SVG fragment refs (`url(#abc)`) that look like short hex, a quoted hash in `content`, hex runs longer than 8, colour-shaped strings outside `create`, `db.create({ color: '#f00' })`, and colours "forged" across an interpolation boundary. Catches hex 3/4/6/8, seven functional notations, pseudo-class and media-query nesting, pseudo-element blocks, gradients, shadow and border shorthands, template literals, both arms of a conditional in a dynamic style, fallback arrays, and `as const` around the style map.

### `overeng/stylex-outline-focus-visible-only`

Reserves `outline`, `outlineOffset` and `outlineColor` for the focus-visible state. This is the lintable half of the focus-ring invariant: StyleX assigns priority per condition **kind**, not by authoring position, so a selected-state shadow beat a focus-visible shadow and an element that was both selected and keyboard-focused silently lost its focus ring. Partitioning the properties makes the collision impossible rather than managed.

Allows the unconditional base value (so `outline: 'none'` can suppress the UA ring), `default`, at-rule conditions (a forced-colours override is legitimate), and pseudo-elements. Any key containing `focus-visible` counts, covering both `:focus-visible` and the accessible-component library's `[data-focus-visible]`. Plain `:focus` does not — that is the mistake it exists to catch. Fires on either nesting order, once per offending pair, and does not treat dynamic styles as an escape hatch.

### `any` vs TSESTree — a deliberate divergence

The sixteen existing rules annotate the untyped plugin API `any` with a NOTE comment. These two use `TSESTree` from `@typescript-eslint/utils` instead. The no-`any` rule is binding and postdates that convention, the dependency is already there, and the type-only import is erased before bundling — so the cost is zero. The existing sixteen are left alone; churning them is not this PR's job.

### Verification

All of the following was re-run **after** the rebase, on the real generated `.oxlintrc.json` and the real built wrapper, not a hand-written probe config.

Violation fixture — one run, both namespaces resolving:

```
$ oxlint packages/@overeng/oxc-config/lt-violation.tsx
× overeng(stylex-no-raw-color):  Raw colour `#ff0000` in `color`. ...
× overeng(stylex-no-raw-color):  Raw colour `#00000014` in `boxShadow`. ...
× overeng(stylex-no-raw-color):  Raw colour `#fff` in `backgroundImage`. ...
× overeng(stylex-outline-focus-visible-only): `outline` is reserved for the
    focus-visible state but is set under `[data-selected]`. ...
× @stylexjs(valid-styles): color value must be one of: ...
Found 0 warnings and 6 errors.
```

Note what upstream did **not** say: nothing about the colour inside `boxShadow`, and nothing about the colour inside the gradient. Only the first-party rule reaches those. That is experiment 0004's central measurement, reproduced here in situ rather than in a scratch project.

Compliant fixture — both StyleX layers silent, including on all the shapes that must not fire (`color: colors.text` from a `*.stylex.ts` module, `backgroundColor: 'transparent'`, a `color-mix()` derivation over a token, `boxShadow` restyled by `[data-selected]`, `outline` under `:focus-visible`, and `fill: 'url(#brandGradient)'`):

```
$ oxlint packages/@overeng/oxc-config/lt-compliant.tsx lt-tokens.stylex.ts
× overeng(jsdoc-require-exports): Missing JSDoc comment for exported 'const colors'.
× overeng(jsdoc-require-exports): Missing JSDoc comment for exported 'const styles'.
Found 0 warnings and 2 errors.
```

Both remaining diagnostics are an unrelated pre-existing house rule reacting to a throwaway fixture with no JSDoc. Zero StyleX diagnostics.

**Regression test is still non-tautological after the rebase** — checked explicitly, because a rebase across a lockfile change is exactly when that can quietly stop being true:

```
$ OXLINT_WRAPPER_BIN=<post-rebase build>  bash …/oxlint-plugin-injection.test.sh
All oxlint plugin injection tests passed

$ OXLINT_WRAPPER_BIN=<pre-fix wrapper>    bash …/oxlint-plugin-injection.test.sh
FAIL: third-party plugin is not clobbered
  expected output NOT to contain: Plugin 'probe' not found
```

Also:

- 56 unit tests across the two rules, `RuleTester` under both the ESLint and TypeScript parsers. The count matches the enumerated cases exactly, so nothing is silently skipped.
- 13 assertions in the wrapper regression test.
- Repo-wide run with the generated config: **0 errors** over 1537 files, 172 rules. The one warning (`import/no-dynamic-require` in `genie/ci-scripts/bundle-smoke.ts`) is pre-existing.
- `tsc --noEmit` clean for `@overeng/oxc-config`, with all six new files confirmed in the program via `--listFiles`.
- `devenv tasks run check:quick` green.

## 3. The pilot package fails the enforcement derived from it

Enabling the rules produced 33 diagnostics over 17 sites, all in `packages/@overeng/effect-schema-form-aria` — the reference implementation this whole pattern was derived from (#1152).

That is not embarrassing; it is the enforcement working. The rules found real drift in the one place everyone would have assumed was clean, on their first run, without anyone having to look. It is also the **second** recorded divergence for that package, not the first — `DELTA-001` is open for its use of lifted React state where own conditions are now preferred. Both need the same visual gate, so #1171 says resolve them together.

- 13 sites use the deprecated top-level pseudo-class syntax.
- 4 raw colours: `#ffffff` x3 in `color`, `rgb(0 0 0 / 0.1)` twice inside one `boxShadow`.

Not fixed here. Nesting a pseudo-class changes which condition wins on that property, and that package has no visual gate — changing it now would be exactly the unverified visual change our requirements forbid. The colours need semantic tokens that do not exist yet, and the tempting fix (`colors.white`, already in the shared scales) would silence the rule while permanently foreclosing scheme variation, because a constant cannot vary by scheme.

**Each of the 17 sites carries a per-line `oxlint-disable-next-line` with a reason, not a file-scoped override.** A file-scoped `off` would disable the rules for *future* code in that package too — bad anywhere, worse in the package people read as the example. Per-line keeps new code gated, makes the debt visible where it is, and makes the cleanup greppable: `grep -rn 'See #1171'`.

Net effect, stated plainly: the machinery is real and green, but in this repo it currently gates only compliant code. That matches the roadmap's own "Enforcement reach" entry, which expects the third target to be the first lint-covered gate.

## Follow-ups filed

- #1171 — migrate the pilot package onto the rules and remove the 17 disables, together with `DELTA-001`.
- The two consumer wrapper workarounds are now removable; both are outside this repo, so reported rather than touched.

<!-- agent-footer:begin v=2 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | dev3.direct.omp.6xjdfab7 |
| `session` | dev3.6xjdfab7 |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.0.11 |
| `agent_runtime` | OMP 18.0.11 |
| `tooling_profile` | dotfiles@5a8d579-dirty |
</details>
<!-- agent-footer:end -->