### PR TITLE
fix(ci): retry devenv resolution and classify incomplete flake input caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -501,7 +501,9 @@ jobs:
           echo "Pinned devenv rev: $DEVENV_REV"
         shell: bash
       - name: Resolve devenv
-        run: 'cd "${EFFECT_UTILS_MEMBER_ROOT:-${GITHUB_WORKSPACE:-$PWD}}" && ''${{ runner.temp }}/composition-state/ci-runtime/resolve-devenv.sh'' ''devenv.lock'''
+        run: |
+          __genie_ci_retry_script='${{ runner.temp }}/composition-state/ci-runtime/run-with-nix-gc-race-retry.sh'
+          bash "$__genie_ci_retry_script" 'resolve devenv (devenv.lock)' 'cd "${EFFECT_UTILS_MEMBER_ROOT:-${GITHUB_WORKSPACE:-$PWD}}" && '"'"'${{ runner.temp }}/composition-state/ci-runtime/resolve-devenv.sh'"'"' '"'"'devenv.lock'"'"''
         shell: bash
       - name: Evict cached pnpm deps for oxlint-npm
         shell: bash
@@ -710,7 +712,9 @@ jobs:
           echo "Pinned devenv rev: $DEVENV_REV"
         shell: bash
       - name: Resolve devenv
-        run: 'cd "${EFFECT_UTILS_MEMBER_ROOT:-${GITHUB_WORKSPACE:-$PWD}}" && ''${{ runner.temp }}/composition-state/ci-runtime/resolve-devenv.sh'' ''devenv.lock'''
+        run: |
+          __genie_ci_retry_script='${{ runner.temp }}/composition-state/ci-runtime/run-with-nix-gc-race-retry.sh'
+          bash "$__genie_ci_retry_script" 'resolve devenv (devenv.lock)' 'cd "${EFFECT_UTILS_MEMBER_ROOT:-${GITHUB_WORKSPACE:-$PWD}}" && '"'"'${{ runner.temp }}/composition-state/ci-runtime/resolve-devenv.sh'"'"' '"'"'devenv.lock'"'"''
         shell: bash
       - name: Evict cached pnpm deps for oxlint-npm
         shell: bash
@@ -907,7 +911,9 @@ jobs:
           echo "Pinned devenv rev: $DEVENV_REV"
         shell: bash
       - name: Resolve devenv
-        run: 'cd "${EFFECT_UTILS_MEMBER_ROOT:-${GITHUB_WORKSPACE:-$PWD}}" && ''${{ runner.temp }}/composition-state/ci-runtime/resolve-devenv.sh'' ''devenv.lock'''
+        run: |
+          __genie_ci_retry_script='${{ runner.temp }}/composition-state/ci-runtime/run-with-nix-gc-race-retry.sh'
+          bash "$__genie_ci_retry_script" 'resolve devenv (devenv.lock)' 'cd "${EFFECT_UTILS_MEMBER_ROOT:-${GITHUB_WORKSPACE:-$PWD}}" && '"'"'${{ runner.temp }}/composition-state/ci-runtime/resolve-devenv.sh'"'"' '"'"'devenv.lock'"'"''
         shell: bash
       - name: Evict cached pnpm deps for oxlint-npm
         shell: bash
@@ -1101,7 +1107,9 @@ jobs:
           echo "Pinned devenv rev: $DEVENV_REV"
         shell: bash
       - name: Resolve devenv
-        run: 'cd "${EFFECT_UTILS_MEMBER_ROOT:-${GITHUB_WORKSPACE:-$PWD}}" && ''${{ runner.temp }}/composition-state/ci-runtime/resolve-devenv.sh'' ''devenv.lock'''
+        run: |
+          __genie_ci_retry_script='${{ runner.temp }}/composition-state/ci-runtime/run-with-nix-gc-race-retry.sh'
+          bash "$__genie_ci_retry_script" 'resolve devenv (devenv.lock)' 'cd "${EFFECT_UTILS_MEMBER_ROOT:-${GITHUB_WORKSPACE:-$PWD}}" && '"'"'${{ runner.temp }}/composition-state/ci-runtime/resolve-devenv.sh'"'"' '"'"'devenv.lock'"'"''
         shell: bash
       - name: Evict cached pnpm deps for oxlint-npm
         shell: bash
@@ -1298,7 +1306,9 @@ jobs:
           echo "Pinned devenv rev: $DEVENV_REV"
         shell: bash
       - name: Resolve devenv
-        run: 'cd "${EFFECT_UTILS_MEMBER_ROOT:-${GITHUB_WORKSPACE:-$PWD}}" && ''${{ runner.temp }}/composition-state/ci-runtime/resolve-devenv.sh'' ''devenv.lock'''
+        run: |
+          __genie_ci_retry_script='${{ runner.temp }}/composition-state/ci-runtime/run-with-nix-gc-race-retry.sh'
+          bash "$__genie_ci_retry_script" 'resolve devenv (devenv.lock)' 'cd "${EFFECT_UTILS_MEMBER_ROOT:-${GITHUB_WORKSPACE:-$PWD}}" && '"'"'${{ runner.temp }}/composition-state/ci-runtime/resolve-devenv.sh'"'"' '"'"'devenv.lock'"'"''
         shell: bash
       - name: Evict cached pnpm deps for oxlint-npm
         shell: bash
@@ -1624,7 +1634,9 @@ jobs:
           echo "Pinned devenv rev: $DEVENV_REV"
         shell: bash
       - name: Resolve devenv
-        run: 'cd "${EFFECT_UTILS_MEMBER_ROOT:-${GITHUB_WORKSPACE:-$PWD}}" && ''${{ runner.temp }}/composition-state/ci-runtime/resolve-devenv.sh'' ''devenv.lock'''
+        run: |
+          __genie_ci_retry_script='${{ runner.temp }}/composition-state/ci-runtime/run-with-nix-gc-race-retry.sh'
+          bash "$__genie_ci_retry_script" 'resolve devenv (devenv.lock)' 'cd "${EFFECT_UTILS_MEMBER_ROOT:-${GITHUB_WORKSPACE:-$PWD}}" && '"'"'${{ runner.temp }}/composition-state/ci-runtime/resolve-devenv.sh'"'"' '"'"'devenv.lock'"'"''
         shell: bash
       - name: Evict cached pnpm deps for oxlint-npm
         shell: bash
@@ -1869,7 +1881,9 @@ jobs:
           echo "Pinned devenv rev: $DEVENV_REV"
         shell: bash
       - name: Resolve devenv
