### PR TITLE
fix(effect-rpc-tanstack): preserve the full serialization contract in the client request-id wrapper

### DIFF
--- a/packages/@overeng/effect-rpc-tanstack/src/client.ts
+++ b/packages/@overeng/effect-rpc-tanstack/src/client.ts
@@ -84,13 +84,15 @@ const isRequestEncoded = (
 ): message is { readonly _tag: 'Request'; readonly id: unknown } =>
   typeof message === 'object' && message !== null && '_tag' in message && message._tag === 'Request'
 
+/**
+ * Wraps an `RpcSerialization` service so outgoing `Request` envelopes are
+ * checked against `validateRequestId`, while every other member of the service
+ * contract (`contentType`, `includesFraming`, `codecFor`, ...) is passed
+ * through unchanged.
+ */
 const withRequestIdPolicy = (serialization: SerializationService): SerializationService =>
-  // `RpcSerialization.of` exists only in the rc.111 sources, not the compiled
-  // package, so the wrapped plain object is asserted to the nominal Service
-  // shape; its members are checked against the parameter above.
-  ({
-    contentType: serialization.contentType,
-    includesFraming: serialization.includesFraming,
+  RpcSerialization.RpcSerialization.of({
+    ...serialization,
     makeUnsafe: () => {
       const parser = serialization.makeUnsafe()
       return {
@@ -103,7 +105,7 @@ const withRequestIdPolicy = (serialization: SerializationService): Serialization
         },
       }
     },
-  }) as unknown as SerializationService
+  })
 
 const requestIdPolicyLayer = (
   base: Layer.Layer<RpcSerialization.RpcSerialization, never, never>,


### PR DESCRIPTION
## Problem

`layerClient` wraps the `RpcSerialization` service to enforce the client
request-id policy. The wrapper rebuilt a fresh object literal with only
`contentType`, `includesFraming`, and `makeUnsafe`, then asserted it to the
service shape (`as unknown as SerializationService`), so any other member of
the service silently disappeared.

effect `4.0.0-rc.112` added `codecFor` to `RpcSerialization`, which the HTTP
RPC protocol calls. Every RPC through `layerClient` on rc.112 died:

```
TypeError: codecFor is not a function
```

Reproduced structurally against real rc.112 — the wrapped service versus the
base ndjson service:

```
base    keys ['codecFor', 'contentType', 'includesFraming', 'makeUnsafe']
before  keys ['contentType', 'includesFraming', 'makeUnsafe']   codecFor: undefined
after   keys ['codecFor', 'contentType', 'includesFraming', 'makeUnsafe']
```

## Goal

The request-id wrapper overrides `makeUnsafe` and nothing else, so the client
keeps working across serialization service shapes — rc.111 today, rc.112's
`codecFor`, and whatever members are added next.

## Decisions

- **Spread the base service instead of enumerating members.** Enumerating is
  what broke: it is a copy of the upstream contract that has to be updated by
  hand every time upstream grows a member. Spreading passes members through by
  reference, so `codecFor` is literally the same function as the base service's.
- **Build through `RpcSerialization.of` and drop the cast.** The old comment
  claimed `of` "exists only in the rc.111 sources, not the compiled package".
  That is wrong: `of` is on `Context.Service` in both rc.111 and rc.112 dist
  (`Context.d.ts` and `Context.js`). Using it type-checks the wrapper against
  the service shape instead of asserting past it, so a future required member
  becomes a compile error rather than a runtime `TypeError`.
- **No new exported test seam.** An earlier draft exported the private layer
  combinator so a unit test could read the wrapped service. The public
  regression surface is the existing custom-fetch transport test exercised by a
  first-party consumer on rc.112 (see Verification); widening the module's API
  for a unit test was not worth it.

## Verification

- `devenv tasks run check:quick` — passes on this branch.
- Downstream first-party consumer pinned to effect `4.0.0-rc.112`: focused
  suite **37/37 passing**, including a real end-to-end RPC round trip over the
  custom fetch transport (`layerClient`), which is exactly the path that threw
  `codecFor is not a function` before this change.
- Wrapper semantics checked directly against real rc.112:

```
before   codecFor: undefined                      → TypeError on first request
after    wrapped.codecFor === base.codecFor        → true
after    encode({_tag:'Request', id:'req-1'})      → identical to base parser
after    encode({_tag:'Request', id:''})           → throws InvalidRequestIdError
```

Request-id validation is unchanged; `src/client.test.ts` covers it and is
untouched by this PR.

## Complexity

No new complexity — the change removes a hand-maintained member list and a
`as unknown as` cast, and is net-simpler than what it replaces.

## Concerns

- Spreading passes members through by reference. That is the intent (identity
  for `codecFor`), but it means the wrapper cannot special-case a member it
  does not know about — if upstream ever adds a member that must be wrapped
  alongside `makeUnsafe` (e.g. a second parser factory), it needs an explicit
  override here. `RpcSerialization.of` at least makes shape changes visible at
  compile time.
- This repo's manifest still declares `4.0.0-rc.111`. The fix is
  shape-agnostic and correct on both, so it is not gated on the bump; the
  rc.112 proof comes from the downstream consumer.

## Friction & bottlenecks

- Friction: the misleading comment about `RpcSerialization.of` not existing in
  the compiled package is what led to the `as unknown as` cast, and the cast is
  what let the dropped member ship silently. A wrong comment plus a cast turned
  an upstream additive change into a runtime crash in a consumer.
- No bottlenecks; nothing measurable was hit.

## Follow-ups

- Bumping this repo's own effect pin to `4.0.0-rc.112` is out of scope here
  (manifests and locks untouched).

## References

None.

## Pre-flip note

The pre-flip gate was satisfied with `devenv tasks run check:quick` plus the
downstream rc.112 consumer suite (37/37) rather than a fresh
`devenv tasks run check:all` in this session — validation was run once by the
coordinating agent and deliberately not repeated. The diff is a single
9-line change in one TypeScript file with no manifest, lock, generated-file,
or Nix impact.

<!-- agent-footer:begin v=2 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | dev3.direct.omp.vg5pg2ne |
| `session` | dev3.vg5pg2ne |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.1.7 |
| `agent_runtime` | OMP 18.1.7 |
| `tooling_profile` | dotfiles@71f00da |
</details>
<!-- agent-footer:end -->