### PR TITLE
feat(devenv): compose secrets tasks directly on SecretSpec 0.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -655,6 +655,15 @@ tsconfig.check.json`, but oxlint 1.39 cannot speak the tsgolint 7 protocol, so
   than duplicated; the accepted event-admission decision records the 35-minute
   performance-lane cost and preserves targeted Buck2 probes as admission
   evidence.
+
+- **devenv SecretSpec tasks**: move the shared secrets workflow onto native
+  SecretSpec 0.20. `secrets:check` now emits the value-free
+  `check --explain` report, `secrets:prefetch` resolves exactly the selected
+  profile through `secretspec run -- true`, and `secrets-run` forwards native
+  profile, provider, scope, file, reason, and caller controls directly. This is
+  a clean break: consumers must replace `[x-op-proxy.refs]` with native
+  provider-backed `ref` declarations, and the wrapper-specific `--cache` option
+  is removed because caching belongs to the configured provider.
 - **buck2 hub**: a Go toolchain and a content-addressed Go module supply. The
   hub declares a `go` `ToolchainAuthority` and `toolchains//:go_bootstrap`, and
   third-party Go code arrives as one `sha256`-pinned `http_archive` per module

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -662,8 +662,8 @@ tsconfig.check.json`, but oxlint 1.39 cannot speak the tsgolint 7 protocol, so
   profile through `secretspec run -- true`, and `secrets-run` forwards native
   profile, provider, scope, file, reason, and caller controls directly. This is
   a clean break: consumers must replace `[x-op-proxy.refs]` with native
-  provider-backed `ref` declarations, and the wrapper-specific `--cache` option
-  is removed because caching belongs to the configured provider.
+  provider-backed `ref` declarations. The wrapper-specific `--cache` option is
+  removed because cache policy belongs to the op-proxy server.
 - **buck2 hub**: a Go toolchain and a content-addressed Go module supply. The
   hub declares a `go` `ToolchainAuthority` and `toolchains//:go_bootstrap`, and
   third-party Go code arrives as one `sha256`-pinned `http_archive` per module

--- a/nix/devenv-modules/tasks/shared/secretspec.nix
+++ b/nix/devenv-modules/tasks/shared/secretspec.nix
@@ -13,8 +13,8 @@
 # Nothing here parses the manifest, discovers it by walking up from the cwd,
 # reads individual references, skips or filters environment variables, exports
 # values, or re-implements provider/profile/reason precedence. Provider-backed
-# values (e.g. the op-proxy provider) are resolved by the provider in one call
-# per selected profile and cached by the provider, not here.
+# values (e.g. the op-proxy provider) are resolved in one call per selected
+# profile; the op-proxy server, not this module or the provider, owns cache policy.
 {
   file ? "secretspec.toml",
 }:

--- a/nix/devenv-modules/tasks/shared/secretspec.nix
+++ b/nix/devenv-modules/tasks/shared/secretspec.nix
@@ -1,8 +1,20 @@
-# SecretSpec tasks and op-proxy-backed runtime injection.
+# SecretSpec tasks — a thin composition over SecretSpec 0.20.
 #
-# Repos commit a `secretspec.toml` with standard SecretSpec declarations.
-# Optional `[x-op-proxy.refs]` entries map env names to `op://...` references for
-# local development without using raw `op` or plaintext dotenv files.
+# Repos commit a `secretspec.toml` with standard SecretSpec declarations. Native
+# SecretSpec owns everything about them: manifest loading and `extends`, profile
+# compilation, requiredness, deterministic planning, provider selection,
+# resolved-over-ambient environment semantics, and reason/caller policy. This
+# module only names three task-shaped compositions on top of it:
+#
+#   secrets:check    -> secretspec check --explain   (value-free resolution report)
+#   secrets:prefetch -> secretspec run -- true       (one resolution of the selected profile)
+#   secrets-run CMD  -> secretspec run -- CMD        (direct run through the provider)
+#
+# Nothing here parses the manifest, discovers it by walking up from the cwd,
+# reads individual references, skips or filters environment variables, exports
+# values, or re-implements provider/profile/reason precedence. Provider-backed
+# values (e.g. the op-proxy provider) are resolved by the provider in one call
+# per selected profile and cached by the provider, not here.
 {
   file ? "secretspec.toml",
 }:
@@ -11,118 +23,34 @@ let
   trace = import ../lib/trace.nix { inherit lib; };
   secretspec = "${pkgs.secretspec}/bin/secretspec";
   escapedFile = lib.escapeShellArg file;
