### PR TITLE
chore(deps): update devenv to 2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -221,6 +221,19 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- **devenv**: bump the pinned devenv input from `v2.2.1` to `v2.3`
+  (`e0781f7bee573eefcab4a7d2788fd9b455560ca2`) and raise `require_version` to
+  `>=2.3`. Only the `devenv` subtree of `devenv.lock` is relocked; the root
+  `nixpkgs`, `git-hooks`, `tsgo`, and `playwright` pins are untouched (the
+  root `nixpkgs` node is renamed `nixpkgs_3` -> `nixpkgs_2` because 2.3 makes
+  `cachix` follow devenv's own nixpkgs, removing one duplicate node). CI needs
+  no regeneration: it reads `DEVENV_REV` out of `devenv.lock`. 2.3 fixes
+  [cachix/devenv#3038](https://github.com/cachix/devenv/issues/3038) (explicit
+  `showOutput` was swallowed by AI-agent auto-quiet), so the caveat in
+  `nix/devenv-modules/tasks/README.md` now records it as fixed, and it ships
+  orphan-process fixes for `devenv tasks run` / `devenv up`, a smaller closure
+  (528 MB -> 376 MB), and bundled Nix 2.35.2.
+
 - **deps**: update the compatible patch and minor dependency cohort, including
   React 19.2.8, OpenTelemetry SDK 2.11, Vite 8.2.2, current TanStack router
   packages, Tailwind CSS 4.3.3, and supporting type, test, formatting, crypto,

--- a/context/otel.md
+++ b/context/otel.md
@@ -93,7 +93,7 @@ otel-trace | cat            # plain text: trace:<trace-id> <url>
 
 The function parses `TRACEPARENT` (W3C format: `version-traceId-spanId-traceFlags`) and constructs a Grafana Explore URL from `OTEL_GRAFANA_LINK_URL`.
 
-**Note:** This repo now uses `devenv.messages` to auto-display the OTEL shell-entry notice. `otel-trace` remains as an on-demand way to reopen the same link later in the session. The repo is temporarily pinned to the upstream post-[cachix/devenv#2661](https://github.com/cachix/devenv/pull/2661) commit while waiting for the next tagged release.
+**Note:** This repo now uses `devenv.messages` to auto-display the OTEL shell-entry notice. `otel-trace` remains as an on-demand way to reopen the same link later in the session. The repo tracks tagged devenv releases (currently `v2.3`), which include the post-[cachix/devenv#2661](https://github.com/cachix/devenv/pull/2661) behaviour this flow needs.
 
 ### `otel-span` -- Trace span CLI
 

--- a/context/workarounds/devenv-issues.md
+++ b/context/workarounds/devenv-issues.md
@@ -92,7 +92,7 @@ removed as they are no longer needed.
 
 **Upstream status:** Fixed by https://github.com/cachix/devenv/pull/2661.
 
-**Repo status:** Temporarily resolved here by pinning `devenv` to the merged upstream commit while waiting for the next tagged release.
+**Repo status:** Resolved by the tagged releases that carry the fix; `devenv.yaml` pins `v2.3`.
 
 **Affected repos:** Any repo wanting to display messages (e.g. trace URLs) on shell entry
 

--- a/devenv.lock
+++ b/devenv.lock
@@ -13,14 +13,17 @@
           "devenv",
           "git-hooks"
         ],
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1777487137,
-        "narHash": "sha256-TuvKVBX60mqyMT6OB5JqVEh1YIWtFMR/igLCaCdC9tw=",
+        "lastModified": 1788181969,
+        "narHash": "sha256-OUB6hPlFBB9FRdZgZXSye4lDOg+fbrqKe8ePv2IM7NY=",
         "owner": "cachix",
         "repo": "cachix",
-        "rev": "a66a440c321d35f7193472c317f42a55ccd1cb93",
+        "rev": "98093e8eea6c1635ef1337a576fa76f3e8bd4f39",
         "type": "github"
       },
       "original": {
@@ -57,20 +60,20 @@
         "git-hooks": "git-hooks",
         "nix": "nix",
         "nixd": "nixd",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1785672150,
-        "narHash": "sha256-S4baMekJYJGWDCo1yOYxZkmgBlAruQ5MLi+h3Zo8als=",
+        "lastModified": 1788786503,
+        "narHash": "sha256-ZH5WcgnRjqV1jY4gCHWOv6DlDVgBz+xLIoja/e8cWjw=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "8f297eae651cb47fb1e8f7c19b942462aa879636",
+        "rev": "e0781f7bee573eefcab4a7d2788fd9b455560ca2",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
-        "ref": "v2.2.1",
+        "ref": "v2.3",
         "repo": "devenv",
         "type": "github"
       }
@@ -115,11 +118,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778716662,
-        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "lastModified": 1788306937,
+        "narHash": "sha256-lbrI1UYVpFgKSsyrU9oeF7FHfnu8nLD9ja0ou9f2rxk=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "rev": "f16b25b8c3d2809b87925d0b76652d7821a75c68",
         "type": "github"
       },
       "original": {
@@ -149,16 +152,17 @@
     "ghostty": {
       "flake": false,
       "locked": {
-        "lastModified": 1784602798,
-        "narHash": "sha256-298x90knBUWX5GHGXh2SKsAKvStjU2ri9UgOGoF79/8=",
+        "lastModified": 1786026742,
+        "narHash": "sha256-tRtgTg/i3w1nFdRHU2IGekfJN8EyP+HARW4MtoUZyqk=",
         "owner": "ghostty-org",
         "repo": "ghostty",
-        "rev": "88b4cd047fa627cdca6781bc7e7dc8b75a2cecb9",
+        "rev": "22d13172cde98a0a4dda05d3d6a3fcb0dd8ed018",
         "type": "github"
       },
       "original": {
         "owner": "ghostty-org",
         "repo": "ghostty",
+        "rev": "22d13172cde98a0a4dda05d3d6a3fcb0dd8ed018",
         "type": "github"
       }
     },
@@ -174,11 +178,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782908218,
-        "narHash": "sha256-wLMOrPgVyeF3XmP+qfYcLqnVdTxikdcSvbIY7rA9jTA=",
+        "lastModified": 1788267358,
+        "narHash": "sha256-nt+lUqYVpc9Y6JeMd2WmXzCDojasdadKo0mWcluvY2Y=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "9f7e99119ece7705299595299f3b031f39356de1",
+        "rev": "27555e2624241fb116b49095df4caaee85a25691",
         "type": "github"
       },
       "original": {
@@ -256,16 +260,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1785349663,
-        "narHash": "sha256-JSD8lPe5kalvPKx5X+inX8ZZdGLeXkAbd3Jiv7UDf+I=",
+        "lastModified": 1788036898,
+        "narHash": "sha256-3NT3yTvoRT7+rxLDNovpyeTDIJkZlBoO72rcu2x9Y9o=",
         "owner": "cachix",
         "repo": "nix",
-        "rev": "f33db89fd6db6edc337d93212f6628ab6d25f407",
+        "rev": "b9b81726b38469c55b9706d80d37d6c73cc7f76c",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
-        "ref": "devenv-2.34",
+        "ref": "devenv-2.35",
         "repo": "nix",
         "type": "github"
       }
