### PR TITLE
ci: run the paired devenv-perf lane nightly and on the perf label

### DIFF
--- a/.github/labels.json
+++ b/.github/labels.json
@@ -91,6 +91,11 @@
       "description": "TypeScript code, tsconfig, and type definitions · Set: manual"
     },
     {
+      "name": "ci:perf",
+      "color": "0e8a16",
+      "description": "Run the paired devenv-perf wall-clock lane on this PR · Set: manual"
+    },
+    {
       "name": "ci:publish-snapshot",
       "color": "0e8a16",
       "description": "Trust this fork PR branch for snapshot publishing · Set: manual"

--- a/.github/labels.json.genie.ts
+++ b/.github/labels.json.genie.ts
@@ -1,5 +1,6 @@
 import { fileURLToPath } from 'node:url'
 
+import { perfLaneLabel } from '../genie/ci.ts'
 import {
   andonLabels,
   commonLabels,
@@ -59,6 +60,15 @@ const effectUtilsSystemLabels: readonly LabelDef[] = deriveSystemLabels({
   describe: (pkg) => `@overeng/${pkg} package`,
 })
 
+/** Repo-local CI capability grants — applying one changes what CI is allowed to do. */
+const effectUtilsCiLabels: readonly LabelDef[] = [
+  {
+    name: perfLaneLabel,
+    color: '0e8a16',
+    description: 'Run the paired devenv-perf wall-clock lane on this PR · Set: manual',
+  },
+]
+
 /** Repo-local utility labels used by automation in this repo. */
 const effectUtilsAutomationLabels: readonly LabelDef[] = [
   {
@@ -91,6 +101,7 @@ export default githubLabels({
     ...andonLabels,
     ...effectUtilsAreaLabels,
     ...effectUtilsSystemLabels,
+    ...effectUtilsCiLabels,
     ...effectUtilsAutomationLabels,
   ],
   // Retire the vestigial `mq:*` labels (no runtime acts on them) alongside the GitHub defaults.

--- a/.github/repo-settings.json
+++ b/.github/repo-settings.json
@@ -78,9 +78,6 @@
             "context": "bootstrap-cold-proof"
           },
           {
-            "context": "devenv-perf"
-          },
-          {
             "context": "nix-closure-sizes"
           },
           {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,10 @@ permissions:
 on:
   push:
     branches: [main]
-  pull_request: null
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
+  schedule:
+    - cron: 17 3 * * *
   workflow_dispatch:
     inputs:
       measurement_baseline_ref:
@@ -35,6 +38,7 @@ on:
 
 jobs:
   default-ref-policy:
+    if: ${{ github.event_name != 'schedule' }}
     runs-on:
       [namespace-profile-linux-x86-64, 'namespace-features:github.run-id=${{ github.run_id }}']
     permissions:
@@ -426,7 +430,7 @@ jobs:
       group: "${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '' && format('measurement-baseline-{0}', inputs.measurement_baseline_ref) || (github.event_name == 'workflow_dispatch' && format('manual-run-{0}', github.run_id) || (github.event_name == 'pull_request' && (github.event.action == 'labeled' || github.event.action == 'unlabeled') && format('label-{0}', github.event.label.name) || 'code')) }}-default-ref-policy"
       cancel-in-progress: ${{ !(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '') && (github.event_name != 'pull_request' || (github.event.action != 'labeled' && github.event.action != 'unlabeled')) }}
   typecheck:
-    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '') }}
+    if: ${{ (!(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '')) && github.event_name != 'schedule' && !(github.event_name == 'pull_request' && github.event.action == 'labeled') }}
     runs-on:
       [namespace-profile-linux-x86-64, 'namespace-features:github.run-id=${{ github.run_id }}']
     timeout-minutes: 30
@@ -635,7 +639,7 @@ jobs:
       group: "${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '' && format('measurement-baseline-{0}', inputs.measurement_baseline_ref) || (github.event_name == 'workflow_dispatch' && format('manual-run-{0}', github.run_id) || (github.event_name == 'pull_request' && (github.event.action == 'labeled' || github.event.action == 'unlabeled') && format('label-{0}', github.event.label.name) || 'code')) }}-typecheck"
       cancel-in-progress: ${{ !(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '') && (github.event_name != 'pull_request' || (github.event.action != 'labeled' && github.event.action != 'unlabeled')) }}
   lint:
-    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '') }}
+    if: ${{ (!(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '')) && github.event_name != 'schedule' && !(github.event_name == 'pull_request' && github.event.action == 'labeled') }}
     runs-on:
       [namespace-profile-linux-x86-64, 'namespace-features:github.run-id=${{ github.run_id }}']
     timeout-minutes: 30
@@ -829,7 +833,7 @@ jobs:
       group: "${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '' && format('measurement-baseline-{0}', inputs.measurement_baseline_ref) || (github.event_name == 'workflow_dispatch' && format('manual-run-{0}', github.run_id) || (github.event_name == 'pull_request' && (github.event.action == 'labeled' || github.event.action == 'unlabeled') && format('label-{0}', github.event.label.name) || 'code')) }}-lint"
       cancel-in-progress: ${{ !(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '') && (github.event_name != 'pull_request' || (github.event.action != 'labeled' && github.event.action != 'unlabeled')) }}
   test:
-    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '') }}
+    if: ${{ (!(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '')) && github.event_name != 'schedule' && !(github.event_name == 'pull_request' && github.event.action == 'labeled') }}
     strategy:
       fail-fast: false
       matrix:
@@ -1026,7 +1030,7 @@ jobs:
       group: "${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '' && format('measurement-baseline-{0}', inputs.measurement_baseline_ref) || (github.event_name == 'workflow_dispatch' && format('manual-run-{0}', github.run_id) || (github.event_name == 'pull_request' && (github.event.action == 'labeled' || github.event.action == 'unlabeled') && format('label-{0}', github.event.label.name) || 'code')) }}-test-${{ strategy.job-index }}"
       cancel-in-progress: ${{ !(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '') && (github.event_name != 'pull_request' || (github.event.action != 'labeled' && github.event.action != 'unlabeled')) }}
   test-megarepo-cold-gc:
-    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '') }}
+    if: ${{ (!(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '')) && github.event_name != 'schedule' && !(github.event_name == 'pull_request' && github.event.action == 'labeled') }}
     runs-on:
       [namespace-profile-linux-x86-64, 'namespace-features:github.run-id=${{ github.run_id }}']
     timeout-minutes: 30
@@ -1220,7 +1224,7 @@ jobs:
       group: "${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '' && format('measurement-baseline-{0}', inputs.measurement_baseline_ref) || (github.event_name == 'workflow_dispatch' && format('manual-run-{0}', github.run_id) || (github.event_name == 'pull_request' && (github.event.action == 'labeled' || github.event.action == 'unlabeled') && format('label-{0}', github.event.label.name) || 'code')) }}-test-megarepo-cold-gc"
       cancel-in-progress: ${{ !(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '') && (github.event_name != 'pull_request' || (github.event.action != 'labeled' && github.event.action != 'unlabeled')) }}
   nix-check:
-    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '') }}
+    if: ${{ (!(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '')) && github.event_name != 'schedule' && !(github.event_name == 'pull_request' && github.event.action == 'labeled') }}
     strategy:
       fail-fast: false
       matrix:
@@ -1417,7 +1421,7 @@ jobs:
       group: "${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '' && format('measurement-baseline-{0}', inputs.measurement_baseline_ref) || (github.event_name == 'workflow_dispatch' && format('manual-run-{0}', github.run_id) || (github.event_name == 'pull_request' && (github.event.action == 'labeled' || github.event.action == 'unlabeled') && format('label-{0}', github.event.label.name) || 'code')) }}-nix-check-${{ strategy.job-index }}"
       cancel-in-progress: ${{ !(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '') && (github.event_name != 'pull_request' || (github.event.action != 'labeled' && github.event.action != 'unlabeled')) }}
   nix-fod-check:
