### PR TITLE
fix: unblock draft PR auto-merge and update Effect 4 docs

### DIFF
--- a/.github/workflows/auto-review.yml
+++ b/.github/workflows/auto-review.yml
@@ -12,12 +12,12 @@ permissions:
 
 jobs:
   request-review:
-    if: github.event.pull_request.user.login == 'schickling-assistant' && github.event.pull_request.draft == false
     runs-on:
       [namespace-profile-linux-x86-64, 'namespace-features:github.run-id=${{ github.run_id }}']
     timeout-minutes: 30
     steps:
       - name: Request review from schickling
+        if: github.event.pull_request.user.login == 'schickling-assistant' && github.event.pull_request.draft == false
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,8 @@ All notable changes to this project will be documented in this file.
   the two dropped members. No behavior change.
 
 ### Fixed
+- **CI**: keep draft assistant PRs mergeable by completing the auto-review job
+  successfully when no review request is needed.
 
 - **@overeng/tui-react**: stop truncating `runResult` values and JSON error
   payloads when a CLI exits non-zero. These exit-path writes now go straight to

--- a/genie/auto-review.ts
+++ b/genie/auto-review.ts
@@ -23,12 +23,12 @@ export const autoReviewWorkflow = ({
     },
     jobs: {
       'request-review': {
-        if: `github.event.pull_request.user.login == '${author}' && github.event.pull_request.draft == false`,
         'runs-on': runner,
         'timeout-minutes': timeoutMinutes,
         steps: [
           {
             name: `Request review from ${reviewer}`,
+            if: `github.event.pull_request.user.login == '${author}' && github.event.pull_request.draft == false`,
             env: { GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}' },
             run: [
               `curl --fail-with-body --silent --show-error --request POST \\`,

--- a/packages/@overeng/effect-ai-claude-cli/README.md
+++ b/packages/@overeng/effect-ai-claude-cli/README.md
@@ -9,7 +9,7 @@ Use your existing **Claude Code subscription** instead of paying for API calls. 
 ## Installation
 
 ```bash
-pnpm add @overeng/effect-ai-claude-cli @effect/ai @effect/platform effect
+pnpm add @overeng/effect-ai-claude-cli @effect/platform-node effect
 ```
 
 Requires the `claude` CLI to be installed and authenticated:
@@ -25,8 +25,8 @@ claude auth
 ## Usage
 
 ```ts
-import { Chat } from '@effect/ai'
-import { NodeCommandExecutor } from '@effect/platform-node'
+import { NodeServices } from '@effect/platform-node'
+import { Chat } from 'effect/unstable/ai'
 import { ClaudeCli } from '@overeng/effect-ai-claude-cli'
 import { Effect, Layer } from 'effect'
 
@@ -36,7 +36,7 @@ const program = Effect.gen(function* () {
   console.log(response.text)
 })
 
-const layer = ClaudeCli.layer({ model: 'sonnet' }).pipe(Layer.provide(NodeCommandExecutor.layer))
+const layer = ClaudeCli.layer({ model: 'sonnet' }).pipe(Layer.provide(NodeServices.layer))
 
 Effect.runPromise(program.pipe(Effect.provide(layer)))
 ```
@@ -76,9 +76,8 @@ The CLI accepts short model names:
 
 ## Dependencies
 
-- `@effect/ai` - Effect AI LanguageModel interface
-- `@effect/platform` - CommandExecutor for CLI invocation
-- `effect` - Core Effect library
+- `effect` - Effect AI and child-process service interfaces
+- `@effect/platform-node` - Node implementations of the required platform services
 
 ## When to use this vs `@effect/ai-anthropic`
 

--- a/packages/@overeng/effect-ai-claude-cli/src/mod.ts
+++ b/packages/@overeng/effect-ai-claude-cli/src/mod.ts
@@ -6,8 +6,8 @@
  *
  * @example
  * ```ts
+ * import { NodeServices } from '@effect/platform-node'
  * import { Chat } from 'effect/unstable/ai'
- * import { NodeCommandExecutor } from '@effect/platform-node'
  * import { ClaudeCli } from '@overeng/effect-ai-claude-cli'
  * import { Effect, Layer } from 'effect'
  *
@@ -19,9 +19,7 @@
  *   console.log(response.text)
  * })
  *
- * const layer = ClaudeCli.layer({ model: 'sonnet' }).pipe(
- *   Layer.provide(NodeCommandExecutor.layer),
- * )
+ * const layer = ClaudeCli.layer({ model: 'sonnet' }).pipe(Layer.provide(NodeServices.layer))
  *
  * Effect.runPromise(program.pipe(Effect.provide(layer)))
  * ```

--- a/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/github-workflow/ci-workflow-helpers.unit.test.ts
@@ -39,6 +39,10 @@ const generatedCiWorkflowYamlSource = readFileSync(
   new URL(['../../../../../../.github/workflows', 'ci.yml'].join('/'), import.meta.url),
   'utf8',
 )
+const generatedAutoReviewWorkflowYamlSource = readFileSync(
+  new URL(['../../../../../../.github/workflows', 'auto-review.yml'].join('/'), import.meta.url),
+  'utf8',
+)
 const generatedRepoSettings = JSON.parse(
   readFileSync(
     new URL(['../../../../../../.github', 'repo-settings.json'].join('/'), import.meta.url),
@@ -220,6 +224,17 @@ const megarepoTaskModuleSource = readFileSync(
   ),
   'utf8',
 )
+
+describe('pull request control-event workflows', () => {
+  it('finishes the auto-review suite successfully when no review request is needed', () => {
+    expect(generatedAutoReviewWorkflowYamlSource).not.toMatch(
+      /  request-review:\n    if: github\.event\.pull_request/,
+    )
+    expect(generatedAutoReviewWorkflowYamlSource).toContain(
+      "      - name: Request review from schickling\n        if: github.event.pull_request.user.login == 'schickling-assistant' && github.event.pull_request.draft == false",
+    )
+  })
+})
 
 describe('ci workflow retry helpers', () => {
   it('keeps non-advisory always-on workflow jobs required by branch protection', () => {

--- a/packages/@overeng/notion-core/package.json.genie.ts
+++ b/packages/@overeng/notion-core/package.json.genie.ts
@@ -13,9 +13,6 @@ const workspaceDeps = catalog.compose({
   workspace: workspaceMember({ memberPath: 'packages/@overeng/notion-core' }),
   devDependencies: {
     workspace: [utilsDevPkg],
-    // utils-dev is injected into this package's pnpm closure and peers on the
-    // repository's Effect 3 cohort. Pin that peer locally so pnpm cannot satisfy
-    // it with react-inspector's intentionally separate Effect 4 development copy.
     external: catalog.pick('@types/node', 'effect', 'typescript', 'vitest'),
   },
 })


### PR DESCRIPTION
## Problem

The `effect-ai-claude-cli` public examples still referenced removed Effect 3 packages and `NodeCommandExecutor`. The notion-core generator also retained a false comment about separate Effect 3 and Effect 4 cohorts.

The same PR exposed a CI control-event bug. The PR was opened as a draft, so the auto-review workflow skipped its only job at job level. GitHub retained that suite-level `skipped` result on the head. A later successful `ready_for_review` suite did not make the merge state clean, so auto-merge remained unstable even though every required check passed.

## Goal

Make active public guidance match the current Effect 4 package graph, and ensure draft assistant PRs can reach a clean auto-merge state after they become ready.

## Decisions

- Move the auto-review author/draft condition from the job to the review-request step. The workflow still requests review only for ready assistant PRs, but every triggered job and suite now completes successfully.
- Keep the workflow triggers and review behavior stable. Removing the `opened` trigger would miss assistant PRs opened as ready.
- Do not treat rerunning a skipped workflow as recovery. GitHub preserves the original event payload, so the live rerun remained skipped.

## Verification

- `devenv tasks run test:genie --no-tui` — 31 files and 432 tests passed after the fix.
- `devenv tasks run genie:check --no-tui` — passed.
- `devenv tasks run check:quick --no-tui` — passed.
- The new regression test failed against the prior generated auto-review workflow, then passed after regeneration.
- Live counter-test: rerunning skipped auto-review run `34135129815` preserved the draft `opened` payload and skipped again. This disproves rerun-as-recovery and confirms that the workflow shape must change.
- The notion-core `catalog.pick('@types/node', 'effect', 'typescript', 'vitest')` expression is unchanged.

## Complexity

No new abstraction. The fix moves one existing predicate from job scope to step scope and adds a generated-workflow regression assertion.

## Concerns

The auto-review job now acquires its configured runner for draft and non-assistant events, then skips only the API step. This small cost is required for the check suite to conclude successfully instead of `skipped`.

The main CI workflow also runs on every label event because `ci:perf` is label-triggered. PR #1222 received six label-event runs after three metadata labels were applied twice. Those runs were not a five-hour queue: the apparent span came from two later manual reruns of one completed run. Keeping one successful job in each label-event suite currently prevents the same suite-level `skipped` merge state. Removing that job without changing the trigger would reintroduce this bug.

## Friction & bottlenecks

- GitHub's GraphQL status rollup reported `SUCCESS` while the REST merge state reported `unstable`; the rollup deduplicated successful check contexts and did not expose the older suite-level `skipped` result.
- No runner regression was found. Attempt-level timestamps showed that the original label-event run completed in under two minutes. Two later reruns changed its top-level `updated_at` timestamp.

## Follow-ups

None required for this fix. A future redesign of the `ci:perf` opt-in should avoid `pull_request:labeled` entirely or provide an explicit successful control-event job. A separate label-triggered workflow alone would still create skipped suites for unrelated labels.

## References

- CI run `34135129784`: full required checks passed on the original head.
- Auto-review run `34135129815`: draft event produced the skipped suite and remained skipped on rerun.

<!-- agent-footer:begin v=2 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | dev3.direct.omp.pxjewe7s |
| `session` | dev3.pxjewe7s |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.1.7 |
| `agent_runtime` | OMP 18.1.7 |
| `tooling_profile` | dotfiles@703d931 |
</details>
<!-- agent-footer:end -->