### PR TITLE
fix(notion-cli): emit type-only write imports

### DIFF
--- a/packages/@overeng/notion-cli/src/codegen.ts
+++ b/packages/@overeng/notion-cli/src/codegen.ts
@@ -952,6 +952,20 @@ export function generateApiCode(opts: GenerateApiCodeOptions): string {
           `  encode${pascalName}Write,`,
           `} from '${schemaImportPath}'`,
         ]
+  const pageType = `export type ${pascalName}Page = TypedPage<${pascalName}PageProperties>`
+  const pageTypeLines =
+    pageType.length <= generatedCodePrintWidth
+      ? [pageType]
+      : [`export type ${pascalName}Page =`, `  TypedPage<${pascalName}PageProperties>`]
+  const encodeCall = `    properties: encode${pascalName}Write(properties as ${pascalName}PageWrite),`
+  const encodeCallLines =
+    encodeCall.length <= generatedCodePrintWidth
+      ? [encodeCall]
+      : [
+          `    properties: encode${pascalName}Write(`,
+          `      properties as ${pascalName}PageWrite,`,
+          `    ),`,
+        ]
 
   // Build the config comment (same options as schema file, always includes includeApi: true)
   const configComment = generateConfigComment({
@@ -1033,7 +1047,7 @@ export function generateApiCode(opts: GenerateApiCodeOptions): string {
     `    schema: ${pascalName}PageProperties,`,
     `  })`,
     ``,
-    `export type ${pascalName}Page = TypedPage<${pascalName}PageProperties>`,
+    ...pageTypeLines,
   ]
 
   // Add create/update if write schema is enabled
@@ -1070,7 +1084,7 @@ export function generateApiCode(opts: GenerateApiCodeOptions): string {
     }
     lines.push(`  NotionPages.update({`)
     lines.push(`    pageId,`)
-    lines.push(`    properties: encode${pascalName}Write(properties as ${pascalName}PageWrite),`)
+    lines.push(...encodeCallLines)
     lines.push(`  })`)
   }
 

--- a/packages/@overeng/notion-cli/src/codegen.ts
+++ b/packages/@overeng/notion-cli/src/codegen.ts
@@ -961,7 +961,7 @@ export function generateApiCode(opts: GenerateApiCodeOptions): string {
     ``,
     `import { Effect, Stream } from 'effect'`,
     `import { NotionDatabases, NotionPages, type TypedPage } from '@overeng/notion-effect-client'`,
-    `import { ${pascalName}PageProperties${includeWrite === true ? `, ${pascalName}PageWrite, encode${pascalName}Write` : ''} } from '${schemaImportPath}'`,
+    `import { ${pascalName}PageProperties${includeWrite === true ? `, type ${pascalName}PageWrite, encode${pascalName}Write` : ''} } from '${schemaImportPath}'`,
     ``,
     `/** Database ID for ${dbInfo.name} */`,
     `const DATABASE_ID = '${dbInfo.id}'`,

--- a/packages/@overeng/notion-cli/src/codegen.ts
+++ b/packages/@overeng/notion-cli/src/codegen.ts
@@ -961,7 +961,15 @@ export function generateApiCode(opts: GenerateApiCodeOptions): string {
     ``,
     `import { Effect, Stream } from 'effect'`,
     `import { NotionDatabases, NotionPages, type TypedPage } from '@overeng/notion-effect-client'`,
-    `import { ${pascalName}PageProperties${includeWrite === true ? `, type ${pascalName}PageWrite, encode${pascalName}Write` : ''} } from '${schemaImportPath}'`,
+    ...(includeWrite === true
+      ? [
+          `import {`,
+          `  ${pascalName}PageProperties,`,
+          `  type ${pascalName}PageWrite,`,
+          `  encode${pascalName}Write,`,
+          `} from '${schemaImportPath}'`,
+        ]
+      : [`import { ${pascalName}PageProperties } from '${schemaImportPath}'`]),
     ``,
     `/** Database ID for ${dbInfo.name} */`,
     `const DATABASE_ID = '${dbInfo.id}'`,

--- a/packages/@overeng/notion-cli/src/codegen.ts
+++ b/packages/@overeng/notion-cli/src/codegen.ts
@@ -960,7 +960,9 @@ export function generateApiCode(opts: GenerateApiCodeOptions): string {
     ...(configComment !== '' ? [configComment] : []),
     ``,
     `import { Effect, Stream } from 'effect'`,
+    ``,
     `import { NotionDatabases, NotionPages, type TypedPage } from '@overeng/notion-effect-client'`,
+    ``,
     ...(includeWrite === true
       ? [
           `import {`,

--- a/packages/@overeng/notion-cli/src/codegen.ts
+++ b/packages/@overeng/notion-cli/src/codegen.ts
@@ -1012,8 +1012,7 @@ export function generateApiCode(opts: GenerateApiCodeOptions): string {
     `/**`,
     ` * Query pages and collect all results.`,
     ` */`,
-    `export const queryAll = (options?: QueryOptions) =>`,
-    `  query(options).pipe(Stream.runCollect)`,
+    `export const queryAll = (options?: QueryOptions) => query(options).pipe(Stream.runCollect)`,
     ``,
     `// -----------------------------------------------------------------------------`,
     `// Get`,
@@ -1054,10 +1053,9 @@ export function generateApiCode(opts: GenerateApiCodeOptions): string {
     lines.push(`/**`)
     lines.push(` * Update an existing page.`)
     lines.push(` */`)
-    lines.push(`export const update = (`)
-    lines.push(`  pageId: string,`)
-    lines.push(`  properties: Partial<${pascalName}PageWrite>,`)
-    lines.push(`) =>`)
+    lines.push(
+      `export const update = (pageId: string, properties: Partial<${pascalName}PageWrite>) =>`,
+    )
     lines.push(`  NotionPages.update({`)
     lines.push(`    pageId,`)
     lines.push(`    properties: encode${pascalName}Write(properties as ${pascalName}PageWrite),`)
@@ -1072,8 +1070,7 @@ export function generateApiCode(opts: GenerateApiCodeOptions): string {
   lines.push(`/**`)
   lines.push(` * Archive (soft-delete) a page.`)
   lines.push(` */`)
-  lines.push(`export const archive = (pageId: string) =>`)
-  lines.push(`  NotionPages.archive({ pageId })`)
+  lines.push(`export const archive = (pageId: string) => NotionPages.archive({ pageId })`)
   lines.push(``)
 
   return lines.join('\n')

--- a/packages/@overeng/notion-cli/src/codegen.ts
+++ b/packages/@overeng/notion-cli/src/codegen.ts
@@ -940,6 +940,18 @@ export function generateApiCode(opts: GenerateApiCodeOptions): string {
 
   const pascalName = toTopLevelIdentifier(schemaName)
   const schemaImportPath = `./${schemaFileName}`
+  const generatedCodePrintWidth = 100
+  const writeImport = `import { ${pascalName}PageProperties, type ${pascalName}PageWrite, encode${pascalName}Write } from '${schemaImportPath}'`
+  const writeImportLines =
+    writeImport.length <= generatedCodePrintWidth
+      ? [writeImport]
+      : [
+          `import {`,
+          `  ${pascalName}PageProperties,`,
+          `  type ${pascalName}PageWrite,`,
+          `  encode${pascalName}Write,`,
+          `} from '${schemaImportPath}'`,
+        ]
 
   // Build the config comment (same options as schema file, always includes includeApi: true)
   const configComment = generateConfigComment({
@@ -964,13 +976,7 @@ export function generateApiCode(opts: GenerateApiCodeOptions): string {
     `import { NotionDatabases, NotionPages, type TypedPage } from '@overeng/notion-effect-client'`,
     ``,
     ...(includeWrite === true
-      ? [
-          `import {`,
-          `  ${pascalName}PageProperties,`,
-          `  type ${pascalName}PageWrite,`,
-          `  encode${pascalName}Write,`,
-          `} from '${schemaImportPath}'`,
-        ]
+      ? writeImportLines
       : [`import { ${pascalName}PageProperties } from '${schemaImportPath}'`]),
     ``,
     `/** Database ID for ${dbInfo.name} */`,
@@ -1053,9 +1059,15 @@ export function generateApiCode(opts: GenerateApiCodeOptions): string {
     lines.push(`/**`)
     lines.push(` * Update an existing page.`)
     lines.push(` */`)
-    lines.push(
-      `export const update = (pageId: string, properties: Partial<${pascalName}PageWrite>) =>`,
-    )
+    const updateSignature = `export const update = (pageId: string, properties: Partial<${pascalName}PageWrite>) =>`
+    if (updateSignature.length <= generatedCodePrintWidth) {
+      lines.push(updateSignature)
+    } else {
+      lines.push(`export const update = (`)
+      lines.push(`  pageId: string,`)
+      lines.push(`  properties: Partial<${pascalName}PageWrite>,`)
+      lines.push(`) =>`)
+    }
     lines.push(`  NotionPages.update({`)
     lines.push(`    pageId,`)
     lines.push(`    properties: encode${pascalName}Write(properties as ${pascalName}PageWrite),`)

--- a/packages/@overeng/notion-cli/src/codegen.unit.test.ts
+++ b/packages/@overeng/notion-cli/src/codegen.unit.test.ts
@@ -141,7 +141,9 @@ describe('codegen', () => {
 
       expect(code).not.toContain(`typeof TestDatabasePageWrite.Type`)
       expect(code).toContain(`export const create = (properties: TestDatabasePageWrite) =>`)
-      expect(code).toContain(`  properties: Partial<TestDatabasePageWrite>,`)
+      expect(code).toContain(
+        `export const update = (pageId: string, properties: Partial<TestDatabasePageWrite>) =>`,
+      )
       expect(code).toContain(
         `    properties: encodeTestDatabaseWrite(properties as TestDatabasePageWrite),`,
       )
@@ -177,6 +179,15 @@ import {
   type PdfDocumentPageWrite,
   encodePdfDocumentWrite,
 } from './pdf-document.gen.ts'`)
+      expect(code).toContain(
+        `export const queryAll = (options?: QueryOptions) => query(options).pipe(Stream.runCollect)`,
+      )
+      expect(code).toContain(
+        `export const update = (pageId: string, properties: Partial<PdfDocumentPageWrite>) =>`,
+      )
+      expect(code).toContain(
+        `export const archive = (pageId: string) => NotionPages.archive({ pageId })`,
+      )
       // Schemas and encoders stay value imports.
       expect(code).toContain(`schema: PdfDocumentPageProperties,`)
       expect(code).toContain(`properties: encodePdfDocumentWrite(properties),`)

--- a/packages/@overeng/notion-cli/src/codegen.unit.test.ts
+++ b/packages/@overeng/notion-cli/src/codegen.unit.test.ts
@@ -146,6 +146,35 @@ describe('codegen', () => {
         `    properties: encodeTestDatabaseWrite(properties as TestDatabasePageWrite),`,
       )
     })
+
+    it('imports the write type with a type-only specifier', () => {
+      const dbInfo: DatabaseInfo = {
+        id: 'pdf-db-id',
+        name: 'PDF Document',
+        url: 'https://notion.so/pdf-document',
+        properties: (
+          [{ id: 'title-prop', name: 'Name', type: 'title' }] satisfies Array<
+            Omit<PropertyInfo, 'schema'>
+          >
+        ).map(makeProperty),
+      }
+
+      const code = generateApiCode({
+        dbInfo,
+        schemaName: 'PDF Document',
+        schemaFileName: 'pdf-document.gen.ts',
+        options: { includeWrite: true },
+      })
+
+      // `PdfDocumentPageWrite` only ever appears in type positions, so it must be
+      // imported with a `type` specifier (verbatimModuleSyntax / consistent-type-imports).
+      expect(code).toContain(
+        `import { PdfDocumentPageProperties, type PdfDocumentPageWrite, encodePdfDocumentWrite } from './pdf-document.gen.ts'`,
+      )
+      // Schemas and encoders stay value imports.
+      expect(code).toContain(`schema: PdfDocumentPageProperties,`)
+      expect(code).toContain(`properties: encodePdfDocumentWrite(properties),`)
+    })
   })
 
   describe('generateSchemaCode', () => {

--- a/packages/@overeng/notion-cli/src/codegen.unit.test.ts
+++ b/packages/@overeng/notion-cli/src/codegen.unit.test.ts
@@ -192,6 +192,39 @@ import {
       expect(code).toContain(`schema: PdfDocumentPageProperties,`)
       expect(code).toContain(`properties: encodePdfDocumentWrite(properties),`)
     })
+    it('selects generated layouts that match the shared 100-column print width', () => {
+      const dbInfo: DatabaseInfo = {
+        id: 'test-db-id',
+        name: 'Test',
+        url: 'https://notion.so/test',
+        properties: (
+          [{ id: 'title-prop', name: 'Name', type: 'title' }] satisfies Array<
+            Omit<PropertyInfo, 'schema'>
+          >
+        ).map(makeProperty),
+      }
+
+      const shortCode = generateApiCode({
+        dbInfo,
+        schemaName: 'Test',
+        schemaFileName: 'test.gen.ts',
+        options: { includeWrite: true },
+      })
+      const longCode = generateApiCode({
+        dbInfo,
+        schemaName: 'Engineering Onboarding Checklist',
+        schemaFileName: 'engineering-onboarding-checklist.gen.ts',
+        options: { includeWrite: true },
+      })
+
+      expect(shortCode).toContain(
+        `import { TestPageProperties, type TestPageWrite, encodeTestWrite } from './test.gen.ts'`,
+      )
+      expect(longCode).toContain(`export const update = (
+  pageId: string,
+  properties: Partial<EngineeringOnboardingChecklistPageWrite>,
+) =>`)
+    })
   })
 
   describe('generateSchemaCode', () => {

--- a/packages/@overeng/notion-cli/src/codegen.unit.test.ts
+++ b/packages/@overeng/notion-cli/src/codegen.unit.test.ts
@@ -224,6 +224,11 @@ import {
   pageId: string,
   properties: Partial<EngineeringOnboardingChecklistPageWrite>,
 ) =>`)
+      expect(longCode).toContain(`export type EngineeringOnboardingChecklistPage =
+  TypedPage<EngineeringOnboardingChecklistPageProperties>`)
+      expect(longCode).toContain(`    properties: encodeEngineeringOnboardingChecklistWrite(
+      properties as EngineeringOnboardingChecklistPageWrite,
+    ),`)
     })
   })
 

--- a/packages/@overeng/notion-cli/src/codegen.unit.test.ts
+++ b/packages/@overeng/notion-cli/src/codegen.unit.test.ts
@@ -168,7 +168,11 @@ describe('codegen', () => {
 
       // `PdfDocumentPageWrite` only ever appears in type positions, so it must be
       // imported with a `type` specifier (verbatimModuleSyntax / consistent-type-imports).
-      expect(code).toContain(`import {
+      expect(code).toContain(`import { Effect, Stream } from 'effect'
+
+import { NotionDatabases, NotionPages, type TypedPage } from '@overeng/notion-effect-client'
+
+import {
   PdfDocumentPageProperties,
   type PdfDocumentPageWrite,
   encodePdfDocumentWrite,

--- a/packages/@overeng/notion-cli/src/codegen.unit.test.ts
+++ b/packages/@overeng/notion-cli/src/codegen.unit.test.ts
@@ -168,9 +168,11 @@ describe('codegen', () => {
 
       // `PdfDocumentPageWrite` only ever appears in type positions, so it must be
       // imported with a `type` specifier (verbatimModuleSyntax / consistent-type-imports).
-      expect(code).toContain(
-        `import { PdfDocumentPageProperties, type PdfDocumentPageWrite, encodePdfDocumentWrite } from './pdf-document.gen.ts'`,
-      )
+      expect(code).toContain(`import {
+  PdfDocumentPageProperties,
+  type PdfDocumentPageWrite,
+  encodePdfDocumentWrite,
+} from './pdf-document.gen.ts'`)
       // Schemas and encoders stay value imports.
       expect(code).toContain(`schema: PdfDocumentPageProperties,`)
       expect(code).toContain(`properties: encodePdfDocumentWrite(properties),`)


### PR DESCRIPTION
## Problem

The Notion API generator imports generated `PageWrite` aliases as runtime values even though generated APIs use them only in type positions. Effect 4's strict `consistent-type-imports` rule therefore warns on regenerated consumers. The generated API also used fixed layouts that drifted when the consumer applied the shared 100-column formatter.

## Goal

Generated write APIs use a type-only import specifier for `PageWrite` while retaining the properties schema and encoder as runtime imports. Generated APIs must round-trip through the shared formatter for short, long, and current consumer schema names.

## Decisions

- Use an inline `type` specifier in the existing mixed import. A separate import would add output churn without changing the module contract.
- Select compact or wrapped output from the shared 100-column print width for name-dependent imports, page aliases, update signatures, and encode calls.

## Verification

- focused `codegen.unit.test.ts`: 28/28 passed
- `devenv tasks run check:quick`: passed at `c12b2046a`
- downstream dotfiles generation: generated `PdfDocument` API passes `oxfmt --check` without a post-generation rewrite
- downstream dotfiles `devenv tasks run check:quick`: passed at `c12b2046a`
- independent final review: short-name, long-name, and `PdfDocument` generated APIs round-trip through oxfmt; no findings
- `devenv tasks run check:all`: reached all relevant package builds and tests, then failed on existing repository gate defects also reproduced on `main` (`buck2:typescript:materialize-dist`, `buck2:check`, and generated-fixture ownership/parse checks)
- a forced fresh test-report run exposed one unrelated Restate scheduling flake; an immediate isolated `test:restate-effect` recheck passed

## Complexity

No new dependency. The generator uses one local print-width constant and explicit output layouts.

## Concerns

None. Generated runtime imports and API behavior are unchanged.

## Friction & bottlenecks

Full-gate evidence is noisy because cached package-test tasks can omit their Vitest JSON report artifacts, and fresh execution exposed an unrelated Restate scheduling flake. The same checkout also spends several minutes in Nix shell evaluation under current host contention. The report-cache defect was recorded in the Agent Feedback database.

## Follow-ups

Merge this PR before the dependent dotfiles migration PR replaces its temporary branch pin with the merged `main` revision.

## References

- Follow-up to #1216
- Tracked by schickling/megarepo-all#114
- Canonicalization context: schickling/megarepo-all#117

<!-- agent-footer:begin v=2 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | dev3.direct.omp.3vjvwkb2 |
| `session` | dev3.3vjvwkb2 |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.1.7 |
| `agent_runtime` | OMP 18.1.7 |
| `tooling_profile` | dotfiles@931583a |
</details>
<!-- agent-footer:end -->