### PR TITLE
feat(buck2): admit foundation TypeScript layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,12 @@ publish exited 1` with nothing to diagnose it by. `CpAMemberMountError` now
 
 ### Changed
 
+- **@overeng/utils-dev, @overeng/stylex-preset**: transfer TypeScript
+  typecheck and declaration emit to Buck as the first dependency-layer
+  admission. Public type conditions consume Buck declarations, legacy project
+  references are removed, and tui-react consumes utils-dev through its Buck
+  dist instead of a source-sibling copy.
+
 - **Buck2 TypeScript admissions**: localize admission declarations in each
   package's `BUCK.genie.ts` and derive root TypeScript authority, member dist
   overlays, declaration materialization, and Buck check targets from the same

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,7 +112,8 @@ publish exited 1` with nothing to diagnose it by. `CpAMemberMountError` now
 
 - **@overeng/utils-dev, @overeng/stylex-preset**: transfer TypeScript
   typecheck and declaration emit to Buck as the first dependency-layer
-  admission. Public type conditions consume Buck declarations, legacy project
+  admission. Public type conditions consume Buck declarations, explicit
+  handwritten declarations are copied as action inputs, legacy project
   references are removed, and tui-react consumes utils-dev through its Buck
   dist instead of a source-sibling copy.
 

--- a/buck2-member.json
+++ b/buck2-member.json
@@ -19,12 +19,20 @@
   ],
   "distOverlays": [
     {
+      "target": "//packages/@overeng/stylex-preset:dist",
+      "destination": "packages/@overeng/stylex-preset/dist"
+    },
+    {
       "target": "//packages/@overeng/tui-core:dist",
       "destination": "packages/@overeng/tui-core/dist"
     },
     {
       "target": "//packages/@overeng/tui-react:dist",
       "destination": "packages/@overeng/tui-react/dist"
+    },
+    {
+      "target": "//packages/@overeng/utils-dev:dist",
+      "destination": "packages/@overeng/utils-dev/dist"
     }
   ],
   "capabilities": [

--- a/buck2/typescript.bzl
+++ b/buck2/typescript.bzl
@@ -100,6 +100,10 @@ def _tsgo_emit_impl(ctx):
         ctx.attrs.declaration_entrypoint,
         directory.as_output(),
     ])
