### PR TITLE
chore(deps): update Vercel CLI to 59.11.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -240,6 +240,20 @@ All notable changes to this project will be documented in this file.
   asset list is unchanged — upstream's `binaries` set still ends at
   `starlark_fmt` — and toolchain identity is in the action key, so this
   invalidates cached Buck actions once.
+- **nix/provider-clis/vercel-cli**: the pinned Vercel CLI moves 54.18.5 →
+  59.11.7, the current stable `latest` release. The pin is a first-party
+  `buildNpmPackage` fixed-output derivation, so the bump is the authority
+  `package.json` dependency, the regenerated `package-lock.json`, the
+  derivation `version`, and a recomputed `npmDepsHash`
+  (`sha256-oaD0HMwJnlFoEoHal47qqsmagE7OnAt/rCqE61FC67M=`, from
+  `prefetch-npm-deps` against the new lock). The wrapper entrypoint is
+  unchanged because 59.11.7 still publishes both `vercel` and `vc` as
+  `dist/vc.js`, and its `engines.node >= 18` stays satisfied by the pinned
+  `nodejs_24`. Five CLI majors are crossed; the deploy path that consumes it
+  (`ci-tools deploy vercel` via `nix/devenv-modules/tasks/shared/vercel.nix`)
+  uses only `pull`, `build`, `deploy --prebuilt` and `alias`, none of which
+  changed shape, but the derivation itself is not yet built or smoke-tested
+  here.
 
 - **CI**: normalize the repository-local CI VRS under `context/ci/` and make
   workflow event admission semantic. Pull requests now trigger only for

--- a/nix/provider-clis/vercel-cli/default.nix
+++ b/nix/provider-clis/vercel-cli/default.nix
@@ -2,7 +2,7 @@
 
 pkgs.buildNpmPackage (finalAttrs: {
   pname = "vercel-cli";
-  version = "54.18.5";
+  version = "59.11.7";
 
   src = pkgs.lib.cleanSourceWith {
     src = ./.;
@@ -13,7 +13,7 @@ pkgs.buildNpmPackage (finalAttrs: {
         "package-lock.json"
       ];
   };
-  npmDepsHash = "sha256-bKO9/3JIO0gQ7cjUW1BeBxhWyR/bFP5tu0a0aJ577A0=";
+  npmDepsHash = "sha256-oaD0HMwJnlFoEoHal47qqsmagE7OnAt/rCqE61FC67M=";
 
   dontNpmBuild = true;
   npmInstallFlags = [ "--omit=optional" ];

--- a/nix/provider-clis/vercel-cli/default.nix
+++ b/nix/provider-clis/vercel-cli/default.nix
@@ -16,8 +16,6 @@ pkgs.buildNpmPackage (finalAttrs: {
   npmDepsHash = "sha256-oaD0HMwJnlFoEoHal47qqsmagE7OnAt/rCqE61FC67M=";
 
   dontNpmBuild = true;
-  npmInstallFlags = [ "--omit=optional" ];
-  npmPruneFlags = [ "--omit=optional" ];
   npmRebuildFlags = [ "--ignore-scripts" ];
   nativeBuildInputs = [ pkgs.makeWrapper ];
 

--- a/nix/provider-clis/vercel-cli/package-lock.json
+++ b/nix/provider-clis/vercel-cli/package-lock.json
@@ -8,7 +8,7 @@
       "name": "effect-utils-vercel-cli-authority",
       "version": "0.0.0",
       "dependencies": {
-        "vercel": "54.18.5"
+        "vercel": "59.11.7"
       }
     },
     "node_modules/@bytecodealliance/preview2-shim": {
@@ -66,21 +66,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
       "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
+        "@emnapi/wasi-threads": "1.2.3",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -89,9 +89,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -813,21 +813,24 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
-      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.3.tgz",
+      "integrity": "sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@tybys/wasm-util": "^0.10.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
       },
       "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
+        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.4",
+        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.4"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -865,10 +868,354 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@oxc-parser/binding-android-arm-eabi": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.121.0.tgz",
+      "integrity": "sha512-n07FQcySwOlzap424/PLMtOkbS7xOu8nsJduKL8P3COGHKgKoDYXwoAHCbChfgFpHnviehrLWIPX0lKGtbEk/A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-android-arm64": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.121.0.tgz",
+      "integrity": "sha512-/Dd1xIXboYAicw+twT2utxPD7bL8qh7d3ej0qvaYIMj3/EgIrGR+tSnjCUkiCT6g6uTC0neSS4JY8LxhdSU/sA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-arm64": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.121.0.tgz",
+      "integrity": "sha512-A0jNEvv7QMtCO1yk205t3DWU9sWUjQ2KNF0hSVO5W9R9r/R1BIvzG01UQAfmtC0dQm7sCrs5puixurKSfr2bRQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-x64": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.121.0.tgz",
+      "integrity": "sha512-SsHzipdxTKUs3I9EOAPmnIimEeJOemqRlRDOp9LIj+96wtxZejF51gNibmoGq8KoqbT1ssAI5po/E3J+vEtXGA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-freebsd-x64": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.121.0.tgz",
+      "integrity": "sha512-v1APOTkCp+RWOIDAHRoaeW/UoaHF15a60E8eUL6kUQXh+i4K7PBwq2Wi7jm8p0ymID5/m/oC1w3W31Z/+r7HQw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.121.0.tgz",
+      "integrity": "sha512-PmqPQuqHZyFVWA4ycr0eu4VnTMmq9laOHZd+8R359w6kzuNZPvmmunmNJ8ybkm769A0nCoVp3TJ6dUz7B3FYIQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.121.0.tgz",
+      "integrity": "sha512-vF24htj+MOH+Q7y9A8NuC6pUZu8t/C2Fr/kDOi2OcNf28oogr2xadBPXAbml802E8wRAVfbta6YLDQTearz+jw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.121.0.tgz",
+      "integrity": "sha512-wjH8cIG2Lu/3d64iZpbYr73hREMgKAfu7fqpXjgM2S16y2zhTfDIp8EQjxO8vlDtKP5Rc7waZW72lh8nZtWrpA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-musl": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.121.0.tgz",
+      "integrity": "sha512-qT663J/W8yQFw3dtscbEi9LKJevr20V7uWs2MPGTnvNZ3rm8anhhE16gXGpxDOHeg9raySaSHKhd4IGa3YZvuw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.121.0.tgz",
+      "integrity": "sha512-mYNe4NhVvDBbPkAP8JaVS8lC1dsoJZWH5WCjpw5E+sjhk1R08wt3NnXYUzum7tIiWPfgQxbCMcoxgeemFASbRw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.121.0.tgz",
+      "integrity": "sha512-+QiFoGxhAbaI/amqX567784cDyyuZIpinBrJNxUzb+/L2aBRX67mN6Jv40pqduHf15yYByI+K5gUEygCuv0z9w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.121.0.tgz",
+      "integrity": "sha512-9ykEgyTa5JD/Uhv2sttbKnCfl2PieUfOjyxJC/oDL2UO0qtXOtjPLl7H8Kaj5G7p3hIvFgu3YWvAxvE0sqY+hQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.121.0.tgz",
+      "integrity": "sha512-DB1EW5VHZdc1lIRjOI3bW/wV6R6y0xlfvdVrqj6kKi7Ayu2U3UqUBdq9KviVkcUGd5Oq+dROqvUEEFRXGAM7EQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-gnu": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.121.0.tgz",
+      "integrity": "sha512-s4lfobX9p4kPTclvMiH3gcQUd88VlnkMTF6n2MTMDAyX5FPNRhhRSFZK05Ykhf8Zy5NibV4PbGR6DnK7FGNN6A==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-musl": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.121.0.tgz",
+      "integrity": "sha512-P9KlyTpuBuMi3NRGpJO8MicuGZfOoqZVRP1WjOecwx8yk4L/+mrCRNc5egSi0byhuReblBF2oVoDSMgV9Bj4Hw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-openharmony-arm64": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.121.0.tgz",
+      "integrity": "sha512-R+4jrWOfF2OAPPhj3Eb3U5CaKNAH9/btMveMULIrcNW/hjfysFQlF8wE0GaVBr81dWz8JLgQlsxwctoL78JwXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.121.0.tgz",
+      "integrity": "sha512-5TFISkPTymKvsmIlKasPVTPuWxzCcrT8pM+p77+mtQbIZDd1UC8zww4CJcRI46kolmgrEX6QpKO8AvWMVZ+ifw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.121.0.tgz",
+      "integrity": "sha512-V0pxh4mql4XTt3aiEtRNUeBAUFOw5jzZNxPABLaOKAWrVzSr9+XUaB095lY7jqMf5t8vkfh8NManGB28zanYKw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.121.0.tgz",
+      "integrity": "sha512-4Ob1qvYMPnlF2N9rdmKdkQFdrq16QVcQwBsO8yiPZXof0fHKFF+LmQV501XFbi7lHyrKm8rlJRfQ/M8bZZPVLw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-x64-msvc": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.121.0.tgz",
+      "integrity": "sha512-BOp1KCzdboB1tPqoCPXgntgFs0jjeSyOXHzgxVFR7B/qfr3F8r4YDacHkTOUNXtDgM8YwKnkf3rE5gwALYX7NA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@oxc-project/types": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.110.0.tgz",
-      "integrity": "sha512-6Ct21OIlrEnFEJk5LT4e63pk3btsI6/TusD/GStLi7wYlGJNOl1GI9qvXAnRAxQU9zqA2Oz+UwhfTOU2rPZVow==",
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.121.0.tgz",
+      "integrity": "sha512-CGtOARQb9tyv7ECgdAlFxi0Fv7lmzvmlm2rpD/RdijOO9rfk/JvB1CjT8EnoD+tjna/IYgKKw3IV7objRb+aYw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
@@ -1491,12 +1838,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@tootallnate/quickjs-emscripten": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
-      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
-      "license": "MIT"
-    },
     "node_modules/@ts-morph/common": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.11.1.tgz",
@@ -1553,13 +1894,13 @@
       }
     },
     "node_modules/@vercel/backends": {
-      "version": "0.8.20",
-      "resolved": "https://registry.npmjs.org/@vercel/backends/-/backends-0.8.20.tgz",
-      "integrity": "sha512-zAWL6X+ZwNrDzecTDBekcUvHH0NoHfFzyun/o4QjsuLVu1MTzyYs5vpubHP405+SbpCXoruZfssgYzzmLZOtcg==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@vercel/backends/-/backends-7.0.2.tgz",
+      "integrity": "sha512-tC1EQ7g7wJTUH4MYc1ve9dDn6l92aLR5VOSChan9slLctLmhOPFfZGD8R0ZlYzkTZLE50NVi6bMwE3jlvdza4Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/build-utils": "13.32.2",
         "@vercel/nft": "1.10.0",
+        "@vercel/static-config": "3.4.3",
         "execa": "3.2.0",
         "fs-extra": "11.1.0",
         "get-port": "5.1.1",
@@ -1568,8 +1909,12 @@
         "resolve.exports": "2.0.3",
         "rolldown": "1.0.0-rc.1",
         "srvx": "0.11.16",
+        "ts-morph": "12.0.0",
         "tsx": "4.21.0",
         "zod": "3.22.4"
+      },
+      "peerDependencies": {
+        "@vercel/build-utils": "14.9.1"
       }
     },
     "node_modules/@vercel/backends/node_modules/zod": {
@@ -1582,11 +1927,12 @@
       }
     },
     "node_modules/@vercel/blob": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-2.4.0.tgz",