@@ -283,11 +287,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1783935112,
-        "narHash": "sha256-IAQ14nteIKXAz4cd75UcZrsHGEVJ7QNrkUwX9rmeZ/Y=",
+        "lastModified": 1788165251,
+        "narHash": "sha256-ITHt6eU6DuwQqlNV1/wehvKYPE6J8sZIlv75CpDjcHI=",
         "owner": "nix-community",
         "repo": "nixd",
-        "rev": "a64cd33e53b316b6b092ea0a966640cd2309bf3d",
+        "rev": "e2ca72c353cfbc3d63e942fe9aeae4ec497863bf",
         "type": "github"
       },
       "original": {
@@ -297,29 +301,32 @@
       }
     },
     "nixpkgs": {
+      "inputs": {
+        "nixpkgs-src": "nixpkgs-src"
+      },
       "locked": {
-        "lastModified": 1772624091,
-        "narHash": "sha256-QKyJ0QGWBn6r0invrMAK8dmJoBYWoOWy7lN+UHzW1jc=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "80bdc1e5ce51f56b19791b52b2901187931f5353",
+        "lastModified": 1787753358,
+        "narHash": "sha256-Tl77VbWyAKrOfRNQhL6JbQtb/MLzbYa/1RG1gWWfICk=",
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "256551e45f6303e142ab4a98be1bf243feb77dc0",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1781607440,
-        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
+        "lastModified": 1787394516,
+        "narHash": "sha256-pRGOQSClnXNI2iLUG6DYpsGvYcuw0drOutVZFTJNw90=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
+        "rev": "c8f90650c15282fa8656a041bfbbd2403997a9a7",
         "type": "github"
       },
       "original": {
@@ -346,25 +353,6 @@
       }
     },
     "nixpkgs_2": {
-      "inputs": {
-        "nixpkgs-src": "nixpkgs-src"
-      },
-      "locked": {
-        "lastModified": 1782132010,
-        "narHash": "sha256-ZnAVHdVrotp80iIMm5CSR1fdxPlw7Uwmwxb+O/wsgZ8=",
-        "owner": "cachix",
-        "repo": "devenv-nixpkgs",
-        "rev": "12866ae2dddbc0ab8b329915f8072bb9c75bde89",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "ref": "rolling",
-        "repo": "devenv-nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
       "locked": {
         "lastModified": 1788614874,
         "narHash": "sha256-7QYjT2vHLuX9Z1pdxHXDKCbh1CR3D/2rywB9Tx0MPRg=",
@@ -423,7 +411,7 @@
       "inputs": {
         "devenv": "devenv",
         "git-hooks": "git-hooks_2",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs_2",
         "playwright": "playwright",
         "tsgo": "tsgo"
       }
@@ -436,11 +424,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782875958,
-        "narHash": "sha256-5eqDcnBjb1424HRQdnhuhNOBZguq1Z2tqSa2OMF/m2c=",
+        "lastModified": 1788332415,
+        "narHash": "sha256-BTFrmyh0oaVDsvA9NNw0YpbbeppTwU0t70iVx672Ew8=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "13139aefa973f3d96c60c0fbab801de058ae25ca",
+        "rev": "860d7c835ab91bfc8972b67092f5f2db8e9390a0",
         "type": "github"
       },
       "original": {
@@ -473,11 +461,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780220602,
-        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
+        "lastModified": 1786901030,
+        "narHash": "sha256-WSFCsDSE5ffgD2MqzkM2CYjeFiKhRF/dJUN8uedb6YE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
+        "rev": "27b3b12a8e6375f28ebe122f07d230ca5459bbfa",
         "type": "github"
       },
       "original": {

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,7 +1,7 @@
-require_version: '>=2.2.1'
+require_version: '>=2.3'
 inputs:
   devenv:
-    url: github:cachix/devenv/v2.2.1
+    url: github:cachix/devenv/v2.3
   nixpkgs:
     url: github:NixOS/nixpkgs/nixos-unstable
   git-hooks:

--- a/nix/devenv-modules/tasks/README.md
+++ b/nix/devenv-modules/tasks/README.md
@@ -156,11 +156,13 @@ all three indistinguishable from one emitted by the step itself. So workflow
 commands work from either stream, and log grouping does too.
 
 One caveat worth knowing when debugging locally: devenv selects quiet verbosity
-when it detects `CLAUDECODE` / `OPENCODE_CLIENT` / `AI_AGENT`, and in 2.1.2 that
-also suppresses `showOutput`
-([cachix/devenv#3038](https://github.com/cachix/devenv/issues/3038)). A task's
-stdout can therefore look missing inside a coding agent while being perfectly
-visible in CI. Use `DEVENV_NO_AI_AGENT=1` or `--verbose` when measuring.
+when it detects `CLAUDECODE` / `OPENCODE_CLIENT` / `AI_AGENT`, and up to 2.2.x
+that also suppressed `showOutput`
+([cachix/devenv#3038](https://github.com/cachix/devenv/issues/3038)), so a
+task's stdout could look missing inside a coding agent while being perfectly
+visible in CI. Fixed upstream in 2.3: explicit `showOutput = true` /
+`--show-output` now streams even at quiet verbosity. On older CLIs, use
+`DEVENV_NO_AI_AGENT=1` or `--verbose` when measuring.
 
 ## Adding New Tasks
 


### PR DESCRIPTION
## Problem

The repository pinned devenv v2.2.1 and still documented workarounds that tagged v2.3 resolves, including the swallowed explicit `showOutput` behavior tracked by cachix/devenv#3038.

## Goal

Pin devenv v2.3, require version 2.3 or newer, refresh its lock subtree, and update the now-resolved workaround documentation.

## Decisions

Keep this independent compatibility-sensitive cohort separate from the compatible dependency update in #1225. Update the devenv-owned lock subtree while leaving the repository's root nixpkgs authority and unrelated top-level inputs unchanged. This PR does not upgrade the Effect RC cohort.

## Verification

- Current GitHub CI completed with 20 checks passing and 6 intentionally skipped; no check failed. Passed coverage includes Linux and macOS tests, both `nix-check` and `nix-fod-check` matrices, `bootstrap-cold-proof`, `source-shape`, and the dependency-contract checks.
- The diff pins `github:cachix/devenv/v2.3`, raises `require_version` to `>=2.3`, records revision `e0781f7bee573eefcab4a7d2788fd9b455560ca2`, and updates the affected devenv documentation.
- Pre-flip deviation: `devenv tasks run check:all` was not run because the current-`main` regression tracked by schickling/dotfiles#2602 makes that gate invoke destructive `mr:apply` behavior; the focused checks in current CI are used instead.

## Complexity

No new abstraction; this is a pin, lock-subtree, minimum-version, and documentation update.

## Concerns

The devenv subtree refresh also updates its transitive inputs and deduplicates one nixpkgs node. The dedicated `devenv-perf` CI lane was skipped, so the upstream closure-size improvement is not claimed as verified here.

## Friction & bottlenecks

Local project-wide validation is blocked by schickling/dotfiles#2602. No measurable bottleneck was observed.

## Follow-ups

None.

## References

- Base compatible dependency cohort: #1225
- devenv `showOutput` issue: cachix/devenv#3038
- Pre-flip validation regression: schickling/dotfiles#2602

<!-- agent-footer:begin v=2 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | dev3.direct.omp.nsyk4mvc |
| `session` | dev3.nsyk4mvc |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.1.7 |
| `agent_runtime` | OMP 18.1.7 |
| `tooling_profile` | dotfiles@8d937c9 |
</details>
<!-- agent-footer:end -->