### PR TITLE
fix(genie): stop CI generators emitting steps only effect-utils can satisfy

### DIFF
--- a/genie/ci-workflow/megarepo.ts
+++ b/genie/ci-workflow/megarepo.ts
@@ -102,9 +102,16 @@ fi
   shell: 'bash',
 } as const
 
-/** Fetch latest refs and apply megarepo workspace. */
+/**
+ * Fetch latest refs and apply megarepo workspace.
+ *
+ * `mr fetch --apply` applies the workspace, so CI requires an explicit
+ * `--worktree-mode`. `tracking` matches this step's intent: it deliberately
+ * moves members to the latest branch heads, so it wants the branch worktrees
+ * under `refs/heads/<branch>/` rather than detached per-commit ones.
+ */
 export const syncMegarepoWorkspaceStep = (opts?: { skip?: string[] }) => {
-  const args = ['mr', 'fetch', '--apply']
+  const args = ['mr', 'fetch', '--apply', '--worktree-mode', 'tracking']
   const skipCsv = opts?.skip?.join(',')
   if (skipCsv !== undefined && skipCsv !== '') args.push('--skip', shellSingleQuote(skipCsv))
   return {
@@ -126,6 +133,12 @@ ${args.join(' ')}`,
  * shape instead of silently drifting to newer branch heads during job setup.
  * Resolves the CLI inline with `nix run` to avoid `nix profile install`
  * conflicts on self-hosted runners.
+ *
+ * `--worktree-mode commit` is mandatory: `mr apply` rejects the implicit `auto`
+ * mode when `CI=true`. `commit` materializes `refs/commits/<sha>/` worktrees,
+ * which is the deterministic reading of the checked-in lock this step exists to
+ * enforce — and is exactly what `auto` used to resolve to in CI before the mode
+ * became explicit, so pinning it here changes nothing but the guard.
  */
 export const applyMegarepoLockStep = (opts?: { skip?: string[]; cacheableStore?: boolean }) => {
   const megarepoStore =
@@ -153,7 +166,7 @@ if [ -n "${'${GITHUB_ENV:-}'}" ]; then
   ${appendGitHubEnvLine({ name: 'MEGAREPO_STORE', valueExpression: '"$MEGAREPO_STORE"' })}
 fi
 ${exportSkipMembersScript}
-nix run "github:overengineeringstudio/effect-utils/$EU_REV#megarepo" -- apply --all${skipArgs !== '' ? ` ${skipArgs}` : ''}`,
+nix run "github:overengineeringstudio/effect-utils/$EU_REV#megarepo" -- apply --all --worktree-mode commit${skipArgs !== '' ? ` ${skipArgs}` : ''}`,
     shell: 'bash',
   }
 }

--- a/genie/ci-workflow/support-files.ts
+++ b/genie/ci-workflow/support-files.ts
@@ -47,6 +47,7 @@ export const ciWorkflowNixGcRaceRetryWrapperPath = 'genie/ci-scripts/run-with-ni
 export const ciWorkflowJobLocalRustStateScriptPath =
   'genie/ci-scripts/prepare-job-local-rust-state.sh'
 export const ciWorkflowResolveDevenvScriptPath = 'genie/ci-scripts/resolve-devenv.sh'
+export const ciWorkflowResolveDevenvCiScriptPath = 'genie/ci-scripts/resolve-devenv-ci.sh'
 
 export const ciWorkflowNixGcRaceRetryScript = String.raw`#!/usr/bin/env bash
 
@@ -218,6 +219,22 @@ export const ciWorkflowSupportFiles = {
   resolveDevenv: {
     path: ciWorkflowResolveDevenvScriptPath,
     output: textArtifact(`#!/usr/bin/env bash\n\n${resolveDevenvFnScript}`),
+  },
+  /**
+   * The CI wrapper around `resolve_devenv`, invoked by `validateNixStoreStepFor`.
+   *
+   * Consumers MUST be able to emit this: the generated step calls it out of the prepared runtime
+   * scripts dir, which is populated from the *consuming* repo's `genie/ci-scripts`. Without an
+   * entry here a consumer regenerates a workflow that references a script it cannot materialize,
+   * and the step dies with exit 127. It ships as a real file for the same reason as
+   * {@link ciWorkflowSupportFiles.prSnapshotArtifact}, and sources `resolve-devenv.sh` out of its
+   * own directory, so consumers must emit that one too.
+   */
+  resolveDevenvCi: {
+    path: ciWorkflowResolveDevenvCiScriptPath,
+    get output() {
+      return sharedScriptArtifact(ciWorkflowResolveDevenvCiScriptPath)
+    },
   },
   nixGcRaceRetry: {
     path: ciWorkflowNixGcRaceRetryScriptPath,

--- a/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
@@ -211,7 +211,12 @@ const mergeQueueSource = extractSourceBlock(
 const installMegarepoStepSource = extractSourceBlock(
   ciWorkflowSource,
   'export const installMegarepoStep = {',
-  '/** Fetch latest refs and apply megarepo workspace. */',
+  'export const syncMegarepoWorkspaceStep = (',
+)
+const syncMegarepoWorkspaceStepSource = extractSourceBlock(
+  ciWorkflowSource,
+  'export const syncMegarepoWorkspaceStep = (',
+  'export const applyMegarepoLockStep = (',
 )
 const megarepoTaskModuleSource = readFileSync(
   new URL(
@@ -593,6 +598,31 @@ printf '%s\\n' "$NIX_OUTPUT"
     expect(applyMegarepoLockStepSource).not.toContain(
       'nix run "github:overengineeringstudio/effect-utils?ref=$EU_REF&rev=$EU_REV#megarepo"',
     )
+  })
+
+  it('gives every workspace-applying megarepo invocation an explicit worktree mode', () => {
+    // `mr apply` (and `mr fetch --apply`) reject the implicit `auto` worktree
+    // mode whenever CI=true, so a generated step without `--worktree-mode`
+    // fails deterministically during job setup, before any real work runs.
+    expect(applyMegarepoLockStepSource).toContain('apply --all --worktree-mode commit')
+    expect(syncMegarepoWorkspaceStepSource).toContain(
+      "['mr', 'fetch', '--apply', '--worktree-mode', 'tracking']",
+    )
+
+    // Sweep every workspace-applying invocation the CI generators can emit —
+    // `nix run … -- apply` and the `'--apply'` argv form — so a newly added
+    // step cannot reintroduce the implicit mode. Matches the command shapes
+    // only, never the surrounding prose.
+    const invocations = [...ciWorkflowSource.matchAll(/(?:-- apply|'--apply')/g)]
+    expect(invocations.length).toBeGreaterThan(0)
+    const unflagged = invocations
+      .filter(
+        (match) =>
+          ciWorkflowSource.slice(match.index, match.index + 140).includes('--worktree-mode') ===
+          false,
+      )
+      .map((match) => ciWorkflowSource.slice(match.index, match.index + 70))
+    expect(unflagged).toEqual([])
   })
 
   it('installs setup-time megarepo from the locked effect-utils commit without mutating nix profiles', () => {

--- a/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
@@ -31,10 +31,7 @@ const ciWorkflowSource = [
   )
   .join('\n')
 const ciWorkflowSupportFilesSource = readFileSync(
-  new URL(
-    ['../../../../../../genie/ci-workflow', 'support-files.ts'].join('/'),
-    import.meta.url,
-  ),
+  new URL(['../../../../../../genie/ci-workflow', 'support-files.ts'].join('/'), import.meta.url),
   'utf8',
 )
 const generatedWorkflowSource = readFileSync(

--- a/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
@@ -30,6 +30,13 @@ const ciWorkflowSource = [
     readFileSync(new URL(['../../../../../../genie', file].join('/'), import.meta.url), 'utf8'),
   )
   .join('\n')
+const ciWorkflowSupportFilesSource = readFileSync(
+  new URL(
+    ['../../../../../../genie/ci-workflow', 'support-files.ts'].join('/'),
+    import.meta.url,
+  ),
+  'utf8',
+)
 const generatedWorkflowSource = readFileSync(
   new URL(['../../../../../../.github/workflows', 'ci.yml.genie.ts'].join('/'), import.meta.url),
   'utf8',
@@ -623,6 +630,51 @@ printf '%s\\n' "$NIX_OUTPUT"
       )
       .map((match) => ciWorkflowSource.slice(match.index, match.index + 70))
     expect(unflagged).toEqual([])
+  })
+
+  it('gives every prepared-runtime script a support-file entry consumers can emit', () => {
+    // `Prepare CI helper scripts` populates the prepared runtime dir from the
+    // CONSUMING repo's genie/ci-scripts, which is generated from
+    // ciWorkflowSupportFiles. A generated step that invokes a script with no
+    // entry references something only this repo can satisfy — the consumer
+    // regenerates a workflow whose step dies with exit 127, while this repo's
+    // own CI stays green off its hand-committed copy and hides the gap.
+    const invoked = new Set<string>()
+    for (const match of ciWorkflowSource.matchAll(
+      /(?:preparedCiRuntimeScriptsDir|scriptsDir)\}\/([A-Za-z0-9._-]+\.(?:sh|mjs|ts))/g,
+    )) {
+      invoked.add(match[1]!)
+    }
+    expect([...invoked].sort()).toEqual([
+      'prepare-job-local-rust-state.sh',
+      'resolve-devenv-ci.sh',
+      'run-with-nix-gc-race-retry.sh',
+    ])
+
+    // Those scripts also source siblings out of their own directory, so the
+    // dependency closure has to land in the prepared dir too, not just the
+    // entrypoints.
+    const required = new Set(invoked)
+    for (const name of invoked) {
+      const script = readFileSync(
+        new URL(['../../../../../../genie/ci-scripts', name].join('/'), import.meta.url),
+        'utf8',
+      )
+      for (const match of script.matchAll(
+        /\$(?:script_dir|\{script_dir\})\/([A-Za-z0-9._-]+\.sh)/g,
+      )) {
+        required.add(match[1]!)
+      }
+    }
+    expect(required.has('resolve-devenv.sh')).toBe(true)
+    expect(required.has('nix-gc-race-retry.sh')).toBe(true)
+
+    const covered = new Set(
+      [...ciWorkflowSupportFilesSource.matchAll(/'genie\/ci-scripts\/([A-Za-z0-9._-]+)'/g)].map(
+        (match) => match[1]!,
+      ),
+    )
+    expect([...required].filter((name) => covered.has(name) === false)).toEqual([])
   })
 
   it('installs setup-time megarepo from the locked effect-utils commit without mutating nix profiles', () => {


### PR DESCRIPTION
## The defect class

**A CI generator emits something only this repo can satisfy.**

Both bugs here have that shape, and it is worth naming because it explains why this repo's CI never caught either one. `effect-utils` authors the shared CI steps *and* consumes them, but it consumes them through a different path than downstream repos do. Anything that happens to be true locally — a mode that resolves, a script that is hand-committed — makes the generated step work here and fail everywhere else. **Green CI in this repo is not evidence that a generated step works.**

Two instances found and fixed. A third would look like: any generated step referencing state that exists in this checkout but is not part of what a consumer generates or receives.

---

## Instance 1 — implicit `--worktree-mode` in workspace-applying steps

`mr apply` refuses the implicit `auto` worktree mode when `CI=true`:

```
packages/@overeng/megarepo/src/cli/commands/engine.ts
const resolvedWorktreeMode = worktreeMode ?? 'auto'
const appliesWorkspace = mode === 'apply' || applyAfterFetch === true

if (appliesWorkspace === true && resolvedWorktreeMode === 'auto' && process.env.CI === 'true') {
  return yield* new InvalidOptionsError({
    message:
      'CI requires an explicit worktree strategy; pass --worktree-mode commit for deterministic detached worktrees or --worktree-mode tracking for branch worktrees',
  })
}
```

Both generators emitted the invocation without a mode:

| generator | emitted command | trips guard via |
| --- | --- | --- |
| `applyMegarepoLockStep` | `nix run …#megarepo -- apply --all` | `mode === 'apply'` |
| `syncMegarepoWorkspaceStep` | `mr fetch --apply` | `applyAfterFetch === true` |

Every consumer that regenerated got a `Sync megarepo dependencies` step that threw during job setup, before any lint/typecheck/test work ran. Measured blast radius across the two consumer repos: **5** and **14** unflagged `apply --all` sites, none carrying a mode, taking 5 of 6 CI jobs red in the first. This repo: **0** sites — it never applies its own lock this way.

**`applyMegarepoLockStep` → `--worktree-mode commit`.** Behaviour-preserving, which is the decisive argument: before the guard landed, `auto` + `CI=true` resolved to exactly `commit`, so pinning it changes nothing but satisfies the guard. It is also the semantically right mode for a step whose whole purpose is holding the checked-in lock shape — `docs/spec.md` calls `commit` `refs/commits/<sha>/`, "deterministic, isolated — exact locked commit guaranteed".

**`syncMegarepoWorkspaceStep` → `--worktree-mode tracking`.** Different intent, different answer: that step deliberately moves members to latest branch heads, so it wants branch worktrees. Matches the existing choice in `genie/ci-scripts/prepare-effect-utils-composition.sh`, which already passes `tracking` because it needs `mr apply` to attach a job-owned branch ref and asserts `member_ref == branch_ref` afterwards. Zero current consumers — but its only purpose is CI, so it was 100% broken dead API waiting to trap the next adopter.

## Instance 2 — `resolve-devenv-ci.sh` had no support-file entry

Unmasked by fixing instance 1: the failure moved exactly one step down.

`validateNixStoreStepFor` (`genie/ci-workflow/setup.ts:1040`) emits a step invoking `resolve-devenv-ci.sh` out of the prepared runtime scripts dir. That dir is populated by `Prepare CI helper scripts` from the **consuming** repo's `genie/ci-scripts`, which is generated from `ciWorkflowSupportFiles` — and there was no entry for that script. Here it is hand-committed with no generator beside it, so this repo resolves it fine.

Observed on a real runner, not hypothesised. Consumer `lint` job step conclusions:

```
Sync megarepo dependencies   success
Prepare CI helper scripts    success
Resolve devenv               failure   ← exit 127
Format + lint                skipped

.../composition-state/ci-runtime/resolve-devenv-ci.sh: No such file or directory
```

Measured: the consumer's `genie/ci-scripts` holds 6 files; this repo's holds 23, including `resolve-devenv-ci.sh`. A consumer cannot generate what has no entry.

Fixed by adding `resolveDevenvCi`, using the same lazy `sharedScriptArtifact` getter as `prSnapshotArtifact` — this module is reachable from the barrel during genie's cold bootstrap, so the read must stay deferred.

### Why the shared source stays hand-written (deliberate, not an oversight)

It would be tempting to also add a `resolve-devenv-ci.sh.genie.ts` here so this repo's copy is generated too, removing a hand-committed file that has no generator. **That would be worse.** The generator would read the very file it writes — a tautology that can never detect drift, only launder it.

The drift risk it would supposedly close does not exist: consumers emit the script through `repoContext.readText(...)`, which reads **this exact file** out of the effect-utils checkout. Verified on a consumer's generated copy — the only difference is genie's own three-line `Generated file - DO NOT EDIT` provenance banner injected after the shebang, exactly as it already treats the sibling `resolve-devenv.sh`; the script body is emitted verbatim, so the two cannot silently disagree. That is precisely the contract already documented on `prSnapshotArtifact` — "Consumers emit it verbatim, so every repo validates candidates with identical code" — and `pr-snapshot-artifact.mjs` likewise ships hand-written with no `.genie.ts` beside it. Instance 2 was a missing *entry*, not a missing generator.

## Tests — the class, not just the instances

Two new tests in `ci-workflow-helpers.unit.test.ts`, both sensitivity-checked against the pre-fix source rather than assumed to work.

**1. Every workspace-applying invocation carries an explicit mode.** Sweeps `-- apply` and the `'--apply'` argv form across the generator sources; matches command shapes only, never prose.

| source | invocation sites | unflagged |
| --- | --- | --- |
| `origin/main` (pre-fix) | 2 | **2** |
| this branch | 2 | **0** |

**2. Every prepared-runtime script has a support-file entry.** Sweeps the scripts the generators invoke out of the prepared dir, follows the `$script_dir` siblings those scripts source, and fails on any without an entry.

| source | required scripts | uncovered |
| --- | --- | --- |
| `origin/main` (pre-fix) | 5 | **1** — `resolve-devenv-ci.sh` |
| this branch | 5 | **0** |

## Audit: is there a third instance?

Asked and answered — **no**, and the negative result is the point.

Full surface of scripts any generated step invokes out of the prepared runtime dir, plus their transitive `$script_dir` dependencies:

| script | reached via | support-file entry |
| --- | --- | --- |
| `prepare-job-local-rust-state.sh` | `shared.ts:371` | `jobLocalRustState` ✅ |
| `run-with-nix-gc-race-retry.sh` | `shared.ts:407` (`withGcRaceRetry`) | `nixGcRaceRetryWrapper` ✅ |
| `resolve-devenv-ci.sh` | `setup.ts:1040` | `resolveDevenvCi` ✅ *(added here)* |
| `resolve-devenv.sh` | sourced by `resolve-devenv-ci.sh` | `resolveDevenv` ✅ |
| `nix-gc-race-retry.sh` | sourced by the retry wrapper | `nixGcRaceRetry` ✅ |

**5 required, 5 covered, 0 gaps.** Enforced by test 2 above, so instance 3 cannot land silently.

## Verification

- `devenv tasks run genie:run` — clean, **no generated-file changes in this repo**, confirming there is no `applyMegarepoLockStep` site here
- `devenv tasks run test:genie` — **420 tests, 0 failed**, including both new tests
- `devenv tasks run check:quick` — exit **0**

### Liveness: a local green does NOT prove instance 1

Stated plainly because the checklist above invites the wrong conclusion. The guard only fires when `CI=true`, so **no local run exercises that change at all** — `genie:run`, `test:genie` and `check:quick` pass identically with and without the flag. They prove the generator emits it and that nothing else regressed; they cannot prove the fix works.

The load-bearing evidence is a green **`Sync megarepo dependencies`** step in a real CI run of a consumer that has repinned and regenerated. **That evidence now exists:** on runner `dev3-8f72183e`, with `CI: true`, the log shows the executed command as

```
nix run "github:overengineeringstudio/effect-utils/$EU_REV#megarepo" -- apply --all --worktree-mode commit
{"_tag":"Success", …"results":[{"name":"effect-utils","status":"cloned","commit":"1412d4a1a…","ref":"main"}]…}
```

and the step's conclusion is `success`. The consumer's `source-policy` job — the only one that was green before, because it does not use this step — still passes, ruling out a regression there.

Instance 2's fix is verified in-file and by test; its own liveness proof comes from the consumer's next run, which needs this branch merged first.

## Consumers need BOTH fixes

Worth stating explicitly, because it is easy to assume otherwise: merging only instance 1 unblocks nobody. A consumer that repins to instance 1 alone gets past `Sync megarepo dependencies` and then dies at `Resolve devenv`. That is exactly what was observed. One consumer's adoption PR is open and waiting on this branch; the other (14 sites) needs the same repin + regenerate and is **not** done here.

<!-- agent-footer:begin v=2 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | dev3.direct.omp.mhx73ur2 |
| `session` | dev3.mhx73ur2 |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.0.11 |
| `agent_runtime` | OMP 18.0.11 |
| `tooling_profile` | dotfiles@e8f0615-dirty |
</details>
<!-- agent-footer:end -->