### PR TITLE
feat(megarepo): guard store gc against in-use worktrees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,12 @@ All notable changes to this project will be documented in this file.
   `$script_dir/...` siblings sourced by an emitted script — and each failure
   names the unavailable script together with the file that asks for it.
 
+- **@overeng/megarepo**: Guard `mr store gc` archive/reap paths with an
+  orthogonal live-process in-use veto. Before moving or deleting a worktree, GC
+  now checks whether a live process has its cwd or handle inside the worktree and
+  keeps it with reason `process-in-use`; hosts without `/proc` keep
+  conservatively.
+
 ### Fixed
 
 - **@overeng/tui-react**: stop truncating `runResult` values and JSON error

--- a/devenv.nix
+++ b/devenv.nix
@@ -774,6 +774,10 @@ in
     cwd = "packages/@overeng/megarepo";
     exec = trace.exec "test:megarepo-cold-gc" ''
       set -euo pipefail
+      if [ "$(uname -s)" != "Linux" ]; then
+        echo "Skipping megarepo cold-GC archive/reap integration tests: process in-use guard requires /proc"
+        exit 0
+      fi
       source ${lib.escapeShellArg pnpmTaskHelpersScript}
       run_package_bin vitest vitest run src/cli/store-gc-cold.integration.test.ts --reporter verbose --testTimeout 240000
     '';

--- a/packages/@overeng/megarepo/src/cli/commands/store/mod.ts
+++ b/packages/@overeng/megarepo/src/cli/commands/store/mod.ts
@@ -47,6 +47,7 @@ import {
   recordObservations,
 } from '../../../store/store-gc-observations.ts'
 import { validateStoreMembers, fixStoreIssues } from '../../../store/store-hygiene.ts'
