### PR TITLE
fix(devenv): assert `repoFlake`'s worktree instead of assuming it

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -6,7 +6,28 @@
   ...
 }:
 let
-  repoFlake = builtins.getFlake "git+file://${toString ./.}";
+  # `git+file://` and not a bare path: `builtins.getFlake (toString ./.)`
+  # parses as a `path:` flakeref, which copies the entire working directory —
+  # gitignored `.devenv/` included, 546 MB / 25,142 files against 18 MB / 2,746
+  # for the git-tracked view — into the store on every eval, and re-copies it
+  # whenever devenv writes its own state. Measured 82.4 s -> 14.6 s median on a
+  # forced eval-cache miss.
+  #
+  # The assertion is the other half. `git+file://` needs `./.` to be a real
+  # worktree, and #1190 is what happens when it is not: config evaluated from a
+  # store-backed source has no `.git`, and this expression dies where a bare
+  # path would have limped on.
+  repoFlake =
+    assert lib.assertMsg (builtins.pathExists (./. + "/.git")) ''
+      devenv.nix: `repoFlake` needs `./.` to be a real git worktree, and
+      ${toString ./.} has no `.git`.
+
+      This is the #1190 regression: `builtins.getFlake "git+file://…"` is fine
+      while `./.` is a checkout and fails the moment this file is evaluated
+      from a store path. If you moved config evaluation onto a store-backed
+      source, pass that source in explicitly rather than re-deriving it here.
+    '';
+    builtins.getFlake "git+file://${toString ./.}";
   currentSystem = pkgs.stdenv.hostPlatform.system;
   flakePkgs = import repoFlake.inputs.nixpkgs { system = currentSystem; };
   # `restate` ships under BSL-1.1; scope allowUnfree to just that package so the


### PR DESCRIPTION
## Problem

`devenv.nix:9` reads

```nix
repoFlake = builtins.getFlake "git+file://${toString ./.}";
```

That explicit `git+file://` is load-bearing and nothing said so. A bare
`builtins.getFlake (toString ./.)` parses as a **`path:`** flakeref, and the
`path:` fetcher copies the entire working directory — gitignored directories
included — into the store on every evaluation. Demonstrated on this branch, by
creating a 500-file gitignored `.devenv/` and evaluating both forms against the
same clean worktree:

| flakeref form | store bytes | files | gitignored `.devenv/` ingested |
|---|---|---|---|
| `toString ./.` (bare path → `path:`) | 34,094,272 | 3,929 | **yes** |
| explicit `"git+file://…"` | 28,881,624 | 3,428 | no |

The 501-file delta is exactly the 500 probe files plus `.git`. On a worked
worktree with a real `.devenv/` the same mechanism measured 546,825,016 B /
25,142 files against 18,358,816 B / 2,746 files, and **82.4 s → 14.6 s median
on a forced eval-cache miss** (four interleaved pairs). It is also
self-invalidating: one devenv run writes into `.devenv/`, which changes the
`path:` output hash, which re-copies everything downstream of `repoFlake`.

So the current line is right. It is also fragile in one specific way, and that
way has already bitten: `git+file://` requires `./.` to be a real worktree.
When config is evaluated from a store-backed source there is no `.git`, and the
expression dies. That is #1190. The window between #1056 and #1190 was closed
by moving the offending module onto a store source — the *requirement* was
never written down, so the next refactor onto a store-backed source
rediscovers it as a stack trace from inside the flake fetcher.

## Goal

The requirement is stated where it is relied on, and violating it produces a
message that names the regression and says what to do instead — rather than an
unattributable fetcher error.

## Decisions

- **Assert, don't work around.** The alternative discussed was a different
  mechanism entirely (e.g. taking the workspace root from an input). That is a
  bigger change with no benefit while `./.` is a worktree, and it would hide
  the constraint instead of naming it. An assertion keeps the fast path and
  makes the constraint legible at the one place that depends on it.
- **`builtins.pathExists (./. + "/.git")`**, not a git invocation: it is pure,
  it is cheap, and it is true for both a normal checkout (`.git` directory) and
  a linked worktree (`.git` file).