+
+  # `secrets-run` is a passthrough into `secretspec run`: every native flag
+  # (-P/--profile, -p/--provider, -S/--scope, --reason, --caller*, -f/--file)
+  # and every SECRETSPEC_* environment channel keeps its own precedence. The one
+  # thing this wrapper owns is defaulting the manifest to the repo's, and only
+  # when the caller did not select one and the repo actually has it.
   secretsRun = pkgs.writeShellApplication {
     name = "secrets-run";
-    runtimeInputs = [
-      pkgs.gawk
-      pkgs.secretspec
-    ];
     text = ''
       set -euo pipefail
 
-      secrets_file=""
-      profile_args=()
-      reason="run command with repo secrets"
-      cache="1d"
-
-      usage() {
-        cat >&2 <<'EOF'
-      Usage: secrets-run [--file secretspec.toml] [--profile name] [--reason text] [--cache ttl] -- command [args...]
-
-      Loads missing variables declared in [x-op-proxy.refs] via op-proxy, then
-      runs the command through `secretspec run --provider env`.
-      EOF
-      }
-
-      while [ "$#" -gt 0 ]; do
-        case "$1" in
-          -f|--file)
-            secrets_file="''${2:-}"
-            shift 2
-            ;;
-          -P|--profile)
-            profile_args+=(--profile "''${2:-}")
-            shift 2
-            ;;
-          --reason)
-            reason="''${2:-}"
-            shift 2
-            ;;
-          --cache)
-            cache="''${2:-}"
-            shift 2
-            ;;
-          --)
-            shift
-            break
-            ;;
-          -h|--help)
-            usage
-            exit 0
-            ;;
-          -*)
-            echo "Unknown option: $1" >&2
-            usage
-            exit 2
-            ;;
-          *)
-            break
-            ;;
-        esac
-      done
-
       if [ "$#" -eq 0 ]; then
-        usage
+        printf '%s\n' \
+          'Usage: secrets-run [secretspec flags] [--] command [args...]' \
+          "" \
+          'Runs a command through "secretspec run", resolving the selected profile' \
+          'once through the configured provider. Flags are forwarded verbatim to' \
+          'SecretSpec, for example:' \
+          '  -P, --profile NAME    -p, --provider NAME    -S, --scope NAME' \
+          '      --reason TEXT         --caller NAME      -f, --file PATH' >&2
         exit 2
       fi
 
-      if [ -z "$secrets_file" ]; then
-        dir="$PWD"
-        while true; do
-          if [ -f "$dir/secretspec.toml" ]; then
-            secrets_file="$dir/secretspec.toml"
-            break
-          fi
-          if [ "$dir" = "/" ]; then
-            echo "No secretspec.toml found; pass --file explicitly." >&2
-            exit 1
-          fi
-          dir="$(dirname "$dir")"
-        done
+      if [ -z "''${SECRETSPEC_FILE:-}" ] && [ -f ${escapedFile} ]; then
+        export SECRETSPEC_FILE=${escapedFile}
       fi
 