-      "integrity": "sha512-ncQ8CRb6XoEAYJwjOTRGpACRT6h/AeY+/33gLyeVxG5BIes27OPm1jmqreF+JHjcTmGhClTP+kBpmyLfbV0xew==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-2.8.0.tgz",
+      "integrity": "sha512-Nu+HWKpkgovCh/ezlG7wCVwF7RErTzLzZMbGKFBdGBCbTKyK+s5VXPLl+0+TpNEQPH8AVaGzOpIsXUOtkqylCQ==",
       "license": "Apache-2.0",
       "dependencies": {
+        "@vercel/oidc": "^3.6.1",
         "async-retry": "^1.3.3",
         "is-buffer": "^2.0.5",
         "is-node-process": "^1.2.0",
@@ -1598,104 +1944,174 @@
       }
     },
     "node_modules/@vercel/blob/node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.1.tgz",
+      "integrity": "sha512-zWpdTVD54H48CIybL0rWQ3ukpb9d23wM7eH5RtfdmeP70cWHNjtfo7P4vZX+5CoDcO53J4Pu5uXp7lNfjc6DRA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
       }
     },
     "node_modules/@vercel/build-utils": {
-      "version": "13.32.2",
-      "resolved": "https://registry.npmjs.org/@vercel/build-utils/-/build-utils-13.32.2.tgz",
-      "integrity": "sha512-XgATgMjt2NHF6HHo1wii6f43qlWjaFx3o+9L7aOUPLQgqwgYp2BGwuuBjg8U6sNgut1QsmFBMvNqTAUBvack9Q==",
+      "version": "14.9.1",
+      "resolved": "https://registry.npmjs.org/@vercel/build-utils/-/build-utils-14.9.1.tgz",
+      "integrity": "sha512-d7Ov4+TA+UAxopVsgh698LPs0Um/LrW430FRU/qPlI7WFWWU55XwGJ2+aXCY8ZbA2zoZ8XjbZJVGjwnTCBG52Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/python-analysis": "0.11.1",
         "cjs-module-lexer": "1.2.3",
         "es-module-lexer": "1.5.0"
       }
     },
     "node_modules/@vercel/cervel": {
-      "version": "0.1.28",
-      "resolved": "https://registry.npmjs.org/@vercel/cervel/-/cervel-0.1.28.tgz",
-      "integrity": "sha512-ISPxpP0X9nxoQZ9kWeLRx+c1nCe0EEzSTVwEQ19MjKUXSP2RYGqInq8V993N4VkQ8jfWmnOC0Kf3C0Nw516i8w==",
+      "version": "0.1.61",
+      "resolved": "https://registry.npmjs.org/@vercel/cervel/-/cervel-0.1.61.tgz",
+      "integrity": "sha512-cm3WyokqnHwtLIK+k9C+NbUSmu+yGldnCPnn/rYB0ZzPZTlwdI3k7/d93Zq7/TEcsbHFpo7fxAwWr+DUAh3ufw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/backends": "0.8.20"
+        "@vercel/backends": "7.0.2"
       },
       "bin": {
         "cervel": "bin/cervel.mjs"
       }
     },
     "node_modules/@vercel/cli-auth": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@vercel/cli-auth/-/cli-auth-0.3.0.tgz",
