### PR TITLE
test(genie): prove every ci-runtime script a generated step invokes is emitted to consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,20 @@ All notable changes to this project will be documented in this file.
   `@layer overeng.reset, priority1, ...;` statement fixes the order by
   declaration rather than by which stylesheet the browser parses first — the
   same "do not depend on injection order" rule the token layer already follows.
+- **genie**: the CI workflow generator proves that every helper script a
+  generated step invokes is a script it actually emits. `prepareCiScriptsStep`
+  copies the *consuming* repository's `genie/ci-scripts/` into the job-local
+  `composition-state/ci-runtime/`, and only `ciWorkflowSupportFiles` puts files
+  there, so a step naming a script that merely happens to be hand-committed in
+  this repo resolves here and exits 127 in every consumer. That is how
+  `.../ci-runtime/resolve-devenv-ci.sh` failed 14 of 15 jobs on
+  schickling/schickling.dev#178 (run 33752627726) while this repo's own CI
+  stayed green: the assertion that existed checked the step *mentioned* the
+  script, never that a consumer could resolve it. Three scans now close the
+  class — generator-source references through any `*ScriptsDir`,
+  `composition-state/ci-runtime/...` references in the generated workflows, and
+  `$script_dir/...` siblings sourced by an emitted script — and each failure
+  names the unavailable script together with the file that asks for it.
 
 ### Fixed
 