-        run: 'cd "${EFFECT_UTILS_MEMBER_ROOT:-${GITHUB_WORKSPACE:-$PWD}}" && ''${{ runner.temp }}/composition-state/ci-runtime/resolve-devenv.sh'' ''devenv.lock'''
+        run: |
+          __genie_ci_retry_script='${{ runner.temp }}/composition-state/ci-runtime/run-with-nix-gc-race-retry.sh'
+          bash "$__genie_ci_retry_script" 'resolve devenv (devenv.lock)' 'cd "${EFFECT_UTILS_MEMBER_ROOT:-${GITHUB_WORKSPACE:-$PWD}}" && '"'"'${{ runner.temp }}/composition-state/ci-runtime/resolve-devenv.sh'"'"' '"'"'devenv.lock'"'"''
         shell: bash
       - name: Evict cached pnpm deps for oxlint-npm
         shell: bash
@@ -2065,7 +2079,9 @@ jobs:
           echo "Pinned devenv rev: $DEVENV_REV"
         shell: bash
       - name: Resolve devenv
-        run: 'cd "${EFFECT_UTILS_MEMBER_ROOT:-${GITHUB_WORKSPACE:-$PWD}}" && ''${{ runner.temp }}/composition-state/ci-runtime/resolve-devenv.sh'' ''devenv.lock'''
+        run: |
+          __genie_ci_retry_script='${{ runner.temp }}/composition-state/ci-runtime/run-with-nix-gc-race-retry.sh'
+          bash "$__genie_ci_retry_script" 'resolve devenv (devenv.lock)' 'cd "${EFFECT_UTILS_MEMBER_ROOT:-${GITHUB_WORKSPACE:-$PWD}}" && '"'"'${{ runner.temp }}/composition-state/ci-runtime/resolve-devenv.sh'"'"' '"'"'devenv.lock'"'"''
         shell: bash
       - name: Evict cached pnpm deps for oxlint-npm
         shell: bash
@@ -2259,7 +2275,9 @@ jobs:
           echo "Pinned devenv rev: $DEVENV_REV"
         shell: bash
       - name: Resolve devenv
-        run: 'cd "${EFFECT_UTILS_MEMBER_ROOT:-${GITHUB_WORKSPACE:-$PWD}}" && ''${{ runner.temp }}/composition-state/ci-runtime/resolve-devenv.sh'' ''devenv.lock'''
+        run: |
+          __genie_ci_retry_script='${{ runner.temp }}/composition-state/ci-runtime/run-with-nix-gc-race-retry.sh'
+          bash "$__genie_ci_retry_script" 'resolve devenv (devenv.lock)' 'cd "${EFFECT_UTILS_MEMBER_ROOT:-${GITHUB_WORKSPACE:-$PWD}}" && '"'"'${{ runner.temp }}/composition-state/ci-runtime/resolve-devenv.sh'"'"' '"'"'devenv.lock'"'"''
         shell: bash
       - name: Evict cached pnpm deps for oxlint-npm
         shell: bash
@@ -2453,7 +2471,9 @@ jobs:
           echo "Pinned devenv rev: $DEVENV_REV"
         shell: bash
       - name: Resolve devenv
-        run: 'cd "${EFFECT_UTILS_MEMBER_ROOT:-${GITHUB_WORKSPACE:-$PWD}}" && ''${{ runner.temp }}/composition-state/ci-runtime/resolve-devenv.sh'' ''devenv.lock'''
+        run: |
+          __genie_ci_retry_script='${{ runner.temp }}/composition-state/ci-runtime/run-with-nix-gc-race-retry.sh'
+          bash "$__genie_ci_retry_script" 'resolve devenv (devenv.lock)' 'cd "${EFFECT_UTILS_MEMBER_ROOT:-${GITHUB_WORKSPACE:-$PWD}}" && '"'"'${{ runner.temp }}/composition-state/ci-runtime/resolve-devenv.sh'"'"' '"'"'devenv.lock'"'"''
         shell: bash
       - name: Evict cached pnpm deps for oxlint-npm
         shell: bash
@@ -2647,7 +2667,9 @@ jobs:
           echo "Pinned devenv rev: $DEVENV_REV"
         shell: bash
       - name: Resolve devenv
-        run: 'cd "${EFFECT_UTILS_MEMBER_ROOT:-${GITHUB_WORKSPACE:-$PWD}}" && ''${{ runner.temp }}/composition-state/ci-runtime/resolve-devenv.sh'' ''devenv.lock'''
+        run: |
+          __genie_ci_retry_script='${{ runner.temp }}/composition-state/ci-runtime/run-with-nix-gc-race-retry.sh'
+          bash "$__genie_ci_retry_script" 'resolve devenv (devenv.lock)' 'cd "${EFFECT_UTILS_MEMBER_ROOT:-${GITHUB_WORKSPACE:-$PWD}}" && '"'"'${{ runner.temp }}/composition-state/ci-runtime/resolve-devenv.sh'"'"' '"'"'devenv.lock'"'"''
         shell: bash
       - name: Evict cached pnpm deps for oxlint-npm
         shell: bash
@@ -2848,7 +2870,9 @@ jobs:
           echo "Pinned devenv rev: $DEVENV_REV"
         shell: bash
       - name: Resolve devenv
-        run: 'cd "${EFFECT_UTILS_MEMBER_ROOT:-${GITHUB_WORKSPACE:-$PWD}}" && ''${{ runner.temp }}/composition-state/ci-runtime/resolve-devenv.sh'' ''devenv.lock'''
+        run: |
+          __genie_ci_retry_script='${{ runner.temp }}/composition-state/ci-runtime/run-with-nix-gc-race-retry.sh'
+          bash "$__genie_ci_retry_script" 'resolve devenv (devenv.lock)' 'cd "${EFFECT_UTILS_MEMBER_ROOT:-${GITHUB_WORKSPACE:-$PWD}}" && '"'"'${{ runner.temp }}/composition-state/ci-runtime/resolve-devenv.sh'"'"' '"'"'devenv.lock'"'"''
         shell: bash
       - name: Evict cached pnpm deps for oxlint-npm
         shell: bash
@@ -3054,7 +3078,9 @@ jobs:
           echo "Pinned devenv rev: $DEVENV_REV"
         shell: bash
       - name: Resolve devenv
-        run: 'cd "${EFFECT_UTILS_MEMBER_ROOT:-${GITHUB_WORKSPACE:-$PWD}}" && ''${{ runner.temp }}/composition-state/ci-runtime/resolve-devenv.sh'' ''devenv.lock'''
+        run: |
+          __genie_ci_retry_script='${{ runner.temp }}/composition-state/ci-runtime/run-with-nix-gc-race-retry.sh'
+          bash "$__genie_ci_retry_script" 'resolve devenv (devenv.lock)' 'cd "${EFFECT_UTILS_MEMBER_ROOT:-${GITHUB_WORKSPACE:-$PWD}}" && '"'"'${{ runner.temp }}/composition-state/ci-runtime/resolve-devenv.sh'"'"' '"'"'devenv.lock'"'"''
         shell: bash
       - name: Evict cached pnpm deps for oxlint-npm
         shell: bash
@@ -3891,7 +3917,9 @@ jobs:
           echo "Pinned devenv rev: $DEVENV_REV"
         shell: bash
       - name: Resolve devenv
