### PR TITLE
perf(genie): single-pass package.json discovery; fix result-* ignore shadowing a tracked file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,9 @@ devenv.local.nix
 # https://github.com/cachix/devenv/issues/2392
 /.devenv.flake.nix
 result
-result-*
+# Anchored: `nix build` writes its extra output links at the repo root, and an unanchored
+# `result-*` shadows source files such as `src/core/result-envelope.ts`.
+/result-*
 .pre-commit-config.yaml
 
 # Storybook

--- a/packages/@overeng/genie/src/core/workspace.ts
+++ b/packages/@overeng/genie/src/core/workspace.ts
@@ -47,36 +47,93 @@ const findWorkspaceRoot = Effect.fn('workspace/findWorkspaceRoot')(function* ({
   }
 })
 
-const findPackageJsonDirs = Effect.fn('workspace/findPackageJsonDirs')(function* ({
-  root,
-}: {
-  root: string
-}) {
-  yield* Observability.annotatePath({ label: 'packages', path: root })
+/** Directory listings are I/O bound, so the few levels a pattern needs are listed in parallel. */
+const LISTING_CONCURRENCY = 32
+
+/**
+ * A workspace pattern reduced to the filesystem work it needs: the leading literal segments,
+ * which are joined without touching the disk, plus the number of directory-listing levels that
+ * follow (`'any'` when the pattern contains `**`).
+ */
+type PatternPlan = {
+  readonly prefix: ReadonlyArray<string>
+  readonly levels: number | 'any'
+}
+
+/**
+ * The cost model of discovery: a pattern's plan says how many directory listings it takes to
+ * resolve. `undefined` when the pattern names a skipped directory and is therefore unreachable.
+ */
+export const planPattern = (pattern: string): PatternPlan | undefined => {
+  const segments = normalizePath(pattern)
+    .split('/')
+    .filter((segment) => segment !== '' && segment !== '.')
+  const firstGlob = segments.findIndex((segment) => segment.includes('*') === true)
+  const prefix = firstGlob === -1 ? segments : segments.slice(0, firstGlob)
+  if (prefix.some((segment) => shouldSkipDir(segment) === true) === true) return undefined
+  if (firstGlob === -1) return { prefix, levels: 0 }
+  const rest = segments.slice(firstGlob)
+  if (rest.some((segment) => segment.includes('**') === true) === true)
+    return { prefix, levels: 'any' }
+  return { prefix, levels: rest.length }
+}
+
+/**
+ * One listing level: the non-skipped entries of every directory in `dirs`, plus the directories
+ * among them that hold a `package.json`. Both answers come out of the same `readDirectory`, so
+ * neither directory-ness nor manifest presence costs an extra `stat`.
+ */
+const listLevel = Effect.fnUntraced(function* (dirs: ReadonlyArray<string>) {
   const fs = yield* FileSystem.FileSystem
   const pathService = yield* Path.Path
-  const results: string[] = []
 
-  const walk: (dir: string) => Effect.Effect<void, Error, FileSystem.FileSystem | Path.Path> =
-    Effect.fnUntraced(function* (dir) {
-      const entries = yield* fs.readDirectory(dir).pipe(Effect.orElseSucceed(() => []))
-      for (const entry of entries) {
-        if (shouldSkipDir(entry) === true) continue
-        const fullPath = pathService.join(dir, entry)
-        const stat = yield* fs.stat(fullPath).pipe(Effect.catch(() => Effect.void))
-        if (stat === undefined) continue
-        if (stat.type === 'Directory') {
-          yield* walk(fullPath)
-          continue
-        }
-        if (entry === 'package.json') {
-          results.push(pathService.dirname(fullPath))
-        }
-      }
-    })
+  const listings = yield* Effect.forEach(
+    dirs,
+    (dir) =>
+      // A file, or a path that does not exist, simply has no entries.
+      fs.readDirectory(dir).pipe(
+        Effect.orElseSucceed((): ReadonlyArray<string> => []),
+        Effect.map((entries) => ({ dir, entries })),
+      ),
+    { concurrency: LISTING_CONCURRENCY },
+  )
 
-  yield* walk(root)
-  return results
+  return {
+    children: listings.flatMap(({ dir, entries }) =>
+      entries
+        .filter((entry) => shouldSkipDir(entry) === false)
+        .map((entry) => pathService.join(dir, entry)),
+    ),
+    packageDirs: listings
+      .filter(({ entries }) => entries.includes('package.json') === true)
+      .map(({ dir }) => dir),
+  }
+})
+
+/**
+ * Directories a pattern could name that hold a `package.json`. A superset of the pattern's
+ * matches — `*` levels list siblings the pattern may reject — so the caller still matches.
+ */
+const expandPlan = Effect.fnUntraced(function* (root: string, plan: PatternPlan) {
+  const pathService = yield* Path.Path
+  const start = plan.prefix.length === 0 ? root : pathService.join(root, ...plan.prefix)
+
+  if (plan.levels === 'any') {
+    const packageDirs: string[] = []
+    let frontier: ReadonlyArray<string> = [start]
+    while (frontier.length > 0) {
+      const level = yield* listLevel(frontier)
+      packageDirs.push(...level.packageDirs)
+      frontier = level.children
+    }
+    return packageDirs
+  }
+
+  let frontier: ReadonlyArray<string> = [start]
+  for (let level = 0; level < plan.levels; level++) {
+    frontier = (yield* listLevel(frontier)).children
+  }
+  return (yield* listLevel(frontier)).packageDirs
 })
 
 const parsePnpmWorkspacePackages = (content: string): string[] => {
@@ -122,21 +179,26 @@ const discoverPnpmPackageJsonPaths = Effect.fn('workspace/discoverPnpmPackageJso
     if (workspaceRoot === undefined) return []
 
     const workspaceFile = pathService.join(workspaceRoot, 'pnpm-workspace.yaml')
-    const packageDirs = yield* findPackageJsonDirs({ root: workspaceRoot })
-    const matched = new Set<string>()
-
     const content = yield* fs.readFileString(workspaceFile).pipe(Effect.orElseSucceed(() => ''))
     const patterns = parsePnpmWorkspacePackages(content)
     if (patterns.length === 0) return []
 
-    for (const packageDir of packageDirs) {
-      const relPath = normalizePath(pathService.relative(workspaceRoot, packageDir)) || '.'
-      if (matchesAnyPattern({ name: relPath, patterns }) === true) {
-        matched.add(pathService.join(packageDir, 'package.json'))
-      }
+    // Discovery is `pnpm-workspace.yaml` composed with the directories its patterns can name, so
+    // only those are listed — never the whole tree.
+    const packageDirs = new Set<string>()
+    for (const pattern of patterns) {
+      const plan = planPattern(pattern)
+      if (plan === undefined) continue
+      for (const packageDir of yield* expandPlan(workspaceRoot, plan)) packageDirs.add(packageDir)
     }
 
-    return Array.from(matched)
+    return Array.from(packageDirs)
+      .filter((packageDir) => {
+        const relPath = normalizePath(pathService.relative(workspaceRoot, packageDir)) || '.'
+        return matchesAnyPattern({ name: relPath, patterns }) === true
+      })
+      .map((packageDir) => pathService.join(packageDir, 'package.json'))
+      .toSorted()
   },
 )
 
@@ -144,8 +206,9 @@ const discoverManualPackageJsonPaths = Effect.fn('workspace/discoverManualPackag
   function* ({ cwd }: { cwd: string }) {
     yield* Observability.annotatePath({ label: 'manual', path: cwd })
     const pathService = yield* Path.Path
-    const packageDirs = yield* findPackageJsonDirs({ root: cwd })
-    return packageDirs.map((dir) => pathService.join(dir, 'package.json'))
+    // No manifest declares the package set here, so every non-skipped directory is a candidate.
+    const packageDirs = yield* expandPlan(cwd, { prefix: [], levels: 'any' })
+    return packageDirs.map((packageDir) => pathService.join(packageDir, 'package.json')).toSorted()
   },
 )
 

--- a/packages/@overeng/genie/src/core/workspace.unit.test.ts
+++ b/packages/@overeng/genie/src/core/workspace.unit.test.ts
@@ -1,0 +1,114 @@
+import * as fs from 'node:fs/promises'
+import * as os from 'node:os'
+import path from 'node:path'
+
+import { NodeServices } from '@effect/platform-node'
+import { Effect } from 'effect'
+import { describe, expect, it, vi } from 'vitest'
+
+import { planPattern, resolveWorkspaceProvider } from './workspace.ts'
+
+const FIXTURE: Record<string, string> = {
+  'pnpm-workspace.yaml': [
+    'packages:',
+    "  - '.'",
+    '  - apps/*',
+    '  - packages/**',
+    '  - legacy/web-*',
+    '  - tmp/pruned',
+    '  - missing/dir',
+    '',
+  ].join('\n'),
+  'package.json': '{"name":"root"}',
+  'apps/a/package.json': '{"name":"a"}',
+  // `apps/*` is a single segment, so a manifest one level deeper is not a workspace package.
+  'apps/b/nested/package.json': '{"name":"nested"}',
+  // A file where a directory listing expects packages.
+  'apps/README.md': '# not a package',
+  'packages/x/package.json': '{"name":"x"}',
+  // Skipped directory names are never traversed, even below a matching pattern.
+  'packages/x/node_modules/dep/package.json': '{"name":"dep"}',
+  'packages/group/y/package.json': '{"name":"y"}',
+  'packages/nomanifest/keep.txt': 'no manifest here',
+  'legacy/web-one/package.json': '{"name":"web-one"}',
+  'legacy/other/package.json': '{"name":"other"}',
+  // Declared, but `tmp` is a skipped directory name.
+  'tmp/pruned/package.json': '{"name":"pruned"}',
+  'unlisted/package.json': '{"name":"unlisted"}',
+}
+
+const withFixture = async (assert: (root: string) => Promise<void>) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'genie-workspace-'))
+  try {
+    for (const [relativePath, content] of Object.entries(FIXTURE)) {
+      const filePath = path.join(root, relativePath)
+      await fs.mkdir(path.dirname(filePath), { recursive: true })
+      await fs.writeFile(filePath, content)
+    }
+    await assert(await fs.realpath(root))
+  } finally {
+    await fs.rm(root, { recursive: true, force: true })
+  }
+}
+
+const discover = async (cwd: string) =>
+  Effect.runPromise(
+    Effect.gen(function* () {
+      const provider = yield* resolveWorkspaceProvider({ cwd })
+      const paths = yield* provider.discoverPackageJsonPaths({ cwd })
+      return paths.map((p) => path.relative(cwd, p).replace(/\\/g, '/')).toSorted()
+    }).pipe(Effect.provide(NodeServices.layer)),
+  )
+
+describe('resolveWorkspaceProvider', () => {
+  it('discovers exactly the manifests the pnpm workspace patterns name', async () => {
+    vi.stubEnv('GENIE_WORKSPACE_PROVIDER', '')
+    await withFixture(async (root) => {
+      expect(await discover(root)).toEqual([
+        'apps/a/package.json',
+        'legacy/web-one/package.json',
+        'package.json',
+        'packages/group/y/package.json',
+        'packages/x/package.json',
+      ])
+    })
+  })
+
+  it('discovers every manifest outside skipped directories without a workspace manifest', async () => {
+    vi.stubEnv('GENIE_WORKSPACE_PROVIDER', 'manual')
+    await withFixture(async (root) => {
+      expect(await discover(root)).toEqual([
+        'apps/a/package.json',
+        'apps/b/nested/package.json',
+        'legacy/other/package.json',
+        'legacy/web-one/package.json',
+        'package.json',
+        'packages/group/y/package.json',
+        'packages/x/package.json',
+        'unlisted/package.json',
+      ])
+    })
+  })
+})
+
+describe('planPattern', () => {
+  it('resolves a literal pattern without any directory listing', () => {
+    expect(planPattern('packages/@overeng/genie')).toEqual({
+      prefix: ['packages', '@overeng', 'genie'],
+      levels: 0,
+    })
+    expect(planPattern('.')).toEqual({ prefix: [], levels: 0 })
+  })
+
+  it('lists one level per `*` segment and the whole subtree for `**`', () => {
+    expect(planPattern('apps/*')).toEqual({ prefix: ['apps'], levels: 1 })
+    expect(planPattern('legacy/web-*')).toEqual({ prefix: ['legacy'], levels: 1 })
+    expect(planPattern('apps/*/plugins/*')).toEqual({ prefix: ['apps'], levels: 3 })
+    expect(planPattern('packages/**')).toEqual({ prefix: ['packages'], levels: 'any' })
+  })
+
+  it('rejects patterns rooted in a skipped directory', () => {
+    expect(planPattern('node_modules/pkg')).toBeUndefined()
+    expect(planPattern('tmp/pruned')).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Problem

**1. `genie` spends seconds walking the repository to learn what `pnpm-workspace.yaml` already states.**

`discoverPackageJsonPaths` (the pnpm and manual workspace providers in
`packages/@overeng/genie/src/core/workspace.ts`) recursed the whole tree with
`fs.readDirectory(dir)` followed by **one Effect-wrapped `fs.stat` per entry**, single-fibered — 4,006
entries across 602 directories in this repo — to produce the **38** `package.json` paths that
`pnpm-workspace.yaml` lists literally. It is ~40–60 % of every `genie --check` / `genie run`
invocation. Measured inside a real `--check` run (temporary `performance.now()` bracket around the
provider call, both variants instrumented identically, 6 interleaved runs):

```
discovery phase, before   5455.6 / 5204.8 / 5119.1 / 5183.0 / 5197.7 / 5907.8 ms   → median 5201.3
```

The read-and-parse of the 38 manifests that discovery feeds costs single-digit milliseconds by
comparison, and `find` does the same traversal in ~10 ms — the cost is the per-entry `stat` through
the Effect runtime, not the filesystem.

**2. `.gitignore`'s unanchored `result-*` shadowed a tracked source file.**

`packages/@overeng/notion-datasource-sync/src/core/result-envelope.ts` matched `result-*` at any
depth. It survives here only because it is already in the index; any fresh `git init` + `git add -A`
of this tree silently drops it:

```
$ git add -A && git ls-files
.gitignore                                  # ← the source file is gone
```

## Goal

- Discovery costs a listing per declared pattern level instead of a `stat` per file in the repo,
  returning **exactly the same paths**.
- No tracked file is matched by an ignore rule; root-level `nix build` output links stay ignored.

## Decisions

- **Pattern-directed, not concurrency-tuned.** Making the same 4,006 `stat`s parallel would have
  been a smaller diff, but the walk is not work that needs doing: discovery is
  `pnpm-workspace.yaml` ∘ the directories its patterns can name. Literal segments (all 44 patterns
  in this repo) are joined without touching the disk; each `*` segment costs one parallel listing
  level; `**` falls back to a bounded walk **of that subtree alone**. The manual provider — no
  workspace manifest, so nothing declares the package set — is the one caller that still walks
  everything, and it now does so with bounded concurrency.
- **`matchesAnyPattern` stays the decision.** Expansion is a deliberate *superset* (a `*` level
  lists siblings the pattern may reject, entries may be files) and the existing matcher filters it.
  Pattern semantics are therefore unchanged by construction, not by re-implementation.
- **Directory-ness and manifest presence come from the same `readDirectory`.** A `stat` per entry
  answered "is this a directory"; a listing answers that *and* "does it contain `package.json`" in
  one call, so the new code issues no `stat` and no `exists` at all.
- **Results are now sorted** rather than in walk order (which was `readdir` order, i.e. not
  deterministic across filesystems). Discovery feeds a `byName` map plus per-package validation, so
  order was never semantic; determinism is free here.
- **`.gitignore`: anchor only `result-*`.** `result` on line 49 shadows no tracked path, and
  un-anchoring it would surface `nix build` links created in subdirectories. Line 50 is the one that
  collides with real source names.

## Verification

**Same paths, before and after.** Both implementations were loaded into one process (baseline
extracted from `HEAD`) and run against the same trees:

| tree | provider | before | after | result |
| --- | --- | --- | --- | --- |
| this repo | pnpm | 38 paths | 38 paths | identical, sorted |
| this repo | manual (`GENIE_WORKSPACE_PROVIDER=manual`) | 53 paths | 53 paths | identical, sorted |
| fixture: `.`, `apps/*`, `packages/**`, `legacy/web-*`, declared-but-skipped `tmp/pruned`, missing `missing/dir`, a `node_modules` manifest, a manifest one level below `apps/*`, a file where a listing expects packages | pnpm | 5 paths | 5 paths | identical |
| same fixture, no workspace manifest | manual | 8 paths | 8 paths | identical |

That fixture is committed as `workspace.unit.test.ts` (both providers, plus `planPattern`'s cost
model: literal → 0 listings, `*` → 1 level each, `**` → whole subtree, skipped-directory pattern →
unreachable). `packages/@overeng/genie`: **421 passed, 2 skipped, 30 files**.

**Discovery phase inside `genie --check`** (same instrumentation in both variants, interleaved
before/after to share load, 32-core Linux host, load average 21–35):

```
before   5455.6 / 5204.8 / 5119.1 / 5183.0 / 5197.7 / 5907.8 ms   → median 5201.3
after    1326.5 / 1228.5 / 1176.6 / 1280.9 /  485.2 / 1272.7 ms   → median 1250.6   (4.2x)
```

**End-to-end `genie --check`** (`--output ci-plain`, `GENIE_ACTIONLINT_BIN` and
`GENIE_EXPORT_TYPE_PROOF_COMPILER` provided, all 116 generators, `rc=0` and `116 unchanged` every
run; two independent interleaved series):

```
series A (uninstrumented, load 38-51)
before  11478 / 12146 /  9855 / 11563 / 12246 /  9368 ms   → median 11520
after   13616 /  9406 /  7651 / 11781 /  6564 /  6799 ms   → median  8528

series B (instrumented, load 21-35)
before   9934 /  9107 /  9217 /  9150 /  9715 / 19132 ms   → median  9466
after    6750 /  6284 /  6088 /  6269 / 15371 /  9172 ms   → median  6517
```

≈3 s off the median run in both series, which is what the 3.95 s phase delta predicts. Wall time on
this host is noisy (concurrent load moves single runs by 2–3x in *both* directions — note
`after` run 5 of series B), so the phase measurement above, not the wall time, is the load-bearing
number.

**Discovery called in isolation** (5 runs, load ~21, same process):

```
pnpm     before 108.3 / 97.0 / 97.3 / 99.8 / 89.7 → median  97.3 ms      after 4.5 / 4.1 / 2.6 / 2.0 / 2.0 → median  2.6 ms
manual   before  92.4 / 76.1 / 70.6 / 71.9 / 81.6 → median  76.1 ms      after 46.6 / 43.9 / 38.9 / 33.3 / 34.4 → median 38.9 ms
```

**`.gitignore`.** Fresh `git init` + `git add -A` over this tree's `.gitignore`, before vs after:

```
[before] tracked: .gitignore
[after]  tracked: .gitignore src/core/result-envelope.ts
```

```
$ git check-ignore -v --no-index packages/@overeng/notion-datasource-sync/src/core/result-envelope.ts
before  .gitignore:50:result-*  packages/@overeng/notion-datasource-sync/src/core/result-envelope.ts
after   (no match, rc=1)

$ git ls-files -z | git check-ignore --no-index --stdin -z     # every tracked file
before  .gitignore:50:result-*  packages/@overeng/notion-datasource-sync/src/core/result-envelope.ts
after   (none)

$ git check-ignore -v --no-index result result-bin result-doc  # nix links still ignored
.gitignore:49:result   result
.gitignore:52:/result-* result-bin
.gitignore:52:/result-* result-doc
```

**Gates.** In a composed worktree (`devenv tasks run mr:setup` first — see *Friction*):

```
$ devenv tasks run check:quick     # ts:check, mr:check, mr:lock-sync-check, mr:source-policy-check,
rc=0                               # lint:check (oxlint + genie), nix:check:quick, workspace:check,
                                   # devenv:trace-audit
$ vitest run   # packages/@overeng/genie
Test Files  30 passed (30)   Tests  421 passed | 2 skipped (423)
```

Two lint/type findings from those gates are folded into the perf commit: `readDirectory`'s
failure fallback needed an explicit `ReadonlyArray<string>` (the untyped `[]` made
`entries.includes(...)` a `never` parameter), and `Array#sort` had to become `Array#toSorted`
(`unicorn/no-array-sort`). The parity probes and the genie suite were re-run against the final code:
38/38 pnpm, 53/53 manual, fixture identical, 421 passing.

## Complexity

`workspace.ts` grows ~60 lines: a `PatternPlan` (literal prefix + listing levels), one listing
primitive, and one expansion. In exchange the naive recursive walk and its per-entry `stat` are
gone, one function now serves both providers, and the pattern matcher is untouched. The plan type is
what makes the cost visible and testable — `planPattern` is exported and asserted precisely because
"how many listings does this pattern cost" is the property that regressed.

## Concerns

- **A `**` pattern still walks its subtree**, and — as before this PR — a symlink cycle inside one
  would recurse. No first-party workspace uses `**` (all 44 patterns here, and those in the
  downstream repos, are literal); parity with the previous behaviour was preferred over adding a
  `realpath` guard nothing exercises.
- **Order changed** from `readdir` order to sorted. Nothing depends on it (verified: full genie
  suite plus 12 green `--check` runs over all 116 generators), but it is an observable change for
  any consumer that assumed walk order.
- The manual provider's improvement (2x, from bounded concurrency) is modest; it is the provider
  nothing declares a package set for, so the walk is irreducible there.

## Friction & bottlenecks

- `genie --check` needs both `GENIE_ACTIONLINT_BIN` and `GENIE_EXPORT_TYPE_PROOF_COMPILER` on the
  environment or it exits 1 after ~35 s of interrupted-path bookkeeping — three of the
  `@overeng/genie` unit tests fail for the same reason outside a `devenv shell`. Benchmarking it
  without them yields meaningless numbers.
- `console.error` from inside genie's core is swallowed by the CLI's console layer, so temporary
  instrumentation had to append to a file. Worth knowing before the next profiling pass.
- In a **fresh, uncomposed** worktree, `check:quick` fails in a way that names nothing useful:
  `lint:check:genie` reports `ENOENT reading "<path>.genie.ts"` for **all 116** generators (the
  files are right there), `mr:check` separately reports `Missing workspace repos/ directory`, and
  `tsgolint` panics with `Expected file '…raw-otel-boundary.unit.test.ts' to be in inferred
  program`. All three clear after `devenv tasks run mr:setup`, which relocates the checkout to
  `repos/effect-utils/` and composes the root — so the ENOENT is a bootstrap symptom, not a genie
  bug, and only the `mr:check` line says so. The other two messages cost real time to disbelieve.

## Follow-ups

- Cap `generateAll`'s `concurrency: 'unbounded'` (`core.ts:262`) at the same
  `min(availableParallelism(), 12)` `checkAll` uses; 116 simultaneous `bun` imports make the
  generate-phase CPU sum swing 2.3x run to run.
- `genie run`'s validation re-imports all 116 generators a second time
  (`generateAll` → `runValidationOrFail` without `preloadedFiles`). Measured at 135–217 ms total, so
  this is a clarity fix, not a performance one.

## References

- Refs #1147 (Epic: Buck2 as the repository build authority) — this is the no-Buck half of the
  devenv-perf finding: under Buck the 38 manifests are declared inputs, so the walk would not exist;
  the walk should not exist today either.
- Refs schickling/dotfiles#2352, schickling/dotfiles#2324, schickling/dotfiles#2329

<!-- agent-footer:begin v=2 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | dev3.direct.omp.f689zvm8 |
| `session` | dev3.f689zvm8 |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.1.2 |
| `agent_runtime` | OMP 18.1.2 |
| `tooling_profile` | dotfiles@0e52305-dirty |
</details>
<!-- agent-footer:end -->