--- a/packages/@overeng/genie/src/runtime/github-workflow/ci-runtime-scripts.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/github-workflow/ci-runtime-scripts.unit.test.ts
@@ -1,0 +1,208 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Availability contract for the CI helper scripts a generated workflow step invokes.
+ *
+ * `prepareCiScriptsStep` copies the *consuming* repository's `genie/ci-scripts/` into the
+ * job-local `.../composition-state/ci-runtime/` directory, and the only thing that puts files
+ * into a consumer's `genie/ci-scripts/` is `ciWorkflowSupportFiles`. A generated step may
+ * therefore only invoke scripts that `ciWorkflowSupportFiles` emits: any other script exists in
+ * this repo alone, so the step resolves here and dies with exit 127 in every consumer.
+ *
+ * That is not hypothetical. `validateNixStoreStepFor` invoked
+ * `.../ci-runtime/resolve-devenv-ci.sh` while `resolve-devenv-ci.sh` was a hand-committed
+ * effect-utils file with no support-file entry, which failed all 14 jobs of
+ * schickling/schickling.dev#178 (run 33752627726) at
+ * `resolve-devenv-ci.sh: No such file or directory`, while effect-utils' own CI stayed green.
+ *
+ * The assertions below read the shared generator source, the generated workflows and the
+ * emitted scripts, so the reference and its availability can never drift apart again.
+ */
+
+const repoRoot = fileURLToPath(new URL('../../../../../../', import.meta.url))
+
+const readRepoText = (repoRelativePath: string) =>
+  readFileSync(join(repoRoot, repoRelativePath), 'utf8')
+
+/** Recursive file walk, sorted for deterministic failure output. */
+const repoFiles = (repoRelativeDir: string, extension: string): string[] => {
+  const walk = (dir: string): string[] =>
+    readdirSync(join(repoRoot, dir), { withFileTypes: true })
+      .flatMap((entry) => {
+        const path = `${dir}/${entry.name}`
+        if (entry.isDirectory() === true) return walk(path)
+        return entry.isFile() === true && entry.name.endsWith(extension) === true ? [path] : []
+      })
+      .sort()
+
+  return walk(repoRelativeDir)
+}
+
+/**
+ * Kept as literals rather than imported: this package is the generator runtime that
+ * `genie/ci-workflow/` builds on, so it must not import back out of it. The two assertions in
+ * `describe('ci runtime script directories')` fail the moment either literal drifts from
+ * `genie/ci-workflow/shared.ts`.
+ */
+const ciScriptsDir = 'genie/ci-scripts'
+const preparedCiScriptsDirSuffix = 'composition-state/ci-runtime'
+
+const supportFilesModule = 'genie/ci-workflow/support-files.ts'
+const sharedModule = 'genie/ci-workflow/shared.ts'
+
+const supportFilesSource = readRepoText(supportFilesModule)
+const sharedSource = readRepoText(sharedModule)
+
+/** `export const ciWorkflowResolveDevenvScriptPath = 'genie/ci-scripts/resolve-devenv.sh'` */
+const supportFilePathConstants = new Map(
+  Array.from(
+    supportFilesSource.matchAll(/export const (\w+Path)\s*=\s*(?:\r?\n\s*)?'([^']+)'/g),
+    ([, constant, path]) => [constant ?? '', path ?? ''] as const,
+  ),
+)
+
+const supportFilesEntriesSource = (() => {
+  const startMarker = 'export const ciWorkflowSupportFiles = {'
+  const start = supportFilesSource.indexOf(startMarker)
+  if (start < 0) throw new Error(`missing ${startMarker} in ${supportFilesModule}`)
+
+  const end = supportFilesSource.indexOf('\n} as const', start)
+  if (end < 0) throw new Error(`missing end of ciWorkflowSupportFiles in ${supportFilesModule}`)
+
+  return supportFilesSource.slice(start, end)
+})()
+
+/** Every `path:` an entry of `ciWorkflowSupportFiles` emits, as a repo-relative path. */
+const emittedSupportFilePaths = Array.from(
+  supportFilesEntriesSource.matchAll(/\bpath:\s*(?:'([^']+)'|([A-Za-z_$][\w$]*))/g),
+).map(([match, literalPath, pathConstant]) => {
+  if (literalPath !== undefined) return literalPath
+
+  const resolved =
+    pathConstant === undefined ? undefined : supportFilePathConstants.get(pathConstant)
+  if (resolved === undefined) {
+    throw new Error(`ciWorkflowSupportFiles entry has an unresolvable path: ${match}`)
+  }
+
+  return resolved
+})
+
+const emittedCiScriptNames = new Set(
+  emittedSupportFilePaths
+    .filter((path) => path.startsWith(`${ciScriptsDir}/`) === true)
+    .map((path) => path.slice(path.lastIndexOf('/') + 1)),
+)
+
+/**
+ * Script references a consumer must be able to resolve, keyed by script name so a
+ * failure names both the missing script and the source that asks for it.
+ */
+const collectReferences = (
+  sources: readonly { readonly origin: string; readonly text: string }[],
+  pattern: RegExp,
+): Map<string, string[]> => {
+  const references = new Map<string, string[]>()
+
+  for (const { origin, text } of sources) {
+    for (const [, referenced] of text.matchAll(new RegExp(pattern.source, 'g'))) {
+      if (referenced === undefined) continue
+      const origins = references.get(referenced)
+      if (origins === undefined) {
+        references.set(referenced, [origin])
+      } else if (origins.includes(origin) === false) {
+        origins.push(origin)
+      }
+    }
+  }
+
+  return references
+}
+
+const unavailable = (references: Map<string, string[]>) =>
+  Array.from(references)
+    .filter(([referenced]) => emittedCiScriptNames.has(referenced) === false)
+    .map(([referenced, origins]) => `${referenced} <- ${origins.join(', ')}`)
+    .sort()
+
+const generatorSources = repoFiles('genie', '.ts').map((path) => ({
+  origin: path,
+  text: readRepoText(path),
+}))
+
+const generatedWorkflowSources = repoFiles('.github/workflows', '.yml').map((path) => ({
+  origin: path,
+  text: readRepoText(path),
+}))
+
+/**
+ * Emitted shell scripts as they exist in this repo. A path that is declared but not
+ * materialized is skipped here so that `ships every emitted support file` reports it as a
+ * list of missing paths, rather than this module throwing before any assertion runs.
+ */
+const emittedScriptSources = emittedSupportFilePaths
+  .filter((path) => path.endsWith('.sh') === true && existsSync(join(repoRoot, path)) === true)
+  .map((path) => ({ origin: path, text: readRepoText(path) }))
+
+describe('ci runtime script directories', () => {
+  it('tracks the script directory literals declared by the shared generator', () => {
+    expect(sharedSource).toContain(`export const defaultCiRuntimeScriptsDir = '${ciScriptsDir}'`)
+    expect(sharedSource).toContain(
+      "export const ciCompositionStateRoot = '${{ runner.temp }}/composition-state'",
+    )
+    expect(sharedSource).toContain(
+      'export const preparedCiRuntimeScriptsDir = `${ciCompositionStateRoot}/ci-runtime`',
+    )
+  })
+
+  it('extracts the emitted support-file set from ciWorkflowSupportFiles', () => {
+    expect(emittedSupportFilePaths).toContain(`${ciScriptsDir}/resolve-devenv.sh`)
+    expect(emittedSupportFilePaths).toContain(`${ciScriptsDir}/nix-gc-race-retry.sh`)
+    expect(emittedSupportFilePaths).toContain(`${ciScriptsDir}/run-with-nix-gc-race-retry.sh`)
+    expect(new Set(emittedSupportFilePaths).size).toBe(emittedSupportFilePaths.length)
+  })
+})
+
+describe('ci runtime scripts referenced by generated steps are emitted to consumers', () => {
+  it('resolves every script the shared generator invokes through a CI scripts directory', () => {
+    const references = collectReferences(
+      generatorSources,
+      /\$\{[A-Za-z0-9]*[sS]criptsDir\}\/([A-Za-z0-9._-]+\.(?:sh|mjs|js))/,
+    )
+
+    expect(references.size).toBeGreaterThan(0)
+    expect(unavailable(references)).toEqual([])
+  })
+
+  it('resolves every ci-runtime script a generated workflow step invokes', () => {
+    const references = collectReferences(
+      generatedWorkflowSources,
+      new RegExp(`${preparedCiScriptsDirSuffix}/([A-Za-z0-9._-]+)`),
+    )
+
+    expect(references.size).toBeGreaterThan(0)
+    expect(unavailable(references)).toEqual([])
+  })
+
+  it('resolves every sibling script an emitted support script sources', () => {
+    const references = collectReferences(
+      emittedScriptSources,
+      /\$\{?script_dir\}?\/([A-Za-z0-9._-]+)/,
+    )
+
+    expect(references.size).toBeGreaterThan(0)
+    expect(unavailable(references)).toEqual([])
+  })
+
+  it('ships every emitted support file in this repo', () => {
+    const missing = emittedSupportFilePaths.filter((path) => {
+      const absolute = join(repoRoot, path)
+      return existsSync(absolute) === false || statSync(absolute).isFile() === false
+    })
+
+    expect(missing).toEqual([])
+  })
+})


