### PR TITLE
chore(deps): update KaTeX to 0.18.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -591,6 +591,23 @@ tsconfig.check.json`, but oxlint 1.39 cannot speak the tsgolint 7 protocol, so
   remeasured locally against the regenerated lockfile (`evergreen fod refresh`,
   x86_64-linux): every one moved, because eslint 10.10.0 replaces keyv 4 with
   the cacheable/keyv v5 chain in the workspace-wide store.
+- **@overeng/notion-react**: KaTeX 0.17.0 → 0.18.7 (optional `katex` peer dep,
+  now `^0.18.7`). KaTeX 0.18.0 prefixed twenty-one generic internal CSS class
+  names — `.accent`, `.base`, `.fix`, `.hdashline`, `.hline`, `.inner`,
+  `.newline`, `.overlay`, `.overline`, `.root`, `.rule`, `.sizing`, `.smash`,
+  `.sout`, `.stretchy`, `.strut`, `.tag`, `.thinbox`, `.underline`, `.vbox`
+  became `katex-`-prefixed and `.hbox` is gone. Nothing in this repo selects
+  KaTeX internals (`web/katex.css` only re-exports `katex/dist/katex.min.css`,
+  and `web/styles.css` plus the vendored Notion stylesheet stay inside
+  `.notion-*`), so the renderer is unchanged: the
+  `renderToString(expression, { displayMode, throwOnError: false, output: 'html' })`
+  call in `src/web/katex.tsx` is API-identical in 0.18. Downstream consumers who
+  override KaTeX internals from their own CSS must re-prefix their selectors.
+  `@types/katex` is dropped from the catalog and from `notion-react`'s
+  devDependencies: KaTeX ships its own `types/katex.d.ts` through its exports
+  map, so the DefinitelyTyped stub was a shadowing duplicate frozen at the
+  0.16 API. KaTeX's `commander` dependency moves 8.3.0 → 15.0.0 in the lock
+  (CLI-only, and the only `commander` consumer in the graph).
 
 - **CI**: normalize the repository-local CI VRS under `context/ci/` and make
   workflow event admission semantic. Pull requests now trigger only for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -607,7 +607,17 @@ tsconfig.check.json`, but oxlint 1.39 cannot speak the tsgolint 7 protocol, so
   devDependencies: KaTeX ships its own `types/katex.d.ts` through its exports
   map, so the DefinitelyTyped stub was a shadowing duplicate frozen at the
   0.16 API. KaTeX's `commander` dependency moves 8.3.0 → 15.0.0 in the lock
-  (CLI-only, and the only `commander` consumer in the graph).
+  (CLI-only, and the only `commander` consumer in the graph). `commander` 15
+  advertises `engines.node >= 22.12`, but that is an install-time advisory
+  rather than a runtime floor — the render path never loads it, so
+  `notion-react`'s documented Node 20+ / Bun 1.1+ baseline is unchanged.
+  `pnpm-lock.yaml` and `buck2/dependencies/` are regenerated, and all eight
+  root CLI dependency-closure hashes are remeasured locally against the
+  regenerated lockfile (`evergreen fod refresh`, x86_64-linux). All eight move
+  even though none of those closures contains KaTeX or `commander`: each
+  staged FOD source includes the root `pnpm-lock.yaml` and fingerprints it
+  into the derivation name, so any lockfile change rotates every
+  prepared-deps hash.
 
 - **CI**: normalize the repository-local CI VRS under `context/ci/` and make
   workflow event admission semantic. Pull requests now trigger only for

--- a/buck2/dependencies/BUCK
+++ b/buck2/dependencies/BUCK
@@ -3,7 +3,7 @@
 
 # Generated file - DO NOT EDIT
 # Source: pnpm-lock.yaml
-# Store fingerprint: sha256:383811c2535a542f96d9e46ea83e55d83c277f7c705a455910617b34c38f624d
+# Store fingerprint: sha256:12e0e730ae6200d2c05b50dd0d455fa0afa8c077eff078b9fc1e3bf8968c7c1f
 
 load("//buck2:materialization.bzl", "export_materialization_inputs")
 
