### PR TITLE
fix(ci): clarify paired devenv perf evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3403,6 +3403,36 @@ jobs:
               done
 
               local base_ran_before_head=0 base_stdout base_stderr base_started base_ended base_status base_duration_ms
+              if [ "$phase" = "warmup" ] && [ "$CI_MEASUREMENT_PAIRED_ENABLED" -eq 1 ] && [ "$paired_baseline_enabled" -eq 1 ]; then
+                base_stdout="$ARTIFACT_DIR/$id.$sample_index.base.stdout"
+                base_stderr="$ARTIFACT_DIR/$id.$sample_index.base.stderr"
+                base_started="$(date +%s%3N)"
+                set +e
+                (cd "$CI_MEASUREMENT_BASE_DIR" && "${expanded[@]}") >"$base_stdout" 2>"$base_stderr"
+                base_status=$?
+                set -e
+                base_ended="$(date +%s%3N)"
+                base_duration_ms=$((base_ended - base_started))
+
+                if [ "$sample_first" -eq 0 ]; then
+                  printf ',' >>"$samples_file"
+                fi
+                sample_first=0
+                jq -cn \
+                  --argjson index "$sample_index" \
+                  --argjson status "$base_status" \
+                  --argjson durationMs "$base_duration_ms" \
+                  --arg stdout "$base_stdout" \
+                  --arg stderr "$base_stderr" \
+                  '{index:$index,measuredIndex:null,pairIndex:null,subject:"base",phase:"warmup",status:$status,durationMs:$durationMs,stdout:$stdout,stderr:$stderr,trace:null,order:null,orderSeed:null}' \
+                  >>"$samples_file"
+
+                if [ "$base_status" -ne 0 ]; then
+                  echo "::warning::$id paired baseline warmup failed after ${base_duration_ms}ms; measured pairs will still determine gate readiness"
+                  tail -40 "$base_stderr" || true
+                fi
+              fi
+
               if [ "$phase" = "measured" ] && [ "$CI_MEASUREMENT_PAIRED_ENABLED" -eq 1 ] && [ "$paired_baseline_enabled" -eq 1 ] && [ $(((measured_index + order_offset) % 2)) -eq 0 ]; then
                 base_ran_before_head=1
                 base_stdout="$ARTIFACT_DIR/$id.$sample_index.base.stdout"