### PR DESCRIPTION
## Problem

`prepareCiScriptsStep` fills the job-local `${{ runner.temp }}/composition-state/ci-runtime/`
from the **consuming** repository's `genie/ci-scripts/`, and the only thing that populates a
consumer's `genie/ci-scripts/` is `ciWorkflowSupportFiles`. A generated step may therefore only
invoke scripts that a support-file entry emits.

Nothing enforced that. `validateNixStoreStepFor` (`genie/ci-workflow/setup.ts`) invoked
`.../ci-runtime/resolve-devenv-ci.sh`, while `resolve-devenv-ci.sh` was a hand-committed
effect-utils file (added in #1056) with **no** entry in `ciWorkflowSupportFiles`. This repo's own
CI stayed green — it carries the file — while every consumer that regenerated CI from a rev
`>= 663e07b0e` lost every job at exit 127:

```
Run cd "${EFFECT_UTILS_MEMBER_ROOT:-...}" && '.../composition-state/ci-runtime/resolve-devenv-ci.sh' 'devenv.lock'
.../composition-state/ci-runtime/resolve-devenv-ci.sh: No such file or directory
##[error]Process completed with exit code 127.
```

14 of 15 jobs on `schickling/schickling.dev#178` (run 33752627726, head `ecd2a20d`) died there,
identically, at ~14s each.

The only assertion that touched this path (`ci-workflow-helpers.unit.test.ts`) checked that the
emitted step *mentioned* `resolve-devenv-ci.sh`. Mentioning it was the bug.

## Goal

The reference and its availability cannot drift apart again. A generated step that names a script
no consumer can resolve fails a unit test here, naming both the unavailable script and the file
that asks for it — on `main` before #1207, this PR's test reported exactly:

```
+   "resolve-devenv-ci.sh <- genie/ci-workflow/setup.ts",
+   "resolve-devenv-ci.sh <- .github/workflows/ci.yml",
```

## Decisions

- **Guard only; the fix is #1207's.** #1207 (merged as `fcd2ef5b7`) fixes the instance the right
  way — it folds the CI wrapper into the generated `resolve-devenv.sh`, deletes the
  hand-committed script, and repoints the step. This PR deliberately touches neither `setup.ts`,
  `support-files.ts`, nor `resolve-devenv*.sh`: a second, competing fix (a `resolveDevenvCi`
  support entry that #1207 then deletes) would have forced the bigger, already-green PR to rebase
  through a conflict for no gain. #1207 fixes the instance; this closes the class.
- **Three scans, because the reference can be written in three places.** The generator source
  (`${...ScriptsDir}/<script>` in any `genie/**/*.ts`), the generated workflow YAML
  (`composition-state/ci-runtime/<script>`), and the emitted scripts themselves
  (`$script_dir/<sibling>`, which is how `run-with-nix-gc-race-retry.sh` loads
  `nix-gc-race-retry.sh` — and how the deleted `resolve-devenv-ci.sh` loaded `resolve-devenv.sh`).
  A YAML-only scan would not be enough: `prepare-job-local-rust-state.sh` appears 15 times in a
  consumer's generated workflow and **zero** times in this repo's own, so only `shared.ts:371`
  names it here. A source-only scan would not be enough either: the generated YAML is the
  artifact a consumer actually copies and runs.
- **Source-text scanning, not importing `support-files.ts`.** That module imports this package's
  runtime (`packages/@overeng/genie/src/runtime/core.ts`); importing it back from a test inside
  the package inverts the dependency and pulls the repo root outside the package's `rootDir`. To
  keep text scanning honest: two assertions pin the directory literals to their declarations in
  `genie/ci-workflow/shared.ts`, three canary assertions pin known members of the extracted
  support-file set, and an unresolvable `path:` in the entry map throws instead of silently
  shrinking the set — a stale regex cannot make the invariant vacuous.
- **Scope is the portable script directory, not every `genie/ci-scripts/...` string.** The
  effect-utils-only composition steps (decision-0020) address their scripts as
  `"$GITHUB_WORKSPACE/genie/ci-scripts/prepare-effect-utils-composition.sh"` literals and are
  correctly out of scope — they are never emitted into a consumer's workflow. Everything that
  goes through a `*ScriptsDir` or through the prepared `ci-runtime` directory is checked with no
  allowlist, because that directory *is* the portable contract.

## Verification

`devenv tasks run test:genie`, same branch, same command, rebased across #1207's merge:

| base | test files | tests | failed |
| --- | --- | --- | --- |
| `main` before #1207 (`ff12684e5`) | 30 | 424 | **2** — both this PR's, naming `resolve-devenv-ci.sh` |
| `main` with #1207 (`fcd2ef5b7`) | 31 | 429 | **0** |

The two failures were the reproduction, not a defect in the test:

```
 FAIL  ci-runtime-scripts.unit.test.ts > ... > resolves every script the shared generator invokes through a CI scripts directory
 AssertionError: expected [ Array(1) ] to deeply equal []
 +   "resolve-devenv-ci.sh <- genie/ci-workflow/setup.ts",

 FAIL  ci-runtime-scripts.unit.test.ts > ... > resolves every ci-runtime script a generated workflow step invokes
 AssertionError: expected [ Array(1) ] to deeply equal []
 +   "resolve-devenv-ci.sh <- .github/workflows/ci.yml",
```

CI proved the same thing before the rebase: run 33782054887 on the pre-#1207 head was green on
every job except the two `test` matrix legs, which reported
`Test Files 1 failed | 30 passed (31)` / `Tests 2 failed | 427 passed (429)` — the two failures
being these assertions. The same job log, 6400 lines earlier, shows this repo's own *Resolve
devenv* step happily running `.../ci-runtime/resolve-devenv-ci.sh`. That asymmetry — works here,
nowhere else — is the whole defect, and it is now a test failure rather than a consumer outage.

On the current head, all six assertions pass:

```
tracks the script directory literals declared by the shared generator          passed
extracts the emitted support-file set from ciWorkflowSupportFiles              passed
resolves every script the shared generator invokes through a CI scripts dir    passed
resolves every ci-runtime script a generated workflow step invokes             passed
resolves every sibling script an emitted support script sources               passed
ships every emitted support file in this repo                                 passed
```

Negative control — scan 2's regex run over `schickling.dev#178`'s committed `ci.yml` at the pin
that failed:

```
referenced:  { "resolve-devenv-ci.sh": 14, "run-with-nix-gc-race-retry.sh": 22 }
present:     [ nix-gc-race-retry.sh, resolve-devenv.sh, run-with-nix-gc-race-retry.sh ]
unavailable: [ "resolve-devenv-ci.sh" ]
```

14 unavailable references, 14 failed jobs.

Local lanes on the rebased branch, all **exit 0** (single run, 19.7s warm):
`test:genie` (31 files / 429 tests / 0 failed), `lint:check` (oxlint, oxfmt, lockfile,
`genie:coverage`, `genie`, asset-import), `ts:check`, `check:quick`. An earlier cold
`check:quick` on the equivalent merged state also passed in 98.4s including `genie:run` (87.9s),
which left no drift.

### Pre-flip deviation — `test (namespace-profile-linux-x86-64)`

That leg is red on this PR (attempts 1 and 2 of run 33790847558) for a reason outside this
change. `test:genie` is ✓ in both attempts (12.7s / 7.54s); the failure is `test:tui-react`:

```
FAIL  test/integration/stdout-drain.test.ts > stdout data channel survives a non-zero exit
      > bun: buffered control truncates, proving the test can fail
AssertionError: expected 1000000 to be less than 1000000
```

That is a negative control which requires Bun's buffered stdout to *lose* bytes on a non-zero
exit; when the runner delivers the whole 1 MB the control passes and the assertion fails.
Reproduced on pristine `main`, not assumed: `523d21a3c` (run 33782219108, job 100738399998)
fails with the byte-identical message, while `main` `30a981065` (run 33783986891) passed the
same leg. #1198 also lost an attempt to it earlier today (run 33775384106, job 100715661118).
Two job reruns produced the same result, so I stopped rather than burn runner time.

Rebased onto the current `main` tip `2c6047b50`, where the same lanes are green again:
`test:genie`, `lint:check`, `ts:check`, `check:quick` all **exit 0** (24.9s warm), and the
six assertions of this test still pass. Getting there needed one unrelated repair — at
`2c6047b50` `buck2:typescript:materialize-dist` first failed with `generated Buck
capabilities do not contain python-bootstrap for x86_64-linux`, which #1197's author
root-caused as a stale owned capability projection: `mr status` reports
`applyNeeded: false` without considering the projection, so the `mr:apply` task's status
guard short-circuits, every Buck task's `after = ["mr:apply"]` ordering becomes vacuous, and
a pre-#1197 projection survives indefinitely. Forcing `mr apply` advanced the generation and
added the capability. Nothing to do with this PR; the durable fix is theirs.

## Complexity

No new abstraction, no dependency, no generator change: one test file and a CHANGELOG entry.

## Concerns

- The scans read source text. That is deliberate (see Decisions) but it is pattern matching: a
  step that builds a script name by concatenation at runtime would slip through. The canary and
  literal-pinning assertions bound the failure mode to "misses a novel spelling", never to
  "passes a known-missing script".
- Scan 1 walks all of `genie/**/*.ts`, so a future `*.genie.ts` that legitimately names a
  non-support script through a `*ScriptsDir` variable would need rewording or scoping. There is
  no such reference today (three total, all in `genie/ci-workflow/`).

## Friction & bottlenecks

- **`devenv tasks run check:quick` at a worktree root relocates your working tree.** `mr:setup`
  synthesized the decision-0020 composition workspace in place: the outer worktree lost its
  `.git` and became `{BUCK, megarepo.kdl, repos/, .megarepo-owned-worktree.json}`, with the real
  checkout moved to `repos/effect-utils/`. Afterwards every `git` command at the old path answers
  `fatal: not a git repository`, and `gh pr create` fails with `Managed agents must create PRs
  from branches that include the current target base` — a misleading error for "there is no repo
  here any more". Nothing is lost (`.megarepo-owned-worktree.json` records head and porcelain),
  but lanes run at the outer root fail with
  `Module not found .../packages/@overeng/megarepo/bin/mr.ts` until you `cd repos/effect-utils`.
  A one-line notice before restructuring would have saved a scare.
- **No cheap way to run one package's vitest file.** A fresh worktree has no `node_modules` and
  the only documented path is the full devenv bootstrap (~7 min cold). For the authoring loop I
  ran the file under `bun test` with a 10-line preload aliasing `vitest` to `bun:test`, then
  re-proved everything under the real runner.

## Follow-ups

None. Overlap check across the 19 open PRs that touch `CHANGELOG.md` or `genie/ci-workflow/`:
only #1030 adds a new prepared-directory reference
(`${preparedCiRuntimeScriptsDir}/nix-gc-race-retry.sh`), which is already a support file and
satisfies this invariant. No file here is touched by any other open PR except `CHANGELOG.md`.

## References

- Refs #1207 — fixed the instance; merged as `fcd2ef5b7`, and this branch is rebased on it
- Refs #1056 — introduced the hand-committed `resolve-devenv-ci.sh` and the reference to it
- Refs `schickling/schickling.dev#178`, run 33752627726 — 14/15 jobs, exit 127, the observed cost
- Refs `schickling/dotfiles#2319` — the consumer chain blocked behind this class of defect

<!-- agent-footer:begin v=2 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | dev3.direct.omp.f689zvm8 |
| `session` | dev3.f689zvm8 |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.1.2 |
| `agent_runtime` | OMP 18.1.2 |
| `tooling_profile` | dotfiles@0e52305-dirty |
</details>
<!-- agent-footer:end -->