### PR TITLE
feat(buck2): transfer independent TypeScript library authority to Buck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,14 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- **Buck2 TypeScript admissions**: transfer typecheck and declaration authority
+  for the remaining independent library packages (effect-path, kdl, oxc-config,
+  npm-release, effect-ai-claude-cli, agent-session-ingest, effect-react,
+  effect-rpc-tanstack, pty-effect, restate-effect, ci-tools,
+  effect-schema-form, react-inspector). Each package leaves both root
+  TypeScript solutions; public type conditions consume Buck declarations while
+  runtime defaults remain at source.
+
 - **CI**: the paired `devenv-perf` wall-clock lane no longer runs on every pull
   request. It now runs on a nightly `schedule` against `main`, on operator
   `workflow_dispatch`, and on a pull request carrying the new `ci:perf` label.

--- a/buck2-member.json
+++ b/buck2-member.json
@@ -19,12 +19,44 @@
   ],
   "distOverlays": [
     {
+      "target": "//packages/@overeng/agent-session-ingest:dist",
+      "destination": "packages/@overeng/agent-session-ingest/dist"
+    },
+    {
+      "target": "//packages/@overeng/ci-tools:dist",
+      "destination": "packages/@overeng/ci-tools/dist"
+    },
+    {
       "target": "//packages/@overeng/content-address:dist",
       "destination": "packages/@overeng/content-address/dist"
     },
     {
+      "target": "//packages/@overeng/effect-ai-claude-cli:dist",
+      "destination": "packages/@overeng/effect-ai-claude-cli/dist"
+    },
+    {
       "target": "//packages/@overeng/effect-distributed-lock:dist",
       "destination": "packages/@overeng/effect-distributed-lock/dist"
+    },
+    {
+      "target": "//packages/@overeng/effect-path:dist",
+      "destination": "packages/@overeng/effect-path/dist"
+    },
+    {
+      "target": "//packages/@overeng/effect-react:dist",
+      "destination": "packages/@overeng/effect-react/dist"
+    },
+    {
+      "target": "//packages/@overeng/effect-rpc-tanstack:dist",
+      "destination": "packages/@overeng/effect-rpc-tanstack/dist"
+    },
+    {
+      "target": "//packages/@overeng/effect-schema-form:dist",
+      "destination": "packages/@overeng/effect-schema-form/dist"
+    },
+    {
+      "target": "//packages/@overeng/kdl:dist",
+      "destination": "packages/@overeng/kdl/dist"
     },
     {
       "target": "//packages/@overeng/notion-cli:dist",
@@ -59,8 +91,28 @@
       "destination": "packages/@overeng/notion-react/dist"
     },
     {
+      "target": "//packages/@overeng/npm-release:dist",
+      "destination": "packages/@overeng/npm-release/dist"
+    },
+    {
       "target": "//packages/@overeng/otel-contract:dist",
       "destination": "packages/@overeng/otel-contract/dist"
+    },
+    {
+      "target": "//packages/@overeng/oxc-config:dist",
+      "destination": "packages/@overeng/oxc-config/dist"
+    },
+    {
+      "target": "//packages/@overeng/pty-effect:dist",
+      "destination": "packages/@overeng/pty-effect/dist"
+    },
+    {
+      "target": "//packages/@overeng/react-inspector:dist",
+      "destination": "packages/@overeng/react-inspector/dist"
+    },
+    {
+      "target": "//packages/@overeng/restate-effect:dist",
+      "destination": "packages/@overeng/restate-effect/dist"
     },
     {
       "target": "//packages/@overeng/stylex-tokens:dist",

--- a/genie/buck2/typescript-admissions.ts
+++ b/genie/buck2/typescript-admissions.ts
@@ -1,8 +1,15 @@
 import { Buffer } from 'node:buffer'
 
+import { buck2TypeScriptAdmission as agentSessionIngestAdmission } from '../../packages/@overeng/agent-session-ingest/BUCK.genie.ts'
+import { buck2TypeScriptAdmission as ciToolsAdmission } from '../../packages/@overeng/ci-tools/BUCK.genie.ts'
 import { buck2TypeScriptAdmission as contentAddressAdmission } from '../../packages/@overeng/content-address/BUCK.genie.ts'
+import { buck2TypeScriptAdmission as effectAiClaudeCliAdmission } from '../../packages/@overeng/effect-ai-claude-cli/BUCK.genie.ts'
 import { buck2TypeScriptAdmission as effectDistributedLockAdmission } from '../../packages/@overeng/effect-distributed-lock/BUCK.genie.ts'
 import { buck2TypeScriptAdmission as effectPathAdmission } from '../../packages/@overeng/effect-path/BUCK.genie.ts'
+import { buck2TypeScriptAdmission as effectReactAdmission } from '../../packages/@overeng/effect-react/BUCK.genie.ts'
+import { buck2TypeScriptAdmission as effectRpcTanstackAdmission } from '../../packages/@overeng/effect-rpc-tanstack/BUCK.genie.ts'
+import { buck2TypeScriptAdmission as effectSchemaFormAdmission } from '../../packages/@overeng/effect-schema-form/BUCK.genie.ts'
+import { buck2TypeScriptAdmission as kdlAdmission } from '../../packages/@overeng/kdl/BUCK.genie.ts'
 import { buck2TypeScriptAdmission as notionCliAdmission } from '../../packages/@overeng/notion-cli/BUCK.genie.ts'
 import { buck2TypeScriptAdmission as notionCoreAdmission } from '../../packages/@overeng/notion-core/BUCK.genie.ts'
 import { buck2TypeScriptAdmission as notionDatasourceSyncAdmission } from '../../packages/@overeng/notion-datasource-sync/BUCK.genie.ts'
@@ -11,7 +18,12 @@ import { buck2TypeScriptAdmission as notionEffectSchemaAdmission } from '../../p
 import { buck2TypeScriptAdmission as notionMdAdmission } from '../../packages/@overeng/notion-md/BUCK.genie.ts'
 import { buck2TypeScriptAdmission as notionPropertyWriteAdmission } from '../../packages/@overeng/notion-property-write/BUCK.genie.ts'
 import { buck2TypeScriptAdmission as notionReactAdmission } from '../../packages/@overeng/notion-react/BUCK.genie.ts'
+import { buck2TypeScriptAdmission as npmReleaseAdmission } from '../../packages/@overeng/npm-release/BUCK.genie.ts'
 import { buck2TypeScriptAdmission as otelContractAdmission } from '../../packages/@overeng/otel-contract/BUCK.genie.ts'
+import { buck2TypeScriptAdmission as oxcConfigAdmission } from '../../packages/@overeng/oxc-config/BUCK.genie.ts'
+import { buck2TypeScriptAdmission as ptyEffectAdmission } from '../../packages/@overeng/pty-effect/BUCK.genie.ts'
+import { buck2TypeScriptAdmission as reactInspectorAdmission } from '../../packages/@overeng/react-inspector/BUCK.genie.ts'
+import { buck2TypeScriptAdmission as restateEffectAdmission } from '../../packages/@overeng/restate-effect/BUCK.genie.ts'
 import { buck2TypeScriptAdmission as stylexTokensAdmission } from '../../packages/@overeng/stylex-tokens/BUCK.genie.ts'
 import { buck2TypeScriptAdmission as tuiCoreAdmission } from '../../packages/@overeng/tui-core/BUCK.genie.ts'
 import { buck2TypeScriptAdmission as tuiReactAdmission } from '../../packages/@overeng/tui-react/BUCK.genie.ts'
@@ -39,9 +51,16 @@ export type AuthoritativeBuck2TypeScriptAdmission = Buck2TypeScriptAuthorityMeta
 
 /** Semantic registry for every package admitted to the Buck TypeScript projection. */
 export const buck2TypeScriptAdmissions = {
+  agentSessionIngest: agentSessionIngestAdmission,
+  ciTools: ciToolsAdmission,
   contentAddress: contentAddressAdmission,
+  effectAiClaudeCli: effectAiClaudeCliAdmission,
   effectDistributedLock: effectDistributedLockAdmission,
   effectPath: effectPathAdmission,
+  effectReact: effectReactAdmission,
+  effectRpcTanstack: effectRpcTanstackAdmission,
+  effectSchemaForm: effectSchemaFormAdmission,
+  kdl: kdlAdmission,
   notionCli: notionCliAdmission,
   notionCore: notionCoreAdmission,
   notionDatasourceSync: notionDatasourceSyncAdmission,
@@ -50,7 +69,12 @@ export const buck2TypeScriptAdmissions = {
   notionMd: notionMdAdmission,
   notionPropertyWrite: notionPropertyWriteAdmission,
   notionReact: notionReactAdmission,
+  npmRelease: npmReleaseAdmission,
   otelContract: otelContractAdmission,
+  oxcConfig: oxcConfigAdmission,
+  ptyEffect: ptyEffectAdmission,
+  reactInspector: reactInspectorAdmission,
+  restateEffect: restateEffectAdmission,
   tuiCore: tuiCoreAdmission,
   tuiReact: tuiReactAdmission,
   stylexTokens: stylexTokensAdmission,

--- a/genie/buck2/typescript-admissions.unit.test.ts
+++ b/genie/buck2/typescript-admissions.unit.test.ts
@@ -49,9 +49,11 @@ describe('Buck2 TypeScript authority derivation', () => {
     expect(projectedManifest.distOverlays).toEqual(buck2TypeScriptDistOverlays)
 
     expect(
-      rootWorkspaceTsconfigProjects.flatMap(({ buck2Authority, path }) =>
-        buck2Authority === undefined ? [] : [{ buck2Authority, path }],
-      ),
+      rootWorkspaceTsconfigProjects
+        .flatMap(({ buck2Authority, path }) =>
+          buck2Authority === undefined ? [] : [{ buck2Authority, path }],
+        )
+        .toSorted((left, right) => Buffer.from(left.path).compare(Buffer.from(right.path))),
     ).toEqual(
       authoritativeBuck2TypeScriptAdmissions
         .filter(({ packagePath }) =>
@@ -64,7 +66,8 @@ describe('Buck2 TypeScript authority derivation', () => {
             typecheckTarget,
           },
           path: packagePath,
-        })),
+        }))
+        .toSorted((left, right) => Buffer.from(left.path).compare(Buffer.from(right.path))),
     )
   })
 })

--- a/genie/buck2/typescript-package-projection.unit.test.ts
+++ b/genie/buck2/typescript-package-projection.unit.test.ts
@@ -2,13 +2,20 @@ import { readFileSync } from 'node:fs'
 import process from 'node:process'
 
 import { describe, expect, it } from 'vitest'
+import type { GenieContext } from '../../packages/@overeng/genie/src/runtime/core.ts'
 
 import ciWorkflow from '../../.github/workflows/ci.yml.genie.ts'
 import dependencyBuck from '../../buck2/dependencies/BUCK.genie.ts'
+import agentSessionIngestBuck from '../../packages/@overeng/agent-session-ingest/BUCK.genie.ts'
+import ciToolsBuck from '../../packages/@overeng/ci-tools/BUCK.genie.ts'
 import contentAddressBuck from '../../packages/@overeng/content-address/BUCK.genie.ts'
+import effectAiClaudeCliBuck from '../../packages/@overeng/effect-ai-claude-cli/BUCK.genie.ts'
 import effectDistributedLockBuck from '../../packages/@overeng/effect-distributed-lock/BUCK.genie.ts'
 import effectPathBuck from '../../packages/@overeng/effect-path/BUCK.genie.ts'
-import type { GenieContext } from '../../packages/@overeng/genie/src/runtime/core.ts'
+import effectReactBuck from '../../packages/@overeng/effect-react/BUCK.genie.ts'
+import effectRpcTanstackBuck from '../../packages/@overeng/effect-rpc-tanstack/BUCK.genie.ts'
+import effectSchemaFormBuck from '../../packages/@overeng/effect-schema-form/BUCK.genie.ts'
+import kdlBuck from '../../packages/@overeng/kdl/BUCK.genie.ts'
 import notionCliBuck from '../../packages/@overeng/notion-cli/BUCK.genie.ts'
 import notionCoreBuck from '../../packages/@overeng/notion-core/BUCK.genie.ts'
 import notionDatasourceSyncBuck from '../../packages/@overeng/notion-datasource-sync/BUCK.genie.ts'
@@ -17,7 +24,12 @@ import notionEffectSchemaBuck from '../../packages/@overeng/notion-effect-schema
 import notionMdBuck from '../../packages/@overeng/notion-md/BUCK.genie.ts'
 import notionPropertyWriteBuck from '../../packages/@overeng/notion-property-write/BUCK.genie.ts'
 import notionReactBuck from '../../packages/@overeng/notion-react/BUCK.genie.ts'
+import npmReleaseBuck from '../../packages/@overeng/npm-release/BUCK.genie.ts'
 import otelContractBuck from '../../packages/@overeng/otel-contract/BUCK.genie.ts'
+import oxcConfigBuck from '../../packages/@overeng/oxc-config/BUCK.genie.ts'
+import ptyEffectBuck from '../../packages/@overeng/pty-effect/BUCK.genie.ts'
+import reactInspectorBuck from '../../packages/@overeng/react-inspector/BUCK.genie.ts'
+import restateEffectBuck from '../../packages/@overeng/restate-effect/BUCK.genie.ts'
 import stylexTokensBuck from '../../packages/@overeng/stylex-tokens/BUCK.genie.ts'
 import tuiCoreBuck from '../../packages/@overeng/tui-core/BUCK.genie.ts'
 import tuiReactBuck from '../../packages/@overeng/tui-react/BUCK.genie.ts'
