### PR TITLE
refactor(effect-schema-form-aria): move the focus ring from boxShadow to outline

### DIFF
--- a/packages/@overeng/effect-schema-form-aria/src/components/LiteralField.tsx
+++ b/packages/@overeng/effect-schema-form-aria/src/components/LiteralField.tsx
@@ -104,12 +104,17 @@ const styles = stylex.create({
     borderColor: tokens.border,
     backgroundColor: tokens.input,
     color: tokens.ink,
-    // `outline` is reserved for the focus ring design-system-wide, so the base
-    // only suppresses the user-agent one. React Aria's own focus-visible state
-    // is preferred over `:focus`: it normalises across input modalities, so a
-    // pointer click no longer paints a keyboard focus ring.
-    outline: 'none',
-    boxShadow: { default: null, '[data-focus-visible]': `0 0 0 1px ${tokens.primary}` },
+    // `outline` is reserved for the focus ring design-system-wide, and this is
+    // now that ring rather than a suppression of the user-agent one. React
+    // Aria's own focus-visible state is preferred over `:focus`: it normalises
+    // across input modalities, so a pointer click no longer paints a keyboard
+    // focus ring.
+    //
+    // The `popover` below writes `boxShadow` for a real elevation shadow. That
+    // is a different element today, so the two never met — but a trigger is
+    // exactly the kind of control that later grows a shadow, and this is the
+    // pair that would have silently collided on one property.
+    outline: { default: 'none', '[data-focus-visible]': `1px solid ${tokens.primary}` },
     opacity: { default: 1, ':disabled': 0.5 },
   },
   triggerValue: {

--- a/packages/@overeng/effect-schema-form-aria/src/components/NumberField.tsx
+++ b/packages/@overeng/effect-schema-form-aria/src/components/NumberField.tsx
@@ -51,8 +51,15 @@ const styles = stylex.create({
     color: tokens.ink,
     // A plain `<input>`, not a React Aria one, so the native focus-visible
     // pseudo-class is the only focus state available here.
-    outline: 'none',
-    boxShadow: { default: null, ':focus-visible': `0 0 0 1px ${tokens.primary}` },
+    //
+    // This is the one ring site in the package keyed on a PSEUDO-CLASS rather
+    // than an attribute, which makes it the site exposed to the upstream
+    // priority-table defect: `@stylexjs/shared@0.19.0` spells pseudo-classes
+    // camelCase in that table, so `:focus-visible` falls through to the
+    // unknown-pseudo default of 40 while `:hover` sits at 130. Nothing writes
+    // `:hover` on `outline` here, so the two cannot meet — and keeping the ring
+    // on its own property is what guarantees that, rather than luck.
+    outline: { default: 'none', ':focus-visible': `1px solid ${tokens.primary}` },
     opacity: { default: 1, ':disabled': 0.5 },
   },
   toggle: {
@@ -85,8 +92,7 @@ const styles = stylex.create({
     borderColor: tokens.border,
     backgroundColor: tokens.input,
     color: tokens.ink,
-    outline: 'none',
-    boxShadow: { default: null, '[data-focus-visible]': `0 0 0 1px ${tokens.primary}` },
+    outline: { default: 'none', '[data-focus-visible]': `1px solid ${tokens.primary}` },
     opacity: { default: 1, ':disabled': 0.5 },
     cursor: { default: null, ':disabled': 'not-allowed' },
   },

--- a/packages/@overeng/effect-schema-form-aria/src/components/TextField.tsx
+++ b/packages/@overeng/effect-schema-form-aria/src/components/TextField.tsx
@@ -48,8 +48,20 @@ const styles = stylex.create({
     borderColor: tokens.border,
     backgroundColor: tokens.input,
     color: tokens.ink,
-    outline: 'none',
-    boxShadow: { default: null, '[data-focus-visible]': `0 0 0 1px ${tokens.primary}` },
+    // The focus ring lives on `outline`, not `boxShadow`, so a decorative
+    // shadow can be added later without one of the two silently winning: StyleX
+    // writes one value per property, and a ring plus a shadow are two writers of
+    // `boxShadow`.
+    //
+    // NOT pixel-equivalent to the `0 0 0 1px` box-shadow ring it replaces, and
+    // the difference is a paint change rather than a layout one. Measured
+    // against a capture of the previous ring, with a self-comparison control at
+    // zero: identical canvas dimensions, 3856 of 73920 pixels differing (5.2%)
+    // at a maximum channel delta of 83, over a bounding box covering the whole
+    // ring perimeter rather than just the corners. So the band moves; it is not
+    // anti-aliasing noise. `outline-offset` is not part of the `outline`
+    // shorthand, so nothing is reset implicitly.
+    outline: { default: 'none', '[data-focus-visible]': `1px solid ${tokens.primary}` },
     opacity: { default: 1, ':disabled': 0.5 },
     cursor: { default: null, ':disabled': 'not-allowed' },
     '::placeholder': {


### PR DESCRIPTION
Top of stack #1177, on #1184. Moves the focus ring from `boxShadow` to `outline` at all four ring sites in the package.

## ⚠ This needs a human decision

**The conversion is not pixel-equivalent.** Accepting the convention means accepting a small visible change to the focus ring on **every field in the package**. That is a design call, not mine, so this PR stays draft until someone makes it.

## The measurement

The `FocusRing` stories added in #1183 caught this **on their first use** — which is the entire argument for having landed them first.

Captured before and after on one host. Self-comparison control at **0 differing pixels**. Canvas dimensions **identical** in every case, so this is paint, not layout:

| story | differing | max channel Δ |
|---|---|---|
| text / number / literal-trigger | **3856 / 73920 px (5.216%)** | 83 |
| optional-number (compact input) | 351 / 61440 px (0.571%) | 91 |

**The bounding box covers the whole ring perimeter, not the corners** — so the band moves. This is not anti-aliasing noise.

`box-shadow: 0 0 0 1px C` and `outline: 1px solid C` are therefore **not interchangeable**, which contradicts what I first wrote in these files. That comment is corrected in place, at the site, with the numbers.

**I have not tuned it back to byte-identical.** Matching a box-shadow's exact band with `outline-offset` would trade a *named visible delta* for an *unexplained coincidence*, and the second is worse.

## Why do it at all

StyleX writes **one value per property**. A ring and a decorative shadow are two writers of `boxShadow`, and when they meet one silently wins — no compile error, nothing for a type checker to see. That composed-shorthand collision is a confirmed defect class in this migration: the design system had **8 genuine same-element collisions** across 9 files where the two coexisted.

`LiteralField` already carries a real elevation shadow on `boxShadow` for its popover. Different element today — but a trigger is exactly the control that later grows one, and that is the pair that would have collided silently.

## One site called out in place

`NumberField`'s compact input is the **only** ring keyed on a pseudo-class rather than an attribute, which makes it the site exposed to the upstream `@stylexjs/shared@0.19.0` priority-table defect: pseudo-classes are spelled camelCase in that table, so `:focus-visible` falls through to the unknown-pseudo default of **40** while `:hover` sits at **130**.

Nothing writes `:hover` on `outline` there, so the two cannot meet — and **keeping the ring on its own property is what guarantees that, rather than luck.**

## Verified

- **Cold composite build**: `tsc --build` in a fresh worktree with **no `dist`** exits 0. That is the configuration CI has, and the one a warm tree cannot see past.
- Zero `boxShadow` focus sites remain; both surviving `boxShadow` uses are real elevation shadows.
- The comparator asserts equal dimensions and a non-empty file set rather than reporting a number, and its self-comparison control runs on every invocation.

## What is not claimed

That the new ring **looks better**, or that 5.2% is acceptable. Only that it is 5.2%, that it is paint rather than layout, and that nothing else in these files changed.

<!-- agent-footer:begin v=2 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | dev3.direct.omp.mhx73ur2 |
| `session` | dev3.mhx73ur2 |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.0.11 |
| `agent_runtime` | OMP 18.0.11 |
| `tooling_profile` | dotfiles@e8f0615-dirty |
</details>
<!-- agent-footer:end -->