-      "integrity": "sha512-9nsdxUpV/L+9CBVGeRw/Qby2azhi2lk01jp0aTH+Hxx2U61+mAmbi5qChHnrbEmQdx2Ih7dp4LxO3nj1Q7f/5Q==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@vercel/cli-auth/-/cli-auth-0.3.5.tgz",
+      "integrity": "sha512-DSkTWamJrhgCUrymOSCWysbiVeLsvPINhoKVTw+mypoyIJxKQxDgQaafvZ0OYGS2qg8wVUY30HgDugzaEdwo6Q==",
       "dependencies": {
         "@napi-rs/keyring": "1.2.0",
-        "@vercel/cli-config": "0.2.0",
+        "@vercel/cli-config": "0.2.4",
         "async-listen": "3.0.0",
         "open": "8.4.0",
         "zod": "4.1.11"
       }
     },
     "node_modules/@vercel/cli-config": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@vercel/cli-config/-/cli-config-0.2.0.tgz",
-      "integrity": "sha512-fJRRRB7734BDuXZ89yBEaA2ncYhH7bWX30mk04W80J6VAfQc+4iB8lyzAdaGpFV3/vNlkt9VZt+/uoQoWX6UsQ==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@vercel/cli-config/-/cli-config-0.2.4.tgz",
+      "integrity": "sha512-kZ5SojbrV06GHoU6QIWGwDXLov+s9rWZ7QqdqKfJfBGCNUieGfgaCjeeenNy8Y+QC0bwC0dZ2B4l5Hvdmrgpdw==",
       "license": "Apache-2.0",
       "dependencies": {
         "xdg-app-paths": "5",
         "zod": "4.1.11"
       }
     },
+    "node_modules/@vercel/cli-exec": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/cli-exec/-/cli-exec-1.0.1.tgz",
+      "integrity": "sha512-g9XerViJ/paZujufXYcu5XYI2vU2rtB4sgdpjUHde5RnOkdmpu0ngH46LCFGHoPXO/C+qDPSczIHIRN+8Q2YKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "execa": "5.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@vercel/cli-exec/node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/@vercel/cli-exec/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@vercel/cli-exec/node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/@vercel/cli-exec/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
     "node_modules/@vercel/container": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@vercel/container/-/container-0.0.4.tgz",
-      "integrity": "sha512-lbUnpg2Iawoi0oDlFE6Se43FNUd2B2nMnCXD9Af7NsysMENFaNu2ajzgsocTxt+O6djUgW9IdBnIRHgnHs+vZQ==",
-      "license": "Apache-2.0"
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/container/-/container-7.0.1.tgz",
+      "integrity": "sha512-kAN2pV5u3kj6AoyqeFa/PrlO9yxceTRBJM5YNJObdqpVVyLC7wlZ3GUx0VpP3TPsSFKK+B12xJPAP0xxxF6CWQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@vercel/build-utils": "14.9.1"
+      }
     },
     "node_modules/@vercel/detect-agent": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@vercel/detect-agent/-/detect-agent-1.2.3.tgz",
-      "integrity": "sha512-VYNCgUc0nOmC4WJmWw9GkrKdfr8Zl4/rxhC5SvgacBgxiW9W/9NRttUoHHXV8xdII3MaRgkZZVX8Ikzc/Jmjag==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@vercel/detect-agent/-/detect-agent-1.2.5.tgz",
+      "integrity": "sha512-0krENrjuitlW8s6TJu0MlqCevyCU7K7JK63jZAf7xZ6n17tx+vUEwzHT3sTxawtwZxaW21hu+oFUpoOrm49FsQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@vercel/elysia": {
-      "version": "0.1.98",
-      "resolved": "https://registry.npmjs.org/@vercel/elysia/-/elysia-0.1.98.tgz",
-      "integrity": "sha512-VJMPfvslPFP5lg7oNN+BZEXHdaejmI25OEyco5OvZWpR80MYpTPil+2+hbkoR6lN3kVUC9/xahtgsdfouOvNbA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/elysia/-/elysia-7.0.1.tgz",
+      "integrity": "sha512-bOCgbU/d0qwOi+3vEOtkQ9oGzrs7CQ6PNcUM8L8iZ/cUirD6lra+T+wQgNEeOPi1q6xNcXCkj92J4uk/jEmMuw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/node": "5.8.22",
-        "@vercel/static-config": "3.4.0"
+        "@vercel/node": "12.0.1",
+        "@vercel/static-config": "3.4.3"
+      },
+      "peerDependencies": {
+        "@vercel/build-utils": "14.9.1"
       }
     },
     "node_modules/@vercel/error-utils": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@vercel/error-utils/-/error-utils-2.2.0.tgz",
-      "integrity": "sha512-WFWiRxfPzoYWYifaj4thSKvAaZZwUOqD4k5GINRIgZgCiS2E3iAJbWbIsIZmkQdTecWFHcWGA6q48CjisgpOBA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@vercel/error-utils/-/error-utils-2.2.1.tgz",
+      "integrity": "sha512-9DhP8jP7raLML4hGsBemxX5fXuQnu5xxMV+HjGygGbzEmVK/+KyJ3QP2Cw7PdF0uXdb9N0Qa4c3tRGH34ZX6vw==",
       "license": "Apache-2.0"
     },
     "node_modules/@vercel/express": {
-      "version": "0.1.111",
-      "resolved": "https://registry.npmjs.org/@vercel/express/-/express-0.1.111.tgz",
-      "integrity": "sha512-lyLDvmMbca2H0pKMsW/tau3FsbpTlIlMe+JeNWLeL/T0znF4JpT4YFak/pUKwomW+v7UTKR7BTujPrsiYxqA8g==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@vercel/express/-/express-7.0.2.tgz",
+      "integrity": "sha512-pRsUuf0YNg0gTypzV1Ne0Z1oO76KnLNVht8HP4ERHit3QS5RrCSh468CgqAB1tbVFexcSgFFTtJ/90oPwDEO9g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/cervel": "0.1.28",
+        "@vercel/cervel": "0.1.61",
         "@vercel/nft": "1.10.0",
-        "@vercel/node": "5.8.22",
-        "@vercel/static-config": "3.4.0",
+        "@vercel/node": "12.0.1",
+        "@vercel/static-config": "3.4.3",
         "fs-extra": "11.1.0",
         "path-to-regexp": "8.3.0",
         "ts-morph": "12.0.0",
         "zod": "3.22.4"
+      },
+      "peerDependencies": {
+        "@vercel/build-utils": "14.9.1"
       }
     },
     "node_modules/@vercel/express/node_modules/zod": {
@@ -1708,13 +2124,16 @@
       }
     },
     "node_modules/@vercel/fastify": {
-      "version": "0.1.101",
-      "resolved": "https://registry.npmjs.org/@vercel/fastify/-/fastify-0.1.101.tgz",
-      "integrity": "sha512-+oUCBpSs8ANQmdQB6CTCWTfdxKutCzKEMkMtUJVLVnO0eaiONADkZeaFjjZwMl4Cg6z49ifhJ3QVJD1IWwIwsA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/fastify/-/fastify-7.0.1.tgz",
+      "integrity": "sha512-oXnXkK7ydsQQO+Ds2Ivfsyqc1MeqJZxbiUvDX+oAG+jZjtTDjkJfs0sD8acKdVUtShFO55m9k8WzTILVaQVVRg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/node": "5.8.22",
-        "@vercel/static-config": "3.4.0"
+        "@vercel/node": "12.0.1",
+        "@vercel/static-config": "3.4.3"
+      },
+      "peerDependencies": {
+        "@vercel/build-utils": "14.9.1"
       }
     },
     "node_modules/@vercel/fun": {
@@ -1774,56 +2193,65 @@
       }
     },
     "node_modules/@vercel/gatsby-plugin-vercel-analytics": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@vercel/gatsby-plugin-vercel-analytics/-/gatsby-plugin-vercel-analytics-1.0.11.tgz",