- **The comment records the measurement, not the history.** It says what a bare
  path costs and why the explicit form exists, so a future reader does not
  "simplify" it back.

## Verification

Guard fires, from a source with no `.git` — `git archive HEAD` extracted to a
temp directory (3,428 files, no `.git`), then `devenv eval packages`:

```
error: devenv.nix: `repoFlake` needs `./.` to be a real git worktree, and
/tmp/eu-nogit-8HTZ has no `.git`.

This is the #1190 regression: `builtins.getFlake "git+file://…"` is fine
while `./.` is a checkout and fails the moment this file is evaluated
from a store path. If you moved config evaluation onto a store-backed
source, pass that source in explicitly rather than re-deriving it here.
```

Guard does not fire in a real worktree — same command in the checkout:

```
$ devenv eval packages
rc=0
{ "packages": [ "/nix/store/…-secretspec-0.10.1", "/nix/store/…-secrets-run", … ] }
```

Before → after, on the failure this addresses:

```
before   error: … git+file:// … does not contain a .git (raw fetcher error, no attribution)
after    error: devenv.nix: `repoFlake` needs `./.` to be a real git worktree … #1190 regression
```

Repo checks, in the composed workspace (`repos/effect-utils`):

```
devenv tasks run check:quick   rc=0   971 s
devenv tasks run check:all     rc=0   440 s
```

`check:all` failed once before that, on
`src/scheduling/scheduled-compose.integration.test.ts > pollLoop composition >
wake: the id ROTATES per cycle and stays externally resolvable`
(`AssertionError: expected '' not to be ''`). Re-run in isolation against
`main`'s `devenv.nix` content it passes (rc=0, 326 s), and the second full
`check:all` on this branch is green — so that is a flake in a scheduling
integration test, not something this assertion can reach. Flagged rather than
silently re-run.

## Complexity

No new complexity: one assertion and the comment that explains why the
flakeref is spelled the way it is. No new file, dependency, or abstraction.

## Concerns

- The assertion is an eval-time guard on a *convention* (`devenv.nix` is only
  ever evaluated with `./.` = a worktree). It makes a violation loud; it does
  not make store-backed evaluation work. That is deliberate — a fallback to the
  `path:` form would silently restore the 546 MB copy.
- `builtins.pathExists` on `.git` is a proxy for "this is a git worktree". A
  directory containing an unrelated `.git` entry would satisfy it. The failure
  mode it exists to catch (a store path) has no `.git` at all.

## Friction & bottlenecks

- _Friction._ The `path:` versus `git+file:` asymmetry is invisible: `nix flake
  metadata <absolute path>` reports `"type": "git"` for the very path that
  `builtins.getFlake` resolves through the `path:` fetcher. The two disagree,
  which is why this was mis-read as equivalent in the first place. Reported
  separately as a Nix-side defect with a standalone reproduction.
- _Bottleneck._ Measured on a loaded shared box (1-minute load average 42–170
  across the window), so absolute walls in this description are upper bounds.
  Every ratio quoted here is either from an interleaved A/B or from a
  structural fact (store bytes, file counts) that load cannot move.

## Follow-ups

- devenv registers its own state directory (`.devenv/bootstrap/*.nix`, `.env`)
  as an eval-cache input, which composes with any `path:`-style ingestion into
  a self-invalidation loop. Upstream, tracked separately.
- `devenv.nix` instantiates nixpkgs three times per config eval (`pkgs`,
  `flakePkgs`, `restatePkgs`); `restatePkgs` exists only to scope `allowUnfree`
  to one package and is replaceable. Out of scope here.

## References

- Refs #1190 — the regression this assertion names.
- Refs #1056 — introduced the explicit `git+file://` form this documents.

<!-- agent-footer:begin v=2 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | dev3.direct.omp.5kvbkxb8 |
| `session` | dev3.5kvbkxb8 |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.1.2 |
| `agent_runtime` | OMP 18.1.2 |
| `tooling_profile` | dotfiles@3fdc95b-dirty |
</details>
<!-- agent-footer:end -->