-    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '') }}
+    if: ${{ (!(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '')) && github.event_name != 'schedule' && !(github.event_name == 'pull_request' && github.event.action == 'labeled') }}
     strategy:
       fail-fast: false
       matrix:
@@ -1549,7 +1553,7 @@ jobs:
       group: "${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '' && format('measurement-baseline-{0}', inputs.measurement_baseline_ref) || (github.event_name == 'workflow_dispatch' && format('manual-run-{0}', github.run_id) || (github.event_name == 'pull_request' && (github.event.action == 'labeled' || github.event.action == 'unlabeled') && format('label-{0}', github.event.label.name) || 'code')) }}-nix-fod-check-${{ strategy.job-index }}"
       cancel-in-progress: ${{ !(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '') && (github.event_name != 'pull_request' || (github.event.action != 'labeled' && github.event.action != 'unlabeled')) }}
   pnpm-builder-contract:
-    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '') }}
+    if: ${{ (!(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '')) && github.event_name != 'schedule' && !(github.event_name == 'pull_request' && github.event.action == 'labeled') }}
     runs-on:
       [namespace-profile-linux-x86-64, 'namespace-features:github.run-id=${{ github.run_id }}']
     timeout-minutes: 30
@@ -1794,7 +1798,7 @@ jobs:
       group: "${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '' && format('measurement-baseline-{0}', inputs.measurement_baseline_ref) || (github.event_name == 'workflow_dispatch' && format('manual-run-{0}', github.run_id) || (github.event_name == 'pull_request' && (github.event.action == 'labeled' || github.event.action == 'unlabeled') && format('label-{0}', github.event.label.name) || 'code')) }}-pnpm-builder-contract"
       cancel-in-progress: ${{ !(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '') && (github.event_name != 'pull_request' || (github.event.action != 'labeled' && github.event.action != 'unlabeled')) }}
   pnpm-regression:
-    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '') }}
+    if: ${{ (!(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '')) && github.event_name != 'schedule' && !(github.event_name == 'pull_request' && github.event.action == 'labeled') }}
     runs-on:
       [namespace-profile-linux-x86-64, 'namespace-features:github.run-id=${{ github.run_id }}']
     timeout-minutes: 30
@@ -1990,7 +1994,7 @@ jobs:
       group: "${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '' && format('measurement-baseline-{0}', inputs.measurement_baseline_ref) || (github.event_name == 'workflow_dispatch' && format('manual-run-{0}', github.run_id) || (github.event_name == 'pull_request' && (github.event.action == 'labeled' || github.event.action == 'unlabeled') && format('label-{0}', github.event.label.name) || 'code')) }}-pnpm-regression"
       cancel-in-progress: ${{ !(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '') && (github.event_name != 'pull_request' || (github.event.action != 'labeled' && github.event.action != 'unlabeled')) }}
   bundle-smoke:
-    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '') }}
+    if: ${{ (!(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '')) && github.event_name != 'schedule' && !(github.event_name == 'pull_request' && github.event.action == 'labeled') }}
     runs-on:
       [namespace-profile-linux-x86-64, 'namespace-features:github.run-id=${{ github.run_id }}']
     timeout-minutes: 30
@@ -2184,7 +2188,7 @@ jobs:
       group: "${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '' && format('measurement-baseline-{0}', inputs.measurement_baseline_ref) || (github.event_name == 'workflow_dispatch' && format('manual-run-{0}', github.run_id) || (github.event_name == 'pull_request' && (github.event.action == 'labeled' || github.event.action == 'unlabeled') && format('label-{0}', github.event.label.name) || 'code')) }}-bundle-smoke"
       cancel-in-progress: ${{ !(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '') && (github.event_name != 'pull_request' || (github.event.action != 'labeled' && github.event.action != 'unlabeled')) }}
   buck2:
-    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '') }}
+    if: ${{ (!(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '')) && github.event_name != 'schedule' && !(github.event_name == 'pull_request' && github.event.action == 'labeled') }}
     runs-on:
       [namespace-profile-linux-x86-64, 'namespace-features:github.run-id=${{ github.run_id }}']
     timeout-minutes: 30
@@ -2378,7 +2382,7 @@ jobs:
       group: "${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '' && format('measurement-baseline-{0}', inputs.measurement_baseline_ref) || (github.event_name == 'workflow_dispatch' && format('manual-run-{0}', github.run_id) || (github.event_name == 'pull_request' && (github.event.action == 'labeled' || github.event.action == 'unlabeled') && format('label-{0}', github.event.label.name) || 'code')) }}-buck2"
       cancel-in-progress: ${{ !(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '') && (github.event_name != 'pull_request' || (github.event.action != 'labeled' && github.event.action != 'unlabeled')) }}
   cargo:
-    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '') }}
+    if: ${{ (!(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '')) && github.event_name != 'schedule' && !(github.event_name == 'pull_request' && github.event.action == 'labeled') }}
     runs-on:
       [namespace-profile-linux-x86-64, 'namespace-features:github.run-id=${{ github.run_id }}']
     timeout-minutes: 30
@@ -2572,7 +2576,7 @@ jobs:
       group: "${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '' && format('measurement-baseline-{0}', inputs.measurement_baseline_ref) || (github.event_name == 'workflow_dispatch' && format('manual-run-{0}', github.run_id) || (github.event_name == 'pull_request' && (github.event.action == 'labeled' || github.event.action == 'unlabeled') && format('label-{0}', github.event.label.name) || 'code')) }}-cargo"
       cancel-in-progress: ${{ !(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '') && (github.event_name != 'pull_request' || (github.event.action != 'labeled' && github.event.action != 'unlabeled')) }}
   weaver:
-    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '') }}
+    if: ${{ (!(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '')) && github.event_name != 'schedule' && !(github.event_name == 'pull_request' && github.event.action == 'labeled') }}
     runs-on:
       [namespace-profile-linux-x86-64, 'namespace-features:github.run-id=${{ github.run_id }}']
     timeout-minutes: 30
@@ -2773,7 +2777,7 @@ jobs:
       group: "${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '' && format('measurement-baseline-{0}', inputs.measurement_baseline_ref) || (github.event_name == 'workflow_dispatch' && format('manual-run-{0}', github.run_id) || (github.event_name == 'pull_request' && (github.event.action == 'labeled' || github.event.action == 'unlabeled') && format('label-{0}', github.event.label.name) || 'code')) }}-weaver"
       cancel-in-progress: ${{ !(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '') && (github.event_name != 'pull_request' || (github.event.action != 'labeled' && github.event.action != 'unlabeled')) }}
   bootstrap-cold-proof:
-    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '') }}
+    if: ${{ (!(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '')) && github.event_name != 'schedule' && !(github.event_name == 'pull_request' && github.event.action == 'labeled') }}
     runs-on:
       [namespace-profile-linux-x86-64, 'namespace-features:github.run-id=${{ github.run_id }}']
     timeout-minutes: 30
