### PR TITLE
chore(deps): update Go toolchain to 1.27.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -226,6 +226,13 @@ All notable changes to this project will be documented in this file.
   packages, Tailwind CSS 4.3.3, and supporting type, test, formatting, crypto,
   syntax-highlighting, and terminal utilities.
 
+- **nix/go.nix**: the hub's official Go release archive moves from 1.26.5 to
+  1.27.1, with all three admitted platform hashes (`linux-amd64`,
+  `linux-arm64`, `darwin-arm64`) taken from `https://go.dev/dl/?mode=json` and
+  verified against the downloaded archive bytes. The derivation is otherwise
+  unchanged: still the unpatched official distribution, so decision 0029's
+  store-reference-free property and `elf-static/v1` reachability are unaffected.
+
 - **CI**: normalize the repository-local CI VRS under `context/ci/` and make
   workflow event admission semantic. Pull requests now trigger only for
   revision-changing `opened`, `reopened`, and `synchronize` activity; the

--- a/nix/go.nix
+++ b/nix/go.nix
@@ -16,20 +16,20 @@
 # linked, so they run unmodified on NixOS and nothing rewrites the tree.
 let
   release = {
-    version = "1.26.5";
+    version = "1.27.1";
     baseUrl = "https://go.dev/dl";
     platforms = {
       x86_64-linux = {
         goPlatform = "linux-amd64";
-        hash = "sha256-XCw7FsrvodloqUwdrKBKfKMBpJbZsIbhetd7uBOT8FM=";
+        hash = "sha256-Y9M58NpatTY1pW8kkKeYTf4S38/yKtdJ9j7a9ZAWhEU=";
       };
       aarch64-linux = {
         goPlatform = "linux-arm64";
-        hash = "sha256-/keJ6SsfMzWGgIZLvocEKJ57tfwgfYBiPDCJNb1pbUk=";
+        hash = "sha256-NFC0Wj+e6FaHknNqXF5wofLps2w1qPdJWMA+UdfZK+w=";
       };
       aarch64-darwin = {
         goPlatform = "darwin-arm64";
-        hash = "sha256-77h/8or5oYjQU2711C5j3VK6gmPNc0Spk8xI3RHe22o=";
+        hash = "sha256-7iFdV+DsJpxgzJzspo5r2jIbqe5a/iT0sJiHA8LYfRI=";
       };
     };
   };


### PR DESCRIPTION
## Problem

The repository's official Go archive derivation remained pinned to Go 1.26.5.

## Goal

Move the official Go distribution to 1.27.1 with hashes for every admitted platform: `linux-amd64`, `linux-arm64`, and `darwin-arm64`.

## Decisions

Keep this independent toolchain cohort separate from the compatible dependency update in #1225. Preserve the existing unpatched official-distribution derivation and update only its version and platform hashes. This PR does not upgrade the Effect RC cohort.

## Verification

- Current GitHub CI completed with 20 checks passing and 6 intentionally skipped; no check failed. Passed coverage includes Linux and macOS tests, both `nix-check` and `nix-fod-check` matrices, `bundle-smoke`, `bootstrap-cold-proof`, and `source-shape`.
- The diff changes `nix/go.nix` from 1.26.5 to 1.27.1 and refreshes exactly the three admitted platform hashes; the derivation shape is otherwise unchanged.
- Pre-flip deviation: `devenv tasks run check:all` was not run because the current-`main` regression tracked by schickling/dotfiles#2602 makes that gate invoke destructive `mr:apply` behavior; the focused checks in current CI are used instead.

## Complexity

No new complexity; this is an existing three-platform toolchain pin update.

## Concerns

No x86_64 Darwin archive is admitted by the current derivation; this PR preserves that existing platform scope.

## Friction & bottlenecks

Local project-wide validation is blocked by schickling/dotfiles#2602. No measurable bottleneck was observed.

## Follow-ups

None.

## References

- Base compatible dependency cohort: #1225
- Pre-flip validation regression: schickling/dotfiles#2602

<!-- agent-footer:begin v=2 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | dev3.direct.omp.nsyk4mvc |
| `session` | dev3.nsyk4mvc |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.1.7 |
| `agent_runtime` | OMP 18.1.7 |
| `tooling_profile` | dotfiles@8d937c9 |
</details>
<!-- agent-footer:end -->