-      "integrity": "sha512-iTEA0vY6RBPuEzkwUTVzSHDATo1aF6bdLLspI68mQ/BTbi5UQEGjpjyzdKOVcSYApDtFU6M6vypZ1t4vIEnHvw==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@vercel/gatsby-plugin-vercel-analytics/-/gatsby-plugin-vercel-analytics-1.0.12.tgz",
+      "integrity": "sha512-Ejlhwxr7EBYJxtwYnlh6Vm6A2dPsUSPxMdYrfv0koZkgAzVwo7cG4aDQiy7iASMaGzwuI/PAnwlY2sJBF5b4OA==",
       "license": "Apache-2.0",
       "dependencies": {
         "web-vitals": "0.2.4"
       }
     },
     "node_modules/@vercel/gatsby-plugin-vercel-builder": {
-      "version": "2.2.24",
-      "resolved": "https://registry.npmjs.org/@vercel/gatsby-plugin-vercel-builder/-/gatsby-plugin-vercel-builder-2.2.24.tgz",
-      "integrity": "sha512-+rqPToquzHOnSsist6FylJY++Z7ScRvl87gJshGhYYXJSCMki5zquX+D8wliOb5H0SW3KGwmTNQ10gUJt52c8w==",
+      "version": "2.2.53",
+      "resolved": "https://registry.npmjs.org/@vercel/gatsby-plugin-vercel-builder/-/gatsby-plugin-vercel-builder-2.2.53.tgz",
+      "integrity": "sha512-2AaKdNQGz5nQDQ9hMG8SeE7NdysDG7DYNK90YlNvRTqVopCvC6ZLAz33QuFc8dnAMAHiqYDOO0UKw+Px1KlBkg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@sinclair/typebox": "0.25.24",
-        "@vercel/build-utils": "13.32.2",
+        "@vercel/build-utils": "14.9.1",
         "esbuild": "0.27.0",
         "etag": "1.8.1",
         "fs-extra": "11.1.0"
       }
     },
     "node_modules/@vercel/go": {
-      "version": "3.10.2",
-      "resolved": "https://registry.npmjs.org/@vercel/go/-/go-3.10.2.tgz",
-      "integrity": "sha512-ZJqx1GzD1qqMkI92jEHp04zCwbZ7tNwcgI58e7t8HiYvILwCZ4Rvq0hfjTjsk+0Zn8A369qs4eAHvCYu38uB5A==",
-      "license": "Apache-2.0"
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/go/-/go-10.0.1.tgz",
+      "integrity": "sha512-qtxY5K4I5c/ll9JgGvxJ2as9mQDKzoiCsvxVB1F4VzsGh03EXJVYdYZoDdBcumdC+q3sy9G4a3UYhIpOspY+8Q==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@vercel/build-utils": "14.9.1"
+      }
     },
     "node_modules/@vercel/h3": {
-      "version": "0.1.107",
-      "resolved": "https://registry.npmjs.org/@vercel/h3/-/h3-0.1.107.tgz",
-      "integrity": "sha512-Vqo5AvE5ku3MIWAi56KlYbLIg/PfX7Xxp94xbNa7J7dbREbO8PZWD0QLKvOw1uGqyoa5YqNZZ3RdtCfDq9Z6oA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/h3/-/h3-7.0.1.tgz",
+      "integrity": "sha512-91utvhU1sigL/MfWgshQ8okSfR4Dfx8iA4kMuA1l2iCRW9cfS3YZxZh6F3IMPyiC/J75e9pCevpf9ze4OHWaNg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/node": "5.8.22",
-        "@vercel/static-config": "3.4.0"
+        "@vercel/node": "12.0.1",
+        "@vercel/static-config": "3.4.3"
+      },
+      "peerDependencies": {
+        "@vercel/build-utils": "14.9.1"
       }
     },
     "node_modules/@vercel/hono": {
-      "version": "0.2.101",
-      "resolved": "https://registry.npmjs.org/@vercel/hono/-/hono-0.2.101.tgz",
-      "integrity": "sha512-sm24D5OUJEo9cuvPHeVgouuc0zhZdIhX28BdtvIek5b7FGmvOE8VExOhteWU5YufhJR0M1y1zbbVC2ULr/arHw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/hono/-/hono-7.0.1.tgz",
+      "integrity": "sha512-ZMDgAZ3RML7M05dUfogmLLLfE2JCJkJTfaCnF6oq9cH/BA0DTxn6QFQvQbIgiA18Ot0FcypuYRl9uge8hdCiYA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@vercel/nft": "1.10.0",
-        "@vercel/node": "5.8.22",
-        "@vercel/static-config": "3.4.0",
+        "@vercel/node": "12.0.1",
+        "@vercel/static-config": "3.4.3",
         "fs-extra": "11.1.0",
         "path-to-regexp": "8.3.0",
         "ts-morph": "12.0.0",
         "zod": "3.22.4"
+      },
+      "peerDependencies": {
+        "@vercel/build-utils": "14.9.1"
       }
     },
     "node_modules/@vercel/hono/node_modules/zod": {
@@ -1836,42 +2264,54 @@
       }
     },
     "node_modules/@vercel/hydrogen": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@vercel/hydrogen/-/hydrogen-1.4.0.tgz",
-      "integrity": "sha512-gf3ELmAjcia7WNGNHAB/rFWFU0l5fJ7mTMgGC5hvcCjSIE4kp8WWuGYiTQgQ8W6GF/1FJAxa2J3BhY/yxjY8tA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/hydrogen/-/hydrogen-8.0.1.tgz",
+      "integrity": "sha512-2CfTbi2XujdyNK/YQxs23j0Llm+jwyZYkysu+NSD8FO/vrpFzK9ozAmlWN+88S4phXoJjnfq35nDGf23YKRkDg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/static-config": "3.4.0",
+        "@vercel/static-config": "3.4.3",
         "ts-morph": "12.0.0"