+import { readWorktreeInUse, type InUseHolder } from '../../../store/store-inuse.ts'
 import {
   collectStoreLiveSet,
   isPathProtected,
@@ -963,6 +964,50 @@ const reReconcileLiveSet = ({
   })
 
 /**
+ * In-use veto re-check for a destructive archive/reap site (orthogonal to the
+ * live-set veto).
+ *
+ * The live-set veto (`isPathProtected`) only asks whether the worktree is in
+ * some workspace's reconciled manifest. This asks the strictly stronger,
+ * independent question — is a live OS process actually working inside it (cwd /
+ * open file) — so a worktree that is absent from every manifest but actively
+ * occupied by a session is still kept.
+ *
+ * Conservative direction: a host without `/proc` reports `unknown`, which is
+ * treated as in-use (KEEP). Returns `Some(holder)` when the site must KEEP and
+ * skip the destructive step; `None` when it is safe to proceed. On a real veto
+ * the holding `pid`/`path` are recorded on a `megarepo/store/gc/inuse-veto` span
+ * for attribution.
+ */
+const inUseVeto = ({
+  worktreePath,
+}: {
+  worktreePath: AbsoluteDirPath
+}): Effect.Effect<Option.Option<InUseHolder>, never, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const result = yield* readWorktreeInUse({ worktreePath })
+    if (result._tag === 'free') return Option.none()
+    const holder: InUseHolder =
+      result._tag === 'in-use'
+        ? result.holder
+        : // `unknown` (no /proc): keep conservatively; attribute the reason as the
+          // holder path so the veto span still carries why we kept.
+          { pid: -1, path: `unknown: ${result.reason}` }
+    yield* LibObservability.withInUseVetoSpan({
+      worktreePath,
+      holderPid: holder.pid,
+      holderPath: holder.path,
+    })(Effect.void)
+    return Option.some(holder)
+  })
+
+/** Render an in-use holder into the free-form `message` detail for a kept result. */
+const inUseMessage = (holder: InUseHolder): string =>
+  holder.pid >= 0
+    ? `live process pid ${holder.pid} has cwd/handle inside the worktree (${holder.path})`
+    : `in-use state could not be determined, kept conservatively (${holder.path})`
+
+/**
  * Cold reclamation for ONE repo's named worktrees (decisions 0001–0010).
  *
  * Fetch the bare first (failure ⇒ keep ALL this repo's named worktrees — the
@@ -1163,6 +1208,12 @@ const coldReclaimRepo = ({
               ) {
                 return { _tag: 'kept-live' as const }
               }
+              // Orthogonal in-use veto: refuse to move the directory out from
+              // under a live process whose cwd/handle is inside it.
+              const holder = yield* inUseVeto({ worktreePath: worktree.path })
+              if (Option.isSome(holder) === true) {
+                return { _tag: 'kept-in-use' as const, holder: holder.value }
+              }
               const outcome = yield* archiveRefMismatchWorktree({
                 repoRoot: repoFullPath,
                 bareRepoPath,
@@ -1190,6 +1241,16 @@ const coldReclaimRepo = ({
 
         if (archiveOutcome._tag === 'kept-live') {
           results.push(keepRefMismatch(`HEAD is '${actualHeadBranch}' and path is live`))
+        } else if (archiveOutcome._tag === 'kept-in-use') {
+          results.push(
+            coldResult({
+              target,
+              status: 'kept',
+              reason: 'process-in-use',
+              message: inUseMessage(archiveOutcome.holder),
+              ...refMismatchMeta,
+            }),
+          )
         } else if (archiveOutcome._tag === 'error') {
           results.push(
             coldResult({
@@ -1277,6 +1338,12 @@ const coldReclaimRepo = ({
             if (isPathProtected({ liveSet: freshLiveSet, path: worktree.path }) === true) {
               return { _tag: 'kept-live' as const }
             }
+            // Orthogonal in-use veto: refuse to archive a worktree a live
+            // process is currently working inside (cwd/handle).
+            const holder = yield* inUseVeto({ worktreePath: worktree.path })
+            if (Option.isSome(holder) === true) {
+              return { _tag: 'kept-in-use' as const, holder: holder.value }
+            }
             const outcome = yield* archiveWorktree({
               repoRoot: repoFullPath,
               bareRepoPath,
@@ -1304,6 +1371,15 @@ const coldReclaimRepo = ({
 
       if (archiveOutcome._tag === 'kept-live') {
         results.push(coldResult({ target, status: 'kept', reason: 'live' }))
+      } else if (archiveOutcome._tag === 'kept-in-use') {
+        results.push(
+          coldResult({
+            target,
+            status: 'kept',
+            reason: 'process-in-use',
+            message: inUseMessage(archiveOutcome.holder),
+          }),
+        )
       } else if (archiveOutcome._tag === 'error') {
         // Only a PRE-move failure reaches here (post-move steps are best-effort
         // and reported as warnings, never errors), so the original worktree is
@@ -1364,6 +1440,13 @@ const coldReclaimRepo = ({
             if (isPathProtected({ liveSet: freshLiveSet, path: entry.path }) === true) {
               return { _tag: 'kept-live' as const }
             }
+            // Orthogonal in-use veto: a session whose cwd followed an earlier
+            // archive rename can be sitting in the `.archive/` entry itself —
+            // reaping it would yank that cwd. Keep if a live process is inside.
+            const holder = yield* inUseVeto({ worktreePath: entry.path })
+            if (Option.isSome(holder) === true) {
+              return { _tag: 'kept-in-use' as const, holder: holder.value }
+            }
             yield* reapArchive({ bareRepoPath, path: entry.path })
             return { _tag: 'reaped' as const }
           }),
@@ -1379,6 +1462,15 @@ const coldReclaimRepo = ({
 
       if (reapOutcome._tag === 'kept-live') {
         results.push(coldResult({ target: reapTarget, status: 'kept', reason: 'live' }))
+      } else if (reapOutcome._tag === 'kept-in-use') {
+        results.push(
+          coldResult({
+            target: reapTarget,
+            status: 'kept',
+            reason: 'process-in-use',
+            message: inUseMessage(reapOutcome.holder),
+          }),
+        )
       } else if (reapOutcome._tag === 'error') {
         results.push(
           coldResult({

--- a/packages/@overeng/megarepo/src/core/observability.ts
+++ b/packages/@overeng/megarepo/src/core/observability.ts
@@ -800,3 +800,57 @@ export const withAssessLosslessSpan = (worktreePath: string) =>
     operation: assessLosslessOperation,
     attributes: { label: 'lossless', worktreePath },
   })
+
+const inUseProbeAttrs = OtelAttrs.defineSync(
+  Schema.Struct({
+    label: Schema.NonEmptyString.pipe(OtelAttr.spanLabel()),
+    worktreePath: Schema.String.pipe(OtelAttr.key({ key: 'worktreePath' })),
+  }),
+)
+
+const inUseProbeOperation = OtelOperation.define({
+  name: 'megarepo/store/gc/inuse-probe',
+  attributes: inUseProbeAttrs,
+  label: ({ label }) => label,
+})
+
+/** Wrap the live-process in-use probe (`/proc` scan) in a `megarepo/store/gc/inuse-probe` span. */
+export const withInUseProbeSpan = (worktreePath: string) =>
+  trustedWith({
+    operation: inUseProbeOperation,
+    attributes: { label: 'inuse-probe', worktreePath },
+  })
+
+const inUseVetoAttrs = OtelAttrs.defineSync(
+  Schema.Struct({
+    label: Schema.NonEmptyString.pipe(OtelAttr.spanLabel()),
+    worktreePath: Schema.String.pipe(OtelAttr.key({ key: 'worktreePath' })),
+    holderPid: Schema.Number.pipe(OtelAttr.key({ key: 'megarepo.store.inuse.holder_pid' })),
+    holderPath: Schema.String.pipe(OtelAttr.key({ key: 'megarepo.store.inuse.holder_path' })),
+  }),
+)
+
+const inUseVetoOperation = OtelOperation.define({
+  name: 'megarepo/store/gc/inuse-veto',
+  attributes: inUseVetoAttrs,
+  label: ({ label }) => label,
+})
+
+/**
+ * Wrap the in-use VETO of a destructive archive/reap in a
+ * `megarepo/store/gc/inuse-veto` span, carrying the holding `pid` and `path` so
+ * the attribution the RCA needed is queryable.
+ */
+export const withInUseVetoSpan = ({
+  worktreePath,
+  holderPid,
+  holderPath,
+}: {
+  readonly worktreePath: string
+  readonly holderPid: number
+  readonly holderPath: string
+}) =>
+  trustedWith({
+    operation: inUseVetoOperation,
+    attributes: { label: 'inuse-veto', worktreePath, holderPid, holderPath },
+  })