+    for declaration_path in sorted(ctx.attrs.declaration_sources.keys()):
+        _require_relative_path(declaration_path, "declaration source")
+        args.add("--copy-declaration", declaration_path)
+    args.add(cmd_args(hidden = ctx.attrs.declaration_sources.values()))
     ctx.actions.run(
         args,
         category = "tsgo_emit",
@@ -122,6 +126,11 @@ tsgo_emit = rule(
         "project": attrs.string(default = "tsconfig.json"),
         "out_dir": attrs.string(default = "dist"),
         "declaration_entrypoint": attrs.string(default = "src/mod.d.ts"),
+        "declaration_sources": attrs.dict(
+            key = attrs.string(),
+            value = attrs.source(),
+            default = {},
+        ),
         "_tsgo": attrs.default_only(attrs.exec_dep(
             default = "//buck2/toolchains:effect_tsgo",
             providers = [EffectTsgoToolchainInfo],

--- a/context/buck2/02-execution/.experiments/2026-09-02-foundation-layer-authority-transfer.md
+++ b/context/buck2/02-execution/.experiments/2026-09-02-foundation-layer-authority-transfer.md
@@ -1,0 +1,51 @@
+# Foundation-Layer TypeScript Authority Transfer
+
+Date: 2026-09-02 — Linux x86_64 — Buck2 pin 2026-08-22.
+
+## Question
+
+Can `@overeng/utils-dev` and `@overeng/stylex-preset` transfer TypeScript typecheck and declaration emit to Buck in one dependency-layer PR while each package retains exclusive authority, package-specific invalidation evidence, and its own deletion-ledger entry?
+
+## Method
+
+Both package-local `BUCK.genie.ts` declarations gained authority metadata. Package export type conditions now resolve to Buck-emitted declarations while runtime defaults remain at source, and both ordinary tsconfigs are write-free. The generated member manifest publishes both dist overlays. The root TypeScript solutions and all dependent project configs were regenerated after deleting legacy project-reference edges. tui-react's Buck package tree now consumes utils-dev through `//packages/@overeng/utils-dev:dist` instead of a source-sibling copy.
+
+The four package targets (`typecheck` and `dist` for both packages) were built together and repeated without changes. A deliberate `number`-to-`string` error was injected separately into `utils-dev/src/cli-contract.ts` and `stylex-preset/src/tokens.stylex.ts`, then each source was restored. A changelog-only mutation exercised irrelevant invalidation. For a fresh warm-cache context, the daemon was stopped and the composition root's generated Buck state was removed before rebuilding. A final run used an otherwise empty environment with a fresh writable HOME and a minimal system/devenv PATH. The `check:quick` task graph materialized declarations before the surviving root TypeScript check.
+
+## Result
+
+- **Target suite PASS:** the initial four-target build succeeded. `utils-dev` emitted `src/node-vitest/mod.d.ts`, `src/node-vitest/setup-fast-check.d.ts`, `src/otelite/mod.d.ts`, and `src/cli-contract.d.ts`; stylex-preset emitted `src/tokens.stylex.d.ts`.
+- **Warm no-op PASS:** the unchanged repeat completed in 0.3 s with zero network traffic and no executed actions.
+- **Fresh warm-cache context PASS:** after daemon shutdown and generated-state removal, 149/149 commands were cache hits, zero commands executed locally, and the Buck build completed in 3.8 s.
+- **Hostile environment PASS:** with an empty environment, fresh writable HOME, and minimal PATH, 149/149 commands were cache hits, zero commands executed locally, and the build completed in 2.3 s.
+- **Relevant mutation — utils-dev PASS:** Buck reported TS2322 in `src/cli-contract.ts`; restoring the source returned the target to green.
+- **Relevant mutation — stylex-preset PASS:** Buck reported TS2322 in `src/tokens.stylex.ts`; restoring the source returned the target to green.
+- **Irrelevant mutation PASS:** a `CHANGELOG.md`-only change completed in 1.03 s with no commands or network traffic.
+- **Buck target gate PASS:** `CI=1 devenv tasks run buck2:check --no-tui`
+  completed successfully in 3m22s with all authoritative typecheck targets.
+- **Integrated bridge PASS:** `CI=1 devenv tasks run check:quick --no-tui`
+  completed successfully in 4m54s; its dependency graph materialized all
+  authoritative declarations before the surviving root TypeScript check.
+- **Generated and Nix authority PASS:** `devenv tasks run genie:check --no-tui` passed after Evergreen refreshed the seven affected root-workspace pnpm FOD hashes.
+
+### Deletion ledger — `@overeng/utils-dev`
+
+- Removed utils-dev from both generated root TypeScript solutions.
+- Deleted 25 dependent project-reference edges.
+- Replaced tui-react's content-tracked utils-dev source sibling with its Buck `dist` edge.
+- Pointed all four public TypeScript export conditions at `dist/src/**/*.d.ts` and made the ordinary tsconfig write-free.
+- No package-local standalone check/build task existed to delete. `check-baseline-test-collection.ts` remains because it validates task collection rather than compiling utils-dev.
+
+### Deletion ledger — `@overeng/stylex-preset`
+
+- Deleted the two dependent project-reference edges in utils and effect-schema-form-aria.
+- Pointed the TypeScript-backed token export at `dist/src/tokens.stylex.d.ts`, preserved the handwritten Vite declaration and JS/CSS runtime exports, and made the ordinary tsconfig write-free.
+- stylex-preset was not a root solution project before admission, so no root-solution entry or standalone package check/build task existed to delete. Buck is now its repository check and declaration producer.
+
+## Conclusion
+
+The foundation dependency layer satisfies exclusive TypeScript authority and the admission budgets for both packages. Each package has an independent failure control and deletion ledger even though the packages land together. The next dependency layer can consume utils-dev only through its Buck declarations.
+
+## VRS Impact
+
+Discharges the next two Phase-3 package admissions under the dependency-layer PR strategy. BUCK-R06, BUCK-R07, BUCK-R09, BUCK-R12, and BUCK-R16 are re-evidenced for both transfers. No requirement change is needed.

--- a/context/buck2/02-execution/.experiments/2026-09-02-foundation-layer-authority-transfer.md
+++ b/context/buck2/02-execution/.experiments/2026-09-02-foundation-layer-authority-transfer.md
@@ -8,24 +8,26 @@ Can `@overeng/utils-dev` and `@overeng/stylex-preset` transfer TypeScript typech
 
 ## Method
 
-Both package-local `BUCK.genie.ts` declarations gained authority metadata. Package export type conditions now resolve to Buck-emitted declarations while runtime defaults remain at source, and both ordinary tsconfigs are write-free. The generated member manifest publishes both dist overlays. The root TypeScript solutions and all dependent project configs were regenerated after deleting legacy project-reference edges. tui-react's Buck package tree now consumes utils-dev through `//packages/@overeng/utils-dev:dist` instead of a source-sibling copy.
+Both package-local `BUCK.genie.ts` declarations gained authority metadata. Package export type conditions now resolve to Buck-emitted declarations while runtime defaults remain at source, and both ordinary tsconfigs are write-free. Explicit package-local `.d.ts` sources are action-keyed and copied into the emitted dist so stylex-preset's handwritten Vite declaration crosses the same authority boundary. The generated member manifest publishes both dist overlays. The root TypeScript solutions and all dependent project configs were regenerated after deleting legacy project-reference edges. tui-react's Buck package tree now consumes utils-dev through `//packages/@overeng/utils-dev:dist` instead of a source-sibling copy.
 
 The four package targets (`typecheck` and `dist` for both packages) were built together and repeated without changes. A deliberate `number`-to-`string` error was injected separately into `utils-dev/src/cli-contract.ts` and `stylex-preset/src/tokens.stylex.ts`, then each source was restored. A changelog-only mutation exercised irrelevant invalidation. For a fresh warm-cache context, the daemon was stopped and the composition root's generated Buck state was removed before rebuilding. A final run used an otherwise empty environment with a fresh writable HOME and a minimal system/devenv PATH. The `check:quick` task graph materialized declarations before the surviving root TypeScript check.
 
 ## Result
 
-- **Target suite PASS:** the initial four-target build succeeded. `utils-dev` emitted `src/node-vitest/mod.d.ts`, `src/node-vitest/setup-fast-check.d.ts`, `src/otelite/mod.d.ts`, and `src/cli-contract.d.ts`; stylex-preset emitted `src/tokens.stylex.d.ts`.
+- **Target suite PASS:** the initial four-target build succeeded. `utils-dev` emitted `src/node-vitest/mod.d.ts`, `src/node-vitest/setup-fast-check.d.ts`, `src/otelite/mod.d.ts`, and `src/cli-contract.d.ts`; stylex-preset emitted `src/tokens.stylex.d.ts` and copied `src/vite-types.d.ts` into the action output.
 - **Warm no-op PASS:** the unchanged repeat completed in 0.3 s with zero network traffic and no executed actions.
 - **Fresh warm-cache context PASS:** after daemon shutdown and generated-state removal, 149/149 commands were cache hits, zero commands executed locally, and the Buck build completed in 3.8 s.
 - **Hostile environment PASS:** with an empty environment, fresh writable HOME, and minimal PATH, 149/149 commands were cache hits, zero commands executed locally, and the build completed in 2.3 s.
 - **Relevant mutation — utils-dev PASS:** Buck reported TS2322 in `src/cli-contract.ts`; restoring the source returned the target to green.
 - **Relevant mutation — stylex-preset PASS:** Buck reported TS2322 in `src/tokens.stylex.ts`; restoring the source returned the target to green.
 - **Irrelevant mutation PASS:** a `CHANGELOG.md`-only change completed in 1.03 s with no commands or network traffic.
-- **Buck target gate PASS:** `CI=1 devenv tasks run buck2:check --no-tui`
-  completed successfully in 3m22s with all authoritative typecheck targets.
-- **Integrated bridge PASS:** `CI=1 devenv tasks run check:quick --no-tui`
-  completed successfully in 4m54s; its dependency graph materialized all
-  authoritative declarations before the surviving root TypeScript check.
+- **Buck target gate PASS:** after declaration-copy integration,
+  `CI=1 devenv tasks run buck2:check --no-tui` completed successfully in 5m51s
+  with all authoritative typecheck targets.
+- **Integrated bridge PASS:** the final
+  `CI=1 devenv tasks run check:quick --no-tui` completed successfully in 3m12s;
+  its dependency graph materialized all authoritative declarations before the
+  surviving root TypeScript check.
 - **Generated and Nix authority PASS:** `devenv tasks run genie:check --no-tui` passed after Evergreen refreshed the seven affected root-workspace pnpm FOD hashes.
 
 ### Deletion ledger — `@overeng/utils-dev`
@@ -39,7 +41,7 @@ The four package targets (`typecheck` and `dist` for both packages) were built t
 ### Deletion ledger — `@overeng/stylex-preset`
 
 - Deleted the two dependent project-reference edges in utils and effect-schema-form-aria.
-- Pointed the TypeScript-backed token export at `dist/src/tokens.stylex.d.ts`, preserved the handwritten Vite declaration and JS/CSS runtime exports, and made the ordinary tsconfig write-free.
+- Pointed both TypeScript-backed exports at their `dist/src/*.d.ts` files, copied the handwritten Vite declaration as an explicit action input, preserved JS/CSS runtime exports, and made the ordinary tsconfig write-free.
 - stylex-preset was not a root solution project before admission, so no root-solution entry or standalone package check/build task existed to delete. Buck is now its repository check and declaration producer.
 
 ## Conclusion

--- a/context/buck2/roadmap.md
+++ b/context/buck2/roadmap.md
@@ -166,6 +166,19 @@ RENAME_EXCHANGE advance.
   assembled package tree. The editor root install remains transitional until
   Phase 4 and is deliberately not deleted by this admission.
 
+- The first dependency-layer admission transfers `@overeng/utils-dev` and
+  `@overeng/stylex-preset` to their package-local Buck `typecheck` and `dist`
+  targets. Each package keeps source runtime defaults while its TypeScript
+  exports consume Buck declarations.
+- The utils-dev deletion-ledger entry removes it from both root solutions,
+  deletes 25 dependent project-reference edges, and changes tui-react's Buck
+  package tree from a utils-dev source sibling to its `dist`. The stylex-preset
+  entry deletes its two dependent project-reference edges; it had no prior root
+  solution entry or standalone package check/build task. Both ordinary
+  tsconfigs are write-free. The integrated gate and package-specific evidence
+  are retained in
+  [`2026-09-02-foundation-layer-authority-transfer.md`](./02-execution/.experiments/2026-09-02-foundation-layer-authority-transfer.md).
+
 ## Phase 4 — dependency-surface authority transfer (gated)
 
 - End-state per [decision 0015](./.decisions/0015-buck-owned-dependency-surface.md)

--- a/genie/buck2/typescript-admissions.ts
+++ b/genie/buck2/typescript-admissions.ts
@@ -70,12 +70,14 @@ export const authoritativeBuck2TypeScriptAdmissions = Object.values(
 )
 
 /** Dist overlays derived from the same package-local authority declarations. */
-export const buck2TypeScriptDistOverlays = authoritativeBuck2TypeScriptAdmissions.map(
-  ({ distTarget, packagePath }) => ({
+export const buck2TypeScriptDistOverlays = authoritativeBuck2TypeScriptAdmissions
+  .map(({ distTarget, packagePath }) => ({
     target: distTarget,
     destination: `${packagePath}/dist`,
-  }),
-)
+  }))
+  .toSorted((left, right) =>
+    Buffer.from(left.destination).compare(Buffer.from(right.destination)),
+  )
 
 /** Byte-sorted package paths whose editor dependency surface is currently admitted. */
 export const editorViewConsumerPackagePaths = Object.values(buck2TypeScriptAdmissions)

--- a/genie/buck2/typescript-admissions.unit.test.ts
+++ b/genie/buck2/typescript-admissions.unit.test.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'node:buffer'
 import process from 'node:process'
 
 import { describe, expect, it } from 'vitest'
@@ -32,10 +33,14 @@ describe('Buck2 TypeScript authority derivation', () => {
 
   it('derives manifest overlays and root TypeScript authority from the same entries', () => {
     expect(buck2TypeScriptDistOverlays).toEqual(
-      authoritativeBuck2TypeScriptAdmissions.map(({ distTarget, packagePath }) => ({
-        destination: `${packagePath}/dist`,
-        target: distTarget,
-      })),
+      authoritativeBuck2TypeScriptAdmissions
+        .map(({ distTarget, packagePath }) => ({
+          destination: `${packagePath}/dist`,
+          target: distTarget,
+        }))
+        .toSorted((left, right) =>
+          Buffer.from(left.destination).compare(Buffer.from(right.destination)),
+        ),
     )
 
     const projectedManifest = decodeBuckMemberManifestJson(
@@ -48,16 +53,18 @@ describe('Buck2 TypeScript authority derivation', () => {
         buck2Authority === undefined ? [] : [{ buck2Authority, path }],
       ),
     ).toEqual(
-      authoritativeBuck2TypeScriptAdmissions.map(
-        ({ distTarget, packagePath, typecheckTarget }) => ({
+      authoritativeBuck2TypeScriptAdmissions
+        .filter(({ packagePath }) =>
+          rootWorkspaceTsconfigProjects.some(({ path }) => path === packagePath),
+        )
+        .map(({ distTarget, packagePath, typecheckTarget }) => ({
           buck2Authority: {
             _tag: 'Buck2TypeScriptAuthority',
             emitTarget: distTarget,
             typecheckTarget,
           },
           path: packagePath,
-        }),
-      ),
+        })),
     )
   })
 })

--- a/genie/buck2/typescript-package-projection.ts
+++ b/genie/buck2/typescript-package-projection.ts
@@ -131,6 +131,7 @@ export const buck2TypeScriptPackageProjection = ({
     throw new Error(`Unsafe package project file: ${projectFile}`)
   }
   const packageSources = discoverPackageSources({ packagePath, sourceRoots })
+  const declarationSources = packageSources.filter((source) => source.endsWith('.d.ts'))
   const buckPackagePaths = new Set(
     [packagePath, ...workspaceSiblings.map((sibling) => sibling.packagePath)].filter((candidate) =>
       existsSync(path.join(process.cwd(), candidate, 'BUCK.genie.ts')),
@@ -216,6 +217,7 @@ export const buck2TypeScriptPackageProjection = ({
     packageName,
     packagePath,
     packageSources,
+    declarationSources,
     packageTreeRuntime: packageTreeRuntime.label,
     packageTreeRuntimeEntry: runtimeEntry,
     projectFile,
@@ -309,6 +311,10 @@ export const buck2TypeScriptPackageProjection = ({
       'tsgo_emit(',
       '    name = "dist",',
       '    package_tree = ":package_tree",',
+      ...renderMap({
+        name: 'declaration_sources',
+        entries: declarationSources.map((source) => [source, source]),
+      }),
       ...(projectFile === 'tsconfig.json' ? [] : [`    project = ${starlarkString(projectFile)},`]),
       ...(authority === undefined
         ? []

--- a/genie/buck2/typescript-package-projection.unit.test.ts
+++ b/genie/buck2/typescript-package-projection.unit.test.ts
@@ -116,6 +116,14 @@ describe('declared-closure package projection', () => {
 
     expect(output).toContain('    declaration_entrypoint = "src/tokens.stylex.d.ts",')
   })
+
+  it('projects only package-local handwritten declarations into emit inputs', () => {
+    expect(outputsByAdmission.stylexPreset).toContain(
+      '        "src/vite-types.d.ts": "src/vite-types.d.ts",',
+    )
+    expect(outputsByAdmission.utils).toContain('    declaration_sources = {')
+    expect(outputsByAdmission.utils).not.toContain('.d.ts":')
+  })
 })
 
 describe('same-cell label projection', () => {

--- a/packages/@overeng/agent-session-ingest/tsconfig.json
+++ b/packages/@overeng/agent-session-ingest/tsconfig.json
@@ -50,9 +50,6 @@
   "references": [
     {
       "path": "../utils"
-    },
-    {
-      "path": "../utils-dev"
     }
   ]
 }

--- a/packages/@overeng/agent-session-ingest/tsconfig.json.genie.ts
+++ b/packages/@overeng/agent-session-ingest/tsconfig.json.genie.ts
@@ -13,5 +13,5 @@ export default tsconfigJson({
     lib: ['ES2023'],
   },
   include: ['src/**/*'],
-  references: [{ path: '../utils' }, { path: '../utils-dev' }],
+  references: [{ path: '../utils' }],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/buck2-tools/src/typescript-runner.ts
+++ b/packages/@overeng/buck2-tools/src/typescript-runner.ts
@@ -1,7 +1,9 @@
+/* oxlint-disable overeng/exports-first -- Focused tests import narrow seams beside the private helpers they exercise. */
 import { createHash, type Hash } from 'node:crypto'
 import { createReadStream, type Stats } from 'node:fs'
 import {
   chmod,
+  copyFile,
   cp,
   lstat,
   mkdir,
@@ -14,6 +16,7 @@ import {
 } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 const signalNumbers = {
   SIGHUP: 1,
@@ -32,6 +35,7 @@ type TypecheckOptions = {
 
 type EmitOptions = {
   readonly declarationEntrypoint: string
+  readonly declarationSources: readonly string[]
   readonly outDir: string
   readonly output: string
   readonly packageTree: string
@@ -105,8 +109,24 @@ const parseTypecheckOptions = (args: readonly string[]): TypecheckOptions => {
   }
 }
 
-const parseEmitOptions = (args: readonly string[]): EmitOptions => {
-  requireExactArgumentCount({ args, command: 'emit', count: 6 })
+/** Parses the fail-closed emit command contract for focused rule/runner tests. */
+export const parseEmitOptions = (args: readonly string[]): EmitOptions => {
+  if (args.length < 6 || (args.length - 6) % 2 !== 0) {
+    fail(
+      `emit expected 6 arguments followed by declaration flag/path pairs, received ${args.length}`,
+    )
+  }
+  const declarationSources: string[] = []
+  for (let index = 6; index < args.length; index += 2) {
+    const flag = requireArgument({ args, index, name: 'declaration flag' })
+    if (flag !== '--copy-declaration') fail(`unexpected emit argument: ${flag}`)
+    declarationSources.push(
+      requireNormalizedRelativePath({
+        name: 'declaration source',
+        value: requireArgument({ args, index: index + 1, name: 'declaration source' }),
+      }),
+    )
+  }
   return {
     tsgo: requireTsgo(requireArgument({ args, index: 0, name: 'tsgo' })),
     packageTree: requireArgument({ args, index: 1, name: 'package tree' }),
@@ -123,6 +143,7 @@ const parseEmitOptions = (args: readonly string[]): EmitOptions => {
       value: requireArgument({ args, index: 4, name: 'declaration entrypoint' }),
     }),
     output: requireArgument({ args, index: 5, name: 'output' }),
+    declarationSources,
   }
 }
 
@@ -267,6 +288,39 @@ const prepareStagedOutput = async (options: {
   await symlink(resolve(output), stagedOutput)
 }
 
+/** Copies only the explicitly action-keyed declaration sources into an emitted dist. */
+export const copyDeclarationSources = async (options: {
+  readonly declarationSources: readonly string[]
+  readonly output: string
+  readonly packageRoot: string
+}): Promise<void> => {
+  await forEachSequential({
+    iterator: options.declarationSources.values(),
+    visit: async (candidate) => {
+      const relativePath = requireNormalizedRelativePath({
+        name: 'declaration source',
+        value: candidate,
+      })
+      const source = join(options.packageRoot, relativePath)
+      let metadata: Stats
+      try {
+        metadata = await lstat(source)
+      } catch (error) {
+        if (isErrnoException(error) === true && error.code === 'ENOENT') {
+          fail(`declaration source does not exist: ${relativePath}`)
+        }
+        throw error
+      }
+      if (metadata.isFile() === false) {
+        fail(`declaration source is not a regular file: ${relativePath}`)
+      }
+      const destination = join(options.output, relativePath)
+      await mkdir(dirname(destination), { recursive: true })
+      await copyFile(source, destination)
+    },
+  })
+}
+
 const validateOutput = async (options: {
   readonly declarationEntrypoint: string
   readonly output: string
@@ -399,8 +453,14 @@ const runEmit = async (options: EmitOptions): Promise<number> => {
       ],
       cwd: packageRoot,
     })
-    if (status === 0)
+    if (status === 0) {
+      await copyDeclarationSources({
+        declarationSources: options.declarationSources,
+        output,
+        packageRoot,
+      })
       await validateOutput({ declarationEntrypoint: options.declarationEntrypoint, output })
+    }
   } catch (error) {
     primaryError = error
   }
@@ -442,24 +502,27 @@ const removeSignalForwarding = (): void => {
   process.removeListener('SIGTERM', signalHandlers.SIGTERM)
 }
 
-const main = async (): Promise<number> => {
-  const [command, ...args] = process.argv.slice(2)
-  if (command === 'typecheck') return runTypecheck(parseTypecheckOptions(args))
-  if (command === 'emit') return runEmit(parseEmitOptions(args))
+/** Runs the hermetic TypeScript action selected by the Buck rule command. */
+export const runTypeScriptCli = async (args: readonly string[]): Promise<number> => {
+  const [command, ...commandArgs] = args
+  if (command === 'typecheck') return runTypecheck(parseTypecheckOptions(commandArgs))
+  if (command === 'emit') return runEmit(parseEmitOptions(commandArgs))
   return fail(`expected command "typecheck" or "emit", received ${command ?? '<missing>'}`)
 }
 
-installSignalForwarding()
-let status = 1
-try {
-  status = await main()
-} catch (error) {
-  console.error(formatError(error))
+if (process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  installSignalForwarding()
+  let status = 1
+  try {
+    status = await runTypeScriptCli(process.argv.slice(2))
+  } catch (error) {
+    console.error(formatError(error))
+  }
+  removeSignalForwarding()
+  if (forwardedSignal !== undefined) {
+    const signal = forwardedSignal
+    process.kill(process.pid, signal)
+    process.exit(128 + signalNumbers[signal])
+  }
+  process.exit(status)
 }
-removeSignalForwarding()
-if (forwardedSignal !== undefined) {
-  const signal = forwardedSignal
-  process.kill(process.pid, signal)
-  process.exit(128 + signalNumbers[signal])
-}
-process.exit(status)

--- a/packages/@overeng/buck2-tools/src/typescript-runner.unit.test.ts
+++ b/packages/@overeng/buck2-tools/src/typescript-runner.unit.test.ts
@@ -1,0 +1,114 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { copyDeclarationSources, parseEmitOptions } from './typescript-runner.ts'
+
+const scratchDirectories: string[] = []
+
+const createFixture = () => {
+  const root = mkdtempSync(join(tmpdir(), 'typescript-runner-'))
+  scratchDirectories.push(root)
+  const packageRoot = join(root, 'package')
+  const output = join(root, 'output')
+  mkdirSync(join(packageRoot, 'src'), { recursive: true })
+  mkdirSync(output)
+  return { root, packageRoot, output }
+}
+
+afterEach(() => {
+  for (const directory of scratchDirectories.splice(0)) rmSync(directory, { recursive: true })
+})
+
+describe('TypeScript emit declaration command', () => {
+  it('parses explicit normalized declaration paths', () => {
+    const options = parseEmitOptions([
+      '/nix/store/toolchain/bin/tsgo',
+      '/package-tree',
+      'tsconfig.json',
+      'dist',
+      'src/mod.d.ts',
+      '/output',
+      '--copy-declaration',
+      'src/vite-types.d.ts',
+    ])
+
+    expect(options.declarationSources).toEqual(['src/vite-types.d.ts'])
+  })
+
+  it.each(['../outside.d.ts', '/outside.d.ts', 'src\\outside.d.ts', 'src//outside.d.ts'])(
+    'rejects unsafe declaration path %s',
+    (declarationPath) => {
+      expect(() =>
+        parseEmitOptions([
+          '/nix/store/toolchain/bin/tsgo',
+          '/package-tree',
+          'tsconfig.json',
+          'dist',
+          'src/mod.d.ts',
+          '/output',
+          '--copy-declaration',
+          declarationPath,
+        ]),
+      ).toThrow('declaration source must be a normalized portable relative path')
+    },
+  )
+})
+
+describe('TypeScript handwritten declaration copy', () => {
+  it('copies only explicit files while preserving their package-relative paths', async () => {
+    const fixture = createFixture()
+    writeFileSync(join(fixture.packageRoot, 'src', 'vite-types.d.ts'), 'export type Vite = true\n')
+    writeFileSync(join(fixture.packageRoot, 'src', 'ambient.d.ts'), 'declare const ambient: true\n')
+
+    await copyDeclarationSources({
+      declarationSources: ['src/vite-types.d.ts'],
+      output: fixture.output,
+      packageRoot: fixture.packageRoot,
+    })
+
+    expect(readFileSync(join(fixture.output, 'src', 'vite-types.d.ts'), 'utf8')).toBe(
+      'export type Vite = true\n',
+    )
+    expect(existsSync(join(fixture.output, 'src', 'ambient.d.ts'))).toBe(false)
+  })
+
+  it('rejects missing, directory, and symlink inputs', async () => {
+    const fixture = createFixture()
+    mkdirSync(join(fixture.packageRoot, 'src', 'directory.d.ts'))
+    writeFileSync(join(fixture.root, 'outside.d.ts'), 'export type Outside = true\n')
+    symlinkSync(join(fixture.root, 'outside.d.ts'), join(fixture.packageRoot, 'src', 'link.d.ts'))
+
+    await expect(
+      copyDeclarationSources({
+        declarationSources: ['src/missing.d.ts'],
+        output: fixture.output,
+        packageRoot: fixture.packageRoot,
+      }),
+    ).rejects.toThrow('declaration source does not exist: src/missing.d.ts')
+    await expect(
+      copyDeclarationSources({
+        declarationSources: ['src/directory.d.ts'],
+        output: fixture.output,
+        packageRoot: fixture.packageRoot,
+      }),
+    ).rejects.toThrow('declaration source is not a regular file: src/directory.d.ts')
+    await expect(
+      copyDeclarationSources({
+        declarationSources: ['src/link.d.ts'],
+        output: fixture.output,
+        packageRoot: fixture.packageRoot,
+      }),
+    ).rejects.toThrow('declaration source is not a regular file: src/link.d.ts')
+  })
+})

--- a/packages/@overeng/buck2-tools/tsconfig.json
+++ b/packages/@overeng/buck2-tools/tsconfig.json
@@ -47,9 +47,5 @@
     "types": ["node", "bun"]
   },
   "include": ["src/**/*"],
-  "references": [
-    {
-      "path": "../utils-dev"
-    }
-  ]
+  "references": []
 }

--- a/packages/@overeng/buck2-tools/tsconfig.json.genie.ts
+++ b/packages/@overeng/buck2-tools/tsconfig.json.genie.ts
@@ -13,5 +13,5 @@ export default tsconfigJson({
     types: ['node', 'bun'],
   },
   include: ['src/**/*'],
-  references: [{ path: '../utils-dev' }],
+  references: [],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/ci-tools/nix/build.nix
+++ b/packages/@overeng/ci-tools/nix/build.nix
@@ -19,7 +19,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-l6YalkN284j9WsvU4Mph7c/Jt5p5V57UvXSJMiLYm9I=";
+      "." = mkSharedHash "sha256-qR3G1Ed7y+s2ZVc2+8vZZh2Rb0nvG27fovTS9E9STCo=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/ci-tools/nix/build.nix
+++ b/packages/@overeng/ci-tools/nix/build.nix
@@ -19,7 +19,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-B/cgkLCJhZ3WczIrFdNAgnfFvZyIQ64R304RYE+qx6E=";
+      "." = mkSharedHash "sha256-l6YalkN284j9WsvU4Mph7c/Jt5p5V57UvXSJMiLYm9I=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/ci-tools/tsconfig.json
+++ b/packages/@overeng/ci-tools/tsconfig.json
@@ -53,9 +53,6 @@
     },
     {
       "path": "../utils"
-    },
-    {
-      "path": "../utils-dev"
     }
   ]
 }

--- a/packages/@overeng/ci-tools/tsconfig.json.genie.ts
+++ b/packages/@overeng/ci-tools/tsconfig.json.genie.ts
@@ -13,5 +13,5 @@ export default tsconfigJson({
     types: ['node', 'bun'],
   },
   include: ['src/**/*', 'bin/**/*.ts'],
-  references: [{ path: '../otel-contract' }, { path: '../utils' }, { path: '../utils-dev' }],
+  references: [{ path: '../otel-contract' }, { path: '../utils' }],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/content-address/BUCK
+++ b/packages/@overeng/content-address/BUCK
@@ -4,7 +4,7 @@
 # Projection source: packages/@overeng/content-address/BUCK.genie.ts
 # Projection schema version: 1
 # Projection generator: effect-utils/genie/buck2-typescript-package-projection
-# Semantic fingerprint: sha256:b113a5cc4be457e0424af7ec4b1ff7a1a161f58435b55bb60055b4bfeb43c6f5
+# Semantic fingerprint: sha256:652236f7fc3083f79f3d8bd1d103165fa0749da594ae034f16e61e9fe59ed3c9
 # Semantic inputs: buck2/dependencies/BUCK.genie.ts, buck2/dependencies/pnpm-lock.sha256.json.genie.ts, genie/buck2/mod.ts, genie/buck2/typescript-package-projection.ts, package.json.genie.ts, packages/@overeng/buck2-tools/src/package-tree.ts, packages/@overeng/buck2-tools/src/real-path.ts, packages/@overeng/content-address/BUCK.genie.ts, packages/@overeng/content-address/BUCK.genie.ts, packages/@overeng/content-address/package.json.genie.ts, packages/@overeng/content-address/src/**/*.cts, packages/@overeng/content-address/src/**/*.mts, packages/@overeng/content-address/src/**/*.ts, packages/@overeng/content-address/src/**/*.tsx, packages/@overeng/content-address/tsconfig.json.genie.ts
 # Regenerate: devenv tasks run genie:run
 
@@ -58,5 +58,7 @@ tsgo_typecheck(
 tsgo_emit(
     name = "dist",
     package_tree = ":package_tree",
+    declaration_sources = {
+    },
     visibility = ["PUBLIC"],
 )

--- a/packages/@overeng/content-address/tsconfig.json
+++ b/packages/@overeng/content-address/tsconfig.json
@@ -47,9 +47,5 @@
     "types": ["node"]
   },
   "include": ["src/**/*"],
-  "references": [
-    {
-      "path": "../utils-dev"
-    }
-  ]
+  "references": []
 }

--- a/packages/@overeng/content-address/tsconfig.json.genie.ts
+++ b/packages/@overeng/content-address/tsconfig.json.genie.ts
@@ -12,5 +12,5 @@ export default tsconfigJson({
     ...nodeTypes,
   },
   include: ['src/**/*'],
-  references: [{ path: '../utils-dev' }],
+  references: [],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/effect-ai-claude-cli/tsconfig.json
+++ b/packages/@overeng/effect-ai-claude-cli/tsconfig.json
@@ -46,9 +46,5 @@
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo"
   },
   "include": ["src/**/*"],
-  "references": [
-    {
-      "path": "../utils-dev"
-    }
-  ]
+  "references": []
 }

--- a/packages/@overeng/effect-ai-claude-cli/tsconfig.json.genie.ts
+++ b/packages/@overeng/effect-ai-claude-cli/tsconfig.json.genie.ts
@@ -12,5 +12,5 @@ export default tsconfigJson({
     lib: domLib,
   },
   include: ['src/**/*'],
-  references: [{ path: '../utils-dev' }],
+  references: [],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/effect-distributed-lock/BUCK
+++ b/packages/@overeng/effect-distributed-lock/BUCK
@@ -4,7 +4,7 @@
 # Projection source: packages/@overeng/effect-distributed-lock/BUCK.genie.ts
 # Projection schema version: 1
 # Projection generator: effect-utils/genie/buck2-typescript-package-projection
-# Semantic fingerprint: sha256:11c89d69f0c6c79bdac0f806b353cc6f41d1ff7d3df652f232bb3bae9f9fe997
+# Semantic fingerprint: sha256:4009e76f6c1f767d7eac57d7854eced4c073e0b3b95ba8a9acdbae800c840149
 # Semantic inputs: buck2/dependencies/BUCK.genie.ts, buck2/dependencies/pnpm-lock.sha256.json.genie.ts, genie/buck2/mod.ts, genie/buck2/typescript-package-projection.ts, package.json.genie.ts, packages/@overeng/buck2-tools/src/package-tree.ts, packages/@overeng/buck2-tools/src/real-path.ts, packages/@overeng/effect-distributed-lock/BUCK.genie.ts, packages/@overeng/effect-distributed-lock/BUCK.genie.ts, packages/@overeng/effect-distributed-lock/package.json.genie.ts, packages/@overeng/effect-distributed-lock/src/**/*.cts, packages/@overeng/effect-distributed-lock/src/**/*.mts, packages/@overeng/effect-distributed-lock/src/**/*.ts, packages/@overeng/effect-distributed-lock/src/**/*.tsx, packages/@overeng/effect-distributed-lock/tsconfig.json.genie.ts
 # Regenerate: devenv tasks run genie:run
 
@@ -64,5 +64,7 @@ tsgo_typecheck(
 tsgo_emit(
     name = "dist",
     package_tree = ":package_tree",
+    declaration_sources = {
+    },
     visibility = ["PUBLIC"],
 )

--- a/packages/@overeng/effect-distributed-lock/tsconfig.json
+++ b/packages/@overeng/effect-distributed-lock/tsconfig.json
@@ -47,9 +47,5 @@
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo"
   },
   "include": ["src/**/*"],
-  "references": [
-    {
-      "path": "../utils-dev"
-    }
-  ]
+  "references": []
 }

--- a/packages/@overeng/effect-distributed-lock/tsconfig.json.genie.ts
+++ b/packages/@overeng/effect-distributed-lock/tsconfig.json.genie.ts
@@ -12,5 +12,5 @@ export default tsconfigJson({
     ...packageTsconfigCompilerOptions,
   },
   include: ['src/**/*'],
-  references: [{ path: '../utils-dev' }],
+  references: [],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/effect-path/tsconfig.json
+++ b/packages/@overeng/effect-path/tsconfig.json
@@ -47,9 +47,5 @@
     "types": ["node"]
   },
   "include": ["src/**/*"],
-  "references": [
-    {
-      "path": "../utils-dev"
-    }
-  ]
+  "references": []
 }

--- a/packages/@overeng/effect-path/tsconfig.json.genie.ts
+++ b/packages/@overeng/effect-path/tsconfig.json.genie.ts
@@ -13,5 +13,5 @@ export default tsconfigJson({
     lib: ['ES2023'],
   },
   include: ['src/**/*'],
-  references: [{ path: '../utils-dev' }],
+  references: [],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/effect-schema-form-aria/tsconfig.json
+++ b/packages/@overeng/effect-schema-form-aria/tsconfig.json
@@ -52,9 +52,6 @@
       "path": "../effect-schema-form"
     },
     {
-      "path": "../stylex-preset"
-    },
-    {
       "path": "../utils"
     }
   ]

--- a/packages/@overeng/effect-schema-form-aria/tsconfig.json.genie.ts
+++ b/packages/@overeng/effect-schema-form-aria/tsconfig.json.genie.ts
@@ -15,9 +15,5 @@ export default tsconfigJson({
     lib: [...domLib],
   },
   include: ['src/**/*'],
-  references: [
-    { path: '../effect-schema-form' },
-    { path: '../stylex-preset' },
-    { path: '../utils' },
-  ],
+  references: [{ path: '../effect-schema-form' }, { path: '../utils' }],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/genie/nix/build.nix
+++ b/packages/@overeng/genie/nix/build.nix
@@ -26,7 +26,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-H5i7VtlBNVLESBX34CzvXPtZx5Q6RnMUX7bk0ePgQIU=";
+      "." = mkSharedHash "sha256-83aAkFJUhroya+6XE8E36gzkvydmG8MvUYcGvk7QZ6g=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/genie/nix/build.nix
+++ b/packages/@overeng/genie/nix/build.nix
@@ -26,7 +26,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-83aAkFJUhroya+6XE8E36gzkvydmG8MvUYcGvk7QZ6g=";
+      "." = mkSharedHash "sha256-LZgGnj38X8RbcfmlNkrIYaF6UHyvW+5lBXCHJ6jjUEI=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/genie/tsconfig.json
+++ b/packages/@overeng/genie/tsconfig.json
@@ -54,9 +54,6 @@
     },
     {
       "path": "../utils"
-    },
-    {
-      "path": "../utils-dev"
     }
   ]
 }

--- a/packages/@overeng/genie/tsconfig.json.genie.ts
+++ b/packages/@overeng/genie/tsconfig.json.genie.ts
@@ -14,5 +14,5 @@ export default tsconfigJson({
     jsx: 'react-jsx',
   },
   include: ['src/**/*.ts', 'src/**/*.tsx', 'bin/**/*.ts', 'bin/**/*.tsx'],
-  references: [{ path: '../otel-contract' }, { path: '../utils' }, { path: '../utils-dev' }],
+  references: [{ path: '../otel-contract' }, { path: '../utils' }],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/kdl-effect/tsconfig.json
+++ b/packages/@overeng/kdl-effect/tsconfig.json
@@ -50,9 +50,6 @@
   "references": [
     {
       "path": "../kdl"
-    },
-    {
-      "path": "../utils-dev"
     }
   ]
 }

--- a/packages/@overeng/kdl-effect/tsconfig.json.genie.ts
+++ b/packages/@overeng/kdl-effect/tsconfig.json.genie.ts
@@ -12,5 +12,5 @@ export default tsconfigJson({
     ...nodeTypes,
   },
   include: ['src/**/*'],
-  references: [{ path: '../kdl' }, { path: '../utils-dev' }],
+  references: [{ path: '../kdl' }],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/kdl/tsconfig.json
+++ b/packages/@overeng/kdl/tsconfig.json
@@ -47,9 +47,5 @@
     "types": ["node"]
   },
   "include": ["src/**/*"],
-  "references": [
-    {
-      "path": "../utils-dev"
-    }
-  ]
+  "references": []
 }

--- a/packages/@overeng/kdl/tsconfig.json.genie.ts
+++ b/packages/@overeng/kdl/tsconfig.json.genie.ts
@@ -12,5 +12,5 @@ export default tsconfigJson({
     ...nodeTypes,
   },
   include: ['src/**/*'],
-  references: [{ path: '../utils-dev' }],
+  references: [],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/megarepo/nix/build.nix
+++ b/packages/@overeng/megarepo/nix/build.nix
@@ -26,7 +26,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-GtREX8LTC77/DXb3zdv+1/kn8jnwwvN9CY+6H9aFJbs=";
+      "." = mkSharedHash "sha256-4mQlTzs81XbEaXcifKlmxxsk/5qSQD65axj/YdSGSzc=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     smokeTestArgs = [ "--help" ];

--- a/packages/@overeng/megarepo/nix/build.nix
+++ b/packages/@overeng/megarepo/nix/build.nix
@@ -26,7 +26,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-4mQlTzs81XbEaXcifKlmxxsk/5qSQD65axj/YdSGSzc=";
+      "." = mkSharedHash "sha256-VG8f4ZzGOgiMrjtIwi4BFXVrn3yDPnu/s1WHdQP5sJg=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     smokeTestArgs = [ "--help" ];

--- a/packages/@overeng/megarepo/tsconfig.json
+++ b/packages/@overeng/megarepo/tsconfig.json
@@ -63,9 +63,6 @@
     },
     {
       "path": "../utils"
-    },
-    {
-      "path": "../utils-dev"
     }
   ]
 }

--- a/packages/@overeng/megarepo/tsconfig.json.genie.ts
+++ b/packages/@overeng/megarepo/tsconfig.json.genie.ts
@@ -21,6 +21,5 @@ export default tsconfigJson({
     { path: '../kdl-effect' },
     { path: '../otel-contract' },
     { path: '../utils' },
-    { path: '../utils-dev' },
   ],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/notion-cli/nix/build.nix
+++ b/packages/@overeng/notion-cli/nix/build.nix
@@ -33,7 +33,7 @@ let
     installRuntimeWorkspace = true;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-Til8x1WHCCNeFQAz66VpZArxtK21DCdyYRZLslpv6pA=";
+      "." = mkSharedHash "sha256-nrmcC4WIyaI295dTUmWu+5gi/vhdeuu4NMoLLWXZuZs=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/notion-cli/nix/build.nix
+++ b/packages/@overeng/notion-cli/nix/build.nix
@@ -33,7 +33,7 @@ let
     installRuntimeWorkspace = true;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-nrmcC4WIyaI295dTUmWu+5gi/vhdeuu4NMoLLWXZuZs=";
+      "." = mkSharedHash "sha256-Kwgyg5nn3cNpxA9i/0nS6JpNW/rADMDATpbu/Z+qDPE=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/notion-cli/tsconfig.json
+++ b/packages/@overeng/notion-cli/tsconfig.json
@@ -68,9 +68,6 @@
     },
     {
       "path": "../utils"
-    },
-    {
-      "path": "../utils-dev"
     }
   ]
 }

--- a/packages/@overeng/notion-cli/tsconfig.json.genie.ts
+++ b/packages/@overeng/notion-cli/tsconfig.json.genie.ts
@@ -20,6 +20,5 @@ export default tsconfigJson({
     { path: '../notion-effect-schema' },
     { path: '../otel-contract' },
     { path: '../utils' },
-    { path: '../utils-dev' },
   ],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/notion-core/tsconfig.json
+++ b/packages/@overeng/notion-core/tsconfig.json
@@ -47,9 +47,5 @@
     "types": ["node"]
   },
   "include": ["src/**/*"],
-  "references": [
-    {
-      "path": "../utils-dev"
-    }
-  ]
+  "references": []
 }

--- a/packages/@overeng/notion-core/tsconfig.json.genie.ts
+++ b/packages/@overeng/notion-core/tsconfig.json.genie.ts
@@ -12,5 +12,5 @@ export default tsconfigJson({
     ...nodeTypes,
   },
   include: ['src/**/*'],
-  references: [{ path: '../utils-dev' }],
+  references: [],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/notion-effect-client/tsconfig.json
+++ b/packages/@overeng/notion-effect-client/tsconfig.json
@@ -62,9 +62,6 @@
     },
     {
       "path": "../utils"
-    },
-    {
-      "path": "../utils-dev"
     }
   ]
 }

--- a/packages/@overeng/notion-effect-client/tsconfig.json.genie.ts
+++ b/packages/@overeng/notion-effect-client/tsconfig.json.genie.ts
@@ -18,6 +18,5 @@ export default tsconfigJson({
     { path: '../notion-effect-schema' },
     { path: '../otel-contract' },
     { path: '../utils' },
-    { path: '../utils-dev' },
   ],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/notion-effect-schema/tsconfig.json
+++ b/packages/@overeng/notion-effect-schema/tsconfig.json
@@ -50,9 +50,6 @@
   "references": [
     {
       "path": "../notion-core"
-    },
-    {
-      "path": "../utils-dev"
     }
   ]
 }

--- a/packages/@overeng/notion-effect-schema/tsconfig.json.genie.ts
+++ b/packages/@overeng/notion-effect-schema/tsconfig.json.genie.ts
@@ -12,5 +12,5 @@ export default tsconfigJson({
     ...nodeTypes,
   },
   include: ['src/**/*'],
-  references: [{ path: '../notion-core' }, { path: '../utils-dev' }],
+  references: [{ path: '../notion-core' }],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/notion-md/nix/build.nix
+++ b/packages/@overeng/notion-md/nix/build.nix
@@ -20,7 +20,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-r5nkolldVWPUzXgbYDg5C7VtFOLBGVxiprcKDi7l80U=";
+      "." = mkSharedHash "sha256-3ljec1KeAj1v0gIzPMtg5kF8/b7euEXRi90Sqn74gn8=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/notion-md/nix/build.nix
+++ b/packages/@overeng/notion-md/nix/build.nix
@@ -20,7 +20,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-3ljec1KeAj1v0gIzPMtg5kF8/b7euEXRi90Sqn74gn8=";
+      "." = mkSharedHash "sha256-T+n0ksfiYHMImkCT6pxiQ3v6UVGjMqFjJRbwsLs+IS4=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/notion-md/tsconfig.json
+++ b/packages/@overeng/notion-md/tsconfig.json
@@ -69,9 +69,6 @@
     },
     {
       "path": "../utils"
-    },
-    {
-      "path": "../utils-dev"
     }
   ]
 }