+      },
+      "peerDependencies": {
+        "@vercel/build-utils": "14.9.1"
       }
     },
     "node_modules/@vercel/koa": {
-      "version": "0.1.81",
-      "resolved": "https://registry.npmjs.org/@vercel/koa/-/koa-0.1.81.tgz",
-      "integrity": "sha512-sAavmnlTM9LhYPWAgIvWuKgpeozk/tB4ZPLe/Fl7qE6EJiN3sCjtaSatXhla5w1Zxy0veBI5u0LCcjref4Oxag==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/koa/-/koa-7.0.1.tgz",
+      "integrity": "sha512-FnQHRkRaL3w1NI+xBznOgFwuu0YfDvqdIdB384KdXTRYjZs3yhBfIC9GY0qmTu69Bh3Sln7ZANANZAK+7hbwmg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/node": "5.8.22",
-        "@vercel/static-config": "3.4.0"
+        "@vercel/node": "12.0.1",
+        "@vercel/static-config": "3.4.3"
+      },
+      "peerDependencies": {
+        "@vercel/build-utils": "14.9.1"
       }
     },
     "node_modules/@vercel/nestjs": {
-      "version": "0.2.102",
-      "resolved": "https://registry.npmjs.org/@vercel/nestjs/-/nestjs-0.2.102.tgz",
-      "integrity": "sha512-CMDoq4dFBI1rLmAuya7UPXfcg7h0y1xdNVCeFhzlZOfp7EF1+PFkn3dVF8tIX46yiUFCz94weiLHSAoh+mRD4g==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/nestjs/-/nestjs-7.0.1.tgz",
+      "integrity": "sha512-kRmI/lJ3w4SpRjtCKZMxt69JSZDQn6ulRGAmrkr/p6ioYVstC1Uf94zRPjafkBIVYJFW0KExNq/kwv5XYU59bw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/node": "5.8.22",
-        "@vercel/static-config": "3.4.0"
+        "@vercel/node": "12.0.1",
+        "@vercel/static-config": "3.4.3"
+      },
+      "peerDependencies": {
+        "@vercel/build-utils": "14.9.1"
       }
     },
     "node_modules/@vercel/next": {
-      "version": "4.20.2",
-      "resolved": "https://registry.npmjs.org/@vercel/next/-/next-4.20.2.tgz",
-      "integrity": "sha512-mroXgsjkmI6i5m1dMRmFNHO8wExhhgOzFRHT0pg195uOVyuNU2JxBCtU47FowbcnLbrAmIfStWkPSHLwPRh6FA==",
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/@vercel/next/-/next-11.0.2.tgz",
+      "integrity": "sha512-c97ybY1jpF7534R0DkxlydWOOcFg93X24rdEdljBHtnho3wWD2RE+E9beC5dzq98uXSYSXrUQUghQko8oiY8sg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@vercel/nft": "1.10.0"
+      },
+      "peerDependencies": {
+        "@vercel/build-utils": "14.9.1"
       }
     },
     "node_modules/@vercel/nft": {
@@ -1901,19 +2341,18 @@
       }
     },
     "node_modules/@vercel/node": {
-      "version": "5.8.22",
-      "resolved": "https://registry.npmjs.org/@vercel/node/-/node-5.8.22.tgz",
-      "integrity": "sha512-WfciIhDVh9RwFmvrWp7FAdYCBPV94bZvIo4JbaHqZbvBJ2Bmnv/Pgj1fTjjLKfnKTbLJy+8HN1FXB8KYDnwGZQ==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/node/-/node-12.0.1.tgz",
+      "integrity": "sha512-aKxdgnp31N/clDxZM69Z9McoZ0gfBo48Ms+iiuFxJ5wt2SilTVvmS3Rn/LZjlTvQwHGKlJPUwamiuDs/Qsfszw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@edge-runtime/node-utils": "2.3.0",
         "@edge-runtime/primitives": "4.1.0",
         "@edge-runtime/vm": "3.2.0",
         "@types/node": "20.11.0",
-        "@vercel/build-utils": "13.32.2",
-        "@vercel/error-utils": "2.2.0",
+        "@vercel/error-utils": "2.2.1",
         "@vercel/nft": "1.10.0",
-        "@vercel/static-config": "3.4.0",
+        "@vercel/static-config": "3.4.3",
         "async-listen": "3.0.0",
         "cjs-module-lexer": "1.2.3",
         "edge-runtime": "2.5.9",
@@ -1928,6 +2367,9 @@
         "tsx": "4.21.0",
         "typescript": "npm:typescript@5.9.3",
         "undici": "5.28.4"
+      },
+      "peerDependencies": {
+        "@vercel/build-utils": "14.9.1"
       }
     },
     "node_modules/@vercel/node/node_modules/es-module-lexer": {
@@ -1975,10 +2417,15 @@
       }
     },
     "node_modules/@vercel/oidc": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
-      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.8.5.tgz",
+      "integrity": "sha512-RwXYtnt6za+5UO4IaLywN/6B95AlLqynPRUWRJxeJ/qufwkcLUbZNUxYtzT0uMpuraWhlNcGqPNGkTnZr4BGBw==",
       "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/cli-config": "0.2.4",
+        "@vercel/cli-exec": "1.0.1",
+        "jose": "^5.9.6"
+      },
       "engines": {
         "node": ">= 20"
       }
@@ -1990,18 +2437,21 @@
       "license": "MIT"
     },
     "node_modules/@vercel/python": {
-      "version": "6.47.3",
-      "resolved": "https://registry.npmjs.org/@vercel/python/-/python-6.47.3.tgz",
-      "integrity": "sha512-h8j5Fln+GYPkWCIXZdhUq1ibFQofjeiV6LMgeY31NEFn/lolz/UxDwqSZswM9H1aP/5lH54VCe/iFE4dMlSWiQ==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/python/-/python-13.0.1.tgz",
+      "integrity": "sha512-w96ozfdjVQxkPXKcY6GEi7/gqc9ZLriiWiflrUS/fBq66gTBkWtga2CFhK166ZaQT+cqgN3/X0NED7gUUzoLGw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/python-analysis": "0.11.1"
+        "@vercel/python-analysis": "0.14.0"
+      },
+      "peerDependencies": {
+        "@vercel/build-utils": "14.9.1"
       }
     },
     "node_modules/@vercel/python-analysis": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@vercel/python-analysis/-/python-analysis-0.11.1.tgz",
-      "integrity": "sha512-EPPLuXJQhIDUx08H9nG76AR2HSgBquwe3OAX5s2w20M923iaWeGGVkhX/4yZ89CJfXEZgE1Aj/mX7lVHOVIcYA==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@vercel/python-analysis/-/python-analysis-0.14.0.tgz",
+      "integrity": "sha512-qyVxbaU14gAi/AsaR8syZLukUsOp69Jkm1xn80rZPy4k9+zRUTIfqs0AOk7L8wwBxDDB6LLjcBUAmafhbJQnUQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bytecodealliance/preview2-shim": "0.17.6",
@@ -2037,15 +2487,18 @@
       }
     },
     "node_modules/@vercel/redwood": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@vercel/redwood/-/redwood-2.5.0.tgz",
-      "integrity": "sha512-LO24CbieV57rGAqrq5n5z/B+fMYeUqbE/Ge3qMeKRuS3Q9awgcBgB6WYLCe8crHM7XJd5AZjbuyoS/6k3r0X0w==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/redwood/-/redwood-9.0.1.tgz",
+      "integrity": "sha512-gamcb5L0T5HA11+10kBxypGbxSm3wTzWcor6qCpJdO3YMNzbvf74PZmwPfEMEsMo9BBb0MV03XgsVObra5lriw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@vercel/nft": "1.10.0",
-        "@vercel/static-config": "3.4.0",
+        "@vercel/static-config": "3.4.3",
         "semver": "6.3.1",
         "ts-morph": "12.0.0"
+      },
+      "peerDependencies": {
+        "@vercel/build-utils": "14.9.1"
       }
     },
     "node_modules/@vercel/redwood/node_modules/semver": {
@@ -2058,17 +2511,20 @@
       }
     },
     "node_modules/@vercel/remix-builder": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@vercel/remix-builder/-/remix-builder-5.9.1.tgz",
-      "integrity": "sha512-s0SpfV640nmQ1BsKCPMYugGrH/V+319onTo2ZILSmsy6NTBlmeN0zJU9nPcP8dBEotGqtp68NfOlOUUdrVBzkw==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/remix-builder/-/remix-builder-12.0.1.tgz",
+      "integrity": "sha512-7X5F2f61bUANZ1NawaXRZh322sHR4RLMADrOKIbteCeMUw1me2FhgM5EjYWxGwCwkD2tmveo+CtDU5cESsmLag==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/error-utils": "2.2.0",
+        "@vercel/error-utils": "2.2.1",
         "@vercel/nft": "1.10.0",
-        "@vercel/static-config": "3.4.0",
+        "@vercel/static-config": "3.4.3",
         "path-to-regexp": "6.1.0",
         "path-to-regexp-updated": "npm:path-to-regexp@6.3.0",
         "ts-morph": "12.0.0"