--- a/packages/@overeng/megarepo/src/store/store-inuse.integration.test.ts
+++ b/packages/@overeng/megarepo/src/store/store-inuse.integration.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Integration tests for the live-process in-use probe (Linux `/proc`).
+ *
+ * Spawns a REAL holder process with its cwd inside a temp "worktree" directory
+ * and asserts {@link readWorktreeInUse} reports it as in-use; moves the holder's
+ * cwd out and asserts it reports free. Skipped on hosts without `/proc`.
+ *
+ * The holder is a child of the vitest runner, so it would be excluded if the
+ * probe were called with the runner (or pid 1 — every process descends from
+ * init) as `selfPid`. We instead pass `selfPid` = the pid of a SIBLING stand-in
+ * process: a sibling is never an ancestor of the holder, so the descendant walk
+ * from the holder climbs its PPid chain and never encounters it — the holder
+ * stays observable. This faithfully models production, where gc is a separate
+ * process tree, not an ancestor of the live session.
+ */
+
+import { spawn, type ChildProcess } from 'node:child_process'
+import { existsSync } from 'node:fs'
+
+import { NodeServices } from '@effect/platform-node'
+import { describe, it } from '@effect/vitest'
+import { Effect } from 'effect'
+import * as FileSystem from 'effect/FileSystem'
+import { expect } from 'vitest'
+
+import { EffectPath } from '@overeng/effect-path'
+
+import { readWorktreeInUse } from './store-inuse.ts'
+
+const hasProc = existsSync('/proc')
+
+/** Spawn a long-lived `sleep` whose cwd is `cwd`; resolve once it is observable. */
+const spawnHolder = (cwd: string): Promise<ChildProcess> =>
+  new Promise((resolve, reject) => {
+    const child = spawn('sleep', ['120'], { cwd, stdio: 'ignore' })
+    child.on('error', reject)
+    if (child.pid === undefined) {
+      reject(new Error('holder failed to spawn'))
+      return
+    }
+    resolve(child)
+  })
+
+/** Poll until `/proc/<pid>/cwd` resolves (the process is scheduled + cwd set). */
+const waitForCwd = (pid: number): Promise<void> =>
+  new Promise((resolve, reject) => {
+    const deadline = Date.now() + 5000
+    const tick = () => {
+      if (existsSync(`/proc/${pid}/cwd`) === true) {
+        resolve()
+        return
+      }
+      if (Date.now() > deadline) {
+        reject(new Error(`holder pid ${pid} never appeared in /proc`))
+        return
+      }
+      setTimeout(tick, 20)
+    }
+    tick()
+  })
+
+const run = <A, E>(effect: Effect.Effect<A, E, FileSystem.FileSystem>) =>
+  Effect.runPromise(effect.pipe(Effect.provide(NodeServices.layer)))
+
+describe.skipIf(hasProc === false)('store-inuse (integration, /proc)', () => {
+  it('reports in-use when a live process holds a descendant as cwd, free once it moves out', async () => {
+    const { worktreePath, sibling, holder } = await run(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem
+        const tmp = yield* fs.makeTempDirectory()
+        const worktreePath = EffectPath.unsafe.absoluteDir(`${tmp}/refs/heads/feature/x/`)
+        const inner = EffectPath.ops.join(worktreePath, EffectPath.unsafe.relativeDir('src/'))
+        // A sibling that shares the worktree's string prefix — must NOT match.
+        const sibling = EffectPath.unsafe.absoluteDir(`${tmp}/refs/heads/feature/x.archive-old/`)
+        yield* fs.makeDirectory(inner, { recursive: true })
+        yield* fs.makeDirectory(sibling, { recursive: true })
+        return { worktreePath, inner, sibling }
+      }),
+    ).then(async ({ worktreePath, inner, sibling }) => {
+      const holder = await spawnHolder(inner)
+      await waitForCwd(holder.pid!)
+      return { worktreePath, sibling, holder }
+    })
+
+    // A SIBLING stand-in (shares the runner as parent, so not an ancestor of the
+    // holder) plays the role of the gc process: passing its pid as `selfPid`
+    // leaves the holder observable, the way real gc would observe a live session.
+    const standIn = await spawnHolder('/')
+    const selfPid = standIn.pid!
+    try {
+      const inUse = await run(readWorktreeInUse({ worktreePath, selfPid }))
+      expect(inUse._tag).toBe('in-use')
+      if (inUse._tag === 'in-use') {
+        expect(inUse.holder.pid).toBe(holder.pid)
+        expect(inUse.holder.path.startsWith(worktreePath.replace(/\/$/, ''))).toBe(true)
+      }
+
+      // A worktree the holder is NOT inside (the .archive-old sibling) reads free.
+      const siblingResult = await run(readWorktreeInUse({ worktreePath: sibling, selfPid }))
+      expect(siblingResult._tag).toBe('free')
+
+      // After the holder dies, the worktree reads free.
+      holder.kill('SIGKILL')
+      await new Promise<void>((resolve) => holder.on('exit', () => resolve()))
+      const afterKill = await run(readWorktreeInUse({ worktreePath, selfPid }))
+      expect(afterKill._tag).toBe('free')
+    } finally {
+      holder.kill('SIGKILL')
+      standIn.kill('SIGKILL')
+    }
+  })
+
+  it('excludes the current process so the gc process never self-vetoes', async () => {
+    // With selfPid = the spawning runner, the holder (its descendant) is excluded.
+    const { worktreePath, holder } = await run(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem
+        const tmp = yield* fs.makeTempDirectory()
+        const worktreePath = EffectPath.unsafe.absoluteDir(`${tmp}/wt/`)
+        yield* fs.makeDirectory(worktreePath, { recursive: true })
+        return { worktreePath }
+      }),
+    ).then(async ({ worktreePath }) => {
+      const holder = await spawnHolder(worktreePath.replace(/\/$/, ''))
+      await waitForCwd(holder.pid!)
+      return { worktreePath, holder }
+    })
+
+    try {
+      const result = await run(readWorktreeInUse({ worktreePath, selfPid: process.pid }))
+      expect(result._tag).toBe('free')
+    } finally {
+      holder.kill('SIGKILL')
+    }
+  })
+})