@@ -32,9 +44,16 @@ import { buck2TypeScriptPackageProjection } from './typescript-package-projectio
 const genieContext: GenieContext = { cwd: process.cwd(), location: '' }
 
 const outputsByAdmission = {
+  agentSessionIngest: agentSessionIngestBuck.stringify(genieContext),
+  ciTools: ciToolsBuck.stringify(genieContext),
   contentAddress: contentAddressBuck.stringify(genieContext),
+  effectAiClaudeCli: effectAiClaudeCliBuck.stringify(genieContext),
   effectDistributedLock: effectDistributedLockBuck.stringify(genieContext),
   effectPath: effectPathBuck.stringify(genieContext),
+  effectReact: effectReactBuck.stringify(genieContext),
+  effectRpcTanstack: effectRpcTanstackBuck.stringify(genieContext),
+  effectSchemaForm: effectSchemaFormBuck.stringify(genieContext),
+  kdl: kdlBuck.stringify(genieContext),
   notionCli: notionCliBuck.stringify(genieContext),
   notionCore: notionCoreBuck.stringify(genieContext),
   notionDatasourceSync: notionDatasourceSyncBuck.stringify(genieContext),
@@ -43,7 +62,12 @@ const outputsByAdmission = {
   notionMd: notionMdBuck.stringify(genieContext),
   notionPropertyWrite: notionPropertyWriteBuck.stringify(genieContext),
   notionReact: notionReactBuck.stringify(genieContext),
+  npmRelease: npmReleaseBuck.stringify(genieContext),
   otelContract: otelContractBuck.stringify(genieContext),
+  oxcConfig: oxcConfigBuck.stringify(genieContext),
+  ptyEffect: ptyEffectBuck.stringify(genieContext),
+  reactInspector: reactInspectorBuck.stringify(genieContext),
+  restateEffect: restateEffectBuck.stringify(genieContext),
   stylexTokens: stylexTokensBuck.stringify(genieContext),
   tuiCore: tuiCoreBuck.stringify(genieContext),
   tuiReact: tuiReactBuck.stringify(genieContext),

--- a/packages/@overeng/agent-session-ingest/BUCK
+++ b/packages/@overeng/agent-session-ingest/BUCK
@@ -1,0 +1,128 @@
+# Generated file - DO NOT EDIT
+# Source: BUCK.genie.ts
+
+# Projection source: packages/@overeng/agent-session-ingest/BUCK.genie.ts
+# Projection schema version: 1
+# Projection generator: effect-utils/genie/buck2-typescript-package-projection
+# Semantic fingerprint: sha256:ee19645b13127931f4fa1d6760ed1f0713b5d0a20f199213c66f8492d5ae58b9
+# Semantic inputs: buck2/dependencies/BUCK.genie.ts, buck2/dependencies/pnpm-lock.sha256.json.genie.ts, genie/buck2/mod.ts, genie/buck2/typescript-package-projection.ts, package.json.genie.ts, packages/@overeng/agent-session-ingest/BUCK.genie.ts, packages/@overeng/agent-session-ingest/BUCK.genie.ts, packages/@overeng/agent-session-ingest/package.json.genie.ts, packages/@overeng/agent-session-ingest/src/**/*.cts, packages/@overeng/agent-session-ingest/src/**/*.js, packages/@overeng/agent-session-ingest/src/**/*.mts, packages/@overeng/agent-session-ingest/src/**/*.ts, packages/@overeng/agent-session-ingest/src/**/*.tsx, packages/@overeng/agent-session-ingest/tsconfig.json.genie.ts, packages/@overeng/buck2-tools/src/package-tree.ts, packages/@overeng/buck2-tools/src/real-path.ts, packages/@overeng/utils-dev/BUCK.genie.ts, packages/@overeng/utils-dev/package.json.genie.ts, packages/@overeng/utils/BUCK.genie.ts, packages/@overeng/utils/package.json.genie.ts
+# Regenerate: devenv tasks run genie:run
+
+load("//buck2:materialization.bzl", "export_materialization_inputs", "package_tree")
+load("//buck2:typescript.bzl", "tsgo_emit", "tsgo_typecheck")
+
+export_file(
+    name = "package.json",
+    src = "package.json",
+    visibility = ["PUBLIC"],
+)
+
+export_materialization_inputs([
+    "src/adapters.integration-test-helpers.ts",
+    "src/adapters/claude.ts",
+    "src/adapters/codex.ts",
+    "src/adapters/jsonl.ts",
+    "src/adapters/opencode.ts",
+    "src/claude.integration.test.ts",
+    "src/codex.integration.test.ts",
+    "src/errors.ts",
+    "src/files/append-only.ts",
+    "src/files/content-version.ts",
+    "src/files/mutable.ts",
+    "src/ingest.unit.test.ts",
+    "src/mod.ts",
+    "src/normalized.unit.test.ts",
+    "src/normalized/mcp-tool-name.ts",
+    "src/normalized/mod.ts",
+    "src/normalized/schema.ts",
+    "src/normalized/translate-claude.ts",
+    "src/normalized/translate-codex.ts",
+    "src/normalized/translate-opencode.ts",
+    "src/opencode.integration.test.ts",
+    "src/schema/core.ts",
+    "src/services.integration.test.ts",
+    "src/services/CheckpointStore.ts",
+    "src/services/SessionIngestor.ts",
+    "src/watch.ts",
+])
+
+alias(
+    name = "node_modules",
+    actual = "//buck2/dependencies:importer_packages_overeng_agent_session_ingest_6dae38a37f1d",
+    visibility = ["PUBLIC"],
+)
+
+alias(
+    name = "editor_inputs",
+    actual = ":node_modules",
+    visibility = ["PUBLIC"],
+)
+
+package_tree(
+    name = "package_tree",
+    node_modules = ":node_modules",
+    files = {
+        "package.json": "package.json",
+        "src/adapters.integration-test-helpers.ts": "src/adapters.integration-test-helpers.ts",
+        "src/adapters/claude.ts": "src/adapters/claude.ts",
+        "src/adapters/codex.ts": "src/adapters/codex.ts",
+        "src/adapters/jsonl.ts": "src/adapters/jsonl.ts",
+        "src/adapters/opencode.ts": "src/adapters/opencode.ts",
+        "src/claude.integration.test.ts": "src/claude.integration.test.ts",
+        "src/codex.integration.test.ts": "src/codex.integration.test.ts",
+        "src/errors.ts": "src/errors.ts",
+        "src/files/append-only.ts": "src/files/append-only.ts",
+        "src/files/content-version.ts": "src/files/content-version.ts",
+        "src/files/mutable.ts": "src/files/mutable.ts",
+        "src/ingest.unit.test.ts": "src/ingest.unit.test.ts",
+        "src/mod.ts": "src/mod.ts",
+        "src/normalized.unit.test.ts": "src/normalized.unit.test.ts",
+        "src/normalized/mcp-tool-name.ts": "src/normalized/mcp-tool-name.ts",
+        "src/normalized/mod.ts": "src/normalized/mod.ts",
+        "src/normalized/schema.ts": "src/normalized/schema.ts",
+        "src/normalized/translate-claude.ts": "src/normalized/translate-claude.ts",
+        "src/normalized/translate-codex.ts": "src/normalized/translate-codex.ts",
+        "src/normalized/translate-opencode.ts": "src/normalized/translate-opencode.ts",
+        "src/opencode.integration.test.ts": "src/opencode.integration.test.ts",
+        "src/schema/core.ts": "src/schema/core.ts",
+        "src/services.integration.test.ts": "src/services.integration.test.ts",
+        "src/services/CheckpointStore.ts": "src/services/CheckpointStore.ts",
+        "src/services/SessionIngestor.ts": "src/services/SessionIngestor.ts",
+        "src/watch.ts": "src/watch.ts",
+        "tsconfig.json": "tsconfig.json",
+    },
+    runtime = "//:package_tree_runtime",
+    runtime_entry = "package-tree.ts",
+    workspace_siblings = {
+        "@overeng/utils": {
+            "files": {
+                "dist": "//packages/@overeng/utils:dist",
+                "package.json": "//packages/@overeng/utils:package.json",
+            },
+            "links": ["@overeng/utils"],
+        },
+        "@overeng/utils-dev": {
+            "files": {
+                "dist": "//packages/@overeng/utils-dev:dist",
+                "package.json": "//packages/@overeng/utils-dev:package.json",
+            },
+            "links": ["@overeng/utils-dev"],
+        },
+    },
+    visibility = ["PUBLIC"],
+)
+
+tsgo_typecheck(
+    name = "typecheck",
+    package_tree = ":package_tree",
+    visibility = ["PUBLIC"],
+)
+
+tsgo_emit(
+    name = "dist",
+    package_tree = ":package_tree",
+    declaration_sources = {
+    },
+    declaration_entrypoint = "src/mod.d.ts",
+    visibility = ["PUBLIC"],
+)

--- a/packages/@overeng/agent-session-ingest/BUCK.genie.ts
+++ b/packages/@overeng/agent-session-ingest/BUCK.genie.ts
@@ -1,0 +1,30 @@
+import type { Buck2TypeScriptAdmission } from '../../../genie/buck2/typescript-admissions.ts'
+import { buck2TypeScriptPackageProjection } from '../../../genie/buck2/typescript-package-projection.ts'
+
+export const buck2TypeScriptAdmission = {
+  dependencyImporter:
+    '//buck2/dependencies:importer_packages_overeng_agent_session_ingest_6dae38a37f1d',
+  packageName: '@overeng/agent-session-ingest',
+  packagePath: 'packages/@overeng/agent-session-ingest',
+  projectionSource: 'packages/@overeng/agent-session-ingest/BUCK.genie.ts',
+  sourceRoots: ['src'],
+  workspaceSiblings: [
+    {
+      packageName: '@overeng/utils',
+      packagePath: 'packages/@overeng/utils',
+      distTarget: '//packages/@overeng/utils:dist',
+    },
+    {
+      packageName: '@overeng/utils-dev',
+      packagePath: 'packages/@overeng/utils-dev',
+      distTarget: '//packages/@overeng/utils-dev:dist',
+    },
+  ],
+  editorViewConsumer: false,
+  authority: {
+    declarationEntrypoint: 'src/mod.d.ts',
+    projectFile: 'tsconfig.json',
+  },
+} as const satisfies Buck2TypeScriptAdmission
+
+export default buck2TypeScriptPackageProjection(buck2TypeScriptAdmission)

--- a/packages/@overeng/agent-session-ingest/package.json
+++ b/packages/@overeng/agent-session-ingest/package.json
@@ -4,11 +4,26 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./src/mod.ts",
-    "./claude": "./src/adapters/claude.ts",
-    "./codex": "./src/adapters/codex.ts",
-    "./jsonl": "./src/adapters/jsonl.ts",
-    "./opencode": "./src/adapters/opencode.ts"
+    ".": {
+      "types": "./dist/src/mod.d.ts",
+      "default": "./src/mod.ts"
+    },
+    "./claude": {
+      "types": "./dist/src/adapters/claude.d.ts",
+      "default": "./src/adapters/claude.ts"
+    },
+    "./codex": {
+      "types": "./dist/src/adapters/codex.d.ts",
+      "default": "./src/adapters/codex.ts"
+    },
+    "./jsonl": {
+      "types": "./dist/src/adapters/jsonl.d.ts",
+      "default": "./src/adapters/jsonl.ts"
+    },
+    "./opencode": {
+      "types": "./dist/src/adapters/opencode.d.ts",
+      "default": "./src/adapters/opencode.ts"
+    }
   },
   "publishConfig": {
     "access": "public",

--- a/packages/@overeng/agent-session-ingest/package.json.genie.ts
+++ b/packages/@overeng/agent-session-ingest/package.json.genie.ts
@@ -44,11 +44,26 @@ export default packageJson(
     name: '@overeng/agent-session-ingest',
     ...privatePackageDefaults,
     exports: {
-      '.': exportEntry('./src/mod.ts', { environment: 'node' }),
-      './codex': exportEntry('./src/adapters/codex.ts', { environment: 'node' }),
-      './claude': exportEntry('./src/adapters/claude.ts', { environment: 'node' }),
-      './opencode': exportEntry('./src/adapters/opencode.ts', { environment: 'node' }),
-      './jsonl': exportEntry('./src/adapters/jsonl.ts', { environment: 'node' }),
+      '.': exportEntry(
+        { types: './dist/src/mod.d.ts', default: './src/mod.ts' },
+        { environment: 'node' },
+      ),
+      './codex': exportEntry(
+        { types: './dist/src/adapters/codex.d.ts', default: './src/adapters/codex.ts' },
+        { environment: 'node' },
+      ),
+      './claude': exportEntry(
+        { types: './dist/src/adapters/claude.d.ts', default: './src/adapters/claude.ts' },
+        { environment: 'node' },
+      ),
+      './opencode': exportEntry(
+        { types: './dist/src/adapters/opencode.d.ts', default: './src/adapters/opencode.ts' },
+        { environment: 'node' },
+      ),
+      './jsonl': exportEntry(
+        { types: './dist/src/adapters/jsonl.d.ts', default: './src/adapters/jsonl.ts' },
+        { environment: 'node' },
+      ),
     },
     publishConfig: {
       access: 'public',

--- a/packages/@overeng/agent-session-ingest/tsconfig.json
+++ b/packages/@overeng/agent-session-ingest/tsconfig.json
@@ -44,7 +44,8 @@
     "composite": true,
     "rootDir": ".",
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
-    "types": ["node"]
+    "types": ["node"],
+    "noEmit": true
   },
   "include": ["src/**/*"]
 }

--- a/packages/@overeng/agent-session-ingest/tsconfig.json.genie.ts
+++ b/packages/@overeng/agent-session-ingest/tsconfig.json.genie.ts
@@ -11,6 +11,7 @@ export default tsconfigJson({
     ...packageTsconfigCompilerOptions,
     ...nodeTypes,
     lib: ['ES2023'],
+    noEmit: true,
   },
   include: ['src/**/*'],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/ci-tools/BUCK
+++ b/packages/@overeng/ci-tools/BUCK
@@ -1,0 +1,119 @@
+# Generated file - DO NOT EDIT
+# Source: BUCK.genie.ts
+
+# Projection source: packages/@overeng/ci-tools/BUCK.genie.ts
+# Projection schema version: 1
+# Projection generator: effect-utils/genie/buck2-typescript-package-projection
+# Semantic fingerprint: sha256:0d0518fe187c979e6dad320952114f771ce774caec997cd7a8990f5080559d14
+# Semantic inputs: buck2/dependencies/BUCK.genie.ts, buck2/dependencies/pnpm-lock.sha256.json.genie.ts, genie/buck2/mod.ts, genie/buck2/typescript-package-projection.ts, package.json.genie.ts, packages/@overeng/buck2-tools/src/package-tree.ts, packages/@overeng/buck2-tools/src/real-path.ts, packages/@overeng/ci-tools/BUCK.genie.ts, packages/@overeng/ci-tools/BUCK.genie.ts, packages/@overeng/ci-tools/package.json.genie.ts, packages/@overeng/ci-tools/src/**/*.cts, packages/@overeng/ci-tools/src/**/*.js, packages/@overeng/ci-tools/src/**/*.mts, packages/@overeng/ci-tools/src/**/*.ts, packages/@overeng/ci-tools/src/**/*.tsx, packages/@overeng/ci-tools/tsconfig.json.genie.ts, packages/@overeng/otel-contract/BUCK.genie.ts, packages/@overeng/otel-contract/package.json.genie.ts, packages/@overeng/utils-dev/BUCK.genie.ts, packages/@overeng/utils-dev/package.json.genie.ts, packages/@overeng/utils/BUCK.genie.ts, packages/@overeng/utils/package.json.genie.ts
+# Regenerate: devenv tasks run genie:run
+
+load("//buck2:materialization.bzl", "export_materialization_inputs", "package_tree")
+load("//buck2:typescript.bzl", "tsgo_emit", "tsgo_typecheck")
+
+export_file(
+    name = "package.json",
+    src = "package.json",
+    visibility = ["PUBLIC"],
+)
+
+export_materialization_inputs([
+    "src/cli-command.ts",
+    "src/cli.contract.test.ts",
+    "src/deploy-domain.contract.ts",
+    "src/deploy-domain.test.ts",
+    "src/deploy-domain.ts",
+    "src/deploy-io.ts",
+    "src/deploy-netlify.e2e.test.ts",
+    "src/deploy-netlify.live.e2e.test.ts",
+    "src/deploy-netlify.ts",
+    "src/deploy-vercel.e2e.test.ts",
+    "src/deploy-vercel.live.e2e.test.ts",
+    "src/deploy-vercel.ts",
+    "src/mod.ts",
+    "src/quarantine.test.ts",
+    "src/quarantine.ts",
+    "src/workflow-report.e2e.test.ts",
+    "src/workflow-report.test.ts",
+    "src/workflow-report.ts",
+])
+
+alias(
+    name = "node_modules",
+    actual = "//buck2/dependencies:importer_packages_overeng_ci_tools_ed163de971d5",
+    visibility = ["PUBLIC"],
+)
+
+alias(
+    name = "editor_inputs",
+    actual = ":node_modules",
+    visibility = ["PUBLIC"],
+)
+
+package_tree(
+    name = "package_tree",
+    node_modules = ":node_modules",
+    files = {
+        "package.json": "package.json",
+        "src/cli-command.ts": "src/cli-command.ts",
+        "src/cli.contract.test.ts": "src/cli.contract.test.ts",
+        "src/deploy-domain.contract.ts": "src/deploy-domain.contract.ts",
+        "src/deploy-domain.test.ts": "src/deploy-domain.test.ts",
+        "src/deploy-domain.ts": "src/deploy-domain.ts",
+        "src/deploy-io.ts": "src/deploy-io.ts",
+        "src/deploy-netlify.e2e.test.ts": "src/deploy-netlify.e2e.test.ts",
+        "src/deploy-netlify.live.e2e.test.ts": "src/deploy-netlify.live.e2e.test.ts",
+        "src/deploy-netlify.ts": "src/deploy-netlify.ts",
+        "src/deploy-vercel.e2e.test.ts": "src/deploy-vercel.e2e.test.ts",
+        "src/deploy-vercel.live.e2e.test.ts": "src/deploy-vercel.live.e2e.test.ts",
+        "src/deploy-vercel.ts": "src/deploy-vercel.ts",
+        "src/mod.ts": "src/mod.ts",
+        "src/quarantine.test.ts": "src/quarantine.test.ts",
+        "src/quarantine.ts": "src/quarantine.ts",
+        "src/workflow-report.e2e.test.ts": "src/workflow-report.e2e.test.ts",
+        "src/workflow-report.test.ts": "src/workflow-report.test.ts",
+        "src/workflow-report.ts": "src/workflow-report.ts",
+        "tsconfig.json": "tsconfig.json",
+    },
+    runtime = "//:package_tree_runtime",
+    runtime_entry = "package-tree.ts",
+    workspace_siblings = {
+        "@overeng/otel-contract": {
+            "files": {
+                "dist": "//packages/@overeng/otel-contract:dist",
+                "package.json": "//packages/@overeng/otel-contract:package.json",
+            },
+            "links": ["@overeng/otel-contract"],
+        },
+        "@overeng/utils": {
+            "files": {
+                "dist": "//packages/@overeng/utils:dist",
+                "package.json": "//packages/@overeng/utils:package.json",
+            },
+            "links": ["@overeng/utils"],
+        },
+        "@overeng/utils-dev": {
+            "files": {
+                "dist": "//packages/@overeng/utils-dev:dist",
+                "package.json": "//packages/@overeng/utils-dev:package.json",
+            },
+            "links": ["@overeng/utils-dev"],
+        },
+    },
+    visibility = ["PUBLIC"],
+)
+
+tsgo_typecheck(
+    name = "typecheck",
+    package_tree = ":package_tree",
+    visibility = ["PUBLIC"],
+)
+
+tsgo_emit(
+    name = "dist",
+    package_tree = ":package_tree",
+    declaration_sources = {
+    },
+    declaration_entrypoint = "src/mod.d.ts",
+    visibility = ["PUBLIC"],
+)

--- a/packages/@overeng/ci-tools/BUCK.genie.ts
+++ b/packages/@overeng/ci-tools/BUCK.genie.ts
@@ -1,0 +1,34 @@
+import type { Buck2TypeScriptAdmission } from '../../../genie/buck2/typescript-admissions.ts'
+import { buck2TypeScriptPackageProjection } from '../../../genie/buck2/typescript-package-projection.ts'
+
+export const buck2TypeScriptAdmission = {
+  dependencyImporter: '//buck2/dependencies:importer_packages_overeng_ci_tools_ed163de971d5',
+  packageName: '@overeng/ci-tools',
+  packagePath: 'packages/@overeng/ci-tools',
+  projectionSource: 'packages/@overeng/ci-tools/BUCK.genie.ts',
+  sourceRoots: ['src'],
+  workspaceSiblings: [
+    {
+      packageName: '@overeng/otel-contract',
+      packagePath: 'packages/@overeng/otel-contract',
+      distTarget: '//packages/@overeng/otel-contract:dist',
+    },
+    {
+      packageName: '@overeng/utils',
+      packagePath: 'packages/@overeng/utils',
+      distTarget: '//packages/@overeng/utils:dist',
+    },
+    {
+      packageName: '@overeng/utils-dev',
+      packagePath: 'packages/@overeng/utils-dev',
+      distTarget: '//packages/@overeng/utils-dev:dist',
+    },
+  ],
+  editorViewConsumer: false,
+  authority: {
+    declarationEntrypoint: 'src/mod.d.ts',
+    projectFile: 'tsconfig.json',
+  },
+} as const satisfies Buck2TypeScriptAdmission
+
+export default buck2TypeScriptPackageProjection(buck2TypeScriptAdmission)

--- a/packages/@overeng/ci-tools/nix/build.nix
+++ b/packages/@overeng/ci-tools/nix/build.nix
@@ -19,7 +19,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-nRrSI3p5vM2ukhCOv1+xpNjptRg00sO9x4h16Ob//FA=";
+      "." = mkSharedHash "sha256-NjgiVIzri3n5MFeW02QwWjY91zk0jX0ewC0BqFbDCUw=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/ci-tools/package.json
+++ b/packages/@overeng/ci-tools/package.json
@@ -4,8 +4,14 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./src/mod.ts",
-    "./cli": "./src/cli-command.ts"
+    ".": {
+      "types": "./dist/src/mod.d.ts",
+      "default": "./src/mod.ts"
+    },
+    "./cli": {
+      "types": "./dist/src/cli-command.d.ts",
+      "default": "./src/cli-command.ts"
+    }
   },
   "publishConfig": {
     "access": "public",

--- a/packages/@overeng/ci-tools/package.json.genie.ts
+++ b/packages/@overeng/ci-tools/package.json.genie.ts
@@ -38,8 +38,14 @@ export default packageJson(
     name: '@overeng/ci-tools',
     ...privatePackageDefaults,
     exports: {
-      '.': exportEntry('./src/mod.ts', { environment: 'node' }),
-      './cli': exportEntry('./src/cli-command.ts', { environment: 'node' }),
+      '.': exportEntry(
+        { types: './dist/src/mod.d.ts', default: './src/mod.ts' },
+        { environment: 'node' },
+      ),
+      './cli': exportEntry(
+        { types: './dist/src/cli-command.d.ts', default: './src/cli-command.ts' },
+        { environment: 'node' },
+      ),
     },
     publishConfig: {
       access: 'public',

--- a/packages/@overeng/ci-tools/tsconfig.json
+++ b/packages/@overeng/ci-tools/tsconfig.json
@@ -44,7 +44,8 @@
     "composite": true,
     "rootDir": ".",
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
-    "types": ["node", "bun"]
+    "types": ["node", "bun"],
+    "noEmit": true
   },
   "include": ["src/**/*", "bin/**/*.ts"]
 }

--- a/packages/@overeng/ci-tools/tsconfig.json.genie.ts
+++ b/packages/@overeng/ci-tools/tsconfig.json.genie.ts
@@ -11,6 +11,7 @@ export default tsconfigJson({
     ...packageTsconfigCompilerOptions,
     ...nodeTypes,
     types: ['node', 'bun'],
+    noEmit: true,
   },
   include: ['src/**/*', 'bin/**/*.ts'],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/effect-ai-claude-cli/BUCK
+++ b/packages/@overeng/effect-ai-claude-cli/BUCK
@@ -1,0 +1,77 @@
+# Generated file - DO NOT EDIT
+# Source: BUCK.genie.ts
+
+# Projection source: packages/@overeng/effect-ai-claude-cli/BUCK.genie.ts
+# Projection schema version: 1
+# Projection generator: effect-utils/genie/buck2-typescript-package-projection
+# Semantic fingerprint: sha256:73f42cac4834a146999a00c6f8ae782e75b0abe6aa3131dc2ca2edba9784f5ff
+# Semantic inputs: buck2/dependencies/BUCK.genie.ts, buck2/dependencies/pnpm-lock.sha256.json.genie.ts, genie/buck2/mod.ts, genie/buck2/typescript-package-projection.ts, package.json.genie.ts, packages/@overeng/buck2-tools/src/package-tree.ts, packages/@overeng/buck2-tools/src/real-path.ts, packages/@overeng/effect-ai-claude-cli/BUCK.genie.ts, packages/@overeng/effect-ai-claude-cli/BUCK.genie.ts, packages/@overeng/effect-ai-claude-cli/package.json.genie.ts, packages/@overeng/effect-ai-claude-cli/src/**/*.cts, packages/@overeng/effect-ai-claude-cli/src/**/*.js, packages/@overeng/effect-ai-claude-cli/src/**/*.mts, packages/@overeng/effect-ai-claude-cli/src/**/*.ts, packages/@overeng/effect-ai-claude-cli/src/**/*.tsx, packages/@overeng/effect-ai-claude-cli/tsconfig.json.genie.ts, packages/@overeng/utils-dev/BUCK.genie.ts, packages/@overeng/utils-dev/package.json.genie.ts
+# Regenerate: devenv tasks run genie:run
+
+load("//buck2:materialization.bzl", "export_materialization_inputs", "package_tree")
+load("//buck2:typescript.bzl", "tsgo_emit", "tsgo_typecheck")
+
+export_file(
+    name = "package.json",
+    src = "package.json",
+    visibility = ["PUBLIC"],
+)
+
+export_materialization_inputs([
+    "src/claude-cli.ts",
+    "src/claude-cli.unit.test.ts",
+    "src/errors.ts",
+    "src/mod.ts",
+])
+
+alias(
+    name = "node_modules",
+    actual = "//buck2/dependencies:importer_packages_overeng_effect_ai_claude_cli_12fdf58adc3f",
+    visibility = ["PUBLIC"],
+)
+
+alias(
+    name = "editor_inputs",
+    actual = ":node_modules",
+    visibility = ["PUBLIC"],
+)
+
+package_tree(
+    name = "package_tree",
+    node_modules = ":node_modules",
+    files = {
+        "package.json": "package.json",
+        "src/claude-cli.ts": "src/claude-cli.ts",
+        "src/claude-cli.unit.test.ts": "src/claude-cli.unit.test.ts",
+        "src/errors.ts": "src/errors.ts",
+        "src/mod.ts": "src/mod.ts",
+        "tsconfig.json": "tsconfig.json",
+    },
+    runtime = "//:package_tree_runtime",
+    runtime_entry = "package-tree.ts",
+    workspace_siblings = {
+        "@overeng/utils-dev": {
+            "files": {
+                "dist": "//packages/@overeng/utils-dev:dist",
+                "package.json": "//packages/@overeng/utils-dev:package.json",
+            },
+            "links": ["@overeng/utils-dev"],
+        },
+    },
+    visibility = ["PUBLIC"],
+)
+
+tsgo_typecheck(
+    name = "typecheck",
+    package_tree = ":package_tree",
+    visibility = ["PUBLIC"],
+)
+
+tsgo_emit(
+    name = "dist",
+    package_tree = ":package_tree",
+    declaration_sources = {
+    },
+    declaration_entrypoint = "src/mod.d.ts",
+    visibility = ["PUBLIC"],
+)

--- a/packages/@overeng/effect-ai-claude-cli/BUCK.genie.ts
+++ b/packages/@overeng/effect-ai-claude-cli/BUCK.genie.ts
@@ -1,0 +1,25 @@
+import type { Buck2TypeScriptAdmission } from '../../../genie/buck2/typescript-admissions.ts'
+import { buck2TypeScriptPackageProjection } from '../../../genie/buck2/typescript-package-projection.ts'
+
+export const buck2TypeScriptAdmission = {
+  dependencyImporter:
+    '//buck2/dependencies:importer_packages_overeng_effect_ai_claude_cli_12fdf58adc3f',
+  packageName: '@overeng/effect-ai-claude-cli',
+  packagePath: 'packages/@overeng/effect-ai-claude-cli',
+  projectionSource: 'packages/@overeng/effect-ai-claude-cli/BUCK.genie.ts',
+  sourceRoots: ['src'],
+  workspaceSiblings: [
+    {
+      packageName: '@overeng/utils-dev',
+      packagePath: 'packages/@overeng/utils-dev',
+      distTarget: '//packages/@overeng/utils-dev:dist',
+    },
+  ],
+  editorViewConsumer: false,
+  authority: {
+    declarationEntrypoint: 'src/mod.d.ts',
+    projectFile: 'tsconfig.json',
+  },
+} as const satisfies Buck2TypeScriptAdmission
+
+export default buck2TypeScriptPackageProjection(buck2TypeScriptAdmission)

--- a/packages/@overeng/effect-ai-claude-cli/package.json
+++ b/packages/@overeng/effect-ai-claude-cli/package.json
@@ -4,7 +4,10 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./src/mod.ts"
+    ".": {
+      "types": "./dist/src/mod.d.ts",
+      "default": "./src/mod.ts"
+    }
   },
   "publishConfig": {
     "access": "public",

--- a/packages/@overeng/effect-ai-claude-cli/package.json.genie.ts
+++ b/packages/@overeng/effect-ai-claude-cli/package.json.genie.ts
@@ -28,7 +28,10 @@ export default packageJson(
     name: '@overeng/effect-ai-claude-cli',
     ...privatePackageDefaults,
     exports: {
-      '.': exportEntry('./src/mod.ts', { environment: 'node' }),
+      '.': exportEntry(
+        { types: './dist/src/mod.d.ts', default: './src/mod.ts' },
+        { environment: 'node' },
+      ),
     },
     publishConfig: {
       access: 'public',

--- a/packages/@overeng/effect-ai-claude-cli/tsconfig.json
+++ b/packages/@overeng/effect-ai-claude-cli/tsconfig.json
@@ -43,8 +43,8 @@
     ],
     "composite": true,
     "rootDir": ".",
-    "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo"
+    "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
+    "noEmit": true
   },
-  "include": ["src/**/*"],
-  "references": []
+  "include": ["src/**/*"]
 }

--- a/packages/@overeng/effect-ai-claude-cli/tsconfig.json.genie.ts
+++ b/packages/@overeng/effect-ai-claude-cli/tsconfig.json.genie.ts
@@ -10,7 +10,7 @@ export default tsconfigJson({
     ...baseTsconfigCompilerOptions,
     ...packageTsconfigCompilerOptions,
     lib: domLib,
+    noEmit: true,
   },
   include: ['src/**/*'],
-  references: [],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/effect-path/BUCK
+++ b/packages/@overeng/effect-path/BUCK
@@ -94,5 +94,6 @@ tsgo_emit(
     package_tree = ":package_tree",
     declaration_sources = {
     },
+    declaration_entrypoint = "src/mod.d.ts",
     visibility = ["PUBLIC"],
 )

--- a/packages/@overeng/effect-path/BUCK.genie.ts
+++ b/packages/@overeng/effect-path/BUCK.genie.ts
@@ -15,6 +15,10 @@ export const buck2TypeScriptAdmission = {
     },
   ],
   editorViewConsumer: false,
+  authority: {
+    declarationEntrypoint: 'src/mod.d.ts',
+    projectFile: 'tsconfig.json',
+  },
 } as const satisfies Buck2TypeScriptAdmission
 
 export default buck2TypeScriptPackageProjection(buck2TypeScriptAdmission)

--- a/packages/@overeng/effect-path/package.json
+++ b/packages/@overeng/effect-path/package.json
@@ -4,7 +4,10 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./src/mod.ts"
+    ".": {
+      "types": "./dist/src/mod.d.ts",
+      "default": "./src/mod.ts"
+    }
   },
   "publishConfig": {
     "access": "public",

--- a/packages/@overeng/effect-path/package.json.genie.ts
+++ b/packages/@overeng/effect-path/package.json.genie.ts
@@ -36,7 +36,10 @@ export default packageJson(
     name: '@overeng/effect-path',
     ...privatePackageDefaults,
     exports: {
-      '.': exportEntry('./src/mod.ts', { environment: 'isomorphic-es2024' }),
+      '.': exportEntry(
+        { types: './dist/src/mod.d.ts', default: './src/mod.ts' },
+        { environment: 'isomorphic-es2024' },
+      ),
     },
     publishConfig: {
       access: 'public',

--- a/packages/@overeng/effect-path/tsconfig.json
+++ b/packages/@overeng/effect-path/tsconfig.json
@@ -44,8 +44,8 @@
     "composite": true,
     "rootDir": ".",
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
-    "types": ["node"]
+    "types": ["node"],
+    "noEmit": true
   },
-  "include": ["src/**/*"],
-  "references": []
+  "include": ["src/**/*"]
 }

--- a/packages/@overeng/effect-path/tsconfig.json.genie.ts
+++ b/packages/@overeng/effect-path/tsconfig.json.genie.ts
@@ -11,7 +11,7 @@ export default tsconfigJson({
     ...packageTsconfigCompilerOptions,
     ...nodeTypes,
     lib: ['ES2023'],
+    noEmit: true,
   },
   include: ['src/**/*'],
-  references: [],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/effect-react/BUCK
+++ b/packages/@overeng/effect-react/BUCK
@@ -1,0 +1,92 @@
+# Generated file - DO NOT EDIT
+# Source: BUCK.genie.ts
+
+# Projection source: packages/@overeng/effect-react/BUCK.genie.ts
+# Projection schema version: 1
+# Projection generator: effect-utils/genie/buck2-typescript-package-projection
+# Semantic fingerprint: sha256:01b4a2599a9e95e5d38d052556b5126541cf8869e904c7388cdfba653b4b0cf4
+# Semantic inputs: buck2/dependencies/BUCK.genie.ts, buck2/dependencies/pnpm-lock.sha256.json.genie.ts, genie/buck2/mod.ts, genie/buck2/typescript-package-projection.ts, package.json.genie.ts, packages/@overeng/buck2-tools/src/package-tree.ts, packages/@overeng/buck2-tools/src/real-path.ts, packages/@overeng/effect-react/BUCK.genie.ts, packages/@overeng/effect-react/BUCK.genie.ts, packages/@overeng/effect-react/package.json.genie.ts, packages/@overeng/effect-react/src/**/*.cts, packages/@overeng/effect-react/src/**/*.js, packages/@overeng/effect-react/src/**/*.mts, packages/@overeng/effect-react/src/**/*.ts, packages/@overeng/effect-react/src/**/*.tsx, packages/@overeng/effect-react/tsconfig.json.genie.ts, packages/@overeng/otel-contract/BUCK.genie.ts, packages/@overeng/otel-contract/package.json.genie.ts, packages/@overeng/utils/BUCK.genie.ts, packages/@overeng/utils/package.json.genie.ts
+# Regenerate: devenv tasks run genie:run
+
+load("//buck2:materialization.bzl", "export_materialization_inputs", "package_tree")
+load("//buck2:typescript.bzl", "tsgo_emit", "tsgo_typecheck")
+
+export_file(
+    name = "package.json",
+    src = "package.json",
+    visibility = ["PUBLIC"],
+)
+
+export_materialization_inputs([
+    "src/context.tsx",
+    "src/effect-button.tsx",
+    "src/external-store.ts",
+    "src/mod.ts",
+    "src/progress-reporter.ts",
+    "src/react-aria/EffectButton.stories.tsx",
+    "src/react-aria/EffectButton.tsx",
+    "src/react-aria/mod.ts",
+])
+
+alias(
+    name = "node_modules",
+    actual = "//buck2/dependencies:importer_packages_overeng_effect_react_111d6e63d407",
+    visibility = ["PUBLIC"],
+)
+
+alias(
+    name = "editor_inputs",
+    actual = ":node_modules",
+    visibility = ["PUBLIC"],
+)
+
+package_tree(
+    name = "package_tree",
+    node_modules = ":node_modules",
+    files = {
+        "package.json": "package.json",
+        "src/context.tsx": "src/context.tsx",
+        "src/effect-button.tsx": "src/effect-button.tsx",
+        "src/external-store.ts": "src/external-store.ts",
+        "src/mod.ts": "src/mod.ts",
+        "src/progress-reporter.ts": "src/progress-reporter.ts",
+        "src/react-aria/EffectButton.stories.tsx": "src/react-aria/EffectButton.stories.tsx",
+        "src/react-aria/EffectButton.tsx": "src/react-aria/EffectButton.tsx",
+        "src/react-aria/mod.ts": "src/react-aria/mod.ts",
+        "tsconfig.json": "tsconfig.json",
+    },
+    runtime = "//:package_tree_runtime",
+    runtime_entry = "package-tree.ts",
+    workspace_siblings = {
+        "@overeng/otel-contract": {
+            "files": {
+                "dist": "//packages/@overeng/otel-contract:dist",
+                "package.json": "//packages/@overeng/otel-contract:package.json",
+            },
+            "links": ["@overeng/otel-contract"],
+        },
+        "@overeng/utils": {
+            "files": {
+                "dist": "//packages/@overeng/utils:dist",
+                "package.json": "//packages/@overeng/utils:package.json",
+            },
+            "links": ["@overeng/utils"],
+        },
+    },
+    visibility = ["PUBLIC"],
+)
+
+tsgo_typecheck(
+    name = "typecheck",
+    package_tree = ":package_tree",
+    visibility = ["PUBLIC"],
+)
+
+tsgo_emit(
+    name = "dist",
+    package_tree = ":package_tree",
+    declaration_sources = {
+    },
+    declaration_entrypoint = "src/mod.d.ts",
+    visibility = ["PUBLIC"],
+)

--- a/packages/@overeng/effect-react/BUCK.genie.ts
+++ b/packages/@overeng/effect-react/BUCK.genie.ts
@@ -1,0 +1,29 @@
+import type { Buck2TypeScriptAdmission } from '../../../genie/buck2/typescript-admissions.ts'
+import { buck2TypeScriptPackageProjection } from '../../../genie/buck2/typescript-package-projection.ts'
+
+export const buck2TypeScriptAdmission = {
+  dependencyImporter: '//buck2/dependencies:importer_packages_overeng_effect_react_111d6e63d407',
+  packageName: '@overeng/effect-react',
+  packagePath: 'packages/@overeng/effect-react',
+  projectionSource: 'packages/@overeng/effect-react/BUCK.genie.ts',
+  sourceRoots: ['src'],
+  workspaceSiblings: [
+    {
+      packageName: '@overeng/otel-contract',
+      packagePath: 'packages/@overeng/otel-contract',
+      distTarget: '//packages/@overeng/otel-contract:dist',
+    },
+    {
+      packageName: '@overeng/utils',
+      packagePath: 'packages/@overeng/utils',
+      distTarget: '//packages/@overeng/utils:dist',
+    },
+  ],
+  editorViewConsumer: false,
+  authority: {
+    declarationEntrypoint: 'src/mod.d.ts',
+    projectFile: 'tsconfig.json',
+  },
+} as const satisfies Buck2TypeScriptAdmission
+
+export default buck2TypeScriptPackageProjection(buck2TypeScriptAdmission)

--- a/packages/@overeng/effect-react/package.json
+++ b/packages/@overeng/effect-react/package.json
@@ -4,8 +4,14 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./src/mod.ts",
-    "./react-aria": "./src/react-aria/mod.ts"
+    ".": {
+      "types": "./dist/src/mod.d.ts",
+      "default": "./src/mod.ts"
+    },
+    "./react-aria": {
+      "types": "./dist/src/react-aria/mod.d.ts",
+      "default": "./src/react-aria/mod.ts"
+    }
   },
   "publishConfig": {
     "access": "public",

--- a/packages/@overeng/effect-react/package.json.genie.ts
+++ b/packages/@overeng/effect-react/package.json.genie.ts
@@ -43,8 +43,14 @@ export default packageJson(
     name: '@overeng/effect-react',
     ...privatePackageDefaults,
     exports: {
-      '.': exportEntry('./src/mod.ts', { environment: 'browser' }),
-      './react-aria': exportEntry('./src/react-aria/mod.ts', { environment: 'browser' }),
+      '.': exportEntry(
+        { types: './dist/src/mod.d.ts', default: './src/mod.ts' },
+        { environment: 'browser' },
+      ),
+      './react-aria': exportEntry(
+        { types: './dist/src/react-aria/mod.d.ts', default: './src/react-aria/mod.ts' },
+        { environment: 'browser' },
+      ),
     },
     publishConfig: {
       access: 'public',

--- a/packages/@overeng/effect-react/tsconfig.json
+++ b/packages/@overeng/effect-react/tsconfig.json
@@ -45,7 +45,8 @@
     "rootDir": ".",
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
     "jsx": "react-jsx",
-    "jsxImportSource": "react"
+    "jsxImportSource": "react",
+    "noEmit": true
   },
   "include": ["src/**/*", "test/**/*"]
 }

--- a/packages/@overeng/effect-react/tsconfig.json.genie.ts
+++ b/packages/@overeng/effect-react/tsconfig.json.genie.ts
@@ -13,6 +13,7 @@ export default tsconfigJson({
     ...reactJsx,
     jsxImportSource: 'react',
     lib: [...domLib],
+    noEmit: true,
   },
   include: ['src/**/*', 'test/**/*'],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/effect-rpc-tanstack/BUCK
+++ b/packages/@overeng/effect-rpc-tanstack/BUCK
@@ -1,0 +1,83 @@
+# Generated file - DO NOT EDIT
+# Source: BUCK.genie.ts
+
+# Projection source: packages/@overeng/effect-rpc-tanstack/BUCK.genie.ts
+# Projection schema version: 1
+# Projection generator: effect-utils/genie/buck2-typescript-package-projection
+# Semantic fingerprint: sha256:6deef741efc4e0a9691362d3de4879f72acf3d9a89de5dfbbd77d34db31e281b
+# Semantic inputs: buck2/dependencies/BUCK.genie.ts, buck2/dependencies/pnpm-lock.sha256.json.genie.ts, genie/buck2/mod.ts, genie/buck2/typescript-package-projection.ts, package.json.genie.ts, packages/@overeng/buck2-tools/src/package-tree.ts, packages/@overeng/buck2-tools/src/real-path.ts, packages/@overeng/effect-rpc-tanstack/BUCK.genie.ts, packages/@overeng/effect-rpc-tanstack/BUCK.genie.ts, packages/@overeng/effect-rpc-tanstack/package.json.genie.ts, packages/@overeng/effect-rpc-tanstack/src/**/*.cts, packages/@overeng/effect-rpc-tanstack/src/**/*.js, packages/@overeng/effect-rpc-tanstack/src/**/*.mts, packages/@overeng/effect-rpc-tanstack/src/**/*.ts, packages/@overeng/effect-rpc-tanstack/src/**/*.tsx, packages/@overeng/effect-rpc-tanstack/tsconfig.json.genie.ts, packages/@overeng/utils/BUCK.genie.ts, packages/@overeng/utils/package.json.genie.ts
+# Regenerate: devenv tasks run genie:run
+
+load("//buck2:materialization.bzl", "export_materialization_inputs", "package_tree")
+load("//buck2:typescript.bzl", "tsgo_emit", "tsgo_typecheck")
+
+export_file(
+    name = "package.json",
+    src = "package.json",
+    visibility = ["PUBLIC"],
+)
+
+export_materialization_inputs([
+    "src/client.test.ts",
+    "src/client.ts",
+    "src/mod.ts",
+    "src/router.ts",
+    "src/rpc-wire-baseline.test.ts",
+    "src/server.ts",
+    "src/streaming.unit.test.ts",
+])
+
+alias(
+    name = "node_modules",
+    actual = "//buck2/dependencies:importer_packages_overeng_effect_rpc_tanstack_269934211838",
+    visibility = ["PUBLIC"],
+)
+
+alias(
+    name = "editor_inputs",
+    actual = ":node_modules",
+    visibility = ["PUBLIC"],
+)
+
+package_tree(
+    name = "package_tree",
+    node_modules = ":node_modules",
+    files = {
+        "package.json": "package.json",
+        "src/client.test.ts": "src/client.test.ts",
+        "src/client.ts": "src/client.ts",
+        "src/mod.ts": "src/mod.ts",
+        "src/router.ts": "src/router.ts",
+        "src/rpc-wire-baseline.test.ts": "src/rpc-wire-baseline.test.ts",
+        "src/server.ts": "src/server.ts",
+        "src/streaming.unit.test.ts": "src/streaming.unit.test.ts",
+        "tsconfig.json": "tsconfig.json",
+    },
+    runtime = "//:package_tree_runtime",
+    runtime_entry = "package-tree.ts",
+    workspace_siblings = {
+        "@overeng/utils": {
+            "files": {
+                "dist": "//packages/@overeng/utils:dist",
+                "package.json": "//packages/@overeng/utils:package.json",
+            },
+            "links": ["@overeng/utils"],
+        },
+    },
+    visibility = ["PUBLIC"],
+)
+
+tsgo_typecheck(
+    name = "typecheck",
+    package_tree = ":package_tree",
+    visibility = ["PUBLIC"],
+)
+
+tsgo_emit(
+    name = "dist",
+    package_tree = ":package_tree",
+    declaration_sources = {
+    },
+    declaration_entrypoint = "src/mod.d.ts",
+    visibility = ["PUBLIC"],
+)

--- a/packages/@overeng/effect-rpc-tanstack/BUCK.genie.ts
+++ b/packages/@overeng/effect-rpc-tanstack/BUCK.genie.ts
@@ -1,0 +1,25 @@
+import type { Buck2TypeScriptAdmission } from '../../../genie/buck2/typescript-admissions.ts'
+import { buck2TypeScriptPackageProjection } from '../../../genie/buck2/typescript-package-projection.ts'
+
+export const buck2TypeScriptAdmission = {
+  dependencyImporter:
+    '//buck2/dependencies:importer_packages_overeng_effect_rpc_tanstack_269934211838',
+  packageName: '@overeng/effect-rpc-tanstack',
+  packagePath: 'packages/@overeng/effect-rpc-tanstack',
+  projectionSource: 'packages/@overeng/effect-rpc-tanstack/BUCK.genie.ts',
+  sourceRoots: ['src'],
+  workspaceSiblings: [
+    {
+      packageName: '@overeng/utils',
+      packagePath: 'packages/@overeng/utils',
+      distTarget: '//packages/@overeng/utils:dist',
+    },
+  ],
+  editorViewConsumer: false,
+  authority: {
+    declarationEntrypoint: 'src/mod.d.ts',
+    projectFile: 'tsconfig.json',
+  },
+} as const satisfies Buck2TypeScriptAdmission
+
+export default buck2TypeScriptPackageProjection(buck2TypeScriptAdmission)

--- a/packages/@overeng/effect-rpc-tanstack/package.json
+++ b/packages/@overeng/effect-rpc-tanstack/package.json
@@ -4,10 +4,22 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./src/mod.ts",
-    "./client": "./src/client.ts",
-    "./router": "./src/router.ts",
-    "./server": "./src/server.ts"
+    ".": {
+      "types": "./dist/src/mod.d.ts",
+      "default": "./src/mod.ts"
+    },
+    "./client": {
+      "types": "./dist/src/client.d.ts",
+      "default": "./src/client.ts"
+    },
+    "./router": {
+      "types": "./dist/src/router.d.ts",
+      "default": "./src/router.ts"
+    },
+    "./server": {
+      "types": "./dist/src/server.d.ts",
+      "default": "./src/server.ts"
+    }
   },
   "publishConfig": {
     "access": "public",

--- a/packages/@overeng/effect-rpc-tanstack/package.json.genie.ts
+++ b/packages/@overeng/effect-rpc-tanstack/package.json.genie.ts
@@ -40,10 +40,22 @@ export default packageJson(
     name: '@overeng/effect-rpc-tanstack',
     ...privatePackageDefaults,
     exports: {
-      '.': exportEntry('./src/mod.ts', { environment: 'browser' }),
-      './client': exportEntry('./src/client.ts', { environment: 'browser' }),
-      './server': exportEntry('./src/server.ts', { environment: 'node' }),
-      './router': exportEntry('./src/router.ts', { environment: 'browser' }),
+      '.': exportEntry(
+        { types: './dist/src/mod.d.ts', default: './src/mod.ts' },
+        { environment: 'browser' },
+      ),
+      './client': exportEntry(
+        { types: './dist/src/client.d.ts', default: './src/client.ts' },
+        { environment: 'browser' },
+      ),
+      './server': exportEntry(
+        { types: './dist/src/server.d.ts', default: './src/server.ts' },
+        { environment: 'node' },
+      ),
+      './router': exportEntry(
+        { types: './dist/src/router.d.ts', default: './src/router.ts' },
+        { environment: 'browser' },
+      ),
     },
     publishConfig: {
       access: 'public',

--- a/packages/@overeng/effect-rpc-tanstack/tsconfig.json
+++ b/packages/@overeng/effect-rpc-tanstack/tsconfig.json
@@ -45,7 +45,8 @@
     "rootDir": ".",
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
     "jsx": "react-jsx",
-    "jsxImportSource": "react"
+    "jsxImportSource": "react",
+    "noEmit": true
   },
   "include": ["src/**/*"]
 }

--- a/packages/@overeng/effect-rpc-tanstack/tsconfig.json.genie.ts
+++ b/packages/@overeng/effect-rpc-tanstack/tsconfig.json.genie.ts
@@ -13,6 +13,7 @@ export default tsconfigJson({
     ...reactJsx,
     jsxImportSource: 'react',
     lib: [...domLib],
+    noEmit: true,
   },
   include: ['src/**/*'],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/effect-schema-form-aria/tsconfig.json
+++ b/packages/@overeng/effect-schema-form-aria/tsconfig.json
@@ -46,10 +46,5 @@
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
     "jsx": "react-jsx"
   },
-  "include": ["src/**/*"],
-  "references": [
-    {
-      "path": "../effect-schema-form"
-    }
-  ]
+  "include": ["src/**/*"]
 }

--- a/packages/@overeng/effect-schema-form-aria/tsconfig.json.genie.ts
+++ b/packages/@overeng/effect-schema-form-aria/tsconfig.json.genie.ts
@@ -15,5 +15,4 @@ export default tsconfigJson({
     lib: [...domLib],
   },
   include: ['src/**/*'],
-  references: [{ path: '../effect-schema-form' }],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/effect-schema-form/BUCK
+++ b/packages/@overeng/effect-schema-form/BUCK
@@ -1,0 +1,77 @@
+# Generated file - DO NOT EDIT
+# Source: BUCK.genie.ts
+
+# Projection source: packages/@overeng/effect-schema-form/BUCK.genie.ts
+# Projection schema version: 1
+# Projection generator: effect-utils/genie/buck2-typescript-package-projection
+# Semantic fingerprint: sha256:442806d87a7f36fb9481a8cb5c5e943511dd5b9a346b776de14c81dcef942a4a
+# Semantic inputs: buck2/dependencies/BUCK.genie.ts, buck2/dependencies/pnpm-lock.sha256.json.genie.ts, genie/buck2/mod.ts, genie/buck2/typescript-package-projection.ts, package.json.genie.ts, packages/@overeng/buck2-tools/src/package-tree.ts, packages/@overeng/buck2-tools/src/real-path.ts, packages/@overeng/effect-schema-form/BUCK.genie.ts, packages/@overeng/effect-schema-form/BUCK.genie.ts, packages/@overeng/effect-schema-form/package.json.genie.ts, packages/@overeng/effect-schema-form/src/**/*.cts, packages/@overeng/effect-schema-form/src/**/*.js, packages/@overeng/effect-schema-form/src/**/*.mts, packages/@overeng/effect-schema-form/src/**/*.ts, packages/@overeng/effect-schema-form/src/**/*.tsx, packages/@overeng/effect-schema-form/tsconfig.json.genie.ts
+# Regenerate: devenv tasks run genie:run
+
+load("//buck2:materialization.bzl", "export_materialization_inputs", "package_tree")
+load("//buck2:typescript.bzl", "tsgo_emit", "tsgo_typecheck")
+
+export_file(
+    name = "package.json",
+    src = "package.json",
+    visibility = ["PUBLIC"],
+)
+
+export_materialization_inputs([
+    "src/SchemaForm.tsx",
+    "src/context.tsx",
+    "src/hooks.ts",
+    "src/introspection.ts",
+    "src/mod.ts",
+    "src/mod.unit.test.tsx",
+    "src/types.ts",
+    "src/utils.ts",
+])
+
+alias(
+    name = "node_modules",
+    actual = "//buck2/dependencies:importer_packages_overeng_effect_schema_form_9234ab1a7f4a",
+    visibility = ["PUBLIC"],
+)
+
+alias(
+    name = "editor_inputs",
+    actual = ":node_modules",
+    visibility = ["PUBLIC"],
+)
+
+package_tree(
+    name = "package_tree",
+    node_modules = ":node_modules",
+    files = {
+        "package.json": "package.json",
+        "src/SchemaForm.tsx": "src/SchemaForm.tsx",
+        "src/context.tsx": "src/context.tsx",
+        "src/hooks.ts": "src/hooks.ts",
+        "src/introspection.ts": "src/introspection.ts",
+        "src/mod.ts": "src/mod.ts",
+        "src/mod.unit.test.tsx": "src/mod.unit.test.tsx",
+        "src/types.ts": "src/types.ts",
+        "src/utils.ts": "src/utils.ts",
+        "tsconfig.json": "tsconfig.json",
+    },
+    runtime = "//:package_tree_runtime",
+    runtime_entry = "package-tree.ts",
+    workspace_siblings = {},
+    visibility = ["PUBLIC"],
+)
+
+tsgo_typecheck(
+    name = "typecheck",
+    package_tree = ":package_tree",
+    visibility = ["PUBLIC"],
+)
+
+tsgo_emit(
+    name = "dist",
+    package_tree = ":package_tree",
+    declaration_sources = {
+    },
+    declaration_entrypoint = "src/mod.d.ts",
+    visibility = ["PUBLIC"],
+)

--- a/packages/@overeng/effect-schema-form/BUCK.genie.ts
+++ b/packages/@overeng/effect-schema-form/BUCK.genie.ts
@@ -1,0 +1,18 @@
+import type { Buck2TypeScriptAdmission } from '../../../genie/buck2/typescript-admissions.ts'
+import { buck2TypeScriptPackageProjection } from '../../../genie/buck2/typescript-package-projection.ts'
+
+export const buck2TypeScriptAdmission = {
+  dependencyImporter:
+    '//buck2/dependencies:importer_packages_overeng_effect_schema_form_9234ab1a7f4a',
+  packageName: '@overeng/effect-schema-form',
+  packagePath: 'packages/@overeng/effect-schema-form',
+  projectionSource: 'packages/@overeng/effect-schema-form/BUCK.genie.ts',
+  sourceRoots: ['src'],
+  editorViewConsumer: false,
+  authority: {
+    declarationEntrypoint: 'src/mod.d.ts',
+    projectFile: 'tsconfig.json',
+  },
+} as const satisfies Buck2TypeScriptAdmission
+
+export default buck2TypeScriptPackageProjection(buck2TypeScriptAdmission)

--- a/packages/@overeng/effect-schema-form/package.json
+++ b/packages/@overeng/effect-schema-form/package.json
@@ -4,7 +4,10 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./src/mod.ts"
+    ".": {
+      "types": "./dist/src/mod.d.ts",
+      "default": "./src/mod.ts"
+    }
   },
   "publishConfig": {
     "access": "public",

--- a/packages/@overeng/effect-schema-form/package.json.genie.ts
+++ b/packages/@overeng/effect-schema-form/package.json.genie.ts
@@ -33,7 +33,10 @@ export default packageJson(
     name: '@overeng/effect-schema-form',
     ...privatePackageDefaults,
     exports: {
-      '.': exportEntry('./src/mod.ts', { environment: 'browser' }),
+      '.': exportEntry(
+        { types: './dist/src/mod.d.ts', default: './src/mod.ts' },
+        { environment: 'browser' },
+      ),
     },
     publishConfig: {
       access: 'public',

--- a/packages/@overeng/effect-schema-form/tsconfig.json
+++ b/packages/@overeng/effect-schema-form/tsconfig.json
@@ -44,7 +44,8 @@
     "composite": true,
     "rootDir": ".",
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "noEmit": true
   },
   "include": ["src/**/*"]
 }

--- a/packages/@overeng/effect-schema-form/tsconfig.json.genie.ts
+++ b/packages/@overeng/effect-schema-form/tsconfig.json.genie.ts
@@ -12,6 +12,7 @@ export default tsconfigJson({
     ...packageTsconfigCompilerOptions,
     ...reactJsx,
     lib: [...domLib],
+    noEmit: true,
   },
   include: ['src/**/*'],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/kdl-effect/tsconfig.json
+++ b/packages/@overeng/kdl-effect/tsconfig.json
@@ -46,10 +46,5 @@
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
     "types": ["node"]
   },
-  "include": ["src/**/*"],
-  "references": [
-    {
-      "path": "../kdl"
-    }
-  ]
+  "include": ["src/**/*"]
 }

--- a/packages/@overeng/kdl-effect/tsconfig.json.genie.ts
+++ b/packages/@overeng/kdl-effect/tsconfig.json.genie.ts
@@ -12,5 +12,4 @@ export default tsconfigJson({
     ...nodeTypes,
   },
   include: ['src/**/*'],
-  references: [{ path: '../kdl' }],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/kdl/BUCK
+++ b/packages/@overeng/kdl/BUCK
@@ -1,0 +1,119 @@
+# Generated file - DO NOT EDIT
+# Source: BUCK.genie.ts
+
+# Projection source: packages/@overeng/kdl/BUCK.genie.ts
+# Projection schema version: 1
+# Projection generator: effect-utils/genie/buck2-typescript-package-projection
+# Semantic fingerprint: sha256:772ef1ca183d7818425a8804b51c7767d4ecac6c7f1aaf3eee13b56b038162d1
+# Semantic inputs: buck2/dependencies/BUCK.genie.ts, buck2/dependencies/pnpm-lock.sha256.json.genie.ts, genie/buck2/mod.ts, genie/buck2/typescript-package-projection.ts, package.json.genie.ts, packages/@overeng/buck2-tools/src/package-tree.ts, packages/@overeng/buck2-tools/src/real-path.ts, packages/@overeng/kdl/BUCK.genie.ts, packages/@overeng/kdl/BUCK.genie.ts, packages/@overeng/kdl/package.json.genie.ts, packages/@overeng/kdl/src/**/*.cts, packages/@overeng/kdl/src/**/*.js, packages/@overeng/kdl/src/**/*.mts, packages/@overeng/kdl/src/**/*.ts, packages/@overeng/kdl/src/**/*.tsx, packages/@overeng/kdl/tsconfig.json.genie.ts, packages/@overeng/utils-dev/BUCK.genie.ts, packages/@overeng/utils-dev/package.json.genie.ts
+# Regenerate: devenv tasks run genie:run
+
+load("//buck2:materialization.bzl", "export_materialization_inputs", "package_tree")
+load("//buck2:typescript.bzl", "tsgo_emit", "tsgo_typecheck")
+
+export_file(
+    name = "package.json",
+    src = "package.json",
+    visibility = ["PUBLIC"],
+)
+
+export_materialization_inputs([
+    "src/clear-format.ts",
+    "src/error.ts",
+    "src/flags.ts",
+    "src/format.ts",
+    "src/locations.ts",
+    "src/mod.ts",
+    "src/mod.unit.test.ts",
+    "src/model/document.ts",
+    "src/model/entry.ts",
+    "src/model/identifier.ts",
+    "src/model/node.ts",
+    "src/model/tag.ts",
+    "src/model/utils.ts",
+    "src/model/value.ts",
+    "src/parse.ts",
+    "src/parser/internal-error.ts",
+    "src/parser/parse-whitespace.ts",
+    "src/parser/parse.ts",
+    "src/parser/token.ts",
+    "src/parser/tokenize/context.ts",
+    "src/parser/tokenize/mod.ts",
+    "src/parser/tokenize/tokenize.ts",
+    "src/parser/tokenize/types.ts",
+    "src/string-utils.ts",
+    "src/upstream.test.ts",
+])
+
+alias(
+    name = "node_modules",
+    actual = "//buck2/dependencies:importer_packages_overeng_kdl_d22c24f7367b",
+    visibility = ["PUBLIC"],
+)
+
+alias(
+    name = "editor_inputs",
+    actual = ":node_modules",
+    visibility = ["PUBLIC"],
+)
+
+package_tree(
+    name = "package_tree",
+    node_modules = ":node_modules",
+    files = {
+        "package.json": "package.json",
+        "src/clear-format.ts": "src/clear-format.ts",
+        "src/error.ts": "src/error.ts",
+        "src/flags.ts": "src/flags.ts",
+        "src/format.ts": "src/format.ts",
+        "src/locations.ts": "src/locations.ts",
+        "src/mod.ts": "src/mod.ts",
+        "src/mod.unit.test.ts": "src/mod.unit.test.ts",
+        "src/model/document.ts": "src/model/document.ts",
+        "src/model/entry.ts": "src/model/entry.ts",
+        "src/model/identifier.ts": "src/model/identifier.ts",
+        "src/model/node.ts": "src/model/node.ts",
+        "src/model/tag.ts": "src/model/tag.ts",
+        "src/model/utils.ts": "src/model/utils.ts",
+        "src/model/value.ts": "src/model/value.ts",
+        "src/parse.ts": "src/parse.ts",
+        "src/parser/internal-error.ts": "src/parser/internal-error.ts",
+        "src/parser/parse-whitespace.ts": "src/parser/parse-whitespace.ts",
+        "src/parser/parse.ts": "src/parser/parse.ts",
+        "src/parser/token.ts": "src/parser/token.ts",
+        "src/parser/tokenize/context.ts": "src/parser/tokenize/context.ts",
+        "src/parser/tokenize/mod.ts": "src/parser/tokenize/mod.ts",
+        "src/parser/tokenize/tokenize.ts": "src/parser/tokenize/tokenize.ts",
+        "src/parser/tokenize/types.ts": "src/parser/tokenize/types.ts",
+        "src/string-utils.ts": "src/string-utils.ts",
+        "src/upstream.test.ts": "src/upstream.test.ts",
+        "tsconfig.json": "tsconfig.json",
+    },
+    runtime = "//:package_tree_runtime",
+    runtime_entry = "package-tree.ts",
+    workspace_siblings = {
+        "@overeng/utils-dev": {
+            "files": {
+                "dist": "//packages/@overeng/utils-dev:dist",
+                "package.json": "//packages/@overeng/utils-dev:package.json",
+            },
+            "links": ["@overeng/utils-dev"],
+        },
+    },
+    visibility = ["PUBLIC"],
+)
+
+tsgo_typecheck(
+    name = "typecheck",
+    package_tree = ":package_tree",
+    visibility = ["PUBLIC"],
+)
+
+tsgo_emit(
+    name = "dist",
+    package_tree = ":package_tree",
+    declaration_sources = {
+    },
+    declaration_entrypoint = "src/mod.d.ts",
+    visibility = ["PUBLIC"],
+)

--- a/packages/@overeng/kdl/BUCK.genie.ts
+++ b/packages/@overeng/kdl/BUCK.genie.ts
@@ -1,0 +1,24 @@
+import type { Buck2TypeScriptAdmission } from '../../../genie/buck2/typescript-admissions.ts'
+import { buck2TypeScriptPackageProjection } from '../../../genie/buck2/typescript-package-projection.ts'
+
+export const buck2TypeScriptAdmission = {
+  dependencyImporter: '//buck2/dependencies:importer_packages_overeng_kdl_d22c24f7367b',
+  packageName: '@overeng/kdl',
+  packagePath: 'packages/@overeng/kdl',
+  projectionSource: 'packages/@overeng/kdl/BUCK.genie.ts',
+  sourceRoots: ['src'],
+  workspaceSiblings: [
+    {
+      packageName: '@overeng/utils-dev',
+      packagePath: 'packages/@overeng/utils-dev',
+      distTarget: '//packages/@overeng/utils-dev:dist',
+    },
+  ],
+  editorViewConsumer: false,
+  authority: {
+    declarationEntrypoint: 'src/mod.d.ts',
+    projectFile: 'tsconfig.json',
+  },
+} as const satisfies Buck2TypeScriptAdmission
+
+export default buck2TypeScriptPackageProjection(buck2TypeScriptAdmission)

--- a/packages/@overeng/kdl/package.json
+++ b/packages/@overeng/kdl/package.json
@@ -4,7 +4,10 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./src/mod.ts"
+    ".": {
+      "types": "./dist/src/mod.d.ts",
+      "default": "./src/mod.ts"
+    }
   },
   "publishConfig": {
     "access": "public",

--- a/packages/@overeng/kdl/package.json.genie.ts
+++ b/packages/@overeng/kdl/package.json.genie.ts
@@ -29,7 +29,10 @@ export default packageJson(
     name: '@overeng/kdl',
     ...privatePackageDefaults,
     exports: {
-      '.': exportEntry('./src/mod.ts', { environment: 'isomorphic-es2024' }),
+      '.': exportEntry(
+        { types: './dist/src/mod.d.ts', default: './src/mod.ts' },
+        { environment: 'isomorphic-es2024' },
+      ),
     },
     publishConfig: {
       access: 'public',

--- a/packages/@overeng/kdl/tsconfig.json
+++ b/packages/@overeng/kdl/tsconfig.json
@@ -44,8 +44,8 @@
     "composite": true,
     "rootDir": ".",
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
-    "types": ["node"]
+    "types": ["node"],
+    "noEmit": true
   },
-  "include": ["src/**/*"],
-  "references": []
+  "include": ["src/**/*"]
 }

--- a/packages/@overeng/kdl/tsconfig.json.genie.ts
+++ b/packages/@overeng/kdl/tsconfig.json.genie.ts
@@ -10,7 +10,7 @@ export default tsconfigJson({
     ...baseTsconfigCompilerOptions,
     ...packageTsconfigCompilerOptions,
     ...nodeTypes,
+    noEmit: true,
   },
   include: ['src/**/*'],
-  references: [],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/megarepo/tsconfig.json
+++ b/packages/@overeng/megarepo/tsconfig.json
@@ -50,12 +50,6 @@
   "include": ["src/**/*", "test/**/*", "bin/**/*"],
   "references": [
     {
-      "path": "../effect-path"
-    },
-    {
-      "path": "../kdl"
-    },
-    {
       "path": "../kdl-effect"
     }
   ]

--- a/packages/@overeng/megarepo/tsconfig.json.genie.ts
+++ b/packages/@overeng/megarepo/tsconfig.json.genie.ts
@@ -15,5 +15,5 @@ export default tsconfigJson({
     types: ['node', 'bun'],
   },
   include: ['src/**/*', 'test/**/*', 'bin/**/*'],
-  references: [{ path: '../effect-path' }, { path: '../kdl' }, { path: '../kdl-effect' }],
+  references: [{ path: '../kdl-effect' }],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/npm-release/BUCK
+++ b/packages/@overeng/npm-release/BUCK
@@ -1,0 +1,79 @@
+# Generated file - DO NOT EDIT
+# Source: BUCK.genie.ts
+
+# Projection source: packages/@overeng/npm-release/BUCK.genie.ts
+# Projection schema version: 1
+# Projection generator: effect-utils/genie/buck2-typescript-package-projection
+# Semantic fingerprint: sha256:b0d9df16bd1c86e119066afbb7ea93724a21fcca24c1e34875ca279db93adc6b
+# Semantic inputs: buck2/dependencies/BUCK.genie.ts, buck2/dependencies/pnpm-lock.sha256.json.genie.ts, genie/buck2/mod.ts, genie/buck2/typescript-package-projection.ts, package.json.genie.ts, packages/@overeng/buck2-tools/src/package-tree.ts, packages/@overeng/buck2-tools/src/real-path.ts, packages/@overeng/npm-release/BUCK.genie.ts, packages/@overeng/npm-release/BUCK.genie.ts, packages/@overeng/npm-release/package.json.genie.ts, packages/@overeng/npm-release/src/**/*.cts, packages/@overeng/npm-release/src/**/*.js, packages/@overeng/npm-release/src/**/*.mts, packages/@overeng/npm-release/src/**/*.ts, packages/@overeng/npm-release/src/**/*.tsx, packages/@overeng/npm-release/tsconfig.json.genie.ts, packages/@overeng/utils-dev/BUCK.genie.ts, packages/@overeng/utils-dev/package.json.genie.ts
+# Regenerate: devenv tasks run genie:run
+
+load("//buck2:materialization.bzl", "export_materialization_inputs", "package_tree")
+load("//buck2:typescript.bzl", "tsgo_emit", "tsgo_typecheck")
+
+export_file(
+    name = "package.json",
+    src = "package.json",
+    visibility = ["PUBLIC"],
+)
+
+export_materialization_inputs([
+    "src/cli.contract.test.ts",
+    "src/cli.ts",
+    "src/mod.test.ts",
+    "src/mod.ts",
+    "src/verify.ts",
+])
+
+alias(
+    name = "node_modules",
+    actual = "//buck2/dependencies:importer_packages_overeng_npm_release_4d3d9fe00538",
+    visibility = ["PUBLIC"],
+)
+
+alias(
+    name = "editor_inputs",
+    actual = ":node_modules",
+    visibility = ["PUBLIC"],
+)
+
+package_tree(
+    name = "package_tree",
+    node_modules = ":node_modules",
+    files = {
+        "package.json": "package.json",
+        "src/cli.contract.test.ts": "src/cli.contract.test.ts",
+        "src/cli.ts": "src/cli.ts",
+        "src/mod.test.ts": "src/mod.test.ts",
+        "src/mod.ts": "src/mod.ts",
+        "src/verify.ts": "src/verify.ts",
+        "tsconfig.json": "tsconfig.json",
+    },
+    runtime = "//:package_tree_runtime",
+    runtime_entry = "package-tree.ts",
+    workspace_siblings = {
+        "@overeng/utils-dev": {
+            "files": {
+                "dist": "//packages/@overeng/utils-dev:dist",
+                "package.json": "//packages/@overeng/utils-dev:package.json",
+            },
+            "links": ["@overeng/utils-dev"],
+        },
+    },
+    visibility = ["PUBLIC"],
+)
+
+tsgo_typecheck(
+    name = "typecheck",
+    package_tree = ":package_tree",
+    visibility = ["PUBLIC"],
+)
+
+tsgo_emit(
+    name = "dist",
+    package_tree = ":package_tree",
+    declaration_sources = {
+    },
+    declaration_entrypoint = "src/mod.d.ts",
+    visibility = ["PUBLIC"],
+)

--- a/packages/@overeng/npm-release/BUCK.genie.ts
+++ b/packages/@overeng/npm-release/BUCK.genie.ts
@@ -1,0 +1,24 @@
+import type { Buck2TypeScriptAdmission } from '../../../genie/buck2/typescript-admissions.ts'
+import { buck2TypeScriptPackageProjection } from '../../../genie/buck2/typescript-package-projection.ts'
+
+export const buck2TypeScriptAdmission = {
+  dependencyImporter: '//buck2/dependencies:importer_packages_overeng_npm_release_4d3d9fe00538',
+  packageName: '@overeng/npm-release',
+  packagePath: 'packages/@overeng/npm-release',
+  projectionSource: 'packages/@overeng/npm-release/BUCK.genie.ts',
+  sourceRoots: ['src'],
+  workspaceSiblings: [
+    {
+      packageName: '@overeng/utils-dev',
+      packagePath: 'packages/@overeng/utils-dev',
+      distTarget: '//packages/@overeng/utils-dev:dist',
+    },
+  ],
+  editorViewConsumer: false,
+  authority: {
+    declarationEntrypoint: 'src/mod.d.ts',
+    projectFile: 'tsconfig.json',
+  },
+} as const satisfies Buck2TypeScriptAdmission
+
+export default buck2TypeScriptPackageProjection(buck2TypeScriptAdmission)

--- a/packages/@overeng/npm-release/nix/build.nix
+++ b/packages/@overeng/npm-release/nix/build.nix
@@ -20,7 +20,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-80NKtZyPEkq1F+uO5VhbHy+4GJX9brFRMTMKHjkhjdo=";
+      "." = mkSharedHash "sha256-z4vo3uTnkUt20ampAe1ZbbgJSq+4GXNajPs3pymABV4=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/npm-release/package.json
+++ b/packages/@overeng/npm-release/package.json
@@ -4,8 +4,14 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./src/mod.ts",
-    "./cli": "./src/cli.ts"
+    ".": {
+      "types": "./dist/src/mod.d.ts",
+      "default": "./src/mod.ts"
+    },
+    "./cli": {
+      "types": "./dist/src/cli.d.ts",
+      "default": "./src/cli.ts"
+    }
   },
   "publishConfig": {
     "access": "public",

--- a/packages/@overeng/npm-release/package.json.genie.ts
+++ b/packages/@overeng/npm-release/package.json.genie.ts
@@ -32,8 +32,14 @@ export default packageJson(
     name: '@overeng/npm-release',
     ...privatePackageDefaults,
     exports: {
-      '.': exportEntry('./src/mod.ts', { environment: 'isomorphic-es2024' }),
-      './cli': exportEntry('./src/cli.ts', { environment: 'bun' }),
+      '.': exportEntry(
+        { types: './dist/src/mod.d.ts', default: './src/mod.ts' },
+        { environment: 'isomorphic-es2024' },
+      ),
+      './cli': exportEntry(
+        { types: './dist/src/cli.d.ts', default: './src/cli.ts' },
+        { environment: 'bun' },
+      ),
     },
     publishConfig: {
       access: 'public',

--- a/packages/@overeng/npm-release/tsconfig.json
+++ b/packages/@overeng/npm-release/tsconfig.json
@@ -44,8 +44,8 @@
     "composite": true,
     "rootDir": ".",
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
-    "types": ["node"]
+    "types": ["node"],
+    "noEmit": true
   },
-  "include": ["src/**/*"],
-  "references": []
+  "include": ["src/**/*"]
 }

--- a/packages/@overeng/npm-release/tsconfig.json.genie.ts
+++ b/packages/@overeng/npm-release/tsconfig.json.genie.ts
@@ -10,7 +10,7 @@ export default tsconfigJson({
     ...baseTsconfigCompilerOptions,
     ...packageTsconfigCompilerOptions,
     ...nodeTypes,
+    noEmit: true,
   },
   include: ['src/**/*'],
-  references: [],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/oxc-config/BUCK
+++ b/packages/@overeng/oxc-config/BUCK
@@ -1,0 +1,141 @@
+# Generated file - DO NOT EDIT
+# Source: BUCK.genie.ts
+
+# Projection source: packages/@overeng/oxc-config/BUCK.genie.ts
+# Projection schema version: 1
+# Projection generator: effect-utils/genie/buck2-typescript-package-projection
+# Semantic fingerprint: sha256:652ebe5ae831cdaeb175951359c645577c09ec7f887ae0957e1fad690a8c739a
+# Semantic inputs: buck2/dependencies/BUCK.genie.ts, buck2/dependencies/pnpm-lock.sha256.json.genie.ts, genie/buck2/mod.ts, genie/buck2/typescript-package-projection.ts, package.json.genie.ts, packages/@overeng/buck2-tools/src/package-tree.ts, packages/@overeng/buck2-tools/src/real-path.ts, packages/@overeng/oxc-config/BUCK.genie.ts, packages/@overeng/oxc-config/BUCK.genie.ts, packages/@overeng/oxc-config/package.json.genie.ts, packages/@overeng/oxc-config/src/**/*.cts, packages/@overeng/oxc-config/src/**/*.js, packages/@overeng/oxc-config/src/**/*.mts, packages/@overeng/oxc-config/src/**/*.ts, packages/@overeng/oxc-config/src/**/*.tsx, packages/@overeng/oxc-config/tsconfig.json.genie.ts
+# Regenerate: devenv tasks run genie:run
+
+load("//buck2:materialization.bzl", "export_materialization_inputs", "package_tree")
+load("//buck2:typescript.bzl", "tsgo_emit", "tsgo_typecheck")
+
+export_file(
+    name = "package.json",
+    src = "package.json",
+    visibility = ["PUBLIC"],
+)
+
+export_materialization_inputs([
+    "src/explicit-boolean-compare.ts",
+    "src/explicit-boolean-compare.unit.test.ts",
+    "src/exports-first.ts",
+    "src/exports-first.unit.test.ts",
+    "src/jsdoc-require-exports.ts",
+    "src/jsdoc-require-exports.unit.test.ts",
+    "src/mod.ts",
+    "src/named-args.ts",
+    "src/named-args.unit.test.ts",
+    "src/no-external-imports.ts",
+    "src/no-external-imports.unit.test.ts",
+    "src/no-non-durable-wait.ts",
+    "src/no-non-durable-wait.unit.test.ts",
+    "src/no-raw-nondeterminism.ts",
+    "src/no-raw-nondeterminism.unit.test.ts",
+    "src/no-raw-otel-primitives.ts",
+    "src/no-raw-otel-primitives.unit.test.ts",
+    "src/otel-contract-in-seam-file.ts",
+    "src/otel-contract-in-seam-file.unit.test.ts",
+    "src/storybook/csf-component.ts",
+    "src/storybook/csf-component.unit.test.ts",
+    "src/storybook/default-exports.ts",
+    "src/storybook/default-exports.unit.test.ts",
+    "src/storybook/hierarchy-separator.ts",
+    "src/storybook/hierarchy-separator.unit.test.ts",
+    "src/storybook/meta-satisfies-type.ts",
+    "src/storybook/meta-satisfies-type.unit.test.ts",
+    "src/storybook/no-redundant-story-name.ts",
+    "src/storybook/no-redundant-story-name.unit.test.ts",
+    "src/storybook/prefer-pascal-case.ts",
+    "src/storybook/prefer-pascal-case.unit.test.ts",
+    "src/storybook/story-exports.ts",
+    "src/storybook/story-exports.unit.test.ts",
+    "src/storybook/utils.ts",
+    "src/stylex-no-raw-color.ts",
+    "src/stylex-no-raw-color.unit.test.ts",
+    "src/stylex-outline-focus-visible-only.ts",
+    "src/stylex-outline-focus-visible-only.unit.test.ts",
+    "src/stylex-shared.ts",
+    "src/stylex-upstream-plugin.ts",
+])
+
+alias(
+    name = "node_modules",
+    actual = "//buck2/dependencies:importer_packages_overeng_oxc_config_0c9db47f45b6",
+    visibility = ["PUBLIC"],
+)
+
+alias(
+    name = "editor_inputs",
+    actual = ":node_modules",
+    visibility = ["PUBLIC"],
+)
+
+package_tree(
+    name = "package_tree",
+    node_modules = ":node_modules",
+    files = {
+        "package.json": "package.json",
+        "src/explicit-boolean-compare.ts": "src/explicit-boolean-compare.ts",
+        "src/explicit-boolean-compare.unit.test.ts": "src/explicit-boolean-compare.unit.test.ts",
+        "src/exports-first.ts": "src/exports-first.ts",
+        "src/exports-first.unit.test.ts": "src/exports-first.unit.test.ts",
+        "src/jsdoc-require-exports.ts": "src/jsdoc-require-exports.ts",
+        "src/jsdoc-require-exports.unit.test.ts": "src/jsdoc-require-exports.unit.test.ts",
+        "src/mod.ts": "src/mod.ts",
+        "src/named-args.ts": "src/named-args.ts",
+        "src/named-args.unit.test.ts": "src/named-args.unit.test.ts",
+        "src/no-external-imports.ts": "src/no-external-imports.ts",
+        "src/no-external-imports.unit.test.ts": "src/no-external-imports.unit.test.ts",
+        "src/no-non-durable-wait.ts": "src/no-non-durable-wait.ts",
+        "src/no-non-durable-wait.unit.test.ts": "src/no-non-durable-wait.unit.test.ts",
+        "src/no-raw-nondeterminism.ts": "src/no-raw-nondeterminism.ts",
+        "src/no-raw-nondeterminism.unit.test.ts": "src/no-raw-nondeterminism.unit.test.ts",
+        "src/no-raw-otel-primitives.ts": "src/no-raw-otel-primitives.ts",
+        "src/no-raw-otel-primitives.unit.test.ts": "src/no-raw-otel-primitives.unit.test.ts",
+        "src/otel-contract-in-seam-file.ts": "src/otel-contract-in-seam-file.ts",
+        "src/otel-contract-in-seam-file.unit.test.ts": "src/otel-contract-in-seam-file.unit.test.ts",
+        "src/storybook/csf-component.ts": "src/storybook/csf-component.ts",
+        "src/storybook/csf-component.unit.test.ts": "src/storybook/csf-component.unit.test.ts",
+        "src/storybook/default-exports.ts": "src/storybook/default-exports.ts",
+        "src/storybook/default-exports.unit.test.ts": "src/storybook/default-exports.unit.test.ts",
+        "src/storybook/hierarchy-separator.ts": "src/storybook/hierarchy-separator.ts",
+        "src/storybook/hierarchy-separator.unit.test.ts": "src/storybook/hierarchy-separator.unit.test.ts",
+        "src/storybook/meta-satisfies-type.ts": "src/storybook/meta-satisfies-type.ts",
+        "src/storybook/meta-satisfies-type.unit.test.ts": "src/storybook/meta-satisfies-type.unit.test.ts",
+        "src/storybook/no-redundant-story-name.ts": "src/storybook/no-redundant-story-name.ts",
+        "src/storybook/no-redundant-story-name.unit.test.ts": "src/storybook/no-redundant-story-name.unit.test.ts",
+        "src/storybook/prefer-pascal-case.ts": "src/storybook/prefer-pascal-case.ts",
+        "src/storybook/prefer-pascal-case.unit.test.ts": "src/storybook/prefer-pascal-case.unit.test.ts",
+        "src/storybook/story-exports.ts": "src/storybook/story-exports.ts",
+        "src/storybook/story-exports.unit.test.ts": "src/storybook/story-exports.unit.test.ts",
+        "src/storybook/utils.ts": "src/storybook/utils.ts",
+        "src/stylex-no-raw-color.ts": "src/stylex-no-raw-color.ts",
+        "src/stylex-no-raw-color.unit.test.ts": "src/stylex-no-raw-color.unit.test.ts",
+        "src/stylex-outline-focus-visible-only.ts": "src/stylex-outline-focus-visible-only.ts",
+        "src/stylex-outline-focus-visible-only.unit.test.ts": "src/stylex-outline-focus-visible-only.unit.test.ts",
+        "src/stylex-shared.ts": "src/stylex-shared.ts",
+        "src/stylex-upstream-plugin.ts": "src/stylex-upstream-plugin.ts",
+        "tsconfig.json": "tsconfig.json",
+    },
+    runtime = "//:package_tree_runtime",
+    runtime_entry = "package-tree.ts",
+    workspace_siblings = {},
+    visibility = ["PUBLIC"],
+)
+
+tsgo_typecheck(
+    name = "typecheck",
+    package_tree = ":package_tree",
+    visibility = ["PUBLIC"],
+)
+
+tsgo_emit(
+    name = "dist",
+    package_tree = ":package_tree",
+    declaration_sources = {
+    },
+    declaration_entrypoint = "src/mod.d.ts",
+    visibility = ["PUBLIC"],
+)

--- a/packages/@overeng/oxc-config/BUCK.genie.ts
+++ b/packages/@overeng/oxc-config/BUCK.genie.ts
@@ -1,0 +1,17 @@
+import type { Buck2TypeScriptAdmission } from '../../../genie/buck2/typescript-admissions.ts'
+import { buck2TypeScriptPackageProjection } from '../../../genie/buck2/typescript-package-projection.ts'
+
+export const buck2TypeScriptAdmission = {
+  dependencyImporter: '//buck2/dependencies:importer_packages_overeng_oxc_config_0c9db47f45b6',
+  packageName: '@overeng/oxc-config',
+  packagePath: 'packages/@overeng/oxc-config',
+  projectionSource: 'packages/@overeng/oxc-config/BUCK.genie.ts',
+  sourceRoots: ['src'],
+  editorViewConsumer: false,
+  authority: {
+    declarationEntrypoint: 'src/mod.d.ts',
+    projectFile: 'tsconfig.json',
+  },
+} as const satisfies Buck2TypeScriptAdmission
+
+export default buck2TypeScriptPackageProjection(buck2TypeScriptAdmission)

--- a/packages/@overeng/oxc-config/nix/build.nix
+++ b/packages/@overeng/oxc-config/nix/build.nix
@@ -14,7 +14,7 @@ import ../../../../nix/oxc-config-plugin.nix {
     ;
   # Managed by Evergreen FOD refresh — do not edit manually.
   depsBuilds = {
-    "." = mkSharedHash "sha256-iskCQQJYzuXg0mL3k+CIlAp8T9hDfFrGuTH72Gpdzww=";
+    "." = mkSharedHash "sha256-Dmdb2G1Lh6hKLaFZrQFYgMzLgfbvejNAS3Jpj/RRw4Q=";
   };
   hashSourcePath = "packages/@overeng/oxc-config/nix/build.nix";
 }

--- a/packages/@overeng/oxc-config/package.json
+++ b/packages/@overeng/oxc-config/package.json
@@ -4,8 +4,14 @@
   "private": true,
   "type": "module",
   "exports": {
-    "./plugin": "./src/mod.ts",
-    "./stylex-upstream-plugin": "./src/stylex-upstream-plugin.ts"
+    "./plugin": {
+      "types": "./dist/src/mod.d.ts",
+      "default": "./src/mod.ts"
+    },
+    "./stylex-upstream-plugin": {
+      "types": "./dist/src/stylex-upstream-plugin.d.ts",
+      "default": "./src/stylex-upstream-plugin.ts"
+    }
   },
   "devDependencies": {
     "@stylexjs/eslint-plugin": "0.19.0",

--- a/packages/@overeng/oxc-config/package.json.genie.ts
+++ b/packages/@overeng/oxc-config/package.json.genie.ts
@@ -42,10 +42,19 @@ export default packageJson(
     name: '@overeng/oxc-config',
     ...privatePackageDefaults,
     exports: {
-      './plugin': exportEntry('./src/mod.ts', { environment: 'node' }),
-      './stylex-upstream-plugin': exportEntry('./src/stylex-upstream-plugin.ts', {
-        environment: 'node',
-      }),
+      './plugin': exportEntry(
+        { types: './dist/src/mod.d.ts', default: './src/mod.ts' },
+        { environment: 'node' },
+      ),
+      './stylex-upstream-plugin': exportEntry(
+        {
+          types: './dist/src/stylex-upstream-plugin.d.ts',
+          default: './src/stylex-upstream-plugin.ts',
+        },
+        {
+          environment: 'node',
+        },
+      ),
     },
   } satisfies PackageJsonInputData,
   deps,

--- a/packages/@overeng/oxc-config/tsconfig.json
+++ b/packages/@overeng/oxc-config/tsconfig.json
@@ -43,7 +43,8 @@
     ],
     "composite": true,
     "rootDir": ".",
-    "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo"
+    "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
+    "noEmit": true
   },
   "include": ["src/**/*.ts"]
 }

--- a/packages/@overeng/oxc-config/tsconfig.json.genie.ts
+++ b/packages/@overeng/oxc-config/tsconfig.json.genie.ts
@@ -8,6 +8,7 @@ export default tsconfigJson({
   compilerOptions: {
     ...baseTsconfigCompilerOptions,
     ...packageTsconfigCompilerOptions,
+    noEmit: true,
   },
   include: ['src/**/*.ts'],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/pty-effect/BUCK
+++ b/packages/@overeng/pty-effect/BUCK
@@ -1,0 +1,102 @@
+# Generated file - DO NOT EDIT
+# Source: BUCK.genie.ts
+
+# Projection source: packages/@overeng/pty-effect/BUCK.genie.ts
+# Projection schema version: 1
+# Projection generator: effect-utils/genie/buck2-typescript-package-projection
+# Semantic fingerprint: sha256:df9e657794001c9507de05532fedec738386c88795469b4b5906c9fc2d491732
+# Semantic inputs: buck2/dependencies/BUCK.genie.ts, buck2/dependencies/pnpm-lock.sha256.json.genie.ts, genie/buck2/mod.ts, genie/buck2/typescript-package-projection.ts, package.json.genie.ts, packages/@overeng/buck2-tools/src/package-tree.ts, packages/@overeng/buck2-tools/src/real-path.ts, packages/@overeng/otel-contract/BUCK.genie.ts, packages/@overeng/otel-contract/package.json.genie.ts, packages/@overeng/pty-effect/BUCK.genie.ts, packages/@overeng/pty-effect/BUCK.genie.ts, packages/@overeng/pty-effect/package.json.genie.ts, packages/@overeng/pty-effect/src/**/*.cts, packages/@overeng/pty-effect/src/**/*.js, packages/@overeng/pty-effect/src/**/*.mts, packages/@overeng/pty-effect/src/**/*.ts, packages/@overeng/pty-effect/src/**/*.tsx, packages/@overeng/pty-effect/tsconfig.json.genie.ts, packages/@overeng/utils-dev/BUCK.genie.ts, packages/@overeng/utils-dev/package.json.genie.ts
+# Regenerate: devenv tasks run genie:run
+
+load("//buck2:materialization.bzl", "export_materialization_inputs", "package_tree")
+load("//buck2:typescript.bzl", "tsgo_emit", "tsgo_typecheck")
+
+export_file(
+    name = "package.json",
+    src = "package.json",
+    visibility = ["PUBLIC"],
+)
+
+export_materialization_inputs([
+    "src/PtyError.ts",
+    "src/PtyEvent.ts",
+    "src/PtyKey.ts",
+    "src/PtySession.test.ts",
+    "src/PtySession.ts",
+    "src/PtySpawner.ts",
+    "src/PtySpec.ts",
+    "src/Screenshot.ts",
+    "src/client.test.ts",
+    "src/client.ts",
+    "src/client.unit.test.ts",
+    "src/mod.ts",
+    "src/pty.contract.ts",
+])
+
+alias(
+    name = "node_modules",
+    actual = "//buck2/dependencies:importer_packages_overeng_pty_effect_ec6c01cbf1c8",
+    visibility = ["PUBLIC"],
+)
+
+alias(
+    name = "editor_inputs",
+    actual = ":node_modules",
+    visibility = ["PUBLIC"],
+)
+
+package_tree(
+    name = "package_tree",
+    node_modules = ":node_modules",
+    files = {
+        "package.json": "package.json",
+        "src/PtyError.ts": "src/PtyError.ts",
+        "src/PtyEvent.ts": "src/PtyEvent.ts",
+        "src/PtyKey.ts": "src/PtyKey.ts",
+        "src/PtySession.test.ts": "src/PtySession.test.ts",
+        "src/PtySession.ts": "src/PtySession.ts",
+        "src/PtySpawner.ts": "src/PtySpawner.ts",
+        "src/PtySpec.ts": "src/PtySpec.ts",
+        "src/Screenshot.ts": "src/Screenshot.ts",
+        "src/client.test.ts": "src/client.test.ts",
+        "src/client.ts": "src/client.ts",
+        "src/client.unit.test.ts": "src/client.unit.test.ts",
+        "src/mod.ts": "src/mod.ts",
+        "src/pty.contract.ts": "src/pty.contract.ts",
+        "tsconfig.json": "tsconfig.json",
+    },
+    runtime = "//:package_tree_runtime",
+    runtime_entry = "package-tree.ts",
+    workspace_siblings = {
+        "@overeng/otel-contract": {
+            "files": {
+                "dist": "//packages/@overeng/otel-contract:dist",
+                "package.json": "//packages/@overeng/otel-contract:package.json",
+            },
+            "links": ["@overeng/otel-contract"],
+        },
+        "@overeng/utils-dev": {
+            "files": {
+                "dist": "//packages/@overeng/utils-dev:dist",
+                "package.json": "//packages/@overeng/utils-dev:package.json",
+            },
+            "links": ["@overeng/utils-dev"],
+        },
+    },
+    visibility = ["PUBLIC"],
+)
+
+tsgo_typecheck(
+    name = "typecheck",
+    package_tree = ":package_tree",
+    visibility = ["PUBLIC"],
+)
+
+tsgo_emit(
+    name = "dist",
+    package_tree = ":package_tree",
+    declaration_sources = {
+    },
+    declaration_entrypoint = "src/mod.d.ts",
+    visibility = ["PUBLIC"],
+)

--- a/packages/@overeng/pty-effect/BUCK.genie.ts
+++ b/packages/@overeng/pty-effect/BUCK.genie.ts
@@ -1,0 +1,29 @@
+import type { Buck2TypeScriptAdmission } from '../../../genie/buck2/typescript-admissions.ts'
+import { buck2TypeScriptPackageProjection } from '../../../genie/buck2/typescript-package-projection.ts'
+
+export const buck2TypeScriptAdmission = {
+  dependencyImporter: '//buck2/dependencies:importer_packages_overeng_pty_effect_ec6c01cbf1c8',
+  packageName: '@overeng/pty-effect',
+  packagePath: 'packages/@overeng/pty-effect',
+  projectionSource: 'packages/@overeng/pty-effect/BUCK.genie.ts',
+  sourceRoots: ['src'],
+  workspaceSiblings: [
+    {
+      packageName: '@overeng/otel-contract',
+      packagePath: 'packages/@overeng/otel-contract',
+      distTarget: '//packages/@overeng/otel-contract:dist',
+    },
+    {
+      packageName: '@overeng/utils-dev',
+      packagePath: 'packages/@overeng/utils-dev',
+      distTarget: '//packages/@overeng/utils-dev:dist',
+    },
+  ],
+  editorViewConsumer: false,
+  authority: {
+    declarationEntrypoint: 'src/mod.d.ts',
+    projectFile: 'tsconfig.json',
+  },
+} as const satisfies Buck2TypeScriptAdmission
+
+export default buck2TypeScriptPackageProjection(buck2TypeScriptAdmission)

--- a/packages/@overeng/pty-effect/package.json
+++ b/packages/@overeng/pty-effect/package.json
@@ -4,8 +4,14 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./src/mod.ts",
-    "./client": "./src/client.ts"
+    ".": {
+      "types": "./dist/src/mod.d.ts",
+      "default": "./src/mod.ts"
+    },
+    "./client": {
+      "types": "./dist/src/client.d.ts",
+      "default": "./src/client.ts"
+    }
   },
   "publishConfig": {
     "access": "public",

--- a/packages/@overeng/pty-effect/package.json.genie.ts
+++ b/packages/@overeng/pty-effect/package.json.genie.ts
@@ -44,8 +44,14 @@ export default packageJson(
       'bundle:smoke': 'bun ../../../genie/ci-scripts/bundle-smoke.ts',
     },
     exports: {
-      '.': exportEntry('./src/mod.ts', { environment: 'node' }),
-      './client': exportEntry('./src/client.ts', { environment: 'node' }),
+      '.': exportEntry(
+        { types: './dist/src/mod.d.ts', default: './src/mod.ts' },
+        { environment: 'node' },
+      ),
+      './client': exportEntry(
+        { types: './dist/src/client.d.ts', default: './src/client.ts' },
+        { environment: 'node' },
+      ),
     },
     publishConfig: {
       access: 'public',

--- a/packages/@overeng/pty-effect/tsconfig.json
+++ b/packages/@overeng/pty-effect/tsconfig.json
@@ -44,8 +44,8 @@
     "composite": true,
     "rootDir": ".",
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
-    "types": ["node"]
+    "types": ["node"],
+    "noEmit": true
   },
-  "include": ["src/**/*"],
-  "references": []
+  "include": ["src/**/*"]
 }

--- a/packages/@overeng/pty-effect/tsconfig.json.genie.ts
+++ b/packages/@overeng/pty-effect/tsconfig.json.genie.ts
@@ -10,7 +10,7 @@ export default tsconfigJson({
     ...baseTsconfigCompilerOptions,
     ...packageTsconfigCompilerOptions,
     ...nodeTypes,
+    noEmit: true,
   },
   include: ['src/**/*'],
-  references: [],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/react-inspector/BUCK
+++ b/packages/@overeng/react-inspector/BUCK
@@ -1,0 +1,135 @@
+# Generated file - DO NOT EDIT
+# Source: BUCK.genie.ts
+
+# Projection source: packages/@overeng/react-inspector/BUCK.genie.ts
+# Projection schema version: 1
+# Projection generator: effect-utils/genie/buck2-typescript-package-projection
+# Semantic fingerprint: sha256:609364c39a2edcb56a7b1fac4dabf2a0c4f43980ee4da0728ad68af11f89dda0
+# Semantic inputs: buck2/dependencies/BUCK.genie.ts, buck2/dependencies/pnpm-lock.sha256.json.genie.ts, genie/buck2/mod.ts, genie/buck2/typescript-package-projection.ts, package.json.genie.ts, packages/@overeng/buck2-tools/src/package-tree.ts, packages/@overeng/buck2-tools/src/real-path.ts, packages/@overeng/react-inspector/BUCK.genie.ts, packages/@overeng/react-inspector/BUCK.genie.ts, packages/@overeng/react-inspector/package.json.genie.ts, packages/@overeng/react-inspector/src/**/*.cts, packages/@overeng/react-inspector/src/**/*.js, packages/@overeng/react-inspector/src/**/*.mts, packages/@overeng/react-inspector/src/**/*.ts, packages/@overeng/react-inspector/src/**/*.tsx, packages/@overeng/react-inspector/tsconfig.json.genie.ts
+# Regenerate: devenv tasks run genie:run
+
+load("//buck2:materialization.bzl", "export_materialization_inputs", "package_tree")
+load("//buck2:typescript.bzl", "tsgo_emit", "tsgo_typecheck")
+
+export_file(
+    name = "package.json",
+    src = "package.json",
+    visibility = ["PUBLIC"],
+)
+
+export_materialization_inputs([
+    "src/dom-inspector/DOMInspector.tsx",
+    "src/dom-inspector/DOMNodePreview.tsx",
+    "src/dom-inspector/shouldInline.tsx",
+    "src/index.tsx",
+    "src/object-inspector/ObjectInspector.tsx",
+    "src/object-inspector/ObjectLabel.tsx",
+    "src/object-inspector/ObjectPreview.tsx",
+    "src/object-inspector/ObjectRootLabel.tsx",
+    "src/object/ObjectName.tsx",
+    "src/object/ObjectValue.tsx",
+    "src/schema/SchemaAwareNodeRenderer.tsx",
+    "src/schema/SchemaAwareObjectPreview.tsx",
+    "src/schema/SchemaAwareObjectValue.tsx",
+    "src/schema/SchemaContext.tsx",
+    "src/schema/SchemaTooltip.tsx",
+    "src/schema/effect4.unit.test.tsx",
+    "src/schema/effectSchema.tsx",
+    "src/schema/lineage.ts",
+    "src/schema/mod.tsx",
+    "src/styles/base.tsx",
+    "src/styles/index.tsx",
+    "src/styles/styles.tsx",
+    "src/styles/themes/chromeDark.tsx",
+    "src/styles/themes/chromeLight.tsx",
+    "src/styles/themes/index.tsx",
+    "src/styles/unselectable.tsx",
+    "src/table-inspector/DataContainer.tsx",
+    "src/table-inspector/HeaderContainer.tsx",
+    "src/table-inspector/TH.tsx",
+    "src/table-inspector/TableInspector.tsx",
+    "src/table-inspector/getHeaders.ts",
+    "src/tree-view/ExpandedPathsContext.tsx",
+    "src/tree-view/TreeNode.tsx",
+    "src/tree-view/TreeView.tsx",
+    "src/tree-view/pathUtils.ts",
+    "src/utils/objectPrototype.tsx",
+    "src/utils/propertyUtils.tsx",
+])
+
+alias(
+    name = "node_modules",
+    actual = "//buck2/dependencies:importer_packages_overeng_react_inspector_57d1a5b765ed",
+    visibility = ["PUBLIC"],
+)
+
+alias(
+    name = "editor_inputs",
+    actual = ":node_modules",
+    visibility = ["PUBLIC"],
+)
+
+package_tree(
+    name = "package_tree",
+    node_modules = ":node_modules",
+    files = {
+        "package.json": "package.json",
+        "src/dom-inspector/DOMInspector.tsx": "src/dom-inspector/DOMInspector.tsx",
+        "src/dom-inspector/DOMNodePreview.tsx": "src/dom-inspector/DOMNodePreview.tsx",
+        "src/dom-inspector/shouldInline.tsx": "src/dom-inspector/shouldInline.tsx",
+        "src/index.tsx": "src/index.tsx",
+        "src/object-inspector/ObjectInspector.tsx": "src/object-inspector/ObjectInspector.tsx",
+        "src/object-inspector/ObjectLabel.tsx": "src/object-inspector/ObjectLabel.tsx",
+        "src/object-inspector/ObjectPreview.tsx": "src/object-inspector/ObjectPreview.tsx",
+        "src/object-inspector/ObjectRootLabel.tsx": "src/object-inspector/ObjectRootLabel.tsx",
+        "src/object/ObjectName.tsx": "src/object/ObjectName.tsx",
+        "src/object/ObjectValue.tsx": "src/object/ObjectValue.tsx",
+        "src/schema/SchemaAwareNodeRenderer.tsx": "src/schema/SchemaAwareNodeRenderer.tsx",
+        "src/schema/SchemaAwareObjectPreview.tsx": "src/schema/SchemaAwareObjectPreview.tsx",
+        "src/schema/SchemaAwareObjectValue.tsx": "src/schema/SchemaAwareObjectValue.tsx",
+        "src/schema/SchemaContext.tsx": "src/schema/SchemaContext.tsx",
+        "src/schema/SchemaTooltip.tsx": "src/schema/SchemaTooltip.tsx",
+        "src/schema/effect4.unit.test.tsx": "src/schema/effect4.unit.test.tsx",
+        "src/schema/effectSchema.tsx": "src/schema/effectSchema.tsx",
+        "src/schema/lineage.ts": "src/schema/lineage.ts",
+        "src/schema/mod.tsx": "src/schema/mod.tsx",
+        "src/styles/base.tsx": "src/styles/base.tsx",
+        "src/styles/index.tsx": "src/styles/index.tsx",
+        "src/styles/styles.tsx": "src/styles/styles.tsx",
+        "src/styles/themes/chromeDark.tsx": "src/styles/themes/chromeDark.tsx",
+        "src/styles/themes/chromeLight.tsx": "src/styles/themes/chromeLight.tsx",
+        "src/styles/themes/index.tsx": "src/styles/themes/index.tsx",
+        "src/styles/unselectable.tsx": "src/styles/unselectable.tsx",
+        "src/table-inspector/DataContainer.tsx": "src/table-inspector/DataContainer.tsx",
+        "src/table-inspector/HeaderContainer.tsx": "src/table-inspector/HeaderContainer.tsx",
+        "src/table-inspector/TH.tsx": "src/table-inspector/TH.tsx",
+        "src/table-inspector/TableInspector.tsx": "src/table-inspector/TableInspector.tsx",
+        "src/table-inspector/getHeaders.ts": "src/table-inspector/getHeaders.ts",
+        "src/tree-view/ExpandedPathsContext.tsx": "src/tree-view/ExpandedPathsContext.tsx",
+        "src/tree-view/TreeNode.tsx": "src/tree-view/TreeNode.tsx",
+        "src/tree-view/TreeView.tsx": "src/tree-view/TreeView.tsx",
+        "src/tree-view/pathUtils.ts": "src/tree-view/pathUtils.ts",
+        "src/utils/objectPrototype.tsx": "src/utils/objectPrototype.tsx",
+        "src/utils/propertyUtils.tsx": "src/utils/propertyUtils.tsx",
+        "tsconfig.json": "tsconfig.json",
+    },
+    runtime = "//:package_tree_runtime",
+    runtime_entry = "package-tree.ts",
+    workspace_siblings = {},
+    visibility = ["PUBLIC"],
+)
+
+tsgo_typecheck(
+    name = "typecheck",
+    package_tree = ":package_tree",
+    visibility = ["PUBLIC"],
+)
+
+tsgo_emit(
+    name = "dist",
+    package_tree = ":package_tree",
+    declaration_sources = {
+    },
+    declaration_entrypoint = "src/index.d.ts",
+    visibility = ["PUBLIC"],
+)

--- a/packages/@overeng/react-inspector/BUCK.genie.ts
+++ b/packages/@overeng/react-inspector/BUCK.genie.ts
@@ -1,0 +1,17 @@
+import type { Buck2TypeScriptAdmission } from '../../../genie/buck2/typescript-admissions.ts'
+import { buck2TypeScriptPackageProjection } from '../../../genie/buck2/typescript-package-projection.ts'
+
+export const buck2TypeScriptAdmission = {
+  dependencyImporter: '//buck2/dependencies:importer_packages_overeng_react_inspector_57d1a5b765ed',
+  packageName: '@overeng/react-inspector',
+  packagePath: 'packages/@overeng/react-inspector',
+  projectionSource: 'packages/@overeng/react-inspector/BUCK.genie.ts',
+  sourceRoots: ['src'],
+  editorViewConsumer: false,
+  authority: {
+    declarationEntrypoint: 'src/index.d.ts',
+    projectFile: 'tsconfig.json',
+  },
+} as const satisfies Buck2TypeScriptAdmission
+
+export default buck2TypeScriptPackageProjection(buck2TypeScriptAdmission)

--- a/packages/@overeng/react-inspector/package.json
+++ b/packages/@overeng/react-inspector/package.json
@@ -11,7 +11,10 @@
   ],
   "type": "module",
   "exports": {
-    ".": "./src/index.tsx"
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "default": "./src/index.tsx"
+    }
   },
   "publishConfig": {
     "access": "public",

--- a/packages/@overeng/react-inspector/package.json.genie.ts
+++ b/packages/@overeng/react-inspector/package.json.genie.ts
@@ -79,7 +79,10 @@ export default packageJson(
     license: 'MIT',
     type: 'module',
     exports: {
-      '.': exportEntry('./src/index.tsx', { environment: 'browser' }),
+      '.': exportEntry(
+        { types: './dist/src/index.d.ts', default: './src/index.tsx' },
+        { environment: 'browser' },
+      ),
     },
     /**
      * Pin the packed contents. Without this, the tarball varied by 169 files

--- a/packages/@overeng/react-inspector/tsconfig.json
+++ b/packages/@overeng/react-inspector/tsconfig.json
@@ -46,8 +46,8 @@
     "checkJs": false,
     "composite": true,
     "noImplicitAny": false,
-    "strictNullChecks": false
+    "strictNullChecks": false,
+    "noEmit": true
   },
-  "include": ["src/**/*"],
-  "references": []
+  "include": ["src/**/*"]
 }

--- a/packages/@overeng/react-inspector/tsconfig.json.genie.ts
+++ b/packages/@overeng/react-inspector/tsconfig.json.genie.ts
@@ -19,7 +19,7 @@ export default tsconfigJson({
     noUncheckedIndexedAccess: false,
     verbatimModuleSyntax: false,
     noImplicitReturns: false,
+    noEmit: true,
   },
   include: ['src/**/*'],
-  references: [],
 } satisfies TSConfigArgs)

--- a/packages/@overeng/restate-effect/BUCK
+++ b/packages/@overeng/restate-effect/BUCK
@@ -1,0 +1,203 @@
+# Generated file - DO NOT EDIT
+# Source: BUCK.genie.ts
+
+# Projection source: packages/@overeng/restate-effect/BUCK.genie.ts
+# Projection schema version: 1
+# Projection generator: effect-utils/genie/buck2-typescript-package-projection
+# Semantic fingerprint: sha256:42e28345bb6b7f06fc6ec934b88b689f44cd08c9d99e0b66a6c97bcbcc920a18
+# Semantic inputs: buck2/dependencies/BUCK.genie.ts, buck2/dependencies/pnpm-lock.sha256.json.genie.ts, genie/buck2/mod.ts, genie/buck2/typescript-package-projection.ts, package.json.genie.ts, packages/@overeng/buck2-tools/src/package-tree.ts, packages/@overeng/buck2-tools/src/real-path.ts, packages/@overeng/otel-contract/BUCK.genie.ts, packages/@overeng/otel-contract/package.json.genie.ts, packages/@overeng/restate-effect/BUCK.genie.ts, packages/@overeng/restate-effect/BUCK.genie.ts, packages/@overeng/restate-effect/package.json.genie.ts, packages/@overeng/restate-effect/src/**/*.cts, packages/@overeng/restate-effect/src/**/*.js, packages/@overeng/restate-effect/src/**/*.mts, packages/@overeng/restate-effect/src/**/*.ts, packages/@overeng/restate-effect/src/**/*.tsx, packages/@overeng/restate-effect/tsconfig.json.genie.ts, packages/@overeng/utils-dev/BUCK.genie.ts, packages/@overeng/utils-dev/package.json.genie.ts, packages/@overeng/utils/BUCK.genie.ts, packages/@overeng/utils/package.json.genie.ts
+# Regenerate: devenv tasks run genie:run
+
+load("//buck2:materialization.bzl", "export_materialization_inputs", "package_tree")
+load("//buck2:typescript.bzl", "tsgo_emit", "tsgo_typecheck")
+
+export_file(
+    name = "package.json",
+    src = "package.json",
+    visibility = ["PUBLIC"],
+)
+
+export_materialization_inputs([
+    "src/admin/AdminApi.ts",
+    "src/admin/admin.integration.test.ts",
+    "src/admin/admin.test.ts",
+    "src/admin/admin.ts",
+    "src/authoring/RestateContext.ts",
+    "src/authoring/Service.ts",
+    "src/authoring/awakeable.integration.test.ts",
+    "src/authoring/capability-inference.types.ts",
+    "src/authoring/concurrency.integration.test.ts",
+    "src/authoring/object.integration.test.ts",
+    "src/authoring/peek.integration.test.ts",
+    "src/authoring/workflow.integration.test.ts",
+    "src/clients/Client.ts",
+    "src/clients/InvocationPolicy.ts",
+    "src/clients/client-ingress.test.ts",
+    "src/clients/contract-policy.integration.test.ts",
+    "src/clients/in-handler-call.integration.test.ts",
+    "src/endpoint/Endpoint.ts",
+    "src/endpoint/examples.integration.test.ts",
+    "src/endpoint/identity.test.ts",
+    "src/endpoint/multi-deployment.integration.test.ts",
+    "src/endpoint/options-surfacing.test.ts",
+    "src/endpoint/restate-effect.integration.test.ts",
+    "src/error/Boundary.ts",
+    "src/error/error-transport.test.ts",
+    "src/error/http-error-classification.integration.test.ts",
+    "src/error/retry-policy.integration.test.ts",
+    "src/error/saga.integration.test.ts",
+    "src/error/suspension.integration.test.ts",
+    "src/mod.ts",
+    "src/observability/Metrics.ts",
+    "src/observability/contract.ts",
+    "src/observability/effect.ts",
+    "src/observability/observability.test.ts",
+    "src/observability/otel-replay.integration.test.ts",
+    "src/observability/otel.test.ts",
+    "src/observability/otel.ts",
+    "src/observability/restate.contract.ts",
+    "src/runtime/Runtime.test.ts",
+    "src/runtime/Runtime.ts",
+    "src/runtime/cancellation.integration.test.ts",
+    "src/scheduling/Reschedule.ts",
+    "src/scheduling/Scheduled.ts",
+    "src/scheduling/scheduled-compose.integration.test.ts",
+    "src/scheduling/scheduled-durability.integration.test.ts",
+    "src/scheduling/scheduled.integration.test.ts",
+    "src/schema/Annotations.test.ts",
+    "src/schema/Annotations.ts",
+    "src/schema/Redaction.test.ts",
+    "src/schema/Redaction.ts",
+    "src/schema/RestateError.ts",
+    "src/schema/Serde.test.ts",
+    "src/schema/Serde.ts",
+    "src/schema/redaction.integration.test.ts",
+    "src/testing/TestContext.test.ts",
+    "src/testing/TestContext.ts",
+    "src/testing/TestEnv.ts",
+    "src/testing/harness.integration.test.ts",
+    "src/testing/test-env.integration.test.ts",
+    "src/testing/testing.ts",
+])
+
+alias(
+    name = "node_modules",
+    actual = "//buck2/dependencies:importer_packages_overeng_restate_effect_1d9088e92885",
+    visibility = ["PUBLIC"],
+)
+
+alias(
+    name = "editor_inputs",
+    actual = ":node_modules",
+    visibility = ["PUBLIC"],
+)
+
+package_tree(
+    name = "package_tree",
+    node_modules = ":node_modules",
+    files = {
+        "package.json": "package.json",
+        "src/admin/AdminApi.ts": "src/admin/AdminApi.ts",
+        "src/admin/admin.integration.test.ts": "src/admin/admin.integration.test.ts",
+        "src/admin/admin.test.ts": "src/admin/admin.test.ts",
+        "src/admin/admin.ts": "src/admin/admin.ts",
+        "src/authoring/RestateContext.ts": "src/authoring/RestateContext.ts",
+        "src/authoring/Service.ts": "src/authoring/Service.ts",
+        "src/authoring/awakeable.integration.test.ts": "src/authoring/awakeable.integration.test.ts",
+        "src/authoring/capability-inference.types.ts": "src/authoring/capability-inference.types.ts",
+        "src/authoring/concurrency.integration.test.ts": "src/authoring/concurrency.integration.test.ts",
+        "src/authoring/object.integration.test.ts": "src/authoring/object.integration.test.ts",
+        "src/authoring/peek.integration.test.ts": "src/authoring/peek.integration.test.ts",
+        "src/authoring/workflow.integration.test.ts": "src/authoring/workflow.integration.test.ts",
+        "src/clients/Client.ts": "src/clients/Client.ts",
+        "src/clients/InvocationPolicy.ts": "src/clients/InvocationPolicy.ts",
+        "src/clients/client-ingress.test.ts": "src/clients/client-ingress.test.ts",
+        "src/clients/contract-policy.integration.test.ts": "src/clients/contract-policy.integration.test.ts",
+        "src/clients/in-handler-call.integration.test.ts": "src/clients/in-handler-call.integration.test.ts",
+        "src/endpoint/Endpoint.ts": "src/endpoint/Endpoint.ts",
+        "src/endpoint/examples.integration.test.ts": "src/endpoint/examples.integration.test.ts",
+        "src/endpoint/identity.test.ts": "src/endpoint/identity.test.ts",
+        "src/endpoint/multi-deployment.integration.test.ts": "src/endpoint/multi-deployment.integration.test.ts",
+        "src/endpoint/options-surfacing.test.ts": "src/endpoint/options-surfacing.test.ts",
+        "src/endpoint/restate-effect.integration.test.ts": "src/endpoint/restate-effect.integration.test.ts",
+        "src/error/Boundary.ts": "src/error/Boundary.ts",
+        "src/error/error-transport.test.ts": "src/error/error-transport.test.ts",
+        "src/error/http-error-classification.integration.test.ts": "src/error/http-error-classification.integration.test.ts",
+        "src/error/retry-policy.integration.test.ts": "src/error/retry-policy.integration.test.ts",
+        "src/error/saga.integration.test.ts": "src/error/saga.integration.test.ts",
+        "src/error/suspension.integration.test.ts": "src/error/suspension.integration.test.ts",
+        "src/mod.ts": "src/mod.ts",
+        "src/observability/Metrics.ts": "src/observability/Metrics.ts",
+        "src/observability/contract.ts": "src/observability/contract.ts",
+        "src/observability/effect.ts": "src/observability/effect.ts",
+        "src/observability/observability.test.ts": "src/observability/observability.test.ts",
+        "src/observability/otel-replay.integration.test.ts": "src/observability/otel-replay.integration.test.ts",
+        "src/observability/otel.test.ts": "src/observability/otel.test.ts",
+        "src/observability/otel.ts": "src/observability/otel.ts",
+        "src/observability/restate.contract.ts": "src/observability/restate.contract.ts",
+        "src/runtime/Runtime.test.ts": "src/runtime/Runtime.test.ts",
+        "src/runtime/Runtime.ts": "src/runtime/Runtime.ts",
+        "src/runtime/cancellation.integration.test.ts": "src/runtime/cancellation.integration.test.ts",
+        "src/scheduling/Reschedule.ts": "src/scheduling/Reschedule.ts",
+        "src/scheduling/Scheduled.ts": "src/scheduling/Scheduled.ts",
+        "src/scheduling/scheduled-compose.integration.test.ts": "src/scheduling/scheduled-compose.integration.test.ts",
+        "src/scheduling/scheduled-durability.integration.test.ts": "src/scheduling/scheduled-durability.integration.test.ts",
+        "src/scheduling/scheduled.integration.test.ts": "src/scheduling/scheduled.integration.test.ts",
+        "src/schema/Annotations.test.ts": "src/schema/Annotations.test.ts",
+        "src/schema/Annotations.ts": "src/schema/Annotations.ts",
+        "src/schema/Redaction.test.ts": "src/schema/Redaction.test.ts",
+        "src/schema/Redaction.ts": "src/schema/Redaction.ts",
+        "src/schema/RestateError.ts": "src/schema/RestateError.ts",
+        "src/schema/Serde.test.ts": "src/schema/Serde.test.ts",
+        "src/schema/Serde.ts": "src/schema/Serde.ts",
+        "src/schema/redaction.integration.test.ts": "src/schema/redaction.integration.test.ts",
+        "src/testing/TestContext.test.ts": "src/testing/TestContext.test.ts",
+        "src/testing/TestContext.ts": "src/testing/TestContext.ts",
+        "src/testing/TestEnv.ts": "src/testing/TestEnv.ts",
+        "src/testing/harness.integration.test.ts": "src/testing/harness.integration.test.ts",
+        "src/testing/test-env.integration.test.ts": "src/testing/test-env.integration.test.ts",
+        "src/testing/testing.ts": "src/testing/testing.ts",
+        "tsconfig.json": "tsconfig.json",
+    },
+    runtime = "//:package_tree_runtime",
+    runtime_entry = "package-tree.ts",
+    workspace_siblings = {
+        "@overeng/otel-contract": {
+            "files": {
+                "dist": "//packages/@overeng/otel-contract:dist",
+                "package.json": "//packages/@overeng/otel-contract:package.json",
+            },
+            "links": ["@overeng/otel-contract"],
+        },
+        "@overeng/utils": {
+            "files": {
+                "dist": "//packages/@overeng/utils:dist",
+                "package.json": "//packages/@overeng/utils:package.json",
+            },
+            "links": ["@overeng/utils"],
+        },
+        "@overeng/utils-dev": {
+            "files": {
+                "dist": "//packages/@overeng/utils-dev:dist",
+                "package.json": "//packages/@overeng/utils-dev:package.json",
+            },
+            "links": ["@overeng/utils-dev"],
+        },
+    },
+    visibility = ["PUBLIC"],
+)
+
+tsgo_typecheck(
+    name = "typecheck",
+    package_tree = ":package_tree",
+    visibility = ["PUBLIC"],
+)
+
+tsgo_emit(
+    name = "dist",
+    package_tree = ":package_tree",
+    declaration_sources = {
+    },
+    declaration_entrypoint = "src/mod.d.ts",
+    visibility = ["PUBLIC"],
+)

--- a/packages/@overeng/restate-effect/BUCK.genie.ts
+++ b/packages/@overeng/restate-effect/BUCK.genie.ts
@@ -1,0 +1,34 @@
+import type { Buck2TypeScriptAdmission } from '../../../genie/buck2/typescript-admissions.ts'
+import { buck2TypeScriptPackageProjection } from '../../../genie/buck2/typescript-package-projection.ts'
+
+export const buck2TypeScriptAdmission = {
+  dependencyImporter: '//buck2/dependencies:importer_packages_overeng_restate_effect_1d9088e92885',
+  packageName: '@overeng/restate-effect',
+  packagePath: 'packages/@overeng/restate-effect',
+  projectionSource: 'packages/@overeng/restate-effect/BUCK.genie.ts',
+  sourceRoots: ['src'],
+  workspaceSiblings: [
+    {
+      packageName: '@overeng/otel-contract',
+      packagePath: 'packages/@overeng/otel-contract',
+      distTarget: '//packages/@overeng/otel-contract:dist',
+    },
+    {
+      packageName: '@overeng/utils',
+      packagePath: 'packages/@overeng/utils',
+      distTarget: '//packages/@overeng/utils:dist',
+    },
+    {
+      packageName: '@overeng/utils-dev',
+      packagePath: 'packages/@overeng/utils-dev',
+      distTarget: '//packages/@overeng/utils-dev:dist',
+    },
+  ],
+  editorViewConsumer: false,
+  authority: {
+    declarationEntrypoint: 'src/mod.d.ts',
+    projectFile: 'tsconfig.json',
+  },
+} as const satisfies Buck2TypeScriptAdmission
+
+export default buck2TypeScriptPackageProjection(buck2TypeScriptAdmission)

--- a/packages/@overeng/restate-effect/package.json
+++ b/packages/@overeng/restate-effect/package.json
@@ -4,10 +4,22 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./src/mod.ts",
-    "./admin": "./src/admin/admin.ts",
-    "./otel": "./src/observability/otel.ts",
-    "./testing": "./src/testing/testing.ts"
+    ".": {
+      "types": "./dist/src/mod.d.ts",
+      "default": "./src/mod.ts"
+    },
+    "./admin": {
+      "types": "./dist/src/admin/admin.d.ts",
+      "default": "./src/admin/admin.ts"
+    },
+    "./otel": {
+      "types": "./dist/src/observability/otel.d.ts",
+      "default": "./src/observability/otel.ts"
+    },
+    "./testing": {
+      "types": "./dist/src/testing/testing.d.ts",
+      "default": "./src/testing/testing.ts"
+    }
   },
   "publishConfig": {
     "access": "public",

--- a/packages/@overeng/restate-effect/package.json.genie.ts
+++ b/packages/@overeng/restate-effect/package.json.genie.ts
@@ -68,10 +68,22 @@ export default packageJson(
     name: '@overeng/restate-effect',
     ...privatePackageDefaults,
     exports: {
-      '.': exportEntry('./src/mod.ts', { environment: 'node' }),
-      './admin': exportEntry('./src/admin/admin.ts', { environment: 'node' }),
-      './otel': exportEntry('./src/observability/otel.ts', { environment: 'node' }),
-      './testing': exportEntry('./src/testing/testing.ts', { environment: 'node' }),
+      '.': exportEntry(
+        { types: './dist/src/mod.d.ts', default: './src/mod.ts' },
+        { environment: 'node' },
+      ),
+      './admin': exportEntry(
+        { types: './dist/src/admin/admin.d.ts', default: './src/admin/admin.ts' },
+        { environment: 'node' },
+      ),
+      './otel': exportEntry(
+        { types: './dist/src/observability/otel.d.ts', default: './src/observability/otel.ts' },
+        { environment: 'node' },
+      ),
+      './testing': exportEntry(
+        { types: './dist/src/testing/testing.d.ts', default: './src/testing/testing.ts' },
+        { environment: 'node' },
+      ),
     },
     publishConfig: {
       access: 'public',

--- a/packages/@overeng/restate-effect/tsconfig.json
+++ b/packages/@overeng/restate-effect/tsconfig.json
@@ -44,7 +44,8 @@
     "composite": true,
     "rootDir": ".",
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
-    "types": ["node"]
+    "types": ["node"],
+    "noEmit": true
   },
   "include": ["src/**/*", "examples/**/*"]
 }

--- a/packages/@overeng/restate-effect/tsconfig.json.genie.ts
+++ b/packages/@overeng/restate-effect/tsconfig.json.genie.ts
@@ -10,6 +10,7 @@ export default tsconfigJson({
     ...baseTsconfigCompilerOptions,
     ...packageTsconfigCompilerOptions,
     ...nodeTypes,
+    noEmit: true,
   },
   include: ['src/**/*', 'examples/**/*'],
 } satisfies TSConfigArgs)

--- a/tsconfig.check.json
+++ b/tsconfig.check.json
@@ -10,31 +10,10 @@
       "path": "./context/opentui"
     },
     {
-      "path": "./packages/@overeng/agent-session-ingest"
-    },
-    {
       "path": "./packages/@overeng/buck2-tools"
     },
     {
-      "path": "./packages/@overeng/ci-tools"
-    },
-    {
-      "path": "./packages/@overeng/effect-ai-claude-cli"
-    },
-    {
-      "path": "./packages/@overeng/effect-path"
-    },
-    {
-      "path": "./packages/@overeng/effect-react"
-    },
-    {
-      "path": "./packages/@overeng/effect-rpc-tanstack"
-    },
-    {
       "path": "./packages/@overeng/effect-rpc-tanstack/examples/basic"
-    },
-    {
-      "path": "./packages/@overeng/effect-schema-form"
     },
     {
       "path": "./packages/@overeng/effect-schema-form-aria"
@@ -43,31 +22,13 @@
       "path": "./packages/@overeng/genie"
     },
     {
-      "path": "./packages/@overeng/kdl"
-    },
-    {
       "path": "./packages/@overeng/kdl-effect"
     },
     {
       "path": "./packages/@overeng/megarepo"
     },
     {
-      "path": "./packages/@overeng/npm-release"
-    },
-    {
-      "path": "./packages/@overeng/oxc-config"
-    },
-    {
-      "path": "./packages/@overeng/pty-effect"
-    },
-    {
-      "path": "./packages/@overeng/react-inspector"
-    },
-    {
       "path": "./packages/@overeng/react-inspector/tsconfig.strict-consumer.json"
-    },
-    {
-      "path": "./packages/@overeng/restate-effect"
     },
     {
       "path": "./packages/@overeng/tui-stories"

--- a/tsconfig.emit.json
+++ b/tsconfig.emit.json
@@ -10,31 +10,10 @@
       "path": "./context/opentui"
     },
     {
-      "path": "./packages/@overeng/agent-session-ingest"
-    },
-    {
       "path": "./packages/@overeng/buck2-tools"
     },
     {
-      "path": "./packages/@overeng/ci-tools"
-    },
-    {
-      "path": "./packages/@overeng/effect-ai-claude-cli"
-    },
-    {
-      "path": "./packages/@overeng/effect-path"
-    },
-    {
-      "path": "./packages/@overeng/effect-react"
-    },
-    {
-      "path": "./packages/@overeng/effect-rpc-tanstack"
-    },
-    {
       "path": "./packages/@overeng/effect-rpc-tanstack/examples/basic"
-    },
-    {
-      "path": "./packages/@overeng/effect-schema-form"
     },
     {
       "path": "./packages/@overeng/effect-schema-form-aria"
@@ -43,31 +22,13 @@
       "path": "./packages/@overeng/genie"
     },
     {
-      "path": "./packages/@overeng/kdl"
-    },
-    {
       "path": "./packages/@overeng/kdl-effect"
     },
     {
       "path": "./packages/@overeng/megarepo"
     },
     {
-      "path": "./packages/@overeng/npm-release"
-    },
-    {
-      "path": "./packages/@overeng/oxc-config"
-    },
-    {
-      "path": "./packages/@overeng/pty-effect"
-    },
-    {
-      "path": "./packages/@overeng/react-inspector"
-    },
-    {
       "path": "./packages/@overeng/react-inspector/tsconfig.strict-consumer.json"
-    },
-    {
-      "path": "./packages/@overeng/restate-effect"
     },
     {
       "path": "./packages/@overeng/tui-stories"


### PR DESCRIPTION
## Problem

Phase 3 TypeScript widening still dual-produces independent library packages in the root `tsconfig.check.json` / `tsconfig.emit.json` solutions. After notion-top (#1209) those solutions still listed 23 project refs. That keeps Buck and tsc as competing producers for packages that have no remaining intra-repo TypeScript dependents in the root solutions.

## Goal

Transfer typecheck and declaration authority for the remaining independent library packages to Buck. Each admitted package leaves both root TypeScript solutions. Public type conditions consume Buck declarations; runtime defaults stay at source.

## Decisions

Admitted in this layer: effect-path, kdl, oxc-config, npm-release, effect-ai-claude-cli, agent-session-ingest, effect-react, effect-rpc-tanstack, pty-effect, restate-effect, ci-tools, effect-schema-form, react-inspector.

Left out, with cause:

- **genie** — import cycle between the admissions registry and the generator.
- **buck2-tools** — the root `BUCK` still sources `package-tree.ts` / `typescript-runner.ts` from that package; a nested `BUCK` steals those files.
- **effect-rpc-tanstack/examples/basic** — route file `users.$id.tsx` fails the package-source safety alphabet.
- **context/effect/socket, context/opentui** — example trees, already `noEmit`; `:dist` tried to write `tsbuildinfo` into a read-only package tree.

Leftover project references on still-dual packages (kdl-effect, effect-schema-form-aria, megarepo) were deleted so oxlint type-aware checking against `tsconfig.check.json` does not pull admitted packages back into the solution.

The admissions unit test now compares authority entries sorted by package path. Registry order and workspace-package order are independent; the previous `toEqual` only passed while the two lists happened to agree.

## Verification

- `devenv tasks run genie:run` succeeded.
- `devenv tasks run lint:fix:oxlint` succeeded (0 warnings, 0 errors) after leftover project refs were removed.
- `devenv tasks run lint:fix:format` succeeded.
- `devenv tasks run genie:buck2:test` — 25 pass / 0 fail.
- `buck2:typescript:materialize-dist` reached BUILD SUCCEEDED (47 local actions) once.

`devenv tasks run check:quick` did not complete after that success: Watchman hit a non-recoverable inotify poison, then a retry spent ~25 minutes on `pnpm_importer` for notion-cli and was cancelled. This PR stays draft until `check:quick` is green.

## Complexity

No new abstraction. Same admission + projection + dist-overlay path as notion-base/top. The test sort is the only behavior change in shared genie code.

## Concerns

Root check/emit still contain 9 refs after this layer (buck2-tools, the tanstack example, two context trees, schema-form-aria, genie, kdl-effect, megarepo, react-inspector strict-consumer, tui-stories). Dual production remains until those layers land.

## Friction & bottlenecks

- Watchman poison: `fs.inotify.max_user_watches` exhausted while walking composed `buck-out` `node_modules` trees. Dist BUILD SUCCEEDED, then the follow-up Buck command died non-recoverable. Logged as agent feedback (area: buck2, kind: friction).
- `pnpm_importer` for an already-admitted notion-cli target ran for tens of minutes after a Watchman fresh-instance graph clear.

## Follow-ups

- Re-run `check:quick` after Watchman is healthy; then flip this PR ready.
- PR2: kdl-effect and effect-schema-form-aria.
- PR3: megarepo (after genie cycle is broken).
- PR4: tui-stories.
- genie, buck2-tools, tanstack example, context trees: separate unblocks.

## References

Stacked on #1209.

<!-- agent-footer:begin v=2 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | dev3.direct.omp.n7e947vb |
| `session` | dev3.n7e947vb |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.1.2 |
| `agent_runtime` | OMP 18.1.2 |
| `tooling_profile` | dotfiles@7534055 |
</details>
<!-- agent-footer:end -->