### PR TITLE
chore(deps): update Restate SDK and server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -618,6 +618,28 @@ tsconfig.check.json`, but oxlint 1.39 cannot speak the tsgolint 7 protocol, so
   staged FOD source includes the root `pnpm-lock.yaml` and fingerprints it
   into the derivation name, so any lockfile change rotates every
   prepared-deps hash.
+- **deps (Restate)**: update the Restate cohort — the JavaScript SDK
+  (`@restatedev/restate-sdk`, `-sdk-clients`, `-sdk-opentelemetry`, and the
+  transitive `-sdk-core`) 1.14.5 -> 1.17.0, and the prebuilt `restate-server` /
+  `restate` CLI in `nix/restate.nix` 1.6.2 -> 1.7.9. The SDK bump carries one
+  breaking change — Node 22 is now the SDK's minimum supported version, which
+  the repo's `nodejs_24` already satisfies — plus `restate.iface` typed service
+  interfaces (1.17), ingress auto-retry and scoped virtual-object clients
+  (1.16), and signals/`InvocationReference`, `PauseError`, and flow-control
+  scopes (1.15); none of the deprecated or renamed surfaces
+  (`@restatedev/restate-sdk-gen`'s `clients` adapter, `restate-sdk-tunnel`
+  reconnect options) are used here. `@restatedev/restate-sdk-opentelemetry@1.17`
+  peers on `@opentelemetry/api >=1.9.0` and `@opentelemetry/core >=2.6.0`, both
+  satisfied by the existing pinned OTel cohort, so the OTel catalog is
+  unchanged. The 1.7 server's breaking configuration changes (snapshot
+  `num-retained`, per-database RocksDB background budgets, enforced ingress
+  request-size limit) touch no key the `./testing` harness sets — it configures
+  only bind/advertised addresses, request identity, log filter, invoker
+  inactivity timeout, and the default retry policy. `./admin` remains written
+  against admin-api-version 3, whose per-id invocation verbs 1.7.9 still
+  serves; its "verified against 1.6.2" notes are left as the last
+  hand-verified point and are re-checked by the `test-integration-restate`
+  lane against the new server rather than by an unverifiable doc edit.
 
 - **CI**: normalize the repository-local CI VRS under `context/ci/` and make
   workflow event admission semantic. Pull requests now trigger only for

--- a/buck2/dependencies/BUCK
+++ b/buck2/dependencies/BUCK
@@ -3,7 +3,7 @@
 
 # Generated file - DO NOT EDIT
 # Source: pnpm-lock.yaml
-# Store fingerprint: sha256:12e0e730ae6200d2c05b50dd0d455fa0afa8c077eff078b9fc1e3bf8968c7c1f
+# Store fingerprint: sha256:0d1a547dfdf101c0045c442e35f35451d563592a1faf4a9b5caec8d9f84b73aa
 
 load("//buck2:materialization.bzl", "export_materialization_inputs")
 
@@ -1652,37 +1652,37 @@ pnpm_package(
 )
 
 pnpm_package(
-    name = "package_restatedev_restate_sdk_clients_1_14_5_a971f34d5252",
+    name = "package_restatedev_restate_sdk_clients_1_17_0_2951ec1ddfca",
     package_name = "@restatedev/restate-sdk-clients",
-    url = "https://registry.npmjs.org/@restatedev/restate-sdk-clients/-/restate-sdk-clients-1.14.5.tgz",
-    sha256 = "4bc979def3219e2dee6fc9072c28fb1bc2ee84dcacf738b5a20634c802dd3d3c",
+    url = "https://registry.npmjs.org/@restatedev/restate-sdk-clients/-/restate-sdk-clients-1.17.0.tgz",
+    sha256 = "551997d51e34b2b5b24812e200c607e69962efd76859fea71008bc28f6c6ba70",
     bins = {
     },
 )
 
 pnpm_package(
-    name = "package_restatedev_restate_sdk_core_1_14_5_2ef145b1bfd0",
+    name = "package_restatedev_restate_sdk_core_1_17_0_c3ee91927806",
     package_name = "@restatedev/restate-sdk-core",
-    url = "https://registry.npmjs.org/@restatedev/restate-sdk-core/-/restate-sdk-core-1.14.5.tgz",
-    sha256 = "368f42f9cc8d1f654b497a0bc263a6fee15f5373e7d694f26be87b8272b22a55",
+    url = "https://registry.npmjs.org/@restatedev/restate-sdk-core/-/restate-sdk-core-1.17.0.tgz",
+    sha256 = "1d73532983b4e28b84f3469f89f889b62fb59b4f363da79f724338efa86a4522",
     bins = {
     },
 )
 
 pnpm_package(
-    name = "package_restatedev_restate_sdk_opentelemetry_1_14_5_382fb492a739",
+    name = "package_restatedev_restate_sdk_opentelemetry_1_17_0_c4ebd3a07d81",
     package_name = "@restatedev/restate-sdk-opentelemetry",
-    url = "https://registry.npmjs.org/@restatedev/restate-sdk-opentelemetry/-/restate-sdk-opentelemetry-1.14.5.tgz",
-    sha256 = "3dcfdce24773841bcd2361ca055f91b7e3345d359cb391abc09275a87bac21ea",
+    url = "https://registry.npmjs.org/@restatedev/restate-sdk-opentelemetry/-/restate-sdk-opentelemetry-1.17.0.tgz",
+    sha256 = "b570c5108011ac592573af36f9d63abe57390b10afb311b43c6a17c200c147e0",
     bins = {
     },
 )
 
 pnpm_package(
-    name = "package_restatedev_restate_sdk_1_14_5_49221c3b922c",
+    name = "package_restatedev_restate_sdk_1_17_0_698cf31e7587",
     package_name = "@restatedev/restate-sdk",
-    url = "https://registry.npmjs.org/@restatedev/restate-sdk/-/restate-sdk-1.14.5.tgz",
-    sha256 = "610d04db29f75fa0e271b693a547d2f22f7cf17176ec85eb766dac0ff39c7746",
+    url = "https://registry.npmjs.org/@restatedev/restate-sdk/-/restate-sdk-1.17.0.tgz",
+    sha256 = "39153cdb91e5cdfe90993d2cacae0c055e3d431dbe6cd7029a3b363d5ad2b909",
     bins = {
     },
 )
@@ -8358,20 +8358,20 @@ pnpm_store_entry(
 )
 
 pnpm_store_entry(
-    name = "entry_restatedev_restate_sdk_clients_1_14_5_a971f34d5252",
-    package = ":package_restatedev_restate_sdk_clients_1_14_5_a971f34d5252",
-    store_key = "@restatedev+restate-sdk-clients@1.14.5",
+    name = "entry_restatedev_restate_sdk_clients_1_17_0_2951ec1ddfca",
+    package = ":package_restatedev_restate_sdk_clients_1_17_0_2951ec1ddfca",
+    store_key = "@restatedev+restate-sdk-clients@1.17.0",
     runtime = ":assemble-store.ts",
     dependencies = {
-        "@restatedev/restate-sdk-core": ":entry_restatedev_restate_sdk_core_1_14_5_2ef145b1bfd0",
+        "@restatedev/restate-sdk-core": ":entry_restatedev_restate_sdk_core_1_17_0_c3ee91927806",
     },
     visibility = ["PUBLIC"],
 )
 
 pnpm_store_entry(
-    name = "entry_restatedev_restate_sdk_core_1_14_5_2ef145b1bfd0",
-    package = ":package_restatedev_restate_sdk_core_1_14_5_2ef145b1bfd0",
-    store_key = "@restatedev+restate-sdk-core@1.14.5",
+    name = "entry_restatedev_restate_sdk_core_1_17_0_c3ee91927806",
+    package = ":package_restatedev_restate_sdk_core_1_17_0_c3ee91927806",
+    store_key = "@restatedev+restate-sdk-core@1.17.0",
     runtime = ":assemble-store.ts",
     dependencies = {
     },
@@ -8379,25 +8379,25 @@ pnpm_store_entry(
 )
 
 pnpm_store_entry(
-    name = "entry_restatedev_restate_sdk_opentelemetry_1_14_5_opentelemetry_api_1_9_1_open_662f553ab2ad",
-    package = ":package_restatedev_restate_sdk_opentelemetry_1_14_5_382fb492a739",
-    store_key = "@restatedev+restate-sdk-opentelemetry@1.14.5_@opentelemetry+api@1.9.1_@opentelemetry+core@2.11.0_@opent_63b6f7e42cd3523e",
+    name = "entry_restatedev_restate_sdk_opentelemetry_1_17_0_opentelemetry_api_1_9_1_open_36bcd961f741",
+    package = ":package_restatedev_restate_sdk_opentelemetry_1_17_0_c4ebd3a07d81",
+    store_key = "@restatedev+restate-sdk-opentelemetry@1.17.0_@opentelemetry+api@1.9.1_@opentelemetry+core@2.11.0_@opent_34d9bd20f00167ae",
     runtime = ":assemble-store.ts",
     dependencies = {
         "@opentelemetry/api": ":entry_opentelemetry_api_1_9_1_65aff18a9fc4",
         "@opentelemetry/core": ":entry_opentelemetry_core_2_11_0_opentelemetry_api_1_9_1_d60465c5ae17",
-        "@restatedev/restate-sdk": ":entry_restatedev_restate_sdk_1_14_5_49221c3b922c",
+        "@restatedev/restate-sdk": ":entry_restatedev_restate_sdk_1_17_0_698cf31e7587",
     },
     visibility = ["PUBLIC"],
 )
 
 pnpm_store_entry(
-    name = "entry_restatedev_restate_sdk_1_14_5_49221c3b922c",
-    package = ":package_restatedev_restate_sdk_1_14_5_49221c3b922c",
-    store_key = "@restatedev+restate-sdk@1.14.5",
+    name = "entry_restatedev_restate_sdk_1_17_0_698cf31e7587",
+    package = ":package_restatedev_restate_sdk_1_17_0_698cf31e7587",
+    store_key = "@restatedev+restate-sdk@1.17.0",
     runtime = ":assemble-store.ts",
     dependencies = {
-        "@restatedev/restate-sdk-core": ":entry_restatedev_restate_sdk_core_1_14_5_2ef145b1bfd0",
+        "@restatedev/restate-sdk-core": ":entry_restatedev_restate_sdk_core_1_17_0_c3ee91927806",
     },
     visibility = ["PUBLIC"],
 )
@@ -32547,9 +32547,9 @@ pnpm_store_view(
         "@opentelemetry/sdk-trace-web": "@opentelemetry+sdk-trace-web@2.11.0_@opentelemetry+api@1.9.1",
         "@opentelemetry/semantic-conventions": "@opentelemetry+semantic-conventions@1.43.0",
         "@playwright/test": "@playwright+test@1.63.0",
-        "@restatedev/restate-sdk": "@restatedev+restate-sdk@1.14.5",
-        "@restatedev/restate-sdk-clients": "@restatedev+restate-sdk-clients@1.14.5",
-        "@restatedev/restate-sdk-opentelemetry": "@restatedev+restate-sdk-opentelemetry@1.14.5_@opentelemetry+api@1.9.1_@opentelemetry+core@2.11.0_@opent_63b6f7e42cd3523e",
+        "@restatedev/restate-sdk": "@restatedev+restate-sdk@1.17.0",
+        "@restatedev/restate-sdk-clients": "@restatedev+restate-sdk-clients@1.17.0",
+        "@restatedev/restate-sdk-opentelemetry": "@restatedev+restate-sdk-opentelemetry@1.17.0_@opentelemetry+api@1.9.1_@opentelemetry+core@2.11.0_@opent_34d9bd20f00167ae",
         "@types/node": "@types+node@26.5.0",
         "effect": "effect@4.0.0-rc.111",
         "typescript": "typescript@7.0.2",
@@ -32583,10 +32583,10 @@ pnpm_store_view(
             "@redis+json@6.2.1_@redis+client@6.2.1_@opentelemetry+api@1.9.1": ":entry_redis_json_6_2_1_redis_client_6_2_1_opentelemetry_api_1_9_1_9e468cc3d6d8",
             "@redis+search@6.2.1_@redis+client@6.2.1_@opentelemetry+api@1.9.1": ":entry_redis_search_6_2_1_redis_client_6_2_1_opentelemetry_api_1_9_1_ff890285deba",
             "@redis+time-series@6.2.1_@redis+client@6.2.1_@opentelemetry+api@1.9.1": ":entry_redis_time_series_6_2_1_redis_client_6_2_1_opentelemetry_api_1_9_1_e4d2523e153b",
-            "@restatedev+restate-sdk-clients@1.14.5": ":entry_restatedev_restate_sdk_clients_1_14_5_a971f34d5252",
-            "@restatedev+restate-sdk-core@1.14.5": ":entry_restatedev_restate_sdk_core_1_14_5_2ef145b1bfd0",
-            "@restatedev+restate-sdk-opentelemetry@1.14.5_@opentelemetry+api@1.9.1_@opentelemetry+core@2.11.0_@opent_63b6f7e42cd3523e": ":entry_restatedev_restate_sdk_opentelemetry_1_14_5_opentelemetry_api_1_9_1_open_662f553ab2ad",
-            "@restatedev+restate-sdk@1.14.5": ":entry_restatedev_restate_sdk_1_14_5_49221c3b922c",
+            "@restatedev+restate-sdk-clients@1.17.0": ":entry_restatedev_restate_sdk_clients_1_17_0_2951ec1ddfca",
+            "@restatedev+restate-sdk-core@1.17.0": ":entry_restatedev_restate_sdk_core_1_17_0_c3ee91927806",
+            "@restatedev+restate-sdk-opentelemetry@1.17.0_@opentelemetry+api@1.9.1_@opentelemetry+core@2.11.0_@opent_34d9bd20f00167ae": ":entry_restatedev_restate_sdk_opentelemetry_1_17_0_opentelemetry_api_1_9_1_open_36bcd961f741",
+            "@restatedev+restate-sdk@1.17.0": ":entry_restatedev_restate_sdk_1_17_0_698cf31e7587",
             "@rolldown+pluginutils@1.0.1": ":entry_rolldown_pluginutils_1_0_1_3f649c36a41c",
             "@standard-schema+spec@1.1.0": ":entry_standard_schema_spec_1_1_0_9bfb5ac2eb33",
             "@types+chai@5.2.3": ":entry_types_chai_5_2_3_fee6bcdc2771",
@@ -32687,10 +32687,10 @@ pnpm_store_view(
             "@redis+json@6.2.1_@redis+client@6.2.1_@opentelemetry+api@1.9.1": ":entry_redis_json_6_2_1_redis_client_6_2_1_opentelemetry_api_1_9_1_9e468cc3d6d8",
             "@redis+search@6.2.1_@redis+client@6.2.1_@opentelemetry+api@1.9.1": ":entry_redis_search_6_2_1_redis_client_6_2_1_opentelemetry_api_1_9_1_ff890285deba",
             "@redis+time-series@6.2.1_@redis+client@6.2.1_@opentelemetry+api@1.9.1": ":entry_redis_time_series_6_2_1_redis_client_6_2_1_opentelemetry_api_1_9_1_e4d2523e153b",
-            "@restatedev+restate-sdk-clients@1.14.5": ":entry_restatedev_restate_sdk_clients_1_14_5_a971f34d5252",
-            "@restatedev+restate-sdk-core@1.14.5": ":entry_restatedev_restate_sdk_core_1_14_5_2ef145b1bfd0",
-            "@restatedev+restate-sdk-opentelemetry@1.14.5_@opentelemetry+api@1.9.1_@opentelemetry+core@2.11.0_@opent_63b6f7e42cd3523e": ":entry_restatedev_restate_sdk_opentelemetry_1_14_5_opentelemetry_api_1_9_1_open_662f553ab2ad",
-            "@restatedev+restate-sdk@1.14.5": ":entry_restatedev_restate_sdk_1_14_5_49221c3b922c",
+            "@restatedev+restate-sdk-clients@1.17.0": ":entry_restatedev_restate_sdk_clients_1_17_0_2951ec1ddfca",
+            "@restatedev+restate-sdk-core@1.17.0": ":entry_restatedev_restate_sdk_core_1_17_0_c3ee91927806",
+            "@restatedev+restate-sdk-opentelemetry@1.17.0_@opentelemetry+api@1.9.1_@opentelemetry+core@2.11.0_@opent_34d9bd20f00167ae": ":entry_restatedev_restate_sdk_opentelemetry_1_17_0_opentelemetry_api_1_9_1_open_36bcd961f741",
+            "@restatedev+restate-sdk@1.17.0": ":entry_restatedev_restate_sdk_1_17_0_698cf31e7587",
             "@rolldown+binding-linux-arm64-gnu@1.2.7": ":entry_rolldown_binding_linux_arm64_gnu_1_2_7_b564cdf057d1",
             "@rolldown+pluginutils@1.0.1": ":entry_rolldown_pluginutils_1_0_1_3f649c36a41c",
             "@standard-schema+spec@1.1.0": ":entry_standard_schema_spec_1_1_0_9bfb5ac2eb33",
@@ -32794,10 +32794,10 @@ pnpm_store_view(
             "@redis+json@6.2.1_@redis+client@6.2.1_@opentelemetry+api@1.9.1": ":entry_redis_json_6_2_1_redis_client_6_2_1_opentelemetry_api_1_9_1_9e468cc3d6d8",
             "@redis+search@6.2.1_@redis+client@6.2.1_@opentelemetry+api@1.9.1": ":entry_redis_search_6_2_1_redis_client_6_2_1_opentelemetry_api_1_9_1_ff890285deba",
             "@redis+time-series@6.2.1_@redis+client@6.2.1_@opentelemetry+api@1.9.1": ":entry_redis_time_series_6_2_1_redis_client_6_2_1_opentelemetry_api_1_9_1_e4d2523e153b",
-            "@restatedev+restate-sdk-clients@1.14.5": ":entry_restatedev_restate_sdk_clients_1_14_5_a971f34d5252",
-            "@restatedev+restate-sdk-core@1.14.5": ":entry_restatedev_restate_sdk_core_1_14_5_2ef145b1bfd0",
-            "@restatedev+restate-sdk-opentelemetry@1.14.5_@opentelemetry+api@1.9.1_@opentelemetry+core@2.11.0_@opent_63b6f7e42cd3523e": ":entry_restatedev_restate_sdk_opentelemetry_1_14_5_opentelemetry_api_1_9_1_open_662f553ab2ad",
-            "@restatedev+restate-sdk@1.14.5": ":entry_restatedev_restate_sdk_1_14_5_49221c3b922c",
+            "@restatedev+restate-sdk-clients@1.17.0": ":entry_restatedev_restate_sdk_clients_1_17_0_2951ec1ddfca",
+            "@restatedev+restate-sdk-core@1.17.0": ":entry_restatedev_restate_sdk_core_1_17_0_c3ee91927806",
+            "@restatedev+restate-sdk-opentelemetry@1.17.0_@opentelemetry+api@1.9.1_@opentelemetry+core@2.11.0_@opent_34d9bd20f00167ae": ":entry_restatedev_restate_sdk_opentelemetry_1_17_0_opentelemetry_api_1_9_1_open_36bcd961f741",
+            "@restatedev+restate-sdk@1.17.0": ":entry_restatedev_restate_sdk_1_17_0_698cf31e7587",
             "@rolldown+binding-linux-x64-gnu@1.2.7": ":entry_rolldown_binding_linux_x64_gnu_1_2_7_2b8bc0885731",
             "@rolldown+pluginutils@1.0.1": ":entry_rolldown_pluginutils_1_0_1_3f649c36a41c",
             "@standard-schema+spec@1.1.0": ":entry_standard_schema_spec_1_1_0_9bfb5ac2eb33",
@@ -32901,10 +32901,10 @@ pnpm_store_view(
             "@redis+json@6.2.1_@redis+client@6.2.1_@opentelemetry+api@1.9.1": ":entry_redis_json_6_2_1_redis_client_6_2_1_opentelemetry_api_1_9_1_9e468cc3d6d8",
             "@redis+search@6.2.1_@redis+client@6.2.1_@opentelemetry+api@1.9.1": ":entry_redis_search_6_2_1_redis_client_6_2_1_opentelemetry_api_1_9_1_ff890285deba",
             "@redis+time-series@6.2.1_@redis+client@6.2.1_@opentelemetry+api@1.9.1": ":entry_redis_time_series_6_2_1_redis_client_6_2_1_opentelemetry_api_1_9_1_e4d2523e153b",
-            "@restatedev+restate-sdk-clients@1.14.5": ":entry_restatedev_restate_sdk_clients_1_14_5_a971f34d5252",
-            "@restatedev+restate-sdk-core@1.14.5": ":entry_restatedev_restate_sdk_core_1_14_5_2ef145b1bfd0",
-            "@restatedev+restate-sdk-opentelemetry@1.14.5_@opentelemetry+api@1.9.1_@opentelemetry+core@2.11.0_@opent_63b6f7e42cd3523e": ":entry_restatedev_restate_sdk_opentelemetry_1_14_5_opentelemetry_api_1_9_1_open_662f553ab2ad",
-            "@restatedev+restate-sdk@1.14.5": ":entry_restatedev_restate_sdk_1_14_5_49221c3b922c",
+            "@restatedev+restate-sdk-clients@1.17.0": ":entry_restatedev_restate_sdk_clients_1_17_0_2951ec1ddfca",
+            "@restatedev+restate-sdk-core@1.17.0": ":entry_restatedev_restate_sdk_core_1_17_0_c3ee91927806",
+            "@restatedev+restate-sdk-opentelemetry@1.17.0_@opentelemetry+api@1.9.1_@opentelemetry+core@2.11.0_@opent_34d9bd20f00167ae": ":entry_restatedev_restate_sdk_opentelemetry_1_17_0_opentelemetry_api_1_9_1_open_36bcd961f741",
+            "@restatedev+restate-sdk@1.17.0": ":entry_restatedev_restate_sdk_1_17_0_698cf31e7587",
             "@rolldown+binding-darwin-arm64@1.2.7": ":entry_rolldown_binding_darwin_arm64_1_2_7_c213ca2a9ab4",
             "@rolldown+pluginutils@1.0.1": ":entry_rolldown_pluginutils_1_0_1_3f649c36a41c",
             "@standard-schema+spec@1.1.0": ":entry_standard_schema_spec_1_1_0_9bfb5ac2eb33",

--- a/buck2/dependencies/pnpm-lock.sha256.json
+++ b/buck2/dependencies/pnpm-lock.sha256.json
@@ -1,6 +1,6 @@
 {
   "schema": "effect-utils/buck2-pnpm-sha256/v1",
-  "lockfileFingerprint": "sha256:3c6a6f0b4ed3e25bd82f6c7705923aa113b101e15ce57966553535c126cbbd9b",
+  "lockfileFingerprint": "sha256:2eb92198e041871736284c44b32b50f5b9ae00cf3622d5f5331af31334ddbfc4",
   "source": "pnpm-lock.yaml",
   "generator": "buck2/dependencies/pnpm-lock.sha256.json.genie.ts",
   "regenerate": "devenv tasks run genie:run",
@@ -3447,5 +3447,5 @@
       "sha256": "2c162e000f5fb5a816987d6f8ad7aad295203f777a5992d514ae4660778a51a4"
     }
   },
-  "fingerprint": "sha256:4dd38833c660520e124476042e22cfb5fa9f7e68ae220c3ac1aa1f24e88ee1b7"
+  "fingerprint": "sha256:ff29ee951507fc0bd05cc6869bd4b53fc92596407c83a5316d27f386129678ba"
 }

--- a/buck2/dependencies/pnpm-lock.sha256.json
+++ b/buck2/dependencies/pnpm-lock.sha256.json
@@ -906,25 +906,25 @@
       "integrity": "sha512-kiYniph04dJOole+L359B6C9E+jYS2uDP7hca6Onj0xF38ZIpyxARO0Iq0W4ZRn1e8Q6vqW00QFZVSMRA/2Ijw==",
       "sha256": "c402c6675f638f90eb7df679ac15651d5667d27dbb175099ead4b8cabb1787cd"
     },
-    "@restatedev/restate-sdk-clients@1.14.5": {
+    "@restatedev/restate-sdk-clients@1.17.0": {
       "bins": {},
-      "integrity": "sha512-uVcjpiMr+7JEMNL3ZeVYxR4UbfoxmamgiOhwdKB42rBpESg0uBtgOgg6CKdeF1sJKEQusUwWE8rm6q+jw+Sb5A==",
-      "sha256": "4bc979def3219e2dee6fc9072c28fb1bc2ee84dcacf738b5a20634c802dd3d3c"
+      "integrity": "sha512-5gz4x9PP/KV5HD/8VUZTVQaX/YsGocOkZ8dLX1q7Pb+Km9sU4wMytciFCJ9SlyH33o0s5iRcpFNR0Soaz+B42g==",
+      "sha256": "551997d51e34b2b5b24812e200c607e69962efd76859fea71008bc28f6c6ba70"
     },
-    "@restatedev/restate-sdk-core@1.14.5": {
+    "@restatedev/restate-sdk-core@1.17.0": {
       "bins": {},
-      "integrity": "sha512-MvlRhyFhnNMDLFRz2t5TbhebIkIAI8oN2reRgoAj9OMADK0xn7mOuBbWHwGF+8MsFfBXmV1HrNqpAXltEeNzqg==",
-      "sha256": "368f42f9cc8d1f654b497a0bc263a6fee15f5373e7d694f26be87b8272b22a55"
+      "integrity": "sha512-439ONo+YDoG4YBZnQ0wXaWkJDdOqDJ0AjqOwUAYZolxoC5JoaHqWzEFWkeRXiSNpsOc1+ODRUUGupDQ7qxcvJg==",
+      "sha256": "1d73532983b4e28b84f3469f89f889b62fb59b4f363da79f724338efa86a4522"
     },
-    "@restatedev/restate-sdk-opentelemetry@1.14.5": {
+    "@restatedev/restate-sdk-opentelemetry@1.17.0": {
       "bins": {},
-      "integrity": "sha512-87D/E0H8Px1XbUiJTp0O8aOu6AWC4UgzecwtP3M8b5zNhdE/wSyHUiCI3JvMEzfj6YNbSHV3xNDLWe/AQ+uWQg==",
-      "sha256": "3dcfdce24773841bcd2361ca055f91b7e3345d359cb391abc09275a87bac21ea"
+      "integrity": "sha512-JsjXFURQ813zh0ArANKkGNTwXY74CgSSh6JKrxcw/LkfwOsyEvo3DbvdI0KLgWktFaYfGXK5Rz5739JW5lnjmw==",
+      "sha256": "b570c5108011ac592573af36f9d63abe57390b10afb311b43c6a17c200c147e0"
     },
-    "@restatedev/restate-sdk@1.14.5": {
+    "@restatedev/restate-sdk@1.17.0": {
       "bins": {},
-      "integrity": "sha512-RvuJU/Ji9MSgLkRBN1pLeGm/AdrpFl380SZZ0sPk/NWC9jpZyX2fntJx7NbIqfQ4PfoTm1/zPH8/gn7AQGuSaQ==",
-      "sha256": "610d04db29f75fa0e271b693a547d2f22f7cf17176ec85eb766dac0ff39c7746"
+      "integrity": "sha512-4b3OrB2M8K0MsG4JA4YBYQgSZpUUdle4gxUrrH7Qs3deOwuAtrdabkKJpRWtR45zvQDdi09gzxwUGee0aCqKmA==",
+      "sha256": "39153cdb91e5cdfe90993d2cacae0c055e3d431dbe6cd7029a3b363d5ad2b909"
     },
     "@rolldown/binding-android-arm-eabi@1.2.7": {
       "bins": {},

--- a/genie/external.ts
+++ b/genie/external.ts
@@ -321,9 +321,9 @@ export const catalog = defineCatalog({
   '@myobie/pty': '0.10.0',
 
   // Restate (durable execution) — see packages/@overeng/restate-effect
-  '@restatedev/restate-sdk': '1.14.5',
-  '@restatedev/restate-sdk-clients': '1.14.5',
-  '@restatedev/restate-sdk-opentelemetry': '1.14.5',
+  '@restatedev/restate-sdk': '1.17.0',
+  '@restatedev/restate-sdk-clients': '1.17.0',
+  '@restatedev/restate-sdk-opentelemetry': '1.17.0',
 
   // Type definitions
   '@types/react': '19.2.18',

--- a/nix/restate.nix
+++ b/nix/restate.nix
@@ -39,7 +39,7 @@ let
   lib = pkgs.lib;
 
   # https://github.com/restatedev/restate/releases for the latest version.
-  version = "1.6.2";
+  version = "1.7.9";
 
   baseUrl = "https://github.com/restatedev/restate/releases/download/v${version}";
 
@@ -56,20 +56,20 @@ let
   # the rest are derived from the assets' `.sha256` sidecars.
   hashes = {
     x86_64-linux = {
-      server = "sha256-DQIui+7+TmHdpzVFCEg5WsYOWBrdN+rQI9j4E9NxK+E=";
-      cli = "sha256-1nG/JDS0EN3wPPc/c5FMzs7dYL/D1m6EGj1/klgTnlQ=";
+      server = "sha256-w25mCaWRqqWRTdIRQySednRXBLVx1KVzXBymwgsTvc8=";
+      cli = "sha256-qwW8Y9FrZGotwntTinkNm0SURW8hDHkljhxt2nQACEY=";
     };
     aarch64-linux = {
-      server = "sha256-w11Uiz6+wToxg8asu93Bw2VqHyZCPX0TrxQXc6CcbPE=";
-      cli = "sha256-Fq1qKWTDmFU66NqRD3bTazvorZqKwwGWORjwb4rRhp0=";
+      server = "sha256-W2nHwKblW7cIApJM6CLqCUPYLZtsrBV/JOuF14jTWXY=";
+      cli = "sha256-KqMeIY6yoAcmYY3PZlknuQdIq9qAi/Tqn5rd3HFogAs=";
     };
     x86_64-darwin = {
-      server = "sha256-RMnJPsvnwPsR8eVQ2ZxJZE1fmsksPvXMl5Zh63U3LtU=";
-      cli = "sha256-bM/zQ+NFqtsNQPj9DywJ6Ei8aaRIaaO07LWj6FF0i1w=";
+      server = "sha256-z8fNLoZwvsBivx53H2fuKDQuvxNm6e3K8MBydPCZfLo=";
+      cli = "sha256-kANn4FvAbtXMchwGPvp250MWSxFGciG7g7m0hsy9i/E=";
     };
     aarch64-darwin = {
-      server = "sha256-EmtLA883y1mYxpypQ4atMhgGEk65t2SzuKM2MDww72E=";
-      cli = "sha256-jBsd+4KUrUSRaBkoMGW8ipi56rDKhWRyRilHfZxufuw=";
+      server = "sha256-7bK3N1Jf/cXc0kSdB0IVr78EFKx7Qf/+Dwu3h4UixYw=";
+      cli = "sha256-VY2ZoGLFeGLJryo5Di2yEKGZ/YNmo+BAH82maiHcRYw=";
     };
   };
 

--- a/packages/@overeng/ci-tools/nix/build.nix
+++ b/packages/@overeng/ci-tools/nix/build.nix
@@ -19,7 +19,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-Ix9O9JsGVwROepo66pGThubYyhK0mjbe04aTlJAhZtQ=";
+      "." = mkSharedHash "sha256-6beDKMIzyIaqNirWOGM1QSeEv6wE8i14X3fzyEepA2A=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/genie/nix/build.nix
+++ b/packages/@overeng/genie/nix/build.nix
@@ -31,7 +31,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-520EAYXJtDJsO1ksstE0VJzK8Vxt1bpUfsFQ4Or/7x0=";
+      "." = mkSharedHash "sha256-LKAcHsE+iiWOTer0NLZryZGWeSgxAkqXXzlbkIFQ/t0=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/megarepo/nix/build.nix
+++ b/packages/@overeng/megarepo/nix/build.nix
@@ -26,7 +26,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-y/D/HIkSJKJdcpXBag2mTIeqs+dYWkkrOojv7NYzbRY=";
+      "." = mkSharedHash "sha256-UCumijrFdvI/xi4q0ASWlpXVyDgMgBCyAWKtpKkQNS0=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     smokeTestArgs = [ "--help" ];

--- a/packages/@overeng/notion-cli/nix/build.nix
+++ b/packages/@overeng/notion-cli/nix/build.nix
@@ -33,7 +33,7 @@ let
     installRuntimeWorkspace = true;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-gKPJk+1pR8OqBT0x7qnIhLNUJvErRQ3ZsaRjaISXa2Y=";
+      "." = mkSharedHash "sha256-0SWP7gW2pRRJgLLR2axXPq0Xn5vlJ/iuhWTy1/LEl7U=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/notion-md/nix/build.nix
+++ b/packages/@overeng/notion-md/nix/build.nix
@@ -20,7 +20,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-rdxVU64jUYymKjeRs5s0xT6jAIow/rzPVX85Or27YOA=";
+      "." = mkSharedHash "sha256-OotDzXiGgkxrR7UubZogwpZW762936gIRtl6wvJWHZs=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/npm-release/nix/build.nix
+++ b/packages/@overeng/npm-release/nix/build.nix
@@ -20,7 +20,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-F7QBz0X9FL8+6sHG4qEHEc2pDnTCjXZT3MiQp9iqd+4=";
+      "." = mkSharedHash "sha256-oulC6ok8tOhamdcTUFwIMqmv/3/0T71HdNkmqyaUOo8=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/oxc-config/nix/build.nix
+++ b/packages/@overeng/oxc-config/nix/build.nix
@@ -14,7 +14,7 @@ import ../../../../nix/oxc-config-plugin.nix {
     ;
   # Managed by Evergreen FOD refresh — do not edit manually.
   depsBuilds = {
-    "." = mkSharedHash "sha256-+DAahk1Zva/5BbTXP+7VM/wEl5QJw9b5RKUKbD0F2dw=";
+    "." = mkSharedHash "sha256-NFRkVu0iTXrQO341Tdy10etMt9UeZb6uaN6JXsDxpRE=";
   };
   hashSourcePath = "packages/@overeng/oxc-config/nix/build.nix";
 }

--- a/packages/@overeng/restate-effect/docs/vrs/requirements.md
+++ b/packages/@overeng/restate-effect/docs/vrs/requirements.md
@@ -55,7 +55,7 @@ the map of which subsystem owns which requirement. The global Assumptions
   (`@effect/opentelemetry`, `@restatedev/restate-sdk-opentelemetry`) are an
   opt-in subpath; the core stays dependency-light.
 - **A10 Server floor ≥1.6:** The binding targets `restate-server` ≥1.6
-  (`nix/restate.nix` pins 1.6.2). Features that need ≥1.6 (e.g. the
+  (`nix/restate.nix` pins 1.7.9). Features that need ≥1.6 (e.g. the
   `metadata._tag` best-effort extra on terminal errors) assume this floor.
 - **A11 Deployment immutability:** A `Deployment` is immutable and versioned; the
   `restate-server` owns deployment versioning and the replay/upgrade contract

--- a/packages/@overeng/restate-effect/package.json
+++ b/packages/@overeng/restate-effect/package.json
@@ -23,8 +23,8 @@
   },
   "dependencies": {
     "@overeng/otel-contract": "workspace:^",
-    "@restatedev/restate-sdk": "1.14.5",
-    "@restatedev/restate-sdk-clients": "1.14.5"
+    "@restatedev/restate-sdk": "1.17.0",
+    "@restatedev/restate-sdk-clients": "1.17.0"
   },
   "devDependencies": {
     "@effect/opentelemetry": "4.0.0-rc.111",
@@ -39,7 +39,7 @@
     "@opentelemetry/semantic-conventions": "1.43.0",
     "@overeng/utils": "workspace:../utils",
     "@overeng/utils-dev": "workspace:^",
-    "@restatedev/restate-sdk-opentelemetry": "1.14.5",
+    "@restatedev/restate-sdk-opentelemetry": "1.17.0",
     "@types/node": "26.5.0",
     "effect": "4.0.0-rc.111",
     "typescript": "7.0.2",
@@ -51,7 +51,7 @@
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/sdk-metrics": "^2.11.0",
     "@playwright/test": "^1.63.0",
-    "@restatedev/restate-sdk-opentelemetry": "^1.14.5",
+    "@restatedev/restate-sdk-opentelemetry": "^1.17.0",
     "effect": "^4.0.0-rc.111"
   },
   "publishConfig": {

--- a/packages/@overeng/restate-effect/src/runtime/Runtime.ts
+++ b/packages/@overeng/restate-effect/src/runtime/Runtime.ts
@@ -207,14 +207,15 @@ export const withAttemptInterruption = <A, E, R>({
 /**
  * Cancel ANOTHER invocation from inside a handler (cooperative cancel — the
  * target surfaces an Effect interruption at its next await point, so its
- * finalizers/compensations run; docs/vrs/04-error-boundary/spec.md §2). Backed by `ctx.cancel`. The
+ * finalizers/compensations run; docs/vrs/04-error-boundary/spec.md §2). Backed by
+ * the SDK's invocation reference. The
  * invocation id is the opaque handle returned by a prior `send` / submission.
  * Requires `RestateContext` (legal in any handler kind).
  */
 export const cancel = (invocationId: string): Effect.Effect<void, never, RestateContext> =>
   Effect.gen(function* () {
     const ctx = yield* RestateContext
-    ctx.cancel(restate.InvocationIdParser.fromString(invocationId))
+    ctx.invocation(restate.InvocationIdParser.fromString(invocationId)).cancel()
   }).pipe(withRestateOperation({ name: 'restate.cancel', label: invocationId }))
 
 /**

--- a/packages/@overeng/tui-stories/nix/build.nix
+++ b/packages/@overeng/tui-stories/nix/build.nix
@@ -21,7 +21,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-4Js+MWstU83VT6YhnJyrEas1fTCwdRlGx15bakLIsvA=";
+      "." = mkSharedHash "sha256-6aEtvLDYPG+LyyyoASnIEoZwKX+jwMjtIf4WKEpUcVU=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1376,11 +1376,11 @@ importers:
         specifier: ^1.63.0
         version: 1.63.0
       '@restatedev/restate-sdk':
-        specifier: 1.14.5
-        version: 1.14.5
+        specifier: 1.17.0
+        version: 1.17.0
       '@restatedev/restate-sdk-clients':
-        specifier: 1.14.5
-        version: 1.14.5
+        specifier: 1.17.0
+        version: 1.17.0
     devDependencies:
       '@effect/opentelemetry':
         specifier: 4.0.0-rc.111
@@ -1419,8 +1419,8 @@ importers:
         specifier: workspace:^
         version: link:../utils-dev
       '@restatedev/restate-sdk-opentelemetry':
-        specifier: 1.14.5
-        version: 1.14.5(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))(@restatedev/restate-sdk@1.14.5)
+        specifier: 1.17.0
+        version: 1.17.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))(@restatedev/restate-sdk@1.17.0)
       '@types/node':
         specifier: 26.5.0
         version: 26.5.0
@@ -2692,21 +2692,21 @@ packages:
     peerDependencies:
       '@redis/client': ^6.2.1
 
-  '@restatedev/restate-sdk-clients@1.14.5':
-    resolution: {integrity: sha512-uVcjpiMr+7JEMNL3ZeVYxR4UbfoxmamgiOhwdKB42rBpESg0uBtgOgg6CKdeF1sJKEQusUwWE8rm6q+jw+Sb5A==}
+  '@restatedev/restate-sdk-clients@1.17.0':
+    resolution: {integrity: sha512-5gz4x9PP/KV5HD/8VUZTVQaX/YsGocOkZ8dLX1q7Pb+Km9sU4wMytciFCJ9SlyH33o0s5iRcpFNR0Soaz+B42g==}
 
-  '@restatedev/restate-sdk-core@1.14.5':
-    resolution: {integrity: sha512-MvlRhyFhnNMDLFRz2t5TbhebIkIAI8oN2reRgoAj9OMADK0xn7mOuBbWHwGF+8MsFfBXmV1HrNqpAXltEeNzqg==}
+  '@restatedev/restate-sdk-core@1.17.0':
+    resolution: {integrity: sha512-439ONo+YDoG4YBZnQ0wXaWkJDdOqDJ0AjqOwUAYZolxoC5JoaHqWzEFWkeRXiSNpsOc1+ODRUUGupDQ7qxcvJg==}
 
-  '@restatedev/restate-sdk-opentelemetry@1.14.5':
-    resolution: {integrity: sha512-87D/E0H8Px1XbUiJTp0O8aOu6AWC4UgzecwtP3M8b5zNhdE/wSyHUiCI3JvMEzfj6YNbSHV3xNDLWe/AQ+uWQg==}
+  '@restatedev/restate-sdk-opentelemetry@1.17.0':
+    resolution: {integrity: sha512-JsjXFURQ813zh0ArANKkGNTwXY74CgSSh6JKrxcw/LkfwOsyEvo3DbvdI0KLgWktFaYfGXK5Rz5739JW5lnjmw==}
     peerDependencies:
       '@opentelemetry/api': '>=1.9.0'
       '@opentelemetry/core': '>=2.6.0'
-      '@restatedev/restate-sdk': ^1.14.5
+      '@restatedev/restate-sdk': ^1.15.0
 
-  '@restatedev/restate-sdk@1.14.5':
-    resolution: {integrity: sha512-RvuJU/Ji9MSgLkRBN1pLeGm/AdrpFl380SZZ0sPk/NWC9jpZyX2fntJx7NbIqfQ4PfoTm1/zPH8/gn7AQGuSaQ==}
+  '@restatedev/restate-sdk@1.17.0':
+    resolution: {integrity: sha512-4b3OrB2M8K0MsG4JA4YBYQgSZpUUdle4gxUrrH7Qs3deOwuAtrdabkKJpRWtR45zvQDdi09gzxwUGee0aCqKmA==}
 
   '@rolldown/binding-android-arm-eabi@1.2.7':
     resolution: {integrity: sha512-EypzgnYCwyVY4NDHKzGmNJT5b+XaQEBniHxsMdeIQLB/tcCzZnhqrzHpZFbX9iaxx+5RiB8caATBtfvZP7zVxQ==}
@@ -5680,21 +5680,21 @@ snapshots:
     dependencies:
       '@redis/client': 6.2.1(@opentelemetry/api@1.9.1)
 
-  '@restatedev/restate-sdk-clients@1.14.5':
+  '@restatedev/restate-sdk-clients@1.17.0':
     dependencies:
-      '@restatedev/restate-sdk-core': 1.14.5
+      '@restatedev/restate-sdk-core': 1.17.0
 
-  '@restatedev/restate-sdk-core@1.14.5': {}
+  '@restatedev/restate-sdk-core@1.17.0': {}
 
-  '@restatedev/restate-sdk-opentelemetry@1.14.5(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))(@restatedev/restate-sdk@1.14.5)':
+  '@restatedev/restate-sdk-opentelemetry@1.17.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))(@restatedev/restate-sdk@1.17.0)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.11.0(@opentelemetry/api@1.9.1)
-      '@restatedev/restate-sdk': 1.14.5
+      '@restatedev/restate-sdk': 1.17.0
 
-  '@restatedev/restate-sdk@1.14.5':
+  '@restatedev/restate-sdk@1.17.0':
     dependencies:
-      '@restatedev/restate-sdk-core': 1.14.5
+      '@restatedev/restate-sdk-core': 1.17.0
 
   '@rolldown/binding-android-arm-eabi@1.2.7':
     optional: true


### PR DESCRIPTION
## Problem

The Restate TypeScript SDK packages and the Nix-packaged Restate server/CLI were behind their current compatible releases.

## Goal

Move the Restate SDK cohort to 1.17.0 and the server/CLI to 1.7.9 while preserving `restate-effect` behavior and repository builds.

## Decisions

This PR is stacked on and depends on the KaTeX update in #1242. The SDK cohort moves together at 1.17.0, while the independently versioned server and CLI move together at 1.7.9. Effect stays at 4.0.0-rc.111.

## Verification

- Installed Restate SDK package versions: 1.17.0.
- Restate Vitest suite: 106 passed, 72 skipped.
- Restate server and CLI Nix build: passed; both report version 1.7.9.
- Full TypeScript build: passed.
- Lock translator suite: 13 tests passed.
- Genie check: passed.
- Genie and oxlint Nix builds: passed.
- All seven root pnpm fixed-output dependency derivations: built successfully.
- Root Nix flake evaluation with `--no-build`: passed.
- Pre-flip deviation: project-wide `devenv tasks run check:all` was not run because the current-`main` regression tracked by schickling/dotfiles#2602 makes that gate invoke destructive `mr:apply` behavior; focused checks and existing/current CI are used instead.

## Complexity

No new complexity; the SDK and server/CLI versions follow their existing independent release lines.

## Concerns

This is the top of the dependency stack and cannot merge before the preceding nine PRs.

## Friction & bottlenecks

The current-`main` validation regression prevents the normal project-wide pre-flip gate; no measurable resource bottleneck was observed.

## Follow-ups

Merge after #1242; no additional dependency-stack follow-up is known.

## References

- Preceding stacked PR: #1242
- Validation regression: schickling/dotfiles#2602

<!-- agent-footer:begin v=2 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | dev3.direct.omp.nsyk4mvc |
| `session` | dev3.nsyk4mvc |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.1.7 |
| `agent_runtime` | OMP 18.1.7 |
| `tooling_profile` | dotfiles@8d937c9 |
</details>
<!-- agent-footer:end -->