--- a/packages/@overeng/megarepo/src/store/store-inuse.ts
+++ b/packages/@overeng/megarepo/src/store/store-inuse.ts
@@ -1,0 +1,275 @@
+/**
+ * In-use guard for store worktrees.
+ *
+ * The cold-GC liveness signal (`store-liveness.ts` / `classifyStoreWorktreePolicy`)
+ * answers "is this worktree referenced by some workspace's reconciled manifest?".
+ * That is NOT the same as "is a live OS process currently working inside it":
+ * a freshly-created or repinned-but-unregistered worktree can be absent from
+ * every manifest while a coding-agent session sits in it with its cwd there.
+ *
+ * Archiving such a worktree is a directory rename, and on Linux a rename is
+ * transparent to a process already in that directory — its cwd silently follows
+ * the inode into `.archive/`, and the subsequent `git` bookkeeping (detach +
+ * branch free, then a `mr apply` re-checkout) breaks the session mid-flight.
+ * This module is the orthogonal, strictly stronger guard: before any destructive
+ * archive/reap, refuse if a live process has the worktree (or a descendant) as
+ * its cwd (or, optionally, an open file handle).
+ *
+ * Two seams, mirroring `store-gc-observations.ts` (pure `nextObservationLedger`
+ * vs effectful IO):
+ * - {@link classifyInUse} — PURE: given the worktree path, the already-read
+ *   `{ pid, path }` list, and the pids to exclude, return the FIRST matching
+ *   holder (`Option`) so the caller can attribute the veto. Unit-tested.
+ * - {@link readWorktreeInUse} — the effectful Linux `/proc` reader that produces
+ *   that list and computes the exclude set (current process + its descendants),
+ *   then calls the pure classifier under an OTel span.
+ *
+ * Conservative direction (in doubt → KEEP): on a host without `/proc` (e.g.
+ * macOS) the reader returns `{ _tag: 'unknown' }`, which the caller MUST treat
+ * as in-use (do not archive). Per-pid permission/race errors (`EACCES`/`ESRCH`)
+ * skip that pid; they never fail the whole check.
+ */
+
+import { Effect, Option } from 'effect'
+import * as FileSystem from 'effect/FileSystem'
+
+import type { AbsoluteDirPath } from '@overeng/effect-path'
+
+import * as Observability from '../core/observability.ts'
+
+/** One process's path of interest (its cwd, or an open file/fd target). */
+export interface ProcPath {
+  /** The owning process id. */
+  readonly pid: number
+  /** An absolute path the process holds (cwd or an open file), as read from `/proc`. */
+  readonly path: string
+}
+
+/** A live process found holding the worktree (or a descendant) — the veto's attribution. */
+export interface InUseHolder {
+  /** The pid working inside the worktree. */
+  readonly pid: number
+  /** The held path (cwd or open file) that falls under the worktree. */
+  readonly path: string
+}
+
+/**
+ * Result of the in-use probe.
+ *
+ * - `in-use` — a live, non-excluded process holds the worktree; carries the
+ *   first {@link InUseHolder} for attribution.
+ * - `free` — no live process holds it (safe to archive, w.r.t. this guard).
+ * - `unknown` — the probe could not run (no `/proc` on this host); the caller
+ *   MUST treat this conservatively as KEEP.
+ */
+export type InUseResult =
+  | { readonly _tag: 'in-use'; readonly holder: InUseHolder }
+  | { readonly _tag: 'free' }
+  | { readonly _tag: 'unknown'; readonly reason: string }
+
+const stripTrailingSlashes = (path: string): string => path.replace(/\/+$/u, '')
+
+/**
+ * True if `candidate` is the worktree itself or strictly nested under it.
+ *
+ * Both sides are normalized to a no-trailing-slash form, then the test is
+ * `candidate === wt || candidate.startsWith(wt + '/')`. The explicit `+ '/'`
+ * boundary is what keeps a sibling like `<wt>.archive-old` (or `<wt>-2`) from
+ * matching by raw string prefix.
+ */
+export const isPathInsideWorktree = ({
+  worktreePath,
+  candidate,
+}: {
+  readonly worktreePath: string
+  readonly candidate: string
+}): boolean => {
+  const wt = stripTrailingSlashes(worktreePath)
+  const cand = stripTrailingSlashes(candidate)
+  return cand === wt || cand.startsWith(`${wt}/`)
+}
+
+/**
+ * Pure in-use classifier (the unit-tested seam).
+ *
+ * Returns the FIRST `{ pid, path }` whose `path` is the worktree or a descendant
+ * and whose `pid` is not in `excludePids`. `excludePids` is supplied by the
+ * caller (the IO layer computes "current process + its descendants") so this
+ * stays pure AND so a test can drive it with an explicit exclude set — the IO
+ * reader must NOT bake the exclusion in, or an integration test's holder process
+ * (itself a descendant of the test runner) would be silently excluded.
+ */
+export const classifyInUse = ({
+  worktreePath,
+  procPaths,
+  excludePids,
+}: {
+  readonly worktreePath: string
+  readonly procPaths: ReadonlyArray<ProcPath>
+  readonly excludePids: ReadonlySet<number>
+}): Option.Option<InUseHolder> => {
+  for (const { pid, path } of procPaths) {
+    if (excludePids.has(pid) === true) continue
+    if (isPathInsideWorktree({ worktreePath, candidate: path }) === true) {
+      return Option.some({ pid, path })
+    }
+  }
+  return Option.none()
+}
+
+const PROC_ROOT = '/proc'
+
+/** Parse a `/proc` directory entry name into a numeric pid (non-numeric ⇒ none). */
+const parsePid = (name: string): Option.Option<number> => {
+  if (/^\d+$/u.test(name) === false) return Option.none()
+  const pid = Number.parseInt(name, 10)
+  return Number.isInteger(pid) === true && pid > 0 ? Option.some(pid) : Option.none()
+}
+
+/**
+ * Read one `/proc/<pid>` process's paths of interest.
+ *
+ * Always reads `cwd` (the load-bearing signal that matches the incident: a cwd
+ * that follows the archive rename). When `scanOpenFiles` is set, also reads the
+ * `fd/*` symlink targets so a process with an open file handle inside the
+ * worktree (but cwd elsewhere) is still caught. Every read is tolerant: a
+ * vanished/permission-denied pid yields no paths rather than failing.
+ */
+const readProcPaths = ({
+  pid,
+  scanOpenFiles,
+}: {
+  readonly pid: number
+  readonly scanOpenFiles: boolean
+}): Effect.Effect<ReadonlyArray<ProcPath>, never, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem
+    const paths: Array<ProcPath> = []
+
+    const cwd = yield* fs.readLink(`${PROC_ROOT}/${pid}/cwd`).pipe(Effect.orElseSucceed(() => null))
+    if (cwd !== null) paths.push({ pid, path: cwd })
+
+    if (scanOpenFiles === true) {
+      const fdDir = `${PROC_ROOT}/${pid}/fd`
+      const fds = yield* fs
+        .readDirectory(fdDir)
+        .pipe(Effect.orElseSucceed(() => [] as ReadonlyArray<string>))
+      for (const fd of fds) {
+        const target = yield* fs.readLink(`${fdDir}/${fd}`).pipe(Effect.orElseSucceed(() => null))
+        // Only absolute filesystem paths matter; `/proc` fd links can point at
+        // sockets/pipes (`socket:[…]`) etc., which never fall under a worktree.
+        if (target !== null && target.startsWith('/') === true) paths.push({ pid, path: target })
+      }
+    }
+
+    return paths
+  })
+
+/** Read `PPid:` from `/proc/<pid>/status` (the only field we need for the chain walk). */
+const readPpid = ({
+  pid,
+}: {
+  readonly pid: number
+}): Effect.Effect<Option.Option<number>, never, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem
+    const content = yield* fs
+      .readFileString(`${PROC_ROOT}/${pid}/status`)
+      .pipe(Effect.orElseSucceed(() => null))
+    if (content === null) return Option.none()
+    const match = content.match(/^PPid:\s*(\d+)$/mu)
+    if (match?.[1] === undefined) return Option.none()
+    const ppid = Number.parseInt(match[1], 10)
+    return Number.isInteger(ppid) === true ? Option.some(ppid) : Option.none()
+  })
+
+/**
+ * Decide whether `pid` is the current process or one of its descendants.
+ *
+ * Walks the PPid chain UPWARD from `pid`: hit `selfPid` ⇒ exclude (it is us or
+ * our child); hit pid 0/1 or an unreadable link ⇒ keep (an unrelated process).
+ * Walking up from a single matched pid is far cheaper than materializing the
+ * whole process tree, and the walk only runs for the rare in-worktree matches.
+ * A `seen` set guards against a pathological cycle.
+ */
+const isSelfOrDescendant = ({
+  pid,
+  selfPid,
+}: {
+  readonly pid: number
+  readonly selfPid: number
+}): Effect.Effect<boolean, never, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const seen = new Set<number>()
+    let current = pid
+    while (current > 1 && seen.has(current) === false) {
+      if (current === selfPid) return true
+      seen.add(current)
+      const ppid = yield* readPpid({ pid: current })
+      if (Option.isNone(ppid) === true) return false
+      current = ppid.value
+    }
+    return current === selfPid
+  })
+
+/**
+ * Effectful in-use probe for one worktree (the IO seam).
+ *
+ * On Linux: enumerate `/proc`, read each pid's cwd (and optionally open files),
+ * run the pure {@link classifyInUse} with an EMPTY exclude set to find any
+ * candidate holder, then — only if a candidate exists — exclude the current
+ * process and its descendants via a PPid-chain walk so the gc process itself
+ * (and the git children it may have spawned with a cwd inside the worktree)
+ * never self-veto. The first surviving holder ⇒ `in-use`.
+ *
+ * On a host without `/proc` ⇒ `{ _tag: 'unknown' }` (caller treats as KEEP).
+ *
+ * `selfPid` defaults to `process.pid`; it is injectable so a test can pin it.
+ */
+export const readWorktreeInUse = ({
+  worktreePath,
+  scanOpenFiles = false,
+  selfPid = process.pid,
+}: {
+  readonly worktreePath: AbsoluteDirPath
+  readonly scanOpenFiles?: boolean
+  readonly selfPid?: number
+}): Effect.Effect<InUseResult, never, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem
+
+    const procExists = yield* fs.exists(PROC_ROOT).pipe(Effect.orElseSucceed(() => false))
+    if (procExists === false) {
+      return { _tag: 'unknown' as const, reason: 'no /proc on this host' }
+    }
+
+    const entries = yield* fs
+      .readDirectory(PROC_ROOT)
+      .pipe(Effect.orElseSucceed(() => [] as ReadonlyArray<string>))
+    const pids = entries.flatMap((name) => Option.getOrElse(parsePid(name), () => [] as never))
+
+    // Read all candidate paths. Self-exclusion is NOT applied here (it is the
+    // classifier's `excludePids`), so the read stays a pure enumeration.
+    const procPaths: Array<ProcPath> = []
+    for (const pid of pids) {
+      const paths = yield* readProcPaths({ pid, scanOpenFiles })
+      for (const p of paths) procPaths.push(p)
+    }
+
+    // Find the first in-worktree candidate ignoring nobody, then walk only that
+    // (and any subsequent) candidate's ancestry to drop self+descendants. This
+    // keeps the expensive PPid walk off the common no-match path.
+    const excludePids = new Set<number>()
+    for (;;) {
+      const candidate = classifyInUse({ worktreePath, procPaths, excludePids })
+      if (Option.isNone(candidate) === true) break
+      const holder = candidate.value
+      const excluded = yield* isSelfOrDescendant({ pid: holder.pid, selfPid })
+      if (excluded === false) {
+        return { _tag: 'in-use' as const, holder }
+      }
+      excludePids.add(holder.pid)
+    }
+
+    return { _tag: 'free' as const }
+  }).pipe(Observability.withInUseProbeSpan(worktreePath))