+      },
+      "peerDependencies": {
+        "@vercel/build-utils": "14.9.1"
       }
     },
     "node_modules/@vercel/remix-builder/node_modules/path-to-regexp": {
@@ -2078,19 +2534,26 @@
       "license": "MIT"
     },
     "node_modules/@vercel/ruby": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@vercel/ruby/-/ruby-2.5.1.tgz",
-      "integrity": "sha512-e23M7pfORQyyxSUmeQ8PqEnyLJ4swhtNrnyctU5E02UCaUYFm5YAdNfdPYRP4It874H4Wyvm+LV8u7CPBrfcPA==",
-      "license": "Apache-2.0"
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/ruby/-/ruby-9.0.1.tgz",
+      "integrity": "sha512-DwqWxQiA7DSnA1/Xr5EkZ8tCfeZ/yc/zbX15DfwBbHsXdcX4dnKLjjQNZan/6zCehHRWstEQja9JMohRK39oeQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@vercel/build-utils": "14.9.1"
+      }
     },
     "node_modules/@vercel/rust": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@vercel/rust/-/rust-1.3.0.tgz",
-      "integrity": "sha512-z1X0z1NM+ISunm/scgRpuENNwcKlh7DjXn0QvKE0n10DcaYqxkBQVK8iRA9X05xSK9AzPlnB9DHdGKiXZO5buw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/rust/-/rust-8.0.1.tgz",
+      "integrity": "sha512-rCXhlyA4P80cXpIsMAueVeymsia8dlyZwFJNXyYKOxeMnVasZsDJ06/xuObwLndww16IaNrGtkf9GQ7uU1JVwA==",
       "license": "Apache-2.0",
       "dependencies": {
         "execa": "5",
+        "get-port": "5.1.1",
         "smol-toml": "1.5.2"
+      },
+      "peerDependencies": {
+        "@vercel/build-utils": "14.9.1"
       }
     },
     "node_modules/@vercel/rust/node_modules/execa": {
@@ -2144,9 +2607,9 @@
       "license": "ISC"
     },
     "node_modules/@vercel/sandbox": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@vercel/sandbox/-/sandbox-2.1.1.tgz",
-      "integrity": "sha512-gKhW+YlvU15Qxya7jQKByB+sqA1dWat5zx/rvxT52E3Ryg9MAIXgqD5wd1d+CoJDbdHL26gIOcksTZY5sFpplA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vercel/sandbox/-/sandbox-3.1.0.tgz",
+      "integrity": "sha512-z124E4rsmNpwGtTnLImiYzEXk972bWniQyhlvkEt35UtwKTdfBAFXcNG2OvqYqwzAsdQaP3B7teQ2pqA9B5Viw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@vercel/oidc": "3.2.0",
@@ -2154,12 +2617,22 @@
         "async-retry": "1.3.3",
         "jose": "6.2.3",
         "jsonlines": "0.1.1",
+        "lru-cache": "^10.4.3",
         "ms": "2.1.3",
         "picocolors": "^1.1.1",
         "tar-stream": "3.1.7",
         "undici": "^7.27.1",
         "xdg-app-paths": "5.1.0",
-        "zod": "3.24.4"
+        "zod": "^4.1.1"
+      }
+    },
+    "node_modules/@vercel/sandbox/node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/@vercel/sandbox/node_modules/jose": {
@@ -2170,6 +2643,12 @@
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
+    },
+    "node_modules/@vercel/sandbox/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
     },
     "node_modules/@vercel/sandbox/node_modules/ms": {
       "version": "2.1.3",
@@ -2184,9 +2663,9 @@
       "license": "ISC"
     },
     "node_modules/@vercel/sandbox/node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.1.tgz",
+      "integrity": "sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -2204,37 +2683,84 @@
         "node": ">=6"
       }
     },
-    "node_modules/@vercel/sandbox/node_modules/zod": {
-      "version": "3.24.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.4.tgz",
-      "integrity": "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@vercel/static-build": {
-      "version": "2.11.4",
-      "resolved": "https://registry.npmjs.org/@vercel/static-build/-/static-build-2.11.4.tgz",
-      "integrity": "sha512-Cyjsg4yfiSSwRSq4TaYnxDzh3Cembx6hlUCKD0z3QCvEYFjTR3j1bFKk8haekwSB16qg25k9fiPEZMP7B/Azag==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/static-build/-/static-build-9.0.1.tgz",
+      "integrity": "sha512-n/4AxdEBprOo/1WEHyQfZdYKw1fmAn54SQGWww0ZP3WRkbYRKui1KjkfqeHLdSkhu6AAsZGpRlYZmK5sghFErA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/gatsby-plugin-vercel-analytics": "1.0.11",
-        "@vercel/gatsby-plugin-vercel-builder": "2.2.24",
-        "@vercel/static-config": "3.4.0",
+        "@vercel/gatsby-plugin-vercel-analytics": "1.0.12",
+        "@vercel/gatsby-plugin-vercel-builder": "2.2.53",
+        "@vercel/static-config": "3.4.3",
         "ts-morph": "12.0.0"
+      },
+      "peerDependencies": {
+        "@vercel/build-utils": "14.9.1"
       }
     },
     "node_modules/@vercel/static-config": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@vercel/static-config/-/static-config-3.4.0.tgz",
-      "integrity": "sha512-wCq90CMUB//ggnFh77NQO1xaLFsS4LigQIqKrH6ohnr9Br/KI1FhlErx62WfCOuueWaW+LVsbLOqNXIUjK8t6A==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@vercel/static-config/-/static-config-3.4.3.tgz",
+      "integrity": "sha512-BY1sL8rNJvIm3TK/8TQ+Q6jIx7NpO5xckQzv7s6c1ypHvRnTl+vf6rmgY5WFXmoYDeGm3tMy4jiy/5M/5jGr/g==",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "8.6.3",
         "json-schema-to-ts": "1.6.4",
+        "oxc-parser": "0.121.0",
         "ts-morph": "12.0.0"
       }
