### PR TITLE
feat(buck2): transfer notion base TypeScript authority to Buck

### DIFF
--- a/buck2-member.json
+++ b/buck2-member.json
@@ -27,6 +27,22 @@
       "destination": "packages/@overeng/effect-distributed-lock/dist"
     },
     {
+      "target": "//packages/@overeng/notion-core:dist",
+      "destination": "packages/@overeng/notion-core/dist"
+    },
+    {
+      "target": "//packages/@overeng/notion-effect-client:dist",
+      "destination": "packages/@overeng/notion-effect-client/dist"
+    },
+    {
+      "target": "//packages/@overeng/notion-effect-schema:dist",
+      "destination": "packages/@overeng/notion-effect-schema/dist"
+    },
+    {
+      "target": "//packages/@overeng/notion-property-write:dist",
+      "destination": "packages/@overeng/notion-property-write/dist"
+    },
+    {
       "target": "//packages/@overeng/otel-contract:dist",
       "destination": "packages/@overeng/otel-contract/dist"
     },

--- a/context/buck2/02-execution/.experiments/2026-09-03-notion-base-authority-transfer.md
+++ b/context/buck2/02-execution/.experiments/2026-09-03-notion-base-authority-transfer.md
@@ -1,0 +1,87 @@
+# Notion Base TypeScript Authority Transfer
+
+Status: accepted
+Date: 2026-09-03
+
+## Question
+
+Can `@overeng/notion-core`, `@overeng/notion-effect-schema`,
+`@overeng/notion-property-write`, and `@overeng/notion-effect-client` transfer
+TypeScript typecheck and declaration-emit authority to Buck as one
+dependency-closed base layer, leaving the top layer
+(`notion-md`, `notion-react`, `notion-datasource-sync`, `notion-cli`) for the
+stacked follow-up that owns those packages?
+
+## Method
+
+Each base package-local `BUCK.genie.ts` admission gained authority metadata
+(`projectFile: 'tsconfig.json'`, `declarationEntrypoint: 'src/mod.d.ts'`).
+Intra-base workspace siblings now consume same-cell Buck `dist` targets instead
+of content-tracked sources: effect-schema consumes notion-core, property-write
+consumes notion-effect-schema, and effect-client consumes notion-core plus
+notion-effect-schema. Root check/emit solutions, the member-manifest dist
+overlays, and the per-package `dist` entrypoint assertions regenerated from the
+same admissions via `devenv tasks run genie:run`.
+
+Entrypoint verification (no guessing): every base package exposes a single
+public `.` export resolving to `./src/mod.ts` (read from each
+`package.json.genie.ts` `exports` block), each `src/mod.ts` exists on disk, each
+package tsconfig is composite with `rootDir: '.'` / `outDir: './dist'` (shared
+`packageTsconfigCompilerOptions`), so the Buck emit produces
+`dist/src/mod.d.ts` — the same shape as the already-authoritative
+single-export packages (`content-address`, `effect-distributed-lock`,
+`otel-contract`, `tui-core`), which all assert `src/mod.d.ts`. The
+`./test` subpath of notion-effect-client is `published: false` and needs no
+dist types condition.
+
+## Result
+
+- **Regen PASS:** `genie:run` touched exactly the expected files — 4
+  `BUCK.genie.ts` sources, 4 regenerated `BUCK` projections
+  (`declaration_entrypoint` + sibling source-to-`dist` swaps), `buck2-member.json`
+  (+4 dist overlays), `tsconfig.check.json` and `tsconfig.emit.json` (31→27
+  refs each). No unrelated drift, no editor-view changes.
+- **Freshness PASS:** `devenv tasks run genie:check --no-tui` exits 0.
+- **Unit PASS:** `devenv tasks run genie:buck2:test --no-tui` — 25 pass, 0 fail
+  across 5 files; both authority unit tests derive expectations dynamically, so
+  no test-expectation updates were required.
+- **Buck target gate DEFERRED to CI:** per the transfer plan, no local
+  `check:all`; CI `buck2:check` proves the four new `typecheck` targets and
+  `check:quick` proves declaration publication before the surviving root check.
+
+### Deletion ledger — notion base layer
+
+- Removed all 4 base packages from both generated root TypeScript solutions
+  (31→27 refs each).
+- Published 4 member-manifest dist overlays (`:dist` → `<package>/dist`).
+- Replaced 4 intra-base content-tracked source siblings with Buck `dist` edges
+  in the generated package trees.
+- Deleted 16 dependent project-reference edges: 4 intra-base (schema→core,
+  property-write→schema, effect-client→core+schema) plus 12 top→base edges in
+  the 4 top packages' `tsconfig.json.genie.ts` (md 4, react 2, ds-sync 4,
+  cli 2). The deletions are REQUIRED in this commit, not cosmetic: a package
+  with `noEmit: true` may not be project-referenced, so every surviving edge
+  fails both `tsgo_emit` (`TS6053`, proven red in CI) and oxlint
+  (`typescript(tsconfig-error)`, proven red in CI). All 16 targets are declared
+  workspace deps, so `tsc` keeps resolving via `node_modules`; companion
+  changes are deletion-only per the #1193 precedent.
+- Set `noEmit: true` on all 4 base tsconfigs (Buck is the sole dist producer).
+- Remaining debt (top-transfer scope): 4 intra-top edges, cli→effect-path
+  (target not yet authoritative), dist-backed `types` conditions.
+
+## Conclusion
+
+The notion base layer satisfies Buck-first TypeScript authority admission:
+root solutions no longer list the base packages, their `dist` overlays are
+published, their package trees consume each other through Buck
+declarations, and all 16 project-reference edges into noEmit packages are
+deleted. Exclusive sole-producer status completes with the top-layer
+transfer (remaining intra-top edges, cli→effect-path, dist-backed type
+conditions), which is unblocked by this commit.
+
+## VRS Impact
+
+Discharges the base half of the notion projection-chain authority transfer
+(base #1204, stacked under top #1205). BUCK-R06, BUCK-R07, BUCK-R09, BUCK-R12,
+and BUCK-R16 are re-evidenced for the admission. No requirement change is
+needed; the 16-edge deletion ledger item is tracked as top-transfer scope.

--- a/packages/@overeng/notion-cli/nix/build.nix
+++ b/packages/@overeng/notion-cli/nix/build.nix
@@ -33,7 +33,7 @@ let
     installRuntimeWorkspace = true;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-cjuCaaAP27X27jwwdyiw0ArTkasxZlIXq7dTq1rfxOk=";
+      "." = mkSharedHash "sha256-a2FdFjTBI9igg6hxN5yjkWOV8Cs1vwbiOXnk2prf+gc=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/notion-cli/tsconfig.json
+++ b/packages/@overeng/notion-cli/tsconfig.json
@@ -52,16 +52,10 @@
       "path": "../effect-path"
     },
     {
-      "path": "../notion-effect-client"
-    },
-    {
       "path": "../notion-datasource-sync"
     },
     {
       "path": "../notion-md"
-    },
-    {
-      "path": "../notion-effect-schema"
     }
   ]
 }