--- a/packages/@overeng/notion-md/tsconfig.json.genie.ts
+++ b/packages/@overeng/notion-md/tsconfig.json.genie.ts
@@ -23,6 +23,5 @@ export default tsconfigJson({
     { path: '../notion-property-write' },
     { path: '../otel-contract' },
     { path: '../utils' },
-    { path: '../utils-dev' },
   ],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/notion-property-write/tsconfig.json
+++ b/packages/@overeng/notion-property-write/tsconfig.json
@@ -50,9 +50,6 @@
   "references": [
     {
       "path": "../notion-effect-schema"
-    },
-    {
-      "path": "../utils-dev"
     }
   ]
 }

--- a/packages/@overeng/notion-property-write/tsconfig.json.genie.ts
+++ b/packages/@overeng/notion-property-write/tsconfig.json.genie.ts
@@ -12,5 +12,5 @@ export default tsconfigJson({
     ...nodeTypes,
   },
   include: ['src/**/*'],
-  references: [{ path: '../notion-effect-schema' }, { path: '../utils-dev' }],
+  references: [{ path: '../notion-effect-schema' }],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/notion-react/tsconfig.json
+++ b/packages/@overeng/notion-react/tsconfig.json
@@ -64,9 +64,6 @@
     },
     {
       "path": "../utils"
-    },
-    {
-      "path": "../utils-dev"
     }
   ]
 }

