### PR TITLE
fix(notion-cli): reuse generated write type aliases

### DIFF
--- a/packages/@overeng/notion-cli/src/codegen.ts
+++ b/packages/@overeng/notion-cli/src/codegen.ts
@@ -304,7 +304,7 @@ const sanitizeLiteralValue = (name: string): string => {
 const toSingleQuotedStringLiteral = (value: string): string => {
   const json = JSON.stringify(value)
   const inner = json.slice(1, -1)
-  return `'${inner.replace(/'/g, "\\'")}'`
+  return `'${inner.replaceAll('\\"', '"').replaceAll("'", "\\'")}'`
 }
 
 const sanitizeLineComment = (comment: string): string =>

--- a/packages/@overeng/notion-cli/src/codegen.ts
+++ b/packages/@overeng/notion-cli/src/codegen.ts
@@ -1031,7 +1031,7 @@ export function generateApiCode(opts: GenerateApiCodeOptions): string {
     lines.push(`/**`)
     lines.push(` * Create a new page in the ${dbInfo.name} database.`)
     lines.push(` */`)
-    lines.push(`export const create = (properties: typeof ${pascalName}PageWrite.Type) =>`)
+    lines.push(`export const create = (properties: ${pascalName}PageWrite) =>`)
     lines.push(`  NotionPages.create({`)
     lines.push(`    parent: { type: 'database_id', database_id: DATABASE_ID },`)
     lines.push(`    properties: encode${pascalName}Write(properties),`)
@@ -1046,13 +1046,11 @@ export function generateApiCode(opts: GenerateApiCodeOptions): string {
     lines.push(` */`)
     lines.push(`export const update = (`)
     lines.push(`  pageId: string,`)
-    lines.push(`  properties: Partial<typeof ${pascalName}PageWrite.Type>,`)
+    lines.push(`  properties: Partial<${pascalName}PageWrite>,`)
     lines.push(`) =>`)
     lines.push(`  NotionPages.update({`)
     lines.push(`    pageId,`)
-    lines.push(
-      `    properties: encode${pascalName}Write(properties as typeof ${pascalName}PageWrite.Type),`,
-    )
+    lines.push(`    properties: encode${pascalName}Write(properties as ${pascalName}PageWrite),`)
     lines.push(`  })`)
   }
 

--- a/packages/@overeng/notion-cli/src/codegen.unit.test.ts
+++ b/packages/@overeng/notion-cli/src/codegen.unit.test.ts
@@ -119,6 +119,33 @@ describe('codegen', () => {
       expect(code).toContain(`NotionDatabases.resolveQueryTarget({ databaseId: DATABASE_ID })`)
       expect(code).toContain(`dataSourceId: queryTarget.dataSourceId`)
     })
+
+    it('uses the exported write type alias instead of typeof', () => {
+      const dbInfo: DatabaseInfo = {
+        id: 'test-db-id',
+        name: 'Test Database',
+        url: 'https://notion.so/test-db',
+        properties: (
+          [{ id: 'title-prop', name: 'Name', type: 'title' }] satisfies Array<
+            Omit<PropertyInfo, 'schema'>
+          >
+        ).map(makeProperty),
+      }
+
+      const code = generateApiCode({
+        dbInfo,
+        schemaName: 'TestDatabase',
+        schemaFileName: 'test-database.gen.ts',
+        options: { includeWrite: true },
+      })
+
+      expect(code).not.toContain(`typeof TestDatabasePageWrite.Type`)
+      expect(code).toContain(`export const create = (properties: TestDatabasePageWrite) =>`)
+      expect(code).toContain(`  properties: Partial<TestDatabasePageWrite>,`)
+      expect(code).toContain(
+        `    properties: encodeTestDatabaseWrite(properties as TestDatabasePageWrite),`,
+      )
+    })
   })
 
   describe('generateSchemaCode', () => {

--- a/packages/@overeng/notion-cli/src/codegen.unit.test.ts
+++ b/packages/@overeng/notion-cli/src/codegen.unit.test.ts
@@ -484,6 +484,30 @@ describe('codegen', () => {
       `)
     })
 
+    it('emits valid single-quoted property descriptions without escaping double quotes', () => {
+      const dbInfo: DatabaseInfo = {
+        id: 'test-db-id',
+        name: 'Test',
+        url: 'https://notion.so/test',
+        properties: (
+          [
+            {
+              id: 'prop1',
+              name: 'Status',
+              type: 'select',
+              description: `He said "don't"; path C:\\tmp; line one\nline two; template \${value}`,
+            },
+          ] satisfies Array<Omit<PropertyInfo, 'schema'>>
+        ).map(makeProperty),
+      }
+
+      const code = generateSchemaCode({ dbInfo, schemaName: 'Test' })
+
+      expect(code).toContain(
+        `description: 'He said "don\\'t"; path C:\\\\tmp; line one\\nline two; template \${value}'`,
+      )
+    })
+
     it('should handle all property types with default transforms', () => {
       const propertyTypes: Array<{
         type: PropertyInfo['type']


### PR DESCRIPTION
## Summary

- emit generated API signatures with the existing `<Database>PageWrite` type alias
- remove redundant `typeof <Database>PageWrite.Type` references
- add a focused generator regression test

## Verification

- `devenv tasks run test:notion-cli`
- `devenv tasks run check:quick`
- standalone generator probe produced no `typeof ... .Type` API signatures
- `check:all` reached the unrelated existing `tui-react` stdout negative-control failure (`expected 1000000 to be less than 1000000`); 242/243 tui-react tests passed

Required by the strict-diagnostic closure tracked in schickling/megarepo-all#114.

<!-- agent-footer:begin v=2 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | dev3.direct.omp.3vjvwkb2 |
| `session` | dev3.3vjvwkb2 |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.1.7 |
| `agent_runtime` | OMP 18.1.7 |
| `tooling_profile` | dotfiles@931583a |
</details>
<!-- agent-footer:end -->