### PR TITLE
chore(nix): align nixpkgs locks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -221,6 +221,17 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- **nix**: realign every committed nixpkgs pin onto one `nixos-unstable`
+  revision, `dc5d91f840324650bac8c379428c7037a416959a` (2026-09-07). The root
+  `flake.lock` is the shared authority downstream repos follow; the independent
+  nested flakes carry their own locks and had drifted off it —
+  `nix/weaver-flake` by two days, `nix/playwright-flake` by nearly three months
+  (`567a49d1`, 2026-06-16), which meant the Playwright driver and the Weaver
+  build toolchain resolved against a different nixpkgs than the rest of the
+  repo. `packages/@overeng/genie` was already on this revision and is unchanged.
+  `devenv.lock`'s nixpkgs node is not part of this change and still pins
+  `c043004d`.
+
 - **deps**: update the compatible patch and minor dependency cohort, including
   React 19.2.8, OpenTelemetry SDK 2.11, Vite 8.2.2, current TanStack router
   packages, Tailwind CSS 4.3.3, and supporting type, test, formatting, crypto,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -228,9 +228,9 @@ All notable changes to this project will be documented in this file.
   `nix/weaver-flake` by two days, `nix/playwright-flake` by nearly three months
   (`567a49d1`, 2026-06-16), which meant the Playwright driver and the Weaver
   build toolchain resolved against a different nixpkgs than the rest of the
-  repo. `packages/@overeng/genie` was already on this revision and is unchanged.
-  `devenv.lock`'s nixpkgs node is not part of this change and still pins
-  `c043004d`.
+  repo. `packages/@overeng/genie` was already on this revision and is unchanged;
+  `devenv.lock`'s root nixpkgs node now mirrors the same pin while preserving
+  its existing devenv v2.2.1 subtree.
 
 - **deps**: update the compatible patch and minor dependency cohort, including
   React 19.2.8, OpenTelemetry SDK 2.11, Vite 8.2.2, current TanStack router

--- a/devenv.lock
+++ b/devenv.lock
@@ -366,11 +366,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1788614874,
-        "narHash": "sha256-7QYjT2vHLuX9Z1pdxHXDKCbh1CR3D/2rywB9Tx0MPRg=",
+        "lastModified": 1788752844,
+        "narHash": "sha256-VaWGJ6+cIYN2erfSecbRV+4ljI185Ty2wUrXyvQbgOw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c043004d1c6985732bcc1cbc5a9c9aecbbb4e0f0",
+        "rev": "dc5d91f840324650bac8c379428c7037a416959a",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1788614874,
-        "narHash": "sha256-7QYjT2vHLuX9Z1pdxHXDKCbh1CR3D/2rywB9Tx0MPRg=",
+        "lastModified": 1788752844,
+        "narHash": "sha256-VaWGJ6+cIYN2erfSecbRV+4ljI185Ty2wUrXyvQbgOw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c043004d1c6985732bcc1cbc5a9c9aecbbb4e0f0",
+        "rev": "dc5d91f840324650bac8c379428c7037a416959a",
         "type": "github"
       },
       "original": {

--- a/nix/playwright-flake/flake.lock
+++ b/nix/playwright-flake/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781577229,
-        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "lastModified": 1788752844,
+        "narHash": "sha256-VaWGJ6+cIYN2erfSecbRV+4ljI185Ty2wUrXyvQbgOw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "rev": "dc5d91f840324650bac8c379428c7037a416959a",
         "type": "github"
       },
       "original": {

--- a/nix/weaver-flake/flake.lock
+++ b/nix/weaver-flake/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1788614874,
-        "narHash": "sha256-7QYjT2vHLuX9Z1pdxHXDKCbh1CR3D/2rywB9Tx0MPRg=",
+        "lastModified": 1788752844,
+        "narHash": "sha256-VaWGJ6+cIYN2erfSecbRV+4ljI185Ty2wUrXyvQbgOw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c043004d1c6985732bcc1cbc5a9c9aecbbb4e0f0",
+        "rev": "dc5d91f840324650bac8c379428c7037a416959a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Problem

The root and nested flakes resolved against different nixpkgs revisions; the Playwright flake was nearly three months behind the root authority and the Weaver flake was two days behind.

## Goal

Align the repository root, devenv root node, Playwright flake, and Weaver flake on nixos-unstable revision `dc5d91f840324650bac8c379428c7037a416959a`.

## Decisions

Keep this independent lock-alignment cohort separate from the compatible dependency update in #1225. Treat the root `flake.lock` as the shared authority while retaining the nested flakes' independent lockfiles; leave the already-aligned Genie lock and the devenv v2.2.1 subtree unchanged. This PR does not upgrade the Effect RC cohort.

## Verification

- Current GitHub CI completed with 20 checks passing and 6 intentionally skipped; no check failed. Passed coverage includes both Linux and macOS `nix-check` and `nix-fod-check` matrices, Linux and macOS tests, `buck2`, `weaver`, `bootstrap-cold-proof`, and `source-shape`.
- The diff records the same revision, timestamp, and nar hash in `flake.lock`, the root nixpkgs node in `devenv.lock`, `nix/playwright-flake/flake.lock`, and `nix/weaver-flake/flake.lock`.
- Pre-flip deviation: `devenv tasks run check:all` was not run because the current-`main` regression tracked by schickling/dotfiles#2602 makes that gate invoke destructive `mr:apply` behavior; the focused checks in current CI are used instead.

## Complexity

No new complexity; four existing lock authorities are synchronized.

## Concerns

A nixpkgs revision change can affect all derivations reached through these flakes, even though the textual diff is limited to lock metadata.

## Friction & bottlenecks

Local project-wide validation is blocked by schickling/dotfiles#2602. No measurable bottleneck was observed.

## Follow-ups

None.

## References

- Base compatible dependency cohort: #1225
- Pre-flip validation regression: schickling/dotfiles#2602

<!-- agent-footer:begin v=2 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | dev3.direct.omp.nsyk4mvc |
| `session` | dev3.nsyk4mvc |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.1.7 |
| `agent_runtime` | OMP 18.1.7 |
| `tooling_profile` | dotfiles@8d937c9 |
</details>
<!-- agent-footer:end -->