--- a/packages/@overeng/notion-react/tsconfig.json.genie.ts
+++ b/packages/@overeng/notion-react/tsconfig.json.genie.ts
@@ -23,6 +23,5 @@ export default tsconfigJson({
     { path: '../notion-md' },
     { path: '../otel-contract' },
     { path: '../utils' },
-    { path: '../utils-dev' },
   ],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/npm-release/nix/build.nix
+++ b/packages/@overeng/npm-release/nix/build.nix
@@ -20,7 +20,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-8lDViRxquFfelhs6M+DmSHS+tYtA3B6Iqf4vb4/Xb+Q=";
+      "." = mkSharedHash "sha256-jiFK45l+d04OZB1SlfG/Srgfkm7V3Ohd0p9bmPbApS8=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/npm-release/tsconfig.json
+++ b/packages/@overeng/npm-release/tsconfig.json
@@ -47,9 +47,5 @@
     "types": ["node"]
   },
   "include": ["src/**/*"],
-  "references": [
-    {
-      "path": "../utils-dev"
-    }
-  ]
+  "references": []
 }

--- a/packages/@overeng/npm-release/tsconfig.json.genie.ts
+++ b/packages/@overeng/npm-release/tsconfig.json.genie.ts
@@ -12,5 +12,5 @@ export default tsconfigJson({
     ...nodeTypes,
   },
   include: ['src/**/*'],
-  references: [{ path: '../utils-dev' }],
+  references: [],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/otel-contract/BUCK
+++ b/packages/@overeng/otel-contract/BUCK
@@ -4,7 +4,7 @@
 # Projection source: packages/@overeng/otel-contract/BUCK.genie.ts
 # Projection schema version: 1
 # Projection generator: effect-utils/genie/buck2-typescript-package-projection
-# Semantic fingerprint: sha256:977f7bdf344a3cc7ebf3adcec113a855004a6e44dbe25849c7ada0ca8f6324f4
+# Semantic fingerprint: sha256:42878eb4db4e5a1025eed0d7b374c82c29f3b6fee67a340ded33771c5e41d9a5
 # Semantic inputs: buck2/dependencies/BUCK.genie.ts, buck2/dependencies/pnpm-lock.sha256.json.genie.ts, genie/buck2/mod.ts, genie/buck2/typescript-package-projection.ts, package.json.genie.ts, packages/@overeng/buck2-tools/src/package-tree.ts, packages/@overeng/buck2-tools/src/real-path.ts, packages/@overeng/otel-contract/BUCK.genie.ts, packages/@overeng/otel-contract/BUCK.genie.ts, packages/@overeng/otel-contract/package.json.genie.ts, packages/@overeng/otel-contract/src/**/*.cts, packages/@overeng/otel-contract/src/**/*.mts, packages/@overeng/otel-contract/src/**/*.ts, packages/@overeng/otel-contract/src/**/*.tsx, packages/@overeng/otel-contract/tsconfig.json.genie.ts
 # Regenerate: devenv tasks run genie:run
 
@@ -82,5 +82,7 @@ tsgo_typecheck(
 tsgo_emit(
     name = "dist",
     package_tree = ":package_tree",
+    declaration_sources = {
+    },
     visibility = ["PUBLIC"],
 )

--- a/packages/@overeng/otel-contract/tsconfig.json
+++ b/packages/@overeng/otel-contract/tsconfig.json
@@ -51,9 +51,6 @@
   "references": [
     {
       "path": "../content-address"
-    },
-    {
-      "path": "../utils-dev"
     }
   ]
 }

--- a/packages/@overeng/otel-contract/tsconfig.json.genie.ts
+++ b/packages/@overeng/otel-contract/tsconfig.json.genie.ts
@@ -13,5 +13,5 @@ export default tsconfigJson({
   },
   include: ['src/**/*'],
   exclude: ['src/**/*.genie.ts'],
-  references: [{ path: '../content-address' }, { path: '../utils-dev' }],
+  references: [{ path: '../content-address' }],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/pty-effect/tsconfig.json
+++ b/packages/@overeng/pty-effect/tsconfig.json
@@ -50,9 +50,6 @@
   "references": [
     {
       "path": "../otel-contract"
-    },
-    {
-      "path": "../utils-dev"
     }
   ]
 }

--- a/packages/@overeng/pty-effect/tsconfig.json.genie.ts
+++ b/packages/@overeng/pty-effect/tsconfig.json.genie.ts
@@ -12,5 +12,5 @@ export default tsconfigJson({
     ...nodeTypes,
   },
   include: ['src/**/*'],
-  references: [{ path: '../otel-contract' }, { path: '../utils-dev' }],
+  references: [{ path: '../otel-contract' }],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/restate-effect/tsconfig.json
+++ b/packages/@overeng/restate-effect/tsconfig.json
@@ -53,9 +53,6 @@
     },
     {
       "path": "../utils"
-    },
-    {
-      "path": "../utils-dev"
     }
   ]
 }