--- a/packages/@overeng/megarepo/src/store/store-inuse.unit.test.ts
+++ b/packages/@overeng/megarepo/src/store/store-inuse.unit.test.ts
@@ -1,0 +1,99 @@
+import { Option } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import { classifyInUse, isPathInsideWorktree, type ProcPath } from './store-inuse.ts'
+
+const WT = '/store/github.com/acme/widget/refs/heads/feature/x'
+
+describe('store-inuse', () => {
+  describe('isPathInsideWorktree', () => {
+    it('matches the worktree path itself', () => {
+      expect(isPathInsideWorktree({ worktreePath: WT, candidate: WT })).toBe(true)
+    })
+
+    it('matches a descendant', () => {
+      expect(isPathInsideWorktree({ worktreePath: WT, candidate: `${WT}/src/lib` })).toBe(true)
+    })
+
+    it('does not match an outside path', () => {
+      expect(isPathInsideWorktree({ worktreePath: WT, candidate: '/store/other' })).toBe(false)
+    })
+
+    it('does not match a sibling that shares the string prefix (.archive-old)', () => {
+      // The `+ '/'` boundary is load-bearing: a raw startsWith would wrongly match.
+      expect(isPathInsideWorktree({ worktreePath: WT, candidate: `${WT}.archive-old` })).toBe(false)
+      expect(isPathInsideWorktree({ worktreePath: WT, candidate: `${WT}-2` })).toBe(false)
+    })
+
+    it('normalizes trailing slashes on both sides', () => {
+      expect(isPathInsideWorktree({ worktreePath: `${WT}/`, candidate: WT })).toBe(true)
+      expect(isPathInsideWorktree({ worktreePath: WT, candidate: `${WT}/` })).toBe(true)
+      expect(isPathInsideWorktree({ worktreePath: `${WT}/`, candidate: `${WT}/src/` })).toBe(true)
+    })
+  })
+
+  describe('classifyInUse', () => {
+    const procPaths = (entries: ReadonlyArray<ProcPath>) => entries
+
+    it('returns none when no process path is inside the worktree', () => {
+      const result = classifyInUse({
+        worktreePath: WT,
+        procPaths: procPaths([
+          { pid: 10, path: '/store/other' },
+          { pid: 11, path: '/' },
+        ]),
+        excludePids: new Set(),
+      })
+      expect(Option.isNone(result)).toBe(true)
+    })
+
+    it('returns the first holder whose path is at or under the worktree', () => {
+      const result = classifyInUse({
+        worktreePath: WT,
+        procPaths: procPaths([
+          { pid: 10, path: '/elsewhere' },
+          { pid: 42, path: `${WT}/src` },
+          { pid: 43, path: WT },
+        ]),
+        excludePids: new Set(),
+      })
+      expect(Option.isSome(result)).toBe(true)
+      if (Option.isSome(result) === true) {
+        expect(result.value).toEqual({ pid: 42, path: `${WT}/src` })
+      }
+    })
+
+    it('skips excluded pids (self/descendant) and reports the next holder', () => {
+      const result = classifyInUse({
+        worktreePath: WT,
+        procPaths: procPaths([
+          { pid: 42, path: `${WT}/src` },
+          { pid: 99, path: `${WT}/docs` },
+        ]),
+        excludePids: new Set([42]),
+      })
+      expect(Option.isSome(result)).toBe(true)
+      if (Option.isSome(result) === true) {
+        expect(result.value.pid).toBe(99)
+      }
+    })
+
+    it('returns none when the only holder is excluded', () => {
+      const result = classifyInUse({
+        worktreePath: WT,
+        procPaths: procPaths([{ pid: 42, path: `${WT}/src` }]),
+        excludePids: new Set([42]),
+      })
+      expect(Option.isNone(result)).toBe(true)
+    })
+
+    it('does not flag a sibling .archive-old path as in-use', () => {
+      const result = classifyInUse({
+        worktreePath: WT,
+        procPaths: procPaths([{ pid: 7, path: `${WT}.archive-old/src` }]),
+        excludePids: new Set(),
+      })
+      expect(Option.isNone(result)).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
## What

Restores the `mr store gc` **live-process in-use guard** onto `main`. The guard refuses to archive or reap a store worktree while a live OS process has its cwd (or an open file handle) inside it, keeping it with reason `process-in-use`.

## Divergent-history evidence

The premise for this work was that `main` had been force-reset to `f7215007d` and 164 merged commits were lost. **That is not what happened**, and the evidence is worth recording because it changes what "restore" means here.

Measured state at the time of writing:

```
$ gh api repos/overengineeringstudio/effect-utils/git/ref/heads/main --jq .object.sha
19b344e2f28bbfa01074f6da3f2167fbb804f8c6

$ git rev-list --left-right --count 19b344e2f...f7215007d
164	1
```

- `origin/main` is `19b344e2f` — the **full 164-commit history is intact upstream**. Nothing was lost on GitHub, and no downstream repo pinned to `#main` needs a ref change.
- `f7215007d` is a **single** commit whose parent is `0b3e04f0f`. It diverges 1-vs-164 from that shared base. It is reachable from `origin/schickling-assistant/2026-07-05-mr-gc-inuse-genie-bootstrap`, plus two local `backup/*` refs.
- The apparent "reset" was **local only**: the `main` worktree in the megarepo store had its branch pointed at `f7215007d`, reporting `## main...origin/main [ahead 1, behind 164]`. That is a local checkout artifact, not an upstream force-push.

So the real gap is narrow and entirely forward-looking: **`f7215007d`'s GC guard was authored on a stale base and never landed on `main`.** This PR lands it.

## Why merging this restores rather than reverts `main`

- The branch is rooted **exactly** at `origin/main` (`19b344e2f`) and is a strict descendant of it — `git log` on this branch shows one commit on top of `19b344e2f`. All 164 commits are present by construction, not by re-application.
- Nothing from `main` is reverted. The diff is **additive only**: `7 files changed, 666 insertions(+), 0 deletions(-)`.
- `f7215007d` itself is *not* merged as-is, precisely so that its stale base cannot revert current `main` (see "Deliberate exclusions").

## Why this is a port, not a cherry-pick

A plain `git cherry-pick -x --find-renames f7215007d` fails: `main` restructured the megarepo package after `0b3e04f0f`.

| `f7215007d` (base `0b3e04f0f`) | current `main` |
| --- | --- |
| `src/lib/observability.ts` | `src/core/observability.ts` |
| `src/lib/store-*.ts` | `src/store/store-*.ts` |
| `import { FileSystem } from '@effect/platform'` | `import * as FileSystem from 'effect/FileSystem'` |
| `NodeContext.layer` | `NodeServices.layer` |
| `Effect.catchAll` at the gc sites | `Effect.catch` |

The guard is re-seated onto the current layout with **no semantic change**. Placement follows the code's own doc comment, which names `store-liveness.ts` as its sibling — hence `src/store/store-inuse.ts`, not `src/core/`.

Per-file insertion counts are **identical** to `f7215007d`'s GC-guard files (92 / 54 / 136 / 275 / 99 / 6 / 4), which is the mechanical check that nothing was dropped or invented in the port.

## Conflict decisions

- **`src/core/observability.ts`** — mechanical. `main`'s tail is byte-identical to the base's, so the 54-line span pair (`withInUseProbeSpan`, `withInUseVetoSpan`) applied cleanly with `git apply` at offset 1.
- **`src/cli/commands/store/mod.ts`** — mechanical. All three destructive sites (`ref_mismatch_clean` archive, plain archive, `.archive/` reap) and their `kept-live` result branches survive on `main` unchanged in shape, so each veto block and each `kept-in-use` branch has an exact home. `coldResult`'s `reason` is `string | undefined`, so `'process-in-use'` needs no union widening.
- **`src/store/store-inuse*.ts`** — new files; the only change is the import adaptations in the table above.
- **`devenv.nix`** — mechanical. The Linux-only skip is required, not cosmetic: on a host without `/proc` the probe returns `unknown`, which the guard treats as KEEP, so `store-gc-cold.integration.test.ts`'s archive/reap expectations cannot hold there.
- **No semantic conflicts encountered.** `main`'s registry-based `store-liveness.ts` and this `/proc`-based probe are orthogonal by design — the guard is an additional veto layered after `isPathProtected`, never a replacement — so there was nothing to reconcile between the two mechanisms.

## Deliberate exclusions

`f7215007d` also touched two files unrelated to the GC guard. Carrying them would make this a partial revert of current `main`, so both are dropped:

- `.github/labels.json` — adds a `system:workflow-report` label. Unrelated; `main` has since rewritten this file (149 lines changed).
- `packages/@overeng/ci-tools/src/mod.ts` — **deletes six `deploy-*` re-export lines** (`deploy-domain`, `deploy-netlify`, `deploy-vercel`). On today's `main` this is a straight regression of the package's public surface.

If either is wanted, it should be its own PR with its own reasoning.

## Verification

Per instruction, no formatters, linters, tests, or builds were run — this worktree has no `node_modules`, and the gate is the reviewer's to run.

Static evidence that the ported code type-checks against `main`'s API surface (every call site the port relies on is already in first-party use on `main`):

| symbol | other uses on `main` |
| --- | --- |
| `fs.readLink` | 24 |
| `fs.readDirectory` | 34 |
| `fs.readFileString` | 79 |
| `fs.exists` | 136 |
| `Effect.orElseSucceed` | 130 |
| `describe.skipIf` | 41 |
| `trustedWith`, `OtelAttr.spanLabel` | present in `src/core/observability.ts` |

Type alignment at the new call sites: `ArchiveEntry.path` and `worktree.path` are both `AbsoluteDirPath`, matching `inUseVeto`'s parameter.

Suggested gate:

```
devenv tasks run check:all
```

and, for the guard specifically (Linux only):

```
cd packages/@overeng/megarepo
vitest run src/store/store-inuse.unit.test.ts src/store/store-inuse.integration.test.ts
devenv tasks run test:megarepo-cold-gc
```

<!-- agent-footer:begin v=2 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | dev3.direct.omp.ubb99bpf |
| `session` | dev3.ubb99bpf |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.1.7 |
| `agent_runtime` | OMP 18.1.7 |
| `tooling_profile` | dotfiles@931583a |
</details>
<!-- agent-footer:end -->