### PR TITLE
chore(nix): track current nixos-unstable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,17 @@ All notable changes to this project will be documented in this file.
   `$script_dir/...` siblings sourced by an emitted script — and each failure
   names the unavailable script together with the file that asks for it.
 
+### Removed
+
+- **@overeng/megarepo**: the deprecated `MegarepoStore` members `getRepoPath`
+  and `hasRepo` are gone. Both were aliases kept only for the rename:
+  `getRepoPath` returned exactly what `getRepoBasePath` returns, and `hasRepo`
+  was `hasBareRepo` under its old name. Migration is a rename at the call site
+  — `store.getRepoPath(source)` → `store.getRepoBasePath(source)` and
+  `store.hasRepo(source)` → `store.hasBareRepo(source)` — including in any
+  hand-written `MegarepoStore` test double, which no longer needs to supply
+  the two dropped members. No behavior change.
+
 ### Fixed
 
 - **@overeng/tui-react**: stop truncating `runResult` values and JSON error

--- a/context/effect/socket/package.json
+++ b/context/effect/socket/package.json
@@ -1,19 +1,19 @@
 {
-  "name": "effect-socket-examples",
-  "private": true,
-  "type": "module",
-  "dependencies": {
-    "@effect/platform-node": "4.0.0-rc.111",
-    "effect": "4.0.0-rc.111"
-  },
-  "devDependencies": {
-    "@types/node": "26.0.0"
-  },
   "$genie": {
     "source": "package.json.genie.ts",
     "warning": "DO NOT EDIT - changes will be overwritten",
     "workspaceClosureDirs": [
       "context/effect/socket"
     ]
+  },
+  "name": "effect-socket-examples",
+  "type": "module",
+  "private": true,
+  "dependencies": {
+    "@effect/platform-node": "4.0.0-rc.111",
+    "effect": "4.0.0-rc.111"
+  },
+  "devDependencies": {
+    "@types/node": "26.0.0"
   }
 }

--- a/context/effect/socket/tsconfig.json
+++ b/context/effect/socket/tsconfig.json
@@ -3,7 +3,11 @@
 {
   "compilerOptions": {
     "target": "ES2024",
-    "lib": ["ES2024", "DOM", "DOM.Iterable"],
+    "lib": [
+      "ES2024",
+      "DOM",
+      "DOM.Iterable"
+    ],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "allowImportingTsExtensions": true,
@@ -45,8 +49,14 @@
     "rootDir": ".",
     "noEmit": true,
     "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
-    "types": ["node"]
+    "types": [
+      "node"
+    ]
   },
-  "include": ["examples/**/*.ts"],
-  "exclude": ["*.genie.ts"]
+  "include": [
+    "examples/**/*.ts"
+  ],
+  "exclude": [
+    "*.genie.ts"
+  ]
 }

--- a/context/opentui/package.json
+++ b/context/opentui/package.json
@@ -1,7 +1,14 @@
 {
+  "$genie": {
+    "source": "package.json.genie.ts",
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "context/opentui"
+    ]
+  },
   "name": "opentui-examples",
-  "private": true,
   "type": "module",
+  "private": true,
   "dependencies": {
     "@effect/atom-react": "4.0.0-rc.111",
     "@opentui/core": "0.4.1",
@@ -12,12 +19,5 @@
   "devDependencies": {
     "@types/node": "26.0.0",
     "@types/react": "19.2.17"
-  },
-  "$genie": {
-    "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten",
-    "workspaceClosureDirs": [
-      "context/opentui"
-    ]
   }
 }

--- a/context/opentui/tsconfig.json
+++ b/context/opentui/tsconfig.json
@@ -3,7 +3,11 @@
 {
   "compilerOptions": {
     "target": "ES2024",
-    "lib": ["ES2024", "DOM", "DOM.Iterable"],
+    "lib": [
+      "ES2024",
+      "DOM",
+      "DOM.Iterable"
+    ],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "allowImportingTsExtensions": true,
@@ -45,10 +49,16 @@
     "rootDir": ".",
     "noEmit": true,
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
-    "types": ["node"],
+    "types": [
+      "node"
+    ],
     "jsx": "react-jsx",
     "jsxImportSource": "@opentui/react"
   },
-  "include": ["examples/**/*.tsx"],
-  "exclude": ["*.genie.ts"]
+  "include": [
+    "examples/**/*.tsx"
+  ],
+  "exclude": [
+    "*.genie.ts"
+  ]
 }