+    },
+    "node_modules/@vercel/vc-native-darwin-arm64": {
+      "version": "59.11.7",
+      "resolved": "https://registry.npmjs.org/@vercel/vc-native-darwin-arm64/-/vc-native-darwin-arm64-59.11.7.tgz",
+      "integrity": "sha512-SeYVrBni2n2GiUdyfLQb8R5ZSzujljsAePMPOlXg3nIC+oxyFjfmZn/vZmDfjfa5bV/Qme/LRtsU5GJQiSE08w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vercel/vc-native-darwin-x64": {
+      "version": "59.11.7",
+      "resolved": "https://registry.npmjs.org/@vercel/vc-native-darwin-x64/-/vc-native-darwin-x64-59.11.7.tgz",
+      "integrity": "sha512-SAwmxo3kfCXWO32Iq9A1VMVRVWi0B0G1zCPO16Fiuz0eFK/PZRnWXbA2J68U6W3hkf4nCpC6IEagNBhJudA72w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vercel/vc-native-linux-arm64": {
+      "version": "59.11.7",
+      "resolved": "https://registry.npmjs.org/@vercel/vc-native-linux-arm64/-/vc-native-linux-arm64-59.11.7.tgz",
+      "integrity": "sha512-UbyQVlA59SPsQmSfUUAdMm37bOVJti/GbcsEF4QwFIsWjjV2wPFJkfzSICeE25xw/TSWCNmVD4GqjXJEnzAGcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vercel/vc-native-linux-x64": {
+      "version": "59.11.7",
+      "resolved": "https://registry.npmjs.org/@vercel/vc-native-linux-x64/-/vc-native-linux-x64-59.11.7.tgz",
+      "integrity": "sha512-zabEvXd4VDxV8kYl1vXHBqJGiG354EWrEAoJD+zTuwQxu4bM38nZON96OvsQEGJt4Q1WG0cjFwPFfqEugrUOfQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/@workflow/serde": {
       "version": "4.1.0-beta.2",
@@ -2252,9 +2778,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
-      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -2315,18 +2841,6 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
-    "node_modules/ast-types": {
-      "version": "0.13.4",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
-      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/async-listen": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/async-listen/-/async-listen-3.0.0.tgz",
@@ -2372,9 +2886,9 @@
       "license": "MIT"
     },
     "node_modules/bare-events": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
-      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.2.tgz",
+      "integrity": "sha512-AIPKioV7/Y/8KfZ3AAhjPJxLLbY49S64Ym5DakZlUg75qQiTgUq9hEJoEwa4eUezPUlXRy/i5NpsKvo9jgKmoA==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "bare-abort-controller": "*"
@@ -2383,15 +2897,6 @@
         "bare-abort-controller": {
           "optional": true
         }
-      }
-    },
-    "node_modules/basic-ftp": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
-      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/bindings": {
@@ -2404,9 +2909,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -2526,15 +3031,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
-      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -2565,20 +3061,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/degenerator": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
-      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ast-types": "^0.13.4",
-        "escodegen": "^2.1.0",
-        "esprima": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/depd": {
@@ -2687,63 +3169,11 @@
         "@esbuild/win32-x64": "0.27.0"
       }
     },
-    "node_modules/escodegen": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
-      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^5.2.0",
-        "esutils": "^2.0.2"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
-      }
-    },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "license": "MIT"
-    },
-    "node_modules/esutils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/etag": {
       "version": "1.8.1",
@@ -2825,9 +3255,9 @@
       }
     },
     "node_modules/fastq": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
-      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.3.tgz",
+      "integrity": "sha512-XKv5nnLs6nLF71NgiKJLIZFLkPyIEuOselLG7ujZnGrRfQK8HpvY+WqKhAJUAdLomwVHErVS4LfxFlPq0/FTAw==",
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -2925,29 +3355,15 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
-      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.3.tgz",
+      "integrity": "sha512-++QEw4DIY7WGoukz+/+A/8dGYPT9l9yIadnmSgZ8Rjr3YVSVDipQSO9CdnJo9ePqFqUUqh+wk9uIaoiAwsiPkA==",
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
       },
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-      }
-    },
-    "node_modules/get-uri": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
-      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
-      "license": "MIT",
-      "dependencies": {
-        "basic-ftp": "^5.0.2",
-        "data-uri-to-buffer": "^6.0.2",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/glob": {
@@ -2989,24 +3405,24 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -3035,19 +3451,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/http-proxy-agent": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -3089,15 +3492,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
-    },
-    "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
     },
     "node_modules/is-buffer": {
       "version": "2.0.5",
@@ -3240,6 +3634,12 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "license": "MIT"
+    },
     "node_modules/jsonfile": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
@@ -3259,9 +3659,9 @@
       "license": "MIT"
     },
     "node_modules/lru-cache": {
-      "version": "11.5.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -3426,15 +3826,6 @@
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
       "license": "MIT"
     },
-    "node_modules/netmask": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
-      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/node-fetch": {
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -3543,6 +3934,43 @@
         "node": ">= 6.0"
       }
     },
+    "node_modules/oxc-parser": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.121.0.tgz",
+      "integrity": "sha512-ek9o58+SCv6AV7nchiAcUJy1DNE2CC5WRdBcO0mF+W4oRjNQfPO7b3pLjTHSFECpHkKGOZSQxx3hk8viIL5YCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "^0.121.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-parser/binding-android-arm-eabi": "0.121.0",
+        "@oxc-parser/binding-android-arm64": "0.121.0",
+        "@oxc-parser/binding-darwin-arm64": "0.121.0",
+        "@oxc-parser/binding-darwin-x64": "0.121.0",
+        "@oxc-parser/binding-freebsd-x64": "0.121.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.121.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.121.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.121.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.121.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.121.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.121.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.121.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.121.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.121.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.121.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.121.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.121.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.121.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.121.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.121.0"
+      }
+    },
     "node_modules/oxc-transform": {
       "version": "0.111.0",
       "resolved": "https://registry.npmjs.org/oxc-transform/-/oxc-transform-0.111.0.tgz",
@@ -3584,38 +4012,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/pac-proxy-agent": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
-      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
-      "license": "MIT",
-      "dependencies": {
-        "@tootallnate/quickjs-emscripten": "^0.23.0",
-        "agent-base": "^7.1.2",
-        "debug": "^4.3.4",
-        "get-uri": "^6.0.1",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.6",
-        "pac-resolver": "^7.0.1",
-        "socks-proxy-agent": "^8.0.5"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/pac-resolver": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
-      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
-      "license": "MIT",
-      "dependencies": {
-        "degenerator": "^5.0.0",
-        "netmask": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/parse-ms": {
@@ -3688,9 +4084,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -3718,40 +4114,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/promisepipe/-/promisepipe-3.0.0.tgz",
       "integrity": "sha512-V6TbZDJ/ZswevgkDNpGt/YqNCiZP9ASfgU+p83uJE6NrGtvSGoOcHLiDCqkMs2+yg7F5qHdLV8d0aS8O26G/KA==",
-      "license": "MIT"
-    },
-    "node_modules/proxy-agent": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.4.0.tgz",
-      "integrity": "sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.0.2",
-        "debug": "^4.3.4",
-        "http-proxy-agent": "^7.0.1",
-        "https-proxy-agent": "^7.0.3",
-        "lru-cache": "^7.14.1",
-        "pac-proxy-agent": "^7.0.1",
-        "proxy-from-env": "^1.1.0",
-        "socks-proxy-agent": "^8.0.2"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/proxy-agent/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
     },
     "node_modules/pump": {
@@ -3907,6 +4269,15 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.1"
       }
     },
+    "node_modules/rolldown/node_modules/@oxc-project/types": {
+      "version": "0.110.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.110.0.tgz",
+      "integrity": "sha512-6Ct21OIlrEnFEJk5LT4e63pk3btsI6/TusD/GStLi7wYlGJNOl1GI9qvXAnRAxQU9zqA2Oz+UwhfTOU2rPZVow==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -3937,14 +4308,15 @@
       "license": "MIT"
     },
     "node_modules/sandbox": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/sandbox/-/sandbox-3.1.2.tgz",
-      "integrity": "sha512-g93rma0Z9Aa6EoTktzYnGZmQvMzm7j73BekJIMwmkdWR5uryZ+6hBCADtd3JKGAB27k+ubnG7HHsZqtscAMzIQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/sandbox/-/sandbox-4.1.0.tgz",
+      "integrity": "sha512-kzDiAyvrGHGdrQ/7mT6Md18K9OUVgZW/KUKO/wBJ/gHouDh6oJPWcGWfOV5i7CSep2map3Pl7vV9gszm3Cvu7Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/sandbox": "2.1.1",
+        "@vercel/sandbox": "3.1.0",
         "async-retry": "1.3.3",
         "debug": "^4.4.1",
