### PR TITLE
chore(deps): upgrade Babel cohort to 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,15 @@ All notable changes to this project will be documented in this file.
   hand-written `MegarepoStore` test double, which no longer needs to supply
   the two dropped members. No behavior change.
 
+- **deps**: the `tw-to-stylex` catalog entry. It was a one-off Tailwind ->
+  StyleX first-pass tool for application files, never referenced by any package
+  in this repo or in any peer repo, and its hand-pass requirement (it silently
+  drops React Aria `data-[*]` state and emits raw values where the token rules
+  require semantic tokens) meant it never paid for holding the whole Babel
+  cohort a major version back. Removed rather than carried forward with an
+  override: an unused alpha dependency is not worth a pinned-old-version
+  exception.
+
 ### Fixed
 - **CI**: keep draft assistant PRs mergeable by completing the auto-review job
   successfully when no review request is needed.
@@ -240,6 +249,13 @@ All notable changes to this project will be documented in this file.
   asset list is unchanged — upstream's `binaries` set still ends at
   `starlark_fmt` — and toolchain identity is in the action key, so this
   invalidates cached Buck actions once.
+- **deps**: Babel moves to 8 (`@babel/core` 8.0.1, `@babel/plugin-syntax-jsx`
+  8.0.1, `@babel/plugin-syntax-typescript` 8.0.3). The Babel 7 hold was not a
+  compatibility fact about our own code — nothing in the workspace imports
+  Babel — it was the transitional `tw-to-stylex` converter, whose only two
+  releases (`0.1.0-alpha.0`/`0.1.0-alpha.1`, both February 2026) depend on
+  `@babel/plugin-syntax-typescript@^7`, which peers `@babel/core@^7` and so
+  fails `strictPeerDependencies` against Babel 8.
 
 - **CI**: normalize the repository-local CI VRS under `context/ci/` and make
   workflow event admission semantic. Pull requests now trigger only for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,7 +137,7 @@ All notable changes to this project will be documented in this file.
 
 - **deps**: the `tw-to-stylex` catalog entry. It was a one-off Tailwind ->
   StyleX first-pass tool for application files, never referenced by any package
-  in this repo or in any peer repo, and its hand-pass requirement (it silently
+  in this repo, and its hand-pass requirement (it silently
   drops React Aria `data-[*]` state and emits raw values where the token rules
   require semantic tokens) meant it never paid for holding the whole Babel
   cohort a major version back. Removed rather than carried forward with an

--- a/genie/external.ts
+++ b/genie/external.ts
@@ -357,31 +357,19 @@ export const catalog = defineCatalog({
   '@stylexjs/eslint-plugin': '0.19.0',
 
   /**
-   * Transitional Tailwind -> StyleX converter, used only as a first pass on
-   * **application** files. Never point it at a shared component package: it
-   * drops React Aria `data-[*]` state and the variant library's slots, and its
-   * output uses raw values where the token rules require semantic tokens, so a
-   * hand-pass is required regardless.
+   * Babel pins for anything in the workspace that registers a Babel plugin by
+   * name: Babel resolves plugin names relative to the *calling* package, not
+   * the plugin's own tree, so the caller has to declare every plugin it names
+   * or the invocation dies with ERR_MODULE_NOT_FOUND.
    *
-   * Only `tw-to-stylex/sync` (or the default export used as a Babel plugin with
-   * options) can be told to report what it dropped. Always pass
-   * `{ logUnsupported: true }`: it defaults to false, and a silent drop is the
-   * dangerous failure mode. The `tw-to-stylex` CLI takes the default and cannot
-   * be made to log, so do not use it. Even with logging on, `data-[*]` classes
-   * are dropped without a warning — audit those by hand.
-   *
-   * The three `@babel/*` pins are undeclared resolution requirements, not
-   * conveniences. Babel resolves plugin names relative to the *calling*
-   * package, not the plugin's own tree, so the consumer must declare them even
-   * though `tw-to-stylex` lists `@babel/plugin-syntax-typescript` as a
-   * dependency; without them every invocation dies with ERR_MODULE_NOT_FOUND.
-   * Held on Babel 7 because `@babel/plugin-syntax-typescript@7` peers
-   * `@babel/core@^7`, and Babel 8 therefore trips `strictPeerDependencies`.
+   * Babel 8's syntax plugins peer `@babel/core@^8`, so the three move as one
+   * cohort — a split generation is rejected by `strictPeerDependencies`.
+   * Babel 8 also raises the runtime floor to Node `^22.18.0 || >=24.11.0`,
+   * which the repo's `nodejs_24` toolchain satisfies.
    */
-  'tw-to-stylex': '0.1.0-alpha.1',
-  '@babel/core': '7.29.7',
-  '@babel/plugin-syntax-jsx': '7.29.7',
-  '@babel/plugin-syntax-typescript': '7.29.7',
+  '@babel/core': '8.0.1',
+  '@babel/plugin-syntax-jsx': '8.0.1',
+  '@babel/plugin-syntax-typescript': '8.0.3',
 
   // Storybook
   // 10.5.x is the floor for the visual gate: `storybookTest({ initialGlobals })`


### PR DESCRIPTION
## Problem

The unused `tw-to-stylex` alpha dependency held the repository's Babel catalog on version 7 through its Babel 7 peer requirements, even though no workspace package imports Babel or uses the converter.

## Goal

Remove `tw-to-stylex` and move the remaining Babel cohort together to `@babel/core` 8.0.1, `@babel/plugin-syntax-jsx` 8.0.1, and `@babel/plugin-syntax-typescript` 8.0.3.

## Decisions

Keep this independent compatibility-sensitive cohort separate from the compatible dependency update in #1225. Remove the unused converter rather than add a peer override; Babel core and syntax plugins move together to satisfy strict peer dependencies. This PR does not upgrade the Effect RC cohort.

## Verification

- Current GitHub CI completed with 20 checks passing and 6 intentionally skipped; no check failed. Passed coverage includes `typecheck`, `lint`, both Linux and macOS test matrices, both `nix-check` and `nix-fod-check` matrices, `pnpm-builder-contract`, `pnpm-regression`, `bundle-smoke`, and `source-shape`.
- The diff removes the `tw-to-stylex` catalog entry and changes only the three retained Babel pins in `genie/external.ts`, plus the changelog.
- Pre-flip deviation: `devenv tasks run check:all` was not run because the current-`main` regression tracked by schickling/dotfiles#2602 makes that gate invoke destructive `mr:apply` behavior; the focused checks in current CI are used instead.

## Complexity

No new complexity; one unused dependency is removed and three existing pins move in lockstep.

## Concerns

Babel 8 raises its Node runtime floor to `^22.18.0 || >=24.11.0`; the repository's pinned Node 24 toolchain satisfies it.

## Friction & bottlenecks

Local project-wide validation is blocked by schickling/dotfiles#2602. No measurable bottleneck was observed.

## Follow-ups

None.

## References

- Base compatible dependency cohort: #1225
- Pre-flip validation regression: schickling/dotfiles#2602

<!-- agent-footer:begin v=2 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | dev3.direct.omp.nsyk4mvc |
| `session` | dev3.nsyk4mvc |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.1.7 |
| `agent_runtime` | OMP 18.1.7 |
| `tooling_profile` | dotfiles@8d937c9 |
</details>
<!-- agent-footer:end -->