-        run: 'cd "${EFFECT_UTILS_MEMBER_ROOT:-${GITHUB_WORKSPACE:-$PWD}}" && ''${{ runner.temp }}/composition-state/ci-runtime/resolve-devenv.sh'' ''devenv.lock'''
+        run: |
+          __genie_ci_retry_script='${{ runner.temp }}/composition-state/ci-runtime/run-with-nix-gc-race-retry.sh'
+          bash "$__genie_ci_retry_script" 'resolve devenv (devenv.lock)' 'cd "${EFFECT_UTILS_MEMBER_ROOT:-${GITHUB_WORKSPACE:-$PWD}}" && '"'"'${{ runner.temp }}/composition-state/ci-runtime/resolve-devenv.sh'"'"' '"'"'devenv.lock'"'"''
         shell: bash
       - name: Evict cached pnpm deps for oxlint-npm
         shell: bash
@@ -7349,7 +7377,9 @@ jobs:
           echo "Pinned devenv rev: $DEVENV_REV"
         shell: bash
       - name: Resolve devenv
-        run: 'cd "${EFFECT_UTILS_MEMBER_ROOT:-${GITHUB_WORKSPACE:-$PWD}}" && ''${{ runner.temp }}/composition-state/ci-runtime/resolve-devenv.sh'' ''devenv.lock'''
+        run: |
+          __genie_ci_retry_script='${{ runner.temp }}/composition-state/ci-runtime/run-with-nix-gc-race-retry.sh'
+          bash "$__genie_ci_retry_script" 'resolve devenv (devenv.lock)' 'cd "${EFFECT_UTILS_MEMBER_ROOT:-${GITHUB_WORKSPACE:-$PWD}}" && '"'"'${{ runner.temp }}/composition-state/ci-runtime/resolve-devenv.sh'"'"' '"'"'devenv.lock'"'"''
         shell: bash
       - name: Evict cached pnpm deps for oxlint-npm
         shell: bash
@@ -7552,7 +7582,9 @@ jobs:
           echo "Pinned devenv rev: $DEVENV_REV"
         shell: bash
       - name: Resolve devenv
-        run: 'cd "${EFFECT_UTILS_MEMBER_ROOT:-${GITHUB_WORKSPACE:-$PWD}}" && ''${{ runner.temp }}/composition-state/ci-runtime/resolve-devenv.sh'' ''devenv.lock'''
+        run: |
+          __genie_ci_retry_script='${{ runner.temp }}/composition-state/ci-runtime/run-with-nix-gc-race-retry.sh'
+          bash "$__genie_ci_retry_script" 'resolve devenv (devenv.lock)' 'cd "${EFFECT_UTILS_MEMBER_ROOT:-${GITHUB_WORKSPACE:-$PWD}}" && '"'"'${{ runner.temp }}/composition-state/ci-runtime/resolve-devenv.sh'"'"' '"'"'devenv.lock'"'"''
         shell: bash
       - name: Evict cached pnpm deps for oxlint-npm
         shell: bash
@@ -7746,7 +7778,9 @@ jobs:
           echo "Pinned devenv rev: $DEVENV_REV"
         shell: bash
       - name: Resolve devenv
-        run: 'cd "${EFFECT_UTILS_MEMBER_ROOT:-${GITHUB_WORKSPACE:-$PWD}}" && ''${{ runner.temp }}/composition-state/ci-runtime/resolve-devenv.sh'' ''devenv.lock'''
+        run: |
+          __genie_ci_retry_script='${{ runner.temp }}/composition-state/ci-runtime/run-with-nix-gc-race-retry.sh'
+          bash "$__genie_ci_retry_script" 'resolve devenv (devenv.lock)' 'cd "${EFFECT_UTILS_MEMBER_ROOT:-${GITHUB_WORKSPACE:-$PWD}}" && '"'"'${{ runner.temp }}/composition-state/ci-runtime/resolve-devenv.sh'"'"' '"'"'devenv.lock'"'"''
         shell: bash
       - name: Evict cached pnpm deps for oxlint-npm
         shell: bash
@@ -7991,7 +8025,9 @@ jobs:
           echo "Pinned devenv rev: $DEVENV_REV"
         shell: bash
       - name: Resolve devenv
-        run: 'cd "${EFFECT_UTILS_MEMBER_ROOT:-${GITHUB_WORKSPACE:-$PWD}}" && ''${{ runner.temp }}/composition-state/ci-runtime/resolve-devenv.sh'' ''devenv.lock'''
+        run: |
+          __genie_ci_retry_script='${{ runner.temp }}/composition-state/ci-runtime/run-with-nix-gc-race-retry.sh'
+          bash "$__genie_ci_retry_script" 'resolve devenv (devenv.lock)' 'cd "${EFFECT_UTILS_MEMBER_ROOT:-${GITHUB_WORKSPACE:-$PWD}}" && '"'"'${{ runner.temp }}/composition-state/ci-runtime/resolve-devenv.sh'"'"' '"'"'devenv.lock'"'"''
         shell: bash
       - name: Evict cached pnpm deps for oxlint-npm
         shell: bash