+        "ws": "^8.21.0",
         "zod": "^4.1.1"
       },
       "bin": {
@@ -4047,16 +4419,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/smart-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
     "node_modules/smol-toml": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.5.2.tgz",
@@ -4067,44 +4429,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/cyyynthia"
-      }
-    },
-    "node_modules/socks": {
-      "version": "2.8.9",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
-      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
-      "license": "MIT",
-      "dependencies": {
-        "ip-address": "^10.1.1",
-        "smart-buffer": "^4.2.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/socks-proxy-agent": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
-      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "^4.3.4",
-        "socks": "^2.8.3"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/srvx": {
@@ -4174,9 +4498,9 @@
       }
     },
     "node_modules/streamx": {
-      "version": "2.28.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
-      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+      "version": "2.28.1",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.1.tgz",
+      "integrity": "sha512-zEzXb0s5Cds7tqMH6rhZ05lcJydCWiQPEwiNngVqzsxCc962vLY4Uw+mW7od8kDH258k2Uz/JrOkdIAAhSh9VA==",
       "license": "MIT",
       "dependencies": {
         "events-universal": "^1.0.0",
@@ -4319,7 +4643,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/tsx": {
       "version": "4.21.0",
@@ -4404,46 +4729,61 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
     "node_modules/vercel": {
-      "version": "54.18.5",
-      "resolved": "https://registry.npmjs.org/vercel/-/vercel-54.18.5.tgz",
-      "integrity": "sha512-a7ts2raj/Wtv27kC7kiOo8Zn3Gr+q2F1CJWqiOmtWuZXRRgY3MHG9n6r5UXIV2cJ85IZSZGg8ENat2gAUTDkCQ==",
+      "version": "59.11.7",
+      "resolved": "https://registry.npmjs.org/vercel/-/vercel-59.11.7.tgz",
+      "integrity": "sha512-C+L/JKmlGDypKGcTU/atckydeK/AKa/7fKwUbvcwveguV1QPlY8beiIGgbwkdbb80bbIpPFHRQYrhi5XPAmCBA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vercel/backends": "0.8.20",
-        "@vercel/blob": "2.4.0",
-        "@vercel/build-utils": "13.32.2",
-        "@vercel/cli-auth": "0.3.0",
-        "@vercel/cli-config": "0.2.0",
-        "@vercel/container": "0.0.4",
-        "@vercel/detect-agent": "1.2.3",
-        "@vercel/elysia": "0.1.98",
-        "@vercel/express": "0.1.111",
-        "@vercel/fastify": "0.1.101",
+        "@vercel/backends": "7.0.2",
+        "@vercel/blob": "2.8.0",
+        "@vercel/build-utils": "14.9.1",
+        "@vercel/cli-auth": "0.3.5",
+        "@vercel/cli-config": "0.2.4",
+        "@vercel/container": "7.0.1",
+        "@vercel/detect-agent": "1.2.5",
+        "@vercel/elysia": "7.0.1",
+        "@vercel/express": "7.0.2",
+        "@vercel/fastify": "7.0.1",
         "@vercel/fun": "1.3.0",
-        "@vercel/go": "3.10.2",
-        "@vercel/h3": "0.1.107",
-        "@vercel/hono": "0.2.101",
-        "@vercel/hydrogen": "1.4.0",
-        "@vercel/koa": "0.1.81",
-        "@vercel/nestjs": "0.2.102",
-        "@vercel/next": "4.20.2",
-        "@vercel/node": "5.8.22",
+        "@vercel/go": "10.0.1",
+        "@vercel/h3": "7.0.1",
+        "@vercel/hono": "7.0.1",
+        "@vercel/hydrogen": "8.0.1",
+        "@vercel/koa": "7.0.1",
+        "@vercel/nestjs": "7.0.1",
+        "@vercel/next": "11.0.2",
+        "@vercel/node": "12.0.1",
         "@vercel/prepare-flags-definitions": "0.3.0",
-        "@vercel/python": "6.47.3",
-        "@vercel/redwood": "2.5.0",
-        "@vercel/remix-builder": "5.9.1",
-        "@vercel/ruby": "2.5.1",
-        "@vercel/rust": "1.3.0",
-        "@vercel/static-build": "2.11.4",
+        "@vercel/python": "13.0.1",
+        "@vercel/python-analysis": "0.14.0",
+        "@vercel/redwood": "9.0.1",
+        "@vercel/remix-builder": "12.0.1",
+        "@vercel/ruby": "9.0.1",
+        "@vercel/rust": "8.0.1",
+        "@vercel/static-build": "9.0.1",
         "chokidar": "4.0.0",
         "esbuild": "0.27.0",
         "jose": "5.9.6",
+        "jsonc-parser": "3.3.1",
         "luxon": "^3.4.0",
-        "proxy-agent": "6.4.0",
-        "sandbox": "3.1.2",
+        "sandbox": "4.1.0",
         "smol-toml": "1.5.2",
         "undici": "5.29.0",
+        "uuid": "14.0.1",
         "zod": "4.1.11"
       },
       "bin": {
@@ -4452,6 +4792,12 @@
       },
       "engines": {
         "node": ">= 18"
+      },
+      "optionalDependencies": {
+        "@vercel/vc-native-darwin-arm64": "59.11.7",
+        "@vercel/vc-native-darwin-x64": "59.11.7",
+        "@vercel/vc-native-linux-arm64": "59.11.7",
+        "@vercel/vc-native-linux-x64": "59.11.7"
       }
     },
     "node_modules/web-vitals": {
@@ -4496,6 +4842,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xdg-app-paths": {
       "version": "5.5.1",

--- a/nix/provider-clis/vercel-cli/package.json
+++ b/nix/provider-clis/vercel-cli/package.json
@@ -3,6 +3,6 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "vercel": "54.18.5"
+    "vercel": "59.11.7"
   }
 }


### PR DESCRIPTION
## Problem

The first-party Vercel CLI derivation remained pinned to 54.18.5 while the current stable CLI is 59.11.7.

## Goal

Move the Vercel CLI derivation to 59.11.7 and keep `package.json`, the regenerated lockfile, derivation version, and `npmDepsHash` aligned.

## Decisions

Keep this independent provider-CLI cohort separate from the compatible dependency update in #1225. Preserve the existing `buildNpmPackage` packaging and wrapper because 59.11.7 still exposes both `vercel` and `vc` through `dist/vc.js`. Keep optional dependencies because `@vercel/static-config` needs the platform-specific Oxc parser binding at runtime. This PR does not upgrade the Effect RC cohort.

## Verification

- `nix build .#vercel-cli --no-link` passed.
- The built dependency closure contains `@oxc-parser/binding-linux-x64-gnu`.
- The diff aligns Vercel CLI 59.11.7 across `default.nix`, `package.json`, and `package-lock.json` and refreshes `npmDepsHash`.
- Current-head GitHub CI is running after the review fix and rebase.
- Pre-flip deviation: `devenv tasks run check:all` was not run because the current-`main` regression tracked by schickling/dotfiles#2602 makes that gate invoke destructive `mr:apply` behavior; focused checks and current CI are used instead.

## Complexity

No new abstraction; the large diff is generated lockfile churn from the provider CLI upgrade.

## Concerns

This crosses five CLI majors. The repository deploy path uses `pull`, `build`, `deploy --prebuilt`, and `alias`, but the live deploy CI lane was skipped, so no live Vercel deployment is claimed.

## Friction & bottlenecks

Local project-wide validation is blocked by schickling/dotfiles#2602. Current CI is delayed by the shared runner queue.

## Follow-ups

None.

## References

- Base compatible dependency cohort: #1225
- Pre-flip validation regression: schickling/dotfiles#2602

<!-- agent-footer:begin v=2 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | dev3.direct.omp.nsyk4mvc |
| `session` | dev3.nsyk4mvc |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.1.7 |
| `agent_runtime` | OMP 18.1.7 |
| `tooling_profile` | dotfiles@8d937c9 |
</details>
<!-- agent-footer:end -->