### PR TITLE
fix(genie): handle semver wildcard ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -334,6 +334,10 @@ violations }` (the offending `DiffOp[]`); block ops and page content
   ordinary-block child scopes keep full mixed-kind ordering. The persisted
   `CacheTree` exactly reflects the identities left live and an immediate
   identical sync emits zero mutations.
+
+- **@overeng/genie/semver**: match trailing `x`, `X`, and `*` range wildcards
+  by their specified major and minor components.
+
 - **Nix prepared dependencies**: normalize ordinary, non-injected local
   `file:` packages through pnpm's exact package-map locator before removing
   transient Source Input aliases. Restored CLI workspaces now resolve the

--- a/packages/@overeng/genie/src/runtime/semver/mod.ts
+++ b/packages/@overeng/genie/src/runtime/semver/mod.ts
@@ -41,6 +41,18 @@ const satisfiesSingle = (version: string, range: string): boolean => {
 
   if (trimmed === '*') return true
 
+  const parts = trimmed.split('.')
+  const wildcardIndex = parts.findIndex((part) => part === 'x' || part === 'X' || part === '*')
+  if (
+    wildcardIndex !== -1 &&
+    parts.length <= 3 &&
+    parts.slice(0, wildcardIndex).every((part) => /^(?:0|[1-9]\d*)$/.test(part)) === true &&
+    parts.slice(wildcardIndex).every((part) => part === 'x' || part === 'X' || part === '*') ===
+      true
+  ) {
+    return parts.slice(0, wildcardIndex).every((part, index) => v[index] === Number(part))
+  }
+
   if (trimmed.startsWith('^') === true) {
     const r = parseVersion(trimmed.slice(1))
     if (gte(v, r) === false) return false

--- a/packages/@overeng/genie/src/runtime/semver/semver.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/semver/semver.unit.test.ts
@@ -135,10 +135,31 @@ describe('satisfiesRange', () => {
     })
   })
 
-  describe('wildcard', () => {
-    it('matches anything', () => {
+  describe('X-ranges', () => {
+    it('matches any version for a bare wildcard', () => {
       expect(satisfiesRange('0.0.1', '*')).toBe(true)
       expect(satisfiesRange('99.99.99', '*')).toBe(true)
+      expect(satisfiesRange('19.2.3', 'x')).toBe(true)
+      expect(satisfiesRange('19.2.3', 'X')).toBe(true)
+    })
+
+    it('matches the specified major for a minor wildcard', () => {
+      expect(satisfiesRange('19.2.3', '19.x')).toBe(true)
+      expect(satisfiesRange('19.2.3', '19.X')).toBe(true)
+      expect(satisfiesRange('19.2.3', '19.*')).toBe(true)
+      expect(satisfiesRange('20.0.0', '19.x')).toBe(false)
+    })
+
+    it('matches the specified major and minor for a patch wildcard', () => {
+      expect(satisfiesRange('19.2.3', '19.2.x')).toBe(true)
+      expect(satisfiesRange('19.2.3', '19.2.X')).toBe(true)
+      expect(satisfiesRange('19.2.3', '19.2.*')).toBe(true)
+      expect(satisfiesRange('19.3.0', '19.2.x')).toBe(false)
+    })
+
+    it('composes wildcard ranges in disjunctions', () => {
+      expect(satisfiesRange('19.2.3', '18.x || 19.2.x')).toBe(true)
+      expect(satisfiesRange('20.0.0', '18.x || 19.2.x')).toBe(false)
     })
   })
 


### PR DESCRIPTION
## Problem

Genie's minimal peer-dependency range checker treated X-ranges such as `19.x`, `19.X`, and `19.*` as exact version strings. A concrete catalog version such as `19.2.3` therefore failed a compatible wildcard range.

## Goal

Match trailing semver wildcards by the numeric major and minor components that precede them, including inside `||` disjunctions.

## Decisions

- Keep the existing focused semver checker instead of adding a general-purpose dependency.
- Accept only one to three dot-separated components with a canonical numeric prefix and a trailing wildcard-only suffix. Malformed or non-trailing wildcard forms continue to fail closed.

## Verification

Behavior covered by the focused unit tests:

```text
before: satisfiesRange("19.2.3", "19.x") = false
after:  satisfiesRange("19.2.3", "19.x") = true

after:  satisfiesRange("20.0.0", "19.x") = false
after:  satisfiesRange("19.2.3", "18.x || 19.2.x") = true
```

Passed locally:

```text
CI=1 devenv tasks run test:genie --no-tui
CI=1 devenv tasks run check:quick --no-tui
```

## Complexity

No new dependency or abstraction. The change adds a bounded X-range branch to the existing checker.

## Concerns

The checker intentionally remains a documented semver subset. This change supports trailing X-ranges; it does not attempt full npm semver compatibility.

## Friction & bottlenecks

Validation was delayed by unrelated local disk pressure. Both required gates completed successfully after capacity recovered.

## Follow-ups

None.

## References

Refs livestorejs/livestore#1497