--- a/context/otel-scrape/spec.md
+++ b/context/otel-scrape/spec.md
@@ -567,12 +567,7 @@ Profile artifacts use the reusable [content-address VRS](../content-address/spec
 ```ts
 interface ProfileLink {
   readonly type:
-    | 'pprof'
-    | 'cpuprofile'
-    | 'rustc-self-profile'
-    | 'tsc-trace'
-    | 'cargo-timings'
-    | string
+    'pprof' | 'cpuprofile' | 'rustc-self-profile' | 'tsc-trace' | 'cargo-timings' | string
   readonly digest: `sha256:${string}`
   readonly uri: `cas:sha256/${string}/${string}`
   readonly ui?: string

--- a/context/workarounds/bun-issues.md
+++ b/context/workarounds/bun-issues.md
@@ -33,12 +33,13 @@ Using `file:../path` dependencies is extremely slow (6-35+ seconds per package) 
 - [#25202 - bun i never exits, spikes cpu and memory on local file dependency](https://github.com/oven-sh/bun/issues/25202)
 
 **Benchmarks (example monorepo with local file: deps):**
-| Package | Registry Deps | Local `file:` Deps | Fresh Install Time |
-|---------|---------------|--------------------|--------------------|
-| `@example/shared` | 2 | 0 | 7ms |
-| `@example/utils` | 143 | 0 | 441ms |
-| `@example/common` | 216 | 3 | 6.5s |
-| `@example/cli` | 267 | 6 | 35s |
+
+| Package           | Registry Deps | Local `file:` Deps | Fresh Install Time |
+| ----------------- | ------------- | ------------------ | ------------------ |
+| `@example/shared` | 2             | 0                  | 7ms                |
+| `@example/utils`  | 143           | 0                  | 441ms              |
+| `@example/common` | 216           | 3                  | 6.5s               |
+| `@example/cli`    | 267           | 6                  | 35s                |
 
 **Solution:** Use `workspace:*` protocol instead of `file:` - workspaces create a single symlink to the package root.
 

--- a/devenv.lock
+++ b/devenv.lock
@@ -366,16 +366,16 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1786201459,
-        "narHash": "sha256-CiOTEjmwAmG2AWnaIno9YaCJJmpca2FXPhMAsnrolCg=",
+        "lastModified": 1788614874,
+        "narHash": "sha256-7QYjT2vHLuX9Z1pdxHXDKCbh1CR3D/2rywB9Tx0MPRg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8b8c811c7c2541c30382c5de7ed26be055569c60",
+        "rev": "c043004d1c6985732bcc1cbc5a9c9aecbbb4e0f0",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "release-26.05",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -3,7 +3,7 @@ inputs:
   devenv:
     url: github:cachix/devenv/v2.2.1
   nixpkgs:
-    url: github:NixOS/nixpkgs/release-26.05
+    url: github:NixOS/nixpkgs/nixos-unstable
   git-hooks:
     url: github:cachix/git-hooks.nix
     inputs:

--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1786201459,
-        "narHash": "sha256-CiOTEjmwAmG2AWnaIno9YaCJJmpca2FXPhMAsnrolCg=",
+        "lastModified": 1788614874,
+        "narHash": "sha256-7QYjT2vHLuX9Z1pdxHXDKCbh1CR3D/2rywB9Tx0MPRg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8b8c811c7c2541c30382c5de7ed26be055569c60",
+        "rev": "c043004d1c6985732bcc1cbc5a9c9aecbbb4e0f0",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "release-26.05",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -10,12 +10,11 @@
   # graph, so downstream repos should make their root nixpkgs follow
   # `effect-utils/nixpkgs` instead of overriding the input the other way around.
   inputs = {
-    # Track release-26.05: the crates.io importCargoLock UA fix (nixpkgs#524985)
-    # was backported there as nixpkgs#524989 and the branch is Hydra-cached.
-    # nixos-unstable has NOT advanced past the 2026-05-27 fix yet (still pinned
-    # at the pre-fix 2026-05-23 rev), so a lock bump on unstable is a no-op for
-    # the 403. Revisit a return to nixos-unstable once it advances. See #703.
-    nixpkgs.url = "github:NixOS/nixpkgs/release-26.05";
+    # Track nixos-unstable: it has now advanced past the crates.io
+    # importCargoLock UA fix (nixpkgs#524985), so the release-26.05 detour from
+    # #703 is no longer needed and this is again the shared root authority every
+    # downstream repo follows.
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     tsgo.url = "github:Effect-TS/tsgo";
   };

--- a/nix/buck2.nix
+++ b/nix/buck2.nix
@@ -1,3 +1,13 @@
+# Repo-local Buck2 package authority: keep nixpkgs' native-binary derivation
+# (unpackCmd/autoPatchelf/installPhase/completions) and replace only the pinned
+# release assets plus the compatible Prelude passthru.
+#
+# CONTRACT: nixpkgs' inherited `installPhase` installs one binary per entry of
+# its own `binaries` list and fails hard (`install` with no source operand) if a
+# corresponding release asset is missing from `srcs`. So `srcs` must stay a
+# SUPERSET of that list. nixpkgs added `starlark_fmt` as a third binary, so the
+# asset list below carries it too; when bumping the pin, check upstream's
+# `pkgs/by-name/bu/buck2/package.nix` `binaries` list for new entries.
 { pkgs }:
 let
   release = rec {
@@ -14,18 +24,21 @@ let
         suffix = "x86_64-unknown-linux-gnu";
         buck2Hash = "sha256-ZcsR/hR5Szrz5zK2Up8scs5OXZKdEeYMAcMfXMuDi6c=";
         rustProjectHash = "sha256-oFfEizUVfMsG7Q33HXf3API5INeaLiXEAsIkjLwENoU=";
+        starlarkFmtHash = "sha256-u2PbMoFq9jU/Csrbnl5iTdts7d05+BDSgTDG/uO/V44=";
       };
       aarch64-linux = {
         executionPlatform = "aarch64-linux";
         suffix = "aarch64-unknown-linux-gnu";
         buck2Hash = "sha256-935OTtLIOgWqh0vFfC+P64yElBLQkWdLNccion3Ph5o=";
         rustProjectHash = "sha256-4zhvmVOM/w+R8VJ74HoNhrkLM4gX6MxrXvHc+Q5Kikg=";
+        starlarkFmtHash = "sha256-mwYNYZGYkk7LcbyYEOffDhTF06gFic7h7tnBvFDQKT4=";
       };
       aarch64-darwin = {
         executionPlatform = "aarch64-macos";
         suffix = "aarch64-apple-darwin";
         buck2Hash = "sha256-odZQ/iiMmM0XCMk6hO2lvRtQ5PCQ93WeSkjtKXfDNS8=";
         rustProjectHash = "sha256-1kI0OHkBV8Cq9YR3T2Fyvn9jk9ZHD9sDD/Zx5eCDk3M=";
+        starlarkFmtHash = "sha256-7UX2aCbpR0cJDIEKqm63kWqeXk9UDfy4+NKuWoxh5YM=";
       };
     };
   };
@@ -44,6 +57,10 @@ pkgs.buck2.overrideAttrs (oldAttrs: {
     (pkgs.fetchurl {
       url = "${release.releaseBaseUrl}/rust-project-${platform.suffix}.zst";
       hash = platform.rustProjectHash;
+    })
+    (pkgs.fetchurl {
+      url = "${release.releaseBaseUrl}/starlark_fmt-${platform.suffix}.zst";
+      hash = platform.starlarkFmtHash;
     })
   ];
   passthru = oldAttrs.passthru // {

--- a/nix/weaver-flake/flake.lock
+++ b/nix/weaver-flake/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1782890111,
-        "narHash": "sha256-PV5IJhIrS7LSr1BERlfw+Oj3+yDA6NheyNF4WNMBhyM=",
+        "lastModified": 1788614874,
+        "narHash": "sha256-7QYjT2vHLuX9Z1pdxHXDKCbh1CR3D/2rywB9Tx0MPRg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "04f26a566d62676a6d1539dc0152131aa26f33fa",
+        "rev": "c043004d1c6985732bcc1cbc5a9c9aecbbb4e0f0",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "release-26.05",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/nix/weaver-flake/flake.nix
+++ b/nix/weaver-flake/flake.nix
@@ -6,8 +6,9 @@
   # upstream release. nixpkgs currently pins 0.23.0; building ourselves lets us
   # stay ahead of that. This flake targets v0.24.2.
   #
-  # nixpkgs (release-26.05) is used only for the build toolchain (rustPlatform,
-  # pnpm, node, openssl, python) - the Weaver sources come from `src` below.
+  # nixpkgs (nixos-unstable — same authority as the repo root) is used only for the
+  # build toolchain (rustPlatform, pnpm, node, openssl, python) - the Weaver sources
+  # come from `src` below.
   #
   # Weaver bundles a Vite/pnpm web UI whose built output (`ui/dist`) is embedded
   # into the binary at compile time via `include_dir!("ui/dist")`, so the UI
@@ -37,7 +38,7 @@
   description = "OpenTelemetry Weaver, built from source (latest upstream)";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/release-26.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
   };
 
   outputs =

--- a/nix/workspace-tools/lib/tests/buck2-bridge.sh
+++ b/nix/workspace-tools/lib/tests/buck2-bridge.sh
@@ -1,6 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Every fixture below is a Linux ELF build product: buck2-bridge.nix hardcodes
+# `platform.os = "linux"` with glibc/musl ABIs, compiles the fixtures with the
+# host `stdenv`/`pkgsStatic` C compilers, patches host ELF interpreters, and the
+# import path executes the built entrypoint. On a non-Linux host the same
+# expressions produce Mach-O binaries described as linux/glibc, so the ELF
+# class, machine, interpreter, DT_NEEDED, and symbol-version assertions cannot
+# be executed at all. The platform-neutral descriptor contract is covered by
+# buck2-build-product-contract.sh, which the gate runs before this script on
+# every platform.
+host_os="$(uname -s)"
+if [ "$host_os" != Linux ]; then
+  echo "buck2-bridge-test: SKIP host=$host_os reason=ELF fixture build, runtime inspection, and artifact import require a Linux host; platform-neutral descriptor coverage runs in buck2-build-product-contract.sh"
+  exit 0
+fi
+
 repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd -P)}"
 export BUCK2_BRIDGE_REPO="$repo_root"
 

--- a/package.json
+++ b/package.json
@@ -1,4 +1,8 @@
 {
+  "$genie": {
+    "source": "package.json.genie.ts",
+    "warning": "DO NOT EDIT - changes will be overwritten"
+  },
   "name": "effect-utils-workspace",
   "private": true,
   "workspaces": [
@@ -41,9 +45,5 @@
     "packages/@overeng/utils",
     "packages/@overeng/utils-dev"
   ],
-  "packageManager": "pnpm@11.8.0",
-  "$genie": {
-    "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten"
-  }
+  "packageManager": "pnpm@11.8.0"
 }

--- a/packages/@overeng/agent-session-ingest/package.json
+++ b/packages/@overeng/agent-session-ingest/package.json
@@ -1,24 +1,26 @@
 {
+  "$genie": {
+    "source": "package.json.genie.ts",
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/agent-session-ingest",
+      "packages/@overeng/content-address",
+      "packages/@overeng/effect-distributed-lock",
+      "packages/@overeng/otel-contract",
+      "packages/@overeng/utils",
+      "packages/@overeng/utils-dev"
+    ]
+  },
   "name": "@overeng/agent-session-ingest",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
+  "private": true,
   "exports": {
     ".": "./src/mod.ts",
     "./claude": "./src/adapters/claude.ts",
     "./codex": "./src/adapters/codex.ts",
     "./jsonl": "./src/adapters/jsonl.ts",
     "./opencode": "./src/adapters/opencode.ts"
-  },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      ".": "./dist/mod.js",
-      "./codex": "./dist/adapters/codex.js",
-      "./claude": "./dist/adapters/claude.js",
-      "./opencode": "./dist/adapters/opencode.js",
-      "./jsonl": "./dist/adapters/jsonl.js"
-    }
   },
   "dependencies": {
     "@effect/opentelemetry": "4.0.0-rc.111",
@@ -41,16 +43,14 @@
   "peerDependencies": {
     "effect": "^4.0.0-rc.111"
   },
-  "$genie": {
-    "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten",
-    "workspaceClosureDirs": [
-      "packages/@overeng/agent-session-ingest",
-      "packages/@overeng/content-address",
-      "packages/@overeng/effect-distributed-lock",
-      "packages/@overeng/otel-contract",
-      "packages/@overeng/utils",
-      "packages/@overeng/utils-dev"
-    ]
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": "./dist/mod.js",
+      "./codex": "./dist/adapters/codex.js",
+      "./claude": "./dist/adapters/claude.js",
+      "./opencode": "./dist/adapters/opencode.js",
+      "./jsonl": "./dist/adapters/jsonl.js"
+    }
   }
 }

--- a/packages/@overeng/agent-session-ingest/tsconfig.json
+++ b/packages/@overeng/agent-session-ingest/tsconfig.json
@@ -3,7 +3,9 @@
 {
   "compilerOptions": {
     "target": "ES2024",
-    "lib": ["ES2023"],
+    "lib": [
+      "ES2023"
+    ],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "allowImportingTsExtensions": true,
@@ -44,7 +46,11 @@
     "composite": true,
     "rootDir": ".",
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
-    "types": ["node"]
+    "types": [
+      "node"
+    ]
   },
-  "include": ["src/**/*"]
+  "include": [
+    "src/**/*"
+  ]
 }

--- a/packages/@overeng/buck2-tools/package.json
+++ b/packages/@overeng/buck2-tools/package.json
@@ -1,16 +1,18 @@
 {
+  "$genie": {
+    "source": "package.json.genie.ts",
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/buck2-tools",
+      "packages/@overeng/utils-dev"
+    ]
+  },
   "name": "@overeng/buck2-tools",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
+  "private": true,
   "exports": {
     ".": "./src/mod.ts"
-  },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      ".": "./dist/mod.js"
-    }
   },
   "devDependencies": {
     "@overeng/utils-dev": "workspace:^",
@@ -19,12 +21,10 @@
     "typescript": "6.0.3",
     "vitest": "4.1.9"
   },
-  "$genie": {
-    "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten",
-    "workspaceClosureDirs": [
-      "packages/@overeng/buck2-tools",
-      "packages/@overeng/utils-dev"
-    ]
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": "./dist/mod.js"
+    }
   }
 }

--- a/packages/@overeng/buck2-tools/src/package-tree.ts
+++ b/packages/@overeng/buck2-tools/src/package-tree.ts
@@ -81,7 +81,7 @@ const parseOptions = (args: readonly string[]): PackageTreeOptions => {
   const workspaceFiles = new Map<string, string>()
   const workspaceLinks = new Map<string, string>()
 
-  for (let index = 0; index < args.length; ) {
+  for (let index = 0; index < args.length;) {
     const flag = requireValue({ args, index, flag: 'argument' })
     if (flag === '--file' || flag === '--workspace-file' || flag === '--workspace-link') {
       const destination = requireRelativePath({

--- a/packages/@overeng/buck2-tools/tsconfig.json
+++ b/packages/@overeng/buck2-tools/tsconfig.json
@@ -3,7 +3,9 @@
 {
   "compilerOptions": {
     "target": "ES2024",
-    "lib": ["ES2024"],
+    "lib": [
+      "ES2024"
+    ],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "allowImportingTsExtensions": true,
@@ -44,8 +46,13 @@
     "composite": true,
     "rootDir": ".",
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
-    "types": ["node", "bun"]
+    "types": [
+      "node",
+      "bun"
+    ]
   },
-  "include": ["src/**/*"],
+  "include": [
+    "src/**/*"
+  ],
   "references": []
 }

--- a/packages/@overeng/ci-tools/nix/build.nix
+++ b/packages/@overeng/ci-tools/nix/build.nix
@@ -19,7 +19,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-nRrSI3p5vM2ukhCOv1+xpNjptRg00sO9x4h16Ob//FA=";
+      "." = mkSharedHash "sha256-TuNqAnSA1ZdHiRpE0ZfcMnCJUMbupLDaK+ck0XzXlec=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/ci-tools/package.json
+++ b/packages/@overeng/ci-tools/package.json
@@ -1,21 +1,23 @@
 {
+  "$genie": {
+    "source": "package.json.genie.ts",
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/ci-tools",
+      "packages/@overeng/content-address",
+      "packages/@overeng/effect-distributed-lock",
+      "packages/@overeng/otel-contract",
+      "packages/@overeng/utils",
+      "packages/@overeng/utils-dev"
+    ]
+  },
   "name": "@overeng/ci-tools",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
+  "private": true,
   "exports": {
     ".": "./src/mod.ts",
     "./cli": "./src/cli-command.ts"
-  },
-  "publishConfig": {
-    "access": "public",
-    "bin": {
-      "ci-tools": "./dist/bin/ci-tools.js"
-    },
-    "exports": {
-      ".": "./dist/src/mod.js",
-      "./cli": "./dist/src/cli-command.js"
-    }
   },
   "dependencies": {
     "@overeng/otel-contract": "workspace:^",
@@ -37,16 +39,14 @@
     "@playwright/test": "^1.61.0",
     "effect": "^4.0.0-rc.111"
   },
-  "$genie": {
-    "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten",
-    "workspaceClosureDirs": [
-      "packages/@overeng/ci-tools",
-      "packages/@overeng/content-address",
-      "packages/@overeng/effect-distributed-lock",
-      "packages/@overeng/otel-contract",
-      "packages/@overeng/utils",
-      "packages/@overeng/utils-dev"
-    ]
+  "publishConfig": {
+    "access": "public",
+    "bin": {
+      "ci-tools": "./dist/bin/ci-tools.js"
+    },
+    "exports": {
+      ".": "./dist/src/mod.js",
+      "./cli": "./dist/src/cli-command.js"
+    }
   }
 }

--- a/packages/@overeng/ci-tools/tsconfig.json
+++ b/packages/@overeng/ci-tools/tsconfig.json
@@ -3,7 +3,9 @@
 {
   "compilerOptions": {
     "target": "ES2024",
-    "lib": ["ES2024"],
+    "lib": [
+      "ES2024"
+    ],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "allowImportingTsExtensions": true,
@@ -44,7 +46,13 @@
     "composite": true,
     "rootDir": ".",
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
-    "types": ["node", "bun"]
+    "types": [
+      "node",
+      "bun"
+    ]
   },
-  "include": ["src/**/*", "bin/**/*.ts"]
+  "include": [
+    "src/**/*",
+    "bin/**/*.ts"
+  ]
 }

--- a/packages/@overeng/content-address/package.json
+++ b/packages/@overeng/content-address/package.json
@@ -1,18 +1,20 @@
 {
+  "$genie": {
+    "source": "package.json.genie.ts",
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/content-address",
+      "packages/@overeng/utils-dev"
+    ]
+  },
   "name": "@overeng/content-address",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
+  "private": true,
   "exports": {
     ".": {
       "types": "./dist/src/mod.d.ts",
       "default": "./src/mod.ts"
-    }
-  },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      ".": "./dist/mod.js"
     }
   },
   "dependencies": {
@@ -26,12 +28,10 @@
     "typescript": "6.0.3",
     "vitest": "4.1.9"
   },
-  "$genie": {
-    "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten",
-    "workspaceClosureDirs": [
-      "packages/@overeng/content-address",
-      "packages/@overeng/utils-dev"
-    ]
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": "./dist/mod.js"
+    }
   }
 }

--- a/packages/@overeng/content-address/tsconfig.json
+++ b/packages/@overeng/content-address/tsconfig.json
@@ -3,7 +3,9 @@
 {
   "compilerOptions": {
     "target": "ES2024",
-    "lib": ["ES2024"],
+    "lib": [
+      "ES2024"
+    ],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "allowImportingTsExtensions": true,
@@ -44,9 +46,13 @@
     "composite": true,
     "rootDir": ".",
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
-    "types": ["node"],
+    "types": [
+      "node"
+    ],
     "noEmit": true
   },
-  "include": ["src/**/*"],
+  "include": [
+    "src/**/*"
+  ],
   "references": []
 }

--- a/packages/@overeng/effect-ai-claude-cli/package.json
+++ b/packages/@overeng/effect-ai-claude-cli/package.json
@@ -1,16 +1,18 @@
 {
+  "$genie": {
+    "source": "package.json.genie.ts",
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/effect-ai-claude-cli",
+      "packages/@overeng/utils-dev"
+    ]
+  },
   "name": "@overeng/effect-ai-claude-cli",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
+  "private": true,
   "exports": {
     ".": "./src/mod.ts"
-  },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      ".": "./dist/mod.js"
-    }
   },
   "devDependencies": {
     "@effect/vitest": "4.0.0-rc.111",
@@ -23,12 +25,10 @@
   "peerDependencies": {
     "effect": "^4.0.0-rc.111"
   },
-  "$genie": {
-    "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten",
-    "workspaceClosureDirs": [
-      "packages/@overeng/effect-ai-claude-cli",
-      "packages/@overeng/utils-dev"
-    ]
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": "./dist/mod.js"
+    }
   }
 }

--- a/packages/@overeng/effect-ai-claude-cli/tsconfig.json
+++ b/packages/@overeng/effect-ai-claude-cli/tsconfig.json
@@ -3,7 +3,11 @@
 {
   "compilerOptions": {
     "target": "ES2024",
-    "lib": ["ES2024", "DOM", "DOM.Iterable"],
+    "lib": [
+      "ES2024",
+      "DOM",
+      "DOM.Iterable"
+    ],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "allowImportingTsExtensions": true,
@@ -45,6 +49,8 @@
     "rootDir": ".",
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo"
   },
-  "include": ["src/**/*"],
+  "include": [
+    "src/**/*"
+  ],
   "references": []
 }

--- a/packages/@overeng/effect-distributed-lock/package.json
+++ b/packages/@overeng/effect-distributed-lock/package.json
@@ -1,18 +1,20 @@
 {
+  "$genie": {
+    "source": "package.json.genie.ts",
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/effect-distributed-lock",
+      "packages/@overeng/utils-dev"
+    ]
+  },
   "name": "@overeng/effect-distributed-lock",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
+  "private": true,
   "exports": {
     ".": {
       "types": "./dist/src/mod.d.ts",
       "default": "./src/mod.ts"
-    }
-  },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      ".": "./dist/mod.js"
     }
   },
   "devDependencies": {
@@ -26,12 +28,10 @@
   "peerDependencies": {
     "effect": "^4.0.0-rc.111"
   },
-  "$genie": {
-    "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten",
-    "workspaceClosureDirs": [
-      "packages/@overeng/effect-distributed-lock",
-      "packages/@overeng/utils-dev"
-    ]
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": "./dist/mod.js"
+    }
   }
 }

--- a/packages/@overeng/effect-distributed-lock/tsconfig.json
+++ b/packages/@overeng/effect-distributed-lock/tsconfig.json
@@ -3,7 +3,9 @@
 {
   "compilerOptions": {
     "target": "ES2024",
-    "lib": ["ES2024"],
+    "lib": [
+      "ES2024"
+    ],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "allowImportingTsExtensions": true,
@@ -41,12 +43,16 @@
         }
       }
     ],
-    "types": ["node"],
+    "types": [
+      "node"
+    ],
     "composite": true,
     "rootDir": ".",
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
     "noEmit": true
   },
-  "include": ["src/**/*"],
+  "include": [
+    "src/**/*"
+  ],
   "references": []
 }

--- a/packages/@overeng/effect-path/package.json
+++ b/packages/@overeng/effect-path/package.json
@@ -1,16 +1,18 @@
 {
+  "$genie": {
+    "source": "package.json.genie.ts",
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/effect-path",
+      "packages/@overeng/utils-dev"
+    ]
+  },
   "name": "@overeng/effect-path",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
+  "private": true,
   "exports": {
     ".": "./src/mod.ts"
-  },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      ".": "./dist/mod.js"
-    }
   },
   "devDependencies": {
     "@effect/platform-node": "4.0.0-rc.111",
@@ -24,12 +26,10 @@
   "peerDependencies": {
     "effect": "^4.0.0-rc.111"
   },
-  "$genie": {
-    "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten",
-    "workspaceClosureDirs": [
-      "packages/@overeng/effect-path",
-      "packages/@overeng/utils-dev"
-    ]
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": "./dist/mod.js"
+    }
   }
 }

--- a/packages/@overeng/effect-path/tsconfig.json
+++ b/packages/@overeng/effect-path/tsconfig.json
@@ -3,7 +3,9 @@
 {
   "compilerOptions": {
     "target": "ES2024",
-    "lib": ["ES2023"],
+    "lib": [
+      "ES2023"
+    ],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "allowImportingTsExtensions": true,
@@ -44,8 +46,12 @@
     "composite": true,
     "rootDir": ".",
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
-    "types": ["node"]
+    "types": [
+      "node"
+    ]
   },
-  "include": ["src/**/*"],
+  "include": [
+    "src/**/*"
+  ],
   "references": []
 }

--- a/packages/@overeng/effect-react/package.json
+++ b/packages/@overeng/effect-react/package.json
@@ -1,18 +1,23 @@
 {
+  "$genie": {
+    "source": "package.json.genie.ts",
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/content-address",
+      "packages/@overeng/effect-distributed-lock",
+      "packages/@overeng/effect-react",
+      "packages/@overeng/otel-contract",
+      "packages/@overeng/utils",
+      "packages/@overeng/utils-dev"
+    ]
+  },
   "name": "@overeng/effect-react",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
+  "private": true,
   "exports": {
     ".": "./src/mod.ts",
     "./react-aria": "./src/react-aria/mod.ts"
-  },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      ".": "./dist/mod.js",
-      "./react-aria": "./dist/react-aria/mod.js"
-    }
   },
   "scripts": {
     "storybook": "storybook dev -p 6009",
@@ -43,16 +48,11 @@
     "react-aria-components": "^1.19.0",
     "react-dom": "^19.2.7"
   },
-  "$genie": {
-    "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten",
-    "workspaceClosureDirs": [
-      "packages/@overeng/content-address",
-      "packages/@overeng/effect-distributed-lock",
-      "packages/@overeng/effect-react",
-      "packages/@overeng/otel-contract",
-      "packages/@overeng/utils",
-      "packages/@overeng/utils-dev"
-    ]
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": "./dist/mod.js",
+      "./react-aria": "./dist/react-aria/mod.js"
+    }
   }
 }

--- a/packages/@overeng/effect-react/tsconfig.json
+++ b/packages/@overeng/effect-react/tsconfig.json
@@ -3,7 +3,11 @@
 {
   "compilerOptions": {
     "target": "ES2024",
-    "lib": ["ES2024", "DOM", "DOM.Iterable"],
+    "lib": [
+      "ES2024",
+      "DOM",
+      "DOM.Iterable"
+    ],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "allowImportingTsExtensions": true,
@@ -47,5 +51,8 @@
     "jsx": "react-jsx",
     "jsxImportSource": "react"
   },
-  "include": ["src/**/*", "test/**/*"]
+  "include": [
+    "src/**/*",
+    "test/**/*"
+  ]
 }

--- a/packages/@overeng/effect-rpc-tanstack/examples/basic/package.json
+++ b/packages/@overeng/effect-rpc-tanstack/examples/basic/package.json
@@ -1,8 +1,20 @@
 {
+  "$genie": {
+    "source": "package.json.genie.ts",
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/content-address",
+      "packages/@overeng/effect-distributed-lock",
+      "packages/@overeng/effect-rpc-tanstack/examples/basic",
+      "packages/@overeng/otel-contract",
+      "packages/@overeng/utils",
+      "packages/@overeng/utils-dev"
+    ]
+  },
   "name": "effect-rpc-tanstack-example-basic",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
+  "private": true,
   "scripts": {
     "dev": "vite",
     "build": "vite build",
@@ -26,17 +38,5 @@
     "@vitejs/plugin-react": "6.0.2",
     "typescript": "6.0.3",
     "vite": "8.0.16"
-  },
-  "$genie": {
-    "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten",
-    "workspaceClosureDirs": [
-      "packages/@overeng/content-address",
-      "packages/@overeng/effect-distributed-lock",
-      "packages/@overeng/effect-rpc-tanstack/examples/basic",
-      "packages/@overeng/otel-contract",
-      "packages/@overeng/utils",
-      "packages/@overeng/utils-dev"
-    ]
   }
 }

--- a/packages/@overeng/effect-rpc-tanstack/examples/basic/tsconfig.json
+++ b/packages/@overeng/effect-rpc-tanstack/examples/basic/tsconfig.json
@@ -3,11 +3,17 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["ES2024", "DOM", "DOM.Iterable"],
+    "lib": [
+      "ES2024",
+      "DOM",
+      "DOM.Iterable"
+    ],
     "module": "ESNext",
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
-    "types": ["node"],
+    "types": [
+      "node"
+    ],
     "jsx": "react-jsx",
     "strict": true,
     "noUncheckedIndexedAccess": true,
@@ -17,5 +23,8 @@
     "isolatedModules": true,
     "noEmit": true
   },
-  "include": ["src/**/*", "vite.config.ts"]
+  "include": [
+    "src/**/*",
+    "vite.config.ts"
+  ]
 }

--- a/packages/@overeng/effect-rpc-tanstack/package.json
+++ b/packages/@overeng/effect-rpc-tanstack/package.json
@@ -1,22 +1,26 @@
 {
+  "$genie": {
+    "source": "package.json.genie.ts",
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/content-address",
+      "packages/@overeng/effect-distributed-lock",
+      "packages/@overeng/effect-rpc-tanstack",
+      "packages/@overeng/effect-rpc-tanstack/examples/basic",
+      "packages/@overeng/otel-contract",
+      "packages/@overeng/utils",
+      "packages/@overeng/utils-dev"
+    ]
+  },
   "name": "@overeng/effect-rpc-tanstack",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
+  "private": true,
   "exports": {
     ".": "./src/mod.ts",
     "./client": "./src/client.ts",
     "./router": "./src/router.ts",
     "./server": "./src/server.ts"
-  },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      ".": "./dist/mod.js",
-      "./client": "./dist/client.js",
-      "./server": "./dist/server.js",
-      "./router": "./dist/router.js"
-    }
   },
   "devDependencies": {
     "@effect/platform-node": "4.0.0-rc.111",
@@ -39,17 +43,13 @@
     "react": "^19.2.7",
     "react-dom": "^19.2.7"
   },
-  "$genie": {
-    "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten",
-    "workspaceClosureDirs": [
-      "packages/@overeng/content-address",
-      "packages/@overeng/effect-distributed-lock",
-      "packages/@overeng/effect-rpc-tanstack",
-      "packages/@overeng/effect-rpc-tanstack/examples/basic",
-      "packages/@overeng/otel-contract",
-      "packages/@overeng/utils",
-      "packages/@overeng/utils-dev"
-    ]
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": "./dist/mod.js",
+      "./client": "./dist/client.js",
+      "./server": "./dist/server.js",
+      "./router": "./dist/router.js"
+    }
   }
 }

--- a/packages/@overeng/effect-rpc-tanstack/tsconfig.json
+++ b/packages/@overeng/effect-rpc-tanstack/tsconfig.json
@@ -3,7 +3,11 @@
 {
   "compilerOptions": {
     "target": "ES2024",
-    "lib": ["ES2024", "DOM", "DOM.Iterable"],
+    "lib": [
+      "ES2024",
+      "DOM",
+      "DOM.Iterable"
+    ],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "allowImportingTsExtensions": true,
@@ -47,5 +51,7 @@
     "jsx": "react-jsx",
     "jsxImportSource": "react"
   },
-  "include": ["src/**/*"]
+  "include": [
+    "src/**/*"
+  ]
 }

--- a/packages/@overeng/effect-schema-form-aria/package.json
+++ b/packages/@overeng/effect-schema-form-aria/package.json
@@ -1,18 +1,25 @@
 {
+  "$genie": {
+    "source": "package.json.genie.ts",
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/content-address",
+      "packages/@overeng/effect-distributed-lock",
+      "packages/@overeng/effect-schema-form",
+      "packages/@overeng/effect-schema-form-aria",
+      "packages/@overeng/otel-contract",
+      "packages/@overeng/stylex-tokens",
+      "packages/@overeng/utils",
+      "packages/@overeng/utils-dev"
+    ]
+  },
   "name": "@overeng/effect-schema-form-aria",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
+  "private": true,
   "exports": {
     ".": "./src/mod.ts",
     "./styles.css": "./src/styles.css"
-  },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      ".": "./dist/mod.js",
-      "./styles.css": "./dist/styles.css"
-    }
   },
   "scripts": {
     "build": "tsc --build tsconfig.json && vite build",
@@ -49,18 +56,11 @@
     "react-aria-components": "^1.19.0",
     "react-dom": "^19.2.7"
   },
-  "$genie": {
-    "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten",
-    "workspaceClosureDirs": [
-      "packages/@overeng/content-address",
-      "packages/@overeng/effect-distributed-lock",
-      "packages/@overeng/effect-schema-form",
-      "packages/@overeng/effect-schema-form-aria",
-      "packages/@overeng/otel-contract",
-      "packages/@overeng/stylex-tokens",
-      "packages/@overeng/utils",
-      "packages/@overeng/utils-dev"
-    ]
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": "./dist/mod.js",
+      "./styles.css": "./dist/styles.css"
+    }
   }
 }

--- a/packages/@overeng/effect-schema-form-aria/tsconfig.json
+++ b/packages/@overeng/effect-schema-form-aria/tsconfig.json
@@ -3,7 +3,11 @@
 {
   "compilerOptions": {
     "target": "ES2024",
-    "lib": ["ES2024", "DOM", "DOM.Iterable"],
+    "lib": [
+      "ES2024",
+      "DOM",
+      "DOM.Iterable"
+    ],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "allowImportingTsExtensions": true,
@@ -46,7 +50,9 @@
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
     "jsx": "react-jsx"
   },
-  "include": ["src/**/*"],
+  "include": [
+    "src/**/*"
+  ],
   "references": [
     {
       "path": "../effect-schema-form"

--- a/packages/@overeng/effect-schema-form-aria/vite.config.ts
+++ b/packages/@overeng/effect-schema-form-aria/vite.config.ts
@@ -38,7 +38,7 @@ export default defineConfig({
       fileName: 'mod',
       cssFileName: 'styles',
     },
-    rollupOptions: {
+    rolldownOptions: {
       external: [
         /^@overeng\/effect-schema-form(?:\/|$)/,
         /^@stylexjs\/stylex(?:\/|$)/,

--- a/packages/@overeng/effect-schema-form/package.json
+++ b/packages/@overeng/effect-schema-form/package.json
@@ -1,16 +1,17 @@
 {
+  "$genie": {
+    "source": "package.json.genie.ts",
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/effect-schema-form"
+    ]
+  },
   "name": "@overeng/effect-schema-form",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
+  "private": true,
   "exports": {
     ".": "./src/mod.ts"
-  },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      ".": "./dist/mod.js"
-    }
   },
   "devDependencies": {
     "@types/react": "19.2.17",
@@ -25,11 +26,10 @@
     "effect": "^4.0.0-rc.111",
     "react": "^19.2.7"
   },
-  "$genie": {
-    "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten",
-    "workspaceClosureDirs": [
-      "packages/@overeng/effect-schema-form"
-    ]
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": "./dist/mod.js"
+    }
   }
 }

--- a/packages/@overeng/effect-schema-form/tsconfig.json
+++ b/packages/@overeng/effect-schema-form/tsconfig.json
@@ -3,7 +3,11 @@
 {
   "compilerOptions": {
     "target": "ES2024",
-    "lib": ["ES2024", "DOM", "DOM.Iterable"],
+    "lib": [
+      "ES2024",
+      "DOM",
+      "DOM.Iterable"
+    ],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "allowImportingTsExtensions": true,
@@ -46,5 +50,7 @@
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
     "jsx": "react-jsx"
   },
-  "include": ["src/**/*"]
+  "include": [
+    "src/**/*"
+  ]
 }

--- a/packages/@overeng/genie/docs/generators/01-otel-semconv/spec.md
+++ b/packages/@overeng/genie/docs/generators/01-otel-semconv/spec.md
@@ -94,7 +94,8 @@ type AttrDef = {
   encode?: 'auto' | 'string' | 'number' | 'boolean' | 'json' | 'drop' | 'redacted'
 }
 
-type Deprecated = // weaver 0.23 STRUCTURED form (string removed)
+type Deprecated =
+  // weaver 0.23 STRUCTURED form (string removed)
   | { reason: 'renamed'; renamed_to: string }
   | { reason: 'obsoleted' | 'uncategorized'; note: string }
 

--- a/packages/@overeng/genie/nix/build.nix
+++ b/packages/@overeng/genie/nix/build.nix
@@ -26,7 +26,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-8I1Os3N5NTwVZRcT0XyXNbazGpFebYtzVHUZuy3oNxw=";
+      "." = mkSharedHash "sha256-mecCNKs36ZGV1OURWa98zOVEtnm8BLhSPHohGCywv1k=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/genie/package.json
+++ b/packages/@overeng/genie/package.json
@@ -1,24 +1,28 @@
 {
+  "$genie": {
+    "source": "package.json.genie.ts",
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/content-address",
+      "packages/@overeng/effect-distributed-lock",
+      "packages/@overeng/genie",
+      "packages/@overeng/otel-contract",
+      "packages/@overeng/tui-core",
+      "packages/@overeng/tui-react",
+      "packages/@overeng/utils",
+      "packages/@overeng/utils-dev"
+    ]
+  },
   "name": "@overeng/genie",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
+  "private": true,
   "exports": {
     ".": "./src/runtime/mod.ts",
     "./cli": "./src/build/mod.tsx",
     "./composition": "./src/runtime/composition/mod.ts",
     "./node": "./src/runtime/node/mod.ts",
     "./sdk": "./src/sdk/mod.ts"
-  },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      ".": "./dist/src/runtime/mod.js",
-      "./node": "./dist/src/runtime/node/mod.js",
-      "./composition": "./dist/src/runtime/composition/mod.js",
-      "./cli": "./dist/src/build/mod.js",
-      "./sdk": "./dist/src/sdk/mod.js"
-    }
   },
   "scripts": {
     "storybook": "storybook dev -p 6008",
@@ -43,6 +47,11 @@
     "typescript": "6.0.3",
     "vitest": "4.1.9"
   },
+  "dependenciesMeta": {
+    "@overeng/tui-react": {
+      "injected": true
+    }
+  },
   "devDependencies": {
     "@effect/atom-react": "4.0.0-rc.111",
     "@effect/platform-node": "4.0.0-rc.111",
@@ -60,11 +69,6 @@
     "storybook": "10.5.10",
     "vitest": "4.1.9"
   },
-  "dependenciesMeta": {
-    "@overeng/tui-react": {
-      "injected": true
-    }
-  },
   "peerDependencies": {
     "@effect/atom-react": "^4.0.0-rc.111",
     "@effect/opentelemetry": "^4.0.0-rc.111",
@@ -80,18 +84,14 @@
     "react-dom": "^19.2.7",
     "react-reconciler": "^0.33.0"
   },
-  "$genie": {
-    "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten",
-    "workspaceClosureDirs": [
-      "packages/@overeng/content-address",
-      "packages/@overeng/effect-distributed-lock",
-      "packages/@overeng/genie",
-      "packages/@overeng/otel-contract",
-      "packages/@overeng/tui-core",
-      "packages/@overeng/tui-react",
-      "packages/@overeng/utils",
-      "packages/@overeng/utils-dev"
-    ]
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": "./dist/src/runtime/mod.js",
+      "./node": "./dist/src/runtime/node/mod.js",
+      "./composition": "./dist/src/runtime/composition/mod.js",
+      "./cli": "./dist/src/build/mod.js",
+      "./sdk": "./dist/src/sdk/mod.js"
+    }
   }
 }

--- a/packages/@overeng/genie/tsconfig.json
+++ b/packages/@overeng/genie/tsconfig.json
@@ -3,7 +3,9 @@
 {
   "compilerOptions": {
     "target": "ES2024",
-    "lib": ["ES2024"],
+    "lib": [
+      "ES2024"
+    ],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "allowImportingTsExtensions": true,
@@ -44,8 +46,16 @@
     "composite": true,
     "rootDir": ".",
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
-    "types": ["node", "bun"],
+    "types": [
+      "node",
+      "bun"
+    ],
     "jsx": "react-jsx"
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", "bin/**/*.ts", "bin/**/*.tsx"]
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "bin/**/*.ts",
+    "bin/**/*.tsx"
+  ]
 }

--- a/packages/@overeng/kdl-effect/package.json
+++ b/packages/@overeng/kdl-effect/package.json
@@ -1,16 +1,19 @@
 {
+  "$genie": {
+    "source": "package.json.genie.ts",
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/kdl",
+      "packages/@overeng/kdl-effect",
+      "packages/@overeng/utils-dev"
+    ]
+  },
   "name": "@overeng/kdl-effect",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
+  "private": true,
   "exports": {
     ".": "./src/mod.ts"
-  },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      ".": "./dist/mod.js"
-    }
   },
   "dependencies": {
     "@overeng/kdl": "workspace:^"
@@ -26,13 +29,10 @@
   "peerDependencies": {
     "effect": "^4.0.0-rc.111"
   },
-  "$genie": {
-    "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten",
-    "workspaceClosureDirs": [
-      "packages/@overeng/kdl",
-      "packages/@overeng/kdl-effect",
-      "packages/@overeng/utils-dev"
-    ]
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": "./dist/mod.js"
+    }
   }
 }

--- a/packages/@overeng/kdl-effect/tsconfig.json
+++ b/packages/@overeng/kdl-effect/tsconfig.json
@@ -3,7 +3,9 @@
 {
   "compilerOptions": {
     "target": "ES2024",
-    "lib": ["ES2024"],
+    "lib": [
+      "ES2024"
+    ],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "allowImportingTsExtensions": true,
@@ -44,9 +46,13 @@
     "composite": true,
     "rootDir": ".",
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
-    "types": ["node"]
+    "types": [
+      "node"
+    ]
   },
-  "include": ["src/**/*"],
+  "include": [
+    "src/**/*"
+  ],
   "references": [
     {
       "path": "../kdl"

--- a/packages/@overeng/kdl/package.json
+++ b/packages/@overeng/kdl/package.json
@@ -1,16 +1,18 @@
 {
+  "$genie": {
+    "source": "package.json.genie.ts",
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/kdl",
+      "packages/@overeng/utils-dev"
+    ]
+  },
   "name": "@overeng/kdl",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
+  "private": true,
   "exports": {
     ".": "./src/mod.ts"
-  },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      ".": "./dist/mod.js"
-    }
   },
   "devDependencies": {
     "@effect/vitest": "4.0.0-rc.111",
@@ -23,12 +25,10 @@
   "peerDependencies": {
     "effect": "^4.0.0-rc.111"
   },
-  "$genie": {
-    "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten",
-    "workspaceClosureDirs": [
-      "packages/@overeng/kdl",
-      "packages/@overeng/utils-dev"
-    ]
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": "./dist/mod.js"
+    }
   }
 }

--- a/packages/@overeng/kdl/tsconfig.json
+++ b/packages/@overeng/kdl/tsconfig.json
@@ -3,7 +3,9 @@
 {
   "compilerOptions": {
     "target": "ES2024",
-    "lib": ["ES2024"],
+    "lib": [
+      "ES2024"
+    ],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "allowImportingTsExtensions": true,
@@ -44,8 +46,12 @@
     "composite": true,
     "rootDir": ".",
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
-    "types": ["node"]
+    "types": [
+      "node"
+    ]
   },
-  "include": ["src/**/*"],
+  "include": [
+    "src/**/*"
+  ],
   "references": []
 }

--- a/packages/@overeng/megarepo/nix/build.nix
+++ b/packages/@overeng/megarepo/nix/build.nix
@@ -26,7 +26,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-mz+BhVqT0S8W/Tf3CV8zkI14L7ozYkOLH7T2DJi6Q9A=";
+      "." = mkSharedHash "sha256-hctDfUSsU8hLiUtNOArxmWeLija7pObcTDxEXVUCwSc=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     smokeTestArgs = [ "--help" ];

--- a/packages/@overeng/megarepo/package.json
+++ b/packages/@overeng/megarepo/package.json
@@ -1,20 +1,29 @@
 {
+  "$genie": {
+    "source": "package.json.genie.ts",
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/content-address",
+      "packages/@overeng/effect-distributed-lock",
+      "packages/@overeng/effect-path",
+      "packages/@overeng/kdl",
+      "packages/@overeng/kdl-effect",
+      "packages/@overeng/megarepo",
+      "packages/@overeng/otel-contract",
+      "packages/@overeng/tui-core",
+      "packages/@overeng/tui-react",
+      "packages/@overeng/utils",
+      "packages/@overeng/utils-dev"
+    ]
+  },
   "name": "@overeng/megarepo",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
+  "private": true,
   "exports": {
     ".": "./src/mod.ts",
     "./buck2-manifest": "./src/buck2-manifest.ts",
     "./cli": "./src/cli/mod.ts"
-  },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      ".": "./dist/mod.js",
-      "./buck2-manifest": "./dist/buck2-manifest.js",
-      "./cli": "./dist/cli.js"
-    }
   },
   "scripts": {
     "storybook": "storybook dev -p 6007",
@@ -43,6 +52,11 @@
     "react-reconciler": "0.33.0",
     "vitest": "4.1.9"
   },
+  "dependenciesMeta": {
+    "@overeng/tui-react": {
+      "injected": true
+    }
+  },
   "devDependencies": {
     "@effect/atom-react": "4.0.0-rc.111",
     "@effect/platform-node": "4.0.0-rc.111",
@@ -65,11 +79,6 @@
     "vite": "8.0.16",
     "vitest": "4.1.9"
   },
-  "dependenciesMeta": {
-    "@overeng/tui-react": {
-      "injected": true
-    }
-  },
   "peerDependencies": {
     "@effect/atom-react": "^4.0.0-rc.111",
     "@effect/opentelemetry": "^4.0.0-rc.111",
@@ -85,21 +94,12 @@
     "react-dom": "^19.2.7",
     "react-reconciler": "^0.33.0"
   },
-  "$genie": {
-    "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten",
-    "workspaceClosureDirs": [
-      "packages/@overeng/content-address",
-      "packages/@overeng/effect-distributed-lock",
-      "packages/@overeng/effect-path",
-      "packages/@overeng/kdl",
-      "packages/@overeng/kdl-effect",
-      "packages/@overeng/megarepo",
-      "packages/@overeng/otel-contract",
-      "packages/@overeng/tui-core",
-      "packages/@overeng/tui-react",
-      "packages/@overeng/utils",
-      "packages/@overeng/utils-dev"
-    ]
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": "./dist/mod.js",
+      "./buck2-manifest": "./dist/buck2-manifest.js",
+      "./cli": "./dist/cli.js"
+    }
   }
 }

--- a/packages/@overeng/megarepo/src/cli/commands/composition.integration.test.ts
+++ b/packages/@overeng/megarepo/src/cli/commands/composition.integration.test.ts
@@ -71,8 +71,6 @@ const makeFixture = Effect.gen(function* () {
     hasWorktree: () => Effect.succeed(true),
     listRepos: Effect.succeed([]),
     listWorktrees: () => Effect.succeed([]),
-    getRepoPath: () => repoBase,
-    hasRepo: () => Effect.succeed(true),
   }
   const lockFile = new LockFile({
     version: 1,

--- a/packages/@overeng/megarepo/src/store/store-hygiene.unit.test.ts
+++ b/packages/@overeng/megarepo/src/store/store-hygiene.unit.test.ts
@@ -50,13 +50,6 @@ const makeTestStore = (basePath: AbsoluteDirPath): MegarepoStore => ({
   hasWorktree: () => Effect.succeed(true),
   listRepos: Effect.succeed([]),
   listWorktrees: () => Effect.succeed([]),
-  getRepoPath: (source) => {
-    if (source.type === 'github') {
-      return EffectPath.unsafe.absoluteDir(`${basePath}github.com/${source.owner}/${source.repo}/`)
-    }
-    return EffectPath.unsafe.absoluteDir(`${basePath}other/`)
-  },
-  hasRepo: () => Effect.succeed(true),
 })
 
 const makeTestConfig = (members: Record<string, string>): MegarepoConfig =>

--- a/packages/@overeng/megarepo/src/store/store.ts
+++ b/packages/@overeng/megarepo/src/store/store.ts
@@ -92,14 +92,6 @@ export interface MegarepoStore {
     }>,
     PlatformError
   >
-
-  // === Legacy compatibility (deprecated) ===
-
-  /** @deprecated Use getRepoBasePath instead */
-  readonly getRepoPath: (source: MemberSource) => AbsoluteDirPath
-
-  /** @deprecated Use hasBareRepo instead */
-  readonly hasRepo: (source: MemberSource) => Effect.Effect<boolean, PlatformError>
 }
 
 /** Store service tag */
@@ -259,9 +251,6 @@ const make = ({
     getBareRepoPath,
     getWorktreePath,
 
-    // Legacy compatibility
-    getRepoPath: getRepoBasePath,
-
     hasBareRepo: (source) => fs.exists(getBareRepoPath(source)),
 
     hasWorktree: (args) => {
@@ -269,9 +258,6 @@ const make = ({
       const gitFilePath = `${worktreePath}.git`.replace(/\/\.git$/, '/.git')
       return fs.exists(gitFilePath)
     },
-
-    // Legacy compatibility
-    hasRepo: (source) => fs.exists(getBareRepoPath(source)),
 
     listRepos: Effect.gen(function* () {
       const exists = yield* fs.exists(basePath)

--- a/packages/@overeng/megarepo/tsconfig.json
+++ b/packages/@overeng/megarepo/tsconfig.json
@@ -3,7 +3,9 @@
 {
   "compilerOptions": {
     "target": "ES2024",
-    "lib": ["ES2024"],
+    "lib": [
+      "ES2024"
+    ],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "allowImportingTsExtensions": true,
@@ -44,10 +46,17 @@
     "composite": true,
     "rootDir": ".",
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
-    "types": ["node", "bun"],
+    "types": [
+      "node",
+      "bun"
+    ],
     "jsx": "react-jsx"
   },
-  "include": ["src/**/*", "test/**/*", "bin/**/*"],
+  "include": [
+    "src/**/*",
+    "test/**/*",
+    "bin/**/*"
+  ],
   "references": [
     {
       "path": "../effect-path"

--- a/packages/@overeng/notion-cli/nix/build.nix
+++ b/packages/@overeng/notion-cli/nix/build.nix
@@ -33,7 +33,7 @@ let
     installRuntimeWorkspace = true;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-a2FdFjTBI9igg6hxN5yjkWOV8Cs1vwbiOXnk2prf+gc=";
+      "." = mkSharedHash "sha256-7cA80aA2cRdo5eQVfeFSpSpBq76YyMlJFSKj5WX4hTU=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/notion-cli/package.json
+++ b/packages/@overeng/notion-cli/package.json
@@ -1,21 +1,32 @@
 {
+  "$genie": {
+    "source": "package.json.genie.ts",
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/content-address",
+      "packages/@overeng/effect-distributed-lock",
+      "packages/@overeng/effect-path",
+      "packages/@overeng/notion-cli",
+      "packages/@overeng/notion-core",
+      "packages/@overeng/notion-datasource-sync",
+      "packages/@overeng/notion-effect-client",
+      "packages/@overeng/notion-effect-schema",
+      "packages/@overeng/notion-md",
+      "packages/@overeng/notion-property-write",
+      "packages/@overeng/otel-contract",
+      "packages/@overeng/tui-core",
+      "packages/@overeng/tui-react",
+      "packages/@overeng/utils",
+      "packages/@overeng/utils-dev"
+    ]
+  },
   "name": "@overeng/notion-cli",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
+  "private": true,
   "exports": {
     ".": "./src/mod.ts",
     "./config": "./src/config-def.ts"
-  },
-  "publishConfig": {
-    "access": "public",
-    "bin": {
-      "notion": "./dist/cli.js"
-    },
-    "exports": {
-      ".": "./dist/mod.js",
-      "./config": "./dist/config-def.js"
-    }
   },
   "scripts": {
     "storybook": "storybook dev -p 6012",
@@ -47,6 +58,11 @@
     "react-reconciler": "0.33.0",
     "vitest": "4.1.9"
   },
+  "dependenciesMeta": {
+    "@overeng/tui-react": {
+      "injected": true
+    }
+  },
   "devDependencies": {
     "@effect/atom-react": "4.0.0-rc.111",
     "@effect/vitest": "4.0.0-rc.111",
@@ -60,11 +76,6 @@
     "typescript": "6.0.3",
     "vite": "8.0.16",
     "vitest": "4.1.9"
-  },
-  "dependenciesMeta": {
-    "@overeng/tui-react": {
-      "injected": true
-    }
   },
   "peerDependencies": {
     "@effect/atom-react": "^4.0.0-rc.111",
@@ -81,25 +92,14 @@
     "react-dom": "^19.2.7",
     "react-reconciler": "^0.33.0"
   },
-  "$genie": {
-    "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten",
-    "workspaceClosureDirs": [
-      "packages/@overeng/content-address",
-      "packages/@overeng/effect-distributed-lock",
-      "packages/@overeng/effect-path",
-      "packages/@overeng/notion-cli",
-      "packages/@overeng/notion-core",
-      "packages/@overeng/notion-datasource-sync",
-      "packages/@overeng/notion-effect-client",
-      "packages/@overeng/notion-effect-schema",
-      "packages/@overeng/notion-md",
-      "packages/@overeng/notion-property-write",
-      "packages/@overeng/otel-contract",
-      "packages/@overeng/tui-core",
-      "packages/@overeng/tui-react",
-      "packages/@overeng/utils",
-      "packages/@overeng/utils-dev"
-    ]
+  "publishConfig": {
+    "access": "public",
+    "bin": {
+      "notion": "./dist/cli.js"
+    },
+    "exports": {
+      ".": "./dist/mod.js",
+      "./config": "./dist/config-def.js"
+    }
   }
 }

--- a/packages/@overeng/notion-cli/tsconfig.json
+++ b/packages/@overeng/notion-cli/tsconfig.json
@@ -3,7 +3,9 @@
 {
   "compilerOptions": {
     "target": "ES2024",
-    "lib": ["ES2024"],
+    "lib": [
+      "ES2024"
+    ],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "allowImportingTsExtensions": true,
@@ -46,7 +48,10 @@
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
     "jsx": "react-jsx"
   },
-  "include": ["src/**/*", "bin/**/*.ts"],
+  "include": [
+    "src/**/*",
+    "bin/**/*.ts"
+  ],
   "references": [
     {
       "path": "../effect-path"

--- a/packages/@overeng/notion-core/package.json
+++ b/packages/@overeng/notion-core/package.json
@@ -1,18 +1,20 @@
 {
+  "$genie": {
+    "source": "package.json.genie.ts",
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/notion-core",
+      "packages/@overeng/utils-dev"
+    ]
+  },
   "name": "@overeng/notion-core",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
+  "private": true,
   "exports": {
     ".": {
       "types": "./dist/src/mod.d.ts",
       "default": "./src/mod.ts"
-    }
-  },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      ".": "./dist/mod.js"
     }
   },
   "devDependencies": {
@@ -22,12 +24,10 @@
     "typescript": "6.0.3",
     "vitest": "4.1.9"
   },
-  "$genie": {
-    "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten",
-    "workspaceClosureDirs": [
-      "packages/@overeng/notion-core",
-      "packages/@overeng/utils-dev"
-    ]
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": "./dist/mod.js"
+    }
   }
 }

--- a/packages/@overeng/notion-core/tsconfig.json
+++ b/packages/@overeng/notion-core/tsconfig.json
@@ -3,7 +3,9 @@
 {
   "compilerOptions": {
     "target": "ES2024",
-    "lib": ["ES2024"],
+    "lib": [
+      "ES2024"
+    ],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "allowImportingTsExtensions": true,
@@ -44,9 +46,13 @@
     "composite": true,
     "rootDir": ".",
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
-    "types": ["node"],
+    "types": [
+      "node"
+    ],
     "noEmit": true
   },
-  "include": ["src/**/*"],
+  "include": [
+    "src/**/*"
+  ],
   "references": []
 }

--- a/packages/@overeng/notion-datasource-sync/docs/vrs/subsystems/replica-api/spec.md
+++ b/packages/@overeng/notion-datasource-sync/docs/vrs/subsystems/replica-api/spec.md
@@ -189,11 +189,7 @@ type NotionConflictResolution = {
   readonly resolutionId: string
   readonly conflictId: SyncEventId
   readonly action:
-    | 'choose_remote'
-    | 'abandon_local'
-    | 'retry_after_refresh'
-    | 'choose_local'
-    | 'manual_value'
+    'choose_remote' | 'abandon_local' | 'retry_after_refresh' | 'choose_local' | 'manual_value'
   readonly valueJson: CanonicalPropertyValueJson | undefined
   readonly status: LocalChangeStatus
 }

--- a/packages/@overeng/notion-datasource-sync/package.json
+++ b/packages/@overeng/notion-datasource-sync/package.json
@@ -1,8 +1,27 @@
 {
+  "$genie": {
+    "source": "package.json.genie.ts",
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/content-address",
+      "packages/@overeng/effect-distributed-lock",
+      "packages/@overeng/notion-core",
+      "packages/@overeng/notion-datasource-sync",
+      "packages/@overeng/notion-effect-client",
+      "packages/@overeng/notion-effect-schema",
+      "packages/@overeng/notion-md",
+      "packages/@overeng/notion-property-write",
+      "packages/@overeng/otel-contract",
+      "packages/@overeng/tui-core",
+      "packages/@overeng/tui-react",
+      "packages/@overeng/utils",
+      "packages/@overeng/utils-dev"
+    ]
+  },
   "name": "@overeng/notion-datasource-sync",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
+  "private": true,
   "exports": {
     ".": "./src/mod.ts",
     "./body": "./src/body/adapter.ts",
@@ -24,6 +43,55 @@
     "./sync/observation": "./src/sync/observation.ts",
     "./testing/*": "./src/testing/*.ts",
     "./webhook": "./src/webhook/mod.ts"
+  },
+  "scripts": {
+    "demo:verify": "NOTION_DATASOURCE_SYNC_LIVE=1 vitest run src/e2e/live-demo-replica.e2e.test.ts --config vitest.config.ts",
+    "demo:verify:full": "NOTION_DATASOURCE_SYNC_LIVE=1 NOTION_DATASOURCE_SYNC_FULL_DEMO=1 vitest run src/e2e/live-demo-replica.e2e.test.ts --config vitest.config.ts",
+    "demo:provision": "NOTION_DATASOURCE_SYNC_LIVE=1 NOTION_DATASOURCE_SYNC_REQUIRED_CAPABILITIES=data_source_retrieve,data_source_query,data_source_metadata_update,page_retrieve,page_property_paginate,page_create vitest run src/e2e/live-notion.e2e.test.ts --config vitest.config.ts -t \"credentialed automated demo showcase\""
+  },
+  "dependencies": {
+    "@overeng/content-address": "workspace:^",
+    "@overeng/notion-core": "workspace:^",
+    "@overeng/notion-effect-client": "workspace:^",
+    "@overeng/notion-effect-schema": "workspace:^",
+    "@overeng/notion-md": "workspace:^",
+    "@overeng/notion-property-write": "workspace:^",
+    "@overeng/otel-contract": "workspace:^",
+    "@overeng/tui-react": "workspace:^",
+    "@overeng/utils": "workspace:^",
+    "react": "19.2.7"
+  },
+  "dependenciesMeta": {
+    "@overeng/tui-react": {
+      "injected": true
+    }
+  },
+  "devDependencies": {
+    "@effect/atom-react": "4.0.0-rc.111",
+    "@effect/opentelemetry": "4.0.0-rc.111",
+    "@effect/platform-node": "4.0.0-rc.111",
+    "@effect/vitest": "4.0.0-rc.111",
+    "@opentui/core": "0.4.1",
+    "@opentui/react": "0.4.1",
+    "@playwright/test": "1.61.0",
+    "@storybook/react": "10.5.10",
+    "@types/node": "26.0.0",
+    "@types/react": "19.2.17",
+    "@types/react-reconciler": "0.33.0",
+    "effect": "4.0.0-rc.111",
+    "react-dom": "19.2.7",
+    "react-reconciler": "0.33.0",
+    "typescript": "6.0.3",
+    "vitest": "4.1.9"
+  },
+  "peerDependencies": {
+    "@effect/opentelemetry": "^4.0.0-rc.111",
+    "@effect/platform-node": "^4.0.0-rc.111",
+    "@playwright/test": "^1.61.0",
+    "effect": "^4.0.0-rc.111"
+  },
+  "engines": {
+    "node": ">=24.0.0"
   },
   "publishConfig": {
     "access": "public",
@@ -49,73 +117,5 @@
       "./testing/*": "./dist/src/testing/*.js",
       "./webhook": "./dist/src/webhook/mod.js"
     }
-  },
-  "scripts": {
-    "demo:verify": "NOTION_DATASOURCE_SYNC_LIVE=1 vitest run src/e2e/live-demo-replica.e2e.test.ts --config vitest.config.ts",
-    "demo:verify:full": "NOTION_DATASOURCE_SYNC_LIVE=1 NOTION_DATASOURCE_SYNC_FULL_DEMO=1 vitest run src/e2e/live-demo-replica.e2e.test.ts --config vitest.config.ts",
-    "demo:provision": "NOTION_DATASOURCE_SYNC_LIVE=1 NOTION_DATASOURCE_SYNC_REQUIRED_CAPABILITIES=data_source_retrieve,data_source_query,data_source_metadata_update,page_retrieve,page_property_paginate,page_create vitest run src/e2e/live-notion.e2e.test.ts --config vitest.config.ts -t \"credentialed automated demo showcase\""
-  },
-  "dependencies": {
-    "@overeng/content-address": "workspace:^",
-    "@overeng/notion-core": "workspace:^",
-    "@overeng/notion-effect-client": "workspace:^",
-    "@overeng/notion-effect-schema": "workspace:^",
-    "@overeng/notion-md": "workspace:^",
-    "@overeng/notion-property-write": "workspace:^",
-    "@overeng/otel-contract": "workspace:^",
-    "@overeng/tui-react": "workspace:^",
-    "@overeng/utils": "workspace:^",
-    "react": "19.2.7"
-  },
-  "devDependencies": {
-    "@effect/atom-react": "4.0.0-rc.111",
-    "@effect/opentelemetry": "4.0.0-rc.111",
-    "@effect/platform-node": "4.0.0-rc.111",
-    "@effect/vitest": "4.0.0-rc.111",
-    "@opentui/core": "0.4.1",
-    "@opentui/react": "0.4.1",
-    "@playwright/test": "1.61.0",
-    "@storybook/react": "10.5.10",
-    "@types/node": "26.0.0",
-    "@types/react": "19.2.17",
-    "@types/react-reconciler": "0.33.0",
-    "effect": "4.0.0-rc.111",
-    "react-dom": "19.2.7",
-    "react-reconciler": "0.33.0",
-    "typescript": "6.0.3",
-    "vitest": "4.1.9"
-  },
-  "dependenciesMeta": {
-    "@overeng/tui-react": {
-      "injected": true
-    }
-  },
-  "peerDependencies": {
-    "@effect/opentelemetry": "^4.0.0-rc.111",
-    "@effect/platform-node": "^4.0.0-rc.111",
-    "@playwright/test": "^1.61.0",
-    "effect": "^4.0.0-rc.111"
-  },
-  "engines": {
-    "node": ">=24.0.0"
-  },
-  "$genie": {
-    "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten",
-    "workspaceClosureDirs": [
-      "packages/@overeng/content-address",
-      "packages/@overeng/effect-distributed-lock",
-      "packages/@overeng/notion-core",
-      "packages/@overeng/notion-datasource-sync",
-      "packages/@overeng/notion-effect-client",
-      "packages/@overeng/notion-effect-schema",
-      "packages/@overeng/notion-md",
-      "packages/@overeng/notion-property-write",
-      "packages/@overeng/otel-contract",
-      "packages/@overeng/tui-core",
-      "packages/@overeng/tui-react",
-      "packages/@overeng/utils",
-      "packages/@overeng/utils-dev"
-    ]
   }
 }

--- a/packages/@overeng/notion-datasource-sync/tsconfig.json
+++ b/packages/@overeng/notion-datasource-sync/tsconfig.json
@@ -3,7 +3,9 @@
 {
   "compilerOptions": {
     "target": "ES2024",
-    "lib": ["ES2023"],
+    "lib": [
+      "ES2023"
+    ],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "allowImportingTsExtensions": true,
@@ -44,10 +46,14 @@
     "composite": true,
     "rootDir": ".",
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
-    "types": ["node"],
+    "types": [
+      "node"
+    ],
     "jsx": "react-jsx"
   },
-  "include": ["src/**/*"],
+  "include": [
+    "src/**/*"
+  ],
   "references": [
     {
       "path": "../notion-md"

--- a/packages/@overeng/notion-effect-client/package.json
+++ b/packages/@overeng/notion-effect-client/package.json
@@ -1,20 +1,28 @@
 {
+  "$genie": {
+    "source": "package.json.genie.ts",
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/content-address",
+      "packages/@overeng/effect-distributed-lock",
+      "packages/@overeng/notion-core",
+      "packages/@overeng/notion-effect-client",
+      "packages/@overeng/notion-effect-schema",
+      "packages/@overeng/otel-contract",
+      "packages/@overeng/utils",
+      "packages/@overeng/utils-dev"
+    ]
+  },
   "name": "@overeng/notion-effect-client",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
+  "private": true,
   "exports": {
     ".": {
       "types": "./dist/src/mod.d.ts",
       "default": "./src/mod.ts"
     },
     "./test": "./src/test/integration/setup.ts"
-  },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      ".": "./dist/mod.js"
-    }
   },
   "dependencies": {
     "@effect/opentelemetry": "4.0.0-rc.111",
@@ -47,18 +55,10 @@
     "typescript": "6.0.3",
     "vitest": "4.1.9"
   },
-  "$genie": {
-    "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten",
-    "workspaceClosureDirs": [
-      "packages/@overeng/content-address",
-      "packages/@overeng/effect-distributed-lock",
-      "packages/@overeng/notion-core",
-      "packages/@overeng/notion-effect-client",
-      "packages/@overeng/notion-effect-schema",
-      "packages/@overeng/otel-contract",
-      "packages/@overeng/utils",
-      "packages/@overeng/utils-dev"
-    ]
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": "./dist/mod.js"
+    }
   }
 }

--- a/packages/@overeng/notion-effect-client/tsconfig.json
+++ b/packages/@overeng/notion-effect-client/tsconfig.json
@@ -3,7 +3,9 @@
 {
   "compilerOptions": {
     "target": "ES2024",
-    "lib": ["ES2024"],
+    "lib": [
+      "ES2024"
+    ],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "allowImportingTsExtensions": true,
@@ -44,9 +46,13 @@
     "composite": true,
     "rootDir": ".",
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
-    "types": ["node"],
+    "types": [
+      "node"
+    ],
     "noEmit": true
   },
-  "include": ["src/**/*"],
+  "include": [
+    "src/**/*"
+  ],
   "references": []
 }

--- a/packages/@overeng/notion-effect-schema/package.json
+++ b/packages/@overeng/notion-effect-schema/package.json
@@ -1,18 +1,21 @@
 {
+  "$genie": {
+    "source": "package.json.genie.ts",
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/notion-core",
+      "packages/@overeng/notion-effect-schema",
+      "packages/@overeng/utils-dev"
+    ]
+  },
   "name": "@overeng/notion-effect-schema",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
+  "private": true,
   "exports": {
     ".": {
       "types": "./dist/src/mod.d.ts",
       "default": "./src/mod.ts"
-    }
-  },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      ".": "./dist/mod.js"
     }
   },
   "dependencies": {
@@ -29,13 +32,10 @@
   "peerDependencies": {
     "effect": "^4.0.0-rc.111"
   },
-  "$genie": {
-    "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten",
-    "workspaceClosureDirs": [
-      "packages/@overeng/notion-core",
-      "packages/@overeng/notion-effect-schema",
-      "packages/@overeng/utils-dev"
-    ]
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": "./dist/mod.js"
+    }
   }
 }

--- a/packages/@overeng/notion-effect-schema/tsconfig.json
+++ b/packages/@overeng/notion-effect-schema/tsconfig.json
@@ -3,7 +3,9 @@
 {
   "compilerOptions": {
     "target": "ES2024",
-    "lib": ["ES2024"],
+    "lib": [
+      "ES2024"
+    ],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "allowImportingTsExtensions": true,
@@ -44,9 +46,13 @@
     "composite": true,
     "rootDir": ".",
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
-    "types": ["node"],
+    "types": [
+      "node"
+    ],
     "noEmit": true
   },
-  "include": ["src/**/*"],
+  "include": [
+    "src/**/*"
+  ],
   "references": []
 }

--- a/packages/@overeng/notion-md/nix/build.nix
+++ b/packages/@overeng/notion-md/nix/build.nix
@@ -20,7 +20,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-EC6MedlXd6mHNasnnHtG88jNRHWU6d7F65/JB8MERIs=";
+      "." = mkSharedHash "sha256-o6d662YMe/Nt+/U/Ckxf9BszxgL4J6ZGTzgBGVDKbDo=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/notion-md/package.json
+++ b/packages/@overeng/notion-md/package.json
@@ -1,23 +1,30 @@
 {
+  "$genie": {
+    "source": "package.json.genie.ts",
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/content-address",
+      "packages/@overeng/effect-distributed-lock",
+      "packages/@overeng/notion-core",
+      "packages/@overeng/notion-effect-client",
+      "packages/@overeng/notion-effect-schema",
+      "packages/@overeng/notion-md",
+      "packages/@overeng/notion-property-write",
+      "packages/@overeng/otel-contract",
+      "packages/@overeng/tui-core",
+      "packages/@overeng/tui-react",
+      "packages/@overeng/utils",
+      "packages/@overeng/utils-dev"
+    ]
+  },
   "name": "@overeng/notion-md",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
+  "private": true,
   "exports": {
     ".": "./src/mod.ts",
     "./cli": "./src/cli.ts",
     "./cli-program": "./src/cli-program.ts"
-  },
-  "publishConfig": {
-    "access": "public",
-    "bin": {
-      "notion-md": "./dist/src/cli.js"
-    },
-    "exports": {
-      ".": "./dist/src/mod.js",
-      "./cli": "./dist/src/cli.js",
-      "./cli-program": "./dist/src/cli-program.js"
-    }
   },
   "scripts": {
     "storybook": "storybook dev -p 6015",
@@ -62,22 +69,15 @@
     "@playwright/test": "^1.61.0",
     "effect": "^4.0.0-rc.111"
   },
-  "$genie": {
-    "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten",
-    "workspaceClosureDirs": [
-      "packages/@overeng/content-address",
-      "packages/@overeng/effect-distributed-lock",
-      "packages/@overeng/notion-core",
-      "packages/@overeng/notion-effect-client",
-      "packages/@overeng/notion-effect-schema",
-      "packages/@overeng/notion-md",
-      "packages/@overeng/notion-property-write",
-      "packages/@overeng/otel-contract",
-      "packages/@overeng/tui-core",
-      "packages/@overeng/tui-react",
-      "packages/@overeng/utils",
-      "packages/@overeng/utils-dev"
-    ]
+  "publishConfig": {
+    "access": "public",
+    "bin": {
+      "notion-md": "./dist/src/cli.js"
+    },
+    "exports": {
+      ".": "./dist/src/mod.js",
+      "./cli": "./dist/src/cli.js",
+      "./cli-program": "./dist/src/cli-program.js"
+    }
   }
 }

--- a/packages/@overeng/notion-md/tsconfig.json
+++ b/packages/@overeng/notion-md/tsconfig.json
@@ -3,7 +3,9 @@
 {
   "compilerOptions": {
     "target": "ES2024",
-    "lib": ["ES2023"],
+    "lib": [
+      "ES2023"
+    ],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "allowImportingTsExtensions": true,
@@ -44,9 +46,13 @@
     "composite": true,
     "rootDir": ".",
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
-    "types": ["node"],
+    "types": [
+      "node"
+    ],
     "jsx": "react-jsx"
   },
-  "include": ["src/**/*"],
+  "include": [
+    "src/**/*"
+  ],
   "references": []
 }

--- a/packages/@overeng/notion-property-write/package.json
+++ b/packages/@overeng/notion-property-write/package.json
@@ -1,18 +1,22 @@
 {
+  "$genie": {
+    "source": "package.json.genie.ts",
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/notion-core",
+      "packages/@overeng/notion-effect-schema",
+      "packages/@overeng/notion-property-write",
+      "packages/@overeng/utils-dev"
+    ]
+  },
   "name": "@overeng/notion-property-write",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
+  "private": true,
   "exports": {
     ".": {
       "types": "./dist/src/mod.d.ts",
       "default": "./src/mod.ts"
-    }
-  },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      ".": "./dist/mod.js"
     }
   },
   "dependencies": {
@@ -29,14 +33,10 @@
   "peerDependencies": {
     "effect": "^4.0.0-rc.111"
   },
-  "$genie": {
-    "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten",
-    "workspaceClosureDirs": [
-      "packages/@overeng/notion-core",
-      "packages/@overeng/notion-effect-schema",
-      "packages/@overeng/notion-property-write",
-      "packages/@overeng/utils-dev"
-    ]
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": "./dist/mod.js"
+    }
   }
 }

--- a/packages/@overeng/notion-property-write/tsconfig.json
+++ b/packages/@overeng/notion-property-write/tsconfig.json
@@ -3,7 +3,9 @@
 {
   "compilerOptions": {
     "target": "ES2024",
-    "lib": ["ES2024"],
+    "lib": [
+      "ES2024"
+    ],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "allowImportingTsExtensions": true,
@@ -44,9 +46,13 @@
     "composite": true,
     "rootDir": ".",
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
-    "types": ["node"],
+    "types": [
+      "node"
+    ],
     "noEmit": true
   },
-  "include": ["src/**/*"],
+  "include": [
+    "src/**/*"
+  ],
   "references": []
 }

--- a/packages/@overeng/notion-react/docs/internals/architecture.md
+++ b/packages/@overeng/notion-react/docs/internals/architecture.md
@@ -82,21 +82,21 @@ Return: `SyncResult { appends, updates, removes, inserts, fallbackReason? }`.
 
 ## Where each requirement lives
 
-| Requirement                    | Implementation                                                                                                          |
+| Requirement | Implementation |
 | ------------------------------ | ----------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
-| R01 1:1 block fidelity         | `components/blocks.tsx`, `renderer/host-config.ts` (`blockProps`)                                                       |
-| R02 Rich text via composition  | `components/inline.tsx`, `renderer/flatten-rich-text.ts`                                                                |
-| R03 Component reuse            | Plain React — no library machinery                                                                                      |
-| R04-R06 Op-minimal sync        | `renderer/sync-diff.ts` (LCS + hash), `renderer/sync.ts` (coalescing)                                                   |
-| R07 Keyed identity             | `renderer/host-config.ts` (reads `blockKey` prop), `renderer/keys.ts`, `renderer/sync-diff.ts` (LCS over `(key, type)`) |
-| R08 Effect return type         | `renderer/render-to-notion.ts`, `renderer/sync.ts`                                                                      |
-| R09 No ambient state           | All dependencies flow through `NotionConfig                                                                             | HttpClient` in the Effect env |
-| R10-R13 Pluggable cache        | `cache/types.ts`, `cache/fs-cache.ts`, `cache/in-memory-cache.ts`                                                       |
-| R14-R15 Uploads                | `renderer/upload-registry.ts` (pre-resolve; Suspense stubs in place)                                                    |
-| R16-R18 Fallbacks              | `renderer/sync.ts` (schema + cold-cache + page-id drift), `SyncResult.fallbackReason`                                   |
-| R19-R20 Testing                | `src/test/integration/` (mock-client + e2e)                                                                             |
-| R21 Web renderer               | `src/web/` (DOM + CSS + stories)                                                                                        |
-| R22-R23 Bounded upstream churn | Pinned versions in `package.json`; host-config hidden behind `renderer/mod.ts`                                          |
+| R01 1:1 block fidelity | `components/blocks.tsx`, `renderer/host-config.ts` (`blockProps`) |
+| R02 Rich text via composition | `components/inline.tsx`, `renderer/flatten-rich-text.ts` |
+| R03 Component reuse | Plain React — no library machinery |
+| R04-R06 Op-minimal sync | `renderer/sync-diff.ts` (LCS + hash), `renderer/sync.ts` (coalescing) |
+| R07 Keyed identity | `renderer/host-config.ts` (reads `blockKey` prop), `renderer/keys.ts`, `renderer/sync-diff.ts` (LCS over `(key, type)`) |
+| R08 Effect return type | `renderer/render-to-notion.ts`, `renderer/sync.ts` |
+| R09 No ambient state | All dependencies flow through `NotionConfig                                                                             | HttpClient` in the Effect env |
+| R10-R13 Pluggable cache | `cache/types.ts`, `cache/fs-cache.ts`, `cache/in-memory-cache.ts` |
+| R14-R15 Uploads | `renderer/upload-registry.ts` (pre-resolve; Suspense stubs in place) |
+| R16-R18 Fallbacks | `renderer/sync.ts` (schema + cold-cache + page-id drift), `SyncResult.fallbackReason` |
+| R19-R20 Testing | `src/test/integration/` (mock-client + e2e) |
+| R21 Web renderer | `src/web/` (DOM + CSS + stories) |
+| R22-R23 Bounded upstream churn | Pinned versions in `package.json`; host-config hidden behind `renderer/mod.ts` |
 
 ## External dependencies
 

--- a/packages/@overeng/notion-react/package.json
+++ b/packages/@overeng/notion-react/package.json
@@ -1,8 +1,27 @@
 {
+  "$genie": {
+    "source": "package.json.genie.ts",
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/content-address",
+      "packages/@overeng/effect-distributed-lock",
+      "packages/@overeng/notion-core",
+      "packages/@overeng/notion-effect-client",
+      "packages/@overeng/notion-effect-schema",
+      "packages/@overeng/notion-md",
+      "packages/@overeng/notion-property-write",
+      "packages/@overeng/notion-react",
+      "packages/@overeng/otel-contract",
+      "packages/@overeng/tui-core",
+      "packages/@overeng/tui-react",
+      "packages/@overeng/utils",
+      "packages/@overeng/utils-dev"
+    ]
+  },
   "name": "@overeng/notion-react",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
+  "private": true,
   "exports": {
     ".": "./src/mod.ts",
     "./markdown": "./src/markdown/mod.ts",
@@ -14,20 +33,6 @@
     "./web": "./src/web/mod.ts",
     "./web/katex.css": "./src/web/katex.css",
     "./web/styles.css": "./src/web/styles.css"
-  },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      ".": "./dist/mod.js",
-      "./markdown": "./dist/markdown/mod.js",
-      "./renderer": "./dist/renderer/mod.js",
-      "./o11y": "./dist/o11y/mod.js",
-      "./o11y/effect": "./dist/o11y/effect-adapter.js",
-      "./o11y/otel": "./dist/o11y/otel-adapter.js",
-      "./web": "./dist/web/mod.js",
-      "./web/styles.css": "./dist/web/styles.css",
-      "./web/katex.css": "./dist/web/katex.css"
-    }
   },
   "scripts": {
     "storybook": "storybook dev -p 6014",
@@ -98,23 +103,18 @@
       "optional": true
     }
   },
-  "$genie": {
-    "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten",
-    "workspaceClosureDirs": [
-      "packages/@overeng/content-address",
-      "packages/@overeng/effect-distributed-lock",
-      "packages/@overeng/notion-core",
-      "packages/@overeng/notion-effect-client",
-      "packages/@overeng/notion-effect-schema",
-      "packages/@overeng/notion-md",
-      "packages/@overeng/notion-property-write",
-      "packages/@overeng/notion-react",
-      "packages/@overeng/otel-contract",
-      "packages/@overeng/tui-core",
-      "packages/@overeng/tui-react",
-      "packages/@overeng/utils",
-      "packages/@overeng/utils-dev"
-    ]
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": "./dist/mod.js",
+      "./markdown": "./dist/markdown/mod.js",
+      "./renderer": "./dist/renderer/mod.js",
+      "./o11y": "./dist/o11y/mod.js",
+      "./o11y/effect": "./dist/o11y/effect-adapter.js",
+      "./o11y/otel": "./dist/o11y/otel-adapter.js",
+      "./web": "./dist/web/mod.js",
+      "./web/styles.css": "./dist/web/styles.css",
+      "./web/katex.css": "./dist/web/katex.css"
+    }
   }
 }

--- a/packages/@overeng/notion-react/tsconfig.json
+++ b/packages/@overeng/notion-react/tsconfig.json
@@ -3,7 +3,11 @@
 {
   "compilerOptions": {
     "target": "ES2024",
-    "lib": ["ES2024", "DOM", "DOM.Iterable"],
+    "lib": [
+      "ES2024",
+      "DOM",
+      "DOM.Iterable"
+    ],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "allowImportingTsExtensions": true,
@@ -44,11 +48,15 @@
     "composite": true,
     "rootDir": ".",
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
-    "types": ["node"],
+    "types": [
+      "node"
+    ],
     "jsx": "react-jsx",
     "jsxImportSource": "react"
   },
-  "include": ["src/**/*"],
+  "include": [
+    "src/**/*"
+  ],
   "references": [
     {
       "path": "../notion-md"

--- a/packages/@overeng/npm-release/nix/build.nix
+++ b/packages/@overeng/npm-release/nix/build.nix
@@ -20,7 +20,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-80NKtZyPEkq1F+uO5VhbHy+4GJX9brFRMTMKHjkhjdo=";
+      "." = mkSharedHash "sha256-EgXe1+Gn784yWCMUir7wjqdVcmn6BmV0vDp1bMvCi+4=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/npm-release/package.json
+++ b/packages/@overeng/npm-release/package.json
@@ -1,18 +1,19 @@
 {
+  "$genie": {
+    "source": "package.json.genie.ts",
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/npm-release",
+      "packages/@overeng/utils-dev"
+    ]
+  },
   "name": "@overeng/npm-release",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
+  "private": true,
   "exports": {
     ".": "./src/mod.ts",
     "./cli": "./src/cli.ts"
-  },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      ".": "./dist/mod.js",
-      "./cli": "./dist/cli.js"
-    }
   },
   "devDependencies": {
     "@effect/platform-node": "4.0.0-rc.111",
@@ -26,12 +27,11 @@
     "@effect/platform-node": "^4.0.0-rc.111",
     "effect": "^4.0.0-rc.111"
   },
-  "$genie": {
-    "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten",
-    "workspaceClosureDirs": [
-      "packages/@overeng/npm-release",
-      "packages/@overeng/utils-dev"
-    ]
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": "./dist/mod.js",
+      "./cli": "./dist/cli.js"
+    }
   }
 }

--- a/packages/@overeng/npm-release/tsconfig.json
+++ b/packages/@overeng/npm-release/tsconfig.json
@@ -3,7 +3,9 @@
 {
   "compilerOptions": {
     "target": "ES2024",
-    "lib": ["ES2024"],
+    "lib": [
+      "ES2024"
+    ],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "allowImportingTsExtensions": true,
@@ -44,8 +46,12 @@
     "composite": true,
     "rootDir": ".",
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
-    "types": ["node"]
+    "types": [
+      "node"
+    ]
   },
-  "include": ["src/**/*"],
+  "include": [
+    "src/**/*"
+  ],
   "references": []
 }

--- a/packages/@overeng/otel-contract/package.json
+++ b/packages/@overeng/otel-contract/package.json
@@ -1,8 +1,17 @@
 {
+  "$genie": {
+    "source": "package.json.genie.ts",
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/content-address",
+      "packages/@overeng/otel-contract",
+      "packages/@overeng/utils-dev"
+    ]
+  },
   "name": "@overeng/otel-contract",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
+  "private": true,
   "exports": {
     ".": {
       "types": "./dist/src/mod.d.ts",
@@ -11,13 +20,6 @@
     "./registry": {
       "types": "./dist/src/registry.d.ts",
       "default": "./src/registry.ts"
-    }
-  },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      ".": "./dist/mod.js",
-      "./registry": "./dist/registry.js"
     }
   },
   "dependencies": {
@@ -33,13 +35,11 @@
   "peerDependencies": {
     "effect": "^4.0.0-rc.111"
   },
-  "$genie": {
-    "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten",
-    "workspaceClosureDirs": [
-      "packages/@overeng/content-address",
-      "packages/@overeng/otel-contract",
-      "packages/@overeng/utils-dev"
-    ]
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": "./dist/mod.js",
+      "./registry": "./dist/registry.js"
+    }
   }
 }

--- a/packages/@overeng/otel-contract/tsconfig.json
+++ b/packages/@overeng/otel-contract/tsconfig.json
@@ -3,7 +3,9 @@
 {
   "compilerOptions": {
     "target": "ES2024",
-    "lib": ["ES2024"],
+    "lib": [
+      "ES2024"
+    ],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "allowImportingTsExtensions": true,
@@ -44,9 +46,15 @@
     "composite": true,
     "rootDir": ".",
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
-    "types": ["node"],
+    "types": [
+      "node"
+    ],
     "noEmit": true
   },
-  "include": ["src/**/*"],
-  "exclude": ["src/**/*.genie.ts"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "src/**/*.genie.ts"
+  ]
 }

--- a/packages/@overeng/otel-scrape/src/lib.rs
+++ b/packages/@overeng/otel-scrape/src/lib.rs
@@ -2996,9 +2996,7 @@ fn signal_env_string(signal_name: &str, generic_name: &str) -> Option<String> {
 }
 
 fn env_string(name: &str) -> Option<String> {
-    std::env::var(name)
-        .ok()
-        .and_then(|value| if value.is_empty() { None } else { Some(value) })
+    std::env::var(name).ok().filter(|value| !value.is_empty())
 }
 
 fn env_bool(name: &str) -> bool {

--- a/packages/@overeng/otel-scrape/tests/cli.rs
+++ b/packages/@overeng/otel-scrape/tests/cli.rs
@@ -8,6 +8,7 @@ use std::{
     thread,
 };
 
+#[cfg(target_os = "linux")]
 use sha2::{Digest, Sha256};
 
 #[cfg(unix)]
@@ -1476,12 +1477,14 @@ fn main() {
     binary
 }
 
+#[cfg(target_os = "linux")]
 fn stable_hash(value: impl AsRef<[u8]>) -> String {
     let mut hasher = Sha256::new();
     hasher.update(value.as_ref());
     format!("sha256:{}", hex(&hasher.finalize()))
 }
 
+#[cfg(target_os = "linux")]
 fn hex(bytes: &[u8]) -> String {
     let mut out = String::with_capacity(bytes.len() * 2);
     for byte in bytes {

--- a/packages/@overeng/otelite/src/run.rs
+++ b/packages/@overeng/otelite/src/run.rs
@@ -341,6 +341,11 @@ async fn spawn_and_wait(rx: &RunningReceiver, opts: &RunOpts) -> std::io::Result
         cmd.env("OTEL_SERVICE_NAME", svc);
     }
 
+    #[cfg(unix)]
+    let mut interrupts = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt())?;
+    // Register before spawning. A fast child can emit readiness before the wait
+    // loop starts; installing the handler in that loop leaves a default-action
+    // window where the shared process-group SIGINT also kills otelite.
     // Child stdout → our stderr (keep our stdout clean for the summary JSON);
     // child stderr inherits our stderr; stdin inherits.
     cmd.stdin(Stdio::inherit());
@@ -356,6 +361,7 @@ async fn spawn_and_wait(rx: &RunningReceiver, opts: &RunOpts) -> std::io::Result
         })
     });
 
+    #[cfg(unix)]
     let status = loop {
         tokio::select! {
             s = child.wait() => break s?,
@@ -363,6 +369,13 @@ async fn spawn_and_wait(rx: &RunningReceiver, opts: &RunOpts) -> std::io::Result
             // swallow it here and keep waiting to drain. Limitation: a SIGTERM
             // sent directly to otelite's PID (not the group) is not caught — the
             // child is then orphaned. A forwarding SIGTERM handler is future work.
+            _ = interrupts.recv() => continue,
+        }
+    };
+    #[cfg(not(unix))]
+    let status = loop {
+        tokio::select! {
+            s = child.wait() => break s?,
             _ = tokio::signal::ctrl_c() => continue,
         }
     };

--- a/packages/@overeng/oxc-config/nix/build.nix
+++ b/packages/@overeng/oxc-config/nix/build.nix
@@ -14,7 +14,7 @@ import ../../../../nix/oxc-config-plugin.nix {
     ;
   # Managed by Evergreen FOD refresh — do not edit manually.
   depsBuilds = {
-    "." = mkSharedHash "sha256-iskCQQJYzuXg0mL3k+CIlAp8T9hDfFrGuTH72Gpdzww=";
+    "." = mkSharedHash "sha256-WZIleSv3b0cj3ztl23lowCDbK2YW4sW/brI16itlPWI=";
   };
   hashSourcePath = "packages/@overeng/oxc-config/nix/build.nix";
 }

--- a/packages/@overeng/oxc-config/package.json
+++ b/packages/@overeng/oxc-config/package.json
@@ -1,8 +1,15 @@
 {
+  "$genie": {
+    "source": "package.json.genie.ts",
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/oxc-config"
+    ]
+  },
   "name": "@overeng/oxc-config",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
+  "private": true,
   "exports": {
     "./plugin": "./src/mod.ts",
     "./stylex-upstream-plugin": "./src/stylex-upstream-plugin.ts"
@@ -17,12 +24,5 @@
     "oxlint-tsgolint": "0.23.0",
     "typescript": "6.0.3",
     "vitest": "4.1.9"
-  },
-  "$genie": {
-    "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten",
-    "workspaceClosureDirs": [
-      "packages/@overeng/oxc-config"
-    ]
   }
 }

--- a/packages/@overeng/oxc-config/tsconfig.json
+++ b/packages/@overeng/oxc-config/tsconfig.json
@@ -3,7 +3,9 @@
 {
   "compilerOptions": {
     "target": "ES2024",
-    "lib": ["ES2024"],
+    "lib": [
+      "ES2024"
+    ],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "allowImportingTsExtensions": true,
@@ -45,5 +47,7 @@
     "rootDir": ".",
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo"
   },
-  "include": ["src/**/*.ts"]
+  "include": [
+    "src/**/*.ts"
+  ]
 }

--- a/packages/@overeng/pty-effect/package.json
+++ b/packages/@overeng/pty-effect/package.json
@@ -1,18 +1,21 @@
 {
+  "$genie": {
+    "source": "package.json.genie.ts",
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/content-address",
+      "packages/@overeng/otel-contract",
+      "packages/@overeng/pty-effect",
+      "packages/@overeng/utils-dev"
+    ]
+  },
   "name": "@overeng/pty-effect",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
+  "private": true,
   "exports": {
     ".": "./src/mod.ts",
     "./client": "./src/client.ts"
-  },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      ".": "./dist/mod.js",
-      "./client": "./dist/client.js"
-    }
   },
   "scripts": {
     "bundle:smoke": "bun ../../../genie/ci-scripts/bundle-smoke.ts"
@@ -33,14 +36,11 @@
   "peerDependencies": {
     "effect": "^4.0.0-rc.111"
   },
-  "$genie": {
-    "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten",
-    "workspaceClosureDirs": [
-      "packages/@overeng/content-address",
-      "packages/@overeng/otel-contract",
-      "packages/@overeng/pty-effect",
-      "packages/@overeng/utils-dev"
-    ]
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": "./dist/mod.js",
+      "./client": "./dist/client.js"
+    }
   }
 }

--- a/packages/@overeng/pty-effect/tsconfig.json
+++ b/packages/@overeng/pty-effect/tsconfig.json
@@ -3,7 +3,9 @@
 {
   "compilerOptions": {
     "target": "ES2024",
-    "lib": ["ES2024"],
+    "lib": [
+      "ES2024"
+    ],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "allowImportingTsExtensions": true,
@@ -44,8 +46,12 @@
     "composite": true,
     "rootDir": ".",
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
-    "types": ["node"]
+    "types": [
+      "node"
+    ]
   },
-  "include": ["src/**/*"],
+  "include": [
+    "src/**/*"
+  ],
   "references": []
 }

--- a/packages/@overeng/react-inspector/package.json
+++ b/packages/@overeng/react-inspector/package.json
@@ -1,24 +1,25 @@
 {
+  "$genie": {
+    "source": "package.json.genie.ts",
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/react-inspector"
+    ]
+  },
   "name": "@overeng/react-inspector",
   "version": "9.0.0",
+  "type": "module",
   "description": "Browser DevTools-style React inspectors with native Effect 4 Schema support",
   "license": "MIT",
+  "exports": {
+    ".": "./src/index.tsx"
+  },
   "files": [
     "package.json",
     "dist",
     "src",
     "!dist/**/*.tsbuildinfo"
   ],
-  "type": "module",
-  "exports": {
-    ".": "./src/index.tsx"
-  },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      ".": "./dist/index.js"
-    }
-  },
   "scripts": {
     "build": "tsc --build tsconfig.json",
     "storybook": "storybook dev -p 6011",
@@ -48,11 +49,10 @@
     "effect": "^4.0.0-rc.111",
     "react": "^19.2.7"
   },
-  "$genie": {
-    "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten",
-    "workspaceClosureDirs": [
-      "packages/@overeng/react-inspector"
-    ]
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": "./dist/index.js"
+    }
   }
 }

--- a/packages/@overeng/react-inspector/tsconfig.json
+++ b/packages/@overeng/react-inspector/tsconfig.json
@@ -3,7 +3,10 @@
 {
   "compilerOptions": {
     "target": "ES2024",
-    "lib": ["ES2023", "DOM"],
+    "lib": [
+      "ES2023",
+      "DOM"
+    ],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "allowImportingTsExtensions": true,
@@ -48,6 +51,8 @@
     "noImplicitAny": false,
     "strictNullChecks": false
   },
-  "include": ["src/**/*"],
+  "include": [
+    "src/**/*"
+  ],
   "references": []
 }

--- a/packages/@overeng/react-inspector/tsconfig.strict-consumer.json
+++ b/packages/@overeng/react-inspector/tsconfig.strict-consumer.json
@@ -3,7 +3,10 @@
 {
   "compilerOptions": {
     "target": "ES2024",
-    "lib": ["ES2023", "DOM"],
+    "lib": [
+      "ES2023",
+      "DOM"
+    ],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "allowImportingTsExtensions": true,
@@ -46,6 +49,10 @@
     "composite": true,
     "noEmit": true
   },
-  "include": ["src/schema/effectSchema.tsx", "src/schema/lineage.ts", "test-d/**/*"],
+  "include": [
+    "src/schema/effectSchema.tsx",
+    "src/schema/lineage.ts",
+    "test-d/**/*"
+  ],
   "references": []
 }

--- a/packages/@overeng/restate-effect/package.json
+++ b/packages/@overeng/restate-effect/package.json
@@ -1,22 +1,25 @@
 {
+  "$genie": {
+    "source": "package.json.genie.ts",
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/content-address",
+      "packages/@overeng/effect-distributed-lock",
+      "packages/@overeng/otel-contract",
+      "packages/@overeng/restate-effect",
+      "packages/@overeng/utils",
+      "packages/@overeng/utils-dev"
+    ]
+  },
   "name": "@overeng/restate-effect",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
+  "private": true,
   "exports": {
     ".": "./src/mod.ts",
     "./admin": "./src/admin/admin.ts",
     "./otel": "./src/observability/otel.ts",
     "./testing": "./src/testing/testing.ts"
-  },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      ".": "./dist/mod.js",
-      "./admin": "./dist/admin/admin.js",
-      "./otel": "./dist/observability/otel.js",
-      "./testing": "./dist/testing/testing.js"
-    }
   },
   "dependencies": {
     "@overeng/otel-contract": "workspace:^",
@@ -51,16 +54,13 @@
     "@restatedev/restate-sdk-opentelemetry": "^1.14.5",
     "effect": "^4.0.0-rc.111"
   },
-  "$genie": {
-    "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten",
-    "workspaceClosureDirs": [
-      "packages/@overeng/content-address",
-      "packages/@overeng/effect-distributed-lock",
-      "packages/@overeng/otel-contract",
-      "packages/@overeng/restate-effect",
-      "packages/@overeng/utils",
-      "packages/@overeng/utils-dev"
-    ]
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": "./dist/mod.js",
+      "./admin": "./dist/admin/admin.js",
+      "./otel": "./dist/observability/otel.js",
+      "./testing": "./dist/testing/testing.js"
+    }
   }
 }

--- a/packages/@overeng/restate-effect/tsconfig.json
+++ b/packages/@overeng/restate-effect/tsconfig.json
@@ -3,7 +3,9 @@
 {
   "compilerOptions": {
     "target": "ES2024",
-    "lib": ["ES2024"],
+    "lib": [
+      "ES2024"
+    ],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "allowImportingTsExtensions": true,
@@ -44,7 +46,12 @@
     "composite": true,
     "rootDir": ".",
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
-    "types": ["node"]
+    "types": [
+      "node"
+    ]
   },
-  "include": ["src/**/*", "examples/**/*"]
+  "include": [
+    "src/**/*",
+    "examples/**/*"
+  ]
 }

--- a/packages/@overeng/stylex-tokens/package.json
+++ b/packages/@overeng/stylex-tokens/package.json
@@ -1,21 +1,21 @@
 {
+  "$genie": {
+    "source": "package.json.genie.ts",
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/stylex-tokens"
+    ]
+  },
   "name": "@overeng/stylex-tokens",
   "version": "0.1.0",
+  "type": "module",
   "private": true,
   "description": "Shared StyleX design-token scales and reset stylesheet (browser-only)",
-  "type": "module",
   "exports": {
     "./preflight.css": "./src/preflight.css",
     "./tokens.stylex": {
       "types": "./dist/src/tokens.stylex.d.ts",
       "default": "./src/tokens.stylex.ts"
-    }
-  },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      "./tokens.stylex": "./dist/tokens.stylex.js",
-      "./preflight.css": "./dist/preflight.css"
     }
   },
   "devDependencies": {
@@ -25,11 +25,11 @@
   "peerDependencies": {
     "@stylexjs/stylex": "^0.19.0"
   },
-  "$genie": {
-    "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten",
-    "workspaceClosureDirs": [
-      "packages/@overeng/stylex-tokens"
-    ]
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      "./tokens.stylex": "./dist/tokens.stylex.js",
+      "./preflight.css": "./dist/preflight.css"
+    }
   }
 }

--- a/packages/@overeng/stylex-tokens/tsconfig.json
+++ b/packages/@overeng/stylex-tokens/tsconfig.json
@@ -3,7 +3,11 @@
 {
   "compilerOptions": {
     "target": "ES2024",
-    "lib": ["ES2024", "DOM", "DOM.Iterable"],
+    "lib": [
+      "ES2024",
+      "DOM",
+      "DOM.Iterable"
+    ],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "allowImportingTsExtensions": true,
@@ -46,5 +50,7 @@
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
     "noEmit": true
   },
-  "include": ["src/**/*"]
+  "include": [
+    "src/**/*"
+  ]
 }

--- a/packages/@overeng/tui-core/package.json
+++ b/packages/@overeng/tui-core/package.json
@@ -1,18 +1,19 @@
 {
+  "$genie": {
+    "source": "package.json.genie.ts",
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/tui-core"
+    ]
+  },
   "name": "@overeng/tui-core",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
+  "private": true,
   "exports": {
     ".": {
       "types": "./dist/src/mod.d.ts",
       "default": "./src/mod.ts"
-    }
-  },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      ".": "./dist/mod.js"
     }
   },
   "devDependencies": {
@@ -20,11 +21,10 @@
     "typescript": "6.0.3",
     "vitest": "4.1.9"
   },
-  "$genie": {
-    "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten",
-    "workspaceClosureDirs": [
-      "packages/@overeng/tui-core"
-    ]
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": "./dist/mod.js"
+    }
   }
 }

--- a/packages/@overeng/tui-core/tsconfig.json
+++ b/packages/@overeng/tui-core/tsconfig.json
@@ -3,7 +3,9 @@
 {
   "compilerOptions": {
     "target": "ES2024",
-    "lib": ["ES2024"],
+    "lib": [
+      "ES2024"
+    ],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "allowImportingTsExtensions": true,
@@ -44,8 +46,13 @@
     "composite": true,
     "rootDir": ".",
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
-    "types": ["node"],
+    "types": [
+      "node"
+    ],
     "noEmit": true
   },
-  "include": ["src/**/*", "test/**/*"]
+  "include": [
+    "src/**/*",
+    "test/**/*"
+  ]
 }

--- a/packages/@overeng/tui-react/README.md
+++ b/packages/@overeng/tui-react/README.md
@@ -193,9 +193,7 @@ Create a TuiApp factory with state/action schemas and reducer:
 const MyApp = createTuiApp({
   stateSchema: MyState, // Effect Schema for state
   actionSchema: MyAction, // Effect Schema for actions
-  initial: {
-    /* ... */
-  }, // Initial state value
+  initial: {/* ... */}, // Initial state value
   reducer: myReducer, // (state, action) => state
 })
 

--- a/packages/@overeng/tui-react/docs/spec.md
+++ b/packages/@overeng/tui-react/docs/spec.md
@@ -276,9 +276,7 @@ const App = createTuiApp({
   reducer,
   ndjson: {
     eventSchema: MyEvent,
-    fromAction: ({ action, prevState }) => [
-      /* events */
-    ],
+    fromAction: ({ action, prevState }) => [/* events */],
   },
 })
 ```
@@ -1058,15 +1056,7 @@ const outputOption: Cli.Options<OutputModeValue>
 const outputModeLayer: (value: OutputModeValue) => Layer<OutputMode>
 
 type OutputModeValue =
-  | 'auto'
-  | 'tty'
-  | 'alt-screen'
-  | 'ci'
-  | 'ci-plain'
-  | 'pipe'
-  | 'log'
-  | 'json'
-  | 'ndjson'
+  'auto' | 'tty' | 'alt-screen' | 'ci' | 'ci-plain' | 'pipe' | 'log' | 'json' | 'ndjson'
 ```
 
 **Note:** `outputModeLayer` configures logging behavior per mode:

--- a/packages/@overeng/tui-react/package.json
+++ b/packages/@overeng/tui-react/package.json
@@ -1,8 +1,21 @@
 {
+  "$genie": {
+    "source": "package.json.genie.ts",
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/content-address",
+      "packages/@overeng/effect-distributed-lock",
+      "packages/@overeng/otel-contract",
+      "packages/@overeng/tui-core",
+      "packages/@overeng/tui-react",
+      "packages/@overeng/utils",
+      "packages/@overeng/utils-dev"
+    ]
+  },
   "name": "@overeng/tui-react",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
+  "private": true,
   "exports": {
     ".": {
       "types": "./dist/src/mod.d.ts",
@@ -19,15 +32,6 @@
     "./storybook": {
       "types": "./dist/src/storybook/mod.d.ts",
       "default": "./src/storybook/mod.tsx"
-    }
-  },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      ".": "./dist/mod.js",
-      "./node": "./dist/node/mod.js",
-      "./storybook": "./dist/storybook/mod.js",
-      "./opentui": "./dist/effect/opentui/mod.js"
     }
   },
   "scripts": {
@@ -91,17 +95,13 @@
     "react-dom": "^19.2.7",
     "react-reconciler": "^0.33.0"
   },
-  "$genie": {
-    "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten",
-    "workspaceClosureDirs": [
-      "packages/@overeng/content-address",
-      "packages/@overeng/effect-distributed-lock",
-      "packages/@overeng/otel-contract",
-      "packages/@overeng/tui-core",
-      "packages/@overeng/tui-react",
-      "packages/@overeng/utils",
-      "packages/@overeng/utils-dev"
-    ]
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": "./dist/mod.js",
+      "./node": "./dist/node/mod.js",
+      "./storybook": "./dist/storybook/mod.js",
+      "./opentui": "./dist/effect/opentui/mod.js"
+    }
   }
 }

--- a/packages/@overeng/tui-react/test/integration/fixtures/stdout-drain-cli.ts
+++ b/packages/@overeng/tui-react/test/integration/fixtures/stdout-drain-cli.ts
@@ -5,8 +5,12 @@
  * shape that truncated real CLI output (`--output json` on a failing command
  * piped into a slower consumer).
  *
- * `DRAIN_STRATEGY=stream` selects the old `process.stdout.write` path, kept as
- * a control so the test can show the difference rather than assert it blindly.
+ * `DRAIN_STRATEGY=stream` selects the old, unfixed `process.stdout.write` path
+ * and keeps it exercisable as a control: the write is queued behind the stream
+ * and `process.exit(1)` runs in the same tick, so whatever the kernel pipe
+ * could not take is thrown away. Whether that loses bytes depends on the
+ * reader — the parent supplies the backpressure (see `pauseReaderUntilExit` in
+ * the test), so this fixture only has to pick the path, never fake a loss.
  */
 
 import { writeStdoutSync } from '../../../src/effect/stdout.node.ts'

--- a/packages/@overeng/tui-react/test/integration/stdout-drain.test.ts
+++ b/packages/@overeng/tui-react/test/integration/stdout-drain.test.ts
@@ -9,11 +9,32 @@
  * Observed before the fix: a 949834-byte JSON payload piped into `cat > file`
  * arrived as 393216 bytes and `jq` failed with `unterminated string`.
  *
- * No sleeps or slow-reader tricks are needed — the parent drains as fast as it
- * can and the buffered path still truncates, because the child's `process.exit`
- * runs in the same tick as the write. Both runtimes are covered since they
- * truncate under different strategies (see the table in
- * `src/effect/stdout.node.ts`).
+ * The positive cases run the fixed `writeStdoutSync` path with the reader
+ * flowing normally: no sleeps, no slow-reader pipeline, the parent drains as
+ * fast as it can, and the payload must still arrive whole.
+ *
+ * The negative control runs the unfixed `process.stdout.write` path and makes
+ * the loss deterministic from the *reader* side instead of depending on how a
+ * given runtime version happens to queue stdout (the per-runtime table in
+ * `src/effect/stdout.node.ts` is a snapshot of measurements, not a guarantee;
+ * a control that relies on it can quietly stop controlling anything). The
+ * parent pauses `child.stdout` immediately after spawn, so the kernel pipe
+ * buffer fills, the rest of the payload sits in the child's stream queue, and
+ * `process.exit(1)` discards it. Whatever the child managed to push into the
+ * pipe is still buffered by the kernel and is counted after the reader
+ * resumes.
+ *
+ * The pause is released on the child's `exit` event, not `close`: `exit` means
+ * the process is gone and is independent of the reader, whereas `close` is
+ * documented to also wait for the child's stdio streams to close — i.e. on the
+ * very reader this test deliberately blocked. Resuming from `close` would make
+ * the resume depend on the backpressure it is supposed to release. Exit and
+ * stdout end are therefore tracked separately and the run settles when both
+ * have happened; no timers are involved.
+ *
+ * Only the stream control is paused. Pausing the sync path would be a
+ * different test: `writeStdoutSync` correctly blocks and retries on EAGAIN, so
+ * it would spin against a reader that never reads.
  */
 
 import { spawn } from 'node:child_process'
@@ -36,13 +57,18 @@ interface FixtureRun {
 /**
  * Run the fixture and count the bytes that actually survive to the pipe's read
  * end, resolving only once stdout has ended *and* the child has exited.
+ *
+ * With `pauseReaderUntilExit` the pipe is left unread until the child is gone,
+ * which is the backpressure the buffered control needs.
  */
 const runFixture = ({
   runtime,
   strategy,
+  pauseReaderUntilExit = false,
 }: {
   runtime: string
   strategy: 'sync' | 'stream'
+  pauseReaderUntilExit?: boolean
 }): Promise<FixtureRun> =>
   new Promise<FixtureRun>((resolve, reject) => {
     const child = spawn(runtime, [FIXTURE], {
@@ -64,6 +90,9 @@ const runFixture = ({
     }
 
     child.on('error', reject)
+
+    // Counting handlers are attached before any pause/resume so nothing that
+    // reaches the read end can be missed.
     child.stdout.on('data', (chunk: Buffer) => {
       byteLength += chunk.length
     })
@@ -71,9 +100,20 @@ const runFixture = ({
       stdoutEnded = true
       settle()
     })
-    child.on('close', (code) => {
+
+    // Stop reading right away: the kernel pipe buffer is the only place the
+    // child's bytes can go, and once it is full the remainder is stuck in the
+    // child's own stream queue where `process.exit(1)` will drop it.
+    if (pauseReaderUntilExit === true) child.stdout.pause()
+
+    child.on('exit', (code) => {
       exitCode = code
       exited = true
+      // Resume on `exit`, not `close`: `close` also waits for the stdio
+      // streams, which is exactly what the pause is holding up. The child is
+      // already gone here, so everything read from now on is precisely what
+      // survived the exit.
+      if (pauseReaderUntilExit === true) child.stdout.resume()
       settle()
     })
   })
@@ -90,11 +130,21 @@ describe('stdout data channel survives a non-zero exit', () => {
     })
 
     test(`${runtime}: buffered control truncates, proving the test can fail`, async () => {
-      const { byteLength } = await runFixture({ runtime, strategy: 'stream' })
+      const { byteLength, exitCode } = await runFixture({
+        runtime,
+        strategy: 'stream',
+        pauseReaderUntilExit: true,
+      })
 
-      // Guards the assertions above: if `process.stdout.write` + `process.exit`
-      // ever delivered everything, they would pass for free and protect nothing.
+      // Guards the assertion above: with the pipe backed up, the unfixed path
+      // must lose the queued tail. If it ever delivered all PAYLOAD_BYTES the
+      // measurement would be meaningless and the positive case would pass for
+      // free, so this fails loudly instead.
       expect(byteLength).toBeLessThan(PAYLOAD_BYTES)
+      // Some bytes must still make it, otherwise we are measuring a crash
+      // rather than a truncation.
+      expect(byteLength).toBeGreaterThan(0)
+      expect(exitCode).toBe(1)
     })
   }
 })

--- a/packages/@overeng/tui-react/tsconfig.buck.json
+++ b/packages/@overeng/tui-react/tsconfig.buck.json
@@ -3,7 +3,11 @@
 {
   "compilerOptions": {
     "target": "ES2024",
-    "lib": ["ES2024", "DOM", "DOM.Iterable"],
+    "lib": [
+      "ES2024",
+      "DOM",
+      "DOM.Iterable"
+    ],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "allowImportingTsExtensions": true,
@@ -44,9 +48,15 @@
     "composite": true,
     "rootDir": ".",
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
-    "types": ["node"],
+    "types": [
+      "node"
+    ],
     "jsx": "react-jsx",
     "noEmit": true
   },
-  "include": ["src/**/*", "test/**/*", "examples/**/*"]
+  "include": [
+    "src/**/*",
+    "test/**/*",
+    "examples/**/*"
+  ]
 }

--- a/packages/@overeng/tui-react/tsconfig.json
+++ b/packages/@overeng/tui-react/tsconfig.json
@@ -3,7 +3,11 @@
 {
   "compilerOptions": {
     "target": "ES2024",
-    "lib": ["ES2024", "DOM", "DOM.Iterable"],
+    "lib": [
+      "ES2024",
+      "DOM",
+      "DOM.Iterable"
+    ],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "allowImportingTsExtensions": true,
@@ -44,9 +48,15 @@
     "composite": true,
     "rootDir": ".",
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
-    "types": ["node"],
+    "types": [
+      "node"
+    ],
     "jsx": "react-jsx",
     "noEmit": true
   },
-  "include": ["src/**/*", "test/**/*", "examples/**/*"]
+  "include": [
+    "src/**/*",
+    "test/**/*",
+    "examples/**/*"
+  ]
 }

--- a/packages/@overeng/tui-stories/nix/build.nix
+++ b/packages/@overeng/tui-stories/nix/build.nix
@@ -21,7 +21,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-K+xt5vY9M6TpS9XOrcr/VS9fGChpFFXC7lykuKToD90=";
+      "." = mkSharedHash "sha256-vvUgMkL6xaCp+Ba5xes3G1bV3PTm30WL9wGDNwHIHM4=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/tui-stories/package.json
+++ b/packages/@overeng/tui-stories/package.json
@@ -1,16 +1,28 @@
 {
+  "$genie": {
+    "source": "package.json.genie.ts",
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/content-address",
+      "packages/@overeng/effect-distributed-lock",
+      "packages/@overeng/effect-path",
+      "packages/@overeng/kdl",
+      "packages/@overeng/kdl-effect",
+      "packages/@overeng/megarepo",
+      "packages/@overeng/otel-contract",
+      "packages/@overeng/tui-core",
+      "packages/@overeng/tui-react",
+      "packages/@overeng/tui-stories",
+      "packages/@overeng/utils",
+      "packages/@overeng/utils-dev"
+    ]
+  },
   "name": "@overeng/tui-stories",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
+  "private": true,
   "exports": {
     ".": "./src/mod.ts"
-  },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      ".": "./dist/mod.js"
-    }
   },
   "scripts": {
     "storybook": "storybook dev -p 6013",
@@ -35,6 +47,11 @@
     "react-reconciler": "0.33.0",
     "vitest": "4.1.9"
   },
+  "dependenciesMeta": {
+    "@overeng/tui-react": {
+      "injected": true
+    }
+  },
   "devDependencies": {
     "@effect/atom-react": "4.0.0-rc.111",
     "@effect/vitest": "4.0.0-rc.111",
@@ -48,11 +65,6 @@
     "storybook": "10.5.10",
     "typescript": "6.0.3",
     "vitest": "4.1.9"
-  },
-  "dependenciesMeta": {
-    "@overeng/tui-react": {
-      "injected": true
-    }
   },
   "peerDependencies": {
     "@effect/atom-react": "^4.0.0-rc.111",
@@ -69,22 +81,10 @@
     "react-dom": "^19.2.7",
     "react-reconciler": "^0.33.0"
   },
-  "$genie": {
-    "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten",
-    "workspaceClosureDirs": [
-      "packages/@overeng/content-address",
-      "packages/@overeng/effect-distributed-lock",
-      "packages/@overeng/effect-path",
-      "packages/@overeng/kdl",
-      "packages/@overeng/kdl-effect",
-      "packages/@overeng/megarepo",
-      "packages/@overeng/otel-contract",
-      "packages/@overeng/tui-core",
-      "packages/@overeng/tui-react",
-      "packages/@overeng/tui-stories",
-      "packages/@overeng/utils",
-      "packages/@overeng/utils-dev"
-    ]
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": "./dist/mod.js"
+    }
   }
 }

--- a/packages/@overeng/tui-stories/tsconfig.json
+++ b/packages/@overeng/tui-stories/tsconfig.json
@@ -3,7 +3,9 @@
 {
   "compilerOptions": {
     "target": "ES2024",
-    "lib": ["ES2024"],
+    "lib": [
+      "ES2024"
+    ],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "allowImportingTsExtensions": true,
@@ -44,10 +46,17 @@
     "composite": true,
     "rootDir": ".",
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
-    "types": ["node"],
+    "types": [
+      "node"
+    ],
     "jsx": "react-jsx"
   },
-  "include": ["src/**/*", "test/**/*", "bin/**/*.ts", "bin/**/*.tsx"],
+  "include": [
+    "src/**/*",
+    "test/**/*",
+    "bin/**/*.ts",
+    "bin/**/*.tsx"
+  ],
   "references": [
     {
       "path": "../megarepo"

--- a/packages/@overeng/utils-dev/package.json
+++ b/packages/@overeng/utils-dev/package.json
@@ -1,8 +1,15 @@
 {
+  "$genie": {
+    "source": "package.json.genie.ts",
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/utils-dev"
+    ]
+  },
   "name": "@overeng/utils-dev",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
+  "private": true,
   "exports": {
     "./cli-contract": {
       "types": "./dist/src/cli-contract.d.ts",
@@ -21,15 +28,6 @@
       "default": "./src/otelite/mod.ts"
     }
   },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      "./node-vitest": "./dist/node-vitest/mod.js",
-      "./node-vitest/setup-fast-check": "./dist/node-vitest/setup-fast-check.js",
-      "./otelite": "./dist/otelite/mod.js",
-      "./cli-contract": "./dist/cli-contract.js"
-    }
-  },
   "devDependencies": {
     "@effect/opentelemetry": "4.0.0-rc.111",
     "@effect/platform-node": "4.0.0-rc.111",
@@ -46,11 +44,13 @@
     "effect": "^4.0.0-rc.111",
     "vitest": "^4.1.9"
   },
-  "$genie": {
-    "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten",
-    "workspaceClosureDirs": [
-      "packages/@overeng/utils-dev"
-    ]
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      "./node-vitest": "./dist/node-vitest/mod.js",
+      "./node-vitest/setup-fast-check": "./dist/node-vitest/setup-fast-check.js",
+      "./otelite": "./dist/otelite/mod.js",
+      "./cli-contract": "./dist/cli-contract.js"
+    }
   }
 }

--- a/packages/@overeng/utils-dev/tsconfig.json
+++ b/packages/@overeng/utils-dev/tsconfig.json
@@ -3,7 +3,9 @@
 {
   "compilerOptions": {
     "target": "ES2024",
-    "lib": ["ES2024"],
+    "lib": [
+      "ES2024"
+    ],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "allowImportingTsExtensions": true,
@@ -44,8 +46,12 @@
     "composite": true,
     "rootDir": ".",
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
-    "types": ["node"],
+    "types": [
+      "node"
+    ],
     "noEmit": true
   },
-  "include": ["src/**/*"]
+  "include": [
+    "src/**/*"
+  ]
 }

--- a/packages/@overeng/utils/package.json
+++ b/packages/@overeng/utils/package.json
@@ -1,8 +1,19 @@
 {
+  "$genie": {
+    "source": "package.json.genie.ts",
+    "warning": "DO NOT EDIT - changes will be overwritten",
+    "workspaceClosureDirs": [
+      "packages/@overeng/content-address",
+      "packages/@overeng/effect-distributed-lock",
+      "packages/@overeng/otel-contract",
+      "packages/@overeng/utils",
+      "packages/@overeng/utils-dev"
+    ]
+  },
   "name": "@overeng/utils",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
+  "private": true,
   "exports": {
     ".": {
       "types": "./dist/src/isomorphic/mod.d.ts",
@@ -79,33 +90,6 @@
       "default": "./src/node/stylex/focus-order.ts"
     }
   },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      ".": "./dist/isomorphic/mod.js",
-      "./node": "./dist/node/mod.js",
-      "./node/cli-help-rewrite": "./dist/node/cli-help-rewrite.js",
-      "./node/cli-version": "./dist/node/cli-version.js",
-      "./node/otel": "./dist/node/otel.js",
-      "./node/otel-attrs": "./dist/node/otel-attrs.js",
-      "./node/playwright": "./dist/node/playwright/mod.js",
-      "./node/playwright/config": "./dist/node/playwright/config/mod.js",
-      "./node/stylex": "./dist/node/stylex/mod.js",
-      "./node/stylex/focus-order": "./dist/node/stylex/focus-order.js",
-      "./node/storybook": "./dist/node/storybook/mod.js",
-      "./node/storybook/config": "./dist/node/storybook/config/mod.js",
-      "./node/storybook/gate": "./dist/node/storybook/gate/mod.js",
-      "./node/storybook/gate/cli": "./dist/node/storybook/gate/cli.js",
-      "./node/storybook/gate/setup": "./dist/node/storybook/gate/setup.js",
-      "./lock": "./dist/lock/mod.js",
-      "./browser": "./dist/browser/mod.js",
-      "./cuid": {
-        "browser": "./dist/cuid/cuid.browser.js",
-        "node": "./dist/cuid/cuid.node.js",
-        "default": "./dist/cuid/mod.js"
-      }
-    }
-  },
   "dependencies": {
     "@effect/opentelemetry": "4.0.0-rc.111",
     "@effect/platform-node": "4.0.0-rc.111",
@@ -151,15 +135,31 @@
     "@playwright/test": "^1.61.0",
     "effect": "^4.0.0-rc.111"
   },
-  "$genie": {
-    "source": "package.json.genie.ts",
-    "warning": "DO NOT EDIT - changes will be overwritten",
-    "workspaceClosureDirs": [
-      "packages/@overeng/content-address",
-      "packages/@overeng/effect-distributed-lock",
-      "packages/@overeng/otel-contract",
-      "packages/@overeng/utils",
-      "packages/@overeng/utils-dev"
-    ]
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": "./dist/isomorphic/mod.js",
+      "./node": "./dist/node/mod.js",
+      "./node/cli-help-rewrite": "./dist/node/cli-help-rewrite.js",
+      "./node/cli-version": "./dist/node/cli-version.js",
+      "./node/otel": "./dist/node/otel.js",
+      "./node/otel-attrs": "./dist/node/otel-attrs.js",
+      "./node/playwright": "./dist/node/playwright/mod.js",
+      "./node/playwright/config": "./dist/node/playwright/config/mod.js",
+      "./node/stylex": "./dist/node/stylex/mod.js",
+      "./node/stylex/focus-order": "./dist/node/stylex/focus-order.js",
+      "./node/storybook": "./dist/node/storybook/mod.js",
+      "./node/storybook/config": "./dist/node/storybook/config/mod.js",
+      "./node/storybook/gate": "./dist/node/storybook/gate/mod.js",
+      "./node/storybook/gate/cli": "./dist/node/storybook/gate/cli.js",
+      "./node/storybook/gate/setup": "./dist/node/storybook/gate/setup.js",
+      "./lock": "./dist/lock/mod.js",
+      "./browser": "./dist/browser/mod.js",
+      "./cuid": {
+        "browser": "./dist/cuid/cuid.browser.js",
+        "node": "./dist/cuid/cuid.node.js",
+        "default": "./dist/cuid/mod.js"
+      }
+    }
   }
 }

--- a/packages/@overeng/utils/src/node/storybook/config/mod.ts
+++ b/packages/@overeng/utils/src/node/storybook/config/mod.ts
@@ -196,10 +196,10 @@ export const createTuiStorybookConfig: CreateTuiStorybookConfig = <TConfig exten
         target: 'esnext',
         rolldownOptions: {
           ...typedConfig.build?.rolldownOptions,
-          // eslint-disable-next-line overeng/named-args -- Rollup API callback signature
-          onwarn: (warning, warn) => {
-            if (warning.code === 'MODULE_LEVEL_DIRECTIVE') return
-            warn(warning)
+          // eslint-disable-next-line overeng/named-args -- Rolldown API callback signature
+          onLog: (level, log, defaultHandler) => {
+            if (log.code === 'MODULE_LEVEL_DIRECTIVE') return
+            defaultHandler(level, log)
           },
         },
       }

--- a/packages/@overeng/utils/src/node/storybook/gate/project.ts
+++ b/packages/@overeng/utils/src/node/storybook/gate/project.ts
@@ -250,17 +250,20 @@ const createProject = ({
     test: {
       name: projectName,
       setupFiles: ['@overeng/utils/node/storybook/gate/setup'],
+      // Capturing several stories concurrently in one browser context
+      // corrupted frames nondeterministically — a few stories per run showed
+      // a stale duplicate band from racing full-page captures. Sequential
+      // capture was byte-stable across runs and the concurrency saving was
+      // under a quarter of the runtime, so it buys nothing.
+      //
+      // Vitest deprecated the `browser.fileParallelism` mirror; the top-level
+      // option is the one that governs browser-mode runs.
+      fileParallelism: false,
       browser: {
         enabled: true,
         headless,
         provider: playwright(),
         instances: [{ browser: 'chromium' }],
-        // Capturing several stories concurrently in one browser context
-        // corrupted frames nondeterministically — a few stories per run showed
-        // a stale duplicate band from racing full-page captures. Sequential
-        // capture was byte-stable across runs and the concurrency saving was
-        // under a quarter of the runtime, so it buys nothing.
-        fileParallelism: false,
         expect: {
           toMatchScreenshot: {
             comparatorName: 'pixelmatch',

--- a/packages/@overeng/utils/src/node/stylex/mod.js
+++ b/packages/@overeng/utils/src/node/stylex/mod.js
@@ -110,9 +110,8 @@ export const createStylexVitePlugins = ({
   })
 
   const upstream = stylex.vite(stylexOptions)
-  const collectCss = /** @type {{ __stylexCollectCss?: () => string }} */ (
-    upstream
-  ).__stylexCollectCss
+  const collectCss =
+    /** @type {{ __stylexCollectCss?: () => string }} */ (upstream).__stylexCollectCss
   if (typeof collectCss !== 'function') {
     throw new Error(
       '[overeng:stylex] @stylexjs/unplugin no longer exposes `__stylexCollectCss`; the virtual-module injection path cannot read compiled rules.',

--- a/packages/@overeng/utils/tsconfig.json
+++ b/packages/@overeng/utils/tsconfig.json
@@ -3,7 +3,9 @@
 {
   "compilerOptions": {
     "target": "ES2024",
-    "lib": ["ES2024"],
+    "lib": [
+      "ES2024"
+    ],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "allowImportingTsExtensions": true,
@@ -44,10 +46,14 @@
     "composite": true,
     "rootDir": ".",
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
-    "types": ["node"],
+    "types": [
+      "node"
+    ],
     "checkJs": true,
     "noEmit": true
   },
-  "include": ["src/**/*"],
+  "include": [
+    "src/**/*"
+  ],
   "references": []
 }

--- a/rust/buck2-tools/product/src/main.rs
+++ b/rust/buck2-tools/product/src/main.rs
@@ -705,9 +705,12 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{io::Read, path::Path};
+    #[cfg(target_os = "linux")]
+    use std::io::Read;
+    use std::path::Path;
     use tempfile::tempdir;
 
+    #[cfg(target_os = "linux")]
     fn clean_elf_fixture(root: &Path) -> PathBuf {
         let mut bytes = fs::read(std::env::current_exe().unwrap()).unwrap();
         let endian = match bytes[5] {
@@ -759,6 +762,7 @@ mod tests {
         }
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn packages_a_canonical_descriptor_from_the_inspected_executable() {
         let temporary = tempdir().unwrap();
@@ -829,6 +833,7 @@ mod tests {
         assert!(!temporary.path().join("artifact.tar").exists());
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn runtime_contract_must_match_the_native_executable() {
         let temporary = tempdir().unwrap();


### PR DESCRIPTION
## Problem

The shared Nix authority remained on the `release-26.05` branch. Current Rust, formatter, linter, and Buck2 package behavior therefore differed across the root flake, Devenv, Weaver, and prepared dependency builds.

## Goal

Use one current `nixos-unstable` authority across all effect-utils build surfaces and keep generated files, lint migrations, Buck2 assets, and fixed-output hashes consistent with that authority.

## Decisions

- Pin authored inputs to `nixos-unstable`; committed locks provide reproducibility.
- Install `starlark_fmt` from the same upstream Buck2 release asset set.
- Regenerate repository projections with the migrated toolchain.
- Keep behavior-preserving lint fixes separate from formatting and generated output.
- Refresh only the eight affected prepared dependency hashes.
- Run ELF-specific Buck2 bridge fixtures only on Linux. The platform-neutral descriptor contract remains covered on every platform.
- Run digest helpers only where the Linux ptrace test consumes them.

## Verification

Passed on the final tree:

- `devenv tasks run check:quick`
- `devenv tasks run check:all` on `aarch64-darwin`
- `cargo test --locked --package buck2-product --bin buck2-product` on Linux: 4 passed
- `cargo test --locked --package buck2-product --bin buck2-product` on `aarch64-darwin`: 2 passed
- `cargo clippy --locked --package otel-scrape --all-targets -- -D warnings` on Linux and `aarch64-darwin`
- stdout-drain integration test: 4 passed, including the deterministic 1,000,000-byte synchronous-drain regression case
- all eight affected prepared dependency derivations
- Buck2, Genie, and Megarepo package builds

The final full gate covered generated-file checks, Nix checks, Rust build/test/clippy/fmt, TypeScript, Buck2 materialization, Devenv module tests, bootstrap closure checks, Weaver checks, and telemetry verification.

## Complexity

No new abstraction. The change aligns existing authority and generated surfaces.

## Concerns

The Buck2 source override now matches upstream nixpkgs byte-for-byte. Removing that redundant override is intentionally separate from this migration.

## Follow-up

- Remove the redundant Buck2 source override in a separate focused change.
- After merge, downstream repositories can replace the temporary PR-head pin with the merged effect-utils revision.

## Related work

- #1162
- #1209
- #1213

<!-- agent-footer:begin v=2 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | dev3.direct.omp.ubb99bpf |
| `session` | dev3.ubb99bpf |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.1.7 |
| `agent_runtime` | OMP 18.1.7 |
| `tooling_profile` | dotfiles@931583a |
</details>
<!-- agent-footer:end -->