### PR TITLE
fix(utils): stop the Storybook factory leaking Vite types across a link: boundary

### DIFF
--- a/packages/@overeng/utils/src/node/storybook/config/mod.ts
+++ b/packages/@overeng/utils/src/node/storybook/config/mod.ts
@@ -136,7 +136,15 @@ export const createDomStorybookConfig: CreateDomStorybookConfig = <TConfig exten
         typedConfig.build = { minify: false }
       }
 
-      return callUserViteFinal({ config: typedConfig, viteFinal })
+      /* Returns the parameter's own contextual type rather than `InlineConfig`. A
+       * cross-checkout `link:` consumer typechecks this source but resolves `vite`
+       * from its OWN node_modules, so naming Vite's type here makes the returned
+       * config a DIFFERENT `InlineConfig` than the `ViteFinal` slot expects. Under
+       * `strict` that cannot be reconciled: `dev.createEnvironment` takes a
+       * `ResolvedConfig`, so parameters compare contravariantly and the check
+       * recurses Vite's whole type graph. Peer-version parity does not help — only
+       * not naming the type across the boundary does. */
+      return (await callUserViteFinal({ config: typedConfig, viteFinal })) as typeof storybookConfig
     },
   } satisfies StorybookConfig
 
@@ -226,7 +234,9 @@ export const createTuiStorybookConfig: CreateTuiStorybookConfig = <TConfig exten
         external: ['@opentui/core', '@opentui/react'],
       }
 
-      return callUserViteFinal({ config: typedConfig, viteFinal })
+      /* See the DOM factory: returns the parameter's contextual type so Vite's
+       * `InlineConfig` never crosses the package boundary. */
+      return (await callUserViteFinal({ config: typedConfig, viteFinal })) as typeof storybookConfig
     },
   } satisfies StorybookConfig
 

--- a/packages/@overeng/utils/src/node/storybook/config/mod.unit.test.ts
+++ b/packages/@overeng/utils/src/node/storybook/config/mod.unit.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs'
+
 import { expect } from 'vitest'
 
 import { Vitest } from '@overeng/utils-dev/node-vitest'
@@ -36,5 +38,35 @@ Vitest.describe('createDomStorybookConfig', () => {
       off: createDomStorybookConfig({}).addons,
       on: createDomStorybookConfig({ a11y: true }).addons,
     }).toEqual({ off: undefined, on: ['@storybook/addon-a11y'] })
+  })
+
+  /**
+   * This module is exported as raw source, so a cross-checkout `link:` consumer
+   * typechecks it while resolving `vite` from its OWN node_modules. If a default
+   * `viteFinal` names Vite's `InlineConfig` in its return type, the value it
+   * returns is a DIFFERENT `InlineConfig` than the consumer's `ViteFinal` slot
+   * expects, and under `strict` the two cannot be reconciled: `dev.createEnvironment`
+   * takes a `ResolvedConfig`, so parameters compare contravariantly and the check
+   * recurses Vite's whole type graph. Aligning peer versions does not help.
+   *
+   * The guard is deliberately source-level. This defect is invisible to both other
+   * kinds of test, which is how it reached a consumer in the first place:
+   * - runtime: the fix is types-only, so before and after return the same value
+   * - type-level: with one Vite copy in this tree, the correct and broken forms
+   *   denote the SAME type, so any assertion passes either way
+   *
+   * Reproducing it needs two checkouts, which a unit test does not have. Asserting
+   * the shape that cannot leak is what is left.
+   */
+  Vitest.it('keeps Vite types out of the default viteFinal return', () => {
+    const source = readFileSync(new URL('./mod.ts', import.meta.url), 'utf8')
+    const returns = [...source.matchAll(/^\s*return \(await callUserViteFinal\(([^\n]*)$/gmu)]
+
+    expect({
+      /* Both factories (DOM + TUI) must route through the boundary cast. */
+      sites: returns.length,
+      leaking: returns.filter((match) => match[1]?.includes('typeof storybookConfig') !== true)
+        .length,
+    }).toEqual({ sites: 2, leaking: 0 })
   })
 })


### PR DESCRIPTION
Unblocks several draft PRs in downstream consumers that repinning to `main` turned red.

## The defect

`@overeng/utils` exports `node/storybook/config` as **raw source**, so a cross-checkout `link:`
consumer typechecks this file while resolving `vite` from its **own** `node_modules`. Both default
`viteFinal` implementations returned Vite's `InlineConfig` — which in that consumer is a
*different* `InlineConfig` than the `ViteFinal` slot they must satisfy. An affected app reported
4 × `TS2322`.

## Why aligning versions cannot work

This is provable, not empirical. `InlineConfig.dev` is `DevEnvironmentOptions`, whose
`createEnvironment` is a **function taking `ResolvedConfig`**. Under `strict`, TypeScript compares
function parameters **contravariantly**, so the two `ResolvedConfig` types must be mutually
assignable and the comparison recurses Vite's whole type graph. Two *different* store paths cannot
satisfy that however close their peer sets.

Measured twice, with this package resolving `vite@8.0.16_…_esbuild@0.28.2_jiti@2.7.0`:

| consumer's Vite key | result |
|---|---|
| `…esbuild@0.27.7_jiti@2.7.0_yaml@2.9.0` | 4 × TS2322 |
| `…esbuild@0.28.2_jiti@2.7.0_yaml@2.9.0` | **still** 4 × TS2322 |

I initially pursued the version-alignment fix on the grounds that esbuild was "the only delta". It
wasn't — the first key differed in **two** peers and I enumerated one. `skipLibCheck` was already
`true` and does not apply: this is source-checking.

## The fix

Both defaults return the **parameter's own contextual type**, so no Vite type crosses the
boundary. Two lines plus comments.

- Internal typing is **unchanged** — the bodies still use `InlineConfig`, which stays
  module-private.
- The runtime value is **identical**: these functions mutate the config in place, so returning the
  parameter's type is the same object.
- Consumers that genuinely need Vite types keep using
  `DomStorybookConfigOptionsWithViteFinal<TConfig>`, which already exists for exactly this and is
  documented as such.

## Verification

**End to end, by swapping only the consumer's symlink on one tree** — same `node_modules`, same
lockfile, only the link target differing:

```
main:         ts:check -> exit 1, 4 errors
this branch:  ts:check -> exit 0, 0 errors
```

`check:quick` green here.

## On the test being source-level

Deliberate, and worth stating because it looks like the weak choice. This defect is invisible to
both other kinds of test, which is how it reached a consumer:

- **runtime** — the fix is types-only, so before and after return the same value
- **type-level** — with one Vite copy in this tree, the correct and broken forms denote the *same*
  type, so any assertion passes either way

Reproducing it needs two checkouts, which a unit test does not have. Asserting the shape that
cannot leak is what is left. If a formatter ever rewraps those lines the guard reports `sites: 0`
and fails loudly rather than silently passing.

**Liveness proven:** reverting one site turns `exit 0, 3 passed` into `exit 1` on
`expected { sites: 1 } to deeply equal { sites: 2 }`.

## Scope

Only consumers that both typecheck this source **and** resolve their own `vite` copy are exposed.
A consumer whose Vite store key already matches this repo's is unaffected, and one such consumer
was verified to be — its repin is independent of this PR.

<!-- agent-footer:begin v=2 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | dev3.direct.omp.mhx73ur2 |
| `session` | dev3.mhx73ur2 |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.0.11 |
| `agent_runtime` | OMP 18.0.11 |
| `tooling_profile` | dotfiles@e8f0615-dirty |
</details>
<!-- agent-footer:end -->