### PR TITLE
Evaluate workflow reports from store-backed sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,8 @@ publish exited 1` with nothing to diagnose it by. `CpAMemberMountError` now
   `./cli` are unchanged). `core/` provably imports nothing from
   `composition/`. The `member-mount-r6` and `member-mount-cp-a` module headers
   now explain their codenames and why they are two modules rather than one.
+- **workflow-report devenv module**: Resolve packages from the module-provided
+  `pkgs` set so consumers can evaluate the module from a pure store source.
 - **@overeng/utils, @overeng/tui-core, @overeng/tui-react**: Effect 4 idiom
   adoption. `base64` is now a thin facade over upstream `Encoding` (net -107
   lines; invalid input throws `Encoding.EncodingError` instead of `DOMException`

--- a/nix/devenv-modules/tasks/shared/tests/workflow-report-module-source.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/workflow-report-module-source.test.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$TESTS_DIR/../../../../.." && pwd)"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+source="$tmpdir/source"
+mkdir -p "$source/nix/devenv-modules/tasks/shared" "$source/nix/devenv-modules/tasks/lib"
+cp "$ROOT/nix/devenv-modules/tasks/shared/workflow-report-module.nix" \
+  "$source/nix/devenv-modules/tasks/shared/workflow-report-module.nix"
+cp "$ROOT/nix/devenv-modules/tasks/lib/trace.nix" \
+  "$source/nix/devenv-modules/tasks/lib/trace.nix"
+
+nix eval --impure --expr "
+  let
+    flake = builtins.getFlake (toString $ROOT);
+    pkgs = import flake.inputs.nixpkgs { system = builtins.currentSystem; };
+    moduleSource = builtins.path {
+      path = $source;
+      name = \"workflow-report-module-source\";
+    };
+    evaluated = pkgs.lib.evalModules {
+      specialArgs = { inherit pkgs; };
+      modules = [
+        ({ ... }: {
+          options.tasks = pkgs.lib.mkOption {
+            type = pkgs.lib.types.attrsOf pkgs.lib.types.anything;
+            default = { };
+          };
+        })
+        (moduleSource + \"/nix/devenv-modules/tasks/shared/workflow-report-module.nix\")
+        {
+          effectUtils.workflowReport.ciToolsBin = \"/ci-tools\";
+        }
+      ];
+    };
+  in evaluated.config.tasks.\"workflow-report:publish\".exec
+" >/dev/null
+
+echo "workflow-report module store-source test passed"

--- a/nix/devenv-modules/tasks/shared/tests/workflow-report-task-e2e.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/workflow-report-task-e2e.test.sh
@@ -70,16 +70,6 @@ extract_workflow_report_task_script() {
 
 echo "Running workflow-report task E2E tests..."
 echo ""
-module_source="$(<"$ROOT/nix/devenv-modules/tasks/shared/workflow-report-module.nix")"
-assert_contains \
-  "$module_source" \
-  'repoFlake = builtins.getFlake "git+file://${toString root}";' \
-  "workflow-report module should evaluate its flake from the Git-filtered repository source"
-assert_contains \
-  "$module_source" \
-  'src = repoSource;' \
-  "workflow-report module should build ci-tools from the Git-filtered repository source"
-
 
 tmpdir="$(mktemp -d)"
 cleanup() {

--- a/nix/devenv-modules/tasks/shared/workflow-report-module.nix
+++ b/nix/devenv-modules/tasks/shared/workflow-report-module.nix
@@ -5,26 +5,22 @@
 {
   config,
   lib,
+  pkgs,
   ...
 }:
 let
   cfg = config.effectUtils.workflowReport;
   trace = import ../lib/trace.nix { inherit lib; };
   root = ../../../..;
-  repoFlake = builtins.getFlake "git+file://${toString root}";
-  repoSource = repoFlake.outPath;
-  pinnedPkgs = import repoFlake.inputs.nixpkgs {
-    system = builtins.currentSystem;
-  };
-  ciToolsPkg = import (repoSource + "/packages/@overeng/ci-tools/nix/build.nix") {
-    pkgs = pinnedPkgs;
-    src = repoSource;
+  ciToolsPkg = import (root + "/packages/@overeng/ci-tools/nix/build.nix") {
+    inherit pkgs;
+    src = root;
     dirty = true;
   };
   resolvedCiToolsBin =
     if cfg.ciToolsBin == null then "${ciToolsPkg}/bin/ci-tools" else cfg.ciToolsBin;
   ciTools = lib.escapeShellArg resolvedCiToolsBin;
-  gh = if cfg.ghBin == null then "${pinnedPkgs.gh}/bin/gh" else cfg.ghBin;
+  gh = if cfg.ghBin == null then "${pkgs.gh}/bin/gh" else cfg.ghBin;
 in
 {
   options.effectUtils.workflowReport = {


### PR DESCRIPTION
## Problem

The shared workflow-report module calls `builtins.getFlake "git+file://..."` on its own source tree. When a downstream consumer imports the module through a Nix store source, that path is not a Git repository and devenv evaluation fails before any task can run.

## Goal

Evaluate workflow-report dependencies from the module-provided pinned `pkgs` set so the module works from both Git worktrees and immutable store sources.

## Decisions

Use the existing module argument as the package authority. Do not recursively reinterpret the source tree as a flake.

## Verification

- The store-source workflow-report regression test passes.
- The dependent dotfiles `devenv tasks list` evaluates successfully with this revision.
- `git diff --check` passes.
- `check:quick` passed before rebasing. After rebasing onto current main, it reaches unrelated current-main composition failures because the canonical branch now expects a composed `repos/` workspace; the focused regression remains green.

## Complexity

No new abstraction. The module uses its existing package input.

## Concerns

None.

## Friction & bottlenecks

The previous failure appeared only when the module was copied into the Nix store, not when evaluated from a Git worktree.

## Follow-ups

None.

## References

- Required by schickling/dotfiles#2305.

<!-- agent-footer:begin v=2 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | dev3.direct.omp.2cshu64q |
| `session` | dev3.2cshu64q |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.0.9 |
| `agent_runtime` | OMP 18.0.9 |
| `tooling_profile` | dotfiles@b607597 |
</details>
<!-- agent-footer:end -->