### PR TITLE
feat(megarepo): add plan-bound store reclamation

### DIFF
--- a/packages/@overeng/megarepo/README.md
+++ b/packages/@overeng/megarepo/README.md
@@ -157,12 +157,13 @@ caller. `mr store lease` propagates the wrapped command's own exit code.
 ### Live-process veto
 
 The lease only excludes an activation that takes it, and a shell or agent session that was already
-sitting inside a worktree announces nothing. On Linux a rename is invisible to a process already in
+sitting inside a worktree announces nothing. On Unix a rename is invisible to a process already in
 that directory — its cwd silently follows the inode into `.archive/` — so every destructive
 worktree step additionally refuses when a live process has its cwd inside the target, reporting
 `kept` with `reason: process-in-use` (a plan-bound application fails instead). Evidence is
-`/proc/<pid>/cwd`; megarepo's own process and its children are excluded so a `git` child cannot
-self-veto. A host without `/proc`, or a scan that cannot be read, is `unknown` and keeps.
+`/proc/<pid>/cwd` on Linux and the system `lsof` cwd table on macOS; megarepo's own process and its
+children are excluded so a `git` child cannot self-veto. A host without a supported process table,
+or a scan that cannot be read, is `unknown` and keeps.
 
 ## Documentation
 

--- a/packages/@overeng/megarepo/README.md
+++ b/packages/@overeng/megarepo/README.md
@@ -87,23 +87,39 @@ Configure the host at `$MEGAREPO_STORE/.state/gc-config.json`:
     "enabled": true,
     "retentionMs": 86400000,
     "allowlist": ["node_modules", ".direnv", "target"],
-    "agentLivenessManifest": "/run/megarepo/agent-liveness.json"
+    "agentLivenessManifest": "/run/megarepo/st2-workspace-activity.json",
+    "agentLivenessEpoch": { "catalog": "/var/lib/st2/catalog", "host": "dev3" }
   }
 }
 ```
 
-The allowlist may contain only the compiled canonical classes. The liveness manifest is a
-short-lived snapshot produced by the host's agent manager:
+The allowlist may contain only the compiled canonical classes. The liveness manifest must be a
+native, short-lived `st2 workspace-activity --json` snapshot:
 
 ```json
 {
-  "version": 1,
-  "expiresAtMs": 1786572000000,
-  "activeWorkspacePaths": ["/absolute/path/to/a/store/worktree"]
+  "schemaVersion": "st2.workspace-activity.v1",
+  "producer": "st2",
+  "epoch": { "catalog": "/var/lib/st2/catalog", "host": "dev3", "catalogGeneration": 42 },
+  "capturedAt": "2026-09-07T08:00:00.000Z",
+  "expiresAt": "2026-09-07T08:01:00.000Z",
+  "complete": true,
+  "errors": [],
+  "claims": [
+    {
+      "workspace": "/absolute/path/to/a/store/worktree",
+      "agents": ["dev3.example.agent"],
+      "activeRuntimeIds": ["dev3.example.agent"],
+      "active": true
+    }
+  ]
 }
 ```
 
-Missing, invalid, or expired liveness data produces `unknown`. A candidate
+Missing, invalid, incomplete, erroneous, expired, or non-canonical liveness data produces
+`unknown`. The configured catalog and host admit the expected epoch, its catalog generation must
+not move between the pre-scan and post-scan reads, and claims must be sorted, unique, and named by
+canonical path. A candidate
 must also be Git-ignored, older than the retention window, absent from Megarepo's live set, and
 inside a clean registered worktree. A capped, timed recursive scan uses the newest nested mtime;
 symlinks or incomplete scans produce `unknown`. JSON results distinguish
@@ -137,6 +153,16 @@ mr store lease --owner-path /path/to/store/worktree -- <activation command>
 A lease is reclaimed only when its record is decodable, names this host, and names a pid that is
 provably gone. A foreign host, a live pid, or an unreadable record keeps the lease and refuses the
 caller. `mr store lease` propagates the wrapped command's own exit code.
+
+### Live-process veto
+
+The lease only excludes an activation that takes it, and a shell or agent session that was already
+sitting inside a worktree announces nothing. On Linux a rename is invisible to a process already in
+that directory — its cwd silently follows the inode into `.archive/` — so every destructive
+worktree step additionally refuses when a live process has its cwd inside the target, reporting
+`kept` with `reason: process-in-use` (a plan-bound application fails instead). Evidence is
+`/proc/<pid>/cwd`; megarepo's own process and its children are excluded so a `git` child cannot
+self-veto. A host without `/proc`, or a scan that cannot be read, is `unknown` and keeps.
 
 ## Documentation
 

--- a/packages/@overeng/megarepo/README.md
+++ b/packages/@overeng/megarepo/README.md
@@ -109,7 +109,26 @@ inside a clean registered worktree. A capped, timed recursive scan uses the newe
 symlinks or incomplete scans produce `unknown`. JSON results distinguish
 `would-delete`, `deleted`, `keep`, and `unknown` and include a deterministic `planSha256`.
 Application recomputes the complete plan, requires the exact digest and a unique candidate, then
-revalidates and removes only that candidate under its owner-worktree lock.
+revalidates and removes only that candidate under its owner-worktree lock and its deletion lease.
+
+### Deletion lease
+
+The liveness manifest is written by an external agent manager, so rereading it cannot exclude an
+activation that starts immediately afterwards. A lease per canonical owner worktree closes that
+window: reclamation holds it across final classification and deletion, and activation holds it from
+before its first worktree write until after it has published the manifest. The lease is one file at
+`$MEGAREPO_STORE/.state/deletion-leases/<sha256-of-owner-path>.lease`, taken by hard-linking onto
+that path — atomic on POSIX, so the loser fails closed instead of proceeding on a stale snapshot.
+
+Activation needs no protocol code of its own; wrap it:
+
+```bash
+mr store lease --owner-path /path/to/store/worktree -- <activation command>
+```
+
+A lease is reclaimed only when its record is decodable, names this host, and names a pid that is
+provably gone. A foreign host, a live pid, or an unreadable record keeps the lease and refuses the
+caller.
 
 ## Documentation
 

--- a/packages/@overeng/megarepo/README.md
+++ b/packages/@overeng/megarepo/README.md
@@ -119,6 +119,10 @@ window: reclamation holds it across final classification and deletion, and activ
 before its first worktree write until after it has published the manifest. The lease is one file at
 `$MEGAREPO_STORE/.state/deletion-leases/<sha256-of-owner-path>.lease`, taken by hard-linking onto
 that path — atomic on POSIX, so the loser fails closed instead of proceeding on a stale snapshot.
+Every plan-bound deletion takes it, whole worktrees and archive reaps included, since an activation
+of the worktree being deleted is exactly what the lease has to exclude. After linking, the acquirer
+re-reads the record and requires its own token: concurrent recovery of one dead holder can otherwise
+let a loser's removal delete the winner's fresh lease, and a mismatch refuses without removing.
 
 Activation needs no protocol code of its own; wrap it:
 
@@ -128,7 +132,7 @@ mr store lease --owner-path /path/to/store/worktree -- <activation command>
 
 A lease is reclaimed only when its record is decodable, names this host, and names a pid that is
 provably gone. A foreign host, a live pid, or an unreadable record keeps the lease and refuses the
-caller.
+caller. `mr store lease` propagates the wrapped command's own exit code.
 
 ## Documentation
 

--- a/packages/@overeng/megarepo/README.md
+++ b/packages/@overeng/megarepo/README.md
@@ -120,9 +120,13 @@ before its first worktree write until after it has published the manifest. The l
 `$MEGAREPO_STORE/.state/deletion-leases/<sha256-of-owner-path>.lease`, taken by hard-linking onto
 that path — atomic on POSIX, so the loser fails closed instead of proceeding on a stale snapshot.
 Every plan-bound deletion takes it, whole worktrees and archive reaps included, since an activation
-of the worktree being deleted is exactly what the lease has to exclude. After linking, the acquirer
-re-reads the record and requires its own token: concurrent recovery of one dead holder can otherwise
-let a loser's removal delete the winner's fresh lease, and a mismatch refuses without removing.
+of the worktree being deleted is exactly what the lease has to exclude.
+
+Reclaiming a dead holder's lease is the only step that can destroy another holder's lease, so it is
+serialized by a per-owner recovery lock (`<sha256>.recover`, hardlink-create-only and never itself
+recovered) and, inside that lock, may remove only the exact record it proved dead. Without both, two
+recoverers of one dead lease can interleave into two believed holders. A crash while holding the
+recovery lock blocks only future recovery — plain acquisition and release stay live.
 
 Activation needs no protocol code of its own; wrap it:
 

--- a/packages/@overeng/megarepo/README.md
+++ b/packages/@overeng/megarepo/README.md
@@ -71,11 +71,12 @@ Branch worktrees use raw Git ref paths in the store, for example `feature/foo` b
 
 ## Generated artifact cleanup
 
-`mr store gc` can plan old generated directories in registered, clean, inactive store worktrees.
-This first slice is deliberately non-mutating:
+`mr store gc` can plan old generated directories in registered, clean, inactive store worktrees,
+then apply exactly one candidate from that immutable plan:
 
 ```bash
 mr store gc --generated-artifacts --dry-run --output json
+mr store gc --generated-artifacts --expected-plan <sha256> --candidate-path <path> --output json
 ```
 
 Configure the host at `$MEGAREPO_STORE/.state/gc-config.json`:
@@ -106,8 +107,9 @@ Missing, invalid, or expired liveness data produces `unknown`. A candidate
 must also be Git-ignored, older than the retention window, absent from Megarepo's live set, and
 inside a clean registered worktree. A capped, timed recursive scan uses the newest nested mtime;
 symlinks or incomplete scans produce `unknown`. JSON results distinguish
-`would-delete`, `keep`, and `unknown` and include a deterministic `planSha256`. Mutation and
-`--expected-plan` are rejected until the deletion transaction has a separately verified design.
+`would-delete`, `deleted`, `keep`, and `unknown` and include a deterministic `planSha256`.
+Application recomputes the complete plan, requires the exact digest and a unique candidate, then
+revalidates and removes only that candidate under its owner-worktree lock.
 
 ## Documentation
 

--- a/packages/@overeng/megarepo/docs/commands.md
+++ b/packages/@overeng/megarepo/docs/commands.md
@@ -120,8 +120,9 @@ worktree, archive, or generated-artifact action after an owner-locked
 revalidation. Missing, ambiguous, changed, or unknown evidence refuses the
 application.
 
-Generated-artifact deletion additionally holds the owner's deletion lease, so an
-activation wrapped in `mr store lease` can never be overtaken.
+Every plan-bound deletion — generated artifact, whole worktree, archive reap —
+additionally holds the lease for its owner path, so an activation wrapped in
+`mr store lease` can never be overtaken.
 
 ### `mr store lease`
 

--- a/packages/@overeng/megarepo/docs/commands.md
+++ b/packages/@overeng/megarepo/docs/commands.md
@@ -106,9 +106,16 @@ mr store fetch [--json]
 ### `mr store gc`
 
 ```bash