--- a/packages/@overeng/notion-cli/tsconfig.json.genie.ts
+++ b/packages/@overeng/notion-cli/tsconfig.json.genie.ts
@@ -14,9 +14,7 @@ export default tsconfigJson({
   include: ['src/**/*', 'bin/**/*.ts'],
   references: [
     { path: '../effect-path' },
-    { path: '../notion-effect-client' },
     { path: '../notion-datasource-sync' },
     { path: '../notion-md' },
-    { path: '../notion-effect-schema' },
   ],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/notion-core/BUCK
+++ b/packages/@overeng/notion-core/BUCK
@@ -82,5 +82,6 @@ tsgo_emit(
     package_tree = ":package_tree",
     declaration_sources = {
     },
+    declaration_entrypoint = "src/mod.d.ts",
     visibility = ["PUBLIC"],
 )

--- a/packages/@overeng/notion-core/BUCK.genie.ts
+++ b/packages/@overeng/notion-core/BUCK.genie.ts
@@ -8,6 +8,10 @@ export const buck2TypeScriptAdmission = {
   projectionSource: 'packages/@overeng/notion-core/BUCK.genie.ts',
   sourceRoots: ['src'],
   editorViewConsumer: false,
+  authority: {
+    declarationEntrypoint: 'src/mod.d.ts',
+    projectFile: 'tsconfig.json',
+  },
 } as const satisfies Buck2TypeScriptAdmission
 
 export default buck2TypeScriptPackageProjection(buck2TypeScriptAdmission)

--- a/packages/@overeng/notion-core/package.json
+++ b/packages/@overeng/notion-core/package.json
@@ -4,7 +4,10 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./src/mod.ts"
+    ".": {
+      "types": "./dist/src/mod.d.ts",
+      "default": "./src/mod.ts"
+    }
   },
   "publishConfig": {
     "access": "public",

--- a/packages/@overeng/notion-core/package.json.genie.ts
+++ b/packages/@overeng/notion-core/package.json.genie.ts
@@ -25,7 +25,10 @@ export default packageJson(
     name: '@overeng/notion-core',
     ...privatePackageDefaults,
     exports: {
-      '.': exportEntry('./src/mod.ts', { environment: 'isomorphic-es2024' }),
+      '.': exportEntry(
+        { types: './dist/src/mod.d.ts', default: './src/mod.ts' },
+        { environment: 'isomorphic-es2024' },
+      ),
     },
     publishConfig: {
       access: 'public',

--- a/packages/@overeng/notion-core/tsconfig.json
+++ b/packages/@overeng/notion-core/tsconfig.json
@@ -44,7 +44,8 @@
     "composite": true,
     "rootDir": ".",
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
-    "types": ["node"]
+    "types": ["node"],
+    "noEmit": true
   },
   "include": ["src/**/*"],
   "references": []

--- a/packages/@overeng/notion-core/tsconfig.json.genie.ts
+++ b/packages/@overeng/notion-core/tsconfig.json.genie.ts
@@ -10,6 +10,7 @@ export default tsconfigJson({
     ...baseTsconfigCompilerOptions,
     ...packageTsconfigCompilerOptions,
     ...nodeTypes,
+    noEmit: true,
   },
   include: ['src/**/*'],
   references: [],

--- a/packages/@overeng/notion-datasource-sync/tsconfig.json
+++ b/packages/@overeng/notion-datasource-sync/tsconfig.json
@@ -50,19 +50,7 @@
   "include": ["src/**/*"],
   "references": [
     {
-      "path": "../notion-core"
-    },
-    {
-      "path": "../notion-effect-client"
-    },
-    {
-      "path": "../notion-effect-schema"
-    },
-    {
       "path": "../notion-md"
-    },
-    {
-      "path": "../notion-property-write"
     }
   ]
 }

--- a/packages/@overeng/notion-datasource-sync/tsconfig.json.genie.ts
+++ b/packages/@overeng/notion-datasource-sync/tsconfig.json.genie.ts
@@ -15,11 +15,5 @@ export default tsconfigJson({
     lib: ['ES2023'],
   },
   include: ['src/**/*'],
-  references: [
-    { path: '../notion-core' },
-    { path: '../notion-effect-client' },
-    { path: '../notion-effect-schema' },
-    { path: '../notion-md' },
-    { path: '../notion-property-write' },
-  ],
+  references: [{ path: '../notion-md' }],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/notion-effect-client/BUCK
+++ b/packages/@overeng/notion-effect-client/BUCK
@@ -4,8 +4,8 @@
 # Projection source: packages/@overeng/notion-effect-client/BUCK.genie.ts
 # Projection schema version: 1
 # Projection generator: effect-utils/genie/buck2-typescript-package-projection
-# Semantic fingerprint: sha256:ddc4ffcd456173a8917d48c1ad8768f9b4b48059dc8fc1955c4fd0d721472809
-# Semantic inputs: buck2/dependencies/BUCK.genie.ts, buck2/dependencies/pnpm-lock.sha256.json.genie.ts, genie/buck2/mod.ts, genie/buck2/typescript-package-projection.ts, package.json.genie.ts, packages/@overeng/buck2-tools/src/package-tree.ts, packages/@overeng/buck2-tools/src/real-path.ts, packages/@overeng/content-address/BUCK.genie.ts, packages/@overeng/content-address/package.json.genie.ts, packages/@overeng/notion-core/BUCK.genie.ts, packages/@overeng/notion-core/package.json.genie.ts, packages/@overeng/notion-core/src/**/*.cts, packages/@overeng/notion-core/src/**/*.js, packages/@overeng/notion-core/src/**/*.mts, packages/@overeng/notion-core/src/**/*.ts, packages/@overeng/notion-core/src/**/*.tsx, packages/@overeng/notion-effect-client/BUCK.genie.ts, packages/@overeng/notion-effect-client/BUCK.genie.ts, packages/@overeng/notion-effect-client/package.json.genie.ts, packages/@overeng/notion-effect-client/src/**/*.cts, packages/@overeng/notion-effect-client/src/**/*.js, packages/@overeng/notion-effect-client/src/**/*.mts, packages/@overeng/notion-effect-client/src/**/*.ts, packages/@overeng/notion-effect-client/src/**/*.tsx, packages/@overeng/notion-effect-client/tsconfig.json.genie.ts, packages/@overeng/notion-effect-schema/BUCK.genie.ts, packages/@overeng/notion-effect-schema/package.json.genie.ts, packages/@overeng/notion-effect-schema/src/**/*.cts, packages/@overeng/notion-effect-schema/src/**/*.js, packages/@overeng/notion-effect-schema/src/**/*.mts, packages/@overeng/notion-effect-schema/src/**/*.ts, packages/@overeng/notion-effect-schema/src/**/*.tsx, packages/@overeng/otel-contract/BUCK.genie.ts, packages/@overeng/otel-contract/package.json.genie.ts, packages/@overeng/utils-dev/BUCK.genie.ts, packages/@overeng/utils-dev/package.json.genie.ts, packages/@overeng/utils/BUCK.genie.ts, packages/@overeng/utils/package.json.genie.ts
+# Semantic fingerprint: sha256:76b3eb2045df7a6d75598848b2e63327513dd58d693766fa6d262146a4547c19
+# Semantic inputs: buck2/dependencies/BUCK.genie.ts, buck2/dependencies/pnpm-lock.sha256.json.genie.ts, genie/buck2/mod.ts, genie/buck2/typescript-package-projection.ts, package.json.genie.ts, packages/@overeng/buck2-tools/src/package-tree.ts, packages/@overeng/buck2-tools/src/real-path.ts, packages/@overeng/content-address/BUCK.genie.ts, packages/@overeng/content-address/package.json.genie.ts, packages/@overeng/notion-core/BUCK.genie.ts, packages/@overeng/notion-core/package.json.genie.ts, packages/@overeng/notion-effect-client/BUCK.genie.ts, packages/@overeng/notion-effect-client/BUCK.genie.ts, packages/@overeng/notion-effect-client/package.json.genie.ts, packages/@overeng/notion-effect-client/src/**/*.cts, packages/@overeng/notion-effect-client/src/**/*.js, packages/@overeng/notion-effect-client/src/**/*.mts, packages/@overeng/notion-effect-client/src/**/*.ts, packages/@overeng/notion-effect-client/src/**/*.tsx, packages/@overeng/notion-effect-client/tsconfig.json.genie.ts, packages/@overeng/notion-effect-schema/BUCK.genie.ts, packages/@overeng/notion-effect-schema/package.json.genie.ts, packages/@overeng/otel-contract/BUCK.genie.ts, packages/@overeng/otel-contract/package.json.genie.ts, packages/@overeng/utils-dev/BUCK.genie.ts, packages/@overeng/utils-dev/package.json.genie.ts, packages/@overeng/utils/BUCK.genie.ts, packages/@overeng/utils/package.json.genie.ts
 # Regenerate: devenv tasks run genie:run
 
 load("//buck2:materialization.bzl", "export_materialization_inputs", "package_tree")
@@ -161,55 +161,15 @@ package_tree(
         },
         "@overeng/notion-core": {
             "files": {
+                "dist": "//packages/@overeng/notion-core:dist",
                 "package.json": "//packages/@overeng/notion-core:package.json",
-                "src/body-fidelity.ts": "//packages/@overeng/notion-core:src/body-fidelity.ts",
-                "src/body-fidelity.unit.test.ts": "//packages/@overeng/notion-core:src/body-fidelity.unit.test.ts",
-                "src/colors.ts": "//packages/@overeng/notion-core:src/colors.ts",
-                "src/colors.unit.test.ts": "//packages/@overeng/notion-core:src/colors.unit.test.ts",
-                "src/constants.ts": "//packages/@overeng/notion-core:src/constants.ts",
-                "src/constants.unit.test.ts": "//packages/@overeng/notion-core:src/constants.unit.test.ts",
-                "src/ids.ts": "//packages/@overeng/notion-core:src/ids.ts",
-                "src/ids.unit.test.ts": "//packages/@overeng/notion-core:src/ids.unit.test.ts",
-                "src/mod.ts": "//packages/@overeng/notion-core:src/mod.ts",
-                "src/properties.ts": "//packages/@overeng/notion-core:src/properties.ts",
-                "src/properties.unit.test.ts": "//packages/@overeng/notion-core:src/properties.unit.test.ts",
-                "src/rich-text.ts": "//packages/@overeng/notion-core:src/rich-text.ts",
-                "src/rich-text.unit.test.ts": "//packages/@overeng/notion-core:src/rich-text.unit.test.ts",
             },
             "links": ["@overeng/notion-core"],
         },
         "@overeng/notion-effect-schema": {
             "files": {
+                "dist": "//packages/@overeng/notion-effect-schema:dist",
                 "package.json": "//packages/@overeng/notion-effect-schema:package.json",
-                "src/common.ts": "//packages/@overeng/notion-effect-schema:src/common.ts",
-                "src/common.unit.test.ts": "//packages/@overeng/notion-effect-schema:src/common.unit.test.ts",
-                "src/mod.ts": "//packages/@overeng/notion-effect-schema:src/mod.ts",
-                "src/objects.ts": "//packages/@overeng/notion-effect-schema:src/objects.ts",
-                "src/objects.unit.test.ts": "//packages/@overeng/notion-effect-schema:src/objects.unit.test.ts",
-                "src/properties.unit.test.ts": "//packages/@overeng/notion-effect-schema:src/properties.unit.test.ts",
-                "src/properties/audit.ts": "//packages/@overeng/notion-effect-schema:src/properties/audit.ts",
-                "src/properties/boolean.ts": "//packages/@overeng/notion-effect-schema:src/properties/boolean.ts",
-                "src/properties/canonical-codec.ts": "//packages/@overeng/notion-effect-schema:src/properties/canonical-codec.ts",
-                "src/properties/canonical-codec.unit.test.ts": "//packages/@overeng/notion-effect-schema:src/properties/canonical-codec.unit.test.ts",
-                "src/properties/canonical.ts": "//packages/@overeng/notion-effect-schema:src/properties/canonical.ts",
-                "src/properties/common.ts": "//packages/@overeng/notion-effect-schema:src/properties/common.ts",
-                "src/properties/computed.ts": "//packages/@overeng/notion-effect-schema:src/properties/computed.ts",
-                "src/properties/contact.ts": "//packages/@overeng/notion-effect-schema:src/properties/contact.ts",
-                "src/properties/date.ts": "//packages/@overeng/notion-effect-schema:src/properties/date.ts",
-                "src/properties/descriptor.ts": "//packages/@overeng/notion-effect-schema:src/properties/descriptor.ts",
-                "src/properties/descriptor.unit.test.ts": "//packages/@overeng/notion-effect-schema:src/properties/descriptor.unit.test.ts",
-                "src/properties/mod.ts": "//packages/@overeng/notion-effect-schema:src/properties/mod.ts",
-                "src/properties/number.ts": "//packages/@overeng/notion-effect-schema:src/properties/number.ts",
-                "src/properties/reference.ts": "//packages/@overeng/notion-effect-schema:src/properties/reference.ts",
-                "src/properties/rollup.ts": "//packages/@overeng/notion-effect-schema:src/properties/rollup.ts",
-                "src/properties/select.ts": "//packages/@overeng/notion-effect-schema:src/properties/select.ts",
-                "src/properties/text.ts": "//packages/@overeng/notion-effect-schema:src/properties/text.ts",
-                "src/property-schema.ts": "//packages/@overeng/notion-effect-schema:src/property-schema.ts",
-                "src/rich-text-utils.ts": "//packages/@overeng/notion-effect-schema:src/rich-text-utils.ts",
-                "src/rich-text-utils.unit.test.ts": "//packages/@overeng/notion-effect-schema:src/rich-text-utils.unit.test.ts",
-                "src/rich-text.ts": "//packages/@overeng/notion-effect-schema:src/rich-text.ts",
-                "src/users.ts": "//packages/@overeng/notion-effect-schema:src/users.ts",
-                "src/webhook.ts": "//packages/@overeng/notion-effect-schema:src/webhook.ts",
             },
             "links": ["@overeng/notion-effect-schema"],
         },
@@ -249,5 +209,6 @@ tsgo_emit(
     package_tree = ":package_tree",
     declaration_sources = {
     },
+    declaration_entrypoint = "src/mod.d.ts",
     visibility = ["PUBLIC"],
 )

--- a/packages/@overeng/notion-effect-client/BUCK.genie.ts
+++ b/packages/@overeng/notion-effect-client/BUCK.genie.ts
@@ -17,12 +17,12 @@ export const buck2TypeScriptAdmission = {
     {
       packageName: '@overeng/notion-core',
       packagePath: 'packages/@overeng/notion-core',
-      sourceRoots: ['src'],
+      distTarget: '//packages/@overeng/notion-core:dist',
     },
     {
       packageName: '@overeng/notion-effect-schema',
       packagePath: 'packages/@overeng/notion-effect-schema',
-      sourceRoots: ['src'],
+      distTarget: '//packages/@overeng/notion-effect-schema:dist',
     },
     {
       packageName: '@overeng/otel-contract',
@@ -41,6 +41,10 @@ export const buck2TypeScriptAdmission = {
     },
   ],
   editorViewConsumer: false,
+  authority: {
+    declarationEntrypoint: 'src/mod.d.ts',
+    projectFile: 'tsconfig.json',
+  },
 } as const satisfies Buck2TypeScriptAdmission
 
 export default buck2TypeScriptPackageProjection(buck2TypeScriptAdmission)

--- a/packages/@overeng/notion-effect-client/package.json
+++ b/packages/@overeng/notion-effect-client/package.json
@@ -4,7 +4,10 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./src/mod.ts",
+    ".": {
+      "types": "./dist/src/mod.d.ts",
+      "default": "./src/mod.ts"
+    },
     "./test": "./src/test/integration/setup.ts"
   },
   "publishConfig": {

--- a/packages/@overeng/notion-effect-client/package.json.genie.ts
+++ b/packages/@overeng/notion-effect-client/package.json.genie.ts
@@ -50,7 +50,10 @@ export default packageJson(
     name: '@overeng/notion-effect-client',
     ...privatePackageDefaults,
     exports: {
-      '.': exportEntry('./src/mod.ts', { environment: 'node' }),
+      '.': exportEntry(
+        { types: './dist/src/mod.d.ts', default: './src/mod.ts' },
+        { environment: 'node' },
+      ),
       './test': exportEntry('./src/test/integration/setup.ts', {
         environment: 'node',
         published: false,

--- a/packages/@overeng/notion-effect-client/tsconfig.json
+++ b/packages/@overeng/notion-effect-client/tsconfig.json
@@ -44,15 +44,9 @@
     "composite": true,
     "rootDir": ".",
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
-    "types": ["node"]
+    "types": ["node"],
+    "noEmit": true
   },
   "include": ["src/**/*"],
-  "references": [
-    {
-      "path": "../notion-core"
-    },
-    {
-      "path": "../notion-effect-schema"
-    }
-  ]
+  "references": []
 }

--- a/packages/@overeng/notion-effect-client/tsconfig.json.genie.ts
+++ b/packages/@overeng/notion-effect-client/tsconfig.json.genie.ts
@@ -10,7 +10,8 @@ export default tsconfigJson({
     ...baseTsconfigCompilerOptions,
     ...packageTsconfigCompilerOptions,
     ...nodeTypes,
+    noEmit: true,
   },
   include: ['src/**/*'],
-  references: [{ path: '../notion-core' }, { path: '../notion-effect-schema' }],
+  references: [],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/notion-effect-schema/BUCK
+++ b/packages/@overeng/notion-effect-schema/BUCK
@@ -4,8 +4,8 @@
 # Projection source: packages/@overeng/notion-effect-schema/BUCK.genie.ts
 # Projection schema version: 1
 # Projection generator: effect-utils/genie/buck2-typescript-package-projection
-# Semantic fingerprint: sha256:bc96640f19512e57cd47b58507cf9438c0ae5c381f6ac2ced35b799056f20461
-# Semantic inputs: buck2/dependencies/BUCK.genie.ts, buck2/dependencies/pnpm-lock.sha256.json.genie.ts, genie/buck2/mod.ts, genie/buck2/typescript-package-projection.ts, package.json.genie.ts, packages/@overeng/buck2-tools/src/package-tree.ts, packages/@overeng/buck2-tools/src/real-path.ts, packages/@overeng/notion-core/BUCK.genie.ts, packages/@overeng/notion-core/package.json.genie.ts, packages/@overeng/notion-core/src/**/*.cts, packages/@overeng/notion-core/src/**/*.js, packages/@overeng/notion-core/src/**/*.mts, packages/@overeng/notion-core/src/**/*.ts, packages/@overeng/notion-core/src/**/*.tsx, packages/@overeng/notion-effect-schema/BUCK.genie.ts, packages/@overeng/notion-effect-schema/BUCK.genie.ts, packages/@overeng/notion-effect-schema/package.json.genie.ts, packages/@overeng/notion-effect-schema/src/**/*.cts, packages/@overeng/notion-effect-schema/src/**/*.js, packages/@overeng/notion-effect-schema/src/**/*.mts, packages/@overeng/notion-effect-schema/src/**/*.ts, packages/@overeng/notion-effect-schema/src/**/*.tsx, packages/@overeng/notion-effect-schema/tsconfig.json.genie.ts, packages/@overeng/utils-dev/BUCK.genie.ts, packages/@overeng/utils-dev/package.json.genie.ts
+# Semantic fingerprint: sha256:09ccd1a70f0d546fb29880d421fb9733e1b296656272465978c23c410c11c0dc
+# Semantic inputs: buck2/dependencies/BUCK.genie.ts, buck2/dependencies/pnpm-lock.sha256.json.genie.ts, genie/buck2/mod.ts, genie/buck2/typescript-package-projection.ts, package.json.genie.ts, packages/@overeng/buck2-tools/src/package-tree.ts, packages/@overeng/buck2-tools/src/real-path.ts, packages/@overeng/notion-core/BUCK.genie.ts, packages/@overeng/notion-core/package.json.genie.ts, packages/@overeng/notion-effect-schema/BUCK.genie.ts, packages/@overeng/notion-effect-schema/BUCK.genie.ts, packages/@overeng/notion-effect-schema/package.json.genie.ts, packages/@overeng/notion-effect-schema/src/**/*.cts, packages/@overeng/notion-effect-schema/src/**/*.js, packages/@overeng/notion-effect-schema/src/**/*.mts, packages/@overeng/notion-effect-schema/src/**/*.ts, packages/@overeng/notion-effect-schema/src/**/*.tsx, packages/@overeng/notion-effect-schema/tsconfig.json.genie.ts, packages/@overeng/utils-dev/BUCK.genie.ts, packages/@overeng/utils-dev/package.json.genie.ts
 # Regenerate: devenv tasks run genie:run
 
 load("//buck2:materialization.bzl", "export_materialization_inputs", "package_tree")
@@ -102,20 +102,8 @@ package_tree(
     workspace_siblings = {
         "@overeng/notion-core": {
             "files": {
+                "dist": "//packages/@overeng/notion-core:dist",
                 "package.json": "//packages/@overeng/notion-core:package.json",
-                "src/body-fidelity.ts": "//packages/@overeng/notion-core:src/body-fidelity.ts",
-                "src/body-fidelity.unit.test.ts": "//packages/@overeng/notion-core:src/body-fidelity.unit.test.ts",
-                "src/colors.ts": "//packages/@overeng/notion-core:src/colors.ts",
-                "src/colors.unit.test.ts": "//packages/@overeng/notion-core:src/colors.unit.test.ts",
-                "src/constants.ts": "//packages/@overeng/notion-core:src/constants.ts",
-                "src/constants.unit.test.ts": "//packages/@overeng/notion-core:src/constants.unit.test.ts",
-                "src/ids.ts": "//packages/@overeng/notion-core:src/ids.ts",
-                "src/ids.unit.test.ts": "//packages/@overeng/notion-core:src/ids.unit.test.ts",
-                "src/mod.ts": "//packages/@overeng/notion-core:src/mod.ts",
-                "src/properties.ts": "//packages/@overeng/notion-core:src/properties.ts",
-                "src/properties.unit.test.ts": "//packages/@overeng/notion-core:src/properties.unit.test.ts",
-                "src/rich-text.ts": "//packages/@overeng/notion-core:src/rich-text.ts",
-                "src/rich-text.unit.test.ts": "//packages/@overeng/notion-core:src/rich-text.unit.test.ts",
             },
             "links": ["@overeng/notion-core"],
         },
@@ -141,5 +129,6 @@ tsgo_emit(
     package_tree = ":package_tree",
     declaration_sources = {
     },
+    declaration_entrypoint = "src/mod.d.ts",
     visibility = ["PUBLIC"],
 )

--- a/packages/@overeng/notion-effect-schema/BUCK.genie.ts
+++ b/packages/@overeng/notion-effect-schema/BUCK.genie.ts
@@ -12,7 +12,7 @@ export const buck2TypeScriptAdmission = {
     {
       packageName: '@overeng/notion-core',
       packagePath: 'packages/@overeng/notion-core',
-      sourceRoots: ['src'],
+      distTarget: '//packages/@overeng/notion-core:dist',
     },
     {
       packageName: '@overeng/utils-dev',
@@ -21,6 +21,10 @@ export const buck2TypeScriptAdmission = {
     },
   ],
   editorViewConsumer: false,
+  authority: {
+    declarationEntrypoint: 'src/mod.d.ts',
+    projectFile: 'tsconfig.json',
+  },
 } as const satisfies Buck2TypeScriptAdmission
 
 export default buck2TypeScriptPackageProjection(buck2TypeScriptAdmission)

--- a/packages/@overeng/notion-effect-schema/package.json
+++ b/packages/@overeng/notion-effect-schema/package.json
@@ -4,7 +4,10 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./src/mod.ts"
+    ".": {
+      "types": "./dist/src/mod.d.ts",
+      "default": "./src/mod.ts"
+    }
   },
   "publishConfig": {
     "access": "public",

--- a/packages/@overeng/notion-effect-schema/package.json.genie.ts
+++ b/packages/@overeng/notion-effect-schema/package.json.genie.ts
@@ -32,7 +32,10 @@ export default packageJson(
     name: '@overeng/notion-effect-schema',
     ...privatePackageDefaults,
     exports: {
-      '.': exportEntry('./src/mod.ts', { environment: 'node' }),
+      '.': exportEntry(
+        { types: './dist/src/mod.d.ts', default: './src/mod.ts' },
+        { environment: 'node' },
+      ),
     },
     publishConfig: {
       access: 'public',

--- a/packages/@overeng/notion-effect-schema/tsconfig.json
+++ b/packages/@overeng/notion-effect-schema/tsconfig.json
@@ -44,12 +44,9 @@
     "composite": true,
     "rootDir": ".",
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
-    "types": ["node"]
+    "types": ["node"],
+    "noEmit": true
   },
   "include": ["src/**/*"],
-  "references": [
-    {
-      "path": "../notion-core"
-    }
-  ]
+  "references": []
 }

--- a/packages/@overeng/notion-effect-schema/tsconfig.json.genie.ts
+++ b/packages/@overeng/notion-effect-schema/tsconfig.json.genie.ts
@@ -10,7 +10,8 @@ export default tsconfigJson({
     ...baseTsconfigCompilerOptions,
     ...packageTsconfigCompilerOptions,
     ...nodeTypes,
+    noEmit: true,
   },
   include: ['src/**/*'],
-  references: [{ path: '../notion-core' }],
+  references: [],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/notion-md/nix/build.nix
+++ b/packages/@overeng/notion-md/nix/build.nix
@@ -20,7 +20,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-bKqseeFsdPOgz+VZCi12yNh6DviSm8dUgf+4bcIeo4U=";
+      "." = mkSharedHash "sha256-EC6MedlXd6mHNasnnHtG88jNRHWU6d7F65/JB8MERIs=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/notion-md/tsconfig.json
+++ b/packages/@overeng/notion-md/tsconfig.json
@@ -48,18 +48,5 @@
     "jsx": "react-jsx"
   },
   "include": ["src/**/*"],
-  "references": [
-    {
-      "path": "../notion-core"
-    },
-    {
-      "path": "../notion-effect-client"
-    },
-    {
-      "path": "../notion-effect-schema"
-    },
-    {
-      "path": "../notion-property-write"
-    }
-  ]
+  "references": []
 }

--- a/packages/@overeng/notion-md/tsconfig.json.genie.ts
+++ b/packages/@overeng/notion-md/tsconfig.json.genie.ts
@@ -15,10 +15,5 @@ export default tsconfigJson({
     lib: ['ES2023'],
   },
   include: ['src/**/*'],
-  references: [
-    { path: '../notion-core' },
-    { path: '../notion-effect-client' },
-    { path: '../notion-effect-schema' },
-    { path: '../notion-property-write' },
-  ],
+  references: [],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/notion-property-write/BUCK
+++ b/packages/@overeng/notion-property-write/BUCK
@@ -4,8 +4,8 @@
 # Projection source: packages/@overeng/notion-property-write/BUCK.genie.ts
 # Projection schema version: 1
 # Projection generator: effect-utils/genie/buck2-typescript-package-projection
-# Semantic fingerprint: sha256:099be049ffdc95b775f56a3257dd52a1925b8d451d68b59fcacb5874844eee95
-# Semantic inputs: buck2/dependencies/BUCK.genie.ts, buck2/dependencies/pnpm-lock.sha256.json.genie.ts, genie/buck2/mod.ts, genie/buck2/typescript-package-projection.ts, package.json.genie.ts, packages/@overeng/buck2-tools/src/package-tree.ts, packages/@overeng/buck2-tools/src/real-path.ts, packages/@overeng/notion-effect-schema/BUCK.genie.ts, packages/@overeng/notion-effect-schema/package.json.genie.ts, packages/@overeng/notion-effect-schema/src/**/*.cts, packages/@overeng/notion-effect-schema/src/**/*.js, packages/@overeng/notion-effect-schema/src/**/*.mts, packages/@overeng/notion-effect-schema/src/**/*.ts, packages/@overeng/notion-effect-schema/src/**/*.tsx, packages/@overeng/notion-property-write/BUCK.genie.ts, packages/@overeng/notion-property-write/BUCK.genie.ts, packages/@overeng/notion-property-write/package.json.genie.ts, packages/@overeng/notion-property-write/src/**/*.cts, packages/@overeng/notion-property-write/src/**/*.js, packages/@overeng/notion-property-write/src/**/*.mts, packages/@overeng/notion-property-write/src/**/*.ts, packages/@overeng/notion-property-write/src/**/*.tsx, packages/@overeng/notion-property-write/tsconfig.json.genie.ts
+# Semantic fingerprint: sha256:1f7f45468bbce0849a06d1b46e48e87451fe59b7bd4ff6d16ad4031c40e3eaad
+# Semantic inputs: buck2/dependencies/BUCK.genie.ts, buck2/dependencies/pnpm-lock.sha256.json.genie.ts, genie/buck2/mod.ts, genie/buck2/typescript-package-projection.ts, package.json.genie.ts, packages/@overeng/buck2-tools/src/package-tree.ts, packages/@overeng/buck2-tools/src/real-path.ts, packages/@overeng/notion-effect-schema/BUCK.genie.ts, packages/@overeng/notion-effect-schema/package.json.genie.ts, packages/@overeng/notion-property-write/BUCK.genie.ts, packages/@overeng/notion-property-write/BUCK.genie.ts, packages/@overeng/notion-property-write/package.json.genie.ts, packages/@overeng/notion-property-write/src/**/*.cts, packages/@overeng/notion-property-write/src/**/*.js, packages/@overeng/notion-property-write/src/**/*.mts, packages/@overeng/notion-property-write/src/**/*.ts, packages/@overeng/notion-property-write/src/**/*.tsx, packages/@overeng/notion-property-write/tsconfig.json.genie.ts
 # Regenerate: devenv tasks run genie:run
 
 load("//buck2:materialization.bzl", "export_materialization_inputs", "package_tree")
@@ -58,36 +58,8 @@ package_tree(
     workspace_siblings = {
         "@overeng/notion-effect-schema": {
             "files": {
+                "dist": "//packages/@overeng/notion-effect-schema:dist",
                 "package.json": "//packages/@overeng/notion-effect-schema:package.json",
-                "src/common.ts": "//packages/@overeng/notion-effect-schema:src/common.ts",
-                "src/common.unit.test.ts": "//packages/@overeng/notion-effect-schema:src/common.unit.test.ts",
-                "src/mod.ts": "//packages/@overeng/notion-effect-schema:src/mod.ts",
-                "src/objects.ts": "//packages/@overeng/notion-effect-schema:src/objects.ts",
-                "src/objects.unit.test.ts": "//packages/@overeng/notion-effect-schema:src/objects.unit.test.ts",
-                "src/properties.unit.test.ts": "//packages/@overeng/notion-effect-schema:src/properties.unit.test.ts",
-                "src/properties/audit.ts": "//packages/@overeng/notion-effect-schema:src/properties/audit.ts",
-                "src/properties/boolean.ts": "//packages/@overeng/notion-effect-schema:src/properties/boolean.ts",
-                "src/properties/canonical-codec.ts": "//packages/@overeng/notion-effect-schema:src/properties/canonical-codec.ts",
-                "src/properties/canonical-codec.unit.test.ts": "//packages/@overeng/notion-effect-schema:src/properties/canonical-codec.unit.test.ts",
-                "src/properties/canonical.ts": "//packages/@overeng/notion-effect-schema:src/properties/canonical.ts",
-                "src/properties/common.ts": "//packages/@overeng/notion-effect-schema:src/properties/common.ts",
-                "src/properties/computed.ts": "//packages/@overeng/notion-effect-schema:src/properties/computed.ts",
-                "src/properties/contact.ts": "//packages/@overeng/notion-effect-schema:src/properties/contact.ts",
-                "src/properties/date.ts": "//packages/@overeng/notion-effect-schema:src/properties/date.ts",
-                "src/properties/descriptor.ts": "//packages/@overeng/notion-effect-schema:src/properties/descriptor.ts",
-                "src/properties/descriptor.unit.test.ts": "//packages/@overeng/notion-effect-schema:src/properties/descriptor.unit.test.ts",
-                "src/properties/mod.ts": "//packages/@overeng/notion-effect-schema:src/properties/mod.ts",
-                "src/properties/number.ts": "//packages/@overeng/notion-effect-schema:src/properties/number.ts",
-                "src/properties/reference.ts": "//packages/@overeng/notion-effect-schema:src/properties/reference.ts",
-                "src/properties/rollup.ts": "//packages/@overeng/notion-effect-schema:src/properties/rollup.ts",
-                "src/properties/select.ts": "//packages/@overeng/notion-effect-schema:src/properties/select.ts",
-                "src/properties/text.ts": "//packages/@overeng/notion-effect-schema:src/properties/text.ts",
-                "src/property-schema.ts": "//packages/@overeng/notion-effect-schema:src/property-schema.ts",
-                "src/rich-text-utils.ts": "//packages/@overeng/notion-effect-schema:src/rich-text-utils.ts",
-                "src/rich-text-utils.unit.test.ts": "//packages/@overeng/notion-effect-schema:src/rich-text-utils.unit.test.ts",
-                "src/rich-text.ts": "//packages/@overeng/notion-effect-schema:src/rich-text.ts",
-                "src/users.ts": "//packages/@overeng/notion-effect-schema:src/users.ts",
-                "src/webhook.ts": "//packages/@overeng/notion-effect-schema:src/webhook.ts",
             },
             "links": ["@overeng/notion-effect-schema"],
         },
@@ -106,5 +78,6 @@ tsgo_emit(
     package_tree = ":package_tree",
     declaration_sources = {
     },
+    declaration_entrypoint = "src/mod.d.ts",
     visibility = ["PUBLIC"],
 )

--- a/packages/@overeng/notion-property-write/BUCK.genie.ts
+++ b/packages/@overeng/notion-property-write/BUCK.genie.ts
@@ -12,10 +12,14 @@ export const buck2TypeScriptAdmission = {
     {
       packageName: '@overeng/notion-effect-schema',
       packagePath: 'packages/@overeng/notion-effect-schema',
-      sourceRoots: ['src'],
+      distTarget: '//packages/@overeng/notion-effect-schema:dist',
     },
   ],
   editorViewConsumer: false,
+  authority: {
+    declarationEntrypoint: 'src/mod.d.ts',
+    projectFile: 'tsconfig.json',
+  },
 } as const satisfies Buck2TypeScriptAdmission
 
 export default buck2TypeScriptPackageProjection(buck2TypeScriptAdmission)

--- a/packages/@overeng/notion-property-write/package.json
+++ b/packages/@overeng/notion-property-write/package.json
@@ -4,7 +4,10 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./src/mod.ts"
+    ".": {
+      "types": "./dist/src/mod.d.ts",
+      "default": "./src/mod.ts"
+    }
   },
   "publishConfig": {
     "access": "public",

--- a/packages/@overeng/notion-property-write/package.json.genie.ts
+++ b/packages/@overeng/notion-property-write/package.json.genie.ts
@@ -32,7 +32,10 @@ export default packageJson(
     name: '@overeng/notion-property-write',
     ...privatePackageDefaults,
     exports: {
-      '.': exportEntry('./src/mod.ts', { environment: 'isomorphic-es2024' }),
+      '.': exportEntry(
+        { types: './dist/src/mod.d.ts', default: './src/mod.ts' },
+        { environment: 'isomorphic-es2024' },
+      ),
     },
     publishConfig: {
       access: 'public',

--- a/packages/@overeng/notion-property-write/tsconfig.json
+++ b/packages/@overeng/notion-property-write/tsconfig.json
@@ -44,12 +44,9 @@
     "composite": true,
     "rootDir": ".",
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
-    "types": ["node"]
+    "types": ["node"],
+    "noEmit": true
   },
   "include": ["src/**/*"],
-  "references": [
-    {
-      "path": "../notion-effect-schema"
-    }
-  ]
+  "references": []
 }

--- a/packages/@overeng/notion-property-write/tsconfig.json.genie.ts
+++ b/packages/@overeng/notion-property-write/tsconfig.json.genie.ts
@@ -10,7 +10,8 @@ export default tsconfigJson({
     ...baseTsconfigCompilerOptions,
     ...packageTsconfigCompilerOptions,
     ...nodeTypes,
+    noEmit: true,
   },
   include: ['src/**/*'],
-  references: [{ path: '../notion-effect-schema' }],
+  references: [],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/notion-react/tsconfig.json
+++ b/packages/@overeng/notion-react/tsconfig.json
@@ -51,12 +51,6 @@
   "include": ["src/**/*"],
   "references": [
     {
-      "path": "../notion-effect-client"
-    },
-    {
-      "path": "../notion-effect-schema"
-    },
-    {
       "path": "../notion-md"
     }
   ]

--- a/packages/@overeng/notion-react/tsconfig.json.genie.ts
+++ b/packages/@overeng/notion-react/tsconfig.json.genie.ts
@@ -17,9 +17,5 @@ export default tsconfigJson({
     lib: [...domLib],
   },
   include: ['src/**/*'],
-  references: [
-    { path: '../notion-effect-client' },
-    { path: '../notion-effect-schema' },
-    { path: '../notion-md' },
-  ],
+  references: [{ path: '../notion-md' }],
 } satisfies TSConfigArgs)

--- a/tsconfig.check.json
+++ b/tsconfig.check.json
@@ -55,22 +55,10 @@
       "path": "./packages/@overeng/notion-cli"
     },
     {
-      "path": "./packages/@overeng/notion-core"
-    },
-    {
       "path": "./packages/@overeng/notion-datasource-sync"
     },
     {
-      "path": "./packages/@overeng/notion-effect-client"
-    },
-    {
-      "path": "./packages/@overeng/notion-effect-schema"
-    },
-    {
       "path": "./packages/@overeng/notion-md"
-    },
-    {
-      "path": "./packages/@overeng/notion-property-write"
     },
     {
       "path": "./packages/@overeng/notion-react"

--- a/tsconfig.emit.json
+++ b/tsconfig.emit.json
@@ -55,22 +55,10 @@
       "path": "./packages/@overeng/notion-cli"
     },
     {
-      "path": "./packages/@overeng/notion-core"
-    },
-    {
       "path": "./packages/@overeng/notion-datasource-sync"
     },
     {
-      "path": "./packages/@overeng/notion-effect-client"
-    },
-    {
-      "path": "./packages/@overeng/notion-effect-schema"
-    },
-    {
       "path": "./packages/@overeng/notion-md"
-    },
-    {
-      "path": "./packages/@overeng/notion-property-write"
     },
     {
       "path": "./packages/@overeng/notion-react"


### PR DESCRIPTION
Stacked on #1205. Buck becomes sole producer of typecheck + declaration emit for notion-core/effect-schema/property-write/effect-client.

Devenv speed/complexity deltas: root check+emit solutions 31->27 refs (-8 total); 4 dual producers eliminated at solution level; intra-base content-tracked sibling closures replaced by Buck dist edges (BUCK files net -100+ lines); +4 member dist overlays.

Known interim: 16 stale dependent project-reference edges survive (12 top->base, 4 intra-base) — tsc still follows them redundantly (green), Buck targets additive. Full exclusivity (edge deletion incl. dist-types rewrites) rides with the top authority transfer.

Proof: genie:check + genie:buck2:test (25/0) green; CI proves the 4 new Buck typecheck targets. Evidence: context/buck2/02-execution/.experiments/2026-09-03-notion-base-authority-transfer.md. Interview: q6+q8.