@@ -2381,15 +2381,6 @@ pnpm_package(
 )
 
 pnpm_package(
-    name = "package_types_katex_0_16_8_3f650f2d083e",
-    package_name = "@types/katex",
-    url = "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
-    sha256 = "f9f54494b75d6c89ed93baf96d0d73d659e52a4318d67cbc6b99671772c4be96",
-    bins = {
-    },
-)
-
-pnpm_package(
     name = "package_types_mdast_4_0_4_20333a456356",
     package_name = "@types/mdast",
     url = "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -3302,10 +3293,10 @@ pnpm_package(
 )
 
 pnpm_package(
-    name = "package_commander_8_3_0_3dc7b9b5cd57",
+    name = "package_commander_15_0_0_d36df49098a7",
     package_name = "commander",
-    url = "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-    sha256 = "1b38e65f9229a84060ca5d041a58e3bc1ea374da6d933f9060ca86a67949c10b",
+    url = "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+    sha256 = "632c1e039b31e98fa79c4fae5b10a5ffbbf9df0f21c9ffb3d74e95734b30696f",
     bins = {
     },
 )
@@ -4204,10 +4195,10 @@ pnpm_package(
 )
 
 pnpm_package(
-    name = "package_katex_0_17_0_a31649006183",
+    name = "package_katex_0_18_7_6ae4a0ab7dfb",
     package_name = "katex",
-    url = "https://registry.npmjs.org/katex/-/katex-0.17.0.tgz",
-    sha256 = "252efd48f892d178136fe3ba3530d3718b2b087ea81c3a40a877227bc61d5256",
+    url = "https://registry.npmjs.org/katex/-/katex-0.18.7.tgz",
+    sha256 = "9a80a3fba2367e99bf67b52bfff52e9534c8c7f198e4eaa12699e4f1df9a0bda",
     bins = {
         "katex": "cli.js",
     },
@@ -9382,16 +9373,6 @@ pnpm_store_entry(
 )
 
 pnpm_store_entry(
-    name = "entry_types_katex_0_16_8_3f650f2d083e",
-    package = ":package_types_katex_0_16_8_3f650f2d083e",
-    store_key = "@types+katex@0.16.8",
-    runtime = ":assemble-store.ts",
-    dependencies = {
-    },
-    visibility = ["PUBLIC"],
-)
-
-pnpm_store_entry(
     name = "entry_types_mdast_4_0_4_20333a456356",
     package = ":package_types_mdast_4_0_4_20333a456356",
     store_key = "@types+mdast@4.0.4",
@@ -10509,9 +10490,9 @@ pnpm_store_entry(
 )
 
 pnpm_store_entry(
-    name = "entry_commander_8_3_0_3dc7b9b5cd57",
-    package = ":package_commander_8_3_0_3dc7b9b5cd57",
-    store_key = "commander@8.3.0",
+    name = "entry_commander_15_0_0_d36df49098a7",
+    package = ":package_commander_15_0_0_d36df49098a7",
+    store_key = "commander@15.0.0",
     runtime = ":assemble-store.ts",
     dependencies = {
     },
@@ -11576,12 +11557,12 @@ pnpm_store_entry(
 )
 
 pnpm_store_entry(
-    name = "entry_katex_0_17_0_a31649006183",
-    package = ":package_katex_0_17_0_a31649006183",
-    store_key = "katex@0.17.0",
+    name = "entry_katex_0_18_7_6ae4a0ab7dfb",
+    package = ":package_katex_0_18_7_6ae4a0ab7dfb",
+    store_key = "katex@0.18.7",
     runtime = ":assemble-store.ts",
     dependencies = {
-        "commander": ":entry_commander_8_3_0_3dc7b9b5cd57",
+        "commander": ":entry_commander_15_0_0_d36df49098a7",
     },
     visibility = ["PUBLIC"],
 )
@@ -28559,13 +28540,12 @@ pnpm_store_view(
         "@playwright/test": "@playwright+test@1.63.0",
         "@storybook/react": "@storybook+react@10.6.0_@types+react-dom@19.2.7_@types+react@19.2.18_@types+react@19.2.18_react-dom@19._c8fa65d991fb5130",
         "@storybook/react-vite": "@storybook+react-vite@10.6.0_@types+react-dom@19.2.7_@types+react@19.2.18_@types+react@19.2.18_react-do_9b5eccc39f239997",
-        "@types/katex": "@types+katex@0.16.8",
         "@types/node": "@types+node@26.5.0",
         "@types/react": "@types+react@19.2.18",
         "@types/react-dom": "@types+react-dom@19.2.7_@types+react@19.2.18",
         "@types/react-reconciler": "@types+react-reconciler@0.33.0_@types+react@19.2.18",
         "effect": "effect@4.0.0-rc.111",
-        "katex": "katex@0.17.0",
+        "katex": "katex@0.18.7",
         "react": "react@19.2.8",
         "react-dom": "react-dom@19.2.8_react@19.2.8",
         "react-reconciler": "react-reconciler@0.33.0_react@19.2.8",
@@ -28660,7 +28640,6 @@ pnpm_store_view(
             "@types+doctrine@0.0.9": ":entry_types_doctrine_0_0_9_bb4eabd24633",
             "@types+estree@1.0.9": ":entry_types_estree_1_0_9_ec29746adee7",
             "@types+hast@3.0.5": ":entry_types_hast_3_0_5_1b23eebfa358",
-            "@types+katex@0.16.8": ":entry_types_katex_0_16_8_3f650f2d083e",
             "@types+mdast@4.0.4": ":entry_types_mdast_4_0_4_20333a456356",
             "@types+node@26.5.0": ":entry_types_node_26_5_0_a0142d056efc",
             "@types+react-dom@19.2.7_@types+react@19.2.18": ":entry_types_react_dom_19_2_7_types_react_19_2_18_cafde4f429b3",
@@ -28708,7 +28687,7 @@ pnpm_store_view(
             "check-error@2.1.3": ":entry_check_error_2_1_3_7cc821aa4c77",
             "cluster-key-slot@1.1.2": ":entry_cluster_key_slot_1_1_2_c0f5d819d288",
             "comma-separated-tokens@2.0.3": ":entry_comma_separated_tokens_2_0_3_84eef10f05ff",
-            "commander@8.3.0": ":entry_commander_8_3_0_3dc7b9b5cd57",
+            "commander@15.0.0": ":entry_commander_15_0_0_d36df49098a7",
             "convert-source-map@2.0.0": ":entry_convert_source_map_2_0_0_46e32cfc1207",
             "css.escape@1.5.1": ":entry_css_escape_1_5_1_dd1a42ad5f03",
             "csstype@3.2.3": ":entry_csstype_3_2_3_d75166202534",
@@ -28759,7 +28738,7 @@ pnpm_store_view(
             "jsesc@3.1.0": ":entry_jsesc_3_1_0_ea0becb009dc",
             "json5@2.2.3": ":entry_json5_2_2_3_16281c6ea25e",
             "jsonc-parser@3.3.1": ":entry_jsonc_parser_3_3_1_867699f9fc7b",
-            "katex@0.17.0": ":entry_katex_0_17_0_a31649006183",
+            "katex@0.18.7": ":entry_katex_0_18_7_6ae4a0ab7dfb",
             "lightningcss@1.33.0": ":entry_lightningcss_1_33_0_7129b0f44113",
             "loupe@3.2.1": ":entry_loupe_3_2_1_6cb5497e77fc",
             "lru-cache@11.5.2": ":entry_lru_cache_11_5_2_e163550123a3",
@@ -28968,7 +28947,6 @@ pnpm_store_view(
             "@types+doctrine@0.0.9": ":entry_types_doctrine_0_0_9_bb4eabd24633",
             "@types+estree@1.0.9": ":entry_types_estree_1_0_9_ec29746adee7",
             "@types+hast@3.0.5": ":entry_types_hast_3_0_5_1b23eebfa358",
-            "@types+katex@0.16.8": ":entry_types_katex_0_16_8_3f650f2d083e",
             "@types+mdast@4.0.4": ":entry_types_mdast_4_0_4_20333a456356",
             "@types+node@26.5.0": ":entry_types_node_26_5_0_a0142d056efc",
             "@types+react-dom@19.2.7_@types+react@19.2.18": ":entry_types_react_dom_19_2_7_types_react_19_2_18_cafde4f429b3",
@@ -29017,7 +28995,7 @@ pnpm_store_view(
             "check-error@2.1.3": ":entry_check_error_2_1_3_7cc821aa4c77",
             "cluster-key-slot@1.1.2": ":entry_cluster_key_slot_1_1_2_c0f5d819d288",
             "comma-separated-tokens@2.0.3": ":entry_comma_separated_tokens_2_0_3_84eef10f05ff",
-            "commander@8.3.0": ":entry_commander_8_3_0_3dc7b9b5cd57",
+            "commander@15.0.0": ":entry_commander_15_0_0_d36df49098a7",
             "convert-source-map@2.0.0": ":entry_convert_source_map_2_0_0_46e32cfc1207",
             "css.escape@1.5.1": ":entry_css_escape_1_5_1_dd1a42ad5f03",
             "csstype@3.2.3": ":entry_csstype_3_2_3_d75166202534",
@@ -29068,7 +29046,7 @@ pnpm_store_view(
             "jsesc@3.1.0": ":entry_jsesc_3_1_0_ea0becb009dc",
             "json5@2.2.3": ":entry_json5_2_2_3_16281c6ea25e",
             "jsonc-parser@3.3.1": ":entry_jsonc_parser_3_3_1_867699f9fc7b",
-            "katex@0.17.0": ":entry_katex_0_17_0_a31649006183",
+            "katex@0.18.7": ":entry_katex_0_18_7_6ae4a0ab7dfb",
             "lightningcss-linux-arm64-gnu@1.33.0": ":entry_lightningcss_linux_arm64_gnu_1_33_0_3c8fab71fd68",
             "lightningcss@1.33.0": ":entry_lightningcss_1_33_0_7129b0f44113",
             "loupe@3.2.1": ":entry_loupe_3_2_1_6cb5497e77fc",
@@ -29278,7 +29256,6 @@ pnpm_store_view(
             "@types+doctrine@0.0.9": ":entry_types_doctrine_0_0_9_bb4eabd24633",
             "@types+estree@1.0.9": ":entry_types_estree_1_0_9_ec29746adee7",
             "@types+hast@3.0.5": ":entry_types_hast_3_0_5_1b23eebfa358",
-            "@types+katex@0.16.8": ":entry_types_katex_0_16_8_3f650f2d083e",
             "@types+mdast@4.0.4": ":entry_types_mdast_4_0_4_20333a456356",
             "@types+node@26.5.0": ":entry_types_node_26_5_0_a0142d056efc",
             "@types+react-dom@19.2.7_@types+react@19.2.18": ":entry_types_react_dom_19_2_7_types_react_19_2_18_cafde4f429b3",
@@ -29327,7 +29304,7 @@ pnpm_store_view(
             "check-error@2.1.3": ":entry_check_error_2_1_3_7cc821aa4c77",
             "cluster-key-slot@1.1.2": ":entry_cluster_key_slot_1_1_2_c0f5d819d288",
             "comma-separated-tokens@2.0.3": ":entry_comma_separated_tokens_2_0_3_84eef10f05ff",
-            "commander@8.3.0": ":entry_commander_8_3_0_3dc7b9b5cd57",
+            "commander@15.0.0": ":entry_commander_15_0_0_d36df49098a7",
             "convert-source-map@2.0.0": ":entry_convert_source_map_2_0_0_46e32cfc1207",
             "css.escape@1.5.1": ":entry_css_escape_1_5_1_dd1a42ad5f03",
             "csstype@3.2.3": ":entry_csstype_3_2_3_d75166202534",
@@ -29378,7 +29355,7 @@ pnpm_store_view(
             "jsesc@3.1.0": ":entry_jsesc_3_1_0_ea0becb009dc",
             "json5@2.2.3": ":entry_json5_2_2_3_16281c6ea25e",
             "jsonc-parser@3.3.1": ":entry_jsonc_parser_3_3_1_867699f9fc7b",
-            "katex@0.17.0": ":entry_katex_0_17_0_a31649006183",
+            "katex@0.18.7": ":entry_katex_0_18_7_6ae4a0ab7dfb",
             "lightningcss-linux-x64-gnu@1.33.0": ":entry_lightningcss_linux_x64_gnu_1_33_0_abda693e4089",
             "lightningcss@1.33.0": ":entry_lightningcss_1_33_0_7129b0f44113",
             "loupe@3.2.1": ":entry_loupe_3_2_1_6cb5497e77fc",
@@ -29588,7 +29565,6 @@ pnpm_store_view(
             "@types+doctrine@0.0.9": ":entry_types_doctrine_0_0_9_bb4eabd24633",
             "@types+estree@1.0.9": ":entry_types_estree_1_0_9_ec29746adee7",
             "@types+hast@3.0.5": ":entry_types_hast_3_0_5_1b23eebfa358",
-            "@types+katex@0.16.8": ":entry_types_katex_0_16_8_3f650f2d083e",
             "@types+mdast@4.0.4": ":entry_types_mdast_4_0_4_20333a456356",
             "@types+node@26.5.0": ":entry_types_node_26_5_0_a0142d056efc",
             "@types+react-dom@19.2.7_@types+react@19.2.18": ":entry_types_react_dom_19_2_7_types_react_19_2_18_cafde4f429b3",
@@ -29637,7 +29613,7 @@ pnpm_store_view(
             "check-error@2.1.3": ":entry_check_error_2_1_3_7cc821aa4c77",
             "cluster-key-slot@1.1.2": ":entry_cluster_key_slot_1_1_2_c0f5d819d288",
             "comma-separated-tokens@2.0.3": ":entry_comma_separated_tokens_2_0_3_84eef10f05ff",
-            "commander@8.3.0": ":entry_commander_8_3_0_3dc7b9b5cd57",
+            "commander@15.0.0": ":entry_commander_15_0_0_d36df49098a7",
             "convert-source-map@2.0.0": ":entry_convert_source_map_2_0_0_46e32cfc1207",
             "css.escape@1.5.1": ":entry_css_escape_1_5_1_dd1a42ad5f03",
             "csstype@3.2.3": ":entry_csstype_3_2_3_d75166202534",
@@ -29689,7 +29665,7 @@ pnpm_store_view(
             "jsesc@3.1.0": ":entry_jsesc_3_1_0_ea0becb009dc",
             "json5@2.2.3": ":entry_json5_2_2_3_16281c6ea25e",
             "jsonc-parser@3.3.1": ":entry_jsonc_parser_3_3_1_867699f9fc7b",
-            "katex@0.17.0": ":entry_katex_0_17_0_a31649006183",
+            "katex@0.18.7": ":entry_katex_0_18_7_6ae4a0ab7dfb",
             "lightningcss-darwin-arm64@1.33.0": ":entry_lightningcss_darwin_arm64_1_33_0_4e7915734c17",
             "lightningcss@1.33.0": ":entry_lightningcss_1_33_0_7129b0f44113",
             "loupe@3.2.1": ":entry_loupe_3_2_1_6cb5497e77fc",
@@ -29811,7 +29787,7 @@ pnpm_store_view(
         },
     },
     bins = {
-        "katex": "katex@0.17.0\tcli.js",
+        "katex": "katex@0.18.7\tcli.js",
         "playwright": "@playwright+test@1.63.0\tcli.js",
         "storybook": "storybook@10.6.0_@types+react-dom@19.2.7_@types+react@19.2.18_@types+react@19.2.18_prettier@3.9.6_react_da9aab27e30e1021\tdist/bin/dispatcher.js",
         "tsc": "typescript@7.0.2\tbin/tsc",

--- a/buck2/dependencies/pnpm-lock.sha256.json
+++ b/buck2/dependencies/pnpm-lock.sha256.json
@@ -1,6 +1,6 @@
 {
   "schema": "effect-utils/buck2-pnpm-sha256/v1",
-  "lockfileFingerprint": "sha256:50221e3b1e66a95f1ea57d8b4bba2c19ab6e6b73c5bcb62eab4b1e506ad5d9b0",
+  "lockfileFingerprint": "sha256:3c6a6f0b4ed3e25bd82f6c7705923aa113b101e15ce57966553535c126cbbd9b",
   "source": "pnpm-lock.yaml",
   "generator": "buck2/dependencies/pnpm-lock.sha256.json.genie.ts",
   "regenerate": "devenv tasks run genie:run",
@@ -3447,5 +3447,5 @@
       "sha256": "2c162e000f5fb5a816987d6f8ad7aad295203f777a5992d514ae4660778a51a4"
     }
   },
-  "fingerprint": "sha256:9abc87bb3e12557221d8a94beb8ce015e63960b16fe29555fb5dc17a7ab75da6"
+  "fingerprint": "sha256:4dd38833c660520e124476042e22cfb5fa9f7e68ae220c3ac1aa1f24e88ee1b7"
 }

--- a/buck2/dependencies/pnpm-lock.sha256.json
+++ b/buck2/dependencies/pnpm-lock.sha256.json
@@ -1311,11 +1311,6 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "sha256": "12dcb1dcff7099bff0663fc220551ba53fcf23c136a22375e323bb6626d95724"
     },
-    "@types/katex@0.16.8": {
-      "bins": {},
-      "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
-      "sha256": "f9f54494b75d6c89ed93baf96d0d73d659e52a4318d67cbc6b99671772c4be96"
-    },
     "@types/mdast@4.0.4": {
       "bins": {},
       "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
@@ -1827,10 +1822,10 @@
       "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
       "sha256": "88123eefbb07a6048efa112653c80f4a0ac2e993bd1388c00273e14de29ec886"
     },
-    "commander@8.3.0": {
+    "commander@15.0.0": {
       "bins": {},
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-      "sha256": "1b38e65f9229a84060ca5d041a58e3bc1ea374da6d933f9060ca86a67949c10b"
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "sha256": "632c1e039b31e98fa79c4fae5b10a5ffbbf9df0f21c9ffb3d74e95734b30696f"
     },
     "convert-source-map@2.0.0": {
       "bins": {},
@@ -2343,12 +2338,12 @@
       "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
       "sha256": "4a0315b8671e7463bae7af7c142cdf19e9aa7ba39eb36dc2df383b8648e3cbc9"
     },
-    "katex@0.17.0": {
+    "katex@0.18.7": {
       "bins": {
         "katex": "cli.js"
       },
-      "integrity": "sha512-Vdw0ATsQ9V+LuegM/BTwQqV/6cTl5lbGcIrU+BCgLxyf6bo38ybOr372tuSIxir3CN720flu1meYR6XzNMwQnw==",
-      "sha256": "252efd48f892d178136fe3ba3530d3718b2b087ea81c3a40a877227bc61d5256"
+      "integrity": "sha512-h+UCwkZ+4Jz8WQ7MLGfj7UVFrRCizGb912fwF4luGdYsC5paYG1vx+jy+KRcC/XkpjGva/P7nAWuxNnPzRvzHw==",
+      "sha256": "9a80a3fba2367e99bf67b52bfff52e9534c8c7f198e4eaa12699e4f1df9a0bda"
     },
     "keyv@5.6.0": {
       "bins": {},

--- a/buck2/dependencies/pnpm-lock.unit.test.ts
+++ b/buck2/dependencies/pnpm-lock.unit.test.ts
@@ -184,8 +184,8 @@ describe('translatePnpmLock', () => {
     const second = translatePnpmLock(options)
 
     expect(second).toEqual(first)
-    expect(Object.keys(first.packages)).toHaveLength(672)
-    expect(Object.keys(first.snapshots)).toHaveLength(673)
+    expect(Object.keys(first.packages)).toHaveLength(671)
+    expect(Object.keys(first.snapshots)).toHaveLength(672)
     expect(Object.keys(first.importers)).toHaveLength(39)
     expect(first.packages['@myobie/pty@0.10.0']!.patch?.path).toBe(
       'packages/@overeng/utils/patches/@myobie__pty@0.10.0.patch',

--- a/buck2/dependencies/pnpm-store.unit.test.ts
+++ b/buck2/dependencies/pnpm-store.unit.test.ts
@@ -486,8 +486,8 @@ describe('normalized store projection of the real lockfile', () => {
   })
 
   it('declares one entry per snapshot and one view per importer', () => {
-    expect(projection.entries).toHaveLength(673)
-    expect(new Set(projection.entries.map((entry) => entry.storeKey)).size).toBe(673)
+    expect(projection.entries).toHaveLength(672)
+    expect(new Set(projection.entries.map((entry) => entry.storeKey)).size).toBe(672)
     expect(projection.views).toHaveLength(Object.keys(metadata.importers).length)
     expect(computeStoreSccs({ metadata })).toEqual(projection.sccs.map((scc) => scc.members))
   })

--- a/genie/external.ts
+++ b/genie/external.ts
@@ -302,7 +302,7 @@ export const catalog = defineCatalog({
   'react-aria-components': '1.21.1',
 
   // Notion rendering (optional peer deps)
-  katex: '0.17.0',
+  katex: '0.18.7',
   shiki: '4.4.3',
 
   // Markdown (notion-md canonical markdown pipeline)
@@ -331,7 +331,6 @@ export const catalog = defineCatalog({
   '@types/node': '26.5.0',
   '@types/bun': '1.4.1',
   '@types/is-dom': '1.1.2',
-  '@types/katex': '0.16.8',
 
   // Build tools
   // TypeScript 7's npm package provides the native compiler plus its process-backed unstable API.

--- a/packages/@overeng/ci-tools/nix/build.nix
+++ b/packages/@overeng/ci-tools/nix/build.nix
@@ -19,7 +19,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-mWVhuFFO6Dxyics7N1mW+YDKWI0NsvibkCDL5ES0wzI=";
+      "." = mkSharedHash "sha256-Ix9O9JsGVwROepo66pGThubYyhK0mjbe04aTlJAhZtQ=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/genie/nix/build.nix
+++ b/packages/@overeng/genie/nix/build.nix
@@ -31,7 +31,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-dzkq9usUwwExKY+LhFgbMpsHhjkbcLs7s4E4ZEHcSoY=";
+      "." = mkSharedHash "sha256-520EAYXJtDJsO1ksstE0VJzK8Vxt1bpUfsFQ4Or/7x0=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/megarepo/nix/build.nix
+++ b/packages/@overeng/megarepo/nix/build.nix
@@ -26,7 +26,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-oWyrH1hcjn1kVoNg/tkRacDr2l0iJi/V0F599FQXljc=";
+      "." = mkSharedHash "sha256-y/D/HIkSJKJdcpXBag2mTIeqs+dYWkkrOojv7NYzbRY=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     smokeTestArgs = [ "--help" ];

--- a/packages/@overeng/notion-cli/nix/build.nix
+++ b/packages/@overeng/notion-cli/nix/build.nix
@@ -33,7 +33,7 @@ let
     installRuntimeWorkspace = true;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-1u+5EpUyZrUpICe8XwXYsqkKZtnr5DuZEGa3EYFKwqY=";
+      "." = mkSharedHash "sha256-gKPJk+1pR8OqBT0x7qnIhLNUJvErRQ3ZsaRjaISXa2Y=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/notion-md/nix/build.nix
+++ b/packages/@overeng/notion-md/nix/build.nix
@@ -20,7 +20,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-NmxTdWmLV5AICr8WK+Ng+YLAvhqUJr/pAogsL++arz4=";
+      "." = mkSharedHash "sha256-rdxVU64jUYymKjeRs5s0xT6jAIow/rzPVX85Or27YOA=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/notion-react/docs/getting-started.md
+++ b/packages/@overeng/notion-react/docs/getting-started.md
@@ -25,7 +25,13 @@ pnpm add @overeng/notion-react effect @effect/platform \
 
 `katex` and `shiki` are optional peer dependencies — install them only
 if you render math equations or syntax-highlighted code in the web
-preview.
+preview. KaTeX 0.18 depends on `commander` 15, whose `engines` field
+advertises Node >= 22.12. That is an install-time advisory, not a
+runtime requirement: npm-family installers may warn about it (and will
+fail only under `engine-strict`), Bun ignores `engines` entirely, and
+the renderer never loads it — `commander` is imported solely by KaTeX's
+`cli.js`, which equation previews do not touch. Rendering keeps the
+Node 20+ / Bun 1.1+ baseline above.
 
 ## First render (cold append)
 

--- a/packages/@overeng/notion-react/package.json
+++ b/packages/@overeng/notion-react/package.json
@@ -68,13 +68,12 @@
     "@overeng/utils-dev": "workspace:^",
     "@storybook/react": "10.6.0",
     "@storybook/react-vite": "10.6.0",
-    "@types/katex": "0.16.8",
     "@types/node": "26.5.0",
     "@types/react": "19.2.18",
     "@types/react-dom": "19.2.7",
     "@types/react-reconciler": "0.33.0",
     "effect": "4.0.0-rc.111",
-    "katex": "0.17.0",
+    "katex": "0.18.7",
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "react-reconciler": "0.33.0",
@@ -87,7 +86,7 @@
   "peerDependencies": {
     "@opentelemetry/api": "^1.9.1",
     "effect": "^4.0.0-rc.111",
-    "katex": "^0.17.0",
+    "katex": "^0.18.7",
     "react": "^19.2.8",
     "react-reconciler": "^0.33.0",
     "shiki": "^4.4.3"

--- a/packages/@overeng/notion-react/package.json.genie.ts
+++ b/packages/@overeng/notion-react/package.json.genie.ts
@@ -31,7 +31,6 @@ const workspaceDeps = catalog.compose({
         '@effect/vitest',
         '@storybook/react',
         '@storybook/react-vite',
-        '@types/katex',
         '@types/node',
         '@types/react',
         '@types/react-dom',

--- a/packages/@overeng/npm-release/nix/build.nix
+++ b/packages/@overeng/npm-release/nix/build.nix
@@ -20,7 +20,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-ANCO5tBslpzsXN1k1KOI9WH48OAZcUs2yE5GFmVARIw=";
+      "." = mkSharedHash "sha256-F7QBz0X9FL8+6sHG4qEHEc2pDnTCjXZT3MiQp9iqd+4=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/oxc-config/nix/build.nix
+++ b/packages/@overeng/oxc-config/nix/build.nix
@@ -14,7 +14,7 @@ import ../../../../nix/oxc-config-plugin.nix {
     ;
   # Managed by Evergreen FOD refresh — do not edit manually.
   depsBuilds = {
-    "." = mkSharedHash "sha256-SUnWuZbbqbGe4dJNrP236kdm1cLw/zoYT+GYnhktxFQ=";
+    "." = mkSharedHash "sha256-+DAahk1Zva/5BbTXP+7VM/wEl5QJw9b5RKUKbD0F2dw=";
   };
   hashSourcePath = "packages/@overeng/oxc-config/nix/build.nix";
 }

--- a/packages/@overeng/tui-stories/nix/build.nix
+++ b/packages/@overeng/tui-stories/nix/build.nix
@@ -21,7 +21,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-R1dBwGM4sHXokZZ1Z3OTzGIX6JnCkIK+WcUYoWEBG3c=";
+      "." = mkSharedHash "sha256-4Js+MWstU83VT6YhnJyrEas1fTCwdRlGx15bakLIsvA=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1189,9 +1189,6 @@ importers:
       '@storybook/react-vite':
         specifier: 10.6.0
         version: 10.6.0(@types/react-dom@19.2.7(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(storybook@10.6.0(@types/react-dom@19.2.7(@types/react@19.2.18))(@types/react@19.2.18)(prettier@3.9.6)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2)(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.2)(jiti@2.7.0)))(typescript@7.0.2)(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.2)(jiti@2.7.0))
-      '@types/katex':
-        specifier: 0.16.8
-        version: 0.16.8
       '@types/node':
         specifier: 26.5.0
         version: 26.5.0
@@ -1199,8 +1196,8 @@ importers:
         specifier: 19.2.7
         version: 19.2.7(@types/react@19.2.18)
       katex:
-        specifier: 0.17.0
-        version: 0.17.0
+        specifier: 0.18.7
+        version: 0.18.7
       shiki:
         specifier: 4.4.3
         version: 4.4.3
@@ -3145,9 +3142,6 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
-  '@types/katex@0.16.8':
-    resolution: {integrity: sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==}
-
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
@@ -3597,9 +3591,9 @@ packages:
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
-  commander@8.3.0:
-    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
-    engines: {node: '>= 12'}
+  commander@15.0.0:
+    resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
+    engines: {node: '>=22.12.0'}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -3982,8 +3976,8 @@ packages:
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
-  katex@0.17.0:
-    resolution: {integrity: sha512-Vdw0ATsQ9V+LuegM/BTwQqV/6cTl5lbGcIrU+BCgLxyf6bo38ybOr372tuSIxir3CN720flu1meYR6XzNMwQnw==}
+  katex@0.18.7:
+    resolution: {integrity: sha512-h+UCwkZ+4Jz8WQ7MLGfj7UVFrRCizGb912fwF4luGdYsC5paYG1vx+jy+KRcC/XkpjGva/P7nAWuxNnPzRvzHw==}
     hasBin: true
 
   keyv@5.6.0:
@@ -6215,8 +6209,6 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
-  '@types/katex@0.16.8': {}
-
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
@@ -6635,7 +6627,7 @@ snapshots:
 
   comma-separated-tokens@2.0.3: {}
 
-  commander@8.3.0: {}
+  commander@15.0.0: {}
 
   convert-source-map@2.0.0: {}
 
@@ -7000,9 +6992,9 @@ snapshots:
 
   jsonc-parser@3.3.1: {}
 
-  katex@0.17.0:
+  katex@0.18.7:
     dependencies:
-      commander: 8.3.0
+      commander: 15.0.0
 
   keyv@5.6.0:
     dependencies:


### PR DESCRIPTION
## Problem

KaTeX was behind 0.18.7, while `notion-react` still carried the now-obsolete external KaTeX type package.

## Goal

Move KaTeX to 0.18.7, use its bundled types, and preserve `notion-react` rendering and package generation.

## Decisions

This PR is stacked on the ESLint cohort update in #1246. The external type package is removed rather than keeping duplicate type ownership. Node 20+ and Bun remain supported for equation rendering; commander 15's Node engine declaration applies only as an install-time advisory for KaTeX's CLI path. Effect stays at 4.0.0-rc.111 and Vitest stays at 4.1.9.

## Verification

- Exact reviewed head: `44cf322261869ced5d086740b0cfd303f33a5e9b`.
- GitHub Actions current-head CI: passed.
- Independent current-head review: approved with no findings after documentation corrections.
- Codex current-head review: no major issues.
- KaTeX: 0.18.7 with bundled type declarations.
- Focused `notion-react` rendering suite: 120 tests passed across 5 files.
- Buck dependency tests: 56 passed; Genie check: passed.
- Full Effect tsgo check, oxfmt, and changed-file Oxlint checks: passed.
- npm-release closure build: passed.
- Lock/Buck/sidecar projections and all eight pnpm fixed-output derivations: regenerated and verified. Each prepared-deps source fingerprints the root lock, so the lock change correctly rotates all eight hashes even though the CLI closures do not contain KaTeX.

The separate worktree-lifecycle repair is #1250 with downstream schickling/dotfiles#2647 and is outside this stack. That current-`main` defect prevents the normal project-wide local gate; focused gates and exact current-head CI cover this PR.

## Complexity

No new abstraction. The update removes redundant external typings.

## Concerns

Consumers now rely on KaTeX's bundled type declarations rather than `@types/katex`.

## Follow-ups

Merge after #1246 and before the Restate update in #1231.

## References

- Preceding stacked PR: #1246
- Next stacked PR: #1231
- Separate lifecycle repair: #1250
- Downstream lifecycle adoption: schickling/dotfiles#2647

<!-- agent-footer:begin v=2 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | dev3.direct.omp.nsyk4mvc |
| `session` | dev3.nsyk4mvc |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.1.7 |
| `agent_runtime` | OMP 18.1.7 |
| `tooling_profile` | dotfiles@8d937c9 |
</details>
<!-- agent-footer:end -->