--- a/genie/ci-scripts/nix-gc-race-retry.sh
+++ b/genie/ci-scripts/nix-gc-race-retry.sh
@@ -9,7 +9,15 @@ run_nix_gc_race_retry() {
   local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
   local daemon_socket_retry_delay="${NIX_DAEMON_SOCKET_RETRY_DELAY_SECONDS:-2}"
   local attempt=1
-  local log log_dir stdout_pipe stderr_pipe rc path start now elapsed hb_pid stdout_tee_pid stderr_tee_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature saw_daemon_socket_failure had_errexit
+  local missing_subpath_repairs=0
+  # The guillemets Nix wraps a flake reference in, built from their UTF-8 bytes so this
+  # generator template stays ASCII: a non-ASCII literal here can be re-encoded by the
+  # transpiler into an escape sequence that String.raw would emit verbatim.
+  local flake_ref_open flake_ref_close nix_cache_root
+  flake_ref_open=$'\302\253'
+  flake_ref_close=$'\302\273'
+  nix_cache_root="${XDG_CACHE_HOME:-$HOME/.cache}/nix"
+  local log log_dir stdout_pipe stderr_pipe rc path missing_subpath start now elapsed hb_pid stdout_tee_pid stderr_tee_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature saw_daemon_socket_failure saw_missing_flake_subpath had_errexit
 
   shift
   start="$(date +%s)"
@@ -83,18 +91,41 @@ run_nix_gc_race_retry() {
       head -1 |
       grep -o "/nix/store/[^']*" |
       tr -d '[:space:]' || true)
+    # A flake input whose source landed in the local fetcher/Git/tarball caches
+    # incompletely renders as an error naming a path INSIDE a flake reference:
+    #   error: path 'FLAKE_REF/<subpath>' does not exist
+    # where Nix wraps FLAKE_REF in guillemets. A genuinely absent store path is reported
+    # with the same wording, so the match is anchored on the guillemet-wrapped form
+    # (built above from its UTF-8 bytes) and on 'path' directly following 'error:'.
+    missing_subpath=$(printf '%s' "$flattened" |
+      grep -o "error:[[:space:]]*path '${flake_ref_open}[^']*${flake_ref_close}[^']*' does not exist" |
+      head -1 |
+      sed -E "s/^error:[[:space:]]*path '//; s/' does not exist$//" || true)
     saw_invalid_path=false
     saw_cachix_signature=false
     saw_fetch_signature=false
     saw_daemon_socket_failure=false
+    saw_missing_flake_subpath=false
     [ -n "$path" ] && saw_invalid_path=true
+    [ -n "$missing_subpath" ] && saw_missing_flake_subpath=true
     printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
     printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
     printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*cannot read file from tarball:[[:space:]]*Truncated tar archive detected while reading data' && saw_fetch_signature=true || true
     printf '%s' "$flattened" | grep -Eq "error:[[:space:]]*cannot connect to socket at '/nix/var/nix/daemon-socket/socket'" && saw_daemon_socket_failure=true || true
     rm -f "$log"
 
-    if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ] && [ "$saw_fetch_signature" != true ] && [ "$saw_daemon_socket_failure" != true ]; then
+    # The guillemet form can also describe a path that upstream removed permanently, which
+    # no amount of cache purging fixes. Repair it once; a second identical failure is
+    # reported as the permanent path error it is, with its own summary note, rather than
+    # falling through to the generic "no transient signature" message or burning $max
+    # attempts.
+    if [ "$saw_missing_flake_subpath" = true ] && [ "$missing_subpath_repairs" -ge 1 ]; then
+      echo "::error::Nix flake input subpath still missing for $task after one cache repair: $missing_subpath; treating it as a permanent missing path"
+      write_summary failure "Nix flake input subpath still missing after one cache repair: $missing_subpath"
+      return "$rc"
+    fi
+
+    if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ] && [ "$saw_fetch_signature" != true ] && [ "$saw_daemon_socket_failure" != true ] && [ "$saw_missing_flake_subpath" != true ]; then
       echo "::warning::[ci] $task failed after $elapsed s without a detected transient Nix failure"
       write_summary failure "No transient Nix failure signature detected"
       return "$rc"