@@ -2967,6 +2971,7 @@ jobs:
       group: "${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '' && format('measurement-baseline-{0}', inputs.measurement_baseline_ref) || (github.event_name == 'workflow_dispatch' && format('manual-run-{0}', github.run_id) || (github.event_name == 'pull_request' && (github.event.action == 'labeled' || github.event.action == 'unlabeled') && format('label-{0}', github.event.label.name) || 'code')) }}-bootstrap-cold-proof"
       cancel-in-progress: ${{ !(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '') && (github.event_name != 'pull_request' || (github.event.action != 'labeled' && github.event.action != 'unlabeled')) }}
   devenv-perf:
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:perf')) }}
     runs-on:
       [
         nscloud-ubuntu-24.04-amd64-16x64-with-features,
@@ -3812,7 +3817,7 @@ jobs:
       group: "${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '' && format('measurement-baseline-{0}', inputs.measurement_baseline_ref) || (github.event_name == 'workflow_dispatch' && format('manual-run-{0}', github.run_id) || (github.event_name == 'pull_request' && (github.event.action == 'labeled' || github.event.action == 'unlabeled') && format('label-{0}', github.event.label.name) || 'code')) }}-devenv-perf"
       cancel-in-progress: ${{ !(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '') && (github.event_name != 'pull_request' || (github.event.action != 'labeled' && github.event.action != 'unlabeled')) }}
   nix-closure-sizes:
-    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '') }}
+    if: ${{ (!(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '')) && !(github.event_name == 'pull_request' && github.event.action == 'labeled') }}
     runs-on:
       [namespace-profile-linux-x86-64, 'namespace-features:github.run-id=${{ github.run_id }}']
     timeout-minutes: 30
@@ -4483,6 +4488,7 @@ jobs:
       group: "${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '' && format('measurement-baseline-{0}', inputs.measurement_baseline_ref) || (github.event_name == 'workflow_dispatch' && format('manual-run-{0}', github.run_id) || (github.event_name == 'pull_request' && (github.event.action == 'labeled' || github.event.action == 'unlabeled') && format('label-{0}', github.event.label.name) || 'code')) }}-nix-closure-sizes"
       cancel-in-progress: ${{ !(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '') && (github.event_name != 'pull_request' || (github.event.action != 'labeled' && github.event.action != 'unlabeled')) }}
   source-shape:
+    if: ${{ !(github.event_name == 'pull_request' && github.event.action == 'labeled') }}
     runs-on:
       [namespace-profile-linux-x86-64, 'namespace-features:github.run-id=${{ github.run_id }}']
     timeout-minutes: 30
@@ -4738,7 +4744,7 @@ jobs:
       cancel-in-progress: ${{ !(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '') && (github.event_name != 'pull_request' || (github.event.action != 'labeled' && github.event.action != 'unlabeled')) }}
   ci-measurements-report:
     name: ci/measurements-report
-    if: ${{ (!(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '')) && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
+    if: ${{ !cancelled() && (!(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '')) && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && needs.devenv-perf.result != 'failure' && needs.nix-closure-sizes.result != 'failure' && needs.source-shape.result != 'failure' }}
     needs: [devenv-perf, nix-closure-sizes, source-shape]
     runs-on:
       [namespace-profile-linux-x86-64, 'namespace-features:github.run-id=${{ github.run_id }}']
@@ -4776,6 +4782,7 @@ jobs:
             echo "$out/bin" >> "$GITHUB_PATH"
           done
       - name: 'Download current measurement artifact: devenv-perf'
+        if: ${{ needs.devenv-perf.result == 'success' }}
         uses: actions/download-artifact@v4
         with:
           name: devenv-perf
@@ -4801,6 +4808,7 @@ jobs:
           BASELINE_SEED_RUNS_JSON: '[]'
           BASELINE_MAX_RUNS: '20'
           BASELINE_MAX_CANDIDATE_RUNS: '60'
+          BASELINE_CANDIDATE_EVENTS: schedule
           BASELINE_REQUIRED_OBSERVATIONS_JSON: '[]'
           BASELINE_DOWNLOAD_TIMEOUT_SECONDS: '120'
         run: |
@@ -4863,16 +4871,21 @@ jobs:
             max_candidate_runs=1
           fi
 
+          candidate_events="${BASELINE_CANDIDATE_EVENTS:-push}"
+          # Run ids increase monotonically, so sorting the merged per-event lists numerically
+          # descending restores "most recent candidate first" across events.
           candidate_runs="$(
-            "$GH_BIN" run list \
-              --repo "$repo" \
-              --workflow "$workflow" \
-              --branch "$branch" \
-              --event push \
-              --status success \
-              --json databaseId,headSha \
-              --limit "$max_candidate_runs" \
-              --jq '[.[] | select(.headSha != env.GITHUB_SHA) | .databaseId] | .[]'
+            for candidate_event in $candidate_events; do
+              "$GH_BIN" run list \
+                --repo "$repo" \
+                --workflow "$workflow" \
+                --branch "$branch" \
+                --event "$candidate_event" \
+                --status success \
+                --json databaseId,headSha \
+                --limit "$max_candidate_runs" \
+                --jq '[.[] | select(.headSha != env.GITHUB_SHA) | .databaseId] | .[]'
+            done | sort -rnu
           )"
 
           candidate_runs="$seed_run_ids
@@ -5062,6 +5075,7 @@ jobs:
           BASELINE_SEED_RUNS_JSON: '[]'
           BASELINE_MAX_RUNS: '20'
           BASELINE_MAX_CANDIDATE_RUNS: '60'
+          BASELINE_CANDIDATE_EVENTS: push
           BASELINE_REQUIRED_OBSERVATIONS_JSON: '[]'
           BASELINE_DOWNLOAD_TIMEOUT_SECONDS: '120'
         run: |
@@ -5124,16 +5138,21 @@ jobs:
             max_candidate_runs=1
           fi
 
+          candidate_events="${BASELINE_CANDIDATE_EVENTS:-push}"
+          # Run ids increase monotonically, so sorting the merged per-event lists numerically
+          # descending restores "most recent candidate first" across events.
           candidate_runs="$(
-            "$GH_BIN" run list \
-              --repo "$repo" \
-              --workflow "$workflow" \
-              --branch "$branch" \
-              --event push \
-              --status success \
-              --json databaseId,headSha \
-              --limit "$max_candidate_runs" \
-              --jq '[.[] | select(.headSha != env.GITHUB_SHA) | .databaseId] | .[]'
+            for candidate_event in $candidate_events; do
+              "$GH_BIN" run list \
+                --repo "$repo" \
+                --workflow "$workflow" \
+                --branch "$branch" \
+                --event "$candidate_event" \
+                --status success \
+                --json databaseId,headSha \
+                --limit "$max_candidate_runs" \
+                --jq '[.[] | select(.headSha != env.GITHUB_SHA) | .databaseId] | .[]'
+            done | sort -rnu
           )"
 
           candidate_runs="$seed_run_ids
@@ -5323,6 +5342,7 @@ jobs:
           BASELINE_SEED_RUNS_JSON: '[{"runId":"26085158592","label":"main baseline","sha":"ce7cf8f8ebfaa1da6c7e9122cd195a5f95ce2fca","source":"manual-backfill","artifacts":["source-shape"],"notes":"Backfilled with the current measurement workflow for the effect-utils #658 rollout."}]'
           BASELINE_MAX_RUNS: '20'
           BASELINE_MAX_CANDIDATE_RUNS: '60'
+          BASELINE_CANDIDATE_EVENTS: push
           BASELINE_REQUIRED_OBSERVATIONS_JSON: '[]'
           BASELINE_DOWNLOAD_TIMEOUT_SECONDS: '120'
         run: |
@@ -5385,16 +5405,21 @@ jobs:
             max_candidate_runs=1
           fi
 
+          candidate_events="${BASELINE_CANDIDATE_EVENTS:-push}"
+          # Run ids increase monotonically, so sorting the merged per-event lists numerically
+          # descending restores "most recent candidate first" across events.
           candidate_runs="$(
