### PR TITLE
chore(deps): update Buck2 to 2026-09-01

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -226,6 +226,21 @@ All notable changes to this project will be documented in this file.
   packages, Tailwind CSS 4.3.3, and supporting type, test, formatting, crypto,
   syntax-highlighting, and terminal utilities.
 
+- **buck2**: advance the repo-local Buck2 package authority from the
+  `2026-08-22` upstream release to `2026-09-01`
+  (`be6971d47dcc835b7356e1698b23039ffee4f4c2`), with the release's own
+  `prelude_hash` revision `1f8c24e0b1f85e645011f93a4073b0c6c762d7b1` and
+  refreshed `buck2`, `rust-project` and `starlark_fmt` asset hashes for all
+  three admitted platforms (`x86_64-linux`, `aarch64-linux`,
+  `aarch64-darwin`). The `buck2` capability protocol moves in lockstep to
+  `facebook/buck2-cli/2026-09-01` in `buck2-member.json`, its genie source,
+  `devenv.nix` and `@overeng/megarepo`'s `MR_COMPOSITION_BUCK2_PROTOCOL`, so a
+  composition root carrying the old protocol fails closed with
+  `BuckCapabilityMismatch` rather than mounting against a different CLI. The
+  asset list is unchanged — upstream's `binaries` set still ends at
+  `starlark_fmt` — and toolchain identity is in the action key, so this
+  invalidates cached Buck actions once.
+
 - **CI**: normalize the repository-local CI VRS under `context/ci/` and make
   workflow event admission semantic. Pull requests now trigger only for
   revision-changing `opened`, `reopened`, and `synchronize` activity; the

--- a/buck2-member.json
+++ b/buck2-member.json
@@ -76,7 +76,7 @@
     },
     {
       "toolId": "buck2",
-      "protocol": "facebook/buck2-cli/2026-08-22",
+      "protocol": "facebook/buck2-cli/2026-09-01",
       "flakePackage": "buck2",
       "executable": "bin/buck2"
     },

--- a/buck2-member.json.genie.ts
+++ b/buck2-member.json.genie.ts
@@ -91,7 +91,7 @@ const manifestProjection = {
     },
     {
       toolId: 'buck2',
-      protocol: 'facebook/buck2-cli/2026-08-22',
+      protocol: 'facebook/buck2-cli/2026-09-01',
       flakePackage: 'buck2',
       executable: 'bin/buck2',
     },

--- a/devenv.nix
+++ b/devenv.nix
@@ -658,7 +658,7 @@ in
   # packaged wrapper; refreshed tasks can invoke composition from owned members.
   env.MR_COMPOSITION_CP_BIN = "${pkgs.coreutils}/bin/cp";
   env.MR_COMPOSITION_BUCK2_BIN = "${buck2Machine}/bin/buck2";
-  env.MR_COMPOSITION_BUCK2_PROTOCOL = "facebook/buck2-cli/2026-08-22";
+  env.MR_COMPOSITION_BUCK2_PROTOCOL = "facebook/buck2-cli/2026-09-01";
   env.MR_COMPOSITION_SYSTEM = currentSystem;
   env.MR_COMPOSITION_PLATFORM = if pkgs.stdenv.hostPlatform.isDarwin then "darwin" else "linux";
   env.MR_COMPOSITION_GIT_BIN = "${pkgs.git}/bin/git";