--- a/packages/@overeng/restate-effect/tsconfig.json.genie.ts
+++ b/packages/@overeng/restate-effect/tsconfig.json.genie.ts
@@ -12,5 +12,5 @@ export default tsconfigJson({
     ...nodeTypes,
   },
   include: ['src/**/*', 'examples/**/*'],
-  references: [{ path: '../otel-contract' }, { path: '../utils' }, { path: '../utils-dev' }],
+  references: [{ path: '../otel-contract' }, { path: '../utils' }],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/stylex-preset/BUCK
+++ b/packages/@overeng/stylex-preset/BUCK
@@ -60,5 +60,6 @@ tsgo_typecheck(
 tsgo_emit(
     name = "dist",
     package_tree = ":package_tree",
+    declaration_entrypoint = "src/tokens.stylex.d.ts",
     visibility = ["PUBLIC"],
 )

--- a/packages/@overeng/stylex-preset/BUCK
+++ b/packages/@overeng/stylex-preset/BUCK
@@ -4,7 +4,7 @@
 # Projection source: packages/@overeng/stylex-preset/BUCK.genie.ts
 # Projection schema version: 1
 # Projection generator: effect-utils/genie/buck2-typescript-package-projection
-# Semantic fingerprint: sha256:cb268f2d4c2603f6be872c75120e8065f3ef6350ff34112ca1423ee24ec74f08
+# Semantic fingerprint: sha256:58e302c7e082880af89b0c49c8d887d0ad5afd2fed58f8d95f22bcfdbba9f276
 # Semantic inputs: buck2/dependencies/BUCK.genie.ts, buck2/dependencies/pnpm-lock.sha256.json.genie.ts, genie/buck2/mod.ts, genie/buck2/typescript-package-projection.ts, package.json.genie.ts, packages/@overeng/buck2-tools/src/package-tree.ts, packages/@overeng/buck2-tools/src/real-path.ts, packages/@overeng/stylex-preset/BUCK.genie.ts, packages/@overeng/stylex-preset/BUCK.genie.ts, packages/@overeng/stylex-preset/package.json.genie.ts, packages/@overeng/stylex-preset/src/**/*.cts, packages/@overeng/stylex-preset/src/**/*.mts, packages/@overeng/stylex-preset/src/**/*.ts, packages/@overeng/stylex-preset/src/**/*.tsx, packages/@overeng/stylex-preset/tsconfig.json.genie.ts
 # Regenerate: devenv tasks run genie:run
 
@@ -60,6 +60,9 @@ tsgo_typecheck(
 tsgo_emit(
     name = "dist",
     package_tree = ":package_tree",
+    declaration_sources = {
+        "src/vite-types.d.ts": "src/vite-types.d.ts",
+    },
     declaration_entrypoint = "src/tokens.stylex.d.ts",
     visibility = ["PUBLIC"],
 )

--- a/packages/@overeng/stylex-preset/BUCK.genie.ts
+++ b/packages/@overeng/stylex-preset/BUCK.genie.ts
@@ -8,6 +8,10 @@ export const buck2TypeScriptAdmission = {
   projectionSource: 'packages/@overeng/stylex-preset/BUCK.genie.ts',
   sourceRoots: ['src'],
   editorViewConsumer: false,
+  authority: {
+    declarationEntrypoint: 'src/tokens.stylex.d.ts',
+    projectFile: 'tsconfig.json',
+  },
 } as const satisfies Buck2TypeScriptAdmission
 
 export default buck2TypeScriptPackageProjection(buck2TypeScriptAdmission)

--- a/packages/@overeng/stylex-preset/package.json
+++ b/packages/@overeng/stylex-preset/package.json
@@ -11,7 +11,7 @@
       "default": "./src/tokens.stylex.ts"
     },
     "./vite": {
-      "types": "./src/vite-types.d.ts",
+      "types": "./dist/src/vite-types.d.ts",
       "default": "./src/vite.js"
     }
   },

--- a/packages/@overeng/stylex-preset/package.json
+++ b/packages/@overeng/stylex-preset/package.json
@@ -6,7 +6,10 @@
   "type": "module",
   "exports": {
     "./preflight.css": "./src/preflight.css",
-    "./tokens.stylex": "./src/tokens.stylex.ts",
+    "./tokens.stylex": {
+      "types": "./dist/src/tokens.stylex.d.ts",
+      "default": "./src/tokens.stylex.ts"
+    },
     "./vite": {
       "types": "./src/vite-types.d.ts",
       "default": "./src/vite.js"

--- a/packages/@overeng/stylex-preset/package.json.genie.ts
+++ b/packages/@overeng/stylex-preset/package.json.genie.ts
@@ -28,7 +28,10 @@ export default packageJson(
     ...privatePackageDefaults,
     description: 'Shared StyleX design tokens, preflight styles, and Vite integration',
     exports: {
-      './tokens.stylex': exportEntry('./src/tokens.stylex.ts', { environment: 'browser' }),
+      './tokens.stylex': exportEntry(
+        { types: './dist/src/tokens.stylex.d.ts', default: './src/tokens.stylex.ts' },
+        { environment: 'browser' },
+      ),
       './preflight.css': exportEntry('./src/preflight.css', { environment: 'browser' }),
       './vite': exportEntry(
         {

--- a/packages/@overeng/stylex-preset/package.json.genie.ts
+++ b/packages/@overeng/stylex-preset/package.json.genie.ts
@@ -35,7 +35,7 @@ export default packageJson(
       './preflight.css': exportEntry('./src/preflight.css', { environment: 'browser' }),
       './vite': exportEntry(
         {
-          types: './src/vite-types.d.ts',
+          types: './dist/src/vite-types.d.ts',
           default: './src/vite.js',
         },
         { environment: 'node' },

--- a/packages/@overeng/stylex-preset/tsconfig.json
+++ b/packages/@overeng/stylex-preset/tsconfig.json
@@ -44,7 +44,8 @@
     "composite": true,
     "rootDir": ".",
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
-    "checkJs": true
+    "checkJs": true,
+    "noEmit": true
   },
   "include": ["src/**/*"]
 }

--- a/packages/@overeng/stylex-preset/tsconfig.json.genie.ts
+++ b/packages/@overeng/stylex-preset/tsconfig.json.genie.ts
@@ -11,6 +11,7 @@ export default tsconfigJson({
     ...packageTsconfigCompilerOptions,
     allowJs: true,
     checkJs: true,
+    noEmit: true,
     lib: [...domLib],
   },
   include: ['src/**/*'],

--- a/packages/@overeng/tui-core/BUCK
+++ b/packages/@overeng/tui-core/BUCK
@@ -4,7 +4,7 @@
 # Projection source: packages/@overeng/tui-core/BUCK.genie.ts
 # Projection schema version: 1
 # Projection generator: effect-utils/genie/buck2-typescript-package-projection
-# Semantic fingerprint: sha256:bf1c0240b87370e99658fcf2dcfdf8f258308615da4f6094d499e1580889c1c7
+# Semantic fingerprint: sha256:08f3840576365cb50c27959e94c1b3e1c0e509d62d00a585a774fc8e919f5666
 # Semantic inputs: buck2/dependencies/BUCK.genie.ts, buck2/dependencies/pnpm-lock.sha256.json.genie.ts, genie/buck2/mod.ts, genie/buck2/typescript-package-projection.ts, package.json.genie.ts, packages/@overeng/buck2-tools/src/package-tree.ts, packages/@overeng/buck2-tools/src/real-path.ts, packages/@overeng/tui-core/BUCK.genie.ts, packages/@overeng/tui-core/BUCK.genie.ts, packages/@overeng/tui-core/package.json.genie.ts, packages/@overeng/tui-core/src/**/*.cts, packages/@overeng/tui-core/src/**/*.mts, packages/@overeng/tui-core/src/**/*.ts, packages/@overeng/tui-core/src/**/*.tsx, packages/@overeng/tui-core/test/**/*.cts, packages/@overeng/tui-core/test/**/*.mts, packages/@overeng/tui-core/test/**/*.ts, packages/@overeng/tui-core/test/**/*.tsx, packages/@overeng/tui-core/tsconfig.json.genie.ts
 # Regenerate: devenv tasks run genie:run
 
@@ -68,6 +68,8 @@ tsgo_typecheck(
 tsgo_emit(
     name = "dist",
     package_tree = ":package_tree",
+    declaration_sources = {
+    },
     declaration_entrypoint = "src/mod.d.ts",
     visibility = ["PUBLIC"],
 )

--- a/packages/@overeng/tui-react/BUCK
+++ b/packages/@overeng/tui-react/BUCK
@@ -4,7 +4,7 @@
 # Projection source: packages/@overeng/tui-react/BUCK.genie.ts
 # Projection schema version: 1
 # Projection generator: effect-utils/genie/buck2-typescript-package-projection
-# Semantic fingerprint: sha256:9ee40ab9d6570de7b416721422e2473f56cf2209ccc3d57541b675bc65f70a17
+# Semantic fingerprint: sha256:0c4a29b58f6d772876e7402be60c62cb0a9fc81658e81095fd7297130aacf7dc
 # Semantic inputs: buck2/dependencies/BUCK.genie.ts, buck2/dependencies/pnpm-lock.sha256.json.genie.ts, genie/buck2/mod.ts, genie/buck2/typescript-package-projection.ts, package.json.genie.ts, packages/@overeng/buck2-tools/src/package-tree.ts, packages/@overeng/buck2-tools/src/real-path.ts, packages/@overeng/tui-core/BUCK.genie.ts, packages/@overeng/tui-core/package.json.genie.ts, packages/@overeng/tui-react/BUCK.genie.ts, packages/@overeng/tui-react/BUCK.genie.ts, packages/@overeng/tui-react/examples/**/*.cts, packages/@overeng/tui-react/examples/**/*.mts, packages/@overeng/tui-react/examples/**/*.ts, packages/@overeng/tui-react/examples/**/*.tsx, packages/@overeng/tui-react/package.json.genie.ts, packages/@overeng/tui-react/src/**/*.cts, packages/@overeng/tui-react/src/**/*.mts, packages/@overeng/tui-react/src/**/*.ts, packages/@overeng/tui-react/src/**/*.tsx, packages/@overeng/tui-react/test/**/*.cts, packages/@overeng/tui-react/test/**/*.mts, packages/@overeng/tui-react/test/**/*.ts, packages/@overeng/tui-react/test/**/*.tsx, packages/@overeng/tui-react/tsconfig.buck.json.genie.ts, packages/@overeng/tui-react/tsconfig.json.genie.ts, packages/@overeng/utils-dev/BUCK.genie.ts, packages/@overeng/utils-dev/package.json.genie.ts, packages/@overeng/utils/BUCK.genie.ts, packages/@overeng/utils/package.json.genie.ts, packages/@overeng/utils/src/**/*.cts, packages/@overeng/utils/src/**/*.mts, packages/@overeng/utils/src/**/*.ts, packages/@overeng/utils/src/**/*.tsx
 # Regenerate: devenv tasks run genie:run
 
@@ -362,6 +362,9 @@ tsgo_typecheck(
 tsgo_emit(
     name = "dist",
     package_tree = ":package_tree",
+    declaration_sources = {
+        "src/storybook/asset-modules.d.ts": "src/storybook/asset-modules.d.ts",
+    },
     project = "tsconfig.buck.json",
     declaration_entrypoint = "src/mod.d.ts",
     visibility = ["PUBLIC"],

--- a/packages/@overeng/tui-react/BUCK
+++ b/packages/@overeng/tui-react/BUCK
@@ -4,8 +4,8 @@
 # Projection source: packages/@overeng/tui-react/BUCK.genie.ts
 # Projection schema version: 1
 # Projection generator: effect-utils/genie/buck2-typescript-package-projection
-# Semantic fingerprint: sha256:994a9ffeb0039819f90c648073e9145c46a213beaddee36ebfa5d25d79649a9a
-# Semantic inputs: buck2/dependencies/BUCK.genie.ts, buck2/dependencies/pnpm-lock.sha256.json.genie.ts, genie/buck2/mod.ts, genie/buck2/typescript-package-projection.ts, package.json.genie.ts, packages/@overeng/buck2-tools/src/package-tree.ts, packages/@overeng/buck2-tools/src/real-path.ts, packages/@overeng/tui-core/BUCK.genie.ts, packages/@overeng/tui-core/package.json.genie.ts, packages/@overeng/tui-react/BUCK.genie.ts, packages/@overeng/tui-react/BUCK.genie.ts, packages/@overeng/tui-react/examples/**/*.cts, packages/@overeng/tui-react/examples/**/*.mts, packages/@overeng/tui-react/examples/**/*.ts, packages/@overeng/tui-react/examples/**/*.tsx, packages/@overeng/tui-react/package.json.genie.ts, packages/@overeng/tui-react/src/**/*.cts, packages/@overeng/tui-react/src/**/*.mts, packages/@overeng/tui-react/src/**/*.ts, packages/@overeng/tui-react/src/**/*.tsx, packages/@overeng/tui-react/test/**/*.cts, packages/@overeng/tui-react/test/**/*.mts, packages/@overeng/tui-react/test/**/*.ts, packages/@overeng/tui-react/test/**/*.tsx, packages/@overeng/tui-react/tsconfig.buck.json.genie.ts, packages/@overeng/tui-react/tsconfig.json.genie.ts, packages/@overeng/utils-dev/BUCK.genie.ts, packages/@overeng/utils-dev/package.json.genie.ts, packages/@overeng/utils-dev/src/**/*.cts, packages/@overeng/utils-dev/src/**/*.mts, packages/@overeng/utils-dev/src/**/*.ts, packages/@overeng/utils-dev/src/**/*.tsx, packages/@overeng/utils/BUCK.genie.ts, packages/@overeng/utils/package.json.genie.ts, packages/@overeng/utils/src/**/*.cts, packages/@overeng/utils/src/**/*.mts, packages/@overeng/utils/src/**/*.ts, packages/@overeng/utils/src/**/*.tsx
+# Semantic fingerprint: sha256:9ee40ab9d6570de7b416721422e2473f56cf2209ccc3d57541b675bc65f70a17
+# Semantic inputs: buck2/dependencies/BUCK.genie.ts, buck2/dependencies/pnpm-lock.sha256.json.genie.ts, genie/buck2/mod.ts, genie/buck2/typescript-package-projection.ts, package.json.genie.ts, packages/@overeng/buck2-tools/src/package-tree.ts, packages/@overeng/buck2-tools/src/real-path.ts, packages/@overeng/tui-core/BUCK.genie.ts, packages/@overeng/tui-core/package.json.genie.ts, packages/@overeng/tui-react/BUCK.genie.ts, packages/@overeng/tui-react/BUCK.genie.ts, packages/@overeng/tui-react/examples/**/*.cts, packages/@overeng/tui-react/examples/**/*.mts, packages/@overeng/tui-react/examples/**/*.ts, packages/@overeng/tui-react/examples/**/*.tsx, packages/@overeng/tui-react/package.json.genie.ts, packages/@overeng/tui-react/src/**/*.cts, packages/@overeng/tui-react/src/**/*.mts, packages/@overeng/tui-react/src/**/*.ts, packages/@overeng/tui-react/src/**/*.tsx, packages/@overeng/tui-react/test/**/*.cts, packages/@overeng/tui-react/test/**/*.mts, packages/@overeng/tui-react/test/**/*.ts, packages/@overeng/tui-react/test/**/*.tsx, packages/@overeng/tui-react/tsconfig.buck.json.genie.ts, packages/@overeng/tui-react/tsconfig.json.genie.ts, packages/@overeng/utils-dev/BUCK.genie.ts, packages/@overeng/utils-dev/package.json.genie.ts, packages/@overeng/utils/BUCK.genie.ts, packages/@overeng/utils/package.json.genie.ts, packages/@overeng/utils/src/**/*.cts, packages/@overeng/utils/src/**/*.mts, packages/@overeng/utils/src/**/*.ts, packages/@overeng/utils/src/**/*.tsx
 # Regenerate: devenv tasks run genie:run
 
 load("//buck2:materialization.bzl", "export_materialization_inputs", "package_tree")
@@ -343,31 +343,8 @@ package_tree(
         },
         "@overeng/utils-dev": {
             "files": {
+                "dist": "//packages/@overeng/utils-dev:dist",
                 "package.json": "//packages/@overeng/utils-dev:package.json",
-                "src/cli-contract.test.ts": "//packages/@overeng/utils-dev:src/cli-contract.test.ts",
-                "src/cli-contract.ts": "//packages/@overeng/utils-dev:src/cli-contract.ts",
-                "src/node-vitest/Vitest.ts": "//packages/@overeng/utils-dev:src/node-vitest/Vitest.ts",
-                "src/node-vitest/global.ts": "//packages/@overeng/utils-dev:src/node-vitest/global.ts",
-                "src/node-vitest/mod.ts": "//packages/@overeng/utils-dev:src/node-vitest/mod.ts",
-                "src/node-vitest/otel-vitest-flush.test.ts": "//packages/@overeng/utils-dev:src/node-vitest/otel-vitest-flush.test.ts",
-                "src/node-vitest/setup-fast-check.ts": "//packages/@overeng/utils-dev:src/node-vitest/setup-fast-check.ts",
-                "src/otelite/Otelite.test.ts": "//packages/@overeng/utils-dev:src/otelite/Otelite.test.ts",
-                "src/otelite/Otelite.ts": "//packages/@overeng/utils-dev:src/otelite/Otelite.ts",
-                "src/otelite/diagnostics.ts": "//packages/@overeng/utils-dev:src/otelite/diagnostics.ts",
-                "src/otelite/emitter.ts": "//packages/@overeng/utils-dev:src/otelite/emitter.ts",
-                "src/otelite/errors.ts": "//packages/@overeng/utils-dev:src/otelite/errors.ts",
-                "src/otelite/mod.ts": "//packages/@overeng/utils-dev:src/otelite/mod.ts",
-                "src/otelite/otel.ts": "//packages/@overeng/utils-dev:src/otelite/otel.ts",
-                "src/otelite/otlp-url.ts": "//packages/@overeng/utils-dev:src/otelite/otlp-url.ts",
-                "src/otelite/schema.ts": "//packages/@overeng/utils-dev:src/otelite/schema.ts",
-                "src/otelite/signal-expect.test.ts": "//packages/@overeng/utils-dev:src/otelite/signal-expect.test.ts",
-                "src/otelite/signal-expect.ts": "//packages/@overeng/utils-dev:src/otelite/signal-expect.ts",
-                "src/otelite/test-harness.test.ts": "//packages/@overeng/utils-dev:src/otelite/test-harness.test.ts",
-                "src/otelite/test-harness.ts": "//packages/@overeng/utils-dev:src/otelite/test-harness.ts",
-                "src/otelite/trace-expect.test.ts": "//packages/@overeng/utils-dev:src/otelite/trace-expect.test.ts",
-                "src/otelite/trace-expect.ts": "//packages/@overeng/utils-dev:src/otelite/trace-expect.ts",
-                "src/otelite/vitest-bridge.test.ts": "//packages/@overeng/utils-dev:src/otelite/vitest-bridge.test.ts",
-                "src/otelite/vitest-bridge.ts": "//packages/@overeng/utils-dev:src/otelite/vitest-bridge.ts",
             },
             "links": ["@overeng/utils-dev"],
         },

--- a/packages/@overeng/tui-react/BUCK.genie.ts
+++ b/packages/@overeng/tui-react/BUCK.genie.ts
@@ -21,7 +21,7 @@ export const buck2TypeScriptAdmission = {
     {
       packageName: '@overeng/utils-dev',
       packagePath: 'packages/@overeng/utils-dev',
-      sourceRoots: ['src'],
+      distTarget: '//packages/@overeng/utils-dev:dist',
     },
   ],
   editorViewConsumer: false,

--- a/packages/@overeng/tui-react/tsconfig.json
+++ b/packages/@overeng/tui-react/tsconfig.json
@@ -52,9 +52,6 @@
   "references": [
     {
       "path": "../utils"
-    },
-    {
-      "path": "../utils-dev"
     }
   ]
 }

--- a/packages/@overeng/tui-react/tsconfig.json.genie.ts
+++ b/packages/@overeng/tui-react/tsconfig.json.genie.ts
@@ -17,5 +17,5 @@ export default tsconfigJson({
     lib: domLib,
   },
   include: ['src/**/*', 'test/**/*', 'examples/**/*'],
-  references: [{ path: '../utils' }, { path: '../utils-dev' }],
+  references: [{ path: '../utils' }],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/tui-stories/nix/build.nix
+++ b/packages/@overeng/tui-stories/nix/build.nix
@@ -21,7 +21,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-o4jhvPQKvCyDDowQk8Cbf10U9ZKsgeTYRg2f+scC2gw=";
+      "." = mkSharedHash "sha256-JNtlE27i+k00rpz5Ad/7Y3OVM1tSdWW/IKPjhe7nvPk=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/tui-stories/nix/build.nix
+++ b/packages/@overeng/tui-stories/nix/build.nix
@@ -21,7 +21,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-JNtlE27i+k00rpz5Ad/7Y3OVM1tSdWW/IKPjhe7nvPk=";
+      "." = mkSharedHash "sha256-NHPPOvFYBjLYFEFjg/yiC+7DnYEsZJv5Zfe19HMt+kk=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/tui-stories/tsconfig.json
+++ b/packages/@overeng/tui-stories/tsconfig.json
@@ -54,9 +54,6 @@
     },
     {
       "path": "../utils"
-    },
-    {
-      "path": "../utils-dev"
     }
   ]
 }

--- a/packages/@overeng/tui-stories/tsconfig.json.genie.ts
+++ b/packages/@overeng/tui-stories/tsconfig.json.genie.ts
@@ -14,5 +14,5 @@ export default tsconfigJson({
     ...reactJsx,
   },
   include: ['src/**/*', 'test/**/*', 'bin/**/*.ts', 'bin/**/*.tsx'],
-  references: [{ path: '../megarepo' }, { path: '../utils' }, { path: '../utils-dev' }],
+  references: [{ path: '../megarepo' }, { path: '../utils' }],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/utils-dev/BUCK
+++ b/packages/@overeng/utils-dev/BUCK
@@ -4,7 +4,7 @@
 # Projection source: packages/@overeng/utils-dev/BUCK.genie.ts
 # Projection schema version: 1
 # Projection generator: effect-utils/genie/buck2-typescript-package-projection
-# Semantic fingerprint: sha256:7dbbeb976514ce6c467dd535b0aa1a3c0622a6ebbd3243a5cf3fd815c0762b8a
+# Semantic fingerprint: sha256:794882fd8fc7c425a0cfd459df6a39037e6e48828bcefa29ccd5d3ebf236f9e8
 # Semantic inputs: buck2/dependencies/BUCK.genie.ts, buck2/dependencies/pnpm-lock.sha256.json.genie.ts, genie/buck2/mod.ts, genie/buck2/typescript-package-projection.ts, package.json.genie.ts, packages/@overeng/buck2-tools/src/package-tree.ts, packages/@overeng/buck2-tools/src/real-path.ts, packages/@overeng/utils-dev/BUCK.genie.ts, packages/@overeng/utils-dev/BUCK.genie.ts, packages/@overeng/utils-dev/package.json.genie.ts, packages/@overeng/utils-dev/src/**/*.cts, packages/@overeng/utils-dev/src/**/*.mts, packages/@overeng/utils-dev/src/**/*.ts, packages/@overeng/utils-dev/src/**/*.tsx, packages/@overeng/utils-dev/tsconfig.json.genie.ts
 # Regenerate: devenv tasks run genie:run
 
@@ -102,6 +102,8 @@ tsgo_typecheck(
 tsgo_emit(
     name = "dist",
     package_tree = ":package_tree",
+    declaration_sources = {
+    },
     declaration_entrypoint = "src/node-vitest/mod.d.ts",
     visibility = ["PUBLIC"],
 )

--- a/packages/@overeng/utils-dev/BUCK
+++ b/packages/@overeng/utils-dev/BUCK
@@ -102,5 +102,6 @@ tsgo_typecheck(
 tsgo_emit(
     name = "dist",
     package_tree = ":package_tree",
+    declaration_entrypoint = "src/node-vitest/mod.d.ts",
     visibility = ["PUBLIC"],
 )

--- a/packages/@overeng/utils-dev/BUCK.genie.ts
+++ b/packages/@overeng/utils-dev/BUCK.genie.ts
@@ -8,6 +8,10 @@ export const buck2TypeScriptAdmission = {
   projectionSource: 'packages/@overeng/utils-dev/BUCK.genie.ts',
   sourceRoots: ['src'],
   editorViewConsumer: false,
+  authority: {
+    declarationEntrypoint: 'src/node-vitest/mod.d.ts',
+    projectFile: 'tsconfig.json',
+  },
 } as const satisfies Buck2TypeScriptAdmission
 
 export default buck2TypeScriptPackageProjection(buck2TypeScriptAdmission)

--- a/packages/@overeng/utils-dev/package.json
+++ b/packages/@overeng/utils-dev/package.json
@@ -4,10 +4,22 @@
   "private": true,
   "type": "module",
   "exports": {
-    "./cli-contract": "./src/cli-contract.ts",
-    "./node-vitest": "./src/node-vitest/mod.ts",
-    "./node-vitest/setup-fast-check": "./src/node-vitest/setup-fast-check.ts",
-    "./otelite": "./src/otelite/mod.ts"
+    "./cli-contract": {
+      "types": "./dist/src/cli-contract.d.ts",
+      "default": "./src/cli-contract.ts"
+    },
+    "./node-vitest": {
+      "types": "./dist/src/node-vitest/mod.d.ts",
+      "default": "./src/node-vitest/mod.ts"
+    },
+    "./node-vitest/setup-fast-check": {
+      "types": "./dist/src/node-vitest/setup-fast-check.d.ts",
+      "default": "./src/node-vitest/setup-fast-check.ts"
+    },
+    "./otelite": {
+      "types": "./dist/src/otelite/mod.d.ts",
+      "default": "./src/otelite/mod.ts"
+    }
   },
   "publishConfig": {
     "access": "public",

--- a/packages/@overeng/utils-dev/package.json.genie.ts
+++ b/packages/@overeng/utils-dev/package.json.genie.ts
@@ -33,12 +33,25 @@ export default packageJson(
     name: '@overeng/utils-dev',
     ...privatePackageDefaults,
     exports: {
-      './node-vitest': exportEntry('./src/node-vitest/mod.ts', { environment: 'node' }),
-      './node-vitest/setup-fast-check': exportEntry('./src/node-vitest/setup-fast-check.ts', {
-        environment: 'node',
-      }),
-      './otelite': exportEntry('./src/otelite/mod.ts', { environment: 'node' }),
-      './cli-contract': exportEntry('./src/cli-contract.ts', { environment: 'node' }),
+      './node-vitest': exportEntry(
+        { types: './dist/src/node-vitest/mod.d.ts', default: './src/node-vitest/mod.ts' },
+        { environment: 'node' },
+      ),
+      './node-vitest/setup-fast-check': exportEntry(
+        {
+          types: './dist/src/node-vitest/setup-fast-check.d.ts',
+          default: './src/node-vitest/setup-fast-check.ts',
+        },
+        { environment: 'node' },
+      ),
+      './otelite': exportEntry(
+        { types: './dist/src/otelite/mod.d.ts', default: './src/otelite/mod.ts' },
+        { environment: 'node' },
+      ),
+      './cli-contract': exportEntry(
+        { types: './dist/src/cli-contract.d.ts', default: './src/cli-contract.ts' },
+        { environment: 'node' },
+      ),
     },
     publishConfig: {
       access: 'public',

--- a/packages/@overeng/utils-dev/tsconfig.json
+++ b/packages/@overeng/utils-dev/tsconfig.json
@@ -44,7 +44,8 @@
     "composite": true,
     "rootDir": ".",
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
-    "types": ["node"]
+    "types": ["node"],
+    "noEmit": true
   },
   "include": ["src/**/*"]
 }

--- a/packages/@overeng/utils-dev/tsconfig.json.genie.ts
+++ b/packages/@overeng/utils-dev/tsconfig.json.genie.ts
@@ -3,13 +3,14 @@ import {
   packageTsconfigCompilerOptions,
   nodeTypes,
 } from '../../../genie/internal.ts'
-import { tsconfigJson } from '../genie/src/runtime/mod.ts'
+import { tsconfigJson, type TSConfigArgs } from '../genie/src/runtime/mod.ts'
 
 export default tsconfigJson({
   compilerOptions: {
     ...baseTsconfigCompilerOptions,
     ...packageTsconfigCompilerOptions,
     ...nodeTypes,
+    noEmit: true,
   },
   include: ['src/**/*'],
-})
+} satisfies TSConfigArgs)

--- a/packages/@overeng/utils/BUCK
+++ b/packages/@overeng/utils/BUCK
@@ -4,7 +4,7 @@
 # Projection source: packages/@overeng/utils/BUCK.genie.ts
 # Projection schema version: 1
 # Projection generator: effect-utils/genie/buck2-typescript-package-projection
-# Semantic fingerprint: sha256:2628261e6497fe925a4ad2cc79a7f456dade965c6f8c895acad8c3ceede298c6
+# Semantic fingerprint: sha256:8634053c2f7fdd2bb409cdb0ad33a50722d1eb0d4dd2f2b14caf84b773b9b101
 # Semantic inputs: buck2/dependencies/BUCK.genie.ts, buck2/dependencies/pnpm-lock.sha256.json.genie.ts, genie/buck2/mod.ts, genie/buck2/typescript-package-projection.ts, package.json.genie.ts, packages/@overeng/buck2-tools/src/package-tree.ts, packages/@overeng/buck2-tools/src/real-path.ts, packages/@overeng/utils/BUCK.genie.ts, packages/@overeng/utils/BUCK.genie.ts, packages/@overeng/utils/package.json.genie.ts, packages/@overeng/utils/src/**/*.cts, packages/@overeng/utils/src/**/*.mts, packages/@overeng/utils/src/**/*.ts, packages/@overeng/utils/src/**/*.tsx, packages/@overeng/utils/tsconfig.json.genie.ts
 # Regenerate: devenv tasks run genie:run
 
@@ -224,5 +224,7 @@ tsgo_typecheck(
 tsgo_emit(
     name = "dist",
     package_tree = ":package_tree",
+    declaration_sources = {
+    },
     visibility = ["PUBLIC"],
 )

--- a/packages/@overeng/utils/tsconfig.json
+++ b/packages/@overeng/utils/tsconfig.json
@@ -53,12 +53,6 @@
     },
     {
       "path": "../otel-contract"
-    },
-    {
-      "path": "../stylex-preset"
-    },
-    {
-      "path": "../utils-dev"
     }
   ]
 }

--- a/packages/@overeng/utils/tsconfig.json.genie.ts
+++ b/packages/@overeng/utils/tsconfig.json.genie.ts
@@ -12,10 +12,5 @@ export default tsconfigJson({
     ...nodeTypes,
   },
   include: ['src/**/*'],
-  references: [
-    { path: '../effect-distributed-lock' },
-    { path: '../otel-contract' },
-    { path: '../stylex-preset' },
-    { path: '../utils-dev' },
-  ],
+  references: [{ path: '../effect-distributed-lock' }, { path: '../otel-contract' }],
 } satisfies TSConfigArgs)

--- a/tsconfig.check.json
+++ b/tsconfig.check.json
@@ -107,9 +107,6 @@
     },
     {
       "path": "./packages/@overeng/utils"
-    },
-    {
-      "path": "./packages/@overeng/utils-dev"
     }
   ]
 }

--- a/tsconfig.emit.json
+++ b/tsconfig.emit.json
@@ -107,9 +107,6 @@
     },
     {
       "path": "./packages/@overeng/utils"
-    },
-    {
-      "path": "./packages/@overeng/utils-dev"
     }
   ]
 }


### PR DESCRIPTION
## Problem

`@overeng/utils-dev` and `@overeng/stylex-preset` still relied on legacy TypeScript producers. utils-dev remained in both root solutions, dependents retained project-reference edges, and stylex-preset's handwritten Vite declaration did not cross a dist-only Buck boundary.

## Goal

Transfer the first dependency-closed layer to Buck while preserving source runtime exports and every public type surface.

## Decisions

- Admit utils-dev and stylex-preset together because they form the foundation layer.
- Remove utils-dev from both root solutions and delete 27 package-scoped project references across the layer.
- Make explicit package-local `.d.ts` files action-keyed inputs that the TypeScript runner copies only after successful emit.
- Point stylex-preset's Vite type export into dist and make tui-react consume utils-dev through its Buck dist.

## Verification

- Both package-specific mutation controls reported TS2322 and returned to green after restore.
- Changelog-only mutation: no commands and no network traffic.
- Fresh context: 149/149 cache hits, zero local commands, 3.8s.
- Empty environment with fresh HOME and minimal PATH: 149/149 cache hits, zero local commands, 2.3s.
- `CI=1 devenv tasks run buck2:check --no-tui` passed in 5m51s.
- `CI=1 devenv tasks run check:quick --no-tui` passed in 3m12s.
- `CI=1 devenv tasks run check:all --no-tui` passed in 5m55s.
- Focused runner/projection tests: 69 passed, zero failed.
- Independent review found no remaining correctness issue.
- Full evidence: [`2026-09-02-foundation-layer-authority-transfer.md`](https://github.com/overengineeringstudio/effect-utils/blob/schickling-assistant/2026-09-02-buck2-admit-foundations/context/buck2/02-execution/.experiments/2026-09-02-foundation-layer-authority-transfer.md).

## Complexity

The handwritten-declaration copy path is shared plumbing required by packages whose public declarations are authored rather than emitted. It accepts only explicit normalized regular files and keeps them in the action key.

## Concerns

PR #1191 overlaps stylex-preset and generated package metadata. The Buck stack will land first; #1191 must rebase afterward.

## Friction & bottlenecks

- Evergreen's post-write verification imported a package build without its required `src`; this was recorded through Axe feedback.
- Package metadata changes required seven root-workspace pnpm fixed-output hash refreshes.

## Follow-ups

- Continue with #1189 and #1193.
- Rebase #1191 after this stack lands.

## References

- Refs #1147
- Depends on #1187
- Stack: #1187 → #1188 → #1189 → #1193

<!-- agent-footer:begin v=2 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | dev3.direct.omp.8ry9k2x2 |
| `session` | dev3.8ry9k2x2 |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.0.11 |
| `agent_runtime` | OMP 18.0.11 |
| `tooling_profile` | dotfiles@e8f0615-dirty |
</details>
<!-- agent-footer:end -->