-            "$GH_BIN" run list \
-              --repo "$repo" \
-              --workflow "$workflow" \
-              --branch "$branch" \
-              --event push \
-              --status success \
-              --json databaseId,headSha \
-              --limit "$max_candidate_runs" \
-              --jq '[.[] | select(.headSha != env.GITHUB_SHA) | .databaseId] | .[]'
+            for candidate_event in $candidate_events; do
+              "$GH_BIN" run list \
+                --repo "$repo" \
+                --workflow "$workflow" \
+                --branch "$branch" \
+                --event "$candidate_event" \
+                --status success \
+                --json databaseId,headSha \
+                --limit "$max_candidate_runs" \
+                --jq '[.[] | select(.headSha != env.GITHUB_SHA) | .databaseId] | .[]'
+            done | sort -rnu
           )"
 
           candidate_runs="$seed_run_ids
@@ -7453,7 +7478,7 @@ jobs:
       group: "${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '' && format('measurement-baseline-{0}', inputs.measurement_baseline_ref) || (github.event_name == 'workflow_dispatch' && format('manual-run-{0}', github.run_id) || (github.event_name == 'pull_request' && (github.event.action == 'labeled' || github.event.action == 'unlabeled') && format('label-{0}', github.event.label.name) || 'code')) }}-test-integration-notion"
       cancel-in-progress: ${{ !(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '') && (github.event_name != 'pull_request' || (github.event.action != 'labeled' && github.event.action != 'unlabeled')) }}
   test-integration-restate:
-    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '') }}
+    if: ${{ (!(github.event_name == 'workflow_dispatch' && inputs.measurement_baseline_ref != '')) && github.event_name != 'schedule' && !(github.event_name == 'pull_request' && github.event.action == 'labeled') }}
     concurrency:
       group: 'test-integration-restate-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}'
       cancel-in-progress: true

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -41,11 +41,8 @@ import {
   withCiSourceRoot,
   defaultRefPolicyCheckJob,
 } from '../../genie/ci-workflow.ts'
-import { type CoreCIJobName } from '../../genie/ci.ts'
-import {
-  githubWorkflowEvent,
-  type GitHubWorkflowArgs,
-} from '../../packages/@overeng/genie/src/runtime/mod.ts'
+import { type CoreCIJobName, perfLaneLabel } from '../../genie/ci.ts'
+import { type GitHubWorkflowArgs } from '../../packages/@overeng/genie/src/runtime/mod.ts'
 
 const workflowReportFlakeRef =
   "github:${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}/${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}#ci-tools"
@@ -291,8 +288,57 @@ const nixDiagnosticsSummaryStep = {
 } as const
 
 const jobTimeoutMinutes = 30
-const normalCiIf = `\${{ ${ciMeasurementNotBaselineBackfillPredicate} }}`
+
+/**
+ * The `labeled` pull-request activity type exists only so `ci:perf` can opt one pull
+ * request into the paired wall-clock lane. It does not change the commit under test, so
+ * every other lane ignores it — a label must never re-run product CI or duplicate a
+ * measurement artifact for a SHA that was already measured.
+ */
+const notPerfLabelEventIf =
+  "!(github.event_name == 'pull_request' && github.event.action == 'labeled')"
+
+/**
+ * `schedule` exists only for the nightly measurement snapshot of `main`: the paired
+ * `devenv-perf` lane, the two deterministic measurement lanes, and the aggregate report.
+ * Product lanes carry this guard so a cron never re-runs the product matrix.
+ */
+const notNightlyMeasurementIf = "github.event_name != 'schedule'"
+
+const normalCiIf = `\${{ (${ciMeasurementNotBaselineBackfillPredicate}) && ${notNightlyMeasurementIf} && ${notPerfLabelEventIf} }}`
 const trustedSecretCiIf = `\${{ (${ciMeasurementNotBaselineBackfillPredicate}) && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}`