--- a/nix/buck2.nix
+++ b/nix/buck2.nix
@@ -11,34 +11,34 @@
 { pkgs }:
 let
   release = rec {
-    version = "2026-08-22";
+    version = "2026-09-01";
     releaseBaseUrl = "https://github.com/facebook/buck2/releases/download/${version}";
     prelude = rec {
-      revision = "b662bc5f374762afc05e7033d6a0f8d4da462d45";
+      revision = "1f8c24e0b1f85e645011f93a4073b0c6c762d7b1";
       url = "https://github.com/facebook/buck2-prelude/archive/${revision}.tar.gz";
-      hash = "sha256-sblbKPjU4t/kK0DyCt16/KW6DqmZaJRA/lXXyE3Ez1k=";
+      hash = "sha256-iwXAuHXXfw/FsR0N2CMR0GXHg1I2BHlhZ2orM7z9qas=";
     };
     platforms = {
       x86_64-linux = {
         executionPlatform = "x86_64-linux";
         suffix = "x86_64-unknown-linux-gnu";
-        buck2Hash = "sha256-ZcsR/hR5Szrz5zK2Up8scs5OXZKdEeYMAcMfXMuDi6c=";
-        rustProjectHash = "sha256-oFfEizUVfMsG7Q33HXf3API5INeaLiXEAsIkjLwENoU=";
-        starlarkFmtHash = "sha256-u2PbMoFq9jU/Csrbnl5iTdts7d05+BDSgTDG/uO/V44=";
+        buck2Hash = "sha256-3JRHvS4Thg/BVwAaGAPFGMCFRE3MbGVGDZ0fVRVLMqM=";
+        rustProjectHash = "sha256-jNF1qQNhFmy6o0RAXODgjrCwxV8IX3LERUAzFdtuELM=";
+        starlarkFmtHash = "sha256-jUQXVSDoS44JDAjcSBXwwwVQfoOIzFwWWoTZuEtKen8=";
       };
       aarch64-linux = {
         executionPlatform = "aarch64-linux";
         suffix = "aarch64-unknown-linux-gnu";
-        buck2Hash = "sha256-935OTtLIOgWqh0vFfC+P64yElBLQkWdLNccion3Ph5o=";
-        rustProjectHash = "sha256-4zhvmVOM/w+R8VJ74HoNhrkLM4gX6MxrXvHc+Q5Kikg=";
-        starlarkFmtHash = "sha256-mwYNYZGYkk7LcbyYEOffDhTF06gFic7h7tnBvFDQKT4=";
+        buck2Hash = "sha256-287nXbAMVX3y27OCxrW+FkPAhrh9kkqrcGCZinptWAE=";
+        rustProjectHash = "sha256-Mk5hgW6OhODKHI/urBnXUZSjR2lrIlDDzrZBUgUUsmw=";
+        starlarkFmtHash = "sha256-gkqGiT8Qr+jRN3uEtNxZWvdBQw9I/gjs3FMtB2GrFxI=";
       };
       aarch64-darwin = {
         executionPlatform = "aarch64-macos";
         suffix = "aarch64-apple-darwin";
-        buck2Hash = "sha256-odZQ/iiMmM0XCMk6hO2lvRtQ5PCQ93WeSkjtKXfDNS8=";
-        rustProjectHash = "sha256-1kI0OHkBV8Cq9YR3T2Fyvn9jk9ZHD9sDD/Zx5eCDk3M=";
-        starlarkFmtHash = "sha256-7UX2aCbpR0cJDIEKqm63kWqeXk9UDfy4+NKuWoxh5YM=";
+        buck2Hash = "sha256-CWLKffGnawcHxro/8SFtMUMdSTrjfvAB6ptC9KdBCck=";
+        rustProjectHash = "sha256-t0D+YOjlFSQR+eKaQ97Zb4jbor0IkthqZgPtpLymG4E=";
+        starlarkFmtHash = "sha256-CIJ6XFRuW2AKZJYjSNOu5fGzJfkRnkTsUaWfCrmbBBY=";
       };
     };
   };

--- a/packages/@overeng/megarepo/nix/build.nix
+++ b/packages/@overeng/megarepo/nix/build.nix
@@ -54,7 +54,7 @@ pkgs.stdenv.mkDerivation {
     makeWrapper ${base}/bin/mr $out/bin/mr \
       --set MR_COMPOSITION_CP_BIN ${pkgs.coreutils}/bin/cp \
       --set MR_COMPOSITION_BUCK2_BIN ${buck2}/bin/buck2 \
-      --set MR_COMPOSITION_BUCK2_PROTOCOL facebook/buck2-cli/2026-08-22 \
+      --set MR_COMPOSITION_BUCK2_PROTOCOL facebook/buck2-cli/2026-09-01 \
       --set MR_COMPOSITION_SYSTEM ${pkgs.stdenv.hostPlatform.system} \
       --set MR_COMPOSITION_PLATFORM ${compositionPlatform} \
       --set MR_COMPOSITION_GIT_BIN ${pkgs.git}/bin/git \


### PR DESCRIPTION
## Problem

The repository-local Buck2 authority remained on the 2026-08-22 release, including the matching prelude, platform assets, and capability protocol.

## Goal

Move Buck2 to the 2026-09-01 release and keep its prelude, three admitted-platform asset hashes, generated member manifest, and composition protocol marker aligned.

## Decisions

Keep this independent compatibility-sensitive cohort separate from the compatible dependency update in #1225. Update the protocol marker everywhere with the executable so mixed-version composition fails closed instead of mounting against a different CLI. This PR does not upgrade the Effect RC cohort.

## Verification

- Current GitHub CI completed with 20 checks passing and 6 intentionally skipped; no check failed. The dedicated `buck2` check passed, as did Linux and macOS tests, both `nix-check` and `nix-fod-check` matrices, `bootstrap-cold-proof`, and `source-shape`.
- The diff aligns `facebook/buck2-cli/2026-09-01` across `buck2-member.json`, its Genie source, `devenv.nix`, and the packaged `@overeng/megarepo` wrapper, while refreshing the release, prelude, and three platform asset hashes in `nix/buck2.nix`.
- Pre-flip deviation: `devenv tasks run check:all` was not run because the current-`main` regression tracked by schickling/dotfiles#2602 makes that gate invoke destructive `mr:apply` behavior; the focused checks in current CI are used instead.

## Complexity

No new abstraction; the existing multi-file Buck2 identity contract is updated consistently.

## Concerns

Changing toolchain identity invalidates cached Buck actions once. The admitted asset set remains `buck2`, `rust-project`, and `starlark_fmt` for x86_64 Linux, aarch64 Linux, and aarch64 Darwin.

## Friction & bottlenecks

Local project-wide validation is blocked by schickling/dotfiles#2602. No measurable bottleneck was observed.

## Follow-ups

None.

## References

- Base compatible dependency cohort: #1225
- Pre-flip validation regression: schickling/dotfiles#2602

<!-- agent-footer:begin v=2 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | dev3.direct.omp.nsyk4mvc |
| `session` | dev3.nsyk4mvc |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.1.7 |
| `agent_runtime` | OMP 18.1.7 |
| `tooling_profile` | dotfiles@8d937c9 |
</details>
<!-- agent-footer:end -->