-mr store gc [--dry-run] [--force] [--all]
+mr store gc [--dry-run] [--force] [--all] [--generated-artifacts]
+mr store gc [--generated-artifacts] --expected-plan <sha256> --candidate-path <absolute-path>
 ```
 
 Removes clean unrooted `refs/commits/*` worktrees. Named `refs/heads/*` and
 `refs/tags/*` worktrees are kept by default. Dirty worktrees are preserved
 unless `--force` is used. `--all` also considers named refs for removal.
+
+Dry-run output includes a canonical `planSha256`. Supplying that digest with one
+candidate path recomputes the complete plan and applies only the selected
+worktree, archive, or generated-artifact action after an owner-locked
+revalidation. Missing, ambiguous, changed, or unknown evidence refuses the
+application.

--- a/packages/@overeng/megarepo/docs/commands.md
+++ b/packages/@overeng/megarepo/docs/commands.md
@@ -119,3 +119,18 @@ candidate path recomputes the complete plan and applies only the selected
 worktree, archive, or generated-artifact action after an owner-locked
 revalidation. Missing, ambiguous, changed, or unknown evidence refuses the
 application.
+
+Generated-artifact deletion additionally holds the owner's deletion lease, so an
+activation wrapped in `mr store lease` can never be overtaken.
+
+### `mr store lease`
+
+```bash
+mr store lease --owner-path <path> -- <command> [args…]
+```
+
+Runs the command while holding the deletion lease for one store worktree and
+propagates its exit code. Wrap workspace activation with it: acquire before the
+first worktree write, publish the agent-liveness manifest inside, and the lease
+is released when the command exits. If reclamation holds the lease, the wrapper
+fails instead of racing it.

--- a/packages/@overeng/megarepo/src/__snapshots__/cli.contract.test.ts.snap
+++ b/packages/@overeng/megarepo/src/__snapshots__/cli.contract.test.ts.snap
@@ -162,6 +162,7 @@ SUBCOMMANDS
   fetch       Fetch all repositories in the store
   gc          Garbage collect unused worktrees
   fix         Fix store issues
+  lease       Run a command while holding a store deletion lease
   worktree    Manage worktrees in the store
 ",
 }

--- a/packages/@overeng/megarepo/src/cli/commands/store/mod.ts
+++ b/packages/@overeng/megarepo/src/cli/commands/store/mod.ts
@@ -2448,8 +2448,19 @@ const storeGcCommand = Cli.Command.make(
                   })
                 }
                 yield* fs.remove(candidate.path, { recursive: true })
-                yield* Git.pruneWorktrees(owner.bareRepoPath)
-                return candidate
+                const pruneWarning = yield* Git.pruneWorktrees(owner.bareRepoPath).pipe(
+                  Effect.as(undefined),
+                  Effect.catch((error) =>
+                    Effect.succeed(
+                      `worktree removed, but git worktree prune failed: ${
+                        error instanceof Error === true ? error.message : String(error)
+                      }`,
+                    ),
+                  ),
+                )
+                return pruneWarning === undefined
+                  ? candidate
+                  : { ...candidate, message: pruneWarning }
               })
             } else {
               const config = yield* loadStoreGcConfig({ storeBasePath: store.basePath })

--- a/packages/@overeng/megarepo/src/cli/commands/store/mod.ts
+++ b/packages/@overeng/megarepo/src/cli/commands/store/mod.ts
@@ -12,8 +12,8 @@ import { isAbsolute, normalize } from 'node:path'
 import { Clock, Effect, Option, Schedule, Schema, Stream } from 'effect'
 import * as FileSystem from 'effect/FileSystem'
 import { type PlatformError } from 'effect/PlatformError'
-import type * as Scope from 'effect/Scope'
 import * as Cli from 'effect/unstable/cli'
+import * as ChildProcess from 'effect/unstable/process/ChildProcess'
 import type { ChildProcessSpawner } from 'effect/unstable/process/ChildProcessSpawner'
 import React from 'react'
 
@@ -36,6 +36,7 @@ import {
   reapArchive,
   scanArchives,
 } from '../../../store/store-archive.ts'
+import { canonicalizeOwnerPath, withDeletionLease } from '../../../store/store-deletion-lease.ts'
 import {
   loadStoreGcConfig,
   type StoreGcConfig,
@@ -1884,7 +1885,7 @@ const storeGcCommand = Cli.Command.make(
       }: {
         progressive: boolean
         ownerLockHeld?: boolean | undefined
-      }): Effect.Effect<void, unknown, FileSystem.FileSystem | Scope.Scope | ChildProcessSpawner> =>
+      }) =>
         Effect.gen(function* () {
           if (progressive === true) {
             yield* dispatchGc({ done: false, forceDispatch: true })
@@ -2034,124 +2035,133 @@ const storeGcCommand = Cli.Command.make(
                 })
               }
               const ownerPath = selected[0]!.workspacePath
-              const applied = yield* storeLock.withWorktreeLock(ownerPath)(
-                Effect.gen(function* () {
-                  const freshLiveSet = yield* reReconcileLiveSet({ store, root, now })
-                  const freshConfig = yield* loadStoreGcConfig({
-                    storeBasePath: store.basePath,
+              const leaseOwnerPath = yield* canonicalizeOwnerPath(ownerPath)
+              // The owner lock serializes megarepo's own reclaimers; the deletion
+              // lease additionally excludes external activation of this worktree,
+              // so the final liveness classification below cannot be overtaken.
+              const applied = yield* Effect.gen(function* () {
+                const freshLiveSet = yield* reReconcileLiveSet({ store, root, now })
+                const freshConfig = yield* loadStoreGcConfig({
+                  storeBasePath: store.basePath,
+                })
+                const freshRepos = yield* store.listRepos
+                const freshRepoWorktrees = yield* Effect.all(
+                  freshRepos.map((repo) =>
+                    Effect.gen(function* () {
+                      const bareRepoPath = EffectPath.ops.join(
+                        repo.fullPath,
+                        EffectPath.unsafe.relativeDir('.bare/'),
+                      )
+                      const worktrees = yield* collectRepoStoreWorktrees({
+                        fs,
+                        repoPath: repo.fullPath,
+                        bareRepoPath,
+                      })
+                      return { repo, worktrees }
+                    }),
+                  ),
+                  { concurrency: repoConcurrency },
+                )
+                const freshPlan = yield* planGeneratedArtifacts({
+                  config: freshConfig,
+                  fs,
+                  liveSet: freshLiveSet,
+                  now,
+                  readCurrentTimeMillis: Clock.currentTimeMillis,
+                  repoWorktrees: freshRepoWorktrees,
+                })
+                if (freshPlan.planSha256 !== expectedPlan.value) {
+                  return yield* new StoreCommandError({
+                    message: 'store gc plan changed under owner lock; refusing deletion',
                   })
-                  const freshRepos = yield* store.listRepos
-                  const freshRepoWorktrees = yield* Effect.all(
-                    freshRepos.map((repo) =>
-                      Effect.gen(function* () {
-                        const bareRepoPath = EffectPath.ops.join(
-                          repo.fullPath,
-                          EffectPath.unsafe.relativeDir('.bare/'),
-                        )
-                        const worktrees = yield* collectRepoStoreWorktrees({
-                          fs,
-                          repoPath: repo.fullPath,
-                          bareRepoPath,
-                        })
-                        return { repo, worktrees }
-                      }),
-                    ),
-                    { concurrency: repoConcurrency },
-                  )
-                  const freshPlan = yield* planGeneratedArtifacts({
-                    config: freshConfig,
-                    fs,
-                    liveSet: freshLiveSet,
-                    now,
-                    readCurrentTimeMillis: Clock.currentTimeMillis,
-                    repoWorktrees: freshRepoWorktrees,
+                }
+                const freshCandidates = freshPlan.results.filter(
+                  (result) =>
+                    normalizeStorePath(result.path) === normalizeStorePath(candidatePath.value) &&
+                    result.outcome === 'would-delete',
+                )
+                if (freshCandidates.length !== 1) {
+                  return yield* new StoreCommandError({
+                    message: 'candidate is missing, ambiguous, or no longer eligible',
                   })
-                  if (freshPlan.planSha256 !== expectedPlan.value) {
-                    return yield* new StoreCommandError({
-                      message: 'store gc plan changed under owner lock; refusing deletion',
-                    })
-                  }
-                  const freshCandidates = freshPlan.results.filter(
-                    (result) =>
-                      normalizeStorePath(result.path) === normalizeStorePath(candidatePath.value) &&
-                      result.outcome === 'would-delete',
-                  )
-                  if (freshCandidates.length !== 1) {
-                    return yield* new StoreCommandError({
-                      message: 'candidate is missing, ambiguous, or no longer eligible',
-                    })
-                  }
-                  const freshCandidate = freshCandidates[0]!
-                  const canonicalOwner = yield* fs.realPath(ownerPath)
-                  const canonicalCandidate = yield* fs.realPath(freshCandidate.path)
-                  if (
-                    freshCandidate.artifactClass === undefined ||
-                    freshCandidate.workspacePath === undefined ||
-                    normalizeStorePath(canonicalCandidate) !==
-                      normalizeStorePath(`${canonicalOwner}/${freshCandidate.artifactClass}`)
-                  ) {
-                    return yield* new StoreCommandError({
-                      message: 'candidate containment changed under owner lock',
-                    })
-                  }
-                  const removalLiveSet = yield* reReconcileLiveSet({ store, root, now })
-                  if (
-                    isPathProtected({
-                      liveSet: removalLiveSet,
-                      path: freshCandidate.workspacePath,
-                    }) === true
-                  ) {
-                    return yield* new StoreCommandError({
-                      message: 'candidate owner became live before deletion',
-                    })
-                  }
-                  const manifestPath = freshConfig.generatedArtifacts.agentLivenessManifest
-                  if (manifestPath === undefined) {
-                    return yield* new StoreCommandError({
-                      message: 'agent liveness became unavailable before deletion',
-                    })
-                  }
-                  const manifestContent = yield* fs
-                    .readFileString(manifestPath)
-                    .pipe(Effect.orElseSucceed(() => undefined))
-                  const manifest =
-                    manifestContent === undefined
-                      ? undefined
-                      : yield* Schema.decodeUnknownEffect(
-                          Schema.fromJsonString(AgentLivenessManifest),
-                        )(manifestContent).pipe(Effect.orElseSucceed(() => undefined))
-                  const removalTime = yield* Clock.currentTimeMillis
-                  if (
-                    manifest === undefined ||
-                    manifest.expiresAtMs < removalTime ||
-                    manifest.activeWorkspacePaths.some(
-                      (path) => isNormalizedAbsolutePath(path) === false,
-                    ) === true
-                  ) {
-                    return yield* new StoreCommandError({
-                      message: 'agent liveness became unknown before deletion',
-                    })
-                  }
-                  const activeAgentPaths = yield* Effect.forEach(
-                    manifest.activeWorkspacePaths,
-                    (path) => fs.realPath(path).pipe(Effect.orElseSucceed(() => undefined)),
-                    { concurrency: 1 },
-                  )
-                  if (
-                    activeAgentPaths.some((path) => path === undefined) === true ||
-                    activeAgentPaths.some(
-                      (path) =>
-                        path !== undefined &&
-                        normalizeStorePath(path) === normalizeStorePath(canonicalOwner),
-                    ) === true
-                  ) {
-                    return yield* new StoreCommandError({
-                      message: 'candidate owner is live or liveness is unknown before deletion',
-                    })
-                  }
-                  yield* fs.remove(freshCandidate.path, { recursive: true })
-                  return { ...freshCandidate, outcome: 'deleted' as const }
+                }
+                const freshCandidate = freshCandidates[0]!
+                const canonicalOwner = yield* fs.realPath(ownerPath)
+                const canonicalCandidate = yield* fs.realPath(freshCandidate.path)
+                if (
+                  freshCandidate.artifactClass === undefined ||
+                  freshCandidate.workspacePath === undefined ||
+                  normalizeStorePath(canonicalCandidate) !==
+                    normalizeStorePath(`${canonicalOwner}/${freshCandidate.artifactClass}`)
+                ) {
+                  return yield* new StoreCommandError({
+                    message: 'candidate containment changed under owner lock',
+                  })
+                }
+                const removalLiveSet = yield* reReconcileLiveSet({ store, root, now })
+                if (
+                  isPathProtected({
+                    liveSet: removalLiveSet,
+                    path: freshCandidate.workspacePath,
+                  }) === true
+                ) {
+                  return yield* new StoreCommandError({
+                    message: 'candidate owner became live before deletion',
+                  })
+                }
+                const manifestPath = freshConfig.generatedArtifacts.agentLivenessManifest
+                if (manifestPath === undefined) {
+                  return yield* new StoreCommandError({
+                    message: 'agent liveness became unavailable before deletion',
+                  })
+                }
+                const manifestContent = yield* fs
+                  .readFileString(manifestPath)
+                  .pipe(Effect.orElseSucceed(() => undefined))
+                const manifest =
+                  manifestContent === undefined
+                    ? undefined
+                    : yield* Schema.decodeUnknownEffect(
+                        Schema.fromJsonString(AgentLivenessManifest),
+                      )(manifestContent).pipe(Effect.orElseSucceed(() => undefined))
+                const removalTime = yield* Clock.currentTimeMillis
+                if (
+                  manifest === undefined ||
+                  manifest.expiresAtMs < removalTime ||
+                  manifest.activeWorkspacePaths.some(
+                    (path) => isNormalizedAbsolutePath(path) === false,
+                  ) === true
+                ) {
+                  return yield* new StoreCommandError({
+                    message: 'agent liveness became unknown before deletion',
+                  })
+                }
+                const activeAgentPaths = yield* Effect.forEach(
+                  manifest.activeWorkspacePaths,
+                  (path) => fs.realPath(path).pipe(Effect.orElseSucceed(() => undefined)),
+                  { concurrency: 1 },
+                )
+                if (
+                  activeAgentPaths.some((path) => path === undefined) === true ||
+                  activeAgentPaths.some(
+                    (path) =>
+                      path !== undefined &&
+                      normalizeStorePath(path) === normalizeStorePath(canonicalOwner),
+                  ) === true
+                ) {
+                  return yield* new StoreCommandError({
+                    message: 'candidate owner is live or liveness is unknown before deletion',
+                  })
+                }
+                yield* fs.remove(freshCandidate.path, { recursive: true })
+                return { ...freshCandidate, outcome: 'deleted' as const }
+              }).pipe(
+                withDeletionLease({
+                  storeBasePath: store.basePath,
+                  ownerPath: leaseOwnerPath,
+                  now,
                 }),
+                storeLock.withWorktreeLock(ownerPath),
               )
               results.splice(0, results.length, applied)
             }
@@ -2412,16 +2422,9 @@ const storeGcCommand = Cli.Command.make(
               })
             }
 
-            if (ownerLockHeld === false) {
-              results.splice(0, results.length)
-              completedRepoCount = 0
-              discoveredWorktreeCount = 0
-              repoCount = undefined
-              planSha256 = undefined
-              return yield* storeLock.withWorktreeLock(candidate.path)(
-                executeGc({ progressive: false, ownerLockHeld: true }),
-              )
-            }
+            // First pass: hand the candidate back so the caller can retake the
+            // plan under this candidate's owner lock (see `runGcTransaction`).
+            if (ownerLockHeld === false) return candidate.path
 
             let applied: StoreGcResult
             if (candidate.status === 'removed') {
@@ -2519,14 +2522,35 @@ const storeGcCommand = Cli.Command.make(
           if (progressive === true || ownerLockHeld === true) {
             yield* dispatchGc({ done: true, forceDispatch: true })
           }
+          return undefined
         })
 
+      /**
+       * Plan-bound application runs the whole GC twice: the first pass computes
+       * the canonical plan and names the candidate, the second recomputes the
+       * complete plan under that candidate's owner lock and only then mutates.
+       * Nothing else may observe the first pass's results, so the accumulators
+       * are reset before the locked pass.
+       */
+      const runGcTransaction = ({ progressive }: { progressive: boolean }) =>
+        Effect.gen(function* () {
+          const lockCandidate = yield* executeGc({ progressive })
+          if (lockCandidate === undefined) return
+          results.splice(0, results.length)
+          completedRepoCount = 0
+          discoveredWorktreeCount = 0
+          repoCount = undefined
+          planSha256 = undefined
+          yield* storeLock.withWorktreeLock(lockCandidate)(
+            executeGc({ progressive: false, ownerLockHeld: true }),
+          )
+        })
       // Final JSON callers want one stable document, not progress states. Run the
       // GC first and serialize only the final StoreApp state.
       const mode = yield* OutputModeTag.pipe(Effect.provide(outputModeLayer(output as never)))
 
       if (mode._tag === 'json' && mode.timing === 'final') {
-        yield* executeGc({ progressive: false })
+        yield* runGcTransaction({ progressive: false })
         yield* runStoreCommand({
           output,
           action: toStoreGcAction({
@@ -2550,7 +2574,7 @@ const storeGcCommand = Cli.Command.make(
           (tui) =>
             Effect.gen(function* () {
               tuiDispatch = tui.dispatch
-              yield* executeGc({ progressive: true })
+              yield* runGcTransaction({ progressive: true })
             }),
           { view: React.createElement(StoreView, { stateAtom: StoreApp.stateAtom }) },
         ).pipe(Effect.provide(outputModeLayer(output as never)))
@@ -3164,6 +3188,56 @@ const storeWorktreeCommand = Cli.Command.make('worktree', {}).pipe(
   Cli.Command.withDescription('Manage worktrees in the store'),
 )
 
+/**
+ * `mr store lease --owner-path <path> -- <command…>`
+ *
+ * Runs a command while holding the deletion lease for one owner worktree, so an
+ * external activation needs no protocol code of its own: wrap the activation
+ * (which must publish its liveness manifest before exiting) and reclamation can
+ * neither observe a stale manifest nor delete underneath it. The child's exit
+ * code is propagated, and the lease is released on every exit path.
+ */
+const storeLeaseCommand = Cli.Command.make(
+  'lease',
+  {
+    ownerPath: Cli.Flag.string('owner-path').pipe(
+      Cli.Flag.withDescription('Store worktree path whose reclamation the lease must exclude'),
+    ),
+    command: Cli.Argument.string('command').pipe(
+      Cli.Argument.withDescription('Command and arguments to run while holding the lease'),
+      Cli.Argument.atLeast(1),
+    ),
+  },
+  ({ ownerPath, command }) =>
+    Effect.gen(function* () {
+      const store = yield* Store
+      const now = yield* Clock.currentTimeMillis
+      const leaseOwnerPath = yield* canonicalizeOwnerPath(ownerPath)
+      const exitCode = yield* withDeletionLease({
+        storeBasePath: store.basePath,
+        ownerPath: leaseOwnerPath,
+        now,
+      })(
+        Effect.gen(function* () {
+          const child = yield* ChildProcess.make(command[0]!, command.slice(1), {
+            stderr: 'inherit',
+            stdin: 'inherit',
+            stdout: 'inherit',
+          })
+          return yield* child.exitCode
+        }).pipe(Effect.scoped),
+      )
+      if (exitCode !== 0) {
+        return yield* new StoreCommandError({
+          message: `leased command exited with code ${exitCode}`,
+        })
+      }
+    }).pipe(
+      Effect.provide(StoreLayer),
+      Observability.withCommandSpan({ name: 'megarepo/store/lease', command: 'store lease' }),
+    ),
+).pipe(Cli.Command.withDescription('Run a command while holding a store deletion lease'))
+
 /** Store subcommand group */
 export const storeCommand = Cli.Command.make('store', {}).pipe(
   Cli.Command.withSubcommands([
@@ -3173,6 +3247,7 @@ export const storeCommand = Cli.Command.make('store', {}).pipe(
     storeFetchCommand,
     storeGcCommand,
     storeFixCommand,
+    storeLeaseCommand,
     storeWorktreeCommand,
   ]),
   Cli.Command.withDescription('Manage the shared git store'),

--- a/packages/@overeng/megarepo/src/cli/commands/store/mod.ts
+++ b/packages/@overeng/megarepo/src/cli/commands/store/mod.ts
@@ -2426,15 +2426,19 @@ const storeGcCommand = Cli.Command.make(
             // plan under this candidate's owner lock (see `runGcTransaction`).
             if (ownerLockHeld === false) return candidate.path
 
-            let applied: StoreGcResult
-            if (candidate.status === 'removed') {
-              const worktree = owner.worktrees.filter((entry) => entry.path === candidate.path)
-              if (worktree.length !== 1) {
-                return yield* new StoreCommandError({
-                  message: 'candidate worktree is missing or ambiguous',
-                })
-              }
-              applied = yield* Effect.gen(function* () {
+            // The activation lease names the owner worktree path itself, so a
+            // whole-worktree removal, archive, or reap must hold it too: the
+            // owner lock alone only excludes megarepo's own reclaimers, and an
+            // activation of this very path would otherwise be unprotected.
+            const leaseOwnerPath = yield* canonicalizeOwnerPath(candidate.path)
+            const applied: StoreGcResult = yield* Effect.gen(function* () {
+              if (candidate.status === 'removed') {
+                const worktree = owner.worktrees.filter((entry) => entry.path === candidate.path)
+                if (worktree.length !== 1) {
+                  return yield* new StoreCommandError({
+                    message: 'candidate worktree is missing or ambiguous',
+                  })
+                }
                 const freshLiveSet = yield* reReconcileLiveSet({ store, root, now })
                 const decision = yield* classifyGcWorktree({
                   worktree: worktree[0]!,
@@ -2464,8 +2468,8 @@ const storeGcCommand = Cli.Command.make(
                 return pruneWarning === undefined
                   ? candidate
                   : { ...candidate, message: pruneWarning }
-              })
-            } else {
+              }
+
               const config = yield* loadStoreGcConfig({ storeBasePath: store.basePath })
               const injectedResolver = yield* Effect.serviceOption(PrStateResolver)
               const prResolver =
@@ -2513,8 +2517,14 @@ const storeGcCommand = Cli.Command.make(
                   message: 'candidate changed during owner-locked revalidation',
                 })
               }
-              applied = matching[0]!
-            }
+              return matching[0]!
+            }).pipe(
+              withDeletionLease({
+                storeBasePath: store.basePath,
+                ownerPath: leaseOwnerPath,
+                now,
+              }),
+            )
             results.splice(0, results.length, applied)
           }
 
@@ -3213,23 +3223,23 @@ const storeLeaseCommand = Cli.Command.make(
       const store = yield* Store
       const now = yield* Clock.currentTimeMillis
       const leaseOwnerPath = yield* canonicalizeOwnerPath(ownerPath)
-      const exitCode = yield* withDeletionLease({
-        storeBasePath: store.basePath,
-        ownerPath: leaseOwnerPath,
-        now,
-      })(
-        Effect.gen(function* () {
-          const child = yield* ChildProcess.make(command[0]!, command.slice(1), {
-            stderr: 'inherit',
-            stdin: 'inherit',
-            stdout: 'inherit',
-          })
-          return yield* child.exitCode
-        }).pipe(Effect.scoped),
+      const exitCode = yield* Effect.gen(function* () {
+        const child = yield* ChildProcess.make(command[0]!, command.slice(1), {
+          stderr: 'inherit',
+          stdin: 'inherit',
+          stdout: 'inherit',
+        })
+        return yield* child.exitCode
+      }).pipe(
+        Effect.scoped,
+        withDeletionLease({ storeBasePath: store.basePath, ownerPath: leaseOwnerPath, now }),
       )
+      // Wrapping must be transparent: the child's own code is the command's code
+      // (`runTuiMain`'s teardown honors an already-set `process.exitCode`), so a
+      // wrapped `exit 42` stays 42 instead of collapsing to a generic failure.
       if (exitCode !== 0) {
-        return yield* new StoreCommandError({
-          message: `leased command exited with code ${exitCode}`,
+        yield* Effect.sync(() => {
+          process.exitCode = exitCode
         })
       }
     }).pipe(

--- a/packages/@overeng/megarepo/src/cli/commands/store/mod.ts
+++ b/packages/@overeng/megarepo/src/cli/commands/store/mod.ts
@@ -999,6 +999,7 @@ const coldReclaimRepo = ({
   now,
   dryRun,
   candidatePath,
+  lockAlreadyHeld = false,
 }: {
   store: Effect.Success<typeof Store>
   storeLock: Effect.Success<typeof StoreLock>
@@ -1014,6 +1015,7 @@ const coldReclaimRepo = ({
   now: number
   dryRun: boolean
   candidatePath?: string | undefined
+  lockAlreadyHeld?: boolean | undefined
 }) =>
   Effect.gen(function* () {
     const results: StoreGcResult[] = []
@@ -1163,32 +1165,34 @@ const coldReclaimRepo = ({
           continue
         }
 
-        const archiveOutcome = yield* storeLock
-          .withWorktreeLock(worktree.path)(
-            Effect.gen(function* () {
-              const freshLiveSet = yield* reReconcileLiveSet({ store, root, now })
-              if (
-                isPathProtected({ liveSet: freshLiveSet, path: worktree.path }) === true ||
-                isPathProtected({ liveSet: freshLiveSet, path: actualBranchPath }) === true
-              ) {
-                return { _tag: 'kept-live' as const }
-              }
-              const outcome = yield* archiveRefMismatchWorktree({
-                repoRoot: repoFullPath,
-                bareRepoPath,
-                worktreePath: worktree.path,
-                pathRef: worktree.ref,
-                actualHeadBranch,
-                commit: worktreeHead,
-                now,
-              })
-              return {
-                _tag: 'archived' as const,
-                recoverPath: outcome.destPath,
-                warnings: outcome.warnings,
-              }
-            }),
-          )
+        const archiveAction = Effect.gen(function* () {
+          const freshLiveSet = yield* reReconcileLiveSet({ store, root, now })
+          if (
+            isPathProtected({ liveSet: freshLiveSet, path: worktree.path }) === true ||
+            isPathProtected({ liveSet: freshLiveSet, path: actualBranchPath }) === true
+          ) {
+            return { _tag: 'kept-live' as const }
+          }
+          const outcome = yield* archiveRefMismatchWorktree({
+            repoRoot: repoFullPath,
+            bareRepoPath,
+            worktreePath: worktree.path,
+            pathRef: worktree.ref,
+            actualHeadBranch,
+            commit: worktreeHead,
+            now,
+          })
+          return {
+            _tag: 'archived' as const,
+            recoverPath: outcome.destPath,
+            warnings: outcome.warnings,
+          }
+        })
+        const archiveOutcome = yield* (
+          lockAlreadyHeld === true
+            ? archiveAction
+            : storeLock.withWorktreeLock(worktree.path)(archiveAction)
+        )
           .pipe(
             Effect.catch((error) =>
               Effect.succeed({
@@ -1280,29 +1284,31 @@ const coldReclaimRepo = ({
         continue
       }
 
-      const archiveOutcome = yield* storeLock
-        .withWorktreeLock(worktree.path)(
-          Effect.gen(function* () {
-            const freshLiveSet = yield* reReconcileLiveSet({ store, root, now })
-            if (isPathProtected({ liveSet: freshLiveSet, path: worktree.path }) === true) {
-              return { _tag: 'kept-live' as const }
-            }
-            const outcome = yield* archiveWorktree({
-              repoRoot: repoFullPath,
-              bareRepoPath,
-              worktreePath: worktree.path,
-              branch: worktree.ref,
-              commit: worktreeHead,
-              reason: decision.reason,
-              now,
-            })
-            return {
-              _tag: 'archived' as const,
-              recoverPath: outcome.destPath,
-              warnings: outcome.warnings,
-            }
-          }),
-        )
+      const archiveAction = Effect.gen(function* () {
+        const freshLiveSet = yield* reReconcileLiveSet({ store, root, now })
+        if (isPathProtected({ liveSet: freshLiveSet, path: worktree.path }) === true) {
+          return { _tag: 'kept-live' as const }
+        }
+        const outcome = yield* archiveWorktree({
+          repoRoot: repoFullPath,
+          bareRepoPath,
+          worktreePath: worktree.path,
+          branch: worktree.ref,
+          commit: worktreeHead,
+          reason: decision.reason,
+          now,
+        })
+        return {
+          _tag: 'archived' as const,
+          recoverPath: outcome.destPath,
+          warnings: outcome.warnings,
+        }
+      })
+      const archiveOutcome = yield* (
+        lockAlreadyHeld === true
+          ? archiveAction
+          : storeLock.withWorktreeLock(worktree.path)(archiveAction)
+      )
         .pipe(
           Effect.catch((error) =>
             Effect.succeed({
@@ -1368,17 +1374,19 @@ const coldReclaimRepo = ({
         continue
       }
 
-      const reapOutcome = yield* storeLock
-        .withWorktreeLock(entry.path)(
-          Effect.gen(function* () {
-            const freshLiveSet = yield* reReconcileLiveSet({ store, root, now })
-            if (isPathProtected({ liveSet: freshLiveSet, path: entry.path }) === true) {
-              return { _tag: 'kept-live' as const }
-            }
-            yield* reapArchive({ bareRepoPath, path: entry.path })
-            return { _tag: 'reaped' as const }
-          }),
-        )
+      const reapAction = Effect.gen(function* () {
+        const freshLiveSet = yield* reReconcileLiveSet({ store, root, now })
+        if (isPathProtected({ liveSet: freshLiveSet, path: entry.path }) === true) {
+          return { _tag: 'kept-live' as const }
+        }
+        yield* reapArchive({ bareRepoPath, path: entry.path })
+        return { _tag: 'reaped' as const }
+      })
+      const reapOutcome = yield* (
+        lockAlreadyHeld === true
+          ? reapAction
+          : storeLock.withWorktreeLock(entry.path)(reapAction)
+      )
         .pipe(
           Effect.catch((error) =>
             Effect.succeed({
@@ -1900,7 +1908,13 @@ const storeGcCommand = Cli.Command.make(
 
       let tuiDispatch: ((action: StoreAction) => void) | undefined
 
-      const executeGc = ({ progressive }: { progressive: boolean }) =>
+      const executeGc = ({
+        progressive,
+        ownerLockHeld = false,
+      }: {
+        progressive: boolean
+        ownerLockHeld?: boolean | undefined
+      }) =>
         Effect.gen(function* () {
           if (progressive === true) {
             yield* dispatchGc({ done: false, forceDispatch: true })
@@ -2103,11 +2117,23 @@ const storeGcCommand = Cli.Command.make(
                   const canonicalCandidate = yield* fs.realPath(freshCandidate.path)
                   if (
                     freshCandidate.artifactClass === undefined ||
+                    freshCandidate.workspacePath === undefined ||
                     normalizeStorePath(canonicalCandidate) !==
                       normalizeStorePath(`${canonicalOwner}/${freshCandidate.artifactClass}`)
                   ) {
                     return yield* new StoreCommandError({
                       message: 'candidate containment changed under owner lock',
+                    })
+                  }
+                  const removalLiveSet = yield* reReconcileLiveSet({ store, root, now })
+                  if (
+                    isPathProtected({
+                      liveSet: removalLiveSet,
+                      path: freshCandidate.workspacePath,
+                    }) === true
+                  ) {
+                    return yield* new StoreCommandError({
+                      message: 'candidate owner became live before deletion',
                     })
                   }
                   yield* fs.remove(freshCandidate.path, { recursive: true })
@@ -2375,6 +2401,17 @@ const storeGcCommand = Cli.Command.make(
               })
             }
 
+            if (ownerLockHeld === false) {
+              results.splice(0, results.length)
+              completedRepoCount = 0
+              discoveredWorktreeCount = 0
+              repoCount = undefined
+              planSha256 = undefined
+              return yield* storeLock.withWorktreeLock(candidate.path)(
+                executeGc({ progressive: false, ownerLockHeld: true }),
+              )
+            }
+
             let applied: StoreGcResult
             if (candidate.status === 'removed') {
               const worktree = owner.worktrees.filter(
@@ -2385,29 +2422,25 @@ const storeGcCommand = Cli.Command.make(
                   message: 'candidate worktree is missing or ambiguous',
                 })
               }
-              applied = yield* storeLock.withWorktreeLock(candidate.path)(
-                Effect.gen(function* () {
-                  const freshLiveSet = yield* reReconcileLiveSet({ store, root, now })
-                  const decision = yield* classifyGcWorktree({
-                    worktree: worktree[0]!,
-                    liveSet: freshLiveSet,
-                    all,
+              applied = yield* Effect.gen(function* () {
+                const freshLiveSet = yield* reReconcileLiveSet({ store, root, now })
+                const decision = yield* classifyGcWorktree({
+                  worktree: worktree[0]!,
+                  liveSet: freshLiveSet,
+                  all,
+                })
+                if (
+                  decision.action !== 'check' ||
+                  (force === false &&
+                    (decision.status.isDirty === true || decision.status.hasUnpushed === true))
+                ) {
+                  return yield* new StoreCommandError({
+                    message: 'candidate is live, dirty, or no longer inspectable',
                   })
-                  if (
-                    decision.action !== 'check' ||
-                    (force === false &&
-                      (decision.status.isDirty === true ||
-                        decision.status.hasUnpushed === true))
-                  ) {
-                    return yield* new StoreCommandError({
-                      message: 'candidate is live, dirty, or no longer inspectable',
-                    })
-                  }
-                  yield* fs.remove(candidate.path, { recursive: true })
-                  return candidate
-                }),
-              )
-              yield* Git.pruneWorktrees(owner.bareRepoPath)
+                }
+                yield* fs.remove(candidate.path, { recursive: true })
+                return candidate
+              })
             } else {
               const config = yield* loadStoreGcConfig({ storeBasePath: store.basePath })
               const injectedResolver = yield* Effect.serviceOption(PrStateResolver)
@@ -2444,6 +2477,7 @@ const storeGcCommand = Cli.Command.make(
                 now,
                 dryRun: false,
                 candidatePath: candidate.path,
+                lockAlreadyHeld: ownerLockHeld,
               })
               const matching = appliedResults.filter(
                 (result) =>

--- a/packages/@overeng/megarepo/src/cli/commands/store/mod.ts
+++ b/packages/@overeng/megarepo/src/cli/commands/store/mod.ts
@@ -12,6 +12,7 @@ import { isAbsolute, normalize } from 'node:path'
 import { Clock, Effect, Option, Schedule, Schema, Stream } from 'effect'
 import * as FileSystem from 'effect/FileSystem'
 import { type PlatformError } from 'effect/PlatformError'
+import type * as Scope from 'effect/Scope'
 import * as Cli from 'effect/unstable/cli'
 import type { ChildProcessSpawner } from 'effect/unstable/process/ChildProcessSpawner'
 import React from 'react'
@@ -197,7 +198,7 @@ const planGeneratedArtifacts = ({
   repoWorktrees: GeneratedArtifactRepoWorktrees
 }): Effect.Effect<
   { readonly results: ReadonlyArray<StoreGcResult>; readonly planSha256: string },
-  never,
+  PlatformError,
   ChildProcessSpawner
 > =>
   Effect.gen(function* () {
@@ -241,7 +242,7 @@ const planGeneratedArtifacts = ({
             worktree.path,
             EffectPath.unsafe.relativeDir(`${artifactClass}/`),
           )
-          if ((yield* fs.exists(artifactPath).pipe(Effect.orElseSucceed(() => false))) === false) {
+          if ((yield* fs.exists(artifactPath)) === false) {
             continue
           }
           const ignored = yield* Git.runCommand({
@@ -677,8 +678,8 @@ const collectStoreWorktrees = ({
       if (entry.startsWith('.') === true) continue
 
       const entryPath = EffectPath.ops.join(currentPath, EffectPath.unsafe.relativeDir(`${entry}/`))
-      const entryStat = yield* fs.stat(entryPath).pipe(Effect.orElseSucceed(() => null))
-      if (entryStat?.type !== 'Directory') continue
+      const entryStat = yield* fs.stat(entryPath)
+      if (entryStat.type !== 'Directory') continue
 
       result.push(
         ...(yield* collectStoreWorktrees({
@@ -706,10 +707,7 @@ const collectRepoStoreWorktrees = ({
   Effect.gen(function* () {
     const repoPrefix = repoPath.replace(/\/+$/, '')
     const refsPrefix = `${repoPrefix}/refs/`
-    const realRepoPrefix = yield* fs.realPath(repoPath).pipe(
-      Effect.map((path) => path.replace(/\/+$/, '')),
-      Effect.orElseSucceed(() => repoPrefix),
-    )
+    const realRepoPrefix = (yield* fs.realPath(repoPath)).replace(/\/+$/, '')
     const realRefsPrefix = `${realRepoPrefix}/refs/`
     const result: Array<CollectedWorktree> = []
     const seenPaths = new Set<string>()
@@ -726,62 +724,41 @@ const collectRepoStoreWorktrees = ({
     // Git's worktree registry can be stale or incomplete after interrupted
     // operations. Use it as a fast hint, then merge in the path layout because
     // the store layout is the durable source of truth for refs/heads|tags|commits.
-    const gitWorktreesResult = yield* Git.listWorktrees(bareRepoPath).pipe(
-      Effect.tapError((error) =>
-        Effect.gen(function* () {
-          yield* Observability.annotateStoreGitWorktreeListFailure(true)
-          yield* Effect.logWarning('Falling back to store layout worktree discovery').pipe(
-            Effect.annotateLogs({
-              repoPath,
-              bareRepoPath,
-              error: error instanceof Error === true ? error.message : String(error),
-            }),
-          )
-        }),
-      ),
-      Effect.result,
-    )
+    const gitWorktrees = yield* Git.listWorktrees(bareRepoPath)
+    for (const worktree of gitWorktrees) {
+      const normalizedPath = worktree.path.replace(/\/+$/, '')
+      const relativePath =
+        normalizedPath.startsWith(refsPrefix) === true
+          ? normalizedPath.slice(refsPrefix.length)
+          : normalizedPath.startsWith(realRefsPrefix) === true
+            ? normalizedPath.slice(realRefsPrefix.length)
+            : undefined
+      if (relativePath === undefined) continue
 
-    if (gitWorktreesResult._tag === 'Success') {
-      for (const worktree of gitWorktreesResult.success) {
-        const normalizedPath = worktree.path.replace(/\/+$/, '')
-        const relativePath =
-          normalizedPath.startsWith(refsPrefix) === true
-            ? normalizedPath.slice(refsPrefix.length)
-            : normalizedPath.startsWith(realRefsPrefix) === true
-              ? normalizedPath.slice(realRefsPrefix.length)
-              : undefined
-        if (relativePath === undefined) continue
+      const separatorIndex = relativePath.indexOf('/')
+      if (separatorIndex === -1) continue
 
-        const separatorIndex = relativePath.indexOf('/')
-        if (separatorIndex === -1) continue
+      const refType = relativePath.slice(0, separatorIndex)
+      if (refType !== 'heads' && refType !== 'tags' && refType !== 'commits') continue
 
-        const refType = relativePath.slice(0, separatorIndex)
-        if (refType !== 'heads' && refType !== 'tags' && refType !== 'commits') continue
+      const ref = relativePath.slice(separatorIndex + 1)
+      if (ref.length === 0) continue
 
-        const ref = relativePath.slice(separatorIndex + 1)
-        if (ref.length === 0) continue
-
-        seenPaths.add(normalizedPath)
-        seenPaths.add(`${repoPrefix}/refs/${relativePath}`)
-        knownRefsByType[refType].add(ref)
-        result.push({
-          ref,
-          refType,
-          path: EffectPath.unsafe.absoluteDir(`${repoPrefix}/refs/${relativePath}/`),
-          broken: false,
-        })
-      }
+      seenPaths.add(normalizedPath)
+      seenPaths.add(`${repoPrefix}/refs/${relativePath}`)
+      knownRefsByType[refType].add(ref)
+      result.push({
+        ref,
+        refType,
+        path: EffectPath.unsafe.absoluteDir(`${repoPrefix}/refs/${relativePath}/`),
+        broken: false,
+      })
     }
 
     // Union in the bare's ref set — the source of truth for worktree roots, and
     // the only signal for a broken worktree absent from the registry above.
-    // Cheap (one streamed `for-each-ref` per namespace); failure degrades to the
-    // worktree-list names already collected.
     for (const namespace of ['heads', 'tags'] as const) {
-      const refNames = yield* Git.listRefShortNames({ bareRepoPath, namespace }).pipe(
-        Effect.orElseSucceed(() => [] as ReadonlyArray<string>),
-      )
+      const refNames = yield* Git.listRefShortNames({ bareRepoPath, namespace })
       for (const refName of refNames) knownRefsByType[namespace].add(refName)
     }
 
@@ -790,8 +767,9 @@ const collectRepoStoreWorktrees = ({
         repoPath,
         EffectPath.unsafe.relativeDir(`refs/${refType}/`),
       )
-      const refTypeStat = yield* fs.stat(refTypePath).pipe(Effect.orElseSucceed(() => null))
-      if (refTypeStat?.type !== 'Directory') continue
+      if ((yield* fs.exists(refTypePath)) === false) continue
+      const refTypeStat = yield* fs.stat(refTypePath)
+      if (refTypeStat.type !== 'Directory') continue
 
       const layoutWorktrees = yield* collectStoreWorktrees({
         fs,
@@ -1192,15 +1170,14 @@ const coldReclaimRepo = ({
           lockAlreadyHeld === true
             ? archiveAction
             : storeLock.withWorktreeLock(worktree.path)(archiveAction)
+        ).pipe(
+          Effect.catch((error) =>
+            Effect.succeed({
+              _tag: 'error' as const,
+              message: error instanceof Error === true ? error.message : String(error),
+            }),
+          ),
         )
-          .pipe(
-            Effect.catch((error) =>
-              Effect.succeed({
-                _tag: 'error' as const,
-                message: error instanceof Error === true ? error.message : String(error),
-              }),
-            ),
-          )
 
         if (archiveOutcome._tag === 'kept-live') {
           results.push(keepRefMismatch(`HEAD is '${actualHeadBranch}' and path is live`))
@@ -1308,15 +1285,14 @@ const coldReclaimRepo = ({
         lockAlreadyHeld === true
           ? archiveAction
           : storeLock.withWorktreeLock(worktree.path)(archiveAction)
+      ).pipe(
+        Effect.catch((error) =>
+          Effect.succeed({
+            _tag: 'error' as const,
+            message: error instanceof Error === true ? error.message : String(error),
+          }),
+        ),
       )
-        .pipe(
-          Effect.catch((error) =>
-            Effect.succeed({
-              _tag: 'error' as const,
-              message: error instanceof Error === true ? error.message : String(error),
-            }),
-          ),
-        )
 
       if (archiveOutcome._tag === 'kept-live') {
         results.push(coldResult({ target, status: 'kept', reason: 'live' }))
@@ -1350,9 +1326,7 @@ const coldReclaimRepo = ({
     }
 
     // Reap archives past the retention TTL, each under lock + a fresh veto.
-    const archives = yield* scanArchives({ repoRoot: repoFullPath, bareRepoPath }).pipe(
-      Effect.orElseSucceed(() => [] as never[]),
-    )
+    const archives = yield* scanArchives({ repoRoot: repoFullPath, bareRepoPath })
     for (const entry of archives) {
       if (candidatePath !== undefined && entry.path !== candidatePath) continue
       if (now - entry.archivedAtMs < config.archiveRetentionMs) continue
@@ -1383,18 +1357,15 @@ const coldReclaimRepo = ({
         return { _tag: 'reaped' as const }
       })
       const reapOutcome = yield* (
-        lockAlreadyHeld === true
-          ? reapAction
-          : storeLock.withWorktreeLock(entry.path)(reapAction)
+        lockAlreadyHeld === true ? reapAction : storeLock.withWorktreeLock(entry.path)(reapAction)
+      ).pipe(
+        Effect.catch((error) =>
+          Effect.succeed({
+            _tag: 'error' as const,
+            message: error instanceof Error === true ? error.message : String(error),
+          }),
+        ),
       )
-        .pipe(
-          Effect.catch((error) =>
-            Effect.succeed({
-              _tag: 'error' as const,
-              message: error instanceof Error === true ? error.message : String(error),
-            }),
-          ),
-        )
 
       if (reapOutcome._tag === 'kept-live') {
         results.push(coldResult({ target: reapTarget, status: 'kept', reason: 'live' }))
@@ -1738,8 +1709,7 @@ const storeGcCommand = Cli.Command.make(
       }
       if (generatedArtifacts === true && dryRun === false && targetedApply === false) {
         return yield* new StoreCommandError({
-          message:
-            '--generated-artifacts mutation requires --expected-plan and --candidate-path',
+          message: '--generated-artifacts mutation requires --expected-plan and --candidate-path',
         })
       }
 
@@ -1914,7 +1884,7 @@ const storeGcCommand = Cli.Command.make(
       }: {
         progressive: boolean
         ownerLockHeld?: boolean | undefined
-      }) =>
+      }): Effect.Effect<void, unknown, FileSystem.FileSystem | Scope.Scope | ChildProcessSpawner> =>
         Effect.gen(function* () {
           if (progressive === true) {
             yield* dispatchGc({ done: false, forceDispatch: true })
@@ -2103,8 +2073,7 @@ const storeGcCommand = Cli.Command.make(
                   }
                   const freshCandidates = freshPlan.results.filter(
                     (result) =>
-                      normalizeStorePath(result.path) ===
-                        normalizeStorePath(candidatePath.value) &&
+                      normalizeStorePath(result.path) === normalizeStorePath(candidatePath.value) &&
                       result.outcome === 'would-delete',
                   )
                   if (freshCandidates.length !== 1) {
@@ -2134,6 +2103,50 @@ const storeGcCommand = Cli.Command.make(
                   ) {
                     return yield* new StoreCommandError({
                       message: 'candidate owner became live before deletion',
+                    })
+                  }
+                  const manifestPath = freshConfig.generatedArtifacts.agentLivenessManifest
+                  if (manifestPath === undefined) {
+                    return yield* new StoreCommandError({
+                      message: 'agent liveness became unavailable before deletion',
+                    })
+                  }
+                  const manifestContent = yield* fs
+                    .readFileString(manifestPath)
+                    .pipe(Effect.orElseSucceed(() => undefined))
+                  const manifest =
+                    manifestContent === undefined
+                      ? undefined
+                      : yield* Schema.decodeUnknownEffect(
+                          Schema.fromJsonString(AgentLivenessManifest),
+                        )(manifestContent).pipe(Effect.orElseSucceed(() => undefined))
+                  const removalTime = yield* Clock.currentTimeMillis
+                  if (
+                    manifest === undefined ||
+                    manifest.expiresAtMs < removalTime ||
+                    manifest.activeWorkspacePaths.some(
+                      (path) => isNormalizedAbsolutePath(path) === false,
+                    ) === true
+                  ) {
+                    return yield* new StoreCommandError({
+                      message: 'agent liveness became unknown before deletion',
+                    })
+                  }
+                  const activeAgentPaths = yield* Effect.forEach(
+                    manifest.activeWorkspacePaths,
+                    (path) => fs.realPath(path).pipe(Effect.orElseSucceed(() => undefined)),
+                    { concurrency: 1 },
+                  )
+                  if (
+                    activeAgentPaths.some((path) => path === undefined) === true ||
+                    activeAgentPaths.some(
+                      (path) =>
+                        path !== undefined &&
+                        normalizeStorePath(path) === normalizeStorePath(canonicalOwner),
+                    ) === true
+                  ) {
+                    return yield* new StoreCommandError({
+                      message: 'candidate owner is live or liveness is unknown before deletion',
                     })
                   }
                   yield* fs.remove(freshCandidate.path, { recursive: true })
@@ -2392,9 +2405,7 @@ const storeGcCommand = Cli.Command.make(
               })
             }
             const candidate = candidates[0]!
-            const owner = repoWorktrees.find(
-              ({ repo }) => repo.relativePath === candidate.repo,
-            )
+            const owner = repoWorktrees.find(({ repo }) => repo.relativePath === candidate.repo)
             if (owner === undefined) {
               return yield* new StoreCommandError({
                 message: 'candidate owner repository is missing',
@@ -2414,9 +2425,7 @@ const storeGcCommand = Cli.Command.make(
 
             let applied: StoreGcResult
             if (candidate.status === 'removed') {
-              const worktree = owner.worktrees.filter(
-                (entry) => entry.path === candidate.path,
-              )
+              const worktree = owner.worktrees.filter((entry) => entry.path === candidate.path)
               if (worktree.length !== 1) {
                 return yield* new StoreCommandError({
                   message: 'candidate worktree is missing or ambiguous',
@@ -2439,6 +2448,7 @@ const storeGcCommand = Cli.Command.make(
                   })
                 }
                 yield* fs.remove(candidate.path, { recursive: true })
+                yield* Git.pruneWorktrees(owner.bareRepoPath)
                 return candidate
               })
             } else {
@@ -2495,7 +2505,7 @@ const storeGcCommand = Cli.Command.make(
           }
 
           statusMessage = undefined
-          if (progressive === true) {
+          if (progressive === true || ownerLockHeld === true) {
             yield* dispatchGc({ done: true, forceDispatch: true })
           }
         })

--- a/packages/@overeng/megarepo/src/cli/commands/store/mod.ts
+++ b/packages/@overeng/megarepo/src/cli/commands/store/mod.ts
@@ -158,6 +158,25 @@ type GeneratedArtifactRepoWorktrees = ReadonlyArray<{
 
 const encodeCanonicalPlan = Schema.encodeSync(Schema.fromJsonString(Schema.Unknown))
 
+const planSha256For = (results: ReadonlyArray<StoreGcResult>): string => {
+  const canonicalPlan = results
+    .map((result) => ({
+      repo: result.repo,
+      ref: result.ref,
+      refType: result.refType,
+      path: result.path,
+      status: result.status,
+      reason: result.reason,
+      kind: result.kind,
+      artifactClass: result.artifactClass,
+      workspacePath: result.workspacePath,
+      outcome: result.outcome,
+      mtimeMs: result.mtimeMs,
+    }))
+    .toSorted((left, right) => compareCanonicalPlanPaths({ left: left.path, right: right.path }))
+  return createHash('sha256').update(encodeCanonicalPlan(canonicalPlan)).digest('hex')
+}
+
 const planGeneratedArtifacts = ({
   config,
   fs,
@@ -371,22 +390,9 @@ const planGeneratedArtifacts = ({
       }
       if (onRepoCompleted !== undefined) yield* onRepoCompleted()
     }
-    const canonicalPlan = generatedResults
-      .map((result) => ({
-        repo: result.repo,
-        ref: result.ref,
-        refType: result.refType,
-        artifactClass: result.artifactClass,
-        path: result.path,
-        workspacePath: result.workspacePath,
-        reason: result.reason,
-        outcome: result.outcome,
-        mtimeMs: result.mtimeMs,
-      }))
-      .toSorted((left, right) => compareCanonicalPlanPaths({ left: left.path, right: right.path }))
     return {
       results: generatedResults,
-      planSha256: createHash('sha256').update(encodeCanonicalPlan(canonicalPlan)).digest('hex'),
+      planSha256: planSha256For(generatedResults),
     }
   })
 
@@ -558,6 +564,7 @@ const toStoreGcAction = ({
   activeWorktreeCount,
   statusMessage,
   done,
+  censusStatus: repoCount === undefined ? 'unknown' : 'complete',
   ...(planSha256 !== undefined ? { planSha256 } : {}),
 })
 
@@ -991,6 +998,7 @@ const coldReclaimRepo = ({
   config,
   now,
   dryRun,
+  candidatePath,
 }: {
   store: Effect.Success<typeof Store>
   storeLock: Effect.Success<typeof StoreLock>
@@ -1005,6 +1013,7 @@ const coldReclaimRepo = ({
   config: StoreGcConfig
   now: number
   dryRun: boolean
+  candidatePath?: string | undefined
 }) =>
   Effect.gen(function* () {
     const results: StoreGcResult[] = []
@@ -1048,6 +1057,7 @@ const coldReclaimRepo = ({
         : undefined
 
     for (const target of namedWorktrees) {
+      if (candidatePath !== undefined && target.worktree.path !== candidatePath) continue
       if (classify === false) break
       const { worktree } = target
       // Only `refs/heads/*` carries a branch identity to reclaim; tags have no
@@ -1338,6 +1348,7 @@ const coldReclaimRepo = ({
       Effect.orElseSucceed(() => [] as never[]),
     )
     for (const entry of archives) {
+      if (candidatePath !== undefined && entry.path !== candidatePath) continue
       if (now - entry.archivedAtMs < config.archiveRetentionMs) continue
 
       const reapTarget: NamedWorktreeTarget = {
@@ -1668,8 +1679,12 @@ const storeGcCommand = Cli.Command.make(
       Cli.Flag.withDescription('Apply only the exact generated-artifact dry-run plan'),
       Cli.Flag.optional,
     ),
+    candidatePath: Cli.Flag.string('candidate-path').pipe(
+      Cli.Flag.withDescription('Apply exactly one candidate from the expected dry-run plan'),
+      Cli.Flag.optional,
+    ),
   },
-  ({ output, dryRun, force, all, generatedArtifacts, expectedPlan }) =>
+  ({ output, dryRun, force, all, generatedArtifacts, expectedPlan, candidatePath }) =>
     Effect.gen(function* () {
       const cwd = yield* Cwd
       const store = yield* Store
@@ -1682,20 +1697,41 @@ const storeGcCommand = Cli.Command.make(
       let repoCount: number | undefined
       let repoConcurrencyForMetrics = 1
       let planSha256: string | undefined
+      const targetedApply =
+        Option.isSome(expectedPlan) === true || Option.isSome(candidatePath) === true
+      const planningOnly = dryRun === true || targetedApply === true
 
       if (generatedArtifacts === true && (all === true || force === true)) {
         return yield* new StoreCommandError({
           message: '--generated-artifacts is incompatible with --all and --force',
         })
       }
-      if (generatedArtifacts === true && dryRun === false) {
-        return yield* new StoreCommandError({
-          message: '--generated-artifacts currently requires --dry-run',
-        })
+      if (targetedApply === true) {
+        if (
+          dryRun === true ||
+          Option.isNone(expectedPlan) === true ||
+          Option.isNone(candidatePath) === true
+        ) {
+          return yield* new StoreCommandError({
+            message:
+              '--expected-plan and --candidate-path must be provided together for a non-dry-run application',
+          })
+        }
+        if (/^[0-9a-f]{64}$/u.test(expectedPlan.value) === false) {
+          return yield* new StoreCommandError({
+            message: '--expected-plan must be a lowercase SHA-256 digest',
+          })
+        }
+        if (isNormalizedAbsolutePath(normalizeStorePath(candidatePath.value)) === false) {
+          return yield* new StoreCommandError({
+            message: '--candidate-path must be a normalized absolute path',
+          })
+        }
       }
-      if (Option.isSome(expectedPlan) === true) {
+      if (generatedArtifacts === true && dryRun === false && targetedApply === false) {
         return yield* new StoreCommandError({
-          message: '--expected-plan is not supported by planning-only GC',
+          message:
+            '--generated-artifacts mutation requires --expected-plan and --candidate-path',
         })
       }
 
@@ -1751,7 +1787,7 @@ const storeGcCommand = Cli.Command.make(
             } satisfies StoreGcResult
           }
 
-          if (dryRun === false) {
+          if (planningOnly === false) {
             const removeResult = yield* storeLock
               .withWorktreeLock(worktree.path)(
                 Effect.gen(function* () {
@@ -1903,8 +1939,8 @@ const storeGcCommand = Cli.Command.make(
             ...(Option.isSome(root) === true ? { currentWorkspaceRoot: root.value } : {}),
             // Generated-artifact mode is a read-only planner. Do not refresh,
             // reconcile, or prune the shared liveness registry while planning.
-            pruneStaleRegistry: generatedArtifacts === false && dryRun === false,
-            refreshCurrentWorkspace: generatedArtifacts === false && dryRun === false,
+            pruneStaleRegistry: generatedArtifacts === false && planningOnly === false,
+            refreshCurrentWorkspace: generatedArtifacts === false && planningOnly === false,
             ...(all === false && generatedArtifacts === false
               ? { reconcileAllWorkspaces: true }
               : {}),
@@ -1970,7 +2006,7 @@ const storeGcCommand = Cli.Command.make(
               fs,
               liveSet,
               now,
-              ...(progressive === true
+              ...(progressive === true && targetedApply === false
                 ? {
                     onArtifact: (result: StoreGcResult) =>
                       Effect.gen(function* () {
@@ -1988,9 +2024,97 @@ const storeGcCommand = Cli.Command.make(
               repoWorktrees,
             })
             planSha256 = generatedPlan.planSha256
-            if (progressive === false) {
-              for (const result of generatedPlan.results) results.push(result)
+            if (progressive === false || targetedApply === true) {
+              results.push(...generatedPlan.results)
               completedRepoCount += repoWorktrees.length
+            }
+
+            if (
+              targetedApply === true &&
+              Option.isSome(expectedPlan) === true &&
+              Option.isSome(candidatePath) === true
+            ) {
+              if (generatedPlan.planSha256 !== expectedPlan.value) {
+                return yield* new StoreCommandError({
+                  message: 'store gc plan changed; refusing candidate application',
+                })
+              }
+              const selected = generatedPlan.results.filter(
+                (result) =>
+                  normalizeStorePath(result.path) === normalizeStorePath(candidatePath.value) &&
+                  result.outcome === 'would-delete',
+              )
+              if (selected.length !== 1 || selected[0]!.workspacePath === undefined) {
+                return yield* new StoreCommandError({
+                  message: 'candidate is missing, ambiguous, or no longer eligible',
+                })
+              }
+              const ownerPath = selected[0]!.workspacePath
+              const applied = yield* storeLock.withWorktreeLock(ownerPath)(
+                Effect.gen(function* () {
+                  const freshLiveSet = yield* reReconcileLiveSet({ store, root, now })
+                  const freshConfig = yield* loadStoreGcConfig({
+                    storeBasePath: store.basePath,
+                  })
+                  const freshRepos = yield* store.listRepos
+                  const freshRepoWorktrees = yield* Effect.all(
+                    freshRepos.map((repo) =>
+                      Effect.gen(function* () {
+                        const bareRepoPath = EffectPath.ops.join(
+                          repo.fullPath,
+                          EffectPath.unsafe.relativeDir('.bare/'),
+                        )
+                        const worktrees = yield* collectRepoStoreWorktrees({
+                          fs,
+                          repoPath: repo.fullPath,
+                          bareRepoPath,
+                        })
+                        return { repo, worktrees }
+                      }),
+                    ),
+                    { concurrency: repoConcurrency },
+                  )
+                  const freshPlan = yield* planGeneratedArtifacts({
+                    config: freshConfig,
+                    fs,
+                    liveSet: freshLiveSet,
+                    now,
+                    readCurrentTimeMillis: Clock.currentTimeMillis,
+                    repoWorktrees: freshRepoWorktrees,
+                  })
+                  if (freshPlan.planSha256 !== expectedPlan.value) {
+                    return yield* new StoreCommandError({
+                      message: 'store gc plan changed under owner lock; refusing deletion',
+                    })
+                  }
+                  const freshCandidates = freshPlan.results.filter(
+                    (result) =>
+                      normalizeStorePath(result.path) ===
+                        normalizeStorePath(candidatePath.value) &&
+                      result.outcome === 'would-delete',
+                  )
+                  if (freshCandidates.length !== 1) {
+                    return yield* new StoreCommandError({
+                      message: 'candidate is missing, ambiguous, or no longer eligible',
+                    })
+                  }
+                  const freshCandidate = freshCandidates[0]!
+                  const canonicalOwner = yield* fs.realPath(ownerPath)
+                  const canonicalCandidate = yield* fs.realPath(freshCandidate.path)
+                  if (
+                    freshCandidate.artifactClass === undefined ||
+                    normalizeStorePath(canonicalCandidate) !==
+                      normalizeStorePath(`${canonicalOwner}/${freshCandidate.artifactClass}`)
+                  ) {
+                    return yield* new StoreCommandError({
+                      message: 'candidate containment changed under owner lock',
+                    })
+                  }
+                  yield* fs.remove(freshCandidate.path, { recursive: true })
+                  return { ...freshCandidate, outcome: 'deleted' as const }
+                }),
+              )
+              results.splice(0, results.length, applied)
             }
           }
 
@@ -2026,7 +2150,7 @@ const storeGcCommand = Cli.Command.make(
             // without the lock) — a planning run must not advance the absence-grace
             // clock and so cause a later real run to archive.
             const ledger =
-              dryRun === true
+              planningOnly === true
                 ? nextObservationLedger({
                     current: yield* readObservationLedger({ storeBasePath: store.basePath }),
                     coldPaths,
@@ -2088,7 +2212,7 @@ const storeGcCommand = Cli.Command.make(
                       ledger,
                       config,
                       now,
-                      dryRun,
+                      dryRun: planningOnly,
                     }).pipe(
                       Effect.ensuring(
                         Effect.sync(() => {
@@ -2150,7 +2274,7 @@ const storeGcCommand = Cli.Command.make(
                                 repoRelativePath: repo.relativePath,
                                 bareRepoPath,
                               })
-                              if (result.status === 'removed' && dryRun === false) {
+                              if (result.status === 'removed' && planningOnly === false) {
                                 removedForRepo += 1
                               }
                               results.push(result)
@@ -2212,6 +2336,128 @@ const storeGcCommand = Cli.Command.make(
                 repoConcurrency,
               }),
             )
+          }
+
+          if (generatedArtifacts === false && planningOnly === true) {
+            planSha256 = planSha256For(results)
+          }
+
+          if (
+            generatedArtifacts === false &&
+            targetedApply === true &&
+            Option.isSome(expectedPlan) === true &&
+            Option.isSome(candidatePath) === true
+          ) {
+            if (planSha256 !== expectedPlan.value) {
+              return yield* new StoreCommandError({
+                message: 'store gc plan changed; refusing candidate application',
+              })
+            }
+            const candidates = results.filter(
+              (result) =>
+                normalizeStorePath(result.path) === normalizeStorePath(candidatePath.value) &&
+                (result.status === 'removed' ||
+                  result.status === 'archived' ||
+                  result.status === 'reaped'),
+            )
+            if (candidates.length !== 1) {
+              return yield* new StoreCommandError({
+                message: 'candidate is missing, ambiguous, or no longer eligible',
+              })
+            }
+            const candidate = candidates[0]!
+            const owner = repoWorktrees.find(
+              ({ repo }) => repo.relativePath === candidate.repo,
+            )
+            if (owner === undefined) {
+              return yield* new StoreCommandError({
+                message: 'candidate owner repository is missing',
+              })
+            }
+
+            let applied: StoreGcResult
+            if (candidate.status === 'removed') {
+              const worktree = owner.worktrees.filter(
+                (entry) => entry.path === candidate.path,
+              )
+              if (worktree.length !== 1) {
+                return yield* new StoreCommandError({
+                  message: 'candidate worktree is missing or ambiguous',
+                })
+              }
+              applied = yield* storeLock.withWorktreeLock(candidate.path)(
+                Effect.gen(function* () {
+                  const freshLiveSet = yield* reReconcileLiveSet({ store, root, now })
+                  const decision = yield* classifyGcWorktree({
+                    worktree: worktree[0]!,
+                    liveSet: freshLiveSet,
+                    all,
+                  })
+                  if (
+                    decision.action !== 'check' ||
+                    (force === false &&
+                      (decision.status.isDirty === true ||
+                        decision.status.hasUnpushed === true))
+                  ) {
+                    return yield* new StoreCommandError({
+                      message: 'candidate is live, dirty, or no longer inspectable',
+                    })
+                  }
+                  yield* fs.remove(candidate.path, { recursive: true })
+                  return candidate
+                }),
+              )
+              yield* Git.pruneWorktrees(owner.bareRepoPath)
+            } else {
+              const config = yield* loadStoreGcConfig({ storeBasePath: store.basePath })
+              const injectedResolver = yield* Effect.serviceOption(PrStateResolver)
+              const prResolver =
+                Option.isSome(injectedResolver) === true
+                  ? injectedResolver.value
+                  : yield* PrStateResolver.pipe(Effect.provide(makePrStateResolverLayer()))
+              const ledger = yield* readObservationLedger({ storeBasePath: store.basePath })
+              const namedWorktrees = owner.worktrees
+                .filter(
+                  (worktree) =>
+                    worktree.broken === false &&
+                    isNamedRefWorktree(worktree) === true &&
+                    worktree.path === candidate.path,
+                )
+                .map((worktree) => ({
+                  repoRelativePath: owner.repo.relativePath,
+                  repoFullPath: owner.repo.fullPath,
+                  bareRepoPath: owner.bareRepoPath,
+                  worktree,
+                }))
+              const appliedResults = yield* coldReclaimRepo({
+                store,
+                storeLock,
+                prResolver,
+                root,
+                repoRelativePath: owner.repo.relativePath,
+                repoFullPath: owner.repo.fullPath,
+                bareRepoPath: owner.bareRepoPath,
+                namedWorktrees,
+                liveSet,
+                ledger,
+                config,
+                now,
+                dryRun: false,
+                candidatePath: candidate.path,
+              })
+              const matching = appliedResults.filter(
+                (result) =>
+                  result.path === candidate.path &&
+                  (result.status === 'archived' || result.status === 'reaped'),
+              )
+              if (matching.length !== 1) {
+                return yield* new StoreCommandError({
+                  message: 'candidate changed during owner-locked revalidation',
+                })
+              }
+              applied = matching[0]!
+            }
+            results.splice(0, results.length, applied)
           }
 
           statusMessage = undefined

--- a/packages/@overeng/megarepo/src/cli/commands/store/mod.ts
+++ b/packages/@overeng/megarepo/src/cli/commands/store/mod.ts
@@ -49,6 +49,7 @@ import {
   recordObservations,
 } from '../../../store/store-gc-observations.ts'
 import { validateStoreMembers, fixStoreIssues } from '../../../store/store-hygiene.ts'
+import { readWorktreeInUse, type InUseHolder } from '../../../store/store-inuse.ts'
 import {
   collectStoreLiveSet,
   isPathProtected,
@@ -147,11 +148,160 @@ type GeneratedArtifactScan =
         | 'io'
     }
 
-const AgentLivenessManifest = Schema.Struct({
-  version: Schema.Literal(1),
-  expiresAtMs: Schema.Finite,
-  activeWorkspacePaths: Schema.Array(Schema.String),
+/**
+ * Native `st2 workspace-activity --json` envelope.
+ *
+ * st2 is the only producer of agent liveness, so this is the shape megarepo
+ * consumes; there is no adapter and no legacy fallback, because an ad-hoc shape
+ * nobody produces cannot be bound to a fleet epoch.
+ */
+const St2WorkspaceActivitySnapshot = Schema.Struct({
+  schemaVersion: Schema.Literal('st2.workspace-activity.v1'),
+  producer: Schema.Literal('st2'),
+  epoch: Schema.Struct({
+    catalog: Schema.String,
+    host: Schema.String,
+    catalogGeneration: Schema.NullOr(Schema.Finite),
+  }),
+  capturedAt: Schema.String,
+  expiresAt: Schema.String,
+  complete: Schema.Boolean,
+  errors: Schema.Array(Schema.String),
+  claims: Schema.Array(
+    Schema.Struct({
+      workspace: Schema.String,
+      agents: Schema.Array(Schema.String),
+      activeRuntimeIds: Schema.Array(Schema.String),
+      active: Schema.Boolean,
+    }),
+  ),
 })
+
+/** The epoch a snapshot was admitted under, so later reads must match it exactly. */
+interface St2ActivityEpoch {
+  readonly catalog: string
+  readonly host: string
+  readonly catalogGeneration: number | null
+}
+
+/** Admitted activity evidence: the canonical active workspace paths and their epoch. */
+interface St2Activity {
+  readonly activePaths: ReadonlySet<string>
+  readonly epoch: St2ActivityEpoch
+}
+
+/** Longest snapshot validity megarepo will honor: liveness must be short-lived. */
+const ST2_ACTIVITY_MAX_WINDOW_MS = 5 * 60 * 1_000
+
+const decodeSt2Activity = Schema.decodeUnknownEffect(
+  Schema.fromJsonString(St2WorkspaceActivitySnapshot),
+)
+
+/** A timestamp is canonical when it round-trips exactly through ISO-8601. */
+const isCanonicalIsoTimestamp = ({ value, epochMs }: { value: string; epochMs: number }): boolean =>
+  Number.isFinite(epochMs) === true && new Date(epochMs).toISOString() === value
+
+const isStrictlySortedUnique = (values: ReadonlyArray<string>): boolean =>
+  values.every((value, index) => index === 0 || values[index - 1]! < value)
+
+/**
+ * Read the native st2 activity snapshot, or `undefined` when it is not usable
+ * as evidence.
+ *
+ * Every rejection is fail-closed by construction: the caller maps `undefined`
+ * to `agent-liveness-unavailable`, which is `unknown`, never `would-delete`.
+ * Rejected: a foreign producer or schema, an incomplete or erroneous capture, a
+ * non-canonical or implausible timestamp pair, a window longer than
+ * {@link ST2_ACTIVITY_MAX_WINDOW_MS}, an expired snapshot, an epoch that is not
+ * the configured catalog/host, a catalog generation that moved since
+ * `admittedEpoch` (the fleet re-derived state mid-decision), unsorted or
+ * duplicated claims, a non-normalized or non-canonical workspace path, and any
+ * claim whose `active` disagrees with its `activeRuntimeIds`.
+ */
+const readSt2Activity = ({
+  fs,
+  config,
+  atMs,
+  admittedEpoch,
+}: {
+  fs: FileSystem.FileSystem
+  config: StoreGcConfig
+  atMs: number
+  admittedEpoch?: St2ActivityEpoch | undefined
+}): Effect.Effect<St2Activity | undefined> =>
+  Effect.gen(function* () {
+    const manifestPath = config.generatedArtifacts.agentLivenessManifest
+    const expectedEpoch = config.generatedArtifacts.agentLivenessEpoch
+    if (manifestPath === undefined || expectedEpoch === undefined) return undefined
+    const content = yield* fs
+      .readFileString(manifestPath)
+      .pipe(Effect.orElseSucceed(() => undefined))
+    if (content === undefined) return undefined
+    const parsed = yield* decodeSt2Activity(content).pipe(Effect.orElseSucceed(() => undefined))
+    if (parsed === undefined) return undefined
+
+    const capturedAtMs = Date.parse(parsed.capturedAt)
+    const expiresAtMs = Date.parse(parsed.expiresAt)
+    const generation = parsed.epoch.catalogGeneration
+    if (
+      parsed.complete === false ||
+      parsed.errors.length > 0 ||
+      isCanonicalIsoTimestamp({ value: parsed.capturedAt, epochMs: capturedAtMs }) === false ||
+      isCanonicalIsoTimestamp({ value: parsed.expiresAt, epochMs: expiresAtMs }) === false ||
+      parsed.epoch.catalog !== expectedEpoch.catalog ||
+      parsed.epoch.host !== expectedEpoch.host ||
+      (generation !== null && (Number.isSafeInteger(generation) === false || generation < 0)) ||
+      (admittedEpoch !== undefined &&
+        (parsed.epoch.catalog !== admittedEpoch.catalog ||
+          parsed.epoch.host !== admittedEpoch.host ||
+          generation !== admittedEpoch.catalogGeneration)) ||
+      capturedAtMs > atMs ||
+      expiresAtMs < capturedAtMs ||
+      expiresAtMs - capturedAtMs > ST2_ACTIVITY_MAX_WINDOW_MS ||
+      expiresAtMs <= atMs ||
+      isStrictlySortedUnique(parsed.claims.map((claim) => claim.workspace)) === false ||
+      parsed.claims.some(
+        (claim) =>
+          isNormalizedAbsolutePath(claim.workspace) === false ||
+          claim.agents.length === 0 ||
+          isStrictlySortedUnique(claim.agents) === false ||
+          isStrictlySortedUnique(claim.activeRuntimeIds) === false ||
+          claim.active !== claim.activeRuntimeIds.length > 0,
+      ) === true
+    ) {
+      return undefined
+    }
+
+    // A claim must name the worktree by its canonical path, so a symlinked or
+    // aliased claim can never silently protect (or fail to protect) a candidate.
+    const canonical = yield* Effect.forEach(
+      parsed.claims,
+      (claim) =>
+        fs.realPath(claim.workspace).pipe(
+          Effect.map((path) => ({ claim, path })),
+          Effect.orElseSucceed(() => undefined),
+        ),
+      { concurrency: 1 },
+    )
+    if (
+      canonical.some(
+        (entry) =>
+          entry === undefined ||
+          normalizeStorePath(entry.path) !== normalizeStorePath(entry.claim.workspace),
+      ) === true
+    ) {
+      return undefined
+    }
+
+    return {
+      activePaths: new Set(
+        canonical.flatMap((entry) =>
+          entry?.claim.active === true ? [normalizeStorePath(entry.path)] : [],
+        ),
+      ),
+      epoch: parsed.epoch,
+    }
+  })
 
 type GeneratedArtifactRepoWorktrees = ReadonlyArray<{
   readonly repo: { readonly relativePath: string }
@@ -204,33 +354,8 @@ const planGeneratedArtifacts = ({
 > =>
   Effect.gen(function* () {
     const generatedResults: StoreGcResult[] = []
-    const readAgentActivePaths = (atMs: number): Effect.Effect<ReadonlySet<string> | undefined> =>
-      Effect.gen(function* () {
-        if (config.generatedArtifacts.agentLivenessManifest === undefined) return undefined
-        const manifestContent = yield* fs
-          .readFileString(config.generatedArtifacts.agentLivenessManifest)
-          .pipe(Effect.orElseSucceed(() => undefined))
-        if (manifestContent === undefined) return undefined
-        const parsed = yield* Schema.decodeUnknownEffect(
-          Schema.fromJsonString(AgentLivenessManifest),
-        )(manifestContent).pipe(Effect.orElseSucceed(() => undefined))
-        if (
-          parsed === undefined ||
-          Number.isFinite(parsed.expiresAtMs) === false ||
-          parsed.activeWorkspacePaths.some((path) => isNormalizedAbsolutePath(path) === false) ===
-            true ||
-          parsed.expiresAtMs < atMs
-        ) {
-          return undefined
-        }
-        const canonicalPaths = yield* Effect.forEach(
-          parsed.activeWorkspacePaths,
-          (path) => fs.realPath(path).pipe(Effect.orElseSucceed(() => undefined)),
-          { concurrency: 1 },
-        )
-        if (canonicalPaths.some((path) => path === undefined) === true) return undefined
-        return new Set(canonicalPaths.map((path) => normalizeStorePath(path!)))
-      })
+    const readActivity = (args: { atMs: number; admittedEpoch?: St2ActivityEpoch | undefined }) =>
+      readSt2Activity({ fs, config, ...args })
     for (const { repo, worktrees } of repoWorktrees) {
       for (const worktree of worktrees) {
         if (worktree.broken === true) continue
@@ -273,15 +398,15 @@ const planGeneratedArtifacts = ({
           const contained =
             canonicalArtifact !== undefined &&
             normalizeStorePath(canonicalArtifact) === expectedCanonicalArtifact
-          const agentActivePaths = yield* readAgentActivePaths(yield* readCurrentTimeMillis)
+          const agentActivity = yield* readActivity({ atMs: yield* readCurrentTimeMillis })
           const agentLive =
             canonicalWorktree === undefined
               ? undefined
-              : agentActivePaths?.has(normalizeStorePath(canonicalWorktree))
+              : agentActivity?.activePaths.has(normalizeStorePath(canonicalWorktree))
           const cheapReason =
             config.generatedArtifacts.enabled === false
               ? 'generated-artifacts-disabled'
-              : agentActivePaths === undefined
+              : agentActivity === undefined
                 ? 'agent-liveness-unavailable'
                 : canonicalWorktree === undefined || contained === false
                   ? 'artifact-scan-incomplete'
@@ -308,10 +433,13 @@ const planGeneratedArtifacts = ({
             traversal?._tag === 'complete'
               ? yield* fs.realPath(artifactPath).pipe(Effect.orElseSucceed(() => undefined))
               : canonicalArtifact
-          const finalAgentActivePaths =
+          const finalAgentActivity =
             traversal?._tag === 'complete'
-              ? yield* readAgentActivePaths(yield* readCurrentTimeMillis)
-              : agentActivePaths
+              ? yield* readActivity({
+                  atMs: yield* readCurrentTimeMillis,
+                  ...(agentActivity === undefined ? {} : { admittedEpoch: agentActivity.epoch }),
+                })
+              : agentActivity
           const finalRemovalStatus =
             traversal?._tag === 'complete'
               ? yield* Git.getWorktreeRemovalStatus(worktree.path).pipe(
@@ -345,9 +473,11 @@ const planGeneratedArtifacts = ({
                   finalCanonicalWorktree !== canonicalWorktree ||
                   finalCanonicalArtifact !== canonicalArtifact
                 ? 'artifact-scan-incomplete'
-                : finalAgentActivePaths === undefined
+                : finalAgentActivity === undefined
                   ? 'agent-liveness-unavailable'
-                  : finalAgentActivePaths.has(normalizeStorePath(finalCanonicalWorktree)) === true
+                  : finalAgentActivity.activePaths.has(
+                        normalizeStorePath(finalCanonicalWorktree),
+                      ) === true
                     ? 'live'
                     : finalRemovalStatus._tag === 'unknown'
                       ? 'cleanliness-unknown'
@@ -949,6 +1079,33 @@ const reReconcileLiveSet = ({
   })
 
 /**
+ * In-use veto for a destructive site, orthogonal to the live-set veto.
+ *
+ * `isPathProtected` only answers "is this worktree in some workspace's
+ * reconciled manifest", and the deletion lease only answers "did an activation
+ * announce itself". This answers the independent question neither covers: is a
+ * live OS process working inside the directory right now. Returns the holder
+ * when the site must KEEP; `undefined` when it is safe to proceed. An
+ * unprobeable host (`unknown`) is reported as a holder, so in doubt we keep.
+ */
+const inUseVeto = ({
+  worktreePath,
+}: {
+  worktreePath: AbsoluteDirPath | string
+}): Effect.Effect<InUseHolder | undefined, never, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const result = yield* readWorktreeInUse({ worktreePath })
+    if (result._tag === 'free') return undefined
+    return result._tag === 'in-use' ? result.holder : { pid: -1, path: `unknown: ${result.reason}` }
+  })
+
+/** Render an in-use holder as the free-form `message` detail of a kept result. */
+const inUseMessage = (holder: InUseHolder): string =>
+  holder.pid >= 0
+    ? `live process pid ${holder.pid} has its cwd inside the worktree (${holder.path})`
+    : `in-use state could not be determined, kept conservatively (${holder.path})`
+
+/**
  * Cold reclamation for ONE repo's named worktrees (decisions 0001–0010).
  *
  * Fetch the bare first (failure ⇒ keep ALL this repo's named worktrees — the
@@ -1152,6 +1309,10 @@ const coldReclaimRepo = ({
           ) {
             return { _tag: 'kept-live' as const }
           }
+          const refMismatchHolder = yield* inUseVeto({ worktreePath: worktree.path })
+          if (refMismatchHolder !== undefined) {
+            return { _tag: 'kept-in-use' as const, holder: refMismatchHolder }
+          }
           const outcome = yield* archiveRefMismatchWorktree({
             repoRoot: repoFullPath,
             bareRepoPath,
@@ -1182,6 +1343,16 @@ const coldReclaimRepo = ({
 
         if (archiveOutcome._tag === 'kept-live') {
           results.push(keepRefMismatch(`HEAD is '${actualHeadBranch}' and path is live`))
+        } else if (archiveOutcome._tag === 'kept-in-use') {
+          results.push(
+            coldResult({
+              target,
+              status: 'kept',
+              reason: 'process-in-use',
+              message: inUseMessage(archiveOutcome.holder),
+              ...refMismatchMeta,
+            }),
+          )
         } else if (archiveOutcome._tag === 'error') {
           results.push(
             coldResult({
@@ -1267,6 +1438,10 @@ const coldReclaimRepo = ({
         if (isPathProtected({ liveSet: freshLiveSet, path: worktree.path }) === true) {
           return { _tag: 'kept-live' as const }
         }
+        const archiveHolder = yield* inUseVeto({ worktreePath: worktree.path })
+        if (archiveHolder !== undefined) {
+          return { _tag: 'kept-in-use' as const, holder: archiveHolder }
+        }
         const outcome = yield* archiveWorktree({
           repoRoot: repoFullPath,
           bareRepoPath,
@@ -1297,6 +1472,15 @@ const coldReclaimRepo = ({
 
       if (archiveOutcome._tag === 'kept-live') {
         results.push(coldResult({ target, status: 'kept', reason: 'live' }))
+      } else if (archiveOutcome._tag === 'kept-in-use') {
+        results.push(
+          coldResult({
+            target,
+            status: 'kept',
+            reason: 'process-in-use',
+            message: inUseMessage(archiveOutcome.holder),
+          }),
+        )
       } else if (archiveOutcome._tag === 'error') {
         // Only a PRE-move failure reaches here (post-move steps are best-effort
         // and reported as warnings, never errors), so the original worktree is
@@ -1354,6 +1538,12 @@ const coldReclaimRepo = ({
         if (isPathProtected({ liveSet: freshLiveSet, path: entry.path }) === true) {
           return { _tag: 'kept-live' as const }
         }
+        // A session whose cwd followed an earlier archive rename can be sitting
+        // in the `.archive/` entry itself; reaping it would yank that cwd.
+        const reapHolder = yield* inUseVeto({ worktreePath: entry.path })
+        if (reapHolder !== undefined) {
+          return { _tag: 'kept-in-use' as const, holder: reapHolder }
+        }
         yield* reapArchive({ bareRepoPath, path: entry.path })
         return { _tag: 'reaped' as const }
       })
@@ -1370,6 +1560,15 @@ const coldReclaimRepo = ({
 
       if (reapOutcome._tag === 'kept-live') {
         results.push(coldResult({ target: reapTarget, status: 'kept', reason: 'live' }))
+      } else if (reapOutcome._tag === 'kept-in-use') {
+        results.push(
+          coldResult({
+            target: reapTarget,
+            status: 'kept',
+            reason: 'process-in-use',
+            message: inUseMessage(reapOutcome.holder),
+          }),
+        )
       } else if (reapOutcome._tag === 'error') {
         results.push(
           coldResult({
@@ -2109,48 +2308,24 @@ const storeGcCommand = Cli.Command.make(
                     message: 'candidate owner became live before deletion',
                   })
                 }
-                const manifestPath = freshConfig.generatedArtifacts.agentLivenessManifest
-                if (manifestPath === undefined) {
-                  return yield* new StoreCommandError({
-                    message: 'agent liveness became unavailable before deletion',
-                  })
-                }
-                const manifestContent = yield* fs
-                  .readFileString(manifestPath)
-                  .pipe(Effect.orElseSucceed(() => undefined))
-                const manifest =
-                  manifestContent === undefined
-                    ? undefined
-                    : yield* Schema.decodeUnknownEffect(
-                        Schema.fromJsonString(AgentLivenessManifest),
-                      )(manifestContent).pipe(Effect.orElseSucceed(() => undefined))
+                // Same native reader and the same epoch admission as the plan,
+                // re-read under the lease: an expired, re-derived, or otherwise
+                // inadmissible snapshot is not evidence, and a snapshot that now
+                // claims this owner active vetoes the deletion outright.
                 const removalTime = yield* Clock.currentTimeMillis
-                if (
-                  manifest === undefined ||
-                  manifest.expiresAtMs < removalTime ||
-                  manifest.activeWorkspacePaths.some(
-                    (path) => isNormalizedAbsolutePath(path) === false,
-                  ) === true
-                ) {
+                const removalActivity = yield* readSt2Activity({
+                  fs,
+                  config: freshConfig,
+                  atMs: removalTime,
+                })
+                if (removalActivity === undefined) {
                   return yield* new StoreCommandError({
                     message: 'agent liveness became unknown before deletion',
                   })
                 }
-                const activeAgentPaths = yield* Effect.forEach(
-                  manifest.activeWorkspacePaths,
-                  (path) => fs.realPath(path).pipe(Effect.orElseSucceed(() => undefined)),
-                  { concurrency: 1 },
-                )
-                if (
-                  activeAgentPaths.some((path) => path === undefined) === true ||
-                  activeAgentPaths.some(
-                    (path) =>
-                      path !== undefined &&
-                      normalizeStorePath(path) === normalizeStorePath(canonicalOwner),
-                  ) === true
-                ) {
+                if (removalActivity.activePaths.has(normalizeStorePath(canonicalOwner)) === true) {
                   return yield* new StoreCommandError({
-                    message: 'candidate owner is live or liveness is unknown before deletion',
+                    message: 'candidate owner is live before deletion',
                   })
                 }
                 yield* fs.remove(freshCandidate.path, { recursive: true })
@@ -2452,6 +2627,12 @@ const storeGcCommand = Cli.Command.make(
                 ) {
                   return yield* new StoreCommandError({
                     message: 'candidate is live, dirty, or no longer inspectable',
+                  })
+                }
+                const holder = yield* inUseVeto({ worktreePath: candidate.path })
+                if (holder !== undefined) {
+                  return yield* new StoreCommandError({
+                    message: `candidate is in use: ${inUseMessage(holder)}`,
                   })
                 }
                 yield* fs.remove(candidate.path, { recursive: true })

--- a/packages/@overeng/megarepo/src/cli/commands/store/mod.ts
+++ b/packages/@overeng/megarepo/src/cli/commands/store/mod.ts
@@ -1092,7 +1092,7 @@ const inUseVeto = ({
   worktreePath,
 }: {
   worktreePath: AbsoluteDirPath | string
-}): Effect.Effect<InUseHolder | undefined, never, FileSystem.FileSystem> =>
+}): Effect.Effect<InUseHolder | undefined, never, FileSystem.FileSystem | ChildProcessSpawner> =>
   Effect.gen(function* () {
     const result = yield* readWorktreeInUse({ worktreePath })
     if (result._tag === 'free') return undefined

--- a/packages/@overeng/megarepo/src/cli/renderers/StoreOutput/schema.ts
+++ b/packages/@overeng/megarepo/src/cli/renderers/StoreOutput/schema.ts
@@ -172,6 +172,7 @@ export const StoreGcState = Schema.TaggedStruct('Gc', {
   done: Schema.optional(Schema.Boolean),
   interrupted: Schema.optional(Schema.Boolean),
   planSha256: Schema.optional(Schema.String),
+  censusStatus: Schema.optional(Schema.Literals(['complete', 'unknown'])),
 })
 
 /**
@@ -324,6 +325,7 @@ export const StoreAction = Schema.Union([
     done: Schema.optional(Schema.Boolean),
     interrupted: Schema.optional(Schema.Boolean),
     planSha256: Schema.optional(Schema.String),
+    censusStatus: Schema.optional(Schema.Literals(['complete', 'unknown'])),
   }),
   Schema.TaggedStruct('SetAdd', {
     status: Schema.Literals(['added', 'already_exists', 'created']),
@@ -405,6 +407,7 @@ export const storeReducer = ({
         done: action.done,
         interrupted: action.interrupted,
         planSha256: action.planSha256,
+        censusStatus: action.censusStatus,
       }
     case 'SetAdd':
       return {

--- a/packages/@overeng/megarepo/src/cli/store-gc-generated.integration.test.ts
+++ b/packages/@overeng/megarepo/src/cli/store-gc-generated.integration.test.ts
@@ -10,6 +10,11 @@ import { expect } from 'vitest'
 import { EffectPath, type AbsoluteDirPath } from '@overeng/effect-path'
 
 import * as Git from '../core/git.ts'
+import {
+  acquireDeletionLease,
+  canonicalizeOwnerPath,
+  releaseDeletionLease,
+} from '../store/store-deletion-lease.ts'
 import { makeConsoleCapture } from '../test-utils/consoleCapture.ts'
 import { decodeJson, encodeJson } from '../test-utils/json.ts'
 import { createStoreFixture } from '../test-utils/store-setup.ts'
@@ -365,6 +370,53 @@ describe('mr store gc --generated-artifacts', () => {
   )
 
   it.effect(
+    'refuses to delete while an activation holds the owner deletion lease',
+    Effect.fnUntraced(
+      function* () {
+        const fs = yield* FileSystem.FileSystem
+        const f = yield* fixture()
+        yield* configure({ config: f.config, manifest: f.manifest })
+        const artifact = yield* oldIgnoredArtifact(f.worktree)
+        const plan = yield* runGc({
+          cwd: f.outside,
+          storePath: f.storePath,
+          args: ['--dry-run'],
+        })
+
+        const candidatePath = generated(plan.results, 'node_modules')!.path
+        // Stand in for `mr store lease -- <activation>`: hold the owner lease
+        // across the whole apply attempt.
+        const ownerPath = yield* canonicalizeOwnerPath(f.worktree)
+        const held = yield* acquireDeletionLease({
+          storeBasePath: f.storePath,
+          ownerPath,
+          now: NOW,
+        })
+        const refused = yield* runGc({
+          cwd: f.outside,
+          storePath: f.storePath,
+          args: ['--expected-plan', plan.planSha256!, '--candidate-path', candidatePath],
+        })
+        expect(refused.exitCode).toBe(1)
+        expect(yield* fs.exists(artifact)).toBe(true)
+
+        // Activation finished (and published its manifest): the same plan applies.
+        yield* releaseDeletionLease(held)
+        const applied = yield* runGc({
+          cwd: f.outside,
+          storePath: f.storePath,
+          args: ['--expected-plan', plan.planSha256!, '--candidate-path', candidatePath],
+        })
+        expect(applied.exitCode).toBe(0)
+        expect(yield* fs.exists(artifact)).toBe(false)
+        expect(yield* fs.exists(held.leasePath)).toBe(false)
+      },
+      Effect.provide(NodeServices.layer),
+      Effect.scoped,
+    ),
+  )
+
+  it.effect(
     'refuses missing and newly-live generated-artifact candidates',
     Effect.fnUntraced(
       function* () {
@@ -377,6 +429,7 @@ describe('mr store gc --generated-artifacts', () => {
           storePath: f.storePath,
           args: ['--dry-run'],
         })
+        const candidatePath = generated(plan.results, 'node_modules')!.path
 
         const missing = yield* runGc({
           cwd: f.outside,
@@ -394,7 +447,7 @@ describe('mr store gc --generated-artifacts', () => {
         const live = yield* runGc({
           cwd: f.outside,
           storePath: f.storePath,
-          args: ['--expected-plan', plan.planSha256!, '--candidate-path', artifact],
+          args: ['--expected-plan', plan.planSha256!, '--candidate-path', candidatePath],
         })
         expect(live.exitCode).toBe(1)
         expect(yield* fs.exists(artifact)).toBe(true)

--- a/packages/@overeng/megarepo/src/cli/store-gc-generated.integration.test.ts
+++ b/packages/@overeng/megarepo/src/cli/store-gc-generated.integration.test.ts
@@ -303,7 +303,7 @@ describe('mr store gc --generated-artifacts', () => {
   )
 
   it.effect(
-    'rejects mutation and expected-plan until a deletion transaction exists',
+    'requires a complete plan-bound candidate selector for mutation',
     Effect.fnUntraced(
       function* () {
         const f = yield* fixture()
@@ -317,6 +317,116 @@ describe('mr store gc --generated-artifacts', () => {
             args: ['--dry-run', '--expected-plan', '0'.repeat(64)],
           })).exitCode,
         ).toBe(1)
+      },
+      Effect.provide(NodeServices.layer),
+      Effect.scoped,
+    ),
+  )
+
+  it.effect(
+    'applies exactly one generated-artifact candidate from an unchanged plan',
+    Effect.fnUntraced(
+      function* () {
+        const fs = yield* FileSystem.FileSystem
+        const f = yield* fixture()
+        yield* configure({ config: f.config, manifest: f.manifest })
+        const artifact = yield* oldIgnoredArtifact(f.worktree)
+        yield* fs.writeFileString(`${f.worktree}/.gitignore`, 'node_modules/\ndist/\n')
+        yield* Git.runCommand({ args: ['add', '.gitignore'], cwd: f.worktree })
+        yield* Git.runCommand({ args: ['commit', '-m', 'ignore dist'], cwd: f.worktree })
+        const sibling = `${f.worktree}/dist`
+        yield* fs.makeDirectory(sibling, { recursive: true })
+        yield* fs.writeFileString(`${sibling}/fixture.txt`, 'generated sibling')
+        yield* Effect.promise(() =>
+          utimes(sibling, new Date(NOW - 2 * DAY_MS), new Date(NOW - 2 * DAY_MS)),
+        )
+
+        const plan = yield* runGc({
+          cwd: f.outside,
+          storePath: f.storePath,
+          args: ['--dry-run'],
+        })
+        const candidate = generated(plan.results, 'node_modules')!
+        const applied = yield* runGc({
+          cwd: f.outside,
+          storePath: f.storePath,
+          args: ['--expected-plan', plan.planSha256!, '--candidate-path', candidate.path],
+        })
+
+        expect(applied.exitCode).toBe(0)
+        expect(applied.results).toHaveLength(1)
+        expect(applied.results[0]).toMatchObject({ path: candidate.path, outcome: 'deleted' })
+        expect(yield* fs.exists(artifact)).toBe(false)
+        expect(yield* fs.exists(sibling)).toBe(true)
+      },
+      Effect.provide(NodeServices.layer),
+      Effect.scoped,
+    ),
+  )
+
+  it.effect(
+    'refuses missing and newly-live generated-artifact candidates',
+    Effect.fnUntraced(
+      function* () {
+        const fs = yield* FileSystem.FileSystem
+        const f = yield* fixture()
+        yield* configure({ config: f.config, manifest: f.manifest })
+        const artifact = yield* oldIgnoredArtifact(f.worktree)
+        const plan = yield* runGc({
+          cwd: f.outside,
+          storePath: f.storePath,
+          args: ['--dry-run'],
+        })
+
+        const missing = yield* runGc({
+          cwd: f.outside,
+          storePath: f.storePath,
+          args: ['--expected-plan', plan.planSha256!, '--candidate-path', `${f.outside}missing`],
+        })
+        expect(missing.exitCode).toBe(1)
+        expect(yield* fs.exists(artifact)).toBe(true)
+
+        yield* configure({
+          config: f.config,
+          manifest: f.manifest,
+          activeWorkspacePaths: [f.worktree.replace(/\/+$/u, '')],
+        })
+        const live = yield* runGc({
+          cwd: f.outside,
+          storePath: f.storePath,
+          args: ['--expected-plan', plan.planSha256!, '--candidate-path', artifact],
+        })
+        expect(live.exitCode).toBe(1)
+        expect(yield* fs.exists(artifact)).toBe(true)
+      },
+      Effect.provide(NodeServices.layer),
+      Effect.scoped,
+    ),
+  )
+
+  it.effect(
+    'refuses application when any part of the canonical plan changed',
+    Effect.fnUntraced(
+      function* () {
+        const fs = yield* FileSystem.FileSystem
+        const f = yield* fixture()
+        yield* configure({ config: f.config, manifest: f.manifest })
+        const artifact = yield* oldIgnoredArtifact(f.worktree)
+        const plan = yield* runGc({
+          cwd: f.outside,
+          storePath: f.storePath,
+          args: ['--dry-run'],
+        })
+        yield* fs.writeFileString(`${artifact}/changed-after-plan.txt`, 'new evidence')
+
+        const changed = yield* runGc({
+          cwd: f.outside,
+          storePath: f.storePath,
+          args: ['--expected-plan', plan.planSha256!, '--candidate-path', artifact],
+        })
+
+        expect(changed.exitCode).toBe(1)
+        expect(yield* fs.exists(artifact)).toBe(true)
       },
       Effect.provide(NodeServices.layer),
       Effect.scoped,
@@ -355,7 +465,7 @@ describe('mr store gc --generated-artifacts', () => {
           args: ['--dry-run'],
           generatedArtifacts: false,
         })
-        expect(result.planSha256).toBeUndefined()
+        expect(result.planSha256).toMatch(/^[0-9a-f]{64}$/)
         expect(result.results.some((row) => row.kind === 'generated-artifact')).toBe(false)
         expect(yield* FileSystem.FileSystem.pipe(Effect.flatMap((fs) => fs.exists(artifact)))).toBe(
           true,

--- a/packages/@overeng/megarepo/src/cli/store-gc-generated.integration.test.ts
+++ b/packages/@overeng/megarepo/src/cli/store-gc-generated.integration.test.ts
@@ -111,23 +111,57 @@ const fixture = () =>
     return { ...created, worktree, outside, manifest, config }
   })
 
+const CATALOG = '/var/lib/st2/catalog'
+const HOST = 'test-host'
+
+/**
+ * Write the gc config plus, when a manifest path is given, a native
+ * `st2.workspace-activity.v1` snapshot claiming `activeWorkspacePaths`.
+ */
 const configure = ({
   config,
   manifest,
   activeWorkspacePaths = [],
-  expiresAtMs = NOW + DAY_MS,
+  expiresAtMs,
+  complete = true,
+  errors = [],
+  epoch = { catalog: CATALOG, host: HOST, catalogGeneration: 1 },
+  omitConfigEpoch = false,
 }: {
   config: string
   manifest?: string | undefined
   activeWorkspacePaths?: ReadonlyArray<string>
   expiresAtMs?: number
+  complete?: boolean
+  errors?: ReadonlyArray<string>
+  epoch?: {
+    readonly catalog: string
+    readonly host: string
+    readonly catalogGeneration: number | null
+  }
+  omitConfigEpoch?: boolean
 }) =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem
     if (manifest !== undefined) {
+      const capturedAtMs = Date.now()
       yield* fs.writeFileString(
         manifest,
-        encodeJson({ version: 1, expiresAtMs, activeWorkspacePaths }),
+        encodeJson({
+          schemaVersion: 'st2.workspace-activity.v1',
+          producer: 'st2',
+          epoch,
+          capturedAt: new Date(capturedAtMs).toISOString(),
+          expiresAt: new Date(expiresAtMs ?? capturedAtMs + 60_000).toISOString(),
+          complete,
+          errors,
+          claims: [...activeWorkspacePaths].toSorted().map((workspace) => ({
+            workspace,
+            agents: ['test.agent'],
+            activeRuntimeIds: ['test.agent'],
+            active: true,
+          })),
+        }),
       )
     }
     yield* fs.writeFileString(
@@ -137,7 +171,14 @@ const configure = ({
           enabled: true,
           retentionMs: DAY_MS,
           allowlist: ['node_modules', 'dist'],
-          ...(manifest !== undefined ? { agentLivenessManifest: manifest } : {}),
+          ...(manifest !== undefined
+            ? {
+                agentLivenessManifest: manifest,
+                ...(omitConfigEpoch === true
+                  ? {}
+                  : { agentLivenessEpoch: { catalog: CATALOG, host: HOST } }),
+              }
+            : {}),
         },
       }),
     )
@@ -219,6 +260,65 @@ describe('mr store gc --generated-artifacts', () => {
           expect(result.completedRepoCount).toBe(1)
           expect(result.discoveredWorktreeCount).toBe(1)
           expect(result.activeWorktreeCount).toBe(0)
+        }
+      },
+      Effect.provide(NodeServices.layer),
+      Effect.scoped,
+    ),
+  )
+
+  it.effect(
+    'keeps an artifact whose worktree is canonically claimed active by st2',
+    Effect.fnUntraced(
+      function* () {
+        const fs = yield* FileSystem.FileSystem
+        const f = yield* fixture()
+        yield* oldIgnoredArtifact(f.worktree)
+        yield* configure({
+          config: f.config,
+          manifest: f.manifest,
+          activeWorkspacePaths: [yield* fs.realPath(f.worktree)],
+        })
+        const result = yield* runGc({ cwd: f.outside, storePath: f.storePath, args: ['--dry-run'] })
+        expect(generated(result.results, 'node_modules')).toMatchObject({
+          outcome: 'keep',
+          reason: 'live',
+        })
+      },
+      Effect.provide(NodeServices.layer),
+      Effect.scoped,
+    ),
+  )
+
+  it.effect(
+    'refuses snapshots outside the admitted epoch or with an incomplete capture',
+    Effect.fnUntraced(
+      function* () {
+        const f = yield* fixture()
+        yield* oldIgnoredArtifact(f.worktree)
+
+        // Each case is evidence megarepo must not trust: a snapshot produced for
+        // another host or catalog, a partial capture, a capture that reported
+        // errors, and a manifest with no configured epoch to admit it at all.
+        const cases = [
+          { epoch: { catalog: CATALOG, host: 'other-host', catalogGeneration: 1 } },
+          { epoch: { catalog: '/var/lib/st2/other', host: HOST, catalogGeneration: 1 } },
+          { complete: false },
+          { errors: ['catalog read failed'] },
+          { omitConfigEpoch: true },
+        ] as const
+
+        for (const override of cases) {
+          yield* configure({ config: f.config, manifest: f.manifest, ...override })
+          const result = yield* runGc({
+            cwd: f.outside,
+            storePath: f.storePath,
+            args: ['--dry-run'],
+          })
+          expect(generated(result.results, 'node_modules')).toMatchObject({
+            outcome: 'unknown',
+            reason: 'agent-liveness-unavailable',
+          })
         }
       },
       Effect.provide(NodeServices.layer),

--- a/packages/@overeng/megarepo/src/cli/store.integration.test.ts
+++ b/packages/@overeng/megarepo/src/cli/store.integration.test.ts
@@ -16,7 +16,12 @@ import { EffectPath, type AbsoluteDirPath } from '@overeng/effect-path'
 import { parseSourceString, isRemoteSource } from '../core/config.ts'
 import * as Git from '../core/git.ts'
 import { LOCK_FILE_NAME, readLockFile } from '../core/lock.ts'
-import { canonicalizeOwnerPath, deletionLeasePath } from '../store/store-deletion-lease.ts'
+import {
+  acquireDeletionLease,
+  canonicalizeOwnerPath,
+  deletionLeasePath,
+  releaseDeletionLease,
+} from '../store/store-deletion-lease.ts'
 import { refreshWorkspaceRegistry } from '../store/store-liveness.ts'
 import { makeStoreLayer, Store } from '../store/store.ts'
 import { makeConsoleCapture } from '../test-utils/consoleCapture.ts'
@@ -546,14 +551,95 @@ describe('mr store lease', () => {
         expect(observed.exitCode).toBe(0)
         expect(yield* fs.exists(leasePath)).toBe(false)
 
-        // A failing command propagates failure and still frees the lease.
-        const failed = yield* runMrCommand({
+        // Wrapping is transparent: the child's own code becomes the command's
+        // code (`process.exitCode`, honored by the CLI teardown), never a
+        // collapsed generic failure — and the lease is freed either way.
+        const previousExitCode = process.exitCode
+        try {
+          process.exitCode = undefined
+          const failed = yield* runMrCommand({
+            cwd,
+            command: ['store', 'lease', '--owner-path', owner, '--', 'sh', '-c', 'exit 42'],
+            env: { MEGAREPO_STORE: storePath },
+          })
+          expect(failed.exitCode).toBe(0)
+          expect(process.exitCode).toBe(42)
+          expect(yield* fs.exists(leasePath)).toBe(false)
+        } finally {
+          process.exitCode = previousExitCode
+        }
+      },
+      Effect.provide(NodeServices.layer),
+      Effect.scoped,
+    ),
+  )
+  it.effect(
+    'refuses whole-worktree application while an activation holds that owner lease',
+    Effect.fnUntraced(
+      function* () {
+        const fs = yield* FileSystem.FileSystem
+        const commit = 'abcdef1234567890abcdef1234567890abcdef12'
+        const { storePath, worktreePaths } = yield* createStoreFixture([
+          {
+            host: 'github.com',
+            owner: 'test-owner',
+            repo: 'leased-worktree-repo',
+            branches: ['main'],
+            commits: [commit],
+          },
+        ])
+        const candidate = worktreePaths[`github.com/test-owner/leased-worktree-repo#${commit}`]!
+        const cwd = EffectPath.unsafe.absoluteDir(`${yield* fs.makeTempDirectoryScoped()}/`)
+        const plan = decodeStoreGcJsonOutput(
+          (yield* runMrCommand({
+            cwd,
+            command: ['store', 'gc', '--dry-run', '--output', 'json'],
+            env: { MEGAREPO_STORE: storePath },
+          })).stdout,
+        )
+
+        // An activation of this very worktree holds its lease, so the plan-bound
+        // whole-worktree deletion must fail closed rather than delete underneath it.
+        const held = yield* acquireDeletionLease({
+          storeBasePath: storePath,
+          ownerPath: yield* canonicalizeOwnerPath(candidate),
+          now: Date.now(),
+        })
+        const refused = yield* runMrCommand({
           cwd,
-          command: ['store', 'lease', '--owner-path', owner, '--', 'false'],
+          command: [
+            'store',
+            'gc',
+            '--expected-plan',
+            plan.planSha256!,
+            '--candidate-path',
+            candidate,
+            '--output',
+            'json',
+          ],
           env: { MEGAREPO_STORE: storePath },
         })
-        expect(failed.exitCode).toBe(1)
-        expect(yield* fs.exists(leasePath)).toBe(false)
+        expect(refused.exitCode).toBe(1)
+        expect(yield* fs.exists(candidate)).toBe(true)
+
+        yield* releaseDeletionLease(held)
+        const applied = yield* runMrCommand({
+          cwd,
+          command: [
+            'store',
+            'gc',
+            '--expected-plan',
+            plan.planSha256!,
+            '--candidate-path',
+            candidate,
+            '--output',
+            'json',
+          ],
+          env: { MEGAREPO_STORE: storePath },
+        })
+        expect(applied.exitCode).toBe(0)
+        expect(yield* fs.exists(candidate)).toBe(false)
+        expect(yield* fs.exists(held.leasePath)).toBe(false)
       },
       Effect.provide(NodeServices.layer),
       Effect.scoped,

--- a/packages/@overeng/megarepo/src/cli/store.integration.test.ts
+++ b/packages/@overeng/megarepo/src/cli/store.integration.test.ts
@@ -37,6 +37,8 @@ const StoreGcJsonOutput = Schema.Struct({
       message: Schema.optional(Schema.String),
     }),
   ),
+  censusStatus: Schema.optional(Schema.Literals(['complete', 'unknown'])),
+  planSha256: Schema.optional(Schema.String),
 })
 
 const decodeStoreGcJsonOutput = Schema.decodeUnknownSync(Schema.fromJsonString(StoreGcJsonOutput))
@@ -439,6 +441,59 @@ describe('mr store gc', () => {
         Effect.scoped,
       ),
     )
+    it.effect(
+      'applies exactly one whole-worktree candidate from an unchanged dry-run plan',
+      Effect.fnUntraced(
+        function* () {
+          const fs = yield* FileSystem.FileSystem
+          const first = 'abcdef1234567890abcdef1234567890abcdef12'
+          const second = '1234567890abcdef1234567890abcdef12345678'
+          const { storePath, worktreePaths } = yield* createStoreFixture([
+            {
+              host: 'github.com',
+              owner: 'test-owner',
+              repo: 'targeted-repo',
+              branches: ['main'],
+              commits: [first, second],
+            },
+          ])
+          const candidate = worktreePaths[`github.com/test-owner/targeted-repo#${first}`]!
+          const sibling = worktreePaths[`github.com/test-owner/targeted-repo#${second}`]!
+          const tmpDir = EffectPath.unsafe.absoluteDir(`${yield* fs.makeTempDirectoryScoped()}/`)
+          const cwd = EffectPath.ops.join(tmpDir, EffectPath.unsafe.relativeDir('outside/'))
+          yield* fs.makeDirectory(cwd, { recursive: true })
+
+          const planned = yield* runMrCommand({
+            cwd,
+            command: ['store', 'gc', '--dry-run', '--output', 'json'],
+            env: { MEGAREPO_STORE: storePath },
+          })
+          const plan = decodeStoreGcJsonOutput(planned.stdout)
+          expect(plan.planSha256).toMatch(/^[0-9a-f]{64}$/)
+          const applied = yield* runMrCommand({
+            cwd,
+            command: [
+              'store',
+              'gc',
+              '--expected-plan',
+              plan.planSha256!,
+              '--candidate-path',
+              candidate,
+              '--output',
+              'json',
+            ],
+            env: { MEGAREPO_STORE: storePath },
+          })
+
+          expect(applied.exitCode).toBe(0)
+          expect(decodeStoreGcJsonOutput(applied.stdout).results).toHaveLength(1)
+          expect(yield* fs.exists(candidate)).toBe(false)
+          expect(yield* fs.exists(sibling)).toBe(true)
+        },
+        Effect.provide(NodeServices.layer),
+        Effect.scoped,
+      ),
+    )
   })
 })
 
@@ -471,6 +526,9 @@ describe('store discovery is bounded to the layout', () => {
         // Legit member at depth 2 (a bare repo placed directly under a pseudo-host
         // dir, like the real store's `other/contrib-bare`) — must be INCLUDED.
         yield* mkdirp('other/contrib/.bare')
+        // Host namespaces may carry their own metadata; a lone `.state` must not
+        // make the host look like a nested store and hide all repos below it.
+        yield* mkdirp('github.com/.state')
         // `_`-prefixed co-tenant namespace holding a NESTED store with a deep working
         // tree: root-skipped, so its `.bare` is never discovered AND its subtree
         // never walked.
@@ -539,7 +597,8 @@ describe('store discovery is bounded to the layout', () => {
           command: ['store', 'gc', '--dry-run', '--output', 'json'],
           env: { MEGAREPO_STORE: storePath },
         })
-        const { results } = decodeStoreGcJsonOutput(stdout)
+        const { results, censusStatus } = decodeStoreGcJsonOutput(stdout)
+        expect(censusStatus).toBe('complete')
 
         // Exactly one result for the broken worktree root, and NONE for paths
         // inside its working tree (pre-fix the walk emitted one per leaf dir).

--- a/packages/@overeng/megarepo/src/cli/store.integration.test.ts
+++ b/packages/@overeng/megarepo/src/cli/store.integration.test.ts
@@ -489,6 +489,28 @@ describe('mr store gc', () => {
           expect(decodeStoreGcJsonOutput(applied.stdout).results).toHaveLength(1)
           expect(yield* fs.exists(candidate)).toBe(false)
           expect(yield* fs.exists(sibling)).toBe(true)
+
+          const secondPlanRun = yield* runMrCommand({
+            cwd,
+            command: ['store', 'gc', '--dry-run', '--output', 'json'],
+            env: { MEGAREPO_STORE: storePath },
+          })
+          const secondPlan = decodeStoreGcJsonOutput(secondPlanRun.stdout)
+          const textApplied = yield* runMrCommand({
+            cwd,
+            command: [
+              'store',
+              'gc',
+              '--expected-plan',
+              secondPlan.planSha256!,
+              '--candidate-path',
+              sibling,
+            ],
+            env: { MEGAREPO_STORE: storePath },
+          })
+          expect(textApplied.exitCode).toBe(0)
+          expect(textApplied.stdout.length).toBeGreaterThan(0)
+          expect(yield* fs.exists(sibling)).toBe(false)
         },
         Effect.provide(NodeServices.layer),
         Effect.scoped,

--- a/packages/@overeng/megarepo/src/cli/store.integration.test.ts
+++ b/packages/@overeng/megarepo/src/cli/store.integration.test.ts
@@ -4,6 +4,9 @@
  * Tests the store GC, ls, and fetch commands with realistic store fixtures.
  */
 
+import { spawn, spawnSync, type ChildProcess } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
 import { NodeServices } from '@effect/platform-node'
 import { describe, it } from '@effect/vitest'
 import { Effect, Exit, Option, Schema } from 'effect'
@@ -640,6 +643,77 @@ describe('mr store lease', () => {
         expect(applied.exitCode).toBe(0)
         expect(yield* fs.exists(candidate)).toBe(false)
         expect(yield* fs.exists(held.leasePath)).toBe(false)
+      },
+      Effect.provide(NodeServices.layer),
+      Effect.scoped,
+    ),
+  )
+
+  // Run through a REAL `mr` process: the probe deliberately excludes its own
+  // descendants (a `git` child megarepo spawns inside the worktree must not
+  // self-veto), so an in-process CLI call could never observe a holder spawned
+  // by this test. A separate process tree is exactly production's shape.
+  it.effect(
+    'refuses whole-worktree application while a live process works inside the candidate',
+    Effect.fnUntraced(
+      function* () {
+        const fs = yield* FileSystem.FileSystem
+        const commit = 'fedcba9876543210fedcba9876543210fedcba98'
+        const { storePath, worktreePaths } = yield* createStoreFixture([
+          {
+            host: 'github.com',
+            owner: 'test-owner',
+            repo: 'inuse-repo',
+            branches: ['main'],
+            commits: [commit],
+          },
+        ])
+        const candidate = worktreePaths[`github.com/test-owner/inuse-repo#${commit}`]!
+        const cliPath = fileURLToPath(new URL('../../bin/mr.ts', import.meta.url))
+        const runCli = (...args: ReadonlyArray<string>) =>
+          spawnSync('bun', [cliPath, ...args], {
+            encoding: 'utf8',
+            env: { ...process.env, MEGAREPO_STORE: storePath, NO_COLOR: '1' },
+          })
+
+        const plan = decodeStoreGcJsonOutput(
+          runCli('store', 'gc', '--dry-run', '--output', 'json').stdout,
+        )
+        const applyArgs = [
+          'store',
+          'gc',
+          '--expected-plan',
+          plan.planSha256!,
+          '--candidate-path',
+          candidate,
+          '--output',
+          'json',
+        ] as const
+
+        // A session that never took a lease is still working inside the
+        // worktree; deleting it would yank that live cwd.
+        const holder = yield* Effect.promise(() => {
+          const { promise, resolve, reject } = Promise.withResolvers<ChildProcess>()
+          const child = spawn('sleep', ['120'], { cwd: candidate, stdio: 'ignore' })
+          child.once('spawn', () => resolve(child))
+          child.once('error', reject)
+          return promise
+        })
+        const refused = runCli(...applyArgs)
+        expect(refused.status).toBe(1)
+        expect(yield* fs.exists(candidate)).toBe(true)
+
+        // Once the session is gone the SAME plan applies, so the veto — not the
+        // plan, the lease, or liveness — was the only thing refusing.
+        yield* Effect.promise(() => {
+          const { promise, resolve } = Promise.withResolvers<void>()
+          holder.once('exit', () => resolve())
+          holder.kill('SIGKILL')
+          return promise
+        })
+        const applied = runCli(...applyArgs)
+        expect(applied.status).toBe(0)
+        expect(yield* fs.exists(candidate)).toBe(false)
       },
       Effect.provide(NodeServices.layer),
       Effect.scoped,

--- a/packages/@overeng/megarepo/src/cli/store.integration.test.ts
+++ b/packages/@overeng/megarepo/src/cli/store.integration.test.ts
@@ -16,6 +16,7 @@ import { EffectPath, type AbsoluteDirPath } from '@overeng/effect-path'
 import { parseSourceString, isRemoteSource } from '../core/config.ts'
 import * as Git from '../core/git.ts'
 import { LOCK_FILE_NAME, readLockFile } from '../core/lock.ts'
+import { canonicalizeOwnerPath, deletionLeasePath } from '../store/store-deletion-lease.ts'
 import { refreshWorkspaceRegistry } from '../store/store-liveness.ts'
 import { makeStoreLayer, Store } from '../store/store.ts'
 import { makeConsoleCapture } from '../test-utils/consoleCapture.ts'
@@ -517,6 +518,47 @@ describe('mr store gc', () => {
       ),
     )
   })
+})
+
+describe('mr store lease', () => {
+  it.effect(
+    'holds the owner lease for the wrapped command and releases it on both outcomes',
+    Effect.fnUntraced(
+      function* () {
+        const fs = yield* FileSystem.FileSystem
+        const { storePath, worktreePaths } = yield* createStoreFixture([
+          { host: 'github.com', owner: 'test-owner', repo: 'leased-repo', branches: ['main'] },
+        ])
+        const owner = worktreePaths['github.com/test-owner/leased-repo#main']!
+        const cwd = EffectPath.unsafe.absoluteDir(`${yield* fs.makeTempDirectoryScoped()}/`)
+        const leasePath = deletionLeasePath({
+          storeBasePath: storePath,
+          ownerPath: yield* canonicalizeOwnerPath(owner),
+        })
+
+        // The wrapped command observes its own lease, proving external activation
+        // is covered from before its first write until after it exits.
+        const observed = yield* runMrCommand({
+          cwd,
+          command: ['store', 'lease', '--owner-path', owner, '--', 'test', '-f', leasePath],
+          env: { MEGAREPO_STORE: storePath },
+        })
+        expect(observed.exitCode).toBe(0)
+        expect(yield* fs.exists(leasePath)).toBe(false)
+
+        // A failing command propagates failure and still frees the lease.
+        const failed = yield* runMrCommand({
+          cwd,
+          command: ['store', 'lease', '--owner-path', owner, '--', 'false'],
+          env: { MEGAREPO_STORE: storePath },
+        })
+        expect(failed.exitCode).toBe(1)
+        expect(yield* fs.exists(leasePath)).toBe(false)
+      },
+      Effect.provide(NodeServices.layer),
+      Effect.scoped,
+    ),
+  )
 })
 
 describe('store discovery is bounded to the layout', () => {

--- a/packages/@overeng/megarepo/src/store/store-deletion-lease.integration.test.ts
+++ b/packages/@overeng/megarepo/src/store/store-deletion-lease.integration.test.ts
@@ -188,6 +188,74 @@ describe('store deletion lease', () => {
   )
 
   it.effect(
+    'never claims a lease replaced between its link and its ownership check',
+    Effect.fnUntraced(
+      function* () {
+        const fs = yield* FileSystem.FileSystem
+        const f = yield* fixture()
+        const ownerPath = yield* canonicalizeOwnerPath(f.owner)
+        const leasePath = yield* writeLease({
+          storePath: f.storePath,
+          ownerPath,
+          content: encodeJson({
+            version: 1,
+            ownerPath,
+            host: hostname(),
+            pid: deadPid(),
+            token: 'stale-token',
+            acquiredAtMs: NOW - 60_000,
+          }),
+        })
+
+        // Deterministic ABA: a competing acquirer that already judged the same
+        // dead holder releasable removes what it finds — possibly OUR fresh
+        // lease — and links its own. Injecting that replacement immediately
+        // after our `link` returns proves the acquisition is decided by the
+        // record's token, not by `link` succeeding, and that losing removes
+        // nothing: the competitor's lease must survive untouched.
+        const competitor = encodeJson({
+          version: 1,
+          ownerPath,
+          host: hostname(),
+          pid: process.pid,
+          token: 'competitor-token',
+          acquiredAtMs: NOW,
+        })
+        const racingFs: FileSystem.FileSystem = {
+          ...fs,
+          link: (from: string, to: string) =>
+            fs
+              .link(from, to)
+              .pipe(
+                Effect.andThen(
+                  to === leasePath
+                    ? fs.remove(to).pipe(Effect.andThen(fs.writeFileString(to, competitor)))
+                    : Effect.void,
+                ),
+              ),
+        }
+
+        const attempt = yield* acquireDeletionLease({
+          storeBasePath: f.storePath,
+          ownerPath,
+          now: NOW,
+        }).pipe(Effect.provideService(FileSystem.FileSystem, racingFs), Effect.result)
+
+        expect(attempt._tag).toBe('Failure')
+        expect(yield* fs.readFileString(leasePath)).toBe(competitor)
+
+        // No staging file survived the losing attempt.
+        const leaseDir = leasePath.slice(0, leasePath.lastIndexOf('/'))
+        expect(yield* fs.readDirectory(leaseDir)).toEqual([
+          leasePath.slice(leasePath.lastIndexOf('/') + 1),
+        ])
+      },
+      Effect.provide(NodeServices.layer),
+      Effect.scoped,
+    ),
+  )
+
+  it.effect(
     'never recovers a foreign-host, live-pid, or unreadable lease',
     Effect.fnUntraced(
       function* () {

--- a/packages/@overeng/megarepo/src/store/store-deletion-lease.integration.test.ts
+++ b/packages/@overeng/megarepo/src/store/store-deletion-lease.integration.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Deletion-lease protocol tests.
+ *
+ * The lease is the ONLY barrier between reclaiming a worktree's generated
+ * artifacts and re-activating that worktree, so these cover both directions of
+ * the mutual exclusion plus every recovery decision: a provably dead same-host
+ * holder is reclaimed, while a foreign host, a live pid, and an unreadable
+ * record all keep the lease and fail the caller closed.
+ */
+
+import { spawnSync } from 'node:child_process'
+import { hostname } from 'node:os'
+
+import { NodeServices } from '@effect/platform-node'
+import { describe, it } from '@effect/vitest'
+import { Effect } from 'effect'
+import * as FileSystem from 'effect/FileSystem'
+import { expect } from 'vitest'
+
+import { EffectPath, type AbsoluteDirPath } from '@overeng/effect-path'
+
+import { encodeJson } from '../test-utils/mod.ts'
+import {
+  acquireDeletionLease,
+  canonicalizeOwnerPath,
+  deletionLeasePath,
+  DeletionLeaseUnavailableError,
+  releaseDeletionLease,
+  withDeletionLease,
+} from './store-deletion-lease.ts'
+
+const NOW = 1_800_000_000_000
+
+/** A pid that is provably gone: the child is reaped before `spawnSync` returns. */
+const deadPid = (): number => {
+  const result = spawnSync(process.execPath, ['-e', ''])
+  const pid = result.pid
+  expect(typeof pid).toBe('number')
+  return pid!
+}
+
+const fixture = () =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem
+    const root = EffectPath.unsafe.absoluteDir(`${yield* fs.makeTempDirectoryScoped()}/`)
+    const storePath = EffectPath.ops.join(root, EffectPath.unsafe.relativeDir('store/'))
+    const owner = EffectPath.ops.join(storePath, EffectPath.unsafe.relativeDir('owner/worktree/'))
+    yield* fs.makeDirectory(owner, { recursive: true })
+    return { storePath, owner }
+  })
+
+const writeLease = ({
+  storePath,
+  ownerPath,
+  content,
+}: {
+  storePath: AbsoluteDirPath
+  ownerPath: string
+  content: string
+}) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem
+    const leasePath = deletionLeasePath({ storeBasePath: storePath, ownerPath })
+    yield* fs.makeDirectory(leasePath.slice(0, leasePath.lastIndexOf('/')), { recursive: true })
+    yield* fs.writeFileString(leasePath, content)
+    return leasePath
+  })
+
+describe('store deletion lease', () => {
+  it.effect(
+    'excludes a second holder while the lease is held, and admits one after release',
+    Effect.fnUntraced(
+      function* () {
+        const f = yield* fixture()
+        const ownerPath = yield* canonicalizeOwnerPath(f.owner)
+
+        const held = yield* acquireDeletionLease({
+          storeBasePath: f.storePath,
+          ownerPath,
+          now: NOW,
+        })
+        const contended = yield* acquireDeletionLease({
+          storeBasePath: f.storePath,
+          ownerPath,
+          now: NOW,
+        }).pipe(Effect.result)
+        expect(contended._tag).toBe('Failure')
+        expect(contended._tag === 'Failure' && contended.failure).toBeInstanceOf(
+          DeletionLeaseUnavailableError,
+        )
+
+        yield* releaseDeletionLease(held)
+        const reacquired = yield* acquireDeletionLease({
+          storeBasePath: f.storePath,
+          ownerPath,
+          now: NOW,
+        })
+        expect(reacquired.token).not.toBe(held.token)
+        yield* releaseDeletionLease(reacquired)
+      },
+      Effect.provide(NodeServices.layer),
+      Effect.scoped,
+    ),
+  )
+
+  it.effect(
+    'activation and deletion cannot both hold the lease, in either order',
+    Effect.fnUntraced(
+      function* () {
+        const f = yield* fixture()
+        const ownerPath = yield* canonicalizeOwnerPath(f.owner)
+        const attemptDelete = withDeletionLease({
+          storeBasePath: f.storePath,
+          ownerPath,
+          now: NOW,
+        })(Effect.succeed('deleted'))
+
+        // Activation holds the lease: reclamation must fail closed.
+        const duringActivation = yield* withDeletionLease({
+          storeBasePath: f.storePath,
+          ownerPath,
+          now: NOW,
+        })(attemptDelete.pipe(Effect.result))
+        expect(duringActivation._tag).toBe('Failure')
+
+        // Nothing leaks: once activation exits, reclamation proceeds.
+        expect(yield* attemptDelete).toBe('deleted')
+      },
+      Effect.provide(NodeServices.layer),
+      Effect.scoped,
+    ),
+  )
+
+  it.effect(
+    'lease survives the holder and is released only by its own token',
+    Effect.fnUntraced(
+      function* () {
+        const fs = yield* FileSystem.FileSystem
+        const f = yield* fixture()
+        const ownerPath = yield* canonicalizeOwnerPath(f.owner)
+        const held = yield* acquireDeletionLease({
+          storeBasePath: f.storePath,
+          ownerPath,
+          now: NOW,
+        })
+
+        yield* releaseDeletionLease({ ...held, token: 'not-our-token' })
+        expect(yield* fs.exists(held.leasePath)).toBe(true)
+
+        yield* releaseDeletionLease(held)
+        expect(yield* fs.exists(held.leasePath)).toBe(false)
+      },
+      Effect.provide(NodeServices.layer),
+      Effect.scoped,
+    ),
+  )
+
+  it.effect(
+    'recovers a same-host lease whose pid is provably dead',
+    Effect.fnUntraced(
+      function* () {
+        const f = yield* fixture()
+        const ownerPath = yield* canonicalizeOwnerPath(f.owner)
+        yield* writeLease({
+          storePath: f.storePath,
+          ownerPath,
+          content: encodeJson({
+            version: 1,
+            ownerPath,
+            host: hostname(),
+            pid: deadPid(),
+            token: 'stale-token',
+            acquiredAtMs: NOW - 60_000,
+          }),
+        })
+
+        const recovered = yield* acquireDeletionLease({
+          storeBasePath: f.storePath,
+          ownerPath,
+          now: NOW,
+        })
+        expect(recovered.token).not.toBe('stale-token')
+        yield* releaseDeletionLease(recovered)
+      },
+      Effect.provide(NodeServices.layer),
+      Effect.scoped,
+    ),
+  )
+
+  it.effect(
+    'never recovers a foreign-host, live-pid, or unreadable lease',
+    Effect.fnUntraced(
+      function* () {
+        const fs = yield* FileSystem.FileSystem
+        const f = yield* fixture()
+        const ownerPath = yield* canonicalizeOwnerPath(f.owner)
+        const refusals: Array<string> = []
+
+        for (const content of [
+          encodeJson({
+            version: 1,
+            ownerPath,
+            host: `${hostname()}-other`,
+            pid: deadPid(),
+            token: 'foreign-host',
+            acquiredAtMs: NOW - 60_000,
+          }),
+          encodeJson({
+            version: 1,
+            ownerPath,
+            host: hostname(),
+            pid: process.pid,
+            token: 'live-pid',
+            acquiredAtMs: NOW - 60_000,
+          }),
+          'not-json',
+        ]) {
+          const leasePath = yield* writeLease({ storePath: f.storePath, ownerPath, content })
+          const attempt = yield* acquireDeletionLease({
+            storeBasePath: f.storePath,
+            ownerPath,
+            now: NOW,
+          }).pipe(Effect.result)
+          refusals.push(attempt._tag)
+          // The refused lease is left exactly as found, and no staging file remains.
+          expect(yield* fs.readFileString(leasePath)).toBe(content)
+          const siblings = yield* fs.readDirectory(
+            leasePath.slice(0, leasePath.lastIndexOf('/')) as string,
+          )
+          expect(siblings).toEqual([leasePath.slice(leasePath.lastIndexOf('/') + 1)])
+          yield* fs.remove(leasePath)
+        }
+
+        expect(refusals).toEqual(['Failure', 'Failure', 'Failure'])
+      },
+      Effect.provide(NodeServices.layer),
+      Effect.scoped,
+    ),
+  )
+
+  it.effect(
+    'names a not-yet-created worktree identically to its created form',
+    Effect.fnUntraced(
+      function* () {
+        const fs = yield* FileSystem.FileSystem
+        const f = yield* fixture()
+        const pending = EffectPath.ops.join(f.owner, EffectPath.unsafe.relativeDir('refs/heads/x/'))
+
+        const beforeCreate = yield* canonicalizeOwnerPath(pending)
+        yield* fs.makeDirectory(pending, { recursive: true })
+        const afterCreate = yield* canonicalizeOwnerPath(pending)
+
+        expect(beforeCreate).toBe(afterCreate)
+        expect(deletionLeasePath({ storeBasePath: f.storePath, ownerPath: beforeCreate })).toBe(
+          deletionLeasePath({ storeBasePath: f.storePath, ownerPath: afterCreate }),
+        )
+      },
+      Effect.provide(NodeServices.layer),
+      Effect.scoped,
+    ),
+  )
+})

--- a/packages/@overeng/megarepo/src/store/store-deletion-lease.integration.test.ts
+++ b/packages/@overeng/megarepo/src/store/store-deletion-lease.integration.test.ts
@@ -256,6 +256,78 @@ describe('store deletion lease', () => {
   )
 
   it.effect(
+    'serializes recovery so a fully verified holder is never removed by a later recoverer',
+    Effect.fnUntraced(
+      function* () {
+        const fs = yield* FileSystem.FileSystem
+        const f = yield* fixture()
+        const ownerPath = yield* canonicalizeOwnerPath(f.owner)
+        const leasePath = yield* writeLease({
+          storePath: f.storePath,
+          ownerPath,
+          content: encodeJson({
+            version: 1,
+            ownerPath,
+            host: hostname(),
+            pid: deadPid(),
+            token: 'stale-token',
+            acquiredAtMs: NOW - 60_000,
+          }),
+        })
+
+        // The interleaving a post-link claim check cannot catch: a second
+        // recoverer (A) completes recover + link + verify and believes it holds
+        // the lease, and only THEN does the first recoverer's (B) removal land,
+        // deleting A's fresh lease before linking its own. Driving A from inside
+        // B's `remove` reproduces exactly that order.
+        let interleaved = false
+        let nestedTag: string | undefined
+        let nestedToken: string | undefined
+        const interleavingFs: FileSystem.FileSystem = {
+          ...fs,
+          remove: (path: string, options?: Parameters<typeof fs.remove>[1]) => {
+            if (path !== leasePath || interleaved === true) return fs.remove(path, options)
+            interleaved = true
+            return acquireDeletionLease({
+              storeBasePath: f.storePath,
+              ownerPath,
+              now: NOW,
+            }).pipe(
+              Effect.provideService(FileSystem.FileSystem, fs),
+              Effect.result,
+              Effect.tap((result) =>
+                Effect.sync(() => {
+                  nestedTag = result._tag
+                  nestedToken = result._tag === 'Success' ? result.success.token : undefined
+                }),
+              ),
+              Effect.andThen(fs.remove(path, options)),
+            )
+          },
+        }
+
+        const outer = yield* acquireDeletionLease({
+          storeBasePath: f.storePath,
+          ownerPath,
+          now: NOW,
+        }).pipe(Effect.provideService(FileSystem.FileSystem, interleavingFs), Effect.result)
+
+        expect(interleaved).toBe(true)
+        const holders = [nestedTag, outer._tag].filter((tag) => tag === 'Success')
+        expect(holders).toHaveLength(1)
+
+        const holderToken = outer._tag === 'Success' ? outer.success.token : nestedToken
+        expect(yield* fs.readFileString(leasePath)).toContain(holderToken)
+
+        // The recovery lock is released, so later recovery is still possible.
+        expect(yield* fs.exists(`${leasePath}.recover`)).toBe(false)
+      },
+      Effect.provide(NodeServices.layer),
+      Effect.scoped,
+    ),
+  )
+
+  it.effect(
     'never recovers a foreign-host, live-pid, or unreadable lease',
     Effect.fnUntraced(
       function* () {

--- a/packages/@overeng/megarepo/src/store/store-deletion-lease.ts
+++ b/packages/@overeng/megarepo/src/store/store-deletion-lease.ts
@@ -200,12 +200,23 @@ export const acquireDeletionLease = ({
       })
     }
 
-    const link = fs.link(stagingPath, leasePath).pipe(
-      Effect.as(true),
-      Effect.orElseSucceed(() => false),
-    )
+    // Link, then prove the lease at the path is OURS. Recovery makes `link`
+    // alone insufficient: two acquirers can judge the same dead record
+    // releasable, and the loser's `remove` can delete the winner's fresh lease
+    // before linking its own (ABA). The record's token is the only ownership
+    // proof, so a mismatch fails closed and — critically — removes nothing,
+    // leaving the actual holder untouched.
+    const linkAndClaim = Effect.gen(function* () {
+      const linked = yield* fs.link(stagingPath, leasePath).pipe(
+        Effect.as(true),
+        Effect.orElseSucceed(() => false),
+      )
+      if (linked === false) return false
+      const current = yield* readLeaseRecord({ fs, leasePath })
+      return current?.token === token
+    })
     const acquired = yield* Effect.gen(function* () {
-      if ((yield* link) === true) return true
+      if ((yield* linkAndClaim) === true) return true
       // Contended: recover only a provably dead same-host holder, then retry once.
       const existing = yield* readLeaseRecord({ fs, leasePath })
       if (existing === undefined || isProvablyReleasable(existing) === false) return false
@@ -214,7 +225,7 @@ export const acquireDeletionLease = ({
         Effect.orElseSucceed(() => false),
       )
       if (removed === false) return false
-      return yield* link
+      return yield* linkAndClaim
     })
 
     yield* fs.remove(stagingPath).pipe(Effect.orElseSucceed(() => undefined))

--- a/packages/@overeng/megarepo/src/store/store-deletion-lease.ts
+++ b/packages/@overeng/megarepo/src/store/store-deletion-lease.ts
@@ -1,0 +1,271 @@
+/**
+ * Store Deletion Lease
+ *
+ * Mutual exclusion between destructive reclamation of a store worktree's
+ * generated artifacts and re-activation of that same worktree.
+ *
+ * The generated-artifact planner reads an EXTERNAL agent-liveness manifest, so
+ * rereading it before deleting cannot exclude an activation that starts right
+ * after the read. This lease closes that window with a single shared object per
+ * canonical owner path: the reclaimer holds it across final classification and
+ * deletion, and the activation wrapper holds it from before its first worktree
+ * write until after it has published the manifest. Whoever loses the race waits
+ * or fails closed — neither side ever proceeds on a stale liveness snapshot.
+ *
+ * Exclusion primitive is `link(2)` on the lease path: creating a hard link to a
+ * freshly written staging file fails with `EEXIST` when the lease exists. That
+ * is atomic on POSIX filesystems and needs no daemon, no TTL guessing, and no
+ * read-then-write window (unlike `StoreLock`, whose backing is advisory and
+ * TTL-expiring — safe for serializing work, unsafe as a deletion barrier).
+ *
+ * Recovery is deliberately narrow: a lease is reclaimed only when its record is
+ * decodable, names THIS host, and names a pid that is provably gone. Anything
+ * else (foreign host, unreadable record, live or unprovable pid) keeps the lease
+ * and fails the caller closed.
+ */
+
+import { createHash, randomUUID } from 'node:crypto'
+import { hostname } from 'node:os'
+
+import { Effect, Schema } from 'effect'
+import * as FileSystem from 'effect/FileSystem'
+
+import { EffectPath, type AbsoluteDirPath } from '@overeng/effect-path'
+
+/** On-disk lease record version. */
+const DELETION_LEASE_VERSION = 1
+
+/** Raised when the lease for an owner path cannot be taken. */
+export class DeletionLeaseUnavailableError extends Schema.TaggedError<DeletionLeaseUnavailableError>()(
+  'DeletionLeaseUnavailableError',
+  {
+    ownerPath: Schema.String,
+    leasePath: Schema.String,
+    message: Schema.String,
+  },
+) {}
+
+/**
+ * Lease record. `token` identifies one acquisition so a holder only ever
+ * releases its own lease; `host`/`pid` are the sole recovery evidence.
+ */
+const DeletionLeaseRecord = Schema.Struct({
+  version: Schema.Literal(DELETION_LEASE_VERSION),
+  ownerPath: Schema.String,
+  host: Schema.String,
+  pid: Schema.Finite,
+  token: Schema.String,
+  acquiredAtMs: Schema.Finite,
+})
+
+type DeletionLeaseRecord = Schema.Schema.Type<typeof DeletionLeaseRecord>
+
+const encodeLeaseRecord = Schema.encodeSync(Schema.fromJsonString(DeletionLeaseRecord))
+const decodeLeaseRecord = Schema.decodeUnknownEffect(Schema.fromJsonString(DeletionLeaseRecord))
+
+/** A held lease: the path that must be removed, and the token that owns it. */
+export interface DeletionLease {
+  readonly leasePath: string
+  readonly ownerPath: string
+  readonly token: string
+}
+
+const normalizeOwnerPath = (path: string): string => path.replace(/\/+$/, '')
+
+/** Directory holding every deletion lease of one store. */
+export const deletionLeaseDirectory = (storeBasePath: AbsoluteDirPath): AbsoluteDirPath =>
+  EffectPath.ops.join(storeBasePath, EffectPath.unsafe.relativeDir('.state/deletion-leases/'))
+
+/**
+ * Lease path for one canonical owner worktree path.
+ *
+ * The owner path is hashed so an arbitrarily deep worktree path always yields
+ * one flat `NAME_MAX`-safe filename, and so both sides derive the identical
+ * name from the identical canonical path without sharing any other state.
+ */
+export const deletionLeasePath = ({
+  storeBasePath,
+  ownerPath,
+}: {
+  storeBasePath: AbsoluteDirPath
+  ownerPath: string
+}): string => {
+  const digest = createHash('sha256').update(normalizeOwnerPath(ownerPath), 'utf8').digest('hex')
+  return `${deletionLeaseDirectory(storeBasePath)}${digest}.lease`
+}
+
+/**
+ * Canonical lease identity for an owner worktree path.
+ *
+ * Both sides MUST derive the lease name through this function: the reclaimer
+ * names an existing worktree, while the activation wrapper takes the lease
+ * BEFORE its first worktree write, when the path may not exist yet. Resolving
+ * the deepest existing ancestor and re-appending the remaining segments makes
+ * both cases agree — for an existing path the result equals `realPath`.
+ */
+export const canonicalizeOwnerPath = (
+  ownerPath: string,
+): Effect.Effect<string, never, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem
+    const normalized = normalizeOwnerPath(ownerPath)
+    const segments = normalized.split('/')
+    for (let depth = segments.length; depth > 1; depth -= 1) {
+      const real = yield* fs
+        .realPath(segments.slice(0, depth).join('/'))
+        .pipe(Effect.orElseSucceed(() => undefined))
+      if (real === undefined) continue
+      const suffix = segments.slice(depth)
+      return normalizeOwnerPath(suffix.length === 0 ? real : `${real}/${suffix.join('/')}`)
+    }
+    return normalized
+  })
+
+const readLeaseRecord = ({
+  fs,
+  leasePath,
+}: {
+  fs: FileSystem.FileSystem
+  leasePath: string
+}): Effect.Effect<DeletionLeaseRecord | undefined> =>
+  Effect.gen(function* () {
+    const content = yield* fs.readFileString(leasePath).pipe(Effect.orElseSucceed(() => undefined))
+    if (content === undefined) return undefined
+    return yield* decodeLeaseRecord(content).pipe(Effect.orElseSucceed(() => undefined))
+  })
+
+/**
+ * True only when the record names this host and a pid that is provably gone.
+ *
+ * `kill(pid, 0)` distinguishes the three cases that matter: success means the
+ * process exists, `EPERM` means it exists under another user, and `ESRCH` means
+ * it is gone. Only `ESRCH` is proof of death, so any other outcome — including
+ * an unexpected error — keeps the lease.
+ */
+const isProvablyReleasable = (record: DeletionLeaseRecord): boolean => {
+  if (record.host !== hostname()) return false
+  if (Number.isInteger(record.pid) === false || record.pid <= 0) return false
+  if (record.pid === process.pid) return false
+  try {
+    process.kill(record.pid, 0)
+    return false
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'ESRCH'
+  }
+}
+
+/**
+ * Take the deletion lease for `ownerPath`, or fail closed.
+ *
+ * One staging file is written per attempt and hard-linked onto the lease path;
+ * the staging link is always dropped, so a crash between link and drop leaves
+ * exactly the lease (recoverable) and never a permanent stray.
+ */
+export const acquireDeletionLease = ({
+  storeBasePath,
+  ownerPath,
+  now,
+}: {
+  storeBasePath: AbsoluteDirPath
+  ownerPath: string
+  now: number
+}): Effect.Effect<DeletionLease, DeletionLeaseUnavailableError, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem
+    const canonicalOwnerPath = normalizeOwnerPath(ownerPath)
+    const leasePath = deletionLeasePath({ storeBasePath, ownerPath: canonicalOwnerPath })
+    const token = randomUUID()
+    const record: DeletionLeaseRecord = {
+      version: DELETION_LEASE_VERSION,
+      ownerPath: canonicalOwnerPath,
+      host: hostname(),
+      pid: process.pid,
+      token,
+      acquiredAtMs: now,
+    }
+    const stagingPath = `${leasePath}.${token}.staging`
+
+    const staged = yield* fs
+      .makeDirectory(deletionLeaseDirectory(storeBasePath), { recursive: true })
+      .pipe(
+        Effect.andThen(fs.writeFileString(stagingPath, encodeLeaseRecord(record))),
+        Effect.as(true),
+        Effect.orElseSucceed(() => false),
+      )
+    if (staged === false) {
+      return yield* new DeletionLeaseUnavailableError({
+        ownerPath: canonicalOwnerPath,
+        leasePath,
+        message: 'deletion lease staging file could not be written',
+      })
+    }
+
+    const link = fs.link(stagingPath, leasePath).pipe(
+      Effect.as(true),
+      Effect.orElseSucceed(() => false),
+    )
+    const acquired = yield* Effect.gen(function* () {
+      if ((yield* link) === true) return true
+      // Contended: recover only a provably dead same-host holder, then retry once.
+      const existing = yield* readLeaseRecord({ fs, leasePath })
+      if (existing === undefined || isProvablyReleasable(existing) === false) return false
+      const removed = yield* fs.remove(leasePath).pipe(
+        Effect.as(true),
+        Effect.orElseSucceed(() => false),
+      )
+      if (removed === false) return false
+      return yield* link
+    })
+
+    yield* fs.remove(stagingPath).pipe(Effect.orElseSucceed(() => undefined))
+
+    if (acquired === false) {
+      return yield* new DeletionLeaseUnavailableError({
+        ownerPath: canonicalOwnerPath,
+        leasePath,
+        message: 'deletion lease is held by another holder',
+      })
+    }
+
+    return { leasePath, ownerPath: canonicalOwnerPath, token }
+  })
+
+/**
+ * Release a held lease.
+ *
+ * The record is re-read and the token compared so a lease already recovered by
+ * another holder is never deleted out from under it.
+ */
+export const releaseDeletionLease = (
+  lease: DeletionLease,
+): Effect.Effect<void, never, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem
+    const record = yield* readLeaseRecord({ fs, leasePath: lease.leasePath })
+    if (record?.token !== lease.token) return
+    yield* fs.remove(lease.leasePath).pipe(Effect.orElseSucceed(() => undefined))
+  })
+
+/**
+ * Run `effect` while holding the deletion lease for `ownerPath`.
+ *
+ * The lease is released on every exit path, including interruption.
+ */
+export const withDeletionLease =
+  ({
+    storeBasePath,
+    ownerPath,
+    now,
+  }: {
+    storeBasePath: AbsoluteDirPath
+    ownerPath: string
+    now: number
+  }) =>
+  <A, E, R>(
+    effect: Effect.Effect<A, E, R>,
+  ): Effect.Effect<A, E | DeletionLeaseUnavailableError, R | FileSystem.FileSystem> =>
+    Effect.acquireUseRelease(
+      acquireDeletionLease({ storeBasePath, ownerPath, now }),
+      () => effect,
+      (lease) => releaseDeletionLease(lease),
+    )

--- a/packages/@overeng/megarepo/src/store/store-deletion-lease.ts
+++ b/packages/@overeng/megarepo/src/store/store-deletion-lease.ts
@@ -200,12 +200,8 @@ export const acquireDeletionLease = ({
       })
     }
 
-    // Link, then prove the lease at the path is OURS. Recovery makes `link`
-    // alone insufficient: two acquirers can judge the same dead record
-    // releasable, and the loser's `remove` can delete the winner's fresh lease
-    // before linking its own (ABA). The record's token is the only ownership
-    // proof, so a mismatch fails closed and — critically — removes nothing,
-    // leaving the actual holder untouched.
+    // Uncontended acquisition is one `link`; the claim check below only guards
+    // the recovery path, where a removal happened at all.
     const linkAndClaim = Effect.gen(function* () {
       const linked = yield* fs.link(stagingPath, leasePath).pipe(
         Effect.as(true),
@@ -215,17 +211,50 @@ export const acquireDeletionLease = ({
       const current = yield* readLeaseRecord({ fs, leasePath })
       return current?.token === token
     })
+
+    // Recovery — remove someone else's lease, then link ours — is the ONLY step
+    // that can destroy another holder's lease, and a post-link claim check
+    // cannot make it safe on its own: two recoverers that both judged the same
+    // dead record releasable can interleave as "A removes, links, verifies" then
+    // "B removes A's fresh lease, links, verifies", leaving two believed holders.
+    //
+    // So recovery runs inside a per-owner recovery lock, and inside it the lease
+    // is re-read and must still be the exact record proven dead. The recovery
+    // lock is hardlink-create-only — never removed by anyone but its holder,
+    // never itself recovered — so it cannot reproduce the problem it solves. A
+    // crash while holding it therefore blocks only future recovery (fail-closed,
+    // and visible as `<sha>.recover`); plain acquisition and release stay live.
+    const recoveryLockPath = `${leasePath}.recover`
+    const withRecoveryLock = (recover: Effect.Effect<boolean>) =>
+      Effect.gen(function* () {
+        const locked = yield* fs.link(stagingPath, recoveryLockPath).pipe(
+          Effect.as(true),
+          Effect.orElseSucceed(() => false),
+        )
+        if (locked === false) return false
+        return yield* Effect.ensuring(
+          recover,
+          fs.remove(recoveryLockPath).pipe(Effect.orElseSucceed(() => undefined)),
+        )
+      })
+
     const acquired = yield* Effect.gen(function* () {
       if ((yield* linkAndClaim) === true) return true
-      // Contended: recover only a provably dead same-host holder, then retry once.
       const existing = yield* readLeaseRecord({ fs, leasePath })
       if (existing === undefined || isProvablyReleasable(existing) === false) return false
-      const removed = yield* fs.remove(leasePath).pipe(
-        Effect.as(true),
-        Effect.orElseSucceed(() => false),
+      return yield* withRecoveryLock(
+        Effect.gen(function* () {
+          const current = yield* readLeaseRecord({ fs, leasePath })
+          if (current === undefined || current.token !== existing.token) return false
+          if (isProvablyReleasable(current) === false) return false
+          const removed = yield* fs.remove(leasePath).pipe(
+            Effect.as(true),
+            Effect.orElseSucceed(() => false),
+          )
+          if (removed === false) return false
+          return yield* linkAndClaim
+        }),
       )
-      if (removed === false) return false
-      return yield* linkAndClaim
     })
 
     yield* fs.remove(stagingPath).pipe(Effect.orElseSucceed(() => undefined))

--- a/packages/@overeng/megarepo/src/store/store-gc-config.ts
+++ b/packages/@overeng/megarepo/src/store/store-gc-config.ts
@@ -58,6 +58,12 @@ export interface StoreGcConfig {
     readonly retentionMs: number
     readonly allowlist: ReadonlyArray<StoreGcGeneratedArtifact>
     readonly agentLivenessManifest?: string | undefined
+    /**
+     * Epoch that admits an `st2.workspace-activity.v1` snapshot: a snapshot is
+     * evidence only when it was produced for THIS catalog and host, so a fresh
+     * snapshot from another fleet epoch can never be trusted.
+     */
+    readonly agentLivenessEpoch?: { readonly catalog: string; readonly host: string } | undefined
   }
 }
 
@@ -84,6 +90,9 @@ const StoreGcConfigOverride = Schema.Struct({
       retentionMs: Schema.optional(Schema.Finite),
       allowlist: Schema.optional(Schema.Array(Schema.Literals([...STORE_GC_GENERATED_ARTIFACTS]))),
       agentLivenessManifest: Schema.optional(Schema.String),
+      agentLivenessEpoch: Schema.optional(
+        Schema.Struct({ catalog: Schema.String, host: Schema.String }),
+      ),
     }),
   ),
 })
@@ -120,6 +129,14 @@ export const mergeStoreGcConfig = (override: StoreGcConfigOverride): StoreGcConf
     override.generatedArtifacts?.agentLivenessManifest === undefined
       ? undefined
       : normalizedAbsolutePath(override.generatedArtifacts.agentLivenessManifest)
+  const overrideEpoch = override.generatedArtifacts?.agentLivenessEpoch
+  // Both halves are load-bearing; a half-configured epoch admits nothing.
+  const agentLivenessEpoch =
+    overrideEpoch === undefined ||
+    normalizedAbsolutePath(overrideEpoch.catalog) === undefined ||
+    overrideEpoch.host.length === 0
+      ? undefined
+      : { catalog: overrideEpoch.catalog, host: overrideEpoch.host }
   return {
     absenceGraceMs: validDuration({
       value: override.absenceGraceMs,
@@ -147,6 +164,7 @@ export const mergeStoreGcConfig = (override: StoreGcConfigOverride): StoreGcConf
         ),
       ],
       ...(agentLivenessManifest === undefined ? {} : { agentLivenessManifest }),
+      ...(agentLivenessEpoch === undefined ? {} : { agentLivenessEpoch }),
     },
   }
 }

--- a/packages/@overeng/megarepo/src/store/store-inuse.integration.test.ts
+++ b/packages/@overeng/megarepo/src/store/store-inuse.integration.test.ts
@@ -1,8 +1,8 @@
 /**
  * Live-process in-use probe tests.
  *
- * The pure classifier is exercised directly (boundaries and exclusion), and the
- * `/proc` reader against a REAL spawned holder whose cwd is inside a temp
+ * The pure classifier and lsof parser are exercised directly, and the native
+ * process-table reader against a REAL spawned holder whose cwd is inside a temp
  * worktree — the incident shape: a live session sitting in a directory that
  * reclamation is about to rename. These cases deliberately drive real OS
  * processes, because the probe's whole job is to observe them; process
@@ -16,7 +16,6 @@
  */
 
 import { spawn, type ChildProcess } from 'node:child_process'
-import { existsSync } from 'node:fs'
 
 import { NodeServices } from '@effect/platform-node'
 import { describe, it } from '@effect/vitest'
@@ -26,9 +25,14 @@ import { expect } from 'vitest'
 
 import { EffectPath } from '@overeng/effect-path'
 
-import { classifyInUse, isInsideWorktree, readWorktreeInUse } from './store-inuse.ts'
+import {
+  classifyInUse,
+  isInsideWorktree,
+  parseLsofProcessCwds,
+  readWorktreeInUse,
+} from './store-inuse.ts'
 
-const hasProc = existsSync('/proc')
+const supportsProcessCwdProbe = process.platform === 'linux' || process.platform === 'darwin'
 
 /** Spawn a long-lived holder in `cwd`, resolved once the OS reports it spawned. */
 const spawnHolder = (cwd: string): Promise<ChildProcess> => {
@@ -48,6 +52,28 @@ const killHolder = (child: ChildProcess): Promise<void> => {
 }
 
 describe('store-inuse classifier', () => {
+  it('parses macOS lsof cwd records with their parent process identities', () => {
+    expect(
+      parseLsofProcessCwds([
+        'p100',
+        'R1',
+        'fcwd',
+        'n/store/repo',
+        'p101',
+        'R100',
+        'fcwd',
+        'n/store/repo/src',
+        'pnot-a-pid',
+        'R101',
+        'fcwd',
+        'n/ignored',
+      ]),
+    ).toEqual([
+      { pid: 100, parentPid: 1, path: '/store/repo' },
+      { pid: 101, parentPid: 100, path: '/store/repo/src' },
+    ])
+  })
+
   it('treats the worktree and its descendants as inside, siblings as outside', () => {
     const worktree = '/store/repo/refs/heads/main'
     expect(isInsideWorktree({ candidate: worktree, worktreePath: `${worktree}/` })).toBe(true)
@@ -85,7 +111,7 @@ describe('store-inuse classifier', () => {
   })
 })
 
-describe.skipIf(hasProc === false)('store-inuse probe (/proc)', () => {
+describe.skipIf(supportsProcessCwdProbe === false)('store-inuse native process probe', () => {
   it.effect(
     'sees a live holder inside the worktree, and frees once it exits',
     Effect.fnUntraced(

--- a/packages/@overeng/megarepo/src/store/store-inuse.integration.test.ts
+++ b/packages/@overeng/megarepo/src/store/store-inuse.integration.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Live-process in-use probe tests.
+ *
+ * The pure classifier is exercised directly (boundaries and exclusion), and the
+ * `/proc` reader against a REAL spawned holder whose cwd is inside a temp
+ * worktree — the incident shape: a live session sitting in a directory that
+ * reclamation is about to rename. These cases deliberately drive real OS
+ * processes, because the probe's whole job is to observe them; process
+ * lifecycle is awaited through node's `spawn`/`exit` events, never a timer, so
+ * no wall-clock guessing is involved.
+ *
+ * `selfPid` is passed as a sibling process's pid in the observable case: a
+ * sibling is never an ancestor of the holder, so the descendant walk never
+ * excludes it. That models production, where gc is its own process tree rather
+ * than an ancestor of the live session.
+ */
+
+import { spawn, type ChildProcess } from 'node:child_process'
+import { existsSync } from 'node:fs'
+
+import { NodeServices } from '@effect/platform-node'
+import { describe, it } from '@effect/vitest'
+import { Effect } from 'effect'
+import * as FileSystem from 'effect/FileSystem'
+import { expect } from 'vitest'
+
+import { EffectPath } from '@overeng/effect-path'
+
+import { classifyInUse, isInsideWorktree, readWorktreeInUse } from './store-inuse.ts'
+
+const hasProc = existsSync('/proc')
+
+/** Spawn a long-lived holder in `cwd`, resolved once the OS reports it spawned. */
+const spawnHolder = (cwd: string): Promise<ChildProcess> => {
+  const { promise, resolve, reject } = Promise.withResolvers<ChildProcess>()
+  const child = spawn('sleep', ['120'], { cwd, stdio: 'ignore' })
+  child.once('spawn', () => resolve(child))
+  child.once('error', reject)
+  return promise
+}
+
+/** Kill a holder and resolve on its real `exit` event. */
+const killHolder = (child: ChildProcess): Promise<void> => {
+  const { promise, resolve } = Promise.withResolvers<void>()
+  child.once('exit', () => resolve())
+  child.kill('SIGKILL')
+  return promise
+}
+
+describe('store-inuse classifier', () => {
+  it('treats the worktree and its descendants as inside, siblings as outside', () => {
+    const worktree = '/store/repo/refs/heads/main'
+    expect(isInsideWorktree({ candidate: worktree, worktreePath: `${worktree}/` })).toBe(true)
+    expect(isInsideWorktree({ candidate: `${worktree}/src/app`, worktreePath: worktree })).toBe(
+      true,
+    )
+    // The bug a raw string prefix would introduce: a sibling directory.
+    expect(isInsideWorktree({ candidate: `${worktree}.archive-old`, worktreePath: worktree })).toBe(
+      false,
+    )
+    expect(
+      isInsideWorktree({ candidate: '/store/repo/refs/heads/other', worktreePath: worktree }),
+    ).toBe(false)
+  })
+
+  it('reports the first non-excluded holder and ignores excluded pids', () => {
+    const worktreePath = '/store/repo/refs/heads/main'
+    const processes = [
+      { pid: 10, path: '/elsewhere' },
+      { pid: 11, path: `${worktreePath}/src` },
+      { pid: 12, path: worktreePath },
+    ]
+
+    expect(classifyInUse({ processes, worktreePath, excludePids: new Set() })).toEqual({
+      _tag: 'in-use',
+      holder: { pid: 11, path: `${worktreePath}/src` },
+    })
+    expect(classifyInUse({ processes, worktreePath, excludePids: new Set([11]) })).toEqual({
+      _tag: 'in-use',
+      holder: { pid: 12, path: worktreePath },
+    })
+    expect(classifyInUse({ processes, worktreePath, excludePids: new Set([11, 12]) })).toEqual({
+      _tag: 'free',
+    })
+  })
+})
+
+describe.skipIf(hasProc === false)('store-inuse probe (/proc)', () => {
+  it.effect(
+    'sees a live holder inside the worktree, and frees once it exits',
+    Effect.fnUntraced(
+      function* () {
+        const fs = yield* FileSystem.FileSystem
+        const root = EffectPath.unsafe.absoluteDir(`${yield* fs.makeTempDirectoryScoped()}/`)
+        const worktree = EffectPath.ops.join(root, EffectPath.unsafe.relativeDir('worktree/'))
+        const sibling = EffectPath.ops.join(root, EffectPath.unsafe.relativeDir('worktree-old/'))
+        yield* fs.makeDirectory(worktree, { recursive: true })
+        yield* fs.makeDirectory(sibling, { recursive: true })
+
+        const holder = yield* Effect.promise(() => spawnHolder(worktree))
+        const standIn = yield* Effect.promise(() => spawnHolder(root))
+
+        const occupied = yield* readWorktreeInUse({
+          worktreePath: worktree,
+          selfPid: standIn.pid!,
+        })
+        expect(occupied).toMatchObject({ _tag: 'in-use', holder: { pid: holder.pid } })
+
+        // The sibling directory is not the worktree, so it reads free.
+        const siblingResult = yield* readWorktreeInUse({
+          worktreePath: sibling,
+          selfPid: standIn.pid!,
+        })
+        expect(siblingResult._tag).toBe('free')
+
+        yield* Effect.promise(() => killHolder(holder))
+        yield* Effect.promise(() => killHolder(standIn))
+
+        const freed = yield* readWorktreeInUse({ worktreePath: worktree, selfPid: 1 })
+        expect(freed._tag).toBe('free')
+      },
+      Effect.provide(NodeServices.layer),
+      Effect.scoped,
+    ),
+  )
+
+  it.effect(
+    'never vetoes on its own descendants',
+    Effect.fnUntraced(
+      function* () {
+        const fs = yield* FileSystem.FileSystem
+        const worktree = EffectPath.unsafe.absoluteDir(`${yield* fs.makeTempDirectoryScoped()}/`)
+        // A descendant of this process, exactly like a `git` child megarepo
+        // spawns inside the worktree it is reclaiming.
+        const child = yield* Effect.promise(() => spawnHolder(worktree))
+        const result = yield* readWorktreeInUse({ worktreePath: worktree })
+        yield* Effect.promise(() => killHolder(child))
+        expect(result._tag).toBe('free')
+      },
+      Effect.provide(NodeServices.layer),
+      Effect.scoped,
+    ),
+  )
+})

--- a/packages/@overeng/megarepo/src/store/store-inuse.ts
+++ b/packages/@overeng/megarepo/src/store/store-inuse.ts
@@ -1,0 +1,192 @@
+/**
+ * Live-process in-use probe
+ *
+ * The deletion lease only excludes an activation that takes it. A shell or agent
+ * session that was already sitting inside a worktree holds no lease, and on
+ * Linux a directory rename is invisible to a process already in that directory:
+ * its cwd silently follows the inode into `.archive/`, and the following git
+ * bookkeeping strips the worktree out from under the live session. That is a
+ * real incident class, not a hypothetical.
+ *
+ * So destructive reclamation additionally asks the strictly stronger question
+ * the liveness manifest cannot answer: is a live OS process working inside this
+ * directory right now? Evidence is `/proc/<pid>/cwd`. Conservative in both
+ * directions that matter: no `/proc`, or an unreadable scan, is `unknown`, and
+ * the caller treats `unknown` as in-use and keeps.
+ */
+
+import { Effect } from 'effect'
+import * as FileSystem from 'effect/FileSystem'
+
+import { type AbsoluteDirPath } from '@overeng/effect-path'
+
+/** The process that holds a worktree, and the in-worktree path proving it. */
+export interface InUseHolder {
+  readonly pid: number
+  readonly path: string
+}
+
+/** Probe outcome. `unknown` MUST be treated as in-use by callers. */
+export type InUseResult =
+  | { readonly _tag: 'free' }
+  | { readonly _tag: 'in-use'; readonly holder: InUseHolder }
+  | { readonly _tag: 'unknown'; readonly reason: 'no-proc' | 'scan-failed' }
+
+/** One observed process cwd, as read from `/proc/<pid>/cwd`. */
+export interface ProcessCwd {
+  readonly pid: number
+  readonly path: string
+}
+
+const normalizePath = (path: string): string => path.replace(/\/+$/, '')
+
+/**
+ * True when `candidate` is the worktree itself or a path inside it.
+ *
+ * Compared on normalized boundaries so a sibling like `<worktree>.archive-old`
+ * never matches by raw string prefix.
+ */
+export const isInsideWorktree = ({
+  candidate,
+  worktreePath,
+}: {
+  candidate: string
+  worktreePath: string
+}): boolean => {
+  const worktree = normalizePath(worktreePath)
+  const path = normalizePath(candidate)
+  return path === worktree || path.startsWith(`${worktree}/`) === true
+}
+
+/**
+ * Pure classifier: the first process whose cwd is inside the worktree and which
+ * is not excluded.
+ *
+ * `excludePids` carries this gc process and its descendants — a `git` child
+ * megarepo itself spawned with a cwd inside the worktree must never self-veto.
+ * Keeping it a parameter is what makes this seam unit-testable and lets the
+ * integration test observe a real spawned holder.
+ */
+export const classifyInUse = ({
+  processes,
+  worktreePath,
+  excludePids,
+}: {
+  processes: ReadonlyArray<ProcessCwd>
+  worktreePath: string
+  excludePids: ReadonlySet<number>
+}): InUseResult => {
+  for (const entry of processes) {
+    if (excludePids.has(entry.pid) === true) continue
+    if (isInsideWorktree({ candidate: entry.path, worktreePath }) === false) continue
+    return { _tag: 'in-use', holder: { pid: entry.pid, path: entry.path } }
+  }
+  return { _tag: 'free' }
+}
+
+const parsePpid = (statusContent: string): number | undefined => {
+  const line = statusContent.split('\n').find((entry) => entry.startsWith('PPid:') === true)
+  if (line === undefined) return undefined
+  const parsed = Number.parseInt(line.slice('PPid:'.length).trim(), 10)
+  return Number.isSafeInteger(parsed) === true && parsed >= 0 ? parsed : undefined
+}
+
+/**
+ * Walk a pid's parent chain; `true` when `ancestorPid` is reached.
+ *
+ * Climbing from the rare in-worktree match is far cheaper than materializing
+ * the whole process tree, and the depth bound keeps a corrupted or recycled
+ * chain from looping.
+ */
+const hasAncestor = ({
+  fs,
+  pid,
+  ancestorPid,
+}: {
+  fs: FileSystem.FileSystem
+  pid: number
+  ancestorPid: number
+}): Effect.Effect<boolean> =>
+  Effect.gen(function* () {
+    let current = pid
+    for (let depth = 0; depth < 64; depth += 1) {
+      if (current === ancestorPid) return true
+      if (current <= 1) return false
+      const status = yield* fs
+        .readFileString(`/proc/${current}/status`)
+        .pipe(Effect.orElseSucceed(() => undefined))
+      const parent = status === undefined ? undefined : parsePpid(status)
+      if (parent === undefined) return false
+      current = parent
+    }
+    return false
+  })
+
+/**
+ * Read every readable process cwd from `/proc`.
+ *
+ * A pid that vanishes mid-scan, or whose cwd belongs to another user, is simply
+ * not evidence — those are skipped rather than failing the whole probe, because
+ * refusing on any unreadable pid would make the probe permanently `unknown` on
+ * a shared host and thereby disable reclamation entirely.
+ */
+const readProcessCwds = (
+  fs: FileSystem.FileSystem,
+): Effect.Effect<ReadonlyArray<ProcessCwd> | undefined> =>
+  Effect.gen(function* () {
+    const entries = yield* fs.readDirectory('/proc').pipe(Effect.orElseSucceed(() => undefined))
+    if (entries === undefined) return undefined
+    const pids = entries.flatMap((entry) => {
+      const pid = Number.parseInt(entry, 10)
+      return `${pid}` === entry && Number.isSafeInteger(pid) === true && pid > 0 ? [pid] : []
+    })
+    const observed = yield* Effect.forEach(
+      pids,
+      (pid) =>
+        fs.readLink(`/proc/${pid}/cwd`).pipe(
+          Effect.map((path) => ({ pid, path })),
+          Effect.orElseSucceed(() => undefined),
+        ),
+      { concurrency: 16 },
+    )
+    return observed.flatMap((entry) => (entry === undefined ? [] : [entry]))
+  })
+
+/**
+ * Probe whether a live process is working inside `worktreePath`.
+ *
+ * `selfPid` defaults to this process; it and its descendants are excluded so
+ * megarepo's own git children can never veto its work.
+ */
+export const readWorktreeInUse = ({
+  worktreePath,
+  selfPid = process.pid,
+}: {
+  worktreePath: AbsoluteDirPath | string
+  selfPid?: number | undefined
+}): Effect.Effect<InUseResult, never, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem
+    if ((yield* fs.exists('/proc').pipe(Effect.orElseSucceed(() => false))) === false) {
+      return { _tag: 'unknown', reason: 'no-proc' } as const
+    }
+    const processes = yield* readProcessCwds(fs)
+    if (processes === undefined) return { _tag: 'unknown', reason: 'scan-failed' } as const
+
+    const inside = processes.filter((entry) =>
+      isInsideWorktree({ candidate: entry.path, worktreePath }),
+    )
+    const excluded = yield* Effect.forEach(
+      inside,
+      (entry) =>
+        hasAncestor({ fs, pid: entry.pid, ancestorPid: selfPid }).pipe(
+          Effect.map((self) => (self === true ? [entry.pid] : [])),
+        ),
+      { concurrency: 8 },
+    )
+    return classifyInUse({
+      processes: inside,
+      worktreePath,
+      excludePids: new Set(excluded.flat()),
+    })
+  })

--- a/packages/@overeng/megarepo/src/store/store-inuse.ts
+++ b/packages/@overeng/megarepo/src/store/store-inuse.ts
@@ -202,18 +202,19 @@ const readProcessCwds = (
   })
 
 /** Read macOS process cwd and parent evidence from the system `lsof`. */
-const readDarwinProcessCwds = (
-  selfPid: number,
-): Effect.Effect<ReadonlyArray<DarwinProcessCwd> | undefined, never, ChildProcessSpawner> =>
-  Effect.gen(function* () {
-    const spawner = yield* ChildProcessSpawner
-    const lines = yield* spawner
-      .lines(ChildProcess.make('/usr/sbin/lsof', ['-n', '-P', '-w', '-d', 'cwd', '-FpnR']))
-      .pipe(Effect.timeout('5 seconds'), Effect.option)
-    if (lines._tag === 'None') return undefined
-    const observed = parseLsofProcessCwds(lines.value)
-    return observed.some((entry) => entry.pid === selfPid) === true ? observed : undefined
-  })
+const readDarwinProcessCwds: Effect.Effect<
+  ReadonlyArray<DarwinProcessCwd> | undefined,
+  never,
+  ChildProcessSpawner
+> = Effect.gen(function* () {
+  const spawner = yield* ChildProcessSpawner
+  const lines = yield* spawner
+    .lines(ChildProcess.make('/usr/sbin/lsof', ['-n', '-P', '-w', '-d', 'cwd', '-FpnR']))
+    .pipe(Effect.timeout('5 seconds'), Effect.option)
+  if (lines._tag === 'None') return undefined
+  const observed = parseLsofProcessCwds(lines.value)
+  return observed.some((entry) => entry.pid === process.pid) === true ? observed : undefined
+})
 
 const hasDarwinAncestor = ({
   parentByPid,
@@ -279,7 +280,7 @@ export const readWorktreeInUse = ({
     if (process.platform !== 'darwin') {
       return { _tag: 'unknown', reason: 'no-proc' } as const
     }
-    const processes = yield* readDarwinProcessCwds(selfPid)
+    const processes = yield* readDarwinProcessCwds
     if (processes === undefined) return { _tag: 'unknown', reason: 'scan-failed' } as const
     const inside = processes.filter((entry) =>
       isInsideWorktree({ candidate: entry.path, worktreePath: canonicalWorktreePath }),

--- a/packages/@overeng/megarepo/src/store/store-inuse.ts
+++ b/packages/@overeng/megarepo/src/store/store-inuse.ts
@@ -251,12 +251,15 @@ export const readWorktreeInUse = ({
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem
     const hasProc = yield* fs.exists('/proc').pipe(Effect.orElseSucceed(() => false))
+    const canonicalWorktreePath = yield* fs
+      .realPath(worktreePath)
+      .pipe(Effect.orElseSucceed(() => worktreePath))
 
     if (hasProc === true) {
       const processes = yield* readProcessCwds(fs)
       if (processes === undefined) return { _tag: 'unknown', reason: 'scan-failed' } as const
       const inside = processes.filter((entry) =>
-        isInsideWorktree({ candidate: entry.path, worktreePath }),
+        isInsideWorktree({ candidate: entry.path, worktreePath: canonicalWorktreePath }),
       )
       const excluded = yield* Effect.forEach(
         inside,
@@ -268,7 +271,7 @@ export const readWorktreeInUse = ({
       )
       return classifyInUse({
         processes: inside,
-        worktreePath,
+        worktreePath: canonicalWorktreePath,
         excludePids: new Set(excluded.flat()),
       })
     }
@@ -279,12 +282,12 @@ export const readWorktreeInUse = ({
     const processes = yield* readDarwinProcessCwds(selfPid)
     if (processes === undefined) return { _tag: 'unknown', reason: 'scan-failed' } as const
     const inside = processes.filter((entry) =>
-      isInsideWorktree({ candidate: entry.path, worktreePath }),
+      isInsideWorktree({ candidate: entry.path, worktreePath: canonicalWorktreePath }),
     )
     const parentByPid = new Map(processes.map((entry) => [entry.pid, entry.parentPid]))
     return classifyInUse({
       processes: inside,
-      worktreePath,
+      worktreePath: canonicalWorktreePath,
       excludePids: new Set(
         inside
           .filter((entry) =>

--- a/packages/@overeng/megarepo/src/store/store-inuse.ts
+++ b/packages/@overeng/megarepo/src/store/store-inuse.ts
@@ -3,20 +3,22 @@
  *
  * The deletion lease only excludes an activation that takes it. A shell or agent
  * session that was already sitting inside a worktree holds no lease, and on
- * Linux a directory rename is invisible to a process already in that directory:
+ * Unix a directory rename is invisible to a process already in that directory:
  * its cwd silently follows the inode into `.archive/`, and the following git
  * bookkeeping strips the worktree out from under the live session. That is a
  * real incident class, not a hypothetical.
  *
  * So destructive reclamation additionally asks the strictly stronger question
  * the liveness manifest cannot answer: is a live OS process working inside this
- * directory right now? Evidence is `/proc/<pid>/cwd`. Conservative in both
- * directions that matter: no `/proc`, or an unreadable scan, is `unknown`, and
- * the caller treats `unknown` as in-use and keeps.
+ * directory right now? Evidence is `/proc/<pid>/cwd` on Linux and `lsof`'s cwd
+ * table on macOS. Conservative in both directions that matter: no supported
+ * process table, or an unreadable scan, is `unknown`, and the caller keeps.
  */
 
 import { Effect } from 'effect'
 import * as FileSystem from 'effect/FileSystem'
+import * as ChildProcess from 'effect/unstable/process/ChildProcess'
+import { ChildProcessSpawner } from 'effect/unstable/process/ChildProcessSpawner'
 
 import { type AbsoluteDirPath } from '@overeng/effect-path'
 
@@ -32,10 +34,14 @@ export type InUseResult =
   | { readonly _tag: 'in-use'; readonly holder: InUseHolder }
   | { readonly _tag: 'unknown'; readonly reason: 'no-proc' | 'scan-failed' }
 
-/** One observed process cwd, as read from `/proc/<pid>/cwd`. */
+/** One observed process cwd. */
 export interface ProcessCwd {
   readonly pid: number
   readonly path: string
+}
+
+interface DarwinProcessCwd extends ProcessCwd {
+  readonly parentPid: number | undefined
 }
 
 const normalizePath = (path: string): string => path.replace(/\/+$/, '')
@@ -89,6 +95,49 @@ const parsePpid = (statusContent: string): number | undefined => {
   if (line === undefined) return undefined
   const parsed = Number.parseInt(line.slice('PPid:'.length).trim(), 10)
   return Number.isSafeInteger(parsed) === true && parsed >= 0 ? parsed : undefined
+}
+
+const parsePidField = (value: string): number | undefined => {
+  const parsed = Number.parseInt(value, 10)
+  return `${parsed}` === value && Number.isSafeInteger(parsed) === true && parsed > 0
+    ? parsed
+    : undefined
+}
+
+/**
+ * Parse `lsof -d cwd -FpnR` output into one cwd record per visible process.
+ *
+ * Process fields precede the selected cwd file record. Keeping the parser pure
+ * makes the Darwin process-table contract independently testable on Linux.
+ */
+export const parseLsofProcessCwds = (
+  lines: ReadonlyArray<string>,
+): ReadonlyArray<DarwinProcessCwd> => {
+  const observed: Array<DarwinProcessCwd> = []
+  let pid: number | undefined
+  let parentPid: number | undefined
+  let path: string | undefined
+
+  const flush = () => {
+    if (pid !== undefined && path !== undefined) observed.push({ pid, parentPid, path })
+  }
+
+  for (const line of lines) {
+    const field = line[0]
+    const value = line.slice(1)
+    if (field === 'p') {
+      flush()
+      pid = parsePidField(value)
+      parentPid = undefined
+      path = undefined
+    } else if (field === 'R') {
+      parentPid = parsePidField(value)
+    } else if (field === 'n') {
+      path = value
+    }
+  }
+  flush()
+  return observed
 }
 
 /**
@@ -152,6 +201,40 @@ const readProcessCwds = (
     return observed.flatMap((entry) => (entry === undefined ? [] : [entry]))
   })
 
+/** Read macOS process cwd and parent evidence from the system `lsof`. */
+const readDarwinProcessCwds = (
+  selfPid: number,
+): Effect.Effect<ReadonlyArray<DarwinProcessCwd> | undefined, never, ChildProcessSpawner> =>
+  Effect.gen(function* () {
+    const spawner = yield* ChildProcessSpawner
+    const lines = yield* spawner
+      .lines(ChildProcess.make('/usr/sbin/lsof', ['-n', '-P', '-w', '-d', 'cwd', '-FpnR']))
+      .pipe(Effect.timeout('5 seconds'), Effect.option)
+    if (lines._tag === 'None') return undefined
+    const observed = parseLsofProcessCwds(lines.value)
+    return observed.some((entry) => entry.pid === selfPid) === true ? observed : undefined
+  })
+
+const hasDarwinAncestor = ({
+  parentByPid,
+  pid,
+  ancestorPid,
+}: {
+  parentByPid: ReadonlyMap<number, number | undefined>
+  pid: number
+  ancestorPid: number
+}): boolean => {
+  let current = pid
+  for (let depth = 0; depth < 64; depth += 1) {
+    if (current === ancestorPid) return true
+    if (current <= 1) return false
+    const parent = parentByPid.get(current)
+    if (parent === undefined) return false
+    current = parent
+  }
+  return false
+}
+
 /**
  * Probe whether a live process is working inside `worktreePath`.
  *
@@ -164,29 +247,50 @@ export const readWorktreeInUse = ({
 }: {
   worktreePath: AbsoluteDirPath | string
   selfPid?: number | undefined
-}): Effect.Effect<InUseResult, never, FileSystem.FileSystem> =>
+}): Effect.Effect<InUseResult, never, FileSystem.FileSystem | ChildProcessSpawner> =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem
-    if ((yield* fs.exists('/proc').pipe(Effect.orElseSucceed(() => false))) === false) {
+    const hasProc = yield* fs.exists('/proc').pipe(Effect.orElseSucceed(() => false))
+
+    if (hasProc === true) {
+      const processes = yield* readProcessCwds(fs)
+      if (processes === undefined) return { _tag: 'unknown', reason: 'scan-failed' } as const
+      const inside = processes.filter((entry) =>
+        isInsideWorktree({ candidate: entry.path, worktreePath }),
+      )
+      const excluded = yield* Effect.forEach(
+        inside,
+        (entry) =>
+          hasAncestor({ fs, pid: entry.pid, ancestorPid: selfPid }).pipe(
+            Effect.map((self) => (self === true ? [entry.pid] : [])),
+          ),
+        { concurrency: 8 },
+      )
+      return classifyInUse({
+        processes: inside,
+        worktreePath,
+        excludePids: new Set(excluded.flat()),
+      })
+    }
+
+    if (process.platform !== 'darwin') {
       return { _tag: 'unknown', reason: 'no-proc' } as const
     }
-    const processes = yield* readProcessCwds(fs)
+    const processes = yield* readDarwinProcessCwds(selfPid)
     if (processes === undefined) return { _tag: 'unknown', reason: 'scan-failed' } as const
-
     const inside = processes.filter((entry) =>
       isInsideWorktree({ candidate: entry.path, worktreePath }),
     )
-    const excluded = yield* Effect.forEach(
-      inside,
-      (entry) =>
-        hasAncestor({ fs, pid: entry.pid, ancestorPid: selfPid }).pipe(
-          Effect.map((self) => (self === true ? [entry.pid] : [])),
-        ),
-      { concurrency: 8 },
-    )
+    const parentByPid = new Map(processes.map((entry) => [entry.pid, entry.parentPid]))
     return classifyInUse({
       processes: inside,
       worktreePath,
-      excludePids: new Set(excluded.flat()),
+      excludePids: new Set(
+        inside
+          .filter((entry) =>
+            hasDarwinAncestor({ parentByPid, pid: entry.pid, ancestorPid: selfPid }),
+          )
+          .map((entry) => entry.pid),
+      ),
     })
   })

--- a/packages/@overeng/megarepo/src/store/store-liveness.integration.test.ts
+++ b/packages/@overeng/megarepo/src/store/store-liveness.integration.test.ts
@@ -429,10 +429,7 @@ describe('store-liveness', () => {
         const fs = yield* FileSystem.FileSystem
         const { storePath } = yield* createStoreFixture([])
         const store = yield* Effect.provide(Store, makeStoreLayer({ basePath: storePath }))
-        const stateDir = EffectPath.ops.join(
-          storePath,
-          EffectPath.unsafe.relativeDir('.state/'),
-        )
+        const stateDir = EffectPath.ops.join(storePath, EffectPath.unsafe.relativeDir('.state/'))
         yield* fs.makeDirectory(stateDir, { recursive: true })
         yield* fs.writeFileString(
           EffectPath.ops.join(stateDir, EffectPath.unsafe.relativeFile('workspaces')),

--- a/packages/@overeng/megarepo/src/store/store-liveness.integration.test.ts
+++ b/packages/@overeng/megarepo/src/store/store-liveness.integration.test.ts
@@ -422,4 +422,61 @@ describe('store-liveness', () => {
       Effect.scoped,
     ),
   )
+  it.effect(
+    'fails closed when the workspace registry cannot be enumerated',
+    Effect.fnUntraced(
+      function* () {
+        const fs = yield* FileSystem.FileSystem
+        const { storePath } = yield* createStoreFixture([])
+        const store = yield* Effect.provide(Store, makeStoreLayer({ basePath: storePath }))
+        const stateDir = EffectPath.ops.join(
+          storePath,
+          EffectPath.unsafe.relativeDir('.state/'),
+        )
+        yield* fs.makeDirectory(stateDir, { recursive: true })
+        yield* fs.writeFileString(
+          EffectPath.ops.join(stateDir, EffectPath.unsafe.relativeFile('workspaces')),
+          'not a directory',
+        )
+
+        const result = yield* collectStoreLiveSet({
+          store,
+          refreshCurrentWorkspace: false,
+        }).pipe(Effect.result)
+
+        expect(result._tag).toBe('Failure')
+      },
+      Effect.provide(NodeServices.layer),
+      Effect.scoped,
+    ),
+  )
+
+  it.effect(
+    'fails closed when a workspace registry record is malformed',
+    Effect.fnUntraced(
+      function* () {
+        const fs = yield* FileSystem.FileSystem
+        const { storePath } = yield* createStoreFixture([])
+        const store = yield* Effect.provide(Store, makeStoreLayer({ basePath: storePath }))
+        const registryDir = EffectPath.ops.join(
+          storePath,
+          EffectPath.unsafe.relativeDir('.state/workspaces/'),
+        )
+        yield* fs.makeDirectory(registryDir, { recursive: true })
+        yield* fs.writeFileString(
+          EffectPath.ops.join(registryDir, EffectPath.unsafe.relativeFile('broken.json')),
+          '{',
+        )
+
+        const result = yield* collectStoreLiveSet({
+          store,
+          refreshCurrentWorkspace: false,
+        }).pipe(Effect.result)
+
+        expect(result._tag).toBe('Failure')
+      },
+      Effect.provide(NodeServices.layer),
+      Effect.scoped,
+    ),
+  )
 })

--- a/packages/@overeng/megarepo/src/store/store-liveness.ts
+++ b/packages/@overeng/megarepo/src/store/store-liveness.ts
@@ -335,12 +335,10 @@ const readRegistryRecords = ({
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem
     const registryDir = workspaceRegistryDir(store)
-    const exists = yield* fs.exists(registryDir).pipe(Effect.orElseSucceed(() => false))
+    const exists = yield* fs.exists(registryDir)
     if (exists === false) return { records: [], uncleanReconcilePaths: new Set<string>() }
 
-    const entries = yield* fs
-      .readDirectory(registryDir)
-      .pipe(Effect.orElseSucceed(() => [] as string[]))
+    const entries = yield* fs.readDirectory(registryDir)
     const records: StoreWorkspaceRecord[] = []
     const uncleanReconcilePaths = new Set<string>()
 
@@ -351,20 +349,16 @@ const readRegistryRecords = ({
         Effect.flatMap((content) =>
           Schema.decodeUnknownEffect(Schema.fromJsonString(StoreWorkspaceRecord))(content),
         ),
-        Effect.orElseSucceed(() => null),
       )
-      if (parsed === null) continue
 
       const workspaceRoot = EffectPath.unsafe.absoluteDir(`${parsed.workspaceRoot}/`)
-      const workspaceExists = yield* fs
-        .exists(parsed.workspaceRoot)
-        .pipe(Effect.orElseSucceed(() => false))
+      const workspaceExists = yield* fs.exists(parsed.workspaceRoot)
 
       // Prune only when the workspace dir is GONE (decision 0010); a
       // present-but-unreadable workspace must never be pruned.
       if (workspaceExists === false) {
         if (pruneStale === true) {
-          yield* fs.remove(recordPath).pipe(Effect.catch(() => Effect.void))
+          yield* fs.remove(recordPath)
         }
         continue
       }

--- a/packages/@overeng/megarepo/src/store/store-liveness.ts
+++ b/packages/@overeng/megarepo/src/store/store-liveness.ts
@@ -345,11 +345,13 @@ const readRegistryRecords = ({
     for (const entry of entries) {
       if (entry.endsWith('.json') === false) continue
       const recordPath = EffectPath.ops.join(registryDir, EffectPath.unsafe.relativeFile(entry))
-      const parsed = yield* fs.readFileString(recordPath).pipe(
-        Effect.flatMap((content) =>
-          Schema.decodeUnknownEffect(Schema.fromJsonString(StoreWorkspaceRecord))(content),
-        ),
-      )
+      const parsed = yield* fs
+        .readFileString(recordPath)
+        .pipe(
+          Effect.flatMap((content) =>
+            Schema.decodeUnknownEffect(Schema.fromJsonString(StoreWorkspaceRecord))(content),
+          ),
+        )
 
       const workspaceRoot = EffectPath.unsafe.absoluteDir(`${parsed.workspaceRoot}/`)
       const workspaceExists = yield* fs.exists(parsed.workspaceRoot)

--- a/packages/@overeng/megarepo/src/store/store.ts
+++ b/packages/@overeng/megarepo/src/store/store.ts
@@ -315,8 +315,8 @@ const make = ({
           // Backstop: never descend past the layout's plausible repo depth, so a
           // pathological non-git directory tree can't drive an unbounded walk.
           if (depth >= STORE_REPO_WALK_MAX_DEPTH) {
-            return yield* Effect.dieMessage(
-              `store listRepos census exceeded the supported depth at ${dir}`,
+            return yield* Effect.die(
+              new Error(`store listRepos census exceeded the supported depth at ${dir}`),
             )
           }
 

--- a/packages/@overeng/megarepo/src/store/store.ts
+++ b/packages/@overeng/megarepo/src/store/store.ts
@@ -296,8 +296,9 @@ const make = ({
           // a real store and mis-claiming non-members:
           //  - `.git` present  → a checked-out worktree, never a namespace dir;
           //    its working tree (node_modules, …) must never be walked.
-          //  - `.state`/`.locks` present → a NESTED megarepo store (e.g. an
-          //    isolated experiment store), whose repos belong to it, not here.
+          //  - `.state`/`.locks` below the host namespace → a NESTED megarepo
+          //    store, whose repos belong to it, not here. Host namespaces may
+          //    carry `.state` metadata of their own.
           const hasGit = yield* fs.exists(
             EffectPath.ops.join(dir, EffectPath.unsafe.relativeFile('.git')),
           )
@@ -306,16 +307,17 @@ const make = ({
             fs.exists(EffectPath.ops.join(dir, EffectPath.unsafe.relativeDir('.state/'))),
             fs.exists(EffectPath.ops.join(dir, EffectPath.unsafe.relativeDir('.locks/'))),
           ])
-          const isNestedStore = hasNestedState === true && hasNestedLocks === true
+          const isHostNamespace = depth === 1 && dir.slice(basePath.length).includes('.')
+          const isNestedStore =
+            isHostNamespace === false && (hasNestedState === true || hasNestedLocks === true)
           if (isNestedStore === true) return
 
           // Backstop: never descend past the layout's plausible repo depth, so a
           // pathological non-git directory tree can't drive an unbounded walk.
           if (depth >= STORE_REPO_WALK_MAX_DEPTH) {
-            yield* Effect.logWarning(
-              'store listRepos: walk depth limit reached; not descending',
-            ).pipe(Effect.annotateLogs({ dir, depth }))
-            return
+            return yield* Effect.dieMessage(
+              `store listRepos census exceeded the supported depth at ${dir}`,
+            )
           }
 
           const entries = yield* fs.readDirectory(dir)

--- a/packages/@overeng/megarepo/src/store/store.ts
+++ b/packages/@overeng/megarepo/src/store/store.ts
@@ -302,10 +302,11 @@ const make = ({
             EffectPath.ops.join(dir, EffectPath.unsafe.relativeFile('.git')),
           )
           if (hasGit === true) return
-          const isNestedStore = yield* Effect.all([
+          const [hasNestedState, hasNestedLocks] = yield* Effect.all([
             fs.exists(EffectPath.ops.join(dir, EffectPath.unsafe.relativeDir('.state/'))),
             fs.exists(EffectPath.ops.join(dir, EffectPath.unsafe.relativeDir('.locks/'))),
-          ]).pipe(Effect.map(([state, locks]) => state === true || locks === true))
+          ])
+          const isNestedStore = hasNestedState === true && hasNestedLocks === true
           if (isNestedStore === true) return
 
           // Backstop: never descend past the layout's plausible repo depth, so a
@@ -329,8 +330,8 @@ const make = ({
                   dir,
                   EffectPath.unsafe.relativeDir(`${entry}/`),
                 )
-                const entryStat = yield* fs.stat(entryPath).pipe(Effect.orElseSucceed(() => null))
-                if (entryStat?.type !== 'Directory') return
+                const entryStat = yield* fs.stat(entryPath)
+                if (entryStat.type !== 'Directory') return
 
                 yield* walk({ dir: entryPath, depth: depth + 1 })
               }),
@@ -351,8 +352,8 @@ const make = ({
               basePath,
               EffectPath.unsafe.relativeDir(`${entry}/`),
             )
-            const entryStat = yield* fs.stat(entryPath).pipe(Effect.orElseSucceed(() => null))
-            if (entryStat?.type !== 'Directory') return
+            const entryStat = yield* fs.stat(entryPath)
+            if (entryStat.type !== 'Directory') return
 
             yield* walk({ dir: entryPath, depth: 1 })
           }),


### PR DESCRIPTION
## Problem

Megarepo store cleanup can plan broad garbage collection, but an external operator cannot safely apply one disk-index-selected candidate. Generated-artifact deletion also needs mutual exclusion with agent activation; a liveness snapshot alone has an activation-after-read race. Whole-worktree deletion also needs to veto already-running processes which predate the lease.

## Goal

Let an operator apply exactly one plan-bound worktree or generated-artifact candidate. Keep Megarepo as the sole deletion authority and fail closed when the census, plan, native st2 activity epoch, process liveness, or lease evidence changes.

## Decisions

- Bind apply to a canonical complete-plan SHA-256 plus one candidate path.
- Recompute under the owner lock before mutation.
- Consume the native `st2.workspace-activity.v1` envelope and require configured catalog/host epoch, complete/error-free generation-stable evidence, canonical claims, and freshness.
- Add native cwd vetoes for already-running processes: `/proc/<pid>/cwd` on Linux and the system `lsof` cwd table on macOS. Unknown evidence keeps the worktree.
- Canonicalize the candidate root before comparing process cwd evidence so filesystem aliases such as macOS `/var` → `/private/var` cannot bypass the veto.
- Use a per-owner hardlink deletion lease shared by GC and activation. Do not turn disk-index into an eligibility authority.
- Expose `mr store lease --owner-path <path> -- <command>` so external agent managers need no protocol implementation.
- Serialize stale recovery with a separate link-only recovery lock and require same-host, provably-dead ownership.

## Verification

- `devenv tasks run check:all` — passed on the final head.
- Focused regression suites: `store-inuse.integration.test.ts`, `store.integration.test.ts`, and `store-gc-otel.integration.test.ts` — 32 tests passed.
- macOS CI exercises the native `lsof` probe with a real holder process; Linux exercises the `/proc` probe.
- Deterministic concurrency regression reproduces the stale-recovery ABA interleaving when serialization is disabled and proves exactly one holder with serialization enabled.
- End-to-end process-veto regression uses a real external holder process, proves refusal while live, and succeeds after exit.
- Independent blocker review found no remaining safety blockers.

## Complexity

The lease is necessary because manifest rereads cannot order activation-before-write against deletion. The process veto is separate because a session already running before lease adoption holds no lease. Both remain owner-local; there is no shared census protocol.

## Concerns

A process crash while holding a recovery lock conservatively wedges stale recovery for that owner until an operator removes the recovery lock. Normal acquire and release remain available.

## Friction & bottlenecks

- The first quick-check invocation ran from the composed workspace root instead of its owned repository cell and produced misleading missing-file failures.
- A later quick-check encountered a stale owned-worktree acquisition lock from a dead process; the unchanged retry passed.
- The first full gate exposed the intended CLI help snapshot update; the rebaselined contract test and final full gate pass.
- macOS CI exposed that the initial Linux-only `/proc` implementation conservatively disabled reclamation on Darwin; the cross-platform probe and physical-path comparison now cover that platform.

## Follow-ups

- Adopt the lease wrapper in the host agent activation path before enabling generated-artifact mutation.
- Compose these owner transactions from the disk-index reclamation policy.
- Supersede the overlapping draft experiments #1086 and #820 after review; this PR reimplements their live contracts on the current store layout and closes their mutation-time gaps.

## References

- Refs #1125
- Supersedes #1086
- Supersedes #820

<!-- agent-footer:begin v=2 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | dev3.direct.omp.6vcqqcra |
| `session` | dev3.6vcqqcra |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.1.7 |
| `agent_runtime` | OMP 18.1.7 |
| `tooling_profile` | dotfiles@cf04941 |
</details>
<!-- agent-footer:end -->