-      refs="$(gawk '
-        /^\[x-op-proxy\.refs\][[:space:]]*$/ { in_refs = 1; next }
-        /^\[/ { in_refs = 0 }
-        in_refs && /^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*[[:space:]]*=/ {
-          key = $0
-          sub(/^[[:space:]]*/, "", key)
-          sub(/[[:space:]]*=.*/, "", key)
-          value = $0
-          sub(/^[^=]*=[[:space:]]*"/, "", value)
-          sub(/"[[:space:]]*(#.*)?$/, "", value)
-          if (value ~ /^op:\/\//) {
-            printf "%s\t%s\n", key, value
-          }
-        }
-      ' "$secrets_file")"
-
-      if [ -n "$refs" ]; then
-        while IFS="$(printf '\t')" read -r name ref; do
-          [ -n "$name" ] || continue
-          if [ -n "''${!name:-}" ]; then
-            continue
-          fi
-          if ! command -v op-proxy >/dev/null 2>&1; then
-            echo "op-proxy is required to resolve missing [x-op-proxy.refs] entry: $name" >&2
-            exit 1
-          fi
-          value="$(op-proxy read "$ref" --reason "$reason" --cache "$cache")"
-          export "$name=$value"
-        done <<< "$refs"
-      fi
-
-      exec secretspec -f "$secrets_file" run --provider env "''${profile_args[@]}" -- "$@"
+      exec ${secretspec} run "$@"
     '';
   };
 in
@@ -134,26 +62,28 @@ in
 
   tasks = {
     "secrets:check" = {
-      description = "Check required secrets against the current process environment";
+      description = "Value-free SecretSpec resolution report for the selected profile";
       exec = trace.exec "secrets:check" ''
         set -euo pipefail
         if [ ! -f ${escapedFile} ]; then
           echo "No ${file}; nothing to check."
           exit 0
         fi
-        ${secretspec} -f ${escapedFile} check --provider env --no-prompt
+        export SECRETSPEC_REASON="''${SECRETSPEC_REASON:-devenv secrets:check}"
+        ${secretspec} --file ${escapedFile} check --explain
       '';
     };
 
     "secrets:prefetch" = {
-      description = "Resolve op-proxy-backed secrets into the op-proxy cache";
+      description = "Resolve the selected profile once so later commands reuse the approval";
       exec = trace.exec "secrets:prefetch" ''
         set -euo pipefail
         if [ ! -f ${escapedFile} ]; then
           echo "No ${file}; nothing to prefetch."
           exit 0
         fi
-        secrets-run --file ${escapedFile} --reason "prefetch repo secrets" -- true
+        export SECRETSPEC_REASON="''${SECRETSPEC_REASON:-devenv secrets:prefetch}"
+        ${secretspec} --file ${escapedFile} run -- true
       '';
     };
   };

--- a/nix/devenv-modules/tasks/shared/tests/secretspec-native-tasks.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/secretspec-native-tasks.test.sh
@@ -22,8 +22,8 @@ set -euo pipefail
 #   6. ERROR PROPAGATION: a failing resolution exits with the same code from
 #      both `secrets-run` and the task exec.
 #   7. NO LEGACY PATH: no gawk parser, no `[x-op-proxy.refs]`, no per-ref
-#      `op-proxy read`, no provider-local `--cache`, no env skip/filter, no
-#      exports, no env-provider handoff anywhere in the module or its scripts.
+#      `op-proxy read`, no wrapper `--cache`, no env skip/filter, no exports,
+#      and no env-provider handoff anywhere in the module or its scripts.
 #   8. STANDALONE REPO: with no manifest both tasks are a clean no-op (exit 0,
 #      zero resolution calls), which keeps repos without secrets working.
 

--- a/nix/devenv-modules/tasks/shared/tests/secretspec-native-tasks.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/secretspec-native-tasks.test.sh
@@ -1,0 +1,280 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Nix-layer coverage for the SecretSpec task module (tasks/shared/secretspec.nix)
+# after the clean break onto native SecretSpec 0.20. Proven WITHOUT a real
+# provider, a real op-proxy, or any real secret: the module is evaluated against
+# an overlay whose `secretspec` is a stub that records every invocation, so the
+# argv the module produces IS the observable contract.
+#
+#   1. ONE RESOLUTION CALL: `secrets:prefetch` over a 3-profile manifest makes
+#      exactly one `secretspec run -- true` call — one selected profile, no
+#      per-secret and no per-profile fan-out.
+#   2. VALUE-FREE CHECK: `secrets:check` is `check --explain` (never `run`,
+#      never `--provider env`) and prints no value.
+#   3. PROFILE FORWARDING: `secrets-run -P NAME` forwards the native flag
+#      verbatim; with no flag the module injects none, so the native
+#      SECRETSPEC_PROFILE channel decides. Same for --provider/--scope/--reason.
+#   4. FILE PRECEDENCE: a caller's SECRETSPEC_FILE is never overridden; the repo
+#      manifest is only a fallback default.
+#   5. REASON: tasks default the reason through the native env channel, and a
+#      caller-provided SECRETSPEC_REASON wins.
+#   6. ERROR PROPAGATION: a failing resolution exits with the same code from
+#      both `secrets-run` and the task exec.
+#   7. NO LEGACY PATH: no gawk parser, no `[x-op-proxy.refs]`, no per-ref
+#      `op-proxy read`, no provider-local `--cache`, no env skip/filter, no
+#      exports, no env-provider handoff anywhere in the module or its scripts.
+#   8. STANDALONE REPO: with no manifest both tasks are a clean no-op (exit 0,
+#      zero resolution calls), which keeps repos without secrets working.
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$TESTS_DIR/../../../../.." && pwd)"
+MODULE="$ROOT/nix/devenv-modules/tasks/shared/secretspec.nix"
+
+_pass=0
+_fail=0
+fail() {
+  echo "FAIL: $1" >&2
+  _fail=$((_fail + 1))
+}
+ok() {
+  _pass=$((_pass + 1))
+}
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+echo "Running secretspec-native-tasks test..."
+
+# --- stub `secretspec`: records argv + the native env channels, then exits ---
+cat > "$tmpdir/secretspec-stub.sh" <<'STUB'
+: "${SECRETSPEC_STUB_CAPTURE:?stub needs SECRETSPEC_STUB_CAPTURE}"
+{
+  printf 'CALL'
+  for arg in "$@"; do printf '\t%s' "$arg"; done
+  printf '\n'
+  printf 'ENV\tfile=%s\tprofile=%s\tprovider=%s\treason=%s\n' \
+    "${SECRETSPEC_FILE:-}" "${SECRETSPEC_PROFILE:-}" "${SECRETSPEC_PROVIDER:-}" "${SECRETSPEC_REASON:-}"
+} >> "$SECRETSPEC_STUB_CAPTURE"
+exit "${SECRETSPEC_STUB_EXIT:-0}"
+STUB
+
+nix_expr_prelude="
+  let
+    flake = builtins.getFlake \"$NIX_FLAKE_REF\";
+    pkgs = import flake.inputs.nixpkgs {
+      system = builtins.currentSystem;
+      overlays = [
+        (final: prev: {
+          secretspec = prev.writeShellScriptBin \"secretspec\" (builtins.readFile \"$tmpdir/secretspec-stub.sh\");
+        })
+      ];
+    };
+    mod = (import $MODULE { }) { lib = pkgs.lib; inherit pkgs; };
+  in"
+
+# `packages` is what devenv puts on PATH, so build exactly that.
+nix build --impure --no-link --print-out-paths --expr "
+  $nix_expr_prelude
+  pkgs.symlinkJoin {
+    name = \"secretspec-tasks-test-env\";
+    paths = mod.packages;
+  }
+" > "$tmpdir/env-path" || {
+  echo "FAIL: nix build of module packages" >&2
+  exit 1
+}
+binDir="$(cat "$tmpdir/env-path")/bin"
+[ -x "$binDir/secrets-run" ] || {
+  echo "FAIL: secrets-run not built at $binDir" >&2
+  exit 1
+}
+[ -x "$binDir/secretspec" ] || {
+  echo "FAIL: module must ship the secretspec CLI in packages" >&2
+  exit 1
+}
+
+task_exec() {
+  nix eval --impure --raw --expr "
+    $nix_expr_prelude
+    mod.tasks.\"$1\".exec
+  "
+}
+check_exec="$(task_exec secrets:check)"
+prefetch_exec="$(task_exec secrets:prefetch)"
+
+# --- a repo whose manifest declares three profiles ---
+repo="$tmpdir/repo"
+mkdir -p "$repo"
+cat > "$repo/secretspec.toml" <<'TOML'
+[project]
+name = "secretspec-tasks-test"
+revision = "1.0"
+
+[profiles.default]
+NOTION_TOKEN = { description = "notion", required = true }
+AIRTABLE_API_KEY = { description = "airtable", required = true }
+
+[profiles.deploy]
+DEPLOY_TOKEN = { description = "deploy", required = true }
+
+[profiles.signing]
+SIGNING_KEY = { description = "signing", required = true }
+TOML
+
+empty="$tmpdir/empty-repo"
+mkdir -p "$empty"
+
+# run_case <capture> <cwd> <mode: run|exec> <payload...> ; extra env via ENV_ARGS
+#
+# PATH holds ONLY the module's own packages, so a task or wrapper that silently
+# depends on an ambient tool (the old gawk/op-proxy path did) fails here.
+bash_bin="${BASH_BIN:-$(command -v bash)}"
+run_case() {
+  local capture="$1" cwd="$2" mode="$3"
+  shift 3
+  : > "$capture"
+  local rc=0
+  if [ "$mode" = exec ]; then
+    local body="$1"
+    shift
+    (
+      cd "$cwd" && env -i PATH="$binDir" HOME="$tmpdir" \
+        SECRETSPEC_STUB_CAPTURE="$capture" "${ENV_ARGS[@]}" \
+        "$bash_bin" -c "$body"
+    ) > "$capture.out" 2> "$capture.err" || rc=$?
+  else
+    (
+      cd "$cwd" && env -i PATH="$binDir" HOME="$tmpdir" \
+        SECRETSPEC_STUB_CAPTURE="$capture" "${ENV_ARGS[@]}" \
+        secrets-run "$@"
+    ) > "$capture.out" 2> "$capture.err" || rc=$?
+  fi
+  echo "$rc"
+}
+
+calls() { grep -c '^CALL' "$1" || true; }
+argv() { sed -n 's/^CALL\t//p' "$1" | head -1; }
+env_field() { sed -n "s/^ENV\t.*\b$2=\([^\t]*\).*/\1/p" "$1" | head -1; }
+
+ENV_ARGS=()
+
+# --- (1) ONE RESOLUTION CALL for one of three profiles ---
+cap="$tmpdir/cap-prefetch"
+ENV_ARGS=(SECRETSPEC_PROFILE=deploy)
+rc="$(run_case "$cap" "$repo" exec "$prefetch_exec")"
+[ "$rc" = 0 ] && ok || fail "secrets:prefetch exited $rc (stderr: $(cat "$cap.err"))"
+[ "$(calls "$cap")" = 1 ] \
+  && ok || fail "secrets:prefetch must make exactly ONE resolution call, made $(calls "$cap")"
+[ "$(argv "$cap")" = "--file	secretspec.toml	run	--	true" ] \
+  && ok || fail "secrets:prefetch argv should be '--file secretspec.toml run -- true', got '$(argv "$cap")'"
+[ "$(env_field "$cap" profile)" = deploy ] \
+  && ok || fail "secrets:prefetch must let the native SECRETSPEC_PROFILE channel select the profile"
+printf '%s' "$prefetch_exec" | grep -qF -- "--profile" \
+  && fail "secrets:prefetch must not inject its own --profile (native precedence owns it)" || ok
+grep -q 'NOTION_TOKEN\|AIRTABLE_API_KEY\|SIGNING_KEY' "$cap" \
+  && fail "secrets:prefetch must not name individual secrets or other profiles" || ok
+
+# --- (1b) reason default flows through the native env channel ---
+[ "$(env_field "$cap" reason)" = "devenv secrets:prefetch" ] \
+  && ok || fail "secrets:prefetch should default SECRETSPEC_REASON, got '$(env_field "$cap" reason)'"
+cap="$tmpdir/cap-prefetch-reason"
+ENV_ARGS=(SECRETSPEC_REASON="caller owned reason")
+rc="$(run_case "$cap" "$repo" exec "$prefetch_exec")"
+[ "$rc" = 0 ] && [ "$(env_field "$cap" reason)" = "caller owned reason" ] \
+  && ok || fail "a caller-provided SECRETSPEC_REASON must win, got '$(env_field "$cap" reason)'"
+
+# --- (2) VALUE-FREE CHECK ---
+cap="$tmpdir/cap-check"
+ENV_ARGS=()
+rc="$(run_case "$cap" "$repo" exec "$check_exec")"
+[ "$rc" = 0 ] && ok || fail "secrets:check exited $rc (stderr: $(cat "$cap.err"))"
+[ "$(calls "$cap")" = 1 ] \
+  && ok || fail "secrets:check must make exactly one call, made $(calls "$cap")"
+[ "$(argv "$cap")" = "--file	secretspec.toml	check	--explain" ] \
+  && ok || fail "secrets:check argv should be '--file secretspec.toml check --explain', got '$(argv "$cap")'"
+[ "$(env_field "$cap" reason)" = "devenv secrets:check" ] \
+  && ok || fail "secrets:check should default SECRETSPEC_REASON, got '$(env_field "$cap" reason)'"
+
+# --- (3) PROFILE / PROVIDER / REASON FORWARDING through secrets-run ---
+cap="$tmpdir/cap-run-profile"
+ENV_ARGS=()
+rc="$(run_case "$cap" "$repo" run -P deploy --reason "run deploy" -- echo hi)"
+[ "$rc" = 0 ] && ok || fail "secrets-run exited $rc (stderr: $(cat "$cap.err"))"
+[ "$(calls "$cap")" = 1 ] \
+  && ok || fail "secrets-run must make exactly one call, made $(calls "$cap")"
+[ "$(argv "$cap")" = "run	-P	deploy	--reason	run deploy	--	echo	hi" ] \
+  && ok || fail "secrets-run must forward native flags verbatim, got '$(argv "$cap")'"
+[ "$(env_field "$cap" file)" = "secretspec.toml" ] \
+  && ok || fail "secrets-run should default the manifest to the repo's, got '$(env_field "$cap" file)'"
+
+cap="$tmpdir/cap-run-bare"
+rc="$(run_case "$cap" "$repo" run -- true)"
+[ "$rc" = 0 ] && [ "$(argv "$cap")" = "run	--	true" ] \
+  && ok || fail "secrets-run with no flags must add none, got '$(argv "$cap")'"
+
+cap="$tmpdir/cap-run-usage"
+rc="$(run_case "$cap" "$repo" run)"
+[ "$rc" = 2 ] && [ "$(calls "$cap")" = 0 ] \
+  && ok || fail "secrets-run with no command must print usage and exit 2, got $rc"
+
+# --- (4) FILE PRECEDENCE: caller's SECRETSPEC_FILE is never overridden ---
+cap="$tmpdir/cap-run-file"
+ENV_ARGS=(SECRETSPEC_FILE="$tmpdir/caller.toml")
+rc="$(run_case "$cap" "$repo" run -- true)"
+[ "$(env_field "$cap" file)" = "$tmpdir/caller.toml" ] \
+  && ok || fail "secrets-run must not override a caller's SECRETSPEC_FILE, got '$(env_field "$cap" file)'"
+
+# --- (6) ERROR PROPAGATION ---
+cap="$tmpdir/cap-run-fail"
+ENV_ARGS=(SECRETSPEC_STUB_EXIT=17)
+rc="$(run_case "$cap" "$repo" run -- true)"
+[ "$rc" = 17 ] && ok || fail "secrets-run must propagate the resolution exit code 17, got $rc"
+cap="$tmpdir/cap-prefetch-fail"
+rc="$(run_case "$cap" "$repo" exec "$prefetch_exec")"
+[ "$rc" = 17 ] && ok || fail "secrets:prefetch must propagate the resolution exit code 17, got $rc"
+cap="$tmpdir/cap-check-fail"
+rc="$(run_case "$cap" "$repo" exec "$check_exec")"
+[ "$rc" = 17 ] && ok || fail "secrets:check must propagate the check exit code 17, got $rc"
+ENV_ARGS=()
+
+# --- (7) NO LEGACY PATH (module source + built script + task execs) ---
+legacy_pattern='gawk|x-op-proxy|op-proxy read|--cache|provider env|SECRETSPEC_STUB'
+for subject in "$MODULE" "$binDir/secrets-run"; do
+  if grep -Eq "$legacy_pattern" "$subject"; then
+    fail "legacy secrets path still present in $subject: $(grep -Eo "$legacy_pattern" "$subject" | sort -u | tr '\n' ' ')"
+  else
+    ok
+  fi
+done
+for body in "$check_exec" "$prefetch_exec"; do
+  if printf '%s' "$body" | grep -Eq "$legacy_pattern"; then
+    fail "legacy secrets path still present in a task exec"
+  else
+    ok
+  fi
+done
+# no per-ref public read and no value handling: the module never exports a
+# resolved value and never inspects the ambient environment for declared names.
+grep -Eq 'export "[^"]*=\$|\$\{!' "$MODULE" \
+  && fail "module must not export resolved values or indirect-expand env names" || ok
+# the closure must not need gawk any more
+nix path-info -r "$(cat "$tmpdir/env-path")" 2>/dev/null | grep -q -- '-gawk-' \
+  && fail "secrets-run closure still contains gawk" || ok
+
+# --- (8) STANDALONE REPO: no manifest -> clean no-op ---
+for pair in "check:$check_exec" "prefetch:$prefetch_exec"; do
+  name="${pair%%:*}"
+  body="${pair#*:}"
+  cap="$tmpdir/cap-empty-$name"
+  rc="$(run_case "$cap" "$empty" exec "$body")"
+  [ "$rc" = 0 ] && [ "$(calls "$cap")" = 0 ] \
+    && ok || fail "secrets:$name without a manifest must no-op (exit 0, no calls), got $rc/$(calls "$cap")"
+  grep -q "No secretspec.toml" "$cap.out" \
+    && ok || fail "secrets:$name without a manifest should say so, got '$(cat "$cap.out")'"
+done
+
+echo ""
+echo "$_pass passed, $_fail failed"
+[ "$_fail" -eq 0 ] && echo "secretspec-native-tasks test passed"
+[ "$_fail" -eq 0 ]

--- a/packages/@overeng/notion-react/docs/testing.md
+++ b/packages/@overeng/notion-react/docs/testing.md
@@ -108,7 +108,7 @@ Missing either env var silently skips the whole E2E suite via
 
 ## Pointing at a different Notion workspace
 
-Export `NOTION_API_TOKEN` and `NOTION_TEST_PARENT_PAGE_ID` in the local shell, or add op-proxy references for them under `[x-op-proxy.refs]` in `secretspec.toml`.
+Export `NOTION_API_TOKEN` and `NOTION_TEST_PARENT_PAGE_ID` in the local shell, or declare them in `secretspec.toml` with a provider-backed `ref` so the configured SecretSpec provider resolves them.
 
 Notes:
 


### PR DESCRIPTION
## Problem

The shared SecretSpec task module (`nix/devenv-modules/tasks/shared/secretspec.nix`) was written against SecretSpec 0.11, which could not compile profiles, plan resolution, or batch a provider. So the module grew its own half of a secrets runtime:

- a `gawk` parser for a non-standard `[x-op-proxy.refs]` manifest table,
- a second manifest discovery loop walking up from `$PWD`,
- an ambient-environment skip/filter deciding per variable whether to resolve,
- one `op-proxy read` per reference plus `export NAME=value` into the child,
- module-local `--cache 1d` / `--reason` defaults, and
- an env-provider handoff (`secretspec run --provider env`) so SecretSpec only saw what the wrapper had already exported.

Consequences, in the module as it stood: one user action fanned out to N provider reads (one approval each), the wrapper owned cache and reason policy that belongs to the op-proxy server, `secrets:check` meant "check my exported environment" rather than "check the manifest", and the manifest schema was non-portable — no other SecretSpec consumer or SDK could read those refs.

The pinned nixpkgs already provides SecretSpec 0.20.0:

```
$ nix eval --impure --raw --expr '(import (builtins.getFlake "git+file://$PWD").inputs.nixpkgs { system = builtins.currentSystem; }).secretspec.version'
0.20.0
```

0.20 owns all of it natively: manifest loading and `extends`, profile compilation, requiredness, deterministic planning, resolved-over-ambient environment semantics, provider selection, batched provider resolution, and reason/caller policy — plus a value-free `check --explain` report.

## Goal

The module contributes only what a task layer should: three named compositions over the real CLI, no secrets logic of its own.

```
secrets:check    -> secretspec check --explain   value-free resolution report
secrets:prefetch -> secretspec run -- true       one resolution of the selected profile
secrets-run CMD  -> secretspec run -- CMD        direct run through the configured provider
```

One selected profile resolves in exactly one provider call; the provider owns resolution; the op-proxy server owns approval and caching; native profile/provider/scope/reason/caller precedence is forwarded, not re-implemented; repos without a `secretspec.toml` keep working unchanged.

## Decisions

- **Forward native controls instead of re-deriving them.** `secrets-run` injects no flags at all — `-P/--profile`, `-p/--provider`, `-S/--scope`, `--reason`, `--caller*`, `-f/--file` and every `SECRETSPEC_*` env channel reach SecretSpec verbatim. Rejected: keeping the wrapper's own `--file/--profile/--reason/--cache` parser, which duplicated upstream precedence and silently outranked it.
- **Default the manifest through the env channel, not argv.** The wrapper exports `SECRETSPEC_FILE` only when the caller selected none *and* the repo manifest exists; a caller's `-f` or env value always wins, and with no repo manifest native walk-up discovery applies. Injecting `--file` alongside caller args would also risk a duplicate global-arg error once a caller passes `-f` itself.
- **Tasks default the reason through `SECRETSPEC_REASON`, not `--reason`.** 0.20 enforces a reason policy natively (`ensure_reason_for(AuditAction::Check)`), but a devenv task takes no flags. Setting `SECRETSPEC_REASON="${SECRETSPEC_REASON:-devenv secrets:check}"` gives the task a truthful default reason while a caller-provided reason still wins — one env fallback, no precedence logic.
- **`secrets:prefetch` stays, as a thin alias.** It is now literally `secretspec run -- true`: one resolution of the selected profile, so an explicit warm-up action still exists (approval acquired up front rather than mid-task) with no machinery behind it. Rejected: deleting prefetch entirely (drops a useful workflow step) and making `check` resolve values (conflicts with upstream's value-free `check`).
- **`secrets:prefetch` calls the CLI directly rather than `secrets-run`.** Keeps the task independent of PATH ordering; it is the same single call either way.
- **`check` is value-free, not provider-free.** 0.20 `check --explain` runs `report()` → `validate_audited(true, Materialize::None)`: it does contact the configured provider, it just never materializes, prints, mints or stores a value. The PR claims exactly that and no more.
- **Usage text uses builtin `printf`, not `cat` heredoc**, so `secrets-run` needs nothing on `PATH` but SecretSpec itself — which the new test enforces by running with `PATH` set to the module's own packages only.

## Verification

Focused, auto-discovered shell test (picked up by `devenv-modules:test`), run in this branch:

```
$ NIX_FLAKE_REF="git+file://$PWD" bash nix/devenv-modules/tasks/shared/tests/secretspec-native-tasks.test.sh
Running secretspec-native-tasks test...
32 passed, 0 failed
secretspec-native-tasks test passed
```

How it proves behavior rather than shape: the module is evaluated under an overlay whose `secretspec` is a recording stub, `symlinkJoin mod.packages` is built (the exact surface devenv puts on `PATH`), both task `exec` strings are `nix eval`-ed and executed with `env -i PATH=<module packages only>` in a fixture repo declaring **three** profiles. Asserted: exactly one resolution call for one of three profiles; exact argv for check and prefetch; `SECRETSPEC_PROFILE` selects the profile with no `--profile` injected; verbatim flag forwarding (`-P deploy --reason "run deploy" -- echo hi`); a caller's `SECRETSPEC_FILE` never overridden; reason default plus caller override; exit-code 17 propagation from `secrets-run`, `secrets:prefetch` and `secrets:check`; no parser/per-ref-read/env-provider strings in the module source, built script or task execs; no `gawk` in the closure (`nix path-info -r`); usage + exit 2 with no command; and no-manifest no-op for both tasks.

Mutation check that the test bites (reverted before commit): restoring `check --provider env --no-prompt` produced

```
FAIL: secrets:check argv should be '--file secretspec.toml check --explain', got '--file	secretspec.toml	check	--provider	env	--no-prompt'
FAIL: legacy secrets path still present in .../secretspec.nix: provider env
FAIL: legacy secrets path still present in a task exec
29 passed, 3 failed
```

Observable before → after for one user action over an 8-secret profile (argv the module produces):

```
before   op-proxy read <ref> --reason ... --cache 1d      x8   (8 approvals, 8 reads)
         then: secretspec run --provider env -- CMD            (SecretSpec sees only exports)
after    secretspec run -- CMD                                 (1 provider resolution, server-owned op-proxy cache)
```

Repo gate, run from the composed member checkout on the rebased head: the CI-equivalent gate (`genie:check` + `lint:check`) passes, and PR CI is 21 pass / 0 fail. Full `devenv tasks run check:quick` is red on one main-side lane only: `lint:nix:format` reports `nix/buck2-products/default.nix: not formatted`. That file is untouched by this branch and fails identically on pristine `main`; CI does not run `lint:nix`.

## Complexity

Net removal: the module drops from 160 to 90 lines and loses a dependency (`gawk`), a bespoke manifest schema, a CLI parser, and a cache/reason policy. The only added code is the test. No new abstraction or module boundary.

## Concerns

- `secrets-run` no longer accepts the old `--file/--profile/--reason/--cache` spellings as its own flags. `--file`, `--profile` and `--reason` still work because SecretSpec has them natively (`--profile` also as `-P`); `--cache` is gone by design — reuse/TTL is the op-proxy server's decision, not a caller flag. Any caller passing `--cache` fails loudly instead of silently doing something else.
- `[x-op-proxy.refs]` is no longer read at all. Manifests must declare secrets natively with a provider-backed `ref`; a manifest left on the old table resolves nothing and `check --explain` reports the secrets as missing. This is the intended clean break, and it is why this lands with the coordinated provider and manifest changes rather than alone.
- `secrets:check` contacts the configured provider (value-free). For a provider that gates access, `check` can therefore require a reason and, on first use, an approval — it is not a pure offline lint.
- Profile selection is now entirely native (`SECRETSPEC_PROFILE` / config / `-P`). A repo that relied on the wrapper's implicit single-profile behavior must name its profile the SecretSpec way.

## Friction & bottlenecks

- Friction: `writeShellApplication` runs shellcheck at build time, and SC2016 rejects backticks inside single-quoted usage text — a build failure for prose. Reworded; worth knowing before writing help text in a shell derivation.
- Friction: a `git worktree move` to normalize a branch/worktree name mismatch was rejected with `fatal: '<path>' already exists` for a relative destination under `refs/heads/...` (the path parses as a ref); the identical absolute destination worked.
- No measured bottleneck. The focused test builds two small derivations and completes in ~5s.

## Follow-ups

- Consumer manifests move to native declarations with provider-backed `ref`s and select the provider through manifest/SecretSpec config — this module intentionally passes no `--provider`. Tracked with the coordinated provider work outside this repo.
- No changeset: Nix/devenv and docs only, no published package surface.

## References

- SecretSpec 0.20 CLI surface: value-free `check --json/--explain`, global `--reason` / `--caller*`, `run --profile/--scope` — https://secretspec.dev
- Docs touched: `packages/@overeng/notion-react/docs/testing.md` (the workspace-switching note pointed at the removed `[x-op-proxy.refs]` table).

<!-- agent-footer:begin v=2 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | dev3.direct.omp.mc6sxyye |
| `session` | dev3.mc6sxyye |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.1.14 |
| `agent_runtime` | OMP 18.1.14 |
| `tooling_profile` | dotfiles@88367be |
</details>
<!-- agent-footer:end -->