@@ -102,6 +133,8 @@ run_nix_gc_race_retry() {
 
     if [ "$saw_daemon_socket_failure" = true ]; then
       echo "::warning::Nix daemon socket failure detected for $task (attempt $attempt/$max); waiting $daemon_socket_retry_delay s for host supervision before retrying without mutating the host daemon"
+    elif [ "$saw_missing_flake_subpath" = true ]; then
+      echo "::warning::Incomplete Nix flake input cache detected for $task (attempt $attempt/$max): $missing_subpath; retrying with a refreshed input cache"
     elif [ "$saw_fetch_signature" = true ]; then
       echo "::warning::Nix source fetch corruption detected for $task (attempt $attempt/$max); retrying with a refreshed eval cache"
     elif [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
@@ -113,7 +146,18 @@ run_nix_gc_race_retry() {
     fi
 
     [ -z "$path" ] || nix-store --realise "$path" 2>/dev/null || true
-    rm -rf ~/.cache/nix/eval-cache-*
+    # Both cache roots: the legacy HOME-relative path and the XDG root this helper resolves,
+    # which diverge whenever XDG_CACHE_HOME is set away from $HOME/.cache.
+    rm -rf ~/.cache/nix/eval-cache-* "$nix_cache_root"/eval-cache-*
+    if [ "$saw_missing_flake_subpath" = true ]; then
+      # Determinate Nix versions these caches, so the bare legacy names match nothing.
+      # The sqlite globs intentionally cover the -shm/-wal sidecars: leaving those behind
+      # next to a deleted database is what turns a repair into a corrupt-cache failure.
+      rm -rf "$nix_cache_root"/tarball-cache-v* "$nix_cache_root"/tarball-cache
+      rm -rf "$nix_cache_root"/gitv*
+      rm -f "$nix_cache_root"/fetcher-cache-v*.sqlite*
+      missing_subpath_repairs=$((missing_subpath_repairs + 1))
+    fi
     if [ "$saw_daemon_socket_failure" = true ] && [ "$attempt" -lt "$max" ]; then
       sleep "$daemon_socket_retry_delay"
     fi

--- a/genie/ci-scripts/nix-gc-race-retry.test.sh
+++ b/genie/ci-scripts/nix-gc-race-retry.test.sh
@@ -60,6 +60,42 @@ assert_not_contains() {
 test_dir="$(mktemp -d)"
 trap 'rm -rf "$test_dir"' EXIT
 
+# The helper deletes Nix caches as part of its repair path. Sandbox HOME and the XDG cache
+# root for the whole suite so no test can ever touch the real developer or runner caches.
+# The two roots are deliberately DIVERGENT (XDG_CACHE_HOME is not under HOME) so the
+# assertions below prove the helper purges the legacy HOME-relative eval cache as well as
+# the XDG root it resolves.
+export HOME="$test_dir/home"
+export XDG_CACHE_HOME="$test_dir/xdg-cache"
+home_nix_cache="$HOME/.cache/nix"
+xdg_nix_cache="$XDG_CACHE_HOME/nix"
+mkdir -p "$home_nix_cache" "$xdg_nix_cache"
+
+seed_nix_caches() {
+  mkdir -p "$xdg_nix_cache/tarball-cache-v2" "$xdg_nix_cache/gitv3" \
+    "$xdg_nix_cache/eval-cache-v6" "$home_nix_cache/eval-cache-v6"
+  : > "$xdg_nix_cache/fetcher-cache-v4.sqlite"
+  : > "$xdg_nix_cache/fetcher-cache-v4.sqlite-shm"
+  : > "$xdg_nix_cache/fetcher-cache-v4.sqlite-wal"
+  : > "$xdg_nix_cache/binary-cache-v7.sqlite"
+}
+
+assert_missing() {
+  if [ -e "$1" ]; then
+    echo "FAIL: $2"
+    echo "  still present: $1"
+    exit 1
+  fi
+}
+
+assert_present() {
+  if [ ! -e "$1" ]; then
+    echo "FAIL: $2"
+    echo "  missing: $1"
+    exit 1
+  fi
+}
+
 echo "Running nix GC race retry helper tests..."
 echo ""
 
@@ -275,6 +311,101 @@ EOF
 )
 CI_PROGRESS_HEARTBEAT_SECONDS=1 NIX_GC_RACE_MAX_RETRIES=2 "$ROOT/genie/ci-scripts/run-with-nix-gc-race-retry.sh" "wrapper-fixture" "$wrapper_command" >/dev/null
 assert_eq "2" "$(cat "$wrapper_attempt_file")" "wrapper retry count"
+
+echo "Test 12: retries missing flake input subpaths rendered with guillemets"
+subpath_fixture="$test_dir/subpath-fixture.sh"
+cat > "$subpath_fixture" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+attempt_file="$test_dir/subpath-attempt"
+attempt=1
+if [ -f "\$attempt_file" ]; then
+  attempt=\$(cat "\$attempt_file")
+fi
+if [ "\$attempt" -eq 1 ]; then
+  echo 2 > "\$attempt_file"
+  echo "error: path '«github:NixOS/nixpkgs/80bdc1e»/pkgs/build-support/fetchpypi' does not exist" >&2
+  exit 1
+fi
+echo "subpath recovered"
+EOF
+chmod +x "$subpath_fixture"
+subpath_stdout="$test_dir/subpath-stdout"
+seed_nix_caches
+CI_PROGRESS_HEARTBEAT_SECONDS=1 NIX_GC_RACE_MAX_RETRIES=2 run_nix_gc_race_retry "subpath-fixture" "$subpath_fixture" >"$subpath_stdout"
+assert_eq "2" "$(cat "$test_dir/subpath-attempt")" "missing flake subpath retry count"
+assert_contains "«github:NixOS/nixpkgs/80bdc1e»/pkgs/build-support/fetchpypi" "$subpath_stdout" "missing subpath is named in the retry warning"
+# The repair must clear the caches Determinate Nix actually uses, including the sqlite
+# sidecars: a database removed without its -shm/-wal leaves a corrupt cache behind.
+assert_missing "$xdg_nix_cache/tarball-cache-v2" "versioned tarball cache purged"
+assert_missing "$xdg_nix_cache/gitv3" "versioned git cache purged"
+assert_missing "$xdg_nix_cache/fetcher-cache-v4.sqlite" "fetcher cache purged"
+assert_missing "$xdg_nix_cache/fetcher-cache-v4.sqlite-shm" "fetcher cache shm sidecar purged"
+assert_missing "$xdg_nix_cache/fetcher-cache-v4.sqlite-wal" "fetcher cache wal sidecar purged"
+# Both eval-cache roots: the XDG root the helper resolves and the legacy HOME-relative one.
+assert_missing "$xdg_nix_cache/eval-cache-v6" "versioned eval cache purged from the XDG root"
+assert_missing "$home_nix_cache/eval-cache-v6" "versioned eval cache purged from the legacy HOME root"
+# Unrelated caches are not collateral damage.
+assert_present "$xdg_nix_cache/binary-cache-v7.sqlite" "binary cache left intact"
+
+echo "Test 13: does not treat a missing plain store path as a missing-subpath transient"
+missing_store_path_fixture="$test_dir/missing-store-path-fixture.sh"
+cat > "$missing_store_path_fixture" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "error: path '/nix/store/does-not-exist-foo' does not exist" >&2
+exit 11
+EOF
+chmod +x "$missing_store_path_fixture"
+set +e
+CI_PROGRESS_HEARTBEAT_SECONDS=1 NIX_GC_RACE_MAX_RETRIES=2 run_nix_gc_race_retry "missing-store-path-fixture" "$missing_store_path_fixture" >/dev/null 2>&1
+exit_code=$?
+set -e
+assert_exit_code 11 "$exit_code" "a missing plain path is not a transient flake-subpath failure"
+
+echo "Test 14: does not retry missing-subpath text that is not anchored to a Nix error"
+subpath_false_positive_fixture="$test_dir/subpath-false-positive-fixture.sh"
+cat > "$subpath_false_positive_fixture" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+# Lowercase `error:` IS present, but 'path' does not directly follow it, so the
+# anchored classifier must not treat this as the transient signature.
+echo "error: assertion failed while checking that path '«github:NixOS/nixpkgs/80bdc1e»/pkgs/build-support/fetchpypi' does not exist" >&2
+exit 12
+EOF
+chmod +x "$subpath_false_positive_fixture"
+set +e
+CI_PROGRESS_HEARTBEAT_SECONDS=1 NIX_GC_RACE_MAX_RETRIES=2 run_nix_gc_race_retry "subpath-false-positive-fixture" "$subpath_false_positive_fixture" >/dev/null 2>&1
+exit_code=$?
+set -e
+assert_exit_code 12 "$exit_code" "unanchored missing-subpath text does not trigger retries"
+
+echo "Test 15: repairs a missing flake subpath once, then reports it as permanent"
+permanent_fixture="$test_dir/permanent-subpath-fixture.sh"
+cat > "$permanent_fixture" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+echo \$((\$(cat "$test_dir/permanent-attempts" 2>/dev/null || echo 0) + 1)) > "$test_dir/permanent-attempts"
+echo "error: path '«github:NixOS/nixpkgs/80bdc1e»/pkgs/build-support/removed-forever' does not exist" >&2
+exit 13
+EOF
+chmod +x "$permanent_fixture"
+permanent_stdout="$test_dir/permanent-stdout"
+permanent_summary="$test_dir/permanent-summary"
+: > "$permanent_summary"
+seed_nix_caches
+set +e
+CI_PROGRESS_HEARTBEAT_SECONDS=1 NIX_GC_RACE_MAX_RETRIES=10 GITHUB_STEP_SUMMARY="$permanent_summary" run_nix_gc_race_retry "permanent-fixture" "$permanent_fixture" >"$permanent_stdout" 2>&1
+exit_code=$?
+set -e
+assert_exit_code 13 "$exit_code" "a permanently missing subpath keeps its exit code"
+assert_eq "2" "$(cat "$test_dir/permanent-attempts")" "a permanently missing subpath is repaired exactly once, not 10 times"
+# It is reported as an error naming the path, not as the generic no-signature warning.
+assert_contains "::error::Nix flake input subpath still missing" "$permanent_stdout" "the permanent case is reported as an error"
+assert_contains "removed-forever" "$permanent_stdout" "the permanent case names the missing path"
+assert_not_contains "without a detected transient Nix failure" "$permanent_stdout" "the permanent case does not fall through to the generic no-signature message"
+assert_contains "Nix flake input subpath still missing after one cache repair" "$permanent_summary" "the step summary carries the specific permanent-path note"
+assert_not_contains "No transient Nix failure signature detected" "$permanent_summary" "the step summary does not carry the generic note"
 
 echo ""
 echo "All nix GC race retry helper tests passed"

--- a/genie/ci-workflow/setup.ts
+++ b/genie/ci-workflow/setup.ts
@@ -1036,9 +1036,17 @@ export const pnpmBuilderContractStep = ({
 export const validateNixStoreStepFor = (lockFile = 'devenv.lock') =>
   ({
     name: 'Resolve devenv',
-    run: withCiSourceRoot(
-      `${shellSingleQuote(`${preparedCiRuntimeScriptsDir}/resolve-devenv.sh`)} ${shellSingleQuote(lockFile)}`,
-    ),
+    // Routed through the shared retry wrapper: resolving devenv is the first step that
+    // evaluates flake inputs, so it is where a transient store/input-cache failure lands
+    // (`path '/nix/store/...' is not valid`, a truncated input tarball, an incompletely
+    // cached flake input). Its own in-script repair covers only the devenv store path, so
+    // without the wrapper any other transient signature fails the job outright.
+    run: withGcRaceRetry({
+      command: withCiSourceRoot(
+        `${shellSingleQuote(`${preparedCiRuntimeScriptsDir}/resolve-devenv.sh`)} ${shellSingleQuote(lockFile)}`,
+      ),
+      label: `resolve devenv (${lockFile})`,
+    }),
     shell: 'bash',
   }) as const
 

--- a/genie/ci-workflow/support-files.ts
+++ b/genie/ci-workflow/support-files.ts
@@ -122,7 +122,15 @@ run_nix_gc_race_retry() {
   local heartbeat="${dollar}{CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
   local daemon_socket_retry_delay="${dollar}{NIX_DAEMON_SOCKET_RETRY_DELAY_SECONDS:-2}"
   local attempt=1
-  local log log_dir stdout_pipe stderr_pipe rc path start now elapsed hb_pid stdout_tee_pid stderr_tee_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature saw_daemon_socket_failure had_errexit
+  local missing_subpath_repairs=0
+  # The guillemets Nix wraps a flake reference in, built from their UTF-8 bytes so this
+  # generator template stays ASCII: a non-ASCII literal here can be re-encoded by the
+  # transpiler into an escape sequence that String.raw would emit verbatim.
+  local flake_ref_open flake_ref_close nix_cache_root
+  flake_ref_open=$'\302\253'
+  flake_ref_close=$'\302\273'
+  nix_cache_root="${dollar}{XDG_CACHE_HOME:-${dollar}HOME/.cache}/nix"
+  local log log_dir stdout_pipe stderr_pipe rc path missing_subpath start now elapsed hb_pid stdout_tee_pid stderr_tee_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature saw_daemon_socket_failure saw_missing_flake_subpath had_errexit
 
   shift
   start="$(date +%s)"
@@ -196,18 +204,41 @@ run_nix_gc_race_retry() {
       head -1 |
       grep -o "/nix/store/[^']*" |
       tr -d '[:space:]' || true)
+    # A flake input whose source landed in the local fetcher/Git/tarball caches
+    # incompletely renders as an error naming a path INSIDE a flake reference:
+    #   error: path 'FLAKE_REF/<subpath>' does not exist
+    # where Nix wraps FLAKE_REF in guillemets. A genuinely absent store path is reported
+    # with the same wording, so the match is anchored on the guillemet-wrapped form
+    # (built above from its UTF-8 bytes) and on 'path' directly following 'error:'.
+    missing_subpath=$(printf '%s' "$flattened" |
+      grep -o "error:[[:space:]]*path '${dollar}{flake_ref_open}[^']*${dollar}{flake_ref_close}[^']*' does not exist" |
+      head -1 |
+      sed -E "s/^error:[[:space:]]*path '//; s/' does not exist${dollar}//" || true)
     saw_invalid_path=false
     saw_cachix_signature=false
     saw_fetch_signature=false
     saw_daemon_socket_failure=false
+    saw_missing_flake_subpath=false
     [ -n "$path" ] && saw_invalid_path=true
+    [ -n "$missing_subpath" ] && saw_missing_flake_subpath=true
     printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
     printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
     printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*cannot read file from tarball:[[:space:]]*Truncated tar archive detected while reading data' && saw_fetch_signature=true || true
     printf '%s' "$flattened" | grep -Eq "error:[[:space:]]*cannot connect to socket at '/nix/var/nix/daemon-socket/socket'" && saw_daemon_socket_failure=true || true
     rm -f "$log"
 
-    if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ] && [ "$saw_fetch_signature" != true ] && [ "$saw_daemon_socket_failure" != true ]; then
+    # The guillemet form can also describe a path that upstream removed permanently, which
+    # no amount of cache purging fixes. Repair it once; a second identical failure is
+    # reported as the permanent path error it is, with its own summary note, rather than
+    # falling through to the generic "no transient signature" message or burning $max
+    # attempts.
+    if [ "$saw_missing_flake_subpath" = true ] && [ "$missing_subpath_repairs" -ge 1 ]; then
+      echo "::error::Nix flake input subpath still missing for $task after one cache repair: $missing_subpath; treating it as a permanent missing path"
+      write_summary failure "Nix flake input subpath still missing after one cache repair: $missing_subpath"
+      return "$rc"
+    fi
+
+    if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ] && [ "$saw_fetch_signature" != true ] && [ "$saw_daemon_socket_failure" != true ] && [ "$saw_missing_flake_subpath" != true ]; then
       echo "::warning::[ci] $task failed after $elapsed s without a detected transient Nix failure"
       write_summary failure "No transient Nix failure signature detected"
       return "$rc"
@@ -215,6 +246,8 @@ run_nix_gc_race_retry() {
 
     if [ "$saw_daemon_socket_failure" = true ]; then
       echo "::warning::Nix daemon socket failure detected for $task (attempt $attempt/$max); waiting $daemon_socket_retry_delay s for host supervision before retrying without mutating the host daemon"
+    elif [ "$saw_missing_flake_subpath" = true ]; then
+      echo "::warning::Incomplete Nix flake input cache detected for $task (attempt $attempt/$max): $missing_subpath; retrying with a refreshed input cache"
     elif [ "$saw_fetch_signature" = true ]; then
       echo "::warning::Nix source fetch corruption detected for $task (attempt $attempt/$max); retrying with a refreshed eval cache"
     elif [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
@@ -226,7 +259,18 @@ run_nix_gc_race_retry() {
     fi
 
     [ -z "$path" ] || nix-store --realise "$path" 2>/dev/null || true
-    rm -rf ~/.cache/nix/eval-cache-*
+    # Both cache roots: the legacy HOME-relative path and the XDG root this helper resolves,
+    # which diverge whenever XDG_CACHE_HOME is set away from $HOME/.cache.
+    rm -rf ~/.cache/nix/eval-cache-* "${dollar}nix_cache_root"/eval-cache-*
+    if [ "$saw_missing_flake_subpath" = true ]; then
+      # Determinate Nix versions these caches, so the bare legacy names match nothing.
+      # The sqlite globs intentionally cover the -shm/-wal sidecars: leaving those behind
+      # next to a deleted database is what turns a repair into a corrupt-cache failure.
+      rm -rf "${dollar}nix_cache_root"/tarball-cache-v* "${dollar}nix_cache_root"/tarball-cache
+      rm -rf "${dollar}nix_cache_root"/gitv*
+      rm -f "${dollar}nix_cache_root"/fetcher-cache-v*.sqlite*
+      missing_subpath_repairs=$((missing_subpath_repairs + 1))
+    fi
     if [ "$saw_daemon_socket_failure" = true ] && [ "$attempt" -lt "$max" ]; then
       sleep "$daemon_socket_retry_delay"
     fi

--- a/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
@@ -258,6 +258,51 @@ describe('ci workflow retry helpers', () => {
     expect(ciWorkflowSource).not.toContain('if [ ! -x "$__genie_ci_retry_script" ]')
   })
 
+  it('routes the devenv resolution step through the shared retry wrapper', () => {
+    expect(validateNixStoreStepSource).toContain('withGcRaceRetry({')
+    expect(validateNixStoreStepSource).toContain('label: `resolve devenv (${lockFile})`')
+    expect(generatedCiWorkflowYamlSource).toContain(
+      'bash "$__genie_ci_retry_script" \'resolve devenv (devenv.lock)\'',
+    )
+  })
+
+  it('classifies an incompletely cached flake input as a bounded transient', () => {
+    expect(nixGcRaceRetryScriptSource).toContain('saw_missing_flake_subpath')
+    // Anchored on the guillemet-wrapped flake reference Nix prints, so a genuinely absent
+    // store path reported with the same wording is not misread as transient.
+    expect(nixGcRaceRetryScriptSource).toContain("flake_ref_open=$'\\302\\253'")
+    expect(nixGcRaceRetryScriptSource).toContain("flake_ref_close=$'\\302\\273'")
+    expect(nixGcRaceRetryScriptSource).toContain(
+      "grep -o \"error:[[:space:]]*path '${flake_ref_open}[^']*${flake_ref_close}[^']*' does not exist\"",
+    )
+    // Determinate Nix versions these caches; the bare legacy names match nothing, and a
+    // sqlite database removed without its -shm/-wal sidecars leaves a corrupt cache.
+    expect(nixGcRaceRetryScriptSource).toContain(
+      'nix_cache_root="${XDG_CACHE_HOME:-$HOME/.cache}/nix"',
+    )
+    expect(nixGcRaceRetryScriptSource).toContain('"$nix_cache_root"/tarball-cache-v*')
+    expect(nixGcRaceRetryScriptSource).toContain('"$nix_cache_root"/gitv*')
+    expect(nixGcRaceRetryScriptSource).toContain('"$nix_cache_root"/fetcher-cache-v*.sqlite*')
+    // The same wording can describe a permanently removed path, so the repair is bounded.
+    expect(nixGcRaceRetryScriptSource).toContain('missing_subpath_repairs')
+    expect(nixGcRaceRetryScriptSource).toContain('[ "$missing_subpath_repairs" -ge 1 ]')
+    expect(nixGcRaceRetryScriptSource).toContain(
+      'rm -rf ~/.cache/nix/eval-cache-* "$nix_cache_root"/eval-cache-*',
+    )
+    // A second identical failure is an error carrying its own summary note and the
+    // original exit code, never the generic no-transient-signature path.
+    expect(nixGcRaceRetryScriptSource).toContain(
+      '::error::Nix flake input subpath still missing for $task',
+    )
+    expect(nixGcRaceRetryScriptSource).toContain(
+      'write_summary failure "Nix flake input subpath still missing after one cache repair',
+    )
+    // ASCII-only template: a guillemet in the generator can be re-encoded as an escape
+    // sequence that String.raw would emit literally into the shipped script.
+    expect(nixGcRaceRetryScriptSource).not.toContain('\\u00AB')
+    expect(nixGcRaceRetryScriptSource).not.toContain('\u00AB')
+  })
+
   it('prepares retry helpers before generated jobs use the prepared retry script', () => {
     const jobBlocks = generatedCiWorkflowYamlSource.split(/\n  [a-zA-Z0-9_-]+:\n/g).slice(1)
 
@@ -583,8 +628,10 @@ printf '%s\\n' "$NIX_OUTPUT"
     expect(resolveDevenvScript).not.toContain('readlink -e')
     expect(validateNixStoreStepSource).toContain('resolve-devenv.sh')
     expect(validateNixStoreStepSource).not.toContain('resolve-devenv-ci.sh')
+    // The invocation is now nested inside the retry wrapper's single-quoted command, so
+    // the script reference carries the escaped inner quotes.
     expect(generatedCiWorkflowYamlSource).toContain(
-      "'${{ runner.temp }}/composition-state/ci-runtime/resolve-devenv.sh'",
+      `'"'"'\${{ runner.temp }}/composition-state/ci-runtime/resolve-devenv.sh'"'"'`,
     )
     expect(generatedCiWorkflowYamlSource).not.toContain('resolve_devenv_once()')
     expect(


### PR DESCRIPTION
## Problem

`Resolve devenv` is the first setup step that evaluates flake inputs, and it was the only one that ran **without** the shared Nix retry wrapper that every `devenv tasks run` step already goes through. Its script (`genie/ci-scripts/resolve-devenv.sh`) repairs exactly one failure mode — an invalid devenv store path — so any other transient Nix failure at that point killed the job on first occurrence.

A downstream consumer's CI run showed the gap concretely: two jobs died in `Resolve devenv` with

```
##[warning]devenv store path invalid, repairing targeted path...
error: path 'FLAKE_REF/pkgs/build-support/fetchpypi' does not exist
##[error]resolve_devenv failed after repair. Last 30 lines of log:
```

(`FLAKE_REF` is printed by Nix wrapped in guillemets.) The targeted repair fixed the devenv path and re-evaluated straight back into the same incompletely-cached flake input, because nothing cleared the fetcher/git/tarball caches that held it — and there was no retry to clear them in.

## Goal

`Resolve devenv` participates in the same transient-failure retry contract as the rest of the graph, and an incompletely cached flake input is recognized, repaired at the cache level, and bounded so a permanently removed path cannot burn ten attempts.

## Decisions

- **Retry wrapper, not a second bespoke repair inside `resolve-devenv.sh`.** The wrapper already owns signature classification, heartbeats, step summaries and attempt accounting; adding a second repair path in the script would fork that logic. The `cd` stays inside the retried command so each attempt re-enters the member root.
- **Anchor on the guillemet-wrapped flake reference.** Nix reports a genuinely absent store path with the *identical* wording (`error: path '...' does not exist`). An earlier draft discriminated on "the quoted path does not start with `/`"; anchoring on the guillemets plus `path` directly following `error:` is the structural difference and does not depend on the path shape.
- **Guillemets built from UTF-8 bytes in the shell (`$'\302\253'`), not written as literals in the generator template.** A non-ASCII literal inside `String.raw` can be re-encoded by the transpiler into an escape sequence that `String.raw` then emits *verbatim*, shipping `\u00AB` into the script. That happened during development and the suite's generator/script drift check caught it; the ASCII-only rule is now asserted.
- **Bounded repair.** The same message can describe a path upstream removed permanently, which no cache purge fixes. One purge, then the second identical failure is an error with its own step-summary note and the original exit code — not ten attempts, and not the generic "no transient signature" message.
- **Versioned cache names.** Determinate Nix uses `tarball-cache-v*`, `gitv*`, `fetcher-cache-v*.sqlite{,-shm,-wal}`, `eval-cache-v*`; the bare legacy names match nothing. The sqlite glob deliberately takes the `-shm`/`-wal` sidecars, because deleting a database without them leaves a corrupt cache behind. `eval-cache-*` is cleared under both the XDG root and the legacy `~/.cache` one, which diverge whenever `XDG_CACHE_HOME` is set away from `$HOME/.cache`.
- **Out of scope, deliberately reverted:** a shared self-hosted-runner guard support file. It was unused upstream, this repo's own release lanes legitimately run on hosted `nscloud-ubuntu-*` labels, and a line-based YAML parser is fail-open for `runs-on: ${{ matrix.* }}`. The consumer repo fixes its own guard with its own workflow context.

## Verification

Focused suites, run from the composed member:

```
$ bash genie/ci-scripts/nix-gc-race-retry.test.sh
Test 1: standalone helper stays aligned with workflow helper source
...
Test 12: retries missing flake input subpaths rendered with guillemets
Test 13: does not treat a missing plain store path as a missing-subpath transient
Test 14: does not retry missing-subpath text that is not anchored to a Nix error
Test 15: repairs a missing flake subpath once, then reports it as permanent
All nix GC race retry helper tests passed          # 15/15

$ vitest run --no-file-parallelism \
    src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts \
    src/runtime/github-workflow/ci-runtime-scripts.unit.test.ts
 Test Files  2 passed (2)
      Tests  72 passed (72)

$ genie --check --cwd genie/ci-scripts     # Checked 4 files: 4 unchanged
$ genie --check --cwd .github/workflows    # Checked 2 files: 2 unchanged
$ oxfmt --check <touched .ts>              # clean
```

New coverage, all failing before the change:

- **Test 12** — the real message retries, the warning names the subpath, and every versioned cache is gone (`tarball-cache-v2`, `gitv3`, `fetcher-cache-v4.sqlite` + `-shm` + `-wal`, `eval-cache-v6` under **both** roots) while `binary-cache-v7.sqlite` survives, so the purge cannot silently widen. HOME and `XDG_CACHE_HOME` are sandboxed to divergent temp roots for the whole suite, so no test can touch a real cache.
- **Test 13** — `error: path '/nix/store/does-not-exist-foo' does not exist` keeps exit code 11: a genuinely absent store path is not this transient.
- **Test 14** — lowercase `error:` present but not anchored to `path` keeps exit code 12.
- **Test 15** — a permanently missing subpath is attempted exactly twice (not ten), keeps exit code 13, emits `::error::Nix flake input subpath still missing`, writes the specific step-summary note, and never emits the generic no-signature message.

Generated workflow, before → after (one of 12 identical `Resolve devenv` steps):

```
-        run: 'cd "${EFFECT_UTILS_MEMBER_ROOT:-...}" && ''.../ci-runtime/resolve-devenv.sh'' ''devenv.lock'''
+        run: |
+          __genie_ci_retry_script='${{ runner.temp }}/composition-state/ci-runtime/run-with-nix-gc-race-retry.sh'
+          bash "$__genie_ci_retry_script" 'resolve devenv (devenv.lock)' 'cd "${EFFECT_UTILS_MEMBER_ROOT:-...}" && ...resolve-devenv.sh ... devenv.lock'
```

### Full gate

`devenv tasks run check:all` from the composed member: **exit 0 in 15m16s** (run label `effect-utils-ci-repair-final-check-all`). No pre-flip deviations remain; the contention-sensitive lanes reported during development (`ci-workflow-helpers` composition workspace, `defer-validation.unit`, `devenv-modules:test`) all pass in the serialized full gate.

## Complexity

No new abstraction, no new file, no new dependency. One additional signature in an existing classifier (+43 lines in the generated helper), one step wrapped in an existing helper (+14 lines), the rest is tests.

## Concerns

- The repair deletes **shared** fetcher/git/tarball caches on the runner, so a concurrent job on the same host loses warm input caches. Bounded to one purge per task invocation, and these caches are regenerable by construction.
- `gitv*` is broader than `gitv3`. Narrowing would pin a version upstream bumps; if a future unrelated `gitv`-prefixed cache appears, this glob would take it too.
- **Open-PR overlap:** #1030 ("Preserve traced setup exports and make shared OTEL/CI helpers portable", last updated 2026-07-30, not draft) touches the same six files, and its hunks are written against pre-`validateNixStoreStepFor` content, so it already needs a rebase against current `main` independently of this PR. Whichever lands second must rebase; nothing here depends on it.
- The retry surface widens: a signature that previously failed fast now costs up to `NIX_GC_RACE_MAX_RETRIES` attempts (10) for the three pre-existing signatures. The new one is capped at 2 by design.

## Friction & bottlenecks

- _Friction_ — `String.raw` plus a transpiler that re-encodes non-ASCII silently ships `\u00AB` into generated shell. Only the suite's generator/script parity check surfaced it; nothing in the type system or lint does. Worked around by materializing the bytes in the shell and asserting the template stays ASCII.
- _Friction_ — the branch worktree became a composed Buck2 workspace root the first time anything invoked `mr apply`, which makes every previously-valid cwd wrong (`devenv.nix` no longer at the branch path). Recoverable but surprising twice in one session.
- _Bottleneck_ — these "unit" suites are integration-shaped: they spawn `bun`, `git`, `nix` and a full megarepo composition, so a shared host makes them timing-dependent (16 s → 36 s under load against a 20 s budget; 10 s → 61 s against 30 s). Numbers above.

## Follow-ups

- Give the composition / `defer-validation` tests budgets matching what they actually do, or mark those suites non-parallel.
- Mirror the CI cargo isolation locally (a per-graph `CARGO_TARGET_DIR`) so a shared `rust/target` cannot produce vanished-`.rmeta` failures.
- Consumer-side: the downstream repo restores its own deleted `run-with-nix-gc-race-retry.sh` (or takes it from the regenerated support files) and fixes its hosted-runner guard locally — routing `Resolve devenv` through the wrapper only helps where the wrapper is actually materialized.

## References

- Retry helper: `genie/ci-scripts/nix-gc-race-retry.sh` (generated from `genie/ci-workflow/support-files.ts`)
- Availability contract for invoked ci-runtime scripts: `packages/@overeng/genie/src/runtime/github-workflow/ci-runtime-scripts.unit.test.ts`

<!-- agent-footer:begin v=2 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | dev3.direct.omp.ubb99bpf |
| `session` | dev3.ubb99bpf |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.1.7 |
| `agent_runtime` | OMP 18.1.7 |
| `tooling_profile` | dotfiles@931583a |
</details>
<!-- agent-footer:end -->