### PR TITLE
Turn on cascade layers for the one target that can take them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,31 @@ All notable changes to this project will be documented in this file.
   rather than a file-scoped override, so new code there is still gated
   (issue #1171).
 
+- **@overeng/utils**: `createStylexVitePlugins` takes `useCSSLayers`, and
+  `@overeng/effect-schema-form-aria` turns it on. Unlayered output was never a
+  preference — it is what lets converted code beat a utility framework's
+  layered utilities without any ordering work — so the option defaults OFF and
+  the flip is per target, on the target that has left the framework. Nothing
+  outside this repo changes.
+  The audit that gates the flip, stated in full because the answer was not the
+  expected one. Utility framework: none — no `package.json` in the repo names
+  one. StyleX consumers: exactly one, `@overeng/effect-schema-form-aria`, plus
+  the token package itself. Global stylesheets: five CSS files, of which three
+  (`notion-react`'s katex, vendored-notion and styles) belong to a package that
+  does not use StyleX and never shares a document with one here, one
+  (`effect-schema-form-aria/src/styles.css`) only re-exports the fifth, and the
+  fifth is `@overeng/stylex-tokens/preflight.css`.
+  **That last one is why "Tailwind-free" was not sufficient.** The reset was
+  unlayered and sets `box-sizing`, `margin`, `padding` and `border` on `*`.
+  Layered CSS loses to *any* unlayered CSS, so flipping layers on without
+  touching it would have handed those four properties to the reset on every
+  component in the package — silently, and in the direction the migration is
+  supposed to prevent. The reset now declares itself in `overeng.reset` and the
+  compiler is configured with `before: ['overeng.reset']`, so the emitted
+  `@layer overeng.reset, priority1, ...;` statement fixes the order by
+  declaration rather than by which stylesheet the browser parses first — the
+  same "do not depend on injection order" rule the token layer already follows.
+
 ### Fixed
 
 - **@overeng/effect-schema-form-aria**: the pilot package's three independent

--- a/packages/@overeng/effect-schema-form-aria/vite.config.ts
+++ b/packages/@overeng/effect-schema-form-aria/vite.config.ts
@@ -24,7 +24,10 @@ export default defineConfig({
     // Both surfaces are named because the compiled StyleX stylesheet is a
     // virtual module that only lands in a bundle where an entry imports it, and
     // the Storybook builder merges this config rather than supplying its own.
-    createStylexVitePlugins({ entries: [publicationEntry, storybookPreviewEntry] }),
+    createStylexVitePlugins({
+      entries: [publicationEntry, storybookPreviewEntry],
+      useCSSLayers: { before: ['overeng.reset'] },
+    }),
     react(),
   ],
   build: {

--- a/packages/@overeng/effect-schema-form-aria/vitest.config.ts
+++ b/packages/@overeng/effect-schema-form-aria/vitest.config.ts
@@ -9,7 +9,7 @@ import { createStylexVitePlugins } from '@overeng/utils/node/stylex'
 // transform it. No `entries` here: the virtual stylesheet is a build-only
 // concern and these tests assert compiled class names, not rendered CSS.
 export default defineConfig({
-  plugins: [createStylexVitePlugins(), react()],
+  plugins: [createStylexVitePlugins({ useCSSLayers: { before: ['overeng.reset'] } }), react()],
   ssr: { noExternal: ['@overeng/stylex-tokens'] },
   test: {
     exclude: ['**/dist/**', '**/node_modules/**'],

--- a/packages/@overeng/effect-schema-form-aria/vitest.gate.config.ts
+++ b/packages/@overeng/effect-schema-form-aria/vitest.gate.config.ts
@@ -15,6 +15,6 @@ import { createStylexVitePlugins } from '@overeng/utils/node/stylex'
 // served, not bundled.
 export default defineConfig(
   mergeConfig(createStoryGateConfig({}), {
-    plugins: [createStylexVitePlugins()],
+    plugins: [createStylexVitePlugins({ useCSSLayers: { before: ['overeng.reset'] } })],
   }),
 )

--- a/packages/@overeng/stylex-tokens/src/preflight.css
+++ b/packages/@overeng/stylex-tokens/src/preflight.css
@@ -1,47 +1,57 @@
 /* Pixel-parity subset of Tailwind CSS v4 preflight (MIT, tailwindlabs/tailwindcss).
  * Component styling belongs in StyleX; this file provides only the shared reset. */
-*,
-::after,
-::before,
-::backdrop,
-::file-selector-button {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
-  border: 0 solid;
-}
+/* Declared inside `overeng.reset` because the StyleX compiler now emits its rules
+ * into cascade layers. Layered CSS loses to ANY unlayered CSS, so an unlayered
+ * reset would beat every component rule for `margin`, `padding`, `border` and
+ * `box-sizing` — the four properties this file sets on `*`. The layer ORDER is
+ * not left to stylesheet concatenation order: the compiler is configured with
+ * `before: ['overeng.reset']`, so its `@layer overeng.reset, priority1, ...;`
+ * statement pins this layer below every StyleX priority regardless of which
+ * stylesheet the browser parses first. */
+@layer overeng.reset {
+  *,
+  ::after,
+  ::before,
+  ::backdrop,
+  ::file-selector-button {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+    border: 0 solid;
+  }
 
-html,
-:host {
-  line-height: 1.5;
-  -webkit-text-size-adjust: 100%;
-  tab-size: 4;
-  font-family:
-    ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
-    'Noto Color Emoji';
-}
+  html,
+  :host {
+    line-height: 1.5;
+    -webkit-text-size-adjust: 100%;
+    tab-size: 4;
+    font-family:
+      ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
+      'Segoe UI Symbol', 'Noto Color Emoji';
+  }
 
-body {
-  line-height: inherit;
-}
+  body {
+    line-height: inherit;
+  }
 
-button,
-input,
-optgroup,
-select,
-textarea {
-  font: inherit;
-  font-feature-settings: inherit;
-  font-variation-settings: inherit;
-  letter-spacing: inherit;
-  color: inherit;
-  opacity: 1;
-  background-color: transparent;
-  border-radius: 0;
-}
+  button,
+  input,
+  optgroup,
+  select,
+  textarea {
+    font: inherit;
+    font-feature-settings: inherit;
+    font-variation-settings: inherit;
+    letter-spacing: inherit;
+    color: inherit;
+    opacity: 1;
+    background-color: transparent;
+    border-radius: 0;
+  }
 
-button,
-input:where([type='button'], [type='reset'], [type='submit']),
-::file-selector-button {
-  appearance: button;
+  button,
+  input:where([type='button'], [type='reset'], [type='submit']),
+  ::file-selector-button {
+    appearance: button;
+  }
 }

--- a/packages/@overeng/utils/src/node/stylex/mod.js
+++ b/packages/@overeng/utils/src/node/stylex/mod.js
@@ -52,6 +52,16 @@ const getCssPostTransformHandler = (cssPostPlugin) => {
  * @typedef {object} StylexVitePluginsOptions
  * @property {readonly string[]} [externalPackages]
  *   Packages that ship uncompiled StyleX source and must be compiled by us.
+ * @property {boolean | { before?: readonly string[], after?: readonly string[], prefix?: string }} [useCSSLayers]
+ *   Emit compiled rules into cascade layers. Defaults to OFF, and that default
+ *   is load-bearing rather than conservative: unlayered StyleX beats a utility
+ *   framework's layered utilities unconditionally, which is what lets converted
+ *   code win during a migration without any ordering work. Turn it on only for
+ *   a target that has left its utility framework AND whose global stylesheets
+ *   are themselves layered — layered CSS loses to *any* unlayered CSS, so one
+ *   unlayered global reset silently outranks every component rule it touches.
+ *   Name those stylesheets' layers in `before` so the emitted `@layer` statement
+ *   fixes the order by declaration instead of by stylesheet parse order.
  * @property {readonly string[]} [entries]
  *   Absolute paths of the build entries that should receive the virtual
  *   stylesheet import — one per surface: the library/app entry, and the
@@ -86,12 +96,17 @@ const getCssPostTransformHandler = (cssPostPlugin) => {
  * @param {StylexVitePluginsOptions} [options]
  * @returns {StylexVitePlugin[]}
  */
-export const createStylexVitePlugins = ({ externalPackages = [], entries = [] } = {}) => {
+export const createStylexVitePlugins = ({
+  externalPackages = [],
+  entries = [],
+  useCSSLayers = false,
+} = {}) => {
   const deduplicatedExternalPackages = [...new Set(['@overeng/stylex-tokens', ...externalPackages])]
   // `externalPackages` is supported at runtime (unplugin core destructures it)
   // but missing from @stylexjs/unplugin@0.19 UserOptions typings.
   const stylexOptions = /** @type {Parameters<typeof stylex.vite>[0]} */ ({
     externalPackages: deduplicatedExternalPackages,
+    useCSSLayers,
   })
 
   const upstream = stylex.vite(stylexOptions)
@@ -124,8 +139,13 @@ export const createStylexVitePlugins = ({ externalPackages = [], entries = [] } 
         : null,
     // Appended, not prepended. Import statements hoist, so this still runs
     // before the module body, but it sorts *after* the entry's own stylesheet
-    // imports — which puts unlayered StyleX rules last, the precedence the
-    // migration relies on while a utility framework is still present.
+    // imports. That ordering is no longer what decides precedence now that the
+    // rules are layered — the emitted `@layer` statement does that, and it does
+    // it independently of parse order, which is the point of naming the reset
+    // in `before`. Appending is kept anyway: a consumer of this factory may
+    // still carry a utility framework — `useCSSLayers` defaults off for exactly
+    // that reason — and there the unlayered-wins property does depend on the
+    // entry's own stylesheets sorting first.
     // oxlint-disable-next-line overeng/named-args -- Vite's Plugin transform hook has a fixed positional signature.
     transform: (code, id) =>
       entryIds.has(stripQuery(id)) === true


### PR DESCRIPTION
Turns cascade layers on for the one target that can take them.

## Why this is a per-target option and not a flat flip

Unlayered output was never a preference — it is what lets converted code beat a
utility framework's layered utilities without any ordering work. So
`createStylexVitePlugins` gains `useCSSLayers`, **defaulting OFF**, and only
`effect-schema-form-aria`'s three configs opt in.

This is a correctness constraint, not taste: the factory is shared through the
megarepo pin, so a flat flip inside it would turn layers on for the other consuming repos
which still carry Tailwind and where layered output loses.

## The audit, in full

- **Utility framework:** none. No `package.json` in the repo names one.
- **StyleX consumers:** exactly one — `@overeng/effect-schema-form-aria` — plus
  the token package itself.
- **Global stylesheets:** five CSS files. Three belong to `notion-react`, which
  does not use StyleX and never shares a document with it here. One
  (`effect-schema-form-aria/src/styles.css`) only re-exports the fifth. The
  fifth is `@overeng/stylex-tokens/preflight.css`.

**"Tailwind-free" turned out not to be sufficient, and that is the finding.**
The reset was unlayered and sets `box-sizing`, `margin`, `padding` and `border`
on `*`. Layered CSS loses to *any* unlayered CSS, so flipping layers on alone
hands those four properties to the reset on every component — silently, and in
exactly the direction this migration exists to prevent. The general rule the
flip actually needs is that **every** unlayered global stylesheet in the graph
is layered and ordered; being free of a utility framework says nothing about it.

## Evidence that the layered output still wins where it must

Both runs against baseline `ff33f7b1b`:

- **Negative control** — reset left unlayered, layers on: the gate fails
  **sixteen stories with DIMENSION mismatches**. Components lose their padding
  and borders and collapse. This is the regression the audit caught.
- **Shipped state** — reset declared in `overeng.reset`, named in the compiler's
  `before` list: **39 compared, 39/39 passed at baseline, 0 changed.** The
  layered output renders identically to the unlayered output it replaces.

## Ordering is fixed by declaration, not by luck

Naming the reset in `before` makes the compiler emit
`@layer overeng.reset, priority1, ...;` ahead of its rules, so the reset sits
below every StyleX priority regardless of which stylesheet the browser parses
first. That is the same "do not depend on bundler injection order" rule the
token layer already follows — this is not another injection-order dependency.

<!-- agent-footer:begin v=2 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | dev3.direct.omp.6xjdfab7 |
| `session` | dev3.6xjdfab7 |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.0.11 |
| `agent_runtime` | OMP 18.0.11 |
| `tooling_profile` | dotfiles@5a8d579-dirty |
</details>
<!-- agent-footer:end -->