+
+/** Deterministic measurement lanes: like `normalCiIf`, but they also feed the nightly snapshot. */
+const measurementLaneIf = `\${{ (${ciMeasurementNotBaselineBackfillPredicate}) && ${notPerfLabelEventIf} }}`
+
+/**
+ * `source-shape` also produces the subject artifact for a measurement baseline backfill,
+ * so unlike the other measurement lanes it keeps the backfill dispatch path.
+ */
+const sourceShapeLaneIf = `\${{ ${notPerfLabelEventIf} }}`
+
+/**
+ * The paired wall-clock lane. Nightly trend telemetry on `main`, an operator dispatch
+ * (including a measurement baseline backfill), or a pull request that carries `ci:perf`.
+ * Deliberately not on every push: 35 advisory minutes per run bought nothing that a
+ * targeted per-admission probe plus a daily trend series does not.
+ */
+const devenvPerfLaneIf = `\${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, '${perfLaneLabel}')) }}`
+
+/**
+ * The report aggregates whichever measurement lanes ran on `main`: all three nightly, the
+ * two deterministic ones on a push. A skipped `devenv-perf` must not skip the report, so
+ * the condition inspects `needs` results instead of relying on implicit success.
+ */
+const measurementReportIf = [
+  '${{ !cancelled()',
+  `&& (${ciMeasurementNotBaselineBackfillPredicate})`,
+  "&& github.ref == 'refs/heads/main'",
+  "&& (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')",
+  "&& needs.devenv-perf.result != 'failure'",
+  "&& needs.nix-closure-sizes.result != 'failure'",
+  "&& needs.source-shape.result != 'failure' }}",
+].join(' ')
 
 const job = ({
   step,
@@ -529,15 +575,25 @@ const devenvPerfMeasurementsDir = '${{ github.workspace }}/tmp/devenv-perf-ci'
 const nixClosureMeasurementsDir = `${effectUtilsMemberTmpDir}/nix-closure-ci`
 const ciMeasurementReportDir = 'tmp/ci-measurement-report'
 
+/**
+ * `actions/download-artifact` fails when the named artifact does not exist, so a producer
+ * lane that did not run in this event needs `producedBy` — the report then aggregates the
+ * lanes that did run instead of failing on the ones that did not.
+ */
 const downloadCurrentMeasurementArtifactStep = ({
   artifactName,
   outputDir,
+  producedBy,
 }: {
   artifactName: string
   outputDir: string
+  producedBy?: string
 }) =>
   ({
     name: `Download current measurement artifact: ${artifactName}`,
+    ...(producedBy === undefined
+      ? {}
+      : { if: `\${{ needs.${producedBy}.result == 'success' }}` }),
     uses: 'actions/download-artifact@v4',
     with: {
       name: artifactName,
@@ -605,6 +661,7 @@ const extraJobs: Record<string, any> = {
     },
   }),
   'devenv-perf': {
+    if: devenvPerfLaneIf,
     ...devenvPerfJob({
       runsOn: namespaceRunner({
         profile: namespaceLinuxX64PairedPerfRunner,
@@ -723,7 +780,7 @@ const extraJobs: Record<string, any> = {
     'timeout-minutes': 90,
   },
   'nix-closure-sizes': {
-    if: normalCiIf,
+    if: measurementLaneIf,
     'runs-on': namespaceRunner({
       profile: 'namespace-profile-linux-x86-64',
       runId: '${{ github.run_id }}',
@@ -756,6 +813,7 @@ const extraJobs: Record<string, any> = {
   },
   // Checkout exemption: source-shape measures actions-checkout bytes only; it runs no devenv/Buck.
   'source-shape': {
+    if: sourceShapeLaneIf,
     'runs-on': namespaceRunner({
       profile: 'namespace-profile-linux-x86-64',
       runId: '${{ github.run_id }}',
@@ -810,7 +868,7 @@ const extraJobs: Record<string, any> = {
   // Checkout exemption: report aggregation uses only Nix-provided tools and downloaded artifacts.
   'ci-measurements-report': {
     name: 'ci/measurements-report',
-    if: trustedSecretCiIf,
+    if: measurementReportIf,
     needs: ['devenv-perf', 'nix-closure-sizes', 'source-shape'],
     'runs-on': namespaceRunner({
       profile: 'namespace-profile-linux-x86-64',
@@ -827,6 +885,7 @@ const extraJobs: Record<string, any> = {
       downloadCurrentMeasurementArtifactStep({
         artifactName: 'devenv-perf',
         outputDir: `${ciMeasurementReportDir}/current/devenv-perf`,
+        producedBy: 'devenv-perf',
       }),
       downloadCurrentMeasurementArtifactStep({
         artifactName: 'nix-closure-measurements',
@@ -839,6 +898,9 @@ const extraJobs: Record<string, any> = {
       downloadPreviousGitHubArtifactStep({
         artifactName: 'devenv-perf',
         outputDir: `${ciMeasurementReportDir}/baseline/devenv-perf`,
+        // The paired lane's trend series is the nightly `schedule` run, so a `push` scan
+        // would burn its whole candidate budget on runs that never carried the artifact.
+        candidateEvents: ['schedule'],
         maxRuns: 20,
       }),
       downloadPreviousGitHubArtifactStep({
@@ -1042,7 +1104,15 @@ export default ciWorkflow({
   name: 'CI',
   on: {
     push: { branches: ['main'] },
-    pull_request: githubWorkflowEvent.all,
+    // `labeled` is present only so applying `ci:perf` materializes the paired
+    // wall-clock lane for a pull request that is already open; every other lane
+    // guards against label events because they do not change the commit under test.
+    pull_request: { types: ['opened', 'reopened', 'synchronize', 'labeled'] },
+    // Nightly measurement snapshot of `main` (03:17 UTC): the paired `devenv-perf`
+    // lane, the two deterministic measurement lanes, and `ci/measurements-report`.
+    // This is the trend series the report compares against, and the only cadence on
+    // which the 35-minute paired lane is paid.
+    schedule: [{ cron: '17 3 * * *' }],
     workflow_dispatch: {
       inputs: {
         ...ciMeasurementBaselineWorkflowDispatchInputs,
@@ -1069,16 +1139,20 @@ export default ciWorkflow({
     // validation branches should fail one authority job, not obscure
     // lint/typecheck/test signal.
     // Checkout exemption: policy scans checkout authority files and never invokes devenv or Buck.
-    'default-ref-policy': defaultRefPolicyCheckJob({
-      // Keep this tiny policy job on the same Namespace runner class as the
-      // rest of CI so source-policy enforcement does not wait on legacy labels.
-      runsOn: namespaceRunner({
-        profile: 'namespace-profile-linux-x86-64',
-        runId: '${{ github.run_id }}',
+    'default-ref-policy': {
+      // A cron carries no code change, so the source-policy scan has nothing to say.
+      if: `\${{ ${notNightlyMeasurementIf} }}`,
+      ...defaultRefPolicyCheckJob({
+        // Keep this tiny policy job on the same Namespace runner class as the
+        // rest of CI so source-policy enforcement does not wait on legacy labels.
+        runsOn: namespaceRunner({
+          profile: 'namespace-profile-linux-x86-64',
+          runId: '${{ github.run_id }}',
+        }),
+        // LiveStore intentionally uses dev as its trunk branch.
+        defaultRefs: { 'livestorejs/livestore': 'dev' },
       }),
-      // LiveStore intentionally uses dev as its trunk branch.
-      defaultRefs: { 'livestorejs/livestore': 'dev' },
-    }),
+    },
     ...jobs,
     ...extraJobs,
     ...deployJobs,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,23 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- **CI**: the paired `devenv-perf` wall-clock lane no longer runs on every pull
+  request. It now runs on a nightly `schedule` against `main`, on operator
+  `workflow_dispatch`, and on a pull request carrying the new `ci:perf` label.
+  Measured on three consecutive `ci.yml` runs the lane took 35.0 / 35.7 / 35.0
+  minutes against a 37.4-minute whole-run wall clock while `compare: false`,
+  `regressionMode: 'warn'` and `prComment.enabled: false` meant it neither
+  blocked a regression nor reported one — so it was pure critical path. The lane
+  is unchanged otherwise: same runner, same probes, same observation ids, so the
+  trend series is continuous. Consequently it is no longer a required status
+  check (a lane that does not run on every pull request reports no check run, so
+  branch protection would wait forever), `ci/measurements-report` now runs on the
+  nightly cadence as well and tolerates a skipped perf lane, and the report's
+  perf baseline scan reads `schedule` runs via the new `candidateEvents` option
+  on `downloadPreviousGitHubArtifactStep` instead of `push` runs. Per-admission
+  benchmark evidence moves to a targeted probe recorded with the admission; see
+  `context/ci-measurements.md` "Lane Cadence".
+
 - **@overeng/stylex-preset -> @overeng/stylex-tokens**: the shared StyleX
   package is renamed to say what it durably is — our design-token package — and
   is now browser-pure. Its generated manifest declares no build-tool dependency

--- a/context/buck2/.decisions/.proposed/benchmark-evidence-is-a-probe-the-paired-lane-is-trend-telemetry.md
+++ b/context/buck2/.decisions/.proposed/benchmark-evidence-is-a-probe-the-paired-lane-is-trend-telemetry.md
@@ -1,0 +1,101 @@
+# Benchmark evidence per admission is a targeted probe; the paired lane is trend telemetry
+
+## Status
+
+proposed
+
+## Context
+
+BUCK-R16 requires that each admission record warm no-op time, fresh-context
+time with a warm shared cache, cache-hit rate for unchanged targets, and the CI
+wall-clock delta against the pre-admission baseline. BUCK-R15 requires a net
+complexity ledger per phase. Both were ratified on 2026-08-29 as requirement
+text (commit `5dd8c4f4b`, "docs(buck2): ratify measurable complexity and
+benchmark requirements") without a decision record, so nothing recorded _where_
+that evidence is produced.
+
+In practice it was produced nowhere in particular, and a lane was paying for it
+anyway. `devenv-perf` — the paired wall-clock lane — ran on every pull request
+with a 90-minute timeout on a 16-vCPU paired Namespace worker, `regressionMode:
+'warn'`, `compare: false`, and `prComment.enabled: false`. It was also a
+required status check. Measured on three consecutive `ci.yml` runs it took
+**35.0 / 35.7 / 35.0 minutes** against a **37.4-minute whole-run wall clock**:
+the lane was the critical path for the entire workflow, and it neither blocked
+on a regression nor said anything on the pull request. Its ~29 probe executions
+measure the whole devenv surface — `pnpm:install`, `genie:run`, `genie:check`,
+warm and forced `check:quick`, shell eval — on every change, including changes
+that touch none of it.
+
+The upcoming Buck2 foundation work makes this concrete rather than theoretical.
+The foundation admissions are a sequence of pull requests whose _own_ cost is
+about 2 minutes of `buck2 check` plus ~17 minutes of macOS validation. Paying 35
+advisory minutes per admission for numbers that nobody reads, and that no
+requirement asks to be collected per pull request, would have dominated the
+schedule of the very work whose efficiency BUCK-R16 exists to measure.
+
+Options considered:
+
+- **Option 0 — leave it required per pull request and make it useful** (enable
+  `prComment`, set `regressionMode: 'block'`). Rejected: this is the more
+  expensive direction, and the lane's own gate policies say wall-clock rows need
+  paired same-run base/head evidence before they can block. `compare: false`
+  means the lane does not even produce that evidence today; making it blocking
+  first would gate merges on historical bands the measurement spec explicitly
+  forbids as a merge gate.
+- **Option 1 (chosen) — split the two jobs the lane was conflating.** A cadence
+  lane for the trend series, a targeted probe for per-admission evidence.
+- **Option 2 — delete the lane and rely on ad-hoc probes.** Rejected: the trend
+  series is the only thing that detects slow drift nobody's individual change is
+  responsible for, and it is exactly what a cadence is good at. Deleting it also
+  throws away the measurement engine, its baseline provenance, and its seeded
+  history.
+
+## Decision
+
+1. **Per-admission BUCK-R16 evidence is a targeted probe recorded with the
+   admission**, in the admission's `.experiments/` record: warm no-op,
+   fresh-context with a warm shared cache, cache-hit rate for unchanged targets,
+   and the CI wall-clock delta. The probe is scoped to the surface the admission
+   touches. BUCK-R16's content is unchanged; only its production site is now
+   stated.
+
+2. **The paired `devenv-perf` lane is trend telemetry on a cadence, not a
+   per-change gate.** It runs on a nightly `schedule` against `main`, on
+   operator `workflow_dispatch` (including measurement baseline backfill), and
+   on a pull request carrying the `ci:perf` label when one genuinely needs the
+   numbers before merge. It is not removed, not narrowed, and its probe set is
+   unchanged — every observation id stays stable, so the series is continuous
+   across the cadence change.
+
+3. **The lane is no longer a required status check**, because a lane that does
+   not run on every pull request cannot be one: a skipped job reports no check
+   run, so branch protection would wait forever. This is a consequence of (2),
+   not an independent loosening — the lane never blocked on a measurement
+   verdict, so nothing that used to fail a merge stops doing so.
+
+4. **The trend series moves with the producer.** The report's baseline candidate
+   scan for the perf family reads `schedule` runs instead of `push` runs. Until
+   nightly runs accumulate, the perf family in `ci/measurements-report` renders
+   current-only, which is the same graceful path the engine already takes for a
+   newly introduced metric.
+
+## Consequences
+
+- A Buck2 foundation admission costs ~2 min `buck2 check` + ~17 min macOS
+  instead of ~37 min, because the 35-minute lane is off the critical path.
+- Wall-clock regression attribution gets coarser: a nightly series localizes a
+  regression to a day of merges rather than to a commit. Accepted — the lane
+  produced no attribution at all while `compare: false` and `prComment` were
+  off, and `ci:perf` recovers per-pull-request numbers on demand for a change
+  that plausibly moves them.
+- The `ci:perf` grant is maintainer-managed and revocable, consistent with the
+  other `ci:*` capability labels.
+- BUCK-R15's ledger is unaffected: this deletes no machinery and adds a trigger
+  predicate plus one label.
+
+## Open
+
+Whether the nightly lane should turn `compare: true` with `regressionMode:
+'warn'` and publish a daily summary now that it has a stable cadence to compare
+against. Deferred: it needs a noise profile from the nightly series first, which
+does not exist yet.

--- a/context/ci-measurements.md
+++ b/context/ci-measurements.md
@@ -30,9 +30,10 @@ semantics match:
 
 Historical comparison is not a substitute for paired wall-clock evidence.
 Budget comparison is not a substitute for owner-approved semantic budgets.
-Branch protection may still require the measurement-producing job to complete
+Branch protection may require the measurement-producing job to complete
 successfully; that requires evidence production, not a red/yellow measurement
-verdict.
+verdict. It may only require a lane that runs on every pull request — see
+[Lane Cadence](#lane-cadence).
 
 ## Observation Contract
 
@@ -229,6 +230,39 @@ Required measurement jobs and required measurement verdicts are separate
 decisions. A repo may require the measurement lane so artifact production and
 comparison code stay healthy while the observations inside that lane remain
 advisory.
+
+## Lane Cadence
+
+A lane's cost is paid on every event it fires on, so cadence is part of its
+design rather than a deployment detail. Three cadences are in use:
+
+| Cadence            | Fits                                                                                 | Merge-blocking |
+| ------------------ | ------------------------------------------------------------------------------------ | -------------- |
+| every pull request | Cheap measurement whose value is attributable to the diff under review               | Yes.           |
+| `schedule`         | Expensive wall-clock measurement whose value is a trend series on the trunk          | No.            |
+| opt-in label       | The same expensive measurement, when one pull request needs the numbers before merge | No.            |
+
+Two rules follow.
+
+**A lane that does not run on every pull request cannot be a required status
+check.** A skipped job reports no check run at all, so branch protection would
+wait for a status that never arrives. Cadence and required-check membership are
+therefore one decision, not two.
+
+**Per-admission evidence is a targeted probe, not a lane.** When a requirement
+asks for a measurement per change — warm no-op time, fresh-context time,
+cache-hit rate, CI wall-clock delta — that evidence is produced by a probe
+scoped to the change and recorded with the change. A standing lane on every
+pull request measures the whole surface repeatedly to answer a question about
+one part of it, and pays full wall-clock cost each time to do so.
+
+In this repo: `nix-closure-sizes` and `source-shape` are per-pull-request
+deterministic lanes and are required. `devenv-perf` is the paired wall-clock
+lane — a nightly `schedule` run against `main` supplies the trend series, and
+the `ci:perf` label opts a single pull request in. Its baseline candidate scan
+reads `schedule` runs rather than `push` runs, because that is where its
+artifacts now exist. `ci/measurements-report` aggregates whichever lanes ran in
+the event that produced it and is advisory in every case.
 
 ## Baseline Model
 

--- a/genie/ci-workflow/measurements.ts
+++ b/genie/ci-workflow/measurements.ts
@@ -231,6 +231,13 @@ export type GitHubPreviousArtifactStepOptions = {
   readonly seedRunIds?: readonly string[]
   readonly maxRuns?: number
   readonly maxCandidateRuns?: number
+  /**
+   * Trigger events whose successful runs may supply a baseline artifact. Defaults to
+   * `push`, which is right for a lane that runs on every merge. A lane that produces its
+   * trend series on a cadence instead names that event, so the scan is not spent on runs
+   * that never carried the artifact.
+   */
+  readonly candidateEvents?: readonly string[]
   readonly downloadTimeoutSeconds?: number
   readonly requiredObservations?: readonly CiMeasurementRequiredBaselineObservation[]
   readonly tokenExpression?: string
@@ -1265,6 +1272,7 @@ export const downloadPreviousGitHubArtifactStep = (opts: GitHubPreviousArtifactS
       BASELINE_MAX_CANDIDATE_RUNS: String(
         opts.maxCandidateRuns ?? Math.max((opts.maxRuns ?? 5) * 3, 20),
       ),
+      BASELINE_CANDIDATE_EVENTS: (opts.candidateEvents ?? ['push']).join(' '),
       BASELINE_REQUIRED_OBSERVATIONS_JSON: ciMeasurementRequiredObservationsJson(opts),
       BASELINE_DOWNLOAD_TIMEOUT_SECONDS: String(opts.downloadTimeoutSeconds ?? 120),
     },
@@ -1327,16 +1335,21 @@ if ! [[ "$max_candidate_runs" =~ ^[0-9]+$ ]] || [ "$max_candidate_runs" -lt 1 ];
   max_candidate_runs=1
 fi
 
+candidate_events="${dollar}{BASELINE_CANDIDATE_EVENTS:-push}"
+# Run ids increase monotonically, so sorting the merged per-event lists numerically
+# descending restores "most recent candidate first" across events.
 candidate_runs="$(
-  "$GH_BIN" run list \
-    --repo "$repo" \
-    --workflow "$workflow" \
-    --branch "$branch" \
-    --event push \
-    --status success \
-    --json databaseId,headSha \
-    --limit "$max_candidate_runs" \
-    --jq '[.[] | select(.headSha != env.GITHUB_SHA) | .databaseId] | .[]'
+  for candidate_event in $candidate_events; do
+    "$GH_BIN" run list \
+      --repo "$repo" \
+      --workflow "$workflow" \
+      --branch "$branch" \
+      --event "$candidate_event" \
+      --status success \
+      --json databaseId,headSha \
+      --limit "$max_candidate_runs" \
+      --jq '[.[] | select(.headSha != env.GITHUB_SHA) | .databaseId] | .[]'
+  done | sort -rnu
 )"
 
 candidate_runs="$seed_run_ids

--- a/genie/ci.ts
+++ b/genie/ci.ts
@@ -44,13 +44,33 @@ export const EXTRA_CI_JOB_NAMES = [
   // Empirical bootstrap-safety authority (R32, issue #884): builds the self-contained nix genie and
   // proves `genie --phase bootstrap` + `pnpm install` run cold (no node_modules). Merge-blocking.
   'bootstrap-cold-proof',
-  'devenv-perf',
   'nix-closure-sizes',
   'source-shape',
   'test-integration-notion',
   'test-integration-restate',
   'test-live-deploy-ci-tools',
 ] as const
+
+/**
+ * Lanes that deliberately do not run on every pull request.
+ *
+ * These cannot be required status checks: a lane that is skipped reports no check run at
+ * all, so branch protection would wait for a status that never arrives.
+ *
+ * `devenv-perf` is the paired wall-clock lane. It is trend telemetry on a nightly cadence
+ * against `main` plus an opt-in `ci:perf` label for a pull request that needs the numbers
+ * before merge, because a 35-minute advisory measurement is not worth paying on every push.
+ */
+export const OPT_IN_CI_JOB_NAMES = ['devenv-perf'] as const
+
+/**
+ * Pull-request label that opts one pull request into the `devenv-perf` lane.
+ *
+ * A maintainer-managed, revocable CI capability grant in the `ci:*` axis, repo-local
+ * because only this repository has the lane. The workflow trigger and the label catalog
+ * must agree on the exact string, so both read it from here.
+ */
+export const perfLaneLabel = 'ci:perf'
 
 /** Required deploy/reporting job keys that block merge when they fail. */
 export const REQUIRED_DEPLOY_CI_JOB_NAMES = ['deploy-storybooks'] as const
@@ -63,6 +83,7 @@ export const CI_JOB_NAMES = [
   DEFAULT_REF_POLICY_CI_JOB_NAME,
   ...CORE_CI_JOB_NAMES,
   ...EXTRA_CI_JOB_NAMES,
+  ...OPT_IN_CI_JOB_NAMES,
   ...REQUIRED_DEPLOY_CI_JOB_NAMES,
   ...advisoryCIJobNames,
 ] as const
@@ -73,9 +94,11 @@ export type CIJobName = (typeof CI_JOB_NAMES)[number]
 /**
  * Merge-blocking CI job keys for branch protection.
  *
- * Every non-advisory workflow lane is required. Measurement jobs can still run
- * warn-mode comparisons internally, but the lane must produce its artifact and
- * complete successfully so branch protection covers CI evidence production.
+ * Every lane that runs on every pull request and is not advisory is required. Measurement
+ * jobs can still run warn-mode comparisons internally, but the lane must produce its
+ * artifact and complete successfully so branch protection covers CI evidence production.
+ * Lanes in `OPT_IN_CI_JOB_NAMES` are excluded because they do not run on every pull
+ * request.
  */
 export const REQUIRED_CI_JOB_NAMES = [
   DEFAULT_REF_POLICY_CI_JOB_NAME,

--- a/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
@@ -119,6 +119,10 @@ const generatedCiJobKeys = Array.from(
 ).filter((jobKey): jobKey is string => jobKey !== undefined)
 
 const advisoryCheckContexts = new Set(['ci/measurements-report', 'notify-alignment'])
+// Opt-in lanes (see OPT_IN_CI_JOB_NAMES in genie/ci.ts) are non-advisory but do not run on
+// every pull request, so branch protection cannot require them: a skipped lane reports no
+// check run at all and a required-but-absent context would wait forever.
+const optInCheckContexts = new Set(['devenv-perf'])
 const matrixCheckJobs = new Set(['test', 'nix-check', 'nix-fod-check'])
 const matrixRunners = ['namespace-profile-linux-x86-64', 'namespace-profile-macos-arm64'] as const
 
@@ -222,10 +226,11 @@ const megarepoTaskModuleSource = readFileSync(
 )
 
 describe('ci workflow retry helpers', () => {
-  it('keeps non-advisory workflow jobs required by branch protection', () => {
-    expect(new Set(generatedRequiredCheckContexts)).toEqual(
-      new Set(generatedNonAdvisoryCheckContexts),
+  it('keeps non-advisory always-on workflow jobs required by branch protection', () => {
+    const requiredCandidates = generatedNonAdvisoryCheckContexts.filter(
+      (context) => optInCheckContexts.has(context) === false,
     )
+    expect(new Set(generatedRequiredCheckContexts)).toEqual(new Set(requiredCandidates))
   })
 
   it('emits compact calls to the checked-in retry helper script', () => {

--- a/packages/@overeng/genie/src/runtime/github-workflow/mod.ts
+++ b/packages/@overeng/genie/src/runtime/github-workflow/mod.ts
@@ -58,6 +58,8 @@ type PushPullRequestTriggerConfig = {
   'paths-ignore'?: string[]
   tags?: string[]
   'tags-ignore'?: string[]
+  /** Activity types for `pull_request` / `pull_request_target`; `push` has none. */
+  types?: string[]
 }
 
 type ScheduleTrigger = {


### PR DESCRIPTION
## Problem

The paired `devenv-perf` wall-clock lane ran on **every pull request** — a
90-minute timeout on a 16-vCPU paired Namespace worker, ~29 probe executions
across the whole devenv surface (`pnpm:install`, `genie:run`, `genie:check`,
warm and forced `check:quick`, shell eval) — while every switch that would make
it actionable was off:

```
regressionMode: 'warn'      # never fails
compare: false              # produces no comparison in the lane
prComment.enabled: false    # says nothing on the PR
```

So it was a required status check that could not fail on a measurement, and a
measurement nobody could read. Measured on three consecutive `ci.yml` runs
(`gh api .../jobs`):

| run | `devenv-perf` | whole-run wall clock |
| --- | ------------: | -------------------: |
| 1   |      35.0 min |             37.4 min |
| 2   |      35.7 min |                    — |
| 3   |      35.0 min |                    — |

The lane *was* the critical path. 850 of the generated workflow's YAML lines
belong to it.

## Goal

The lane keeps its job — a wall-clock trend series and on-demand numbers — at a
cadence proportional to what it answers, and stops being the thing every pull
request waits on. Nothing about the measurement changes: same runner, same probe
set, same observation ids, so the series is continuous across this change.

## Decisions

**Cadence, not deletion.** `schedule` (nightly, `main`) supplies the trend
series; `workflow_dispatch` keeps the operator and measurement-baseline-backfill
paths; the new `ci:perf` label opts a single pull request in when a change
plausibly moves these numbers. Deleting the lane would throw away the
measurement engine, its baseline provenance, and its seeded history — and a
cadence is exactly what catches drift no single change is responsible for.

**Rejected: keep it per-PR and make it useful** (enable `prComment`, set
`regressionMode: 'block'`). That is the *more* expensive direction, and
`context/ci-measurements.md` already forbids it: a wall-clock row may only block
on same-run paired base/head evidence, and `compare: false` means the lane does
not produce that today. Making it blocking first would gate merges on historical
bands the spec explicitly rules out as a merge gate.

**Required-check membership follows cadence.** A lane that does not run on every
pull request cannot be a required status check: a skipped job reports no check
run at all, so branch protection waits for a status that never arrives. This is
a consequence, not an independent loosening — the lane never blocked on a
measurement verdict. New `OPT_IN_CI_JOB_NAMES` in `genie/ci.ts` names that
category so the next such lane cannot silently become required.

**The report follows its producers.** `ci/measurements-report` now also runs on
the nightly cadence, and its condition inspects `needs.*.result` so a skipped
`devenv-perf` does not skip the report. The perf current-artifact download is
gated on `needs.devenv-perf.result == 'success'`, because
`actions/download-artifact` fails on a missing artifact; the comparison script
already tolerates a missing family (it only errors when *no* current
measurements exist).

**Baselines follow the producer too.** The baseline scan was hardcoded to
`--event push`. With the producer on `schedule`, a push scan would spend its
whole candidate budget on runs that never carried the artifact. New
`candidateEvents` option on `downloadPreviousGitHubArtifactStep` (default
`['push']`, unchanged for every other caller); the perf family passes
`['schedule']`.

**`labeled` is opt-in only.** It joins the `pull_request` activity types so
applying `ci:perf` materializes the lane on an already-open PR. Every other lane
guards against it — a label does not change the commit under test, and a
duplicate measurement artifact for an already-measured SHA would pollute the
baseline history. Existing job-level concurrency already keys label events
separately and does not cancel in-flight code runs, so no concurrency change was
needed.

**One cron guard, centrally.** `schedule` fires the whole workflow, so product
lanes gained `github.event_name != 'schedule'` through the shared `normalCiIf`
predicate rather than 20 individual edits. `trustedSecretCiIf` already excluded
it (it requires `push`/`workflow_dispatch`). The nightly run is therefore
exactly: `devenv-perf` + `nix-closure-sizes` + `source-shape` +
`ci/measurements-report`.

## Verification

`devenv tasks run check:quick` — green:

```
✓ Running buck2:typescript:materialize-dist in 13.2s
• Running ts:check
✓ Running ts:check in 15.3s
• Running check:quick
✓ Running check:quick in 65.2ms
✓ Running tasks in 51.3s
```

`genie:run` regenerated `ci.yml`, `repo-settings.json` and `labels.json`, and
`lint:check:genie` (inside `check:quick`) confirms zero drift between sources
and generated output.

Generated `.github/workflows/ci.yml`, before → after:

```diff
 on:
   push:
     branches: [main]
-  pull_request: null
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
+  schedule:
+    - cron: 17 3 * * *
   workflow_dispatch:
```

```diff
   devenv-perf:
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'pull_request'
+      && contains(github.event.pull_request.labels.*.name, 'ci:perf')) }}
     timeout-minutes: 90
```

```diff
   ci-measurements-report:
     name: ci/measurements-report
-    if: ${{ (!(… baseline_ref …)) && github.ref == 'refs/heads/main'
-      && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
+    if: ${{ !cancelled() && (!(… baseline_ref …)) && github.ref == 'refs/heads/main'
+      && (github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+      || github.event_name == 'schedule')
+      && needs.devenv-perf.result != 'failure'
+      && needs.nix-closure-sizes.result != 'failure'
+      && needs.source-shape.result != 'failure' }}
     needs: [devenv-perf, nix-closure-sizes, source-shape]
       - name: 'Download current measurement artifact: devenv-perf'
+        if: ${{ needs.devenv-perf.result == 'success' }}
```

Required status checks, `.github/repo-settings.json`:

```diff
-          {
-            "context": "devenv-perf"
-          },
```

The generated diff is only the intended change. Every other generated `if:` hunk
is the same two-clause cron/label guard appended to the existing
baseline-backfill predicate, one per product lane; the three
`downloadPreviousGitHubArtifactStep` script hunks are the same
`candidateEvents` loop, with `BASELINE_CANDIDATE_EVENTS: push` (unchanged
behavior) for the closure-size and source-shape families and `schedule` for the
perf family.

Expected effect on a foundation pull request: ~2 min `buck2 check` + ~17 min
macOS validation instead of ~37 min, because the 35-minute lane leaves the
critical path.

## Complexity

Five predicate constants in the workflow generator, one optional option on an
existing step helper, one optional `types` field on the workflow trigger type,
one label. No new module, dependency, or abstraction; no machinery deleted or
duplicated. The alternative — a separate workflow file for the lane — would
break `ci/measurements-report`, which needs the perf artifact from the same run.

## Concerns

- **Wall-clock regression attribution gets coarser.** A nightly series localizes
  a regression to a day of merges rather than to a commit. Accepted: with
  `compare: false` and `prComment` off, the lane produced no attribution at all,
  and `ci:perf` recovers per-PR numbers on demand.
- **The perf baseline starts empty.** No `schedule` runs exist yet, so until
  nightlies accumulate, the perf family in `ci/measurements-report` renders
  current-only. That is the same graceful path the engine already takes for a
  newly introduced metric, and it self-heals within ~20 days for a full
  `maxRuns: 20` window.
- **The live branch-protection ruleset must be re-applied.** This PR changes the
  generated `.github/repo-settings.json`; the ruleset on GitHub still lists
  `devenv-perf` until someone `PUT`s it (command is in the header of
  `.github/repo-settings.json.genie.ts`). Until then a pull request will wait on
  a check that no longer runs. **This should be applied at merge time.**
- **`ci:perf` must exist as a label before it can be applied** —
  `devenv tasks run gh:apply-labels` provisions it from the regenerated
  `labels.json`.
- **`types:` on `PushPullRequestTriggerConfig`** is shared between `push` and
  `pull_request` in the genie runtime type, and `push` has no activity types.
  The field is documented as PR-only. Splitting the two trigger types is a
  larger refactor than this change warrants.

## Friction & bottlenecks

- **Friction:** `devenv tasks run check:quick` in a fresh `branchy new
  effect-utils` worktree fails on its first invocation. `mr:setup` converts the
  worktree into a composed root *while the run is in progress*, so the tasks
  scheduled in parallel with it resolve paths that have already moved
  (`ENOENT` on `.genie.ts` files, a `tsgolint` panic on a missing fixture,
  `Module not found .../megarepo/bin/mr.ts`). After `mr:setup` completes,
  `check:quick` from the composed member root is green with no source change.
  The first run is not a usable signal, which costs one full cycle every time
  and reads like a real failure. Worth a tracked issue against the composed
  default worktree flow (decision 0027) — the recomposition should either
  complete before dependent tasks are scheduled or fail with one clear message
  instead of eight misleading ones.
- **Bottleneck:** the one this PR is about — 35.0–35.7 min of a 37.4 min
  whole-run wall clock, numbers above.

## Follow-ups

- Re-apply the branch-protection ruleset from the regenerated
  `.github/repo-settings.json` at merge time, and run
  `devenv tasks run gh:apply-labels`.
- Ratify (or reject) the proposed decision record
  `context/buck2/.decisions/.proposed/benchmark-evidence-is-a-probe-the-paired-lane-is-trend-telemetry.md`.
  It is `.proposed` because BUCK-R15/R16 were ratified as requirement text with
  no decision record to amend, and requirements are protected.
- Open question recorded in that record: whether the nightly lane should turn
  `compare: true` + `regressionMode: 'warn'` and publish a daily summary now
  that it has a stable cadence to compare against. It needs a noise profile from
  the nightly series first.

## References

- Refs #1147
- Refs schickling/dotfiles#2319
- `context/ci-measurements.md` — new "Lane Cadence" section
- `context/buck2/requirements.md` — BUCK-R15, BUCK-R16 (unchanged; only their
  production site is now stated)

<!-- agent-footer:begin v=2 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | dev3.direct.omp.f689zvm8 |
| `session` | dev3.f689zvm8 |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.1.2 |
| `agent_runtime` | OMP 18.1.2 |
| `tooling_profile` | dotfiles@0e52305-dirty |
</details>
<!-- agent-footer:end -->