@@ -3739,9 +3769,23 @@ jobs:
             {
               echo "### Devenv perf"
               echo ""
-              echo "| Probe | Status | Duration |"
-              echo "| --- | ---: | ---: |"
-              jq -r '.[] | "| \(.label // .id) | \(.status) | \(.durationMs) ms |"' "$ARTIFACT_DIR/timings.json"
+              echo "| Probe | Runs | Head total | Base total | Head median | Paired delta | Measured share |"
+              echo "| --- | ---: | ---: | ---: | ---: | ---: | ---: |"
+              jq -r '
+                def seconds:
+                  if . == null then "n/a" else ((. / 100 | round) / 10 | tostring) + " s" end;
+                (map([.samples[]?.durationMs] | add // 0) | add) as $allDurationMs
+                | .[]
+                | ([.samples[]? | select((.subject // "head") == "head") | .durationMs] | add // 0) as $headDurationMs
+                | ([.samples[]? | select(.subject == "base") | .durationMs] | add // 0) as $baseDurationMs
+                | ($headDurationMs + $baseDurationMs) as $probeDurationMs
+                | (
+                    if $allDurationMs == 0 then "0%"
+                    else (($probeDurationMs / $allDurationMs * 1000 | round) / 10 | tostring) + "%"
+                    end
+                  ) as $share
+                | "| \(.label // .id) | \(.samples | length) | \($headDurationMs | seconds) | \($baseDurationMs | seconds) | \(.statistics.medianDurationMs | seconds) | \(.statistics.pairedDeltaMedianDurationMs | seconds) | \($share) |"
+              ' "$ARTIFACT_DIR/timings.json"
               echo ""
               echo "- Artifact directory: \`$ARTIFACT_DIR\`"
               echo "- OTEL service: \`${OTEL_SERVICE_NAME:-unknown}\`"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **CI performance evidence**: run every gated probe's configured warmup against
+  both base and head worktrees, and report per-probe run counts, cumulative
+  head/base time, medians, paired deltas, and measured-time share in the GitHub
+  Actions summary.
+
 - **CI performance gate**: keep `devenv-perf` merge-blocking while giving its
   pull-request-only paired base/head plan a 90-minute budget and a 288 GB
   Namespace runner that can retain both Nix closures. Gate-disabled diagnostics

--- a/genie/ci-workflow/measurements.ts
+++ b/genie/ci-workflow/measurements.ts
@@ -838,6 +838,36 @@ measure() {
     done
 
     local base_ran_before_head=0 base_stdout base_stderr base_started base_ended base_status base_duration_ms
+    if [ "$phase" = "warmup" ] && [ "$CI_MEASUREMENT_PAIRED_ENABLED" -eq 1 ] && [ "$paired_baseline_enabled" -eq 1 ]; then
+      base_stdout="$ARTIFACT_DIR/$id.$sample_index.base.stdout"
+      base_stderr="$ARTIFACT_DIR/$id.$sample_index.base.stderr"
+      base_started="$(date +%s%3N)"
+      set +e
+      (cd "$CI_MEASUREMENT_BASE_DIR" && "${dollar}{expanded[@]}") >"$base_stdout" 2>"$base_stderr"
+      base_status=$?
+      set -e
+      base_ended="$(date +%s%3N)"
+      base_duration_ms=$((base_ended - base_started))
+
+      if [ "$sample_first" -eq 0 ]; then
+        printf ',' >>"$samples_file"
+      fi
+      sample_first=0
+      jq -cn \
+        --argjson index "$sample_index" \
+        --argjson status "$base_status" \
+        --argjson durationMs "$base_duration_ms" \
+        --arg stdout "$base_stdout" \
+        --arg stderr "$base_stderr" \
+        '{index:$index,measuredIndex:null,pairIndex:null,subject:"base",phase:"warmup",status:$status,durationMs:$durationMs,stdout:$stdout,stderr:$stderr,trace:null,order:null,orderSeed:null}' \
+        >>"$samples_file"
+
+      if [ "$base_status" -ne 0 ]; then
+        echo "::warning::$id paired baseline warmup failed after ${dollar}{base_duration_ms}ms; measured pairs will still determine gate readiness"
+        tail -40 "$base_stderr" || true
+      fi
+    fi
+
     if [ "$phase" = "measured" ] && [ "$CI_MEASUREMENT_PAIRED_ENABLED" -eq 1 ] && [ "$paired_baseline_enabled" -eq 1 ] && [ $(((measured_index + order_offset) % 2)) -eq 0 ]; then
       base_ran_before_head=1
       base_stdout="$ARTIFACT_DIR/$id.$sample_index.base.stdout"
@@ -1166,9 +1196,23 @@ if [ -n "${dollar}{GITHUB_STEP_SUMMARY:-}" ]; then
   {
     echo "### Devenv perf"
     echo ""
-    echo "| Probe | Status | Duration |"
-    echo "| --- | ---: | ---: |"
-    jq -r '.[] | "| \(.label // .id) | \(.status) | \(.durationMs) ms |"' "$ARTIFACT_DIR/timings.json"
+    echo "| Probe | Runs | Head total | Base total | Head median | Paired delta | Measured share |"
+    echo "| --- | ---: | ---: | ---: | ---: | ---: | ---: |"
+    jq -r '
+      def seconds:
+        if . == null then "n/a" else ((. / 100 | round) / 10 | tostring) + " s" end;
+      (map([.samples[]?.durationMs] | add // 0) | add) as $allDurationMs
+      | .[]
+      | ([.samples[]? | select((.subject // "head") == "head") | .durationMs] | add // 0) as $headDurationMs
+      | ([.samples[]? | select(.subject == "base") | .durationMs] | add // 0) as $baseDurationMs
+      | ($headDurationMs + $baseDurationMs) as $probeDurationMs
+      | (
+          if $allDurationMs == 0 then "0%"
+          else (($probeDurationMs / $allDurationMs * 1000 | round) / 10 | tostring) + "%"
+          end
+        ) as $share
+      | "| \(.label // .id) | \(.samples | length) | \($headDurationMs | seconds) | \($baseDurationMs | seconds) | \(.statistics.medianDurationMs | seconds) | \(.statistics.pairedDeltaMedianDurationMs | seconds) | \($share) |"
+    ' "$ARTIFACT_DIR/timings.json"
     echo ""
     echo "- Artifact directory: \`$ARTIFACT_DIR\`"
     echo "- OTEL service: \`${dollar}{OTEL_SERVICE_NAME:-unknown}\`"

--- a/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
@@ -867,6 +867,10 @@ describe('ci workflow devenv perf helpers', () => {
     expect(generatedCiWorkflowYamlSource).toContain(
       `paired_baseline_enabled="$(jq -r 'if .enabled == true then 1 else 0 end' <<<"$gate_policy")"`,
     )
+    expect(generatedCiWorkflowYamlSource).toContain(
+      `if [ "$phase" = "warmup" ] && [ "$CI_MEASUREMENT_PAIRED_ENABLED" -eq 1 ] && [ "$paired_baseline_enabled" -eq 1 ]; then`,
+    )
+    expect(generatedCiWorkflowYamlSource).toContain('subject:"base",phase:"warmup",status:$status')
     expect(generatedDevenvPerfJob).toContain('timeout-minutes: 90')
     expect(generatedDevenvPerfJob).toContain('nscloud-ubuntu-24.04-amd64-16x64-with-features')
     expect(generatedCiWorkflowYamlSource).toContain("measure 'shell_eval_warm' 'Warm shell eval'")
@@ -888,6 +892,12 @@ describe('ci workflow devenv perf helpers', () => {
     )
     expect(generatedCiWorkflowYamlSource).toContain('probeLabel: .label')
     expect(generatedCiWorkflowYamlSource).toContain('sampleCount: (.statistics.sampleCount // 1)')
+    expect(generatedCiWorkflowYamlSource).toContain(
+      '| Probe | Runs | Head total | Base total | Head median | Paired delta | Measured share |',
+    )
+    expect(generatedCiWorkflowYamlSource).toContain(
+      'map([.samples[]?.durationMs] | add // 0) | add',
+    )
     expect(generatedCiWorkflowYamlSource).toContain('baselineSources')
     expect(generatedCiWorkflowYamlSource).toContain('low_baseline_count')
     expect(generatedCiWorkflowYamlSource).toContain('low_current_sample_count')


### PR DESCRIPTION
## Problem

PR #1056 introduced paired base/head measurements, but configured warmups ran only against the head. The GitHub Actions summary also showed only the head median, which hid the 100-process protocol amplification and the cumulative base/head cost of each probe.

## Goal

Make paired evidence easier to interpret and ensure both subjects receive the configured warmup before measured pairs begin.

## Decisions

- Run each gated probe warmup against both base and head. Warmup samples remain excluded from paired gate statistics.
- Keep all sample counts and gate policies unchanged.
- Extend the existing job summary instead of introducing another artifact or reporting path.

## Verification

- `CI=1 devenv tasks run test:genie --no-tui` — passed.
- `CI=1 devenv tasks run check:quick --no-tui` — passed.
- `CI=1 devenv tasks run test:run --refresh-task-cache --no-tui` — passed and regenerated complete test proof summaries.
- `CI=1 devenv tasks run check:all --no-tui` — passed.
- The summary `jq` expression was exercised with representative base/head warmup and measured samples. It rendered run count, cumulative totals, medians, paired delta, and measured-time share.

## Complexity

No new abstraction or dependency. The change extends the existing measurement loop and summary projection.

## Concerns

A pull-request perf run now executes one additional base command for every configured warmup of a gated probe. The current effect-utils matrix adds eight processes. This increases runtime but removes the cold-base/warm-head asymmetry.

## Friction & bottlenecks

- The required perf protocol executes many serial CLI processes. The new summary makes that cost attributable per probe.
- A fresh composed worktree changed its physical member root during `check:quick`; subsequent validation had to continue from the composed member root.
- One full-gate attempt reused task-cache entries without complete test proof summaries. A forced real test run repaired the proof surface before the final green `check:all`.

## Follow-ups

Use the new per-probe totals to identify whether task loading, workspace status, or forced `check:quick` owns most non-Buck time before changing samples or task dependencies.

## References

- Follow-up to #1056.

<!-- agent-footer:begin v=2 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | dev3.direct.omp.p2sgp2j7 |
| `session` | dev3.p2sgp2j7 |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.0.11 |
| `agent_runtime` | OMP 18.0.11 |
| `tooling_profile` | dotfiles@b79dd7b-dirty |
</details>
<!-- agent-footer:end -->