### PR TITLE
chore(deps): update ESLint rule-testing cohort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -579,10 +579,11 @@ tsconfig.check.json`, but oxlint 1.39 cannot speak the tsgolint 7 protocol, so
   `@types/estree` and `@types/json-schema` it dragged along still arrive via
   `eslint` and `@typescript-eslint/rule-tester`; and `typescript-eslint` (the
   flat-config meta-package) had no consumer in this repo or in any megarepo
-  member. `pnpm-lock.yaml` and `buck2/dependencies/` are regenerated; the
-  `@overeng/oxc-config` pnpm FOD hash in
-  `packages/@overeng/oxc-config/nix/build.nix` is not, because computing it
-  requires a Nix build — Evergreen refresh is left to CI (see the PR body).
+  member. `pnpm-lock.yaml` and `buck2/dependencies/` are regenerated, and all
+  eight root CLI dependency-closure hashes are remeasured locally against the
+  regenerated lockfile (`evergreen fod refresh`, x86_64-linux): every one moved,
+  because eslint 10.10.0 replaces keyv 4 with the cacheable/keyv v5 chain in the
+  workspace-wide store.
 
 - **CI**: normalize the repository-local CI VRS under `context/ci/` and make
   workflow event admission semantic. Pull requests now trigger only for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -558,6 +558,32 @@ tsconfig.check.json`, but oxlint 1.39 cannot speak the tsgolint 7 protocol, so
   `@opentui/core` store entry built against it. Declaring the dependency
   collapses both back onto the catalog's 7.0.2.
 
+- **deps/@overeng/oxc-config**: update the ESLint rule-testing cohort — the only
+  ESLint surface left in the repo, since runtime linting is oxlint and stays
+  that way. `eslint` 10.5.0 -> 10.10.0 and `@typescript-eslint/parser`,
+  `/rule-tester` and `/utils` 8.61.1 -> 8.69.0, all four inside 8.69.0's
+  `eslint ^8.57 || ^9 || ^10` and `typescript >=4.8.4 <6.1.0` peer windows, so
+  the repo's TypeScript 6.0.3 needs no exception and `strictPeerDependencies`
+  resolves clean. 8.70.0 exists but was published the same day; taking it made
+  pnpm's release-age gate write nine `minimumReleaseAgeExclude` entries into
+  generated `pnpm-workspace.yaml`, and a routine bump does not get to weaken a
+  supply-chain policy, so the cohort lands one weekly release back.
+  Neither upstream changed a rule-tester API across this window, and the 187
+  rule-tester cases for `explicit-boolean-compare`, `exports-first`,
+  `jsdoc-require-exports` and `named-args` pass unchanged against the new
+  cohort, so no test needed a compatibility edit. Two catalog entries are
+  removed rather than carried forward at their old pins: `@types/eslint`
+  (9.6.1, last published for the ESLint 9 API in 2024) is dead weight because
+  `eslint/package.json` declares `types`, so TypeScript never consults
+  DefinitelyTyped for it — the rule sources typecheck with it absent, and the
+  `@types/estree` and `@types/json-schema` it dragged along still arrive via
+  `eslint` and `@typescript-eslint/rule-tester`; and `typescript-eslint` (the
+  flat-config meta-package) had no consumer in this repo or in any megarepo
+  member. `pnpm-lock.yaml` and `buck2/dependencies/` are regenerated; the
+  `@overeng/oxc-config` pnpm FOD hash in
+  `packages/@overeng/oxc-config/nix/build.nix` is not, because computing it
+  requires a Nix build — Evergreen refresh is left to CI (see the PR body).
+
 - **CI**: normalize the repository-local CI VRS under `context/ci/` and make
   workflow event admission semantic. Pull requests now trigger only for
   revision-changing `opened`, `reopened`, and `synchronize` activity; the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -562,12 +562,17 @@ tsconfig.check.json`, but oxlint 1.39 cannot speak the tsgolint 7 protocol, so
   ESLint surface left in the repo, since runtime linting is oxlint and stays
   that way. `eslint` 10.5.0 -> 10.10.0 and `@typescript-eslint/parser`,
   `/rule-tester` and `/utils` 8.61.1 -> 8.69.0, all four inside 8.69.0's
-  `eslint ^8.57 || ^9 || ^10` and `typescript >=4.8.4 <6.1.0` peer windows, so
-  the repo's TypeScript 6.0.3 needs no exception and `strictPeerDependencies`
-  resolves clean. 8.70.0 exists but was published the same day; taking it made
-  pnpm's release-age gate write nine `minimumReleaseAgeExclude` entries into
-  generated `pnpm-workspace.yaml`, and a routine bump does not get to weaken a
-  supply-chain policy, so the cohort lands one weekly release back.
+  `eslint ^8.57 || ^9 || ^10` and `typescript >=4.8.4 <6.1.0` peer windows. The
+  repo compiler is TypeScript 7.0.2, which that window excludes, so
+  `@overeng/oxc-config` keeps its own `typescript` pin at 5.9.3 — the isolation
+  the oxlint cohort introduced, because @typescript-eslint does not yet support
+  the TypeScript 7 package API. That per-package pin is what satisfies the peer
+  range, so no exception is needed and `strictPeerDependencies` resolves clean
+  with the rest of the workspace still on 7.0.2. 8.70.0 exists but was published
+  the same day; taking it made pnpm's release-age gate write nine
+  `minimumReleaseAgeExclude` entries into generated `pnpm-workspace.yaml`, and a
+  routine bump does not get to weaken a supply-chain policy, so the cohort lands
+  one weekly release back.
   Neither upstream changed a rule-tester API across this window, and the 187
   rule-tester cases for `explicit-boolean-compare`, `exports-first`,
   `jsdoc-require-exports` and `named-args` pass unchanged against the new

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -581,14 +581,16 @@ tsconfig.check.json`, but oxlint 1.39 cannot speak the tsgolint 7 protocol, so
   (9.6.1, last published for the ESLint 9 API in 2024) is dead weight because
   `eslint/package.json` declares `types`, so TypeScript never consults
   DefinitelyTyped for it — the rule sources typecheck with it absent, and the
-  `@types/estree` and `@types/json-schema` it dragged along still arrive via
-  `eslint` and `@typescript-eslint/rule-tester`; and `typescript-eslint` (the
-  flat-config meta-package) had no consumer in this repo or in any megarepo
-  member. `pnpm-lock.yaml` and `buck2/dependencies/` are regenerated, and all
-  eight root CLI dependency-closure hashes are remeasured locally against the
-  regenerated lockfile (`evergreen fod refresh`, x86_64-linux): every one moved,
-  because eslint 10.10.0 replaces keyv 4 with the cacheable/keyv v5 chain in the
-  workspace-wide store.
+  `@types/estree` and `@types/json-schema` it dragged along are still in the
+  lock on their own account: `@types/estree` as a direct dependency of `eslint`
+  itself (and of `eslint-scope`, `@rollup/pluginutils`, `estree-walker`), and
+  `@types/json-schema` through its single dependent `@eslint/core`; and
+  `typescript-eslint` (the flat-config meta-package) had no consumer in this
+  repo or in any megarepo member. `pnpm-lock.yaml` and `buck2/dependencies/`
+  are regenerated, and all eight root CLI dependency-closure hashes are
+  remeasured locally against the regenerated lockfile (`evergreen fod refresh`,
+  x86_64-linux): every one moved, because eslint 10.10.0 replaces keyv 4 with
+  the cacheable/keyv v5 chain in the workspace-wide store.
 
 - **CI**: normalize the repository-local CI VRS under `context/ci/` and make
   workflow event admission semantic. Pull requests now trigger only for

--- a/buck2/dependencies/BUCK
+++ b/buck2/dependencies/BUCK
@@ -3,7 +3,7 @@
 
 # Generated file - DO NOT EDIT
 # Source: pnpm-lock.yaml
-# Store fingerprint: sha256:8c1b14503e3fa8061f6fb76e89bac543a806076d0f1c60592c7093995c3f7f46
+# Store fingerprint: sha256:d296d1e76e7818347f8d13f0393fe6b8cc9c8cad01da38772d3a0cd953721621
 
 load("//buck2:materialization.bzl", "export_materialization_inputs")
 
@@ -249,6 +249,24 @@ pnpm_package(
     package_name = "@blazediff/core",
     url = "https://registry.npmjs.org/@blazediff/core/-/core-1.9.1.tgz",
     sha256 = "d10e0acae6327276066fc6720dbd65bd372ba81cb4445e7f472ca50addab186a",
+    bins = {
+    },
+)
+
+pnpm_package(
+    name = "package_cacheable_memory_2_2_0_ebfb4ac2b5f5",
+    package_name = "@cacheable/memory",
+    url = "https://registry.npmjs.org/@cacheable/memory/-/memory-2.2.0.tgz",
+    sha256 = "9dffad84622ba74be37dcec88ba7537cc9d168551e349588757add056f5289b9",
+    bins = {
+    },
+)
+
+pnpm_package(
+    name = "package_cacheable_utils_2_5_0_22620a8f2225",
+    package_name = "@cacheable/utils",
+    url = "https://registry.npmjs.org/@cacheable/utils/-/utils-2.5.0.tgz",
+    sha256 = "243841e7a895205b7984be00bfd162aab703423d878a4837367e617033689a02",
     bins = {
     },
 )
@@ -632,10 +650,10 @@ pnpm_package(
 )
 
 pnpm_package(
-    name = "package_eslint_config_helpers_0_6_0_f9d65331f01d",
+    name = "package_eslint_config_helpers_0_7_0_5e96e6a5142e",
     package_name = "@eslint/config-helpers",
-    url = "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
-    sha256 = "7cc51f23f4603beeff1e02d0dacacc8ca29a404d5cc112c779636feb20a97a7a",
+    url = "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+    sha256 = "a4186192e9463523090de29e3e5256f6963ccdd126216219c56a17b6ca9f17ca",
     bins = {
     },
 )
@@ -659,10 +677,10 @@ pnpm_package(
 )
 
 pnpm_package(
-    name = "package_eslint_plugin_kit_0_7_2_61f595114b42",
+    name = "package_eslint_plugin_kit_0_7_3_2d232f4b4408",
     package_name = "@eslint/plugin-kit",
-    url = "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
-    sha256 = "50b22954f78c880d1de67c861725d430560a08f2c8c20ad13b65d4ab18dd6cbb",
+    url = "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.3.tgz",
+    sha256 = "8bd10d0644bb4e2c62424eb4e213888121affbc644339912f2869858f079a2b5",
     bins = {
     },
 )
@@ -789,6 +807,24 @@ pnpm_package(
     package_name = "@jridgewell/trace-mapping",
     url = "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
     sha256 = "c64c71a119630d5abe8246889edf334b2ca9ddad094e20d623332956b1453ccf",
+    bins = {
+    },
+)
+
+pnpm_package(
+    name = "package_keyv_bigmap_1_3_1_fa7ffff71a39",
+    package_name = "@keyv/bigmap",
+    url = "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
+    sha256 = "054607db65aa02c4f2d82d81a9a5c4d0d00386e2af77135893ea067a834ffb79",
+    bins = {
+    },
+)
+
+pnpm_package(
+    name = "package_keyv_serialize_1_1_1_aa477d4d1034",
+    package_name = "@keyv/serialize",
+    url = "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
+    sha256 = "5730adf7d1edef7c84a7ce658c3a2915386529b4d795523265c30a2e94f91366",
     bins = {
     },
 )
@@ -2300,15 +2336,6 @@ pnpm_package(
 )
 
 pnpm_package(
-    name = "package_types_eslint_9_6_1_5064d03d8c70",
-    package_name = "@types/eslint",
-    url = "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
-    sha256 = "efdbf20891541064adf48c4b6e3cad1b0cc4e99a5d29620fdc5b724de88ee5d0",
-    bins = {
-    },
-)
-
-pnpm_package(
     name = "package_types_esrecurse_4_3_1_fe5a4a38ec87",
     package_name = "@types/esrecurse",
     url = "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
@@ -2453,82 +2480,82 @@ pnpm_package(
 )
 
 pnpm_package(
-    name = "package_typescript_eslint_parser_8_61_1_b500a9b1fcc2",
+    name = "package_typescript_eslint_parser_8_69_0_7cb7aa2d1392",
     package_name = "@typescript-eslint/parser",
-    url = "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.61.1.tgz",
-    sha256 = "2f702563464215a7097f902f2d69b9ceef43fc56fc760876bc529d813960662e",
+    url = "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.69.0.tgz",
+    sha256 = "957fcddbdffd801b9015e7761337f611f31eee6b473fba42c1989995a72ae7de",
     bins = {
     },
 )
 
 pnpm_package(
-    name = "package_typescript_eslint_project_service_8_61_1_cd6e6899a5f4",
+    name = "package_typescript_eslint_project_service_8_69_0_d7ff9add22af",
     package_name = "@typescript-eslint/project-service",
-    url = "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.1.tgz",
-    sha256 = "39260fd897790a0951f21862cb8434b1ebdcb12a30ba6f267c24e0a60c118fb0",
+    url = "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.69.0.tgz",
+    sha256 = "5d7bb205ffdc1207d3de1316c812c18e0291d8e9214005a0dfea8e0a7e98d0ea",
     bins = {
     },
 )
 
 pnpm_package(
-    name = "package_typescript_eslint_rule_tester_8_61_1_5e59a9491378",
+    name = "package_typescript_eslint_rule_tester_8_69_0_061f4c18226e",
     package_name = "@typescript-eslint/rule-tester",
-    url = "https://registry.npmjs.org/@typescript-eslint/rule-tester/-/rule-tester-8.61.1.tgz",
-    sha256 = "e49c2077da2711492eb4588c17d6fed6e19d163fe42bf916bce25667ba6d046c",
+    url = "https://registry.npmjs.org/@typescript-eslint/rule-tester/-/rule-tester-8.69.0.tgz",
+    sha256 = "d9e13fd84e456c1c90ecd3ba18a5d03a0e0b286c3b96c5b1b53d019b9a0a47f7",
     bins = {
     },
 )
 
 pnpm_package(
-    name = "package_typescript_eslint_scope_manager_8_61_1_377564d41d32",
+    name = "package_typescript_eslint_scope_manager_8_69_0_2028cc75233f",
     package_name = "@typescript-eslint/scope-manager",
-    url = "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.61.1.tgz",
-    sha256 = "ab6ba6a21f675eb974b131098d94557569bb93c14deb0195806b48462f9437f5",
+    url = "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.69.0.tgz",
+    sha256 = "279aaf75556c1b94aac921ce974f9fc3f8b72ff1208ba3edd034bdb90b3b0a73",
     bins = {
     },
 )
 
 pnpm_package(
-    name = "package_typescript_eslint_tsconfig_utils_8_61_1_d3d1d656eb33",
+    name = "package_typescript_eslint_tsconfig_utils_8_69_0_588922a57adb",
     package_name = "@typescript-eslint/tsconfig-utils",
-    url = "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.1.tgz",
-    sha256 = "488c9043baf2be49ca088fea091289f118330d77a08828f00f9efa687895b2df",
+    url = "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.69.0.tgz",
+    sha256 = "6344c0366c934c508952ad64933073643f9189bdc45a1a850fc25cf6fc4e49f9",
     bins = {
     },
 )
 
 pnpm_package(
-    name = "package_typescript_eslint_types_8_61_1_a114619f393d",
+    name = "package_typescript_eslint_types_8_69_0_33daa92e85d2",
     package_name = "@typescript-eslint/types",
-    url = "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.1.tgz",
-    sha256 = "aedff90199f8f750807cea8cb2120267ca879dbe794ad7111a7a3eb83914fb4b",
+    url = "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.69.0.tgz",
+    sha256 = "a00d6eed789a21302261164f79e335bd57a0f3bafb8619aa23177af59b97e377",
     bins = {
     },
 )
 
 pnpm_package(
-    name = "package_typescript_eslint_typescript_estree_8_61_1_3234ed579ea5",
+    name = "package_typescript_eslint_typescript_estree_8_69_0_7f3c34d2b24e",
     package_name = "@typescript-eslint/typescript-estree",
-    url = "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.1.tgz",
-    sha256 = "1eaaae4d873d13abcd7eb75645b4b23e2728137f8ce60a5e2f676294907d569f",
+    url = "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.69.0.tgz",
+    sha256 = "1b0e9f380f1533a016937018fb78ad348ca01633fff78af69142faa16c0b612f",
     bins = {
     },
 )
 
 pnpm_package(
-    name = "package_typescript_eslint_utils_8_61_1_0cff09d7fc88",
+    name = "package_typescript_eslint_utils_8_69_0_257ad29d4511",
     package_name = "@typescript-eslint/utils",
-    url = "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.61.1.tgz",
-    sha256 = "5fce1c237ff15f4a480a4abd2bbf2cbb517765ce71981928140f73ad426b2157",
+    url = "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.69.0.tgz",
+    sha256 = "fb89448a616b8761e255de806682b9fe1c9a2705edcfac008bc5d21ae0bf7972",
     bins = {
     },
 )
 
 pnpm_package(
-    name = "package_typescript_eslint_visitor_keys_8_61_1_8533254a16ad",
+    name = "package_typescript_eslint_visitor_keys_8_69_0_9c87b69f53c8",
     package_name = "@typescript-eslint/visitor-keys",
-    url = "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.1.tgz",
-    sha256 = "eee8972fd313747542440605a5d3ec7fd9863d66321c054ff87c1a5fb981b854",
+    url = "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.69.0.tgz",
+    sha256 = "1e722561d1374b57180d8de3426389ac5aca97d3c17f840b9e85fc8fe3d37d1b",
     bins = {
     },
 )
@@ -3140,6 +3167,15 @@ pnpm_package(
 )
 
 pnpm_package(
+    name = "package_cacheable_2_5_0_0a9dd0dffb1a",
+    package_name = "cacheable",
+    url = "https://registry.npmjs.org/cacheable/-/cacheable-2.5.0.tgz",
+    sha256 = "69a2c0e6d81c1a38c601bf34bf0935998823043a219a01401455d23e29377bab",
+    bins = {
+    },
+)
+
+pnpm_package(
     name = "package_caniuse_lite_1_0_30001810_2279b0f6b9ea",
     package_name = "caniuse-lite",
     url = "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
@@ -3582,10 +3618,10 @@ pnpm_package(
 )
 
 pnpm_package(
-    name = "package_eslint_10_5_0_0f347c0e43c0",
+    name = "package_eslint_10_10_0_22ff8f9ebaf4",
     package_name = "eslint",
-    url = "https://registry.npmjs.org/eslint/-/eslint-10.5.0.tgz",
-    sha256 = "d2e5cae195d7660bb12c543d8faf3dfe762dafd6a39fac96ab4fbb1bb4a95412",
+    url = "https://registry.npmjs.org/eslint/-/eslint-10.10.0.tgz",
+    sha256 = "897c8ff1a16dbc0420d9815b59bfbad27d079c3ddaef6ee1099bb4b4593c0031",
     bins = {
         "eslint": "bin/eslint.js",
     },
@@ -3747,10 +3783,10 @@ pnpm_package(
 )
 
 pnpm_package(
-    name = "package_file_entry_cache_8_0_0_cfd34b733a3c",
+    name = "package_file_entry_cache_11_1_5_ac300dcb09f1",
     package_name = "file-entry-cache",
-    url = "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
-    sha256 = "67ac5a6cea2268114a1f8935ca3ad60fe634fed04dd7914939bf24ceaa2d57b8",
+    url = "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.5.tgz",
+    sha256 = "941235c20a7060285e2d85777a03864d194b2f4bbe54b9730c8b026a62e2ace9",
     bins = {
     },
 )
@@ -3774,10 +3810,10 @@ pnpm_package(
 )
 
 pnpm_package(
-    name = "package_flat_cache_4_0_1_2a36811f99d5",
+    name = "package_flat_cache_6_1_23_4b2ba8bae97d",
     package_name = "flat-cache",
-    url = "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
-    sha256 = "e2085ae2b084792812a4f4102f6b4967e93cfda8457361b7debe610cf2aedaf0",
+    url = "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.23.tgz",
+    sha256 = "e1abb7dc35422099057cc42348a136336f4ca5ab88b118404d16d39122f77105",
     bins = {
     },
 )
@@ -3865,6 +3901,15 @@ pnpm_package(
 )
 
 pnpm_package(
+    name = "package_hashery_1_5_1_e1122633ff95",
+    package_name = "hashery",
+    url = "https://registry.npmjs.org/hashery/-/hashery-1.5.1.tgz",
+    sha256 = "9a174c770b98d20b26e16a6563b37f79d53d3bcef6dadcf08507dd4993158d0f",
+    bins = {
+    },
+)
+
+pnpm_package(
     name = "package_hasown_2_0_4_ba2e3a5fbd10",
     package_name = "hasown",
     url = "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
@@ -3887,6 +3932,24 @@ pnpm_package(
     package_name = "hast-util-whitespace",
     url = "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
     sha256 = "673f97f5bba3cac0184726f519a5750273e4434b839a769f4fbf09e4b4da2ceb",
+    bins = {
+    },
+)
+
+pnpm_package(
+    name = "package_hookified_1_15_1_e5243a6e8f47",
+    package_name = "hookified",
+    url = "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
+    sha256 = "7f96a9aa7ee1230008083deecaf2b512f9d2b9b8c08efe1a3252fccd09edca70",
+    bins = {
+    },
+)
+
+pnpm_package(
+    name = "package_hookified_2_2_0_28f9e2a047fb",
+    package_name = "hookified",
+    url = "https://registry.npmjs.org/hookified/-/hookified-2.2.0.tgz",
+    sha256 = "01aa4e32fec989b18ab2b7a6b593ec968efdd4db287d7fef94813678bc2b1564",
     bins = {
     },
 )
@@ -4104,15 +4167,6 @@ pnpm_package(
 )
 
 pnpm_package(
-    name = "package_json_buffer_3_0_1_adbc921fc34d",
-    package_name = "json-buffer",
-    url = "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-    sha256 = "d1f7464db9713c5f73c919da72de334fce0bcbd76fb08727d36712ef5dfef5a5",
-    bins = {
-    },
-)
-
-pnpm_package(
     name = "package_json_schema_traverse_0_4_1_224390b16484",
     package_name = "json-schema-traverse",
     url = "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -4160,10 +4214,10 @@ pnpm_package(
 )
 
 pnpm_package(
-    name = "package_keyv_4_5_4_b44ddb67514f",
+    name = "package_keyv_5_6_0_b95898f12ca2",
     package_name = "keyv",
-    url = "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-    sha256 = "eb26f1c561e57af4a4365e6b54f5f3e745e3963747a93845af1f000a747b6098",
+    url = "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+    sha256 = "db982b7c83daadc135266141d1cb542443f26d42c72f25ee2d45644fc631e7e0",
     bins = {
     },
 )
@@ -5104,6 +5158,15 @@ pnpm_package(
     package_name = "pure-rand",
     url = "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.2.tgz",
     sha256 = "3ce449c758cb2ea0db7ff30a1b378d381d9e74681acec74e1e2591ea6aa381ca",
+    bins = {
+    },
+)
+
+pnpm_package(
+    name = "package_qified_0_10_1_b3b25bd21152",
+    package_name = "qified",
+    url = "https://registry.npmjs.org/qified/-/qified-0.10.1.tgz",
+    sha256 = "5acca41a42576ff888cf16cbcf505efbe3b0d4f55232edf3a931298a4b5ca662",
     bins = {
     },
 )
@@ -6111,49 +6174,48 @@ pnpm_store_scc(
 )
 
 pnpm_store_scc(
-    name = "scc_eslint_community_eslint_utils_4_10_1_eslint_10_5_0_jiti_2_7_0_eslint_10__8e534452c059",
+    name = "scc_eslint_community_eslint_utils_4_10_1_eslint_10_10_0_jiti_2_7_0_eslint_10_22c0e0a437c0",
     runtime = ":assemble-store.ts",
     members = {
-        "@eslint-community+eslint-utils@4.10.1_eslint@10.5.0_jiti@2.7.0": ":package_eslint_community_eslint_utils_4_10_1_81c7dfd40d2f",
-        "eslint@10.5.0_jiti@2.7.0": ":package_eslint_10_5_0_0f347c0e43c0",
+        "@eslint-community+eslint-utils@4.10.1_eslint@10.10.0_jiti@2.7.0": ":package_eslint_community_eslint_utils_4_10_1_81c7dfd40d2f",
+        "eslint@10.10.0_jiti@2.7.0": ":package_eslint_10_10_0_22ff8f9ebaf4",
     },
     internal_edges = {
-        "@eslint-community+eslint-utils@4.10.1_eslint@10.5.0_jiti@2.7.0\teslint": "eslint@10.5.0_jiti@2.7.0",
-        "eslint@10.5.0_jiti@2.7.0\t@eslint-community/eslint-utils": "@eslint-community+eslint-utils@4.10.1_eslint@10.5.0_jiti@2.7.0",
+        "@eslint-community+eslint-utils@4.10.1_eslint@10.10.0_jiti@2.7.0\teslint": "eslint@10.10.0_jiti@2.7.0",
+        "eslint@10.10.0_jiti@2.7.0\t@eslint-community/eslint-utils": "@eslint-community+eslint-utils@4.10.1_eslint@10.10.0_jiti@2.7.0",
     },
     external_edges = {
-        "@eslint-community+eslint-utils@4.10.1_eslint@10.5.0_jiti@2.7.0\t@types/eslint": ":entry_types_eslint_9_6_1_5064d03d8c70",
-        "@eslint-community+eslint-utils@4.10.1_eslint@10.5.0_jiti@2.7.0\teslint-visitor-keys": ":entry_eslint_visitor_keys_3_4_3_d73964c6d2eb",
-        "eslint@10.5.0_jiti@2.7.0\t@eslint-community/regexpp": ":entry_eslint_community_regexpp_4_12_2_1d1887a9bf30",
-        "eslint@10.5.0_jiti@2.7.0\t@eslint/config-array": ":entry_eslint_config_array_0_23_5_c4003c9d3aa0",
-        "eslint@10.5.0_jiti@2.7.0\t@eslint/config-helpers": ":entry_eslint_config_helpers_0_6_0_f9d65331f01d",
-        "eslint@10.5.0_jiti@2.7.0\t@eslint/core": ":entry_eslint_core_1_2_1_8011bd8ea054",
-        "eslint@10.5.0_jiti@2.7.0\t@eslint/plugin-kit": ":entry_eslint_plugin_kit_0_7_2_61f595114b42",
-        "eslint@10.5.0_jiti@2.7.0\t@humanfs/node": ":entry_humanfs_node_0_16_8_f153f8244a2e",
-        "eslint@10.5.0_jiti@2.7.0\t@humanwhocodes/module-importer": ":entry_humanwhocodes_module_importer_1_0_1_2281c2232c28",
-        "eslint@10.5.0_jiti@2.7.0\t@humanwhocodes/retry": ":entry_humanwhocodes_retry_0_4_3_726321f5c138",
-        "eslint@10.5.0_jiti@2.7.0\t@types/estree": ":entry_types_estree_1_0_9_ec29746adee7",
-        "eslint@10.5.0_jiti@2.7.0\tajv": ":entry_ajv_6_15_0_ad437bedcb08",
-        "eslint@10.5.0_jiti@2.7.0\tcross-spawn": ":entry_cross_spawn_7_0_6_50cb51119b3e",
-        "eslint@10.5.0_jiti@2.7.0\tdebug": ":entry_debug_4_4_3_6390bf853aed",
-        "eslint@10.5.0_jiti@2.7.0\tescape-string-regexp": ":entry_escape_string_regexp_4_0_0_8c51af36cd57",
-        "eslint@10.5.0_jiti@2.7.0\teslint-scope": ":entry_eslint_scope_9_1_2_1242bb0a2257",
-        "eslint@10.5.0_jiti@2.7.0\teslint-visitor-keys": ":entry_eslint_visitor_keys_5_0_1_77649af58b26",
-        "eslint@10.5.0_jiti@2.7.0\tespree": ":entry_espree_11_2_0_23d4e7a3725d",
-        "eslint@10.5.0_jiti@2.7.0\tesquery": ":entry_esquery_1_7_0_0e77450dbf69",
-        "eslint@10.5.0_jiti@2.7.0\tesutils": ":entry_esutils_2_0_3_cbd4dd8d594e",
-        "eslint@10.5.0_jiti@2.7.0\tfast-deep-equal": ":entry_fast_deep_equal_3_1_3_60db03f2d949",
-        "eslint@10.5.0_jiti@2.7.0\tfile-entry-cache": ":entry_file_entry_cache_8_0_0_cfd34b733a3c",
-        "eslint@10.5.0_jiti@2.7.0\tfind-up": ":entry_find_up_5_0_0_36b5efd728dd",
-        "eslint@10.5.0_jiti@2.7.0\tglob-parent": ":entry_glob_parent_6_0_2_7b90c3653564",
-        "eslint@10.5.0_jiti@2.7.0\tignore": ":entry_ignore_5_3_2_8280c55d2633",
-        "eslint@10.5.0_jiti@2.7.0\timurmurhash": ":entry_imurmurhash_0_1_4_d1af6342e06c",
-        "eslint@10.5.0_jiti@2.7.0\tis-glob": ":entry_is_glob_4_0_3_ab2c83c8b42b",
-        "eslint@10.5.0_jiti@2.7.0\tjiti": ":entry_jiti_2_7_0_443514e89728",
-        "eslint@10.5.0_jiti@2.7.0\tjson-stable-stringify-without-jsonify": ":entry_json_stable_stringify_without_jsonify_1_0_1_0e74de0204bb",
-        "eslint@10.5.0_jiti@2.7.0\tminimatch": ":entry_minimatch_10_2_6_7dfd90b95b04",
-        "eslint@10.5.0_jiti@2.7.0\tnatural-compare": ":entry_natural_compare_1_4_0_de1347ea1b99",
-        "eslint@10.5.0_jiti@2.7.0\toptionator": ":entry_optionator_0_9_4_b028d685c41c",
+        "@eslint-community+eslint-utils@4.10.1_eslint@10.10.0_jiti@2.7.0\teslint-visitor-keys": ":entry_eslint_visitor_keys_3_4_3_d73964c6d2eb",
+        "eslint@10.10.0_jiti@2.7.0\t@eslint-community/regexpp": ":entry_eslint_community_regexpp_4_12_2_1d1887a9bf30",
+        "eslint@10.10.0_jiti@2.7.0\t@eslint/config-array": ":entry_eslint_config_array_0_23_5_c4003c9d3aa0",
+        "eslint@10.10.0_jiti@2.7.0\t@eslint/config-helpers": ":entry_eslint_config_helpers_0_7_0_5e96e6a5142e",
+        "eslint@10.10.0_jiti@2.7.0\t@eslint/core": ":entry_eslint_core_1_2_1_8011bd8ea054",
+        "eslint@10.10.0_jiti@2.7.0\t@eslint/plugin-kit": ":entry_eslint_plugin_kit_0_7_3_2d232f4b4408",
+        "eslint@10.10.0_jiti@2.7.0\t@humanfs/node": ":entry_humanfs_node_0_16_8_f153f8244a2e",
+        "eslint@10.10.0_jiti@2.7.0\t@humanwhocodes/module-importer": ":entry_humanwhocodes_module_importer_1_0_1_2281c2232c28",
+        "eslint@10.10.0_jiti@2.7.0\t@humanwhocodes/retry": ":entry_humanwhocodes_retry_0_4_3_726321f5c138",
+        "eslint@10.10.0_jiti@2.7.0\t@types/estree": ":entry_types_estree_1_0_9_ec29746adee7",
+        "eslint@10.10.0_jiti@2.7.0\tajv": ":entry_ajv_6_15_0_ad437bedcb08",
+        "eslint@10.10.0_jiti@2.7.0\tcross-spawn": ":entry_cross_spawn_7_0_6_50cb51119b3e",
+        "eslint@10.10.0_jiti@2.7.0\tdebug": ":entry_debug_4_4_3_6390bf853aed",
+        "eslint@10.10.0_jiti@2.7.0\tescape-string-regexp": ":entry_escape_string_regexp_4_0_0_8c51af36cd57",
+        "eslint@10.10.0_jiti@2.7.0\teslint-scope": ":entry_eslint_scope_9_1_2_1242bb0a2257",
+        "eslint@10.10.0_jiti@2.7.0\teslint-visitor-keys": ":entry_eslint_visitor_keys_5_0_1_77649af58b26",
+        "eslint@10.10.0_jiti@2.7.0\tespree": ":entry_espree_11_2_0_23d4e7a3725d",
+        "eslint@10.10.0_jiti@2.7.0\tesquery": ":entry_esquery_1_7_0_0e77450dbf69",
+        "eslint@10.10.0_jiti@2.7.0\tesutils": ":entry_esutils_2_0_3_cbd4dd8d594e",
+        "eslint@10.10.0_jiti@2.7.0\tfast-deep-equal": ":entry_fast_deep_equal_3_1_3_60db03f2d949",
+        "eslint@10.10.0_jiti@2.7.0\tfile-entry-cache": ":entry_file_entry_cache_11_1_5_ac300dcb09f1",
+        "eslint@10.10.0_jiti@2.7.0\tfind-up": ":entry_find_up_5_0_0_36b5efd728dd",
+        "eslint@10.10.0_jiti@2.7.0\tglob-parent": ":entry_glob_parent_6_0_2_7b90c3653564",
+        "eslint@10.10.0_jiti@2.7.0\tignore": ":entry_ignore_5_3_2_8280c55d2633",
+        "eslint@10.10.0_jiti@2.7.0\timurmurhash": ":entry_imurmurhash_0_1_4_d1af6342e06c",
+        "eslint@10.10.0_jiti@2.7.0\tis-glob": ":entry_is_glob_4_0_3_ab2c83c8b42b",
+        "eslint@10.10.0_jiti@2.7.0\tjiti": ":entry_jiti_2_7_0_443514e89728",
+        "eslint@10.10.0_jiti@2.7.0\tjson-stable-stringify-without-jsonify": ":entry_json_stable_stringify_without_jsonify_1_0_1_0e74de0204bb",
+        "eslint@10.10.0_jiti@2.7.0\tminimatch": ":entry_minimatch_10_2_6_7dfd90b95b04",
+        "eslint@10.10.0_jiti@2.7.0\tnatural-compare": ":entry_natural_compare_1_4_0_de1347ea1b99",
+        "eslint@10.10.0_jiti@2.7.0\toptionator": ":entry_optionator_0_9_4_b028d685c41c",
     },
 )
 
@@ -6582,6 +6644,32 @@ pnpm_store_entry(
 )
 
 pnpm_store_entry(
+    name = "entry_cacheable_memory_2_2_0_ebfb4ac2b5f5",
+    package = ":package_cacheable_memory_2_2_0_ebfb4ac2b5f5",
+    store_key = "@cacheable+memory@2.2.0",
+    runtime = ":assemble-store.ts",
+    dependencies = {
+        "@cacheable/utils": ":entry_cacheable_utils_2_5_0_22620a8f2225",
+        "@keyv/bigmap": ":entry_keyv_bigmap_1_3_1_keyv_5_6_0_cdc95803ccc6",
+        "hookified": ":entry_hookified_1_15_1_e5243a6e8f47",
+        "keyv": ":entry_keyv_5_6_0_b95898f12ca2",
+    },
+    visibility = ["PUBLIC"],
+)
+
+pnpm_store_entry(
+    name = "entry_cacheable_utils_2_5_0_22620a8f2225",
+    package = ":package_cacheable_utils_2_5_0_22620a8f2225",
+    store_key = "@cacheable+utils@2.5.0",
+    runtime = ":assemble-store.ts",
+    dependencies = {
+        "hashery": ":entry_hashery_1_5_1_e1122633ff95",
+        "keyv": ":entry_keyv_5_6_0_b95898f12ca2",
+    },
+    visibility = ["PUBLIC"],
+)
+
+pnpm_store_entry(
     name = "entry_csstools_css_tokenizer_3_0_4_1364f68e1d48",
     package = ":package_csstools_css_tokenizer_3_0_4_1364f68e1d48",
     store_key = "@csstools+css-tokenizer@3.0.4",
@@ -7004,11 +7092,11 @@ pnpm_store_entry(
 )
 
 pnpm_store_entry(
-    name = "entry_eslint_community_eslint_utils_4_10_1_eslint_10_5_0_jiti_2_7_0_f722ea313427",
+    name = "entry_eslint_community_eslint_utils_4_10_1_eslint_10_10_0_jiti_2_7_0_002b1c3db5db",
     package = ":package_eslint_community_eslint_utils_4_10_1_81c7dfd40d2f",
-    store_key = "@eslint-community+eslint-utils@4.10.1_eslint@10.5.0_jiti@2.7.0",
+    store_key = "@eslint-community+eslint-utils@4.10.1_eslint@10.10.0_jiti@2.7.0",
     runtime = ":assemble-store.ts",
-    scc = ":scc_eslint_community_eslint_utils_4_10_1_eslint_10_5_0_jiti_2_7_0_eslint_10__8e534452c059",
+    scc = ":scc_eslint_community_eslint_utils_4_10_1_eslint_10_10_0_jiti_2_7_0_eslint_10_22c0e0a437c0",
     visibility = ["PUBLIC"],
 )
 
@@ -7036,9 +7124,9 @@ pnpm_store_entry(
 )
 
 pnpm_store_entry(
-    name = "entry_eslint_config_helpers_0_6_0_f9d65331f01d",
-    package = ":package_eslint_config_helpers_0_6_0_f9d65331f01d",
-    store_key = "@eslint+config-helpers@0.6.0",
+    name = "entry_eslint_config_helpers_0_7_0_5e96e6a5142e",
+    package = ":package_eslint_config_helpers_0_7_0_5e96e6a5142e",
+    store_key = "@eslint+config-helpers@0.7.0",
     runtime = ":assemble-store.ts",
     dependencies = {
         "@eslint/core": ":entry_eslint_core_1_2_1_8011bd8ea054",
@@ -7068,9 +7156,9 @@ pnpm_store_entry(
 )
 
 pnpm_store_entry(
-    name = "entry_eslint_plugin_kit_0_7_2_61f595114b42",
-    package = ":package_eslint_plugin_kit_0_7_2_61f595114b42",
-    store_key = "@eslint+plugin-kit@0.7.2",
+    name = "entry_eslint_plugin_kit_0_7_3_2d232f4b4408",
+    package = ":package_eslint_plugin_kit_0_7_3_2d232f4b4408",
+    store_key = "@eslint+plugin-kit@0.7.3",
     runtime = ":assemble-store.ts",
     dependencies = {
         "@eslint/core": ":entry_eslint_core_1_2_1_8011bd8ea054",
@@ -7232,6 +7320,29 @@ pnpm_store_entry(
     dependencies = {
         "@jridgewell/resolve-uri": ":entry_jridgewell_resolve_uri_3_1_2_3ba312251f16",
         "@jridgewell/sourcemap-codec": ":entry_jridgewell_sourcemap_codec_1_6_0_c92d70f5295d",
+    },
+    visibility = ["PUBLIC"],
+)
+
+pnpm_store_entry(
+    name = "entry_keyv_bigmap_1_3_1_keyv_5_6_0_cdc95803ccc6",
+    package = ":package_keyv_bigmap_1_3_1_fa7ffff71a39",
+    store_key = "@keyv+bigmap@1.3.1_keyv@5.6.0",
+    runtime = ":assemble-store.ts",
+    dependencies = {
+        "hashery": ":entry_hashery_1_5_1_e1122633ff95",
+        "hookified": ":entry_hookified_1_15_1_e5243a6e8f47",
+        "keyv": ":entry_keyv_5_6_0_b95898f12ca2",
+    },
+    visibility = ["PUBLIC"],
+)
+
+pnpm_store_entry(
+    name = "entry_keyv_serialize_1_1_1_aa477d4d1034",
+    package = ":package_keyv_serialize_1_1_1_aa477d4d1034",
+    store_key = "@keyv+serialize@1.1.1",
+    runtime = ":assemble-store.ts",
+    dependencies = {
     },
     visibility = ["PUBLIC"],
 )
@@ -7625,6 +7736,51 @@ pnpm_store_entry(
 )
 
 pnpm_store_entry(
+    name = "entry_opentui_core_0_5_11_typescript_5_9_3_web_tree_sitter_0_25_10_a10e00595b07",
+    package = ":package_opentui_core_0_5_11_520f91ec2257",
+    store_key = "@opentui+core@0.5.11_typescript@5.9.3_web-tree-sitter@0.25.10",
+    runtime = ":assemble-store.ts",
+    dependencies_by_platform = {
+        "javascript_portable": {
+            "bun-ffi-structs": ":entry_bun_ffi_structs_0_3_1_typescript_5_9_3_6c9acefa6d69",
+            "diff": ":entry_diff_9_0_0_5a9cf482041d",
+            "marked": ":entry_marked_17_0_1_ff2a6dda0662",
+            "string-width": ":entry_string_width_7_2_0_dd9742ed9e8e",
+            "strip-ansi": ":entry_strip_ansi_7_1_2_9d924b927a03",
+            "web-tree-sitter": ":entry_web_tree_sitter_0_25_10_634644d3bdf9",
+        },
+        "linux_aarch64": {
+            "@opentui/core-linux-arm64": ":entry_opentui_core_linux_arm64_0_5_11_c1c63b0c0df3",
+            "bun-ffi-structs": ":entry_bun_ffi_structs_0_3_1_typescript_5_9_3_6c9acefa6d69",
+            "diff": ":entry_diff_9_0_0_5a9cf482041d",
+            "marked": ":entry_marked_17_0_1_ff2a6dda0662",
+            "string-width": ":entry_string_width_7_2_0_dd9742ed9e8e",
+            "strip-ansi": ":entry_strip_ansi_7_1_2_9d924b927a03",
+            "web-tree-sitter": ":entry_web_tree_sitter_0_25_10_634644d3bdf9",
+        },
+        "linux_x86_64": {
+            "@opentui/core-linux-x64": ":entry_opentui_core_linux_x64_0_5_11_7bd266afe6f5",
+            "bun-ffi-structs": ":entry_bun_ffi_structs_0_3_1_typescript_5_9_3_6c9acefa6d69",
+            "diff": ":entry_diff_9_0_0_5a9cf482041d",
+            "marked": ":entry_marked_17_0_1_ff2a6dda0662",
+            "string-width": ":entry_string_width_7_2_0_dd9742ed9e8e",
+            "strip-ansi": ":entry_strip_ansi_7_1_2_9d924b927a03",
+            "web-tree-sitter": ":entry_web_tree_sitter_0_25_10_634644d3bdf9",
+        },
+        "macos_aarch64": {
+            "@opentui/core-darwin-arm64": ":entry_opentui_core_darwin_arm64_0_5_11_b33ab39400ed",
+            "bun-ffi-structs": ":entry_bun_ffi_structs_0_3_1_typescript_5_9_3_6c9acefa6d69",
+            "diff": ":entry_diff_9_0_0_5a9cf482041d",
+            "marked": ":entry_marked_17_0_1_ff2a6dda0662",
+            "string-width": ":entry_string_width_7_2_0_dd9742ed9e8e",
+            "strip-ansi": ":entry_strip_ansi_7_1_2_9d924b927a03",
+            "web-tree-sitter": ":entry_web_tree_sitter_0_25_10_634644d3bdf9",
+        },
+    },
+    visibility = ["PUBLIC"],
+)
+
+pnpm_store_entry(
     name = "entry_opentui_core_0_5_11_typescript_7_0_2_web_tree_sitter_0_25_10_8aedbdcd6736",
     package = ":package_opentui_core_0_5_11_520f91ec2257",
     store_key = "@opentui+core@0.5.11_typescript@7.0.2_web-tree-sitter@0.25.10",
@@ -7665,6 +7821,23 @@ pnpm_store_entry(
             "strip-ansi": ":entry_strip_ansi_7_1_2_9d924b927a03",
             "web-tree-sitter": ":entry_web_tree_sitter_0_25_10_634644d3bdf9",
         },
+    },
+    visibility = ["PUBLIC"],
+)
+
+pnpm_store_entry(
+    name = "entry_opentui_react_0_5_11_react_devtools_core_7_0_1_react_19_2_8_typescript_5_aca50de0a7c2",
+    package = ":package_opentui_react_0_5_11_f97ba836b99a",
+    store_key = "@opentui+react@0.5.11_react-devtools-core@7.0.1_react@19.2.8_typescript@5.9.3_web-tree-sitter@0.25.10_ws@8.21.3",
+    runtime = ":assemble-store.ts",
+    dependencies = {
+        "@opentui/core": ":entry_opentui_core_0_5_11_typescript_5_9_3_web_tree_sitter_0_25_10_a10e00595b07",
+        "@types/react": ":entry_types_react_19_2_18_231c43c28c72",
+        "@types/ws": ":entry_types_ws_8_18_1_ee1128304b54",
+        "react": ":entry_react_19_2_8_f0ed5178d6d7",
+        "react-devtools-core": ":entry_react_devtools_core_7_0_1_ac60f63532b4",
+        "react-reconciler": ":entry_react_reconciler_0_33_0_react_19_2_8_00837bbcd720",
+        "ws": ":entry_ws_8_21_3_d250ffc75a80",
     },
     visibility = ["PUBLIC"],
 )
@@ -9220,18 +9393,6 @@ pnpm_store_entry(
 )
 
 pnpm_store_entry(
-    name = "entry_types_eslint_9_6_1_5064d03d8c70",
-    package = ":package_types_eslint_9_6_1_5064d03d8c70",
-    store_key = "@types+eslint@9.6.1",
-    runtime = ":assemble-store.ts",
-    dependencies = {
-        "@types/estree": ":entry_types_estree_1_0_9_ec29746adee7",
-        "@types/json-schema": ":entry_types_json_schema_7_0_15_7a6781250b86",
-    },
-    visibility = ["PUBLIC"],
-)
-
-pnpm_store_entry(
     name = "entry_types_esrecurse_4_3_1_fe5a4a38ec87",
     package = ":package_types_esrecurse_4_3_1_fe5a4a38ec87",
     store_key = "@types+esrecurse@4.3.1",
@@ -9399,31 +9560,30 @@ pnpm_store_entry(
 )
 
 pnpm_store_entry(
-    name = "entry_typescript_eslint_parser_8_61_1_eslint_10_5_0_jiti_2_7_0_typescript_5_9__db10cd9d22ed",
-    package = ":package_typescript_eslint_parser_8_61_1_b500a9b1fcc2",
-    store_key = "@typescript-eslint+parser@8.61.1_eslint@10.5.0_jiti@2.7.0_typescript@5.9.3",
+    name = "entry_typescript_eslint_parser_8_69_0_eslint_10_10_0_jiti_2_7_0_typescript_5_9_d9e60fd503d2",
+    package = ":package_typescript_eslint_parser_8_69_0_7cb7aa2d1392",
+    store_key = "@typescript-eslint+parser@8.69.0_eslint@10.10.0_jiti@2.7.0_typescript@5.9.3",
     runtime = ":assemble-store.ts",
     dependencies = {
-        "@types/eslint": ":entry_types_eslint_9_6_1_5064d03d8c70",
-        "@typescript-eslint/scope-manager": ":entry_typescript_eslint_scope_manager_8_61_1_377564d41d32",
-        "@typescript-eslint/types": ":entry_typescript_eslint_types_8_61_1_a114619f393d",
-        "@typescript-eslint/typescript-estree": ":entry_typescript_eslint_typescript_estree_8_61_1_typescript_5_9_3_8637d48df218",
-        "@typescript-eslint/visitor-keys": ":entry_typescript_eslint_visitor_keys_8_61_1_8533254a16ad",
+        "@typescript-eslint/scope-manager": ":entry_typescript_eslint_scope_manager_8_69_0_2028cc75233f",
+        "@typescript-eslint/types": ":entry_typescript_eslint_types_8_69_0_33daa92e85d2",
+        "@typescript-eslint/typescript-estree": ":entry_typescript_eslint_typescript_estree_8_69_0_typescript_5_9_3_3ca384a764ff",
+        "@typescript-eslint/visitor-keys": ":entry_typescript_eslint_visitor_keys_8_69_0_9c87b69f53c8",
         "debug": ":entry_debug_4_4_3_6390bf853aed",
-        "eslint": ":entry_eslint_10_5_0_jiti_2_7_0_cb3b30c8d310",
+        "eslint": ":entry_eslint_10_10_0_jiti_2_7_0_beba109a7b3d",
         "typescript": ":entry_typescript_5_9_3_44bd9e04e2c2",
     },
     visibility = ["PUBLIC"],
 )
 
 pnpm_store_entry(
-    name = "entry_typescript_eslint_project_service_8_61_1_typescript_5_9_3_2e7be0af28e9",
-    package = ":package_typescript_eslint_project_service_8_61_1_cd6e6899a5f4",
-    store_key = "@typescript-eslint+project-service@8.61.1_typescript@5.9.3",
+    name = "entry_typescript_eslint_project_service_8_69_0_typescript_5_9_3_f94092ffe911",
+    package = ":package_typescript_eslint_project_service_8_69_0_d7ff9add22af",
+    store_key = "@typescript-eslint+project-service@8.69.0_typescript@5.9.3",
     runtime = ":assemble-store.ts",
     dependencies = {
-        "@typescript-eslint/tsconfig-utils": ":entry_typescript_eslint_tsconfig_utils_8_61_1_typescript_5_9_3_3082d785c130",
-        "@typescript-eslint/types": ":entry_typescript_eslint_types_8_61_1_a114619f393d",
+        "@typescript-eslint/tsconfig-utils": ":entry_typescript_eslint_tsconfig_utils_8_69_0_typescript_5_9_3_4c4d2fa014b7",
+        "@typescript-eslint/types": ":entry_typescript_eslint_types_8_69_0_33daa92e85d2",
         "debug": ":entry_debug_4_4_3_6390bf853aed",
         "typescript": ":entry_typescript_5_9_3_44bd9e04e2c2",
     },
@@ -9431,17 +9591,16 @@ pnpm_store_entry(
 )
 
 pnpm_store_entry(
-    name = "entry_typescript_eslint_rule_tester_8_61_1_eslint_10_5_0_jiti_2_7_0_typescript_fd314d3a9ba4",
-    package = ":package_typescript_eslint_rule_tester_8_61_1_5e59a9491378",
-    store_key = "@typescript-eslint+rule-tester@8.61.1_eslint@10.5.0_jiti@2.7.0_typescript@5.9.3",
+    name = "entry_typescript_eslint_rule_tester_8_69_0_eslint_10_10_0_jiti_2_7_0_typescrip_98e25cc77e12",
+    package = ":package_typescript_eslint_rule_tester_8_69_0_061f4c18226e",
+    store_key = "@typescript-eslint+rule-tester@8.69.0_eslint@10.10.0_jiti@2.7.0_typescript@5.9.3",
     runtime = ":assemble-store.ts",
     dependencies = {
-        "@types/eslint": ":entry_types_eslint_9_6_1_5064d03d8c70",
-        "@typescript-eslint/parser": ":entry_typescript_eslint_parser_8_61_1_eslint_10_5_0_jiti_2_7_0_typescript_5_9__db10cd9d22ed",
-        "@typescript-eslint/typescript-estree": ":entry_typescript_eslint_typescript_estree_8_61_1_typescript_5_9_3_8637d48df218",
-        "@typescript-eslint/utils": ":entry_typescript_eslint_utils_8_61_1_eslint_10_5_0_jiti_2_7_0_typescript_5_9_3_db1f20e6f2e0",
+        "@typescript-eslint/parser": ":entry_typescript_eslint_parser_8_69_0_eslint_10_10_0_jiti_2_7_0_typescript_5_9_d9e60fd503d2",
+        "@typescript-eslint/typescript-estree": ":entry_typescript_eslint_typescript_estree_8_69_0_typescript_5_9_3_3ca384a764ff",
+        "@typescript-eslint/utils": ":entry_typescript_eslint_utils_8_69_0_eslint_10_10_0_jiti_2_7_0_typescript_5_9__82b3965462e6",
         "ajv": ":entry_ajv_6_15_0_ad437bedcb08",
-        "eslint": ":entry_eslint_10_5_0_jiti_2_7_0_cb3b30c8d310",
+        "eslint": ":entry_eslint_10_10_0_jiti_2_7_0_beba109a7b3d",
         "json-stable-stringify-without-jsonify": ":entry_json_stable_stringify_without_jsonify_1_0_1_0e74de0204bb",
         "lodash.merge": ":entry_lodash_merge_4_6_2_996e40d63a94",
         "semver": ":entry_semver_7_8_5_82a86616e50d",
@@ -9451,21 +9610,21 @@ pnpm_store_entry(
 )
 
 pnpm_store_entry(
-    name = "entry_typescript_eslint_scope_manager_8_61_1_377564d41d32",
-    package = ":package_typescript_eslint_scope_manager_8_61_1_377564d41d32",
-    store_key = "@typescript-eslint+scope-manager@8.61.1",
+    name = "entry_typescript_eslint_scope_manager_8_69_0_2028cc75233f",
+    package = ":package_typescript_eslint_scope_manager_8_69_0_2028cc75233f",
+    store_key = "@typescript-eslint+scope-manager@8.69.0",
     runtime = ":assemble-store.ts",
     dependencies = {
-        "@typescript-eslint/types": ":entry_typescript_eslint_types_8_61_1_a114619f393d",
-        "@typescript-eslint/visitor-keys": ":entry_typescript_eslint_visitor_keys_8_61_1_8533254a16ad",
+        "@typescript-eslint/types": ":entry_typescript_eslint_types_8_69_0_33daa92e85d2",
+        "@typescript-eslint/visitor-keys": ":entry_typescript_eslint_visitor_keys_8_69_0_9c87b69f53c8",
     },
     visibility = ["PUBLIC"],
 )
 
 pnpm_store_entry(
-    name = "entry_typescript_eslint_tsconfig_utils_8_61_1_typescript_5_9_3_3082d785c130",
-    package = ":package_typescript_eslint_tsconfig_utils_8_61_1_d3d1d656eb33",
-    store_key = "@typescript-eslint+tsconfig-utils@8.61.1_typescript@5.9.3",
+    name = "entry_typescript_eslint_tsconfig_utils_8_69_0_typescript_5_9_3_4c4d2fa014b7",
+    package = ":package_typescript_eslint_tsconfig_utils_8_69_0_588922a57adb",
+    store_key = "@typescript-eslint+tsconfig-utils@8.69.0_typescript@5.9.3",
     runtime = ":assemble-store.ts",
     dependencies = {
         "typescript": ":entry_typescript_5_9_3_44bd9e04e2c2",
@@ -9474,9 +9633,9 @@ pnpm_store_entry(
 )
 
 pnpm_store_entry(
-    name = "entry_typescript_eslint_types_8_61_1_a114619f393d",
-    package = ":package_typescript_eslint_types_8_61_1_a114619f393d",
-    store_key = "@typescript-eslint+types@8.61.1",
+    name = "entry_typescript_eslint_types_8_69_0_33daa92e85d2",
+    package = ":package_typescript_eslint_types_8_69_0_33daa92e85d2",
+    store_key = "@typescript-eslint+types@8.69.0",
     runtime = ":assemble-store.ts",
     dependencies = {
     },
@@ -9484,15 +9643,15 @@ pnpm_store_entry(
 )
 
 pnpm_store_entry(
-    name = "entry_typescript_eslint_typescript_estree_8_61_1_typescript_5_9_3_8637d48df218",
-    package = ":package_typescript_eslint_typescript_estree_8_61_1_3234ed579ea5",
-    store_key = "@typescript-eslint+typescript-estree@8.61.1_typescript@5.9.3",
+    name = "entry_typescript_eslint_typescript_estree_8_69_0_typescript_5_9_3_3ca384a764ff",
+    package = ":package_typescript_eslint_typescript_estree_8_69_0_7f3c34d2b24e",
+    store_key = "@typescript-eslint+typescript-estree@8.69.0_typescript@5.9.3",
     runtime = ":assemble-store.ts",
     dependencies = {
-        "@typescript-eslint/project-service": ":entry_typescript_eslint_project_service_8_61_1_typescript_5_9_3_2e7be0af28e9",
-        "@typescript-eslint/tsconfig-utils": ":entry_typescript_eslint_tsconfig_utils_8_61_1_typescript_5_9_3_3082d785c130",
-        "@typescript-eslint/types": ":entry_typescript_eslint_types_8_61_1_a114619f393d",
-        "@typescript-eslint/visitor-keys": ":entry_typescript_eslint_visitor_keys_8_61_1_8533254a16ad",
+        "@typescript-eslint/project-service": ":entry_typescript_eslint_project_service_8_69_0_typescript_5_9_3_f94092ffe911",
+        "@typescript-eslint/tsconfig-utils": ":entry_typescript_eslint_tsconfig_utils_8_69_0_typescript_5_9_3_4c4d2fa014b7",
+        "@typescript-eslint/types": ":entry_typescript_eslint_types_8_69_0_33daa92e85d2",
+        "@typescript-eslint/visitor-keys": ":entry_typescript_eslint_visitor_keys_8_69_0_9c87b69f53c8",
         "debug": ":entry_debug_4_4_3_6390bf853aed",
         "minimatch": ":entry_minimatch_10_2_6_7dfd90b95b04",
         "semver": ":entry_semver_7_8_5_82a86616e50d",
@@ -9504,29 +9663,28 @@ pnpm_store_entry(
 )
 
 pnpm_store_entry(
-    name = "entry_typescript_eslint_utils_8_61_1_eslint_10_5_0_jiti_2_7_0_typescript_5_9_3_db1f20e6f2e0",
-    package = ":package_typescript_eslint_utils_8_61_1_0cff09d7fc88",
-    store_key = "@typescript-eslint+utils@8.61.1_eslint@10.5.0_jiti@2.7.0_typescript@5.9.3",
+    name = "entry_typescript_eslint_utils_8_69_0_eslint_10_10_0_jiti_2_7_0_typescript_5_9__82b3965462e6",
+    package = ":package_typescript_eslint_utils_8_69_0_257ad29d4511",
+    store_key = "@typescript-eslint+utils@8.69.0_eslint@10.10.0_jiti@2.7.0_typescript@5.9.3",
     runtime = ":assemble-store.ts",
     dependencies = {
-        "@eslint-community/eslint-utils": ":entry_eslint_community_eslint_utils_4_10_1_eslint_10_5_0_jiti_2_7_0_f722ea313427",
-        "@types/eslint": ":entry_types_eslint_9_6_1_5064d03d8c70",
-        "@typescript-eslint/scope-manager": ":entry_typescript_eslint_scope_manager_8_61_1_377564d41d32",
-        "@typescript-eslint/types": ":entry_typescript_eslint_types_8_61_1_a114619f393d",
-        "@typescript-eslint/typescript-estree": ":entry_typescript_eslint_typescript_estree_8_61_1_typescript_5_9_3_8637d48df218",
-        "eslint": ":entry_eslint_10_5_0_jiti_2_7_0_cb3b30c8d310",
+        "@eslint-community/eslint-utils": ":entry_eslint_community_eslint_utils_4_10_1_eslint_10_10_0_jiti_2_7_0_002b1c3db5db",
+        "@typescript-eslint/scope-manager": ":entry_typescript_eslint_scope_manager_8_69_0_2028cc75233f",
+        "@typescript-eslint/types": ":entry_typescript_eslint_types_8_69_0_33daa92e85d2",
+        "@typescript-eslint/typescript-estree": ":entry_typescript_eslint_typescript_estree_8_69_0_typescript_5_9_3_3ca384a764ff",
+        "eslint": ":entry_eslint_10_10_0_jiti_2_7_0_beba109a7b3d",
         "typescript": ":entry_typescript_5_9_3_44bd9e04e2c2",
     },
     visibility = ["PUBLIC"],
 )
 
 pnpm_store_entry(
-    name = "entry_typescript_eslint_visitor_keys_8_61_1_8533254a16ad",
-    package = ":package_typescript_eslint_visitor_keys_8_61_1_8533254a16ad",
-    store_key = "@typescript-eslint+visitor-keys@8.61.1",
+    name = "entry_typescript_eslint_visitor_keys_8_69_0_9c87b69f53c8",
+    package = ":package_typescript_eslint_visitor_keys_8_69_0_9c87b69f53c8",
+    store_key = "@typescript-eslint+visitor-keys@8.69.0",
     runtime = ":assemble-store.ts",
     dependencies = {
-        "@typescript-eslint/types": ":entry_typescript_eslint_types_8_61_1_a114619f393d",
+        "@typescript-eslint/types": ":entry_typescript_eslint_types_8_69_0_33daa92e85d2",
         "eslint-visitor-keys": ":entry_eslint_visitor_keys_5_0_1_77649af58b26",
     },
     visibility = ["PUBLIC"],
@@ -10217,6 +10375,17 @@ pnpm_store_entry(
 )
 
 pnpm_store_entry(
+    name = "entry_bun_ffi_structs_0_3_1_typescript_5_9_3_6c9acefa6d69",
+    package = ":package_bun_ffi_structs_0_3_1_b795c25b36d8",
+    store_key = "bun-ffi-structs@0.3.1_typescript@5.9.3",
+    runtime = ":assemble-store.ts",
+    dependencies = {
+        "typescript": ":entry_typescript_5_9_3_44bd9e04e2c2",
+    },
+    visibility = ["PUBLIC"],
+)
+
+pnpm_store_entry(
     name = "entry_bun_ffi_structs_0_3_1_typescript_7_0_2_051e106cc9bb",
     package = ":package_bun_ffi_structs_0_3_1_b795c25b36d8",
     store_key = "bun-ffi-structs@0.3.1_typescript@7.0.2",
@@ -10245,6 +10414,21 @@ pnpm_store_entry(
     runtime = ":assemble-store.ts",
     dependencies = {
         "run-applescript": ":entry_run_applescript_7_1_0_d5373e028313",
+    },
+    visibility = ["PUBLIC"],
+)
+
+pnpm_store_entry(
+    name = "entry_cacheable_2_5_0_0a9dd0dffb1a",
+    package = ":package_cacheable_2_5_0_0a9dd0dffb1a",
+    store_key = "cacheable@2.5.0",
+    runtime = ":assemble-store.ts",
+    dependencies = {
+        "@cacheable/memory": ":entry_cacheable_memory_2_2_0_ebfb4ac2b5f5",
+        "@cacheable/utils": ":entry_cacheable_utils_2_5_0_22620a8f2225",
+        "hookified": ":entry_hookified_1_15_1_e5243a6e8f47",
+        "keyv": ":entry_keyv_5_6_0_b95898f12ca2",
+        "qified": ":entry_qified_0_10_1_b3b25bd21152",
     },
     visibility = ["PUBLIC"],
 )
@@ -10775,11 +10959,11 @@ pnpm_store_entry(
 )
 
 pnpm_store_entry(
-    name = "entry_eslint_10_5_0_jiti_2_7_0_cb3b30c8d310",
-    package = ":package_eslint_10_5_0_0f347c0e43c0",
-    store_key = "eslint@10.5.0_jiti@2.7.0",
+    name = "entry_eslint_10_10_0_jiti_2_7_0_beba109a7b3d",
+    package = ":package_eslint_10_10_0_22ff8f9ebaf4",
+    store_key = "eslint@10.10.0_jiti@2.7.0",
     runtime = ":assemble-store.ts",
-    scc = ":scc_eslint_community_eslint_utils_4_10_1_eslint_10_5_0_jiti_2_7_0_eslint_10__8e534452c059",
+    scc = ":scc_eslint_community_eslint_utils_4_10_1_eslint_10_10_0_jiti_2_7_0_eslint_10_22c0e0a437c0",
     visibility = ["PUBLIC"],
 )
 
@@ -10962,12 +11146,12 @@ pnpm_store_entry(
 )
 
 pnpm_store_entry(
-    name = "entry_file_entry_cache_8_0_0_cfd34b733a3c",
-    package = ":package_file_entry_cache_8_0_0_cfd34b733a3c",
-    store_key = "file-entry-cache@8.0.0",
+    name = "entry_file_entry_cache_11_1_5_ac300dcb09f1",
+    package = ":package_file_entry_cache_11_1_5_ac300dcb09f1",
+    store_key = "file-entry-cache@11.1.5",
     runtime = ":assemble-store.ts",
     dependencies = {
-        "flat-cache": ":entry_flat_cache_4_0_1_2a36811f99d5",
+        "flat-cache": ":entry_flat_cache_6_1_23_4b2ba8bae97d",
     },
     visibility = ["PUBLIC"],
 )
@@ -10996,13 +11180,14 @@ pnpm_store_entry(
 )
 
 pnpm_store_entry(
-    name = "entry_flat_cache_4_0_1_2a36811f99d5",
-    package = ":package_flat_cache_4_0_1_2a36811f99d5",
-    store_key = "flat-cache@4.0.1",
+    name = "entry_flat_cache_6_1_23_4b2ba8bae97d",
+    package = ":package_flat_cache_6_1_23_4b2ba8bae97d",
+    store_key = "flat-cache@6.1.23",
     runtime = ":assemble-store.ts",
     dependencies = {
+        "cacheable": ":entry_cacheable_2_5_0_0a9dd0dffb1a",
         "flatted": ":entry_flatted_3_4_4_57b7d7dc886d",
-        "keyv": ":entry_keyv_4_5_4_b44ddb67514f",
+        "hookified": ":entry_hookified_1_15_1_e5243a6e8f47",
     },
     visibility = ["PUBLIC"],
 )
@@ -11111,6 +11296,17 @@ pnpm_store_entry(
 )
 
 pnpm_store_entry(
+    name = "entry_hashery_1_5_1_e1122633ff95",
+    package = ":package_hashery_1_5_1_e1122633ff95",
+    store_key = "hashery@1.5.1",
+    runtime = ":assemble-store.ts",
+    dependencies = {
+        "hookified": ":entry_hookified_1_15_1_e5243a6e8f47",
+    },
+    visibility = ["PUBLIC"],
+)
+
+pnpm_store_entry(
     name = "entry_hasown_2_0_4_ba2e3a5fbd10",
     package = ":package_hasown_2_0_4_ba2e3a5fbd10",
     store_key = "hasown@2.0.4",
@@ -11149,6 +11345,26 @@ pnpm_store_entry(
     runtime = ":assemble-store.ts",
     dependencies = {
         "@types/hast": ":entry_types_hast_3_0_5_1b23eebfa358",
+    },
+    visibility = ["PUBLIC"],
+)
+
+pnpm_store_entry(
+    name = "entry_hookified_1_15_1_e5243a6e8f47",
+    package = ":package_hookified_1_15_1_e5243a6e8f47",
+    store_key = "hookified@1.15.1",
+    runtime = ":assemble-store.ts",
+    dependencies = {
+    },
+    visibility = ["PUBLIC"],
+)
+
+pnpm_store_entry(
+    name = "entry_hookified_2_2_0_28f9e2a047fb",
+    package = ":package_hookified_2_2_0_28f9e2a047fb",
+    store_key = "hookified@2.2.0",
+    runtime = ":assemble-store.ts",
+    dependencies = {
     },
     visibility = ["PUBLIC"],
 )
@@ -11393,16 +11609,6 @@ pnpm_store_entry(
 )
 
 pnpm_store_entry(
-    name = "entry_json_buffer_3_0_1_adbc921fc34d",
-    package = ":package_json_buffer_3_0_1_adbc921fc34d",
-    store_key = "json-buffer@3.0.1",
-    runtime = ":assemble-store.ts",
-    dependencies = {
-    },
-    visibility = ["PUBLIC"],
-)
-
-pnpm_store_entry(
     name = "entry_json_schema_traverse_0_4_1_224390b16484",
     package = ":package_json_schema_traverse_0_4_1_224390b16484",
     store_key = "json-schema-traverse@0.4.1",
@@ -11454,12 +11660,12 @@ pnpm_store_entry(
 )
 
 pnpm_store_entry(
-    name = "entry_keyv_4_5_4_b44ddb67514f",
-    package = ":package_keyv_4_5_4_b44ddb67514f",
-    store_key = "keyv@4.5.4",
+    name = "entry_keyv_5_6_0_b95898f12ca2",
+    package = ":package_keyv_5_6_0_b95898f12ca2",
+    store_key = "keyv@5.6.0",
     runtime = ":assemble-store.ts",
     dependencies = {
-        "json-buffer": ":entry_json_buffer_3_0_1_adbc921fc34d",
+        "@keyv/serialize": ":entry_keyv_serialize_1_1_1_aa477d4d1034",
     },
     visibility = ["PUBLIC"],
 )
@@ -12728,6 +12934,17 @@ pnpm_store_entry(
     store_key = "pure-rand@8.4.2",
     runtime = ":assemble-store.ts",
     dependencies = {
+    },
+    visibility = ["PUBLIC"],
+)
+
+pnpm_store_entry(
+    name = "entry_qified_0_10_1_b3b25bd21152",
+    package = ":package_qified_0_10_1_b3b25bd21152",
+    store_key = "qified@0.10.1",
+    runtime = ":assemble-store.ts",
+    dependencies = {
+        "hookified": ":entry_hookified_2_2_0_28f9e2a047fb",
     },
     visibility = ["PUBLIC"],
 )
@@ -14143,25 +14360,24 @@ pnpm_store_view(
     runtime = ":assemble-store.ts",
     direct = {
         "@effect/atom-react": "@effect+atom-react@4.0.0-rc.111_effect@4.0.0-rc.111_react@19.2.8_scheduler@0.27.0",
-        "@opentui/core": "@opentui+core@0.5.11_typescript@7.0.2_web-tree-sitter@0.25.10",
-        "@opentui/react": "@opentui+react@0.5.11_react-devtools-core@7.0.1_react@19.2.8_typescript@7.0.2_web-tree-sitter@0.25.10_ws@8.21.3",
+        "@opentui/core": "@opentui+core@0.5.11_typescript@5.9.3_web-tree-sitter@0.25.10",
+        "@opentui/react": "@opentui+react@0.5.11_react-devtools-core@7.0.1_react@19.2.8_typescript@5.9.3_web-tree-sitter@0.25.10_ws@8.21.3",
         "@types/node": "@types+node@26.5.0",
         "@types/react": "@types+react@19.2.18",
         "effect": "effect@4.0.0-rc.111",
         "react": "react@19.2.8",
-        "typescript": "typescript@7.0.2",
     },
     closure_by_platform = {
         "javascript_portable": {
             "@effect+atom-react@4.0.0-rc.111_effect@4.0.0-rc.111_react@19.2.8_scheduler@0.27.0": ":entry_effect_atom_react_4_0_0_rc_111_effect_4_0_0_rc_111_react_19_2_8_schedule_879f75095f22",
-            "@opentui+core@0.5.11_typescript@7.0.2_web-tree-sitter@0.25.10": ":entry_opentui_core_0_5_11_typescript_7_0_2_web_tree_sitter_0_25_10_8aedbdcd6736",
-            "@opentui+react@0.5.11_react-devtools-core@7.0.1_react@19.2.8_typescript@7.0.2_web-tree-sitter@0.25.10_ws@8.21.3": ":entry_opentui_react_0_5_11_react_devtools_core_7_0_1_react_19_2_8_typescript_7_cb7918c1f170",
+            "@opentui+core@0.5.11_typescript@5.9.3_web-tree-sitter@0.25.10": ":entry_opentui_core_0_5_11_typescript_5_9_3_web_tree_sitter_0_25_10_a10e00595b07",
+            "@opentui+react@0.5.11_react-devtools-core@7.0.1_react@19.2.8_typescript@5.9.3_web-tree-sitter@0.25.10_ws@8.21.3": ":entry_opentui_react_0_5_11_react_devtools_core_7_0_1_react_19_2_8_typescript_5_aca50de0a7c2",
             "@standard-schema+spec@1.1.0": ":entry_standard_schema_spec_1_1_0_9bfb5ac2eb33",
             "@types+node@26.5.0": ":entry_types_node_26_5_0_a0142d056efc",
             "@types+react@19.2.18": ":entry_types_react_19_2_18_231c43c28c72",
             "@types+ws@8.18.1": ":entry_types_ws_8_18_1_ee1128304b54",
             "ansi-regex@6.3.0": ":entry_ansi_regex_6_3_0_87b6edc6ebb4",
-            "bun-ffi-structs@0.3.1_typescript@7.0.2": ":entry_bun_ffi_structs_0_3_1_typescript_7_0_2_051e106cc9bb",
+            "bun-ffi-structs@0.3.1_typescript@5.9.3": ":entry_bun_ffi_structs_0_3_1_typescript_5_9_3_6c9acefa6d69",
             "csstype@3.2.3": ":entry_csstype_3_2_3_d75166202534",
             "detect-libc@2.1.2": ":entry_detect_libc_2_1_2_a7155eec83d1",
             "diff@9.0.0": ":entry_diff_9_0_0_5a9cf482041d",
@@ -14182,7 +14398,7 @@ pnpm_store_view(
             "string-width@7.2.0": ":entry_string_width_7_2_0_dd9742ed9e8e",
             "strip-ansi@7.1.2": ":entry_strip_ansi_7_1_2_9d924b927a03",
             "strip-ansi@7.2.0": ":entry_strip_ansi_7_2_0_c04be5885def",
-            "typescript@7.0.2": ":entry_typescript_7_0_2_a7cefd323dc7",
+            "typescript@5.9.3": ":entry_typescript_5_9_3_44bd9e04e2c2",
             "undici-types@8.9.0": ":entry_undici_types_8_9_0_53cb0487b88b",
             "web-tree-sitter@0.25.10": ":entry_web_tree_sitter_0_25_10_634644d3bdf9",
             "ws@7.5.13": ":entry_ws_7_5_13_ccf43b94a1cd",
@@ -14192,15 +14408,14 @@ pnpm_store_view(
             "@effect+atom-react@4.0.0-rc.111_effect@4.0.0-rc.111_react@19.2.8_scheduler@0.27.0": ":entry_effect_atom_react_4_0_0_rc_111_effect_4_0_0_rc_111_react_19_2_8_schedule_879f75095f22",
             "@msgpackr-extract+msgpackr-extract-linux-arm64@3.0.4": ":entry_msgpackr_extract_msgpackr_extract_linux_arm64_3_0_4_cf31bccf54bd",
             "@opentui+core-linux-arm64@0.5.11": ":entry_opentui_core_linux_arm64_0_5_11_c1c63b0c0df3",
-            "@opentui+core@0.5.11_typescript@7.0.2_web-tree-sitter@0.25.10": ":entry_opentui_core_0_5_11_typescript_7_0_2_web_tree_sitter_0_25_10_8aedbdcd6736",
-            "@opentui+react@0.5.11_react-devtools-core@7.0.1_react@19.2.8_typescript@7.0.2_web-tree-sitter@0.25.10_ws@8.21.3": ":entry_opentui_react_0_5_11_react_devtools_core_7_0_1_react_19_2_8_typescript_7_cb7918c1f170",
+            "@opentui+core@0.5.11_typescript@5.9.3_web-tree-sitter@0.25.10": ":entry_opentui_core_0_5_11_typescript_5_9_3_web_tree_sitter_0_25_10_a10e00595b07",
+            "@opentui+react@0.5.11_react-devtools-core@7.0.1_react@19.2.8_typescript@5.9.3_web-tree-sitter@0.25.10_ws@8.21.3": ":entry_opentui_react_0_5_11_react_devtools_core_7_0_1_react_19_2_8_typescript_5_aca50de0a7c2",
             "@standard-schema+spec@1.1.0": ":entry_standard_schema_spec_1_1_0_9bfb5ac2eb33",
             "@types+node@26.5.0": ":entry_types_node_26_5_0_a0142d056efc",
             "@types+react@19.2.18": ":entry_types_react_19_2_18_231c43c28c72",
             "@types+ws@8.18.1": ":entry_types_ws_8_18_1_ee1128304b54",
-            "@typescript+typescript-linux-arm64@7.0.2": ":entry_typescript_typescript_linux_arm64_7_0_2_dbe899afde8f",
             "ansi-regex@6.3.0": ":entry_ansi_regex_6_3_0_87b6edc6ebb4",
-            "bun-ffi-structs@0.3.1_typescript@7.0.2": ":entry_bun_ffi_structs_0_3_1_typescript_7_0_2_051e106cc9bb",
+            "bun-ffi-structs@0.3.1_typescript@5.9.3": ":entry_bun_ffi_structs_0_3_1_typescript_5_9_3_6c9acefa6d69",
             "csstype@3.2.3": ":entry_csstype_3_2_3_d75166202534",
             "detect-libc@2.1.2": ":entry_detect_libc_2_1_2_a7155eec83d1",
             "diff@9.0.0": ":entry_diff_9_0_0_5a9cf482041d",
@@ -14221,7 +14436,7 @@ pnpm_store_view(
             "string-width@7.2.0": ":entry_string_width_7_2_0_dd9742ed9e8e",
             "strip-ansi@7.1.2": ":entry_strip_ansi_7_1_2_9d924b927a03",
             "strip-ansi@7.2.0": ":entry_strip_ansi_7_2_0_c04be5885def",
-            "typescript@7.0.2": ":entry_typescript_7_0_2_a7cefd323dc7",
+            "typescript@5.9.3": ":entry_typescript_5_9_3_44bd9e04e2c2",
             "undici-types@8.9.0": ":entry_undici_types_8_9_0_53cb0487b88b",
             "web-tree-sitter@0.25.10": ":entry_web_tree_sitter_0_25_10_634644d3bdf9",
             "ws@7.5.13": ":entry_ws_7_5_13_ccf43b94a1cd",
@@ -14231,15 +14446,14 @@ pnpm_store_view(
             "@effect+atom-react@4.0.0-rc.111_effect@4.0.0-rc.111_react@19.2.8_scheduler@0.27.0": ":entry_effect_atom_react_4_0_0_rc_111_effect_4_0_0_rc_111_react_19_2_8_schedule_879f75095f22",
             "@msgpackr-extract+msgpackr-extract-linux-x64@3.0.4": ":entry_msgpackr_extract_msgpackr_extract_linux_x64_3_0_4_d261ffc94c45",
             "@opentui+core-linux-x64@0.5.11": ":entry_opentui_core_linux_x64_0_5_11_7bd266afe6f5",
-            "@opentui+core@0.5.11_typescript@7.0.2_web-tree-sitter@0.25.10": ":entry_opentui_core_0_5_11_typescript_7_0_2_web_tree_sitter_0_25_10_8aedbdcd6736",
-            "@opentui+react@0.5.11_react-devtools-core@7.0.1_react@19.2.8_typescript@7.0.2_web-tree-sitter@0.25.10_ws@8.21.3": ":entry_opentui_react_0_5_11_react_devtools_core_7_0_1_react_19_2_8_typescript_7_cb7918c1f170",
+            "@opentui+core@0.5.11_typescript@5.9.3_web-tree-sitter@0.25.10": ":entry_opentui_core_0_5_11_typescript_5_9_3_web_tree_sitter_0_25_10_a10e00595b07",
+            "@opentui+react@0.5.11_react-devtools-core@7.0.1_react@19.2.8_typescript@5.9.3_web-tree-sitter@0.25.10_ws@8.21.3": ":entry_opentui_react_0_5_11_react_devtools_core_7_0_1_react_19_2_8_typescript_5_aca50de0a7c2",
             "@standard-schema+spec@1.1.0": ":entry_standard_schema_spec_1_1_0_9bfb5ac2eb33",
             "@types+node@26.5.0": ":entry_types_node_26_5_0_a0142d056efc",
             "@types+react@19.2.18": ":entry_types_react_19_2_18_231c43c28c72",
             "@types+ws@8.18.1": ":entry_types_ws_8_18_1_ee1128304b54",
-            "@typescript+typescript-linux-x64@7.0.2": ":entry_typescript_typescript_linux_x64_7_0_2_f03df44f666b",
             "ansi-regex@6.3.0": ":entry_ansi_regex_6_3_0_87b6edc6ebb4",
-            "bun-ffi-structs@0.3.1_typescript@7.0.2": ":entry_bun_ffi_structs_0_3_1_typescript_7_0_2_051e106cc9bb",
+            "bun-ffi-structs@0.3.1_typescript@5.9.3": ":entry_bun_ffi_structs_0_3_1_typescript_5_9_3_6c9acefa6d69",
             "csstype@3.2.3": ":entry_csstype_3_2_3_d75166202534",
             "detect-libc@2.1.2": ":entry_detect_libc_2_1_2_a7155eec83d1",
             "diff@9.0.0": ":entry_diff_9_0_0_5a9cf482041d",
@@ -14260,7 +14474,7 @@ pnpm_store_view(
             "string-width@7.2.0": ":entry_string_width_7_2_0_dd9742ed9e8e",
             "strip-ansi@7.1.2": ":entry_strip_ansi_7_1_2_9d924b927a03",
             "strip-ansi@7.2.0": ":entry_strip_ansi_7_2_0_c04be5885def",
-            "typescript@7.0.2": ":entry_typescript_7_0_2_a7cefd323dc7",
+            "typescript@5.9.3": ":entry_typescript_5_9_3_44bd9e04e2c2",
             "undici-types@8.9.0": ":entry_undici_types_8_9_0_53cb0487b88b",
             "web-tree-sitter@0.25.10": ":entry_web_tree_sitter_0_25_10_634644d3bdf9",
             "ws@7.5.13": ":entry_ws_7_5_13_ccf43b94a1cd",
@@ -14270,15 +14484,14 @@ pnpm_store_view(
             "@effect+atom-react@4.0.0-rc.111_effect@4.0.0-rc.111_react@19.2.8_scheduler@0.27.0": ":entry_effect_atom_react_4_0_0_rc_111_effect_4_0_0_rc_111_react_19_2_8_schedule_879f75095f22",
             "@msgpackr-extract+msgpackr-extract-darwin-arm64@3.0.4": ":entry_msgpackr_extract_msgpackr_extract_darwin_arm64_3_0_4_fa8bce50cc94",
             "@opentui+core-darwin-arm64@0.5.11": ":entry_opentui_core_darwin_arm64_0_5_11_b33ab39400ed",
-            "@opentui+core@0.5.11_typescript@7.0.2_web-tree-sitter@0.25.10": ":entry_opentui_core_0_5_11_typescript_7_0_2_web_tree_sitter_0_25_10_8aedbdcd6736",
-            "@opentui+react@0.5.11_react-devtools-core@7.0.1_react@19.2.8_typescript@7.0.2_web-tree-sitter@0.25.10_ws@8.21.3": ":entry_opentui_react_0_5_11_react_devtools_core_7_0_1_react_19_2_8_typescript_7_cb7918c1f170",
+            "@opentui+core@0.5.11_typescript@5.9.3_web-tree-sitter@0.25.10": ":entry_opentui_core_0_5_11_typescript_5_9_3_web_tree_sitter_0_25_10_a10e00595b07",
+            "@opentui+react@0.5.11_react-devtools-core@7.0.1_react@19.2.8_typescript@5.9.3_web-tree-sitter@0.25.10_ws@8.21.3": ":entry_opentui_react_0_5_11_react_devtools_core_7_0_1_react_19_2_8_typescript_5_aca50de0a7c2",
             "@standard-schema+spec@1.1.0": ":entry_standard_schema_spec_1_1_0_9bfb5ac2eb33",
             "@types+node@26.5.0": ":entry_types_node_26_5_0_a0142d056efc",
             "@types+react@19.2.18": ":entry_types_react_19_2_18_231c43c28c72",
             "@types+ws@8.18.1": ":entry_types_ws_8_18_1_ee1128304b54",
-            "@typescript+typescript-darwin-arm64@7.0.2": ":entry_typescript_typescript_darwin_arm64_7_0_2_38ca3d6d9939",
             "ansi-regex@6.3.0": ":entry_ansi_regex_6_3_0_87b6edc6ebb4",
-            "bun-ffi-structs@0.3.1_typescript@7.0.2": ":entry_bun_ffi_structs_0_3_1_typescript_7_0_2_051e106cc9bb",
+            "bun-ffi-structs@0.3.1_typescript@5.9.3": ":entry_bun_ffi_structs_0_3_1_typescript_5_9_3_6c9acefa6d69",
             "csstype@3.2.3": ":entry_csstype_3_2_3_d75166202534",
             "detect-libc@2.1.2": ":entry_detect_libc_2_1_2_a7155eec83d1",
             "diff@9.0.0": ":entry_diff_9_0_0_5a9cf482041d",
@@ -14299,7 +14512,7 @@ pnpm_store_view(
             "string-width@7.2.0": ":entry_string_width_7_2_0_dd9742ed9e8e",
             "strip-ansi@7.1.2": ":entry_strip_ansi_7_1_2_9d924b927a03",
             "strip-ansi@7.2.0": ":entry_strip_ansi_7_2_0_c04be5885def",
-            "typescript@7.0.2": ":entry_typescript_7_0_2_a7cefd323dc7",
+            "typescript@5.9.3": ":entry_typescript_5_9_3_44bd9e04e2c2",
             "undici-types@8.9.0": ":entry_undici_types_8_9_0_53cb0487b88b",
             "web-tree-sitter@0.25.10": ":entry_web_tree_sitter_0_25_10_634644d3bdf9",
             "ws@7.5.13": ":entry_ws_7_5_13_ccf43b94a1cd",
@@ -14307,7 +14520,6 @@ pnpm_store_view(
         },
     },
     bins = {
-        "tsc": "typescript@7.0.2\tbin/tsc",
     },
     workspace_trees = {
     },
@@ -30409,11 +30621,10 @@ pnpm_store_view(
     runtime = ":assemble-store.ts",
     direct = {
         "@stylexjs/eslint-plugin": "@stylexjs+eslint-plugin@0.19.0",
-        "@types/eslint": "@types+eslint@9.6.1",
-        "@typescript-eslint/parser": "@typescript-eslint+parser@8.61.1_eslint@10.5.0_jiti@2.7.0_typescript@5.9.3",
-        "@typescript-eslint/rule-tester": "@typescript-eslint+rule-tester@8.61.1_eslint@10.5.0_jiti@2.7.0_typescript@5.9.3",
-        "@typescript-eslint/utils": "@typescript-eslint+utils@8.61.1_eslint@10.5.0_jiti@2.7.0_typescript@5.9.3",
-        "eslint": "eslint@10.5.0_jiti@2.7.0",
+        "@typescript-eslint/parser": "@typescript-eslint+parser@8.69.0_eslint@10.10.0_jiti@2.7.0_typescript@5.9.3",
+        "@typescript-eslint/rule-tester": "@typescript-eslint+rule-tester@8.69.0_eslint@10.10.0_jiti@2.7.0_typescript@5.9.3",
+        "@typescript-eslint/utils": "@typescript-eslint+utils@8.69.0_eslint@10.10.0_jiti@2.7.0_typescript@5.9.3",
+        "eslint": "eslint@10.10.0_jiti@2.7.0",
         "oxlint-tsgolint": "oxlint-tsgolint@7.0.2001",
         "typescript": "typescript@5.9.3",
         "vitest": "vitest@4.1.9_@opentelemetry+api@1.9.1_@types+node@26.5.0_@vitest+browser-playwright@4.1.9_happy-dom@20._f830263be88a0e28",
@@ -30421,13 +30632,15 @@ pnpm_store_view(
     closure_by_platform = {
         "javascript_portable": {
             "@blazediff+core@1.9.1": ":entry_blazediff_core_1_9_1_2c297fb3187d",
+            "@cacheable+memory@2.2.0": ":entry_cacheable_memory_2_2_0_ebfb4ac2b5f5",
+            "@cacheable+utils@2.5.0": ":entry_cacheable_utils_2_5_0_22620a8f2225",
             "@csstools+css-tokenizer@3.0.4": ":entry_csstools_css_tokenizer_3_0_4_1364f68e1d48",
             "@eslint+config-array@0.23.5": ":entry_eslint_config_array_0_23_5_c4003c9d3aa0",
-            "@eslint+config-helpers@0.6.0": ":entry_eslint_config_helpers_0_6_0_f9d65331f01d",
+            "@eslint+config-helpers@0.7.0": ":entry_eslint_config_helpers_0_7_0_5e96e6a5142e",
             "@eslint+core@1.2.1": ":entry_eslint_core_1_2_1_8011bd8ea054",
             "@eslint+object-schema@3.0.5": ":entry_eslint_object_schema_3_0_5_a42e0543fbb6",
-            "@eslint+plugin-kit@0.7.2": ":entry_eslint_plugin_kit_0_7_2_61f595114b42",
-            "@eslint-community+eslint-utils@4.10.1_eslint@10.5.0_jiti@2.7.0": ":entry_eslint_community_eslint_utils_4_10_1_eslint_10_5_0_jiti_2_7_0_f722ea313427",
+            "@eslint+plugin-kit@0.7.3": ":entry_eslint_plugin_kit_0_7_3_2d232f4b4408",
+            "@eslint-community+eslint-utils@4.10.1_eslint@10.10.0_jiti@2.7.0": ":entry_eslint_community_eslint_utils_4_10_1_eslint_10_10_0_jiti_2_7_0_002b1c3db5db",
             "@eslint-community+regexpp@4.12.2": ":entry_eslint_community_regexpp_4_12_2_1d1887a9bf30",
             "@humanfs+core@0.19.2": ":entry_humanfs_core_0_19_2_70b26b91b2ae",
             "@humanfs+node@0.16.8": ":entry_humanfs_node_0_16_8_f153f8244a2e",
@@ -30435,6 +30648,8 @@ pnpm_store_view(
             "@humanwhocodes+module-importer@1.0.1": ":entry_humanwhocodes_module_importer_1_0_1_2281c2232c28",
             "@humanwhocodes+retry@0.4.3": ":entry_humanwhocodes_retry_0_4_3_726321f5c138",
             "@jridgewell+sourcemap-codec@1.6.0": ":entry_jridgewell_sourcemap_codec_1_6_0_c92d70f5295d",
+            "@keyv+bigmap@1.3.1_keyv@5.6.0": ":entry_keyv_bigmap_1_3_1_keyv_5_6_0_cdc95803ccc6",
+            "@keyv+serialize@1.1.1": ":entry_keyv_serialize_1_1_1_aa477d4d1034",
             "@opentelemetry+api@1.9.1": ":entry_opentelemetry_api_1_9_1_65aff18a9fc4",
             "@oxc-project+types@0.148.0": ":entry_oxc_project_types_0_148_0_25bb4dfc3213",
             "@polka+url@1.0.0-next.29": ":entry_polka_url_1_0_0_next_29_d5677997de50",
@@ -30444,22 +30659,21 @@ pnpm_store_view(
             "@stylexjs+shared@0.19.0": ":entry_stylexjs_shared_0_19_0_cc10928d6623",
             "@types+chai@5.2.3": ":entry_types_chai_5_2_3_fee6bcdc2771",
             "@types+deep-eql@4.0.2": ":entry_types_deep_eql_4_0_2_1a2f07d7379e",
-            "@types+eslint@9.6.1": ":entry_types_eslint_9_6_1_5064d03d8c70",
             "@types+esrecurse@4.3.1": ":entry_types_esrecurse_4_3_1_fe5a4a38ec87",
             "@types+estree@1.0.9": ":entry_types_estree_1_0_9_ec29746adee7",
             "@types+json-schema@7.0.15": ":entry_types_json_schema_7_0_15_7a6781250b86",
             "@types+node@26.5.0": ":entry_types_node_26_5_0_a0142d056efc",
             "@types+whatwg-mimetype@3.0.2": ":entry_types_whatwg_mimetype_3_0_2_462b750ec991",
             "@types+ws@8.18.1": ":entry_types_ws_8_18_1_ee1128304b54",
-            "@typescript-eslint+parser@8.61.1_eslint@10.5.0_jiti@2.7.0_typescript@5.9.3": ":entry_typescript_eslint_parser_8_61_1_eslint_10_5_0_jiti_2_7_0_typescript_5_9__db10cd9d22ed",
-            "@typescript-eslint+project-service@8.61.1_typescript@5.9.3": ":entry_typescript_eslint_project_service_8_61_1_typescript_5_9_3_2e7be0af28e9",
-            "@typescript-eslint+rule-tester@8.61.1_eslint@10.5.0_jiti@2.7.0_typescript@5.9.3": ":entry_typescript_eslint_rule_tester_8_61_1_eslint_10_5_0_jiti_2_7_0_typescript_fd314d3a9ba4",
-            "@typescript-eslint+scope-manager@8.61.1": ":entry_typescript_eslint_scope_manager_8_61_1_377564d41d32",
-            "@typescript-eslint+tsconfig-utils@8.61.1_typescript@5.9.3": ":entry_typescript_eslint_tsconfig_utils_8_61_1_typescript_5_9_3_3082d785c130",
-            "@typescript-eslint+types@8.61.1": ":entry_typescript_eslint_types_8_61_1_a114619f393d",
-            "@typescript-eslint+typescript-estree@8.61.1_typescript@5.9.3": ":entry_typescript_eslint_typescript_estree_8_61_1_typescript_5_9_3_8637d48df218",
-            "@typescript-eslint+utils@8.61.1_eslint@10.5.0_jiti@2.7.0_typescript@5.9.3": ":entry_typescript_eslint_utils_8_61_1_eslint_10_5_0_jiti_2_7_0_typescript_5_9_3_db1f20e6f2e0",
-            "@typescript-eslint+visitor-keys@8.61.1": ":entry_typescript_eslint_visitor_keys_8_61_1_8533254a16ad",
+            "@typescript-eslint+parser@8.69.0_eslint@10.10.0_jiti@2.7.0_typescript@5.9.3": ":entry_typescript_eslint_parser_8_69_0_eslint_10_10_0_jiti_2_7_0_typescript_5_9_d9e60fd503d2",
+            "@typescript-eslint+project-service@8.69.0_typescript@5.9.3": ":entry_typescript_eslint_project_service_8_69_0_typescript_5_9_3_f94092ffe911",
+            "@typescript-eslint+rule-tester@8.69.0_eslint@10.10.0_jiti@2.7.0_typescript@5.9.3": ":entry_typescript_eslint_rule_tester_8_69_0_eslint_10_10_0_jiti_2_7_0_typescrip_98e25cc77e12",
+            "@typescript-eslint+scope-manager@8.69.0": ":entry_typescript_eslint_scope_manager_8_69_0_2028cc75233f",
+            "@typescript-eslint+tsconfig-utils@8.69.0_typescript@5.9.3": ":entry_typescript_eslint_tsconfig_utils_8_69_0_typescript_5_9_3_4c4d2fa014b7",
+            "@typescript-eslint+types@8.69.0": ":entry_typescript_eslint_types_8_69_0_33daa92e85d2",
+            "@typescript-eslint+typescript-estree@8.69.0_typescript@5.9.3": ":entry_typescript_eslint_typescript_estree_8_69_0_typescript_5_9_3_3ca384a764ff",
+            "@typescript-eslint+utils@8.69.0_eslint@10.10.0_jiti@2.7.0_typescript@5.9.3": ":entry_typescript_eslint_utils_8_69_0_eslint_10_10_0_jiti_2_7_0_typescript_5_9__82b3965462e6",
+            "@typescript-eslint+visitor-keys@8.69.0": ":entry_typescript_eslint_visitor_keys_8_69_0_9c87b69f53c8",
             "@vitest+browser-playwright@4.1.9_playwright@1.63.0_vite@8.2.2_@types+node@26.5.0_esbuild@0.28.2_jiti@2.7.0_vitest@4.1.9": ":entry_vitest_browser_playwright_4_1_9_playwright_1_63_0_vite_8_2_2_types_node__93bedb6b746a",
             "@vitest+browser@4.1.9_vite@8.2.2_@types+node@26.5.0_esbuild@0.28.2_jiti@2.7.0_vitest@4.1.9": ":entry_vitest_browser_4_1_9_vite_8_2_2_types_node_26_5_0_esbuild_0_28_2_jiti_2__b24a5721e00f",
             "@vitest+expect@4.1.9": ":entry_vitest_expect_4_1_9_ac26383f14b6",
@@ -30477,6 +30691,7 @@ pnpm_store_view(
             "brace-expansion@5.0.9": ":entry_brace_expansion_5_0_9_8d760e4ad257",
             "braces@3.0.3": ":entry_braces_3_0_3_ffc711d3f86d",
             "buffer-image-size@0.6.4": ":entry_buffer_image_size_0_6_4_22c01178368e",
+            "cacheable@2.5.0": ":entry_cacheable_2_5_0_0a9dd0dffb1a",
             "chai@6.2.2": ":entry_chai_6_2_2_558bd039a17f",
             "convert-source-map@2.0.0": ":entry_convert_source_map_2_0_0_46e32cfc1207",
             "cross-spawn@7.0.6": ":entry_cross_spawn_7_0_6_50cb51119b3e",
@@ -30490,7 +30705,7 @@ pnpm_store_view(
             "eslint-scope@9.1.2": ":entry_eslint_scope_9_1_2_1242bb0a2257",
             "eslint-visitor-keys@3.4.3": ":entry_eslint_visitor_keys_3_4_3_d73964c6d2eb",
             "eslint-visitor-keys@5.0.1": ":entry_eslint_visitor_keys_5_0_1_77649af58b26",
-            "eslint@10.5.0_jiti@2.7.0": ":entry_eslint_10_5_0_jiti_2_7_0_cb3b30c8d310",
+            "eslint@10.10.0_jiti@2.7.0": ":entry_eslint_10_10_0_jiti_2_7_0_beba109a7b3d",
             "espree@11.2.0": ":entry_espree_11_2_0_23d4e7a3725d",
             "esquery@1.7.0": ":entry_esquery_1_7_0_0e77450dbf69",
             "esrecurse@4.3.0": ":entry_esrecurse_4_3_0_19afb85871ec",
@@ -30502,13 +30717,16 @@ pnpm_store_view(
             "fast-json-stable-stringify@2.1.0": ":entry_fast_json_stable_stringify_2_1_0_a49874e94660",
             "fast-levenshtein@2.0.6": ":entry_fast_levenshtein_2_0_6_45c405680bb2",
             "fdir@6.5.0_picomatch@4.0.7": ":entry_fdir_6_5_0_picomatch_4_0_7_0e611784cb76",
-            "file-entry-cache@8.0.0": ":entry_file_entry_cache_8_0_0_cfd34b733a3c",
+            "file-entry-cache@11.1.5": ":entry_file_entry_cache_11_1_5_ac300dcb09f1",
             "fill-range@7.1.1": ":entry_fill_range_7_1_1_15fb888391f0",
             "find-up@5.0.0": ":entry_find_up_5_0_0_36b5efd728dd",
-            "flat-cache@4.0.1": ":entry_flat_cache_4_0_1_2a36811f99d5",
+            "flat-cache@6.1.23": ":entry_flat_cache_6_1_23_4b2ba8bae97d",
             "flatted@3.4.4": ":entry_flatted_3_4_4_57b7d7dc886d",
             "glob-parent@6.0.2": ":entry_glob_parent_6_0_2_7b90c3653564",
             "happy-dom@20.14.0": ":entry_happy_dom_20_14_0_02b00a98d4e4",
+            "hashery@1.5.1": ":entry_hashery_1_5_1_e1122633ff95",
+            "hookified@1.15.1": ":entry_hookified_1_15_1_e5243a6e8f47",
+            "hookified@2.2.0": ":entry_hookified_2_2_0_28f9e2a047fb",
             "ignore@5.3.2": ":entry_ignore_5_3_2_8280c55d2633",
             "imurmurhash@0.1.4": ":entry_imurmurhash_0_1_4_d1af6342e06c",
             "is-extglob@2.1.1": ":entry_is_extglob_2_1_1_9975757ae9e0",
@@ -30516,10 +30734,9 @@ pnpm_store_view(
             "is-number@7.0.0": ":entry_is_number_7_0_0_08fd04d109dd",
             "isexe@2.0.0": ":entry_isexe_2_0_0_2f62e711a692",
             "jiti@2.7.0": ":entry_jiti_2_7_0_443514e89728",
-            "json-buffer@3.0.1": ":entry_json_buffer_3_0_1_adbc921fc34d",
             "json-schema-traverse@0.4.1": ":entry_json_schema_traverse_0_4_1_224390b16484",
             "json-stable-stringify-without-jsonify@1.0.1": ":entry_json_stable_stringify_without_jsonify_1_0_1_0e74de0204bb",
-            "keyv@4.5.4": ":entry_keyv_4_5_4_b44ddb67514f",
+            "keyv@5.6.0": ":entry_keyv_5_6_0_b95898f12ca2",
             "levn@0.4.1": ":entry_levn_0_4_1_c90baa3b36b6",
             "lightningcss@1.33.0": ":entry_lightningcss_1_33_0_7129b0f44113",
             "locate-path@6.0.0": ":entry_locate_path_6_0_0_ad481860c229",
@@ -30549,6 +30766,7 @@ pnpm_store_view(
             "postcss@8.5.26": ":entry_postcss_8_5_26_dd6223d49d4c",
             "prelude-ls@1.2.1": ":entry_prelude_ls_1_2_1_78fc019ae342",
             "punycode@2.3.1": ":entry_punycode_2_3_1_3fe331f5536b",
+            "qified@0.10.1": ":entry_qified_0_10_1_b3b25bd21152",
             "rolldown@1.2.7": ":entry_rolldown_1_2_7_f28636c54a2e",
             "semver@7.8.5": ":entry_semver_7_8_5_82a86616e50d",
             "shebang-command@2.0.0": ":entry_shebang_command_2_0_0_a9cba97b71b8",
@@ -30580,14 +30798,16 @@ pnpm_store_view(
         },
         "linux_aarch64": {
             "@blazediff+core@1.9.1": ":entry_blazediff_core_1_9_1_2c297fb3187d",
+            "@cacheable+memory@2.2.0": ":entry_cacheable_memory_2_2_0_ebfb4ac2b5f5",
+            "@cacheable+utils@2.5.0": ":entry_cacheable_utils_2_5_0_22620a8f2225",
             "@csstools+css-tokenizer@3.0.4": ":entry_csstools_css_tokenizer_3_0_4_1364f68e1d48",
             "@esbuild+linux-arm64@0.28.2": ":entry_esbuild_linux_arm64_0_28_2_a67bfa3d5003",
             "@eslint+config-array@0.23.5": ":entry_eslint_config_array_0_23_5_c4003c9d3aa0",
-            "@eslint+config-helpers@0.6.0": ":entry_eslint_config_helpers_0_6_0_f9d65331f01d",
+            "@eslint+config-helpers@0.7.0": ":entry_eslint_config_helpers_0_7_0_5e96e6a5142e",
             "@eslint+core@1.2.1": ":entry_eslint_core_1_2_1_8011bd8ea054",
             "@eslint+object-schema@3.0.5": ":entry_eslint_object_schema_3_0_5_a42e0543fbb6",
-            "@eslint+plugin-kit@0.7.2": ":entry_eslint_plugin_kit_0_7_2_61f595114b42",
-            "@eslint-community+eslint-utils@4.10.1_eslint@10.5.0_jiti@2.7.0": ":entry_eslint_community_eslint_utils_4_10_1_eslint_10_5_0_jiti_2_7_0_f722ea313427",
+            "@eslint+plugin-kit@0.7.3": ":entry_eslint_plugin_kit_0_7_3_2d232f4b4408",
+            "@eslint-community+eslint-utils@4.10.1_eslint@10.10.0_jiti@2.7.0": ":entry_eslint_community_eslint_utils_4_10_1_eslint_10_10_0_jiti_2_7_0_002b1c3db5db",
             "@eslint-community+regexpp@4.12.2": ":entry_eslint_community_regexpp_4_12_2_1d1887a9bf30",
             "@humanfs+core@0.19.2": ":entry_humanfs_core_0_19_2_70b26b91b2ae",
             "@humanfs+node@0.16.8": ":entry_humanfs_node_0_16_8_f153f8244a2e",
@@ -30595,6 +30815,8 @@ pnpm_store_view(
             "@humanwhocodes+module-importer@1.0.1": ":entry_humanwhocodes_module_importer_1_0_1_2281c2232c28",
             "@humanwhocodes+retry@0.4.3": ":entry_humanwhocodes_retry_0_4_3_726321f5c138",
             "@jridgewell+sourcemap-codec@1.6.0": ":entry_jridgewell_sourcemap_codec_1_6_0_c92d70f5295d",
+            "@keyv+bigmap@1.3.1_keyv@5.6.0": ":entry_keyv_bigmap_1_3_1_keyv_5_6_0_cdc95803ccc6",
+            "@keyv+serialize@1.1.1": ":entry_keyv_serialize_1_1_1_aa477d4d1034",
             "@opentelemetry+api@1.9.1": ":entry_opentelemetry_api_1_9_1_65aff18a9fc4",
             "@oxc-project+types@0.148.0": ":entry_oxc_project_types_0_148_0_25bb4dfc3213",
             "@oxlint-tsgolint+linux-arm64@7.0.2001": ":entry_oxlint_tsgolint_linux_arm64_7_0_2001_edffccc99dea",
@@ -30606,22 +30828,21 @@ pnpm_store_view(
             "@stylexjs+shared@0.19.0": ":entry_stylexjs_shared_0_19_0_cc10928d6623",
             "@types+chai@5.2.3": ":entry_types_chai_5_2_3_fee6bcdc2771",
             "@types+deep-eql@4.0.2": ":entry_types_deep_eql_4_0_2_1a2f07d7379e",
-            "@types+eslint@9.6.1": ":entry_types_eslint_9_6_1_5064d03d8c70",
             "@types+esrecurse@4.3.1": ":entry_types_esrecurse_4_3_1_fe5a4a38ec87",
             "@types+estree@1.0.9": ":entry_types_estree_1_0_9_ec29746adee7",
             "@types+json-schema@7.0.15": ":entry_types_json_schema_7_0_15_7a6781250b86",
             "@types+node@26.5.0": ":entry_types_node_26_5_0_a0142d056efc",
             "@types+whatwg-mimetype@3.0.2": ":entry_types_whatwg_mimetype_3_0_2_462b750ec991",
             "@types+ws@8.18.1": ":entry_types_ws_8_18_1_ee1128304b54",
-            "@typescript-eslint+parser@8.61.1_eslint@10.5.0_jiti@2.7.0_typescript@5.9.3": ":entry_typescript_eslint_parser_8_61_1_eslint_10_5_0_jiti_2_7_0_typescript_5_9__db10cd9d22ed",
-            "@typescript-eslint+project-service@8.61.1_typescript@5.9.3": ":entry_typescript_eslint_project_service_8_61_1_typescript_5_9_3_2e7be0af28e9",
-            "@typescript-eslint+rule-tester@8.61.1_eslint@10.5.0_jiti@2.7.0_typescript@5.9.3": ":entry_typescript_eslint_rule_tester_8_61_1_eslint_10_5_0_jiti_2_7_0_typescript_fd314d3a9ba4",
-            "@typescript-eslint+scope-manager@8.61.1": ":entry_typescript_eslint_scope_manager_8_61_1_377564d41d32",
-            "@typescript-eslint+tsconfig-utils@8.61.1_typescript@5.9.3": ":entry_typescript_eslint_tsconfig_utils_8_61_1_typescript_5_9_3_3082d785c130",
-            "@typescript-eslint+types@8.61.1": ":entry_typescript_eslint_types_8_61_1_a114619f393d",
-            "@typescript-eslint+typescript-estree@8.61.1_typescript@5.9.3": ":entry_typescript_eslint_typescript_estree_8_61_1_typescript_5_9_3_8637d48df218",
-            "@typescript-eslint+utils@8.61.1_eslint@10.5.0_jiti@2.7.0_typescript@5.9.3": ":entry_typescript_eslint_utils_8_61_1_eslint_10_5_0_jiti_2_7_0_typescript_5_9_3_db1f20e6f2e0",
-            "@typescript-eslint+visitor-keys@8.61.1": ":entry_typescript_eslint_visitor_keys_8_61_1_8533254a16ad",
+            "@typescript-eslint+parser@8.69.0_eslint@10.10.0_jiti@2.7.0_typescript@5.9.3": ":entry_typescript_eslint_parser_8_69_0_eslint_10_10_0_jiti_2_7_0_typescript_5_9_d9e60fd503d2",
+            "@typescript-eslint+project-service@8.69.0_typescript@5.9.3": ":entry_typescript_eslint_project_service_8_69_0_typescript_5_9_3_f94092ffe911",
+            "@typescript-eslint+rule-tester@8.69.0_eslint@10.10.0_jiti@2.7.0_typescript@5.9.3": ":entry_typescript_eslint_rule_tester_8_69_0_eslint_10_10_0_jiti_2_7_0_typescrip_98e25cc77e12",
+            "@typescript-eslint+scope-manager@8.69.0": ":entry_typescript_eslint_scope_manager_8_69_0_2028cc75233f",
+            "@typescript-eslint+tsconfig-utils@8.69.0_typescript@5.9.3": ":entry_typescript_eslint_tsconfig_utils_8_69_0_typescript_5_9_3_4c4d2fa014b7",
+            "@typescript-eslint+types@8.69.0": ":entry_typescript_eslint_types_8_69_0_33daa92e85d2",
+            "@typescript-eslint+typescript-estree@8.69.0_typescript@5.9.3": ":entry_typescript_eslint_typescript_estree_8_69_0_typescript_5_9_3_3ca384a764ff",
+            "@typescript-eslint+utils@8.69.0_eslint@10.10.0_jiti@2.7.0_typescript@5.9.3": ":entry_typescript_eslint_utils_8_69_0_eslint_10_10_0_jiti_2_7_0_typescript_5_9__82b3965462e6",
+            "@typescript-eslint+visitor-keys@8.69.0": ":entry_typescript_eslint_visitor_keys_8_69_0_9c87b69f53c8",
             "@vitest+browser-playwright@4.1.9_playwright@1.63.0_vite@8.2.2_@types+node@26.5.0_esbuild@0.28.2_jiti@2.7.0_vitest@4.1.9": ":entry_vitest_browser_playwright_4_1_9_playwright_1_63_0_vite_8_2_2_types_node__93bedb6b746a",
             "@vitest+browser@4.1.9_vite@8.2.2_@types+node@26.5.0_esbuild@0.28.2_jiti@2.7.0_vitest@4.1.9": ":entry_vitest_browser_4_1_9_vite_8_2_2_types_node_26_5_0_esbuild_0_28_2_jiti_2__b24a5721e00f",
             "@vitest+expect@4.1.9": ":entry_vitest_expect_4_1_9_ac26383f14b6",
@@ -30639,6 +30860,7 @@ pnpm_store_view(
             "brace-expansion@5.0.9": ":entry_brace_expansion_5_0_9_8d760e4ad257",
             "braces@3.0.3": ":entry_braces_3_0_3_ffc711d3f86d",
             "buffer-image-size@0.6.4": ":entry_buffer_image_size_0_6_4_22c01178368e",
+            "cacheable@2.5.0": ":entry_cacheable_2_5_0_0a9dd0dffb1a",
             "chai@6.2.2": ":entry_chai_6_2_2_558bd039a17f",
             "convert-source-map@2.0.0": ":entry_convert_source_map_2_0_0_46e32cfc1207",
             "cross-spawn@7.0.6": ":entry_cross_spawn_7_0_6_50cb51119b3e",
@@ -30652,7 +30874,7 @@ pnpm_store_view(
             "eslint-scope@9.1.2": ":entry_eslint_scope_9_1_2_1242bb0a2257",
             "eslint-visitor-keys@3.4.3": ":entry_eslint_visitor_keys_3_4_3_d73964c6d2eb",
             "eslint-visitor-keys@5.0.1": ":entry_eslint_visitor_keys_5_0_1_77649af58b26",
-            "eslint@10.5.0_jiti@2.7.0": ":entry_eslint_10_5_0_jiti_2_7_0_cb3b30c8d310",
+            "eslint@10.10.0_jiti@2.7.0": ":entry_eslint_10_10_0_jiti_2_7_0_beba109a7b3d",
             "espree@11.2.0": ":entry_espree_11_2_0_23d4e7a3725d",
             "esquery@1.7.0": ":entry_esquery_1_7_0_0e77450dbf69",
             "esrecurse@4.3.0": ":entry_esrecurse_4_3_0_19afb85871ec",
@@ -30664,13 +30886,16 @@ pnpm_store_view(
             "fast-json-stable-stringify@2.1.0": ":entry_fast_json_stable_stringify_2_1_0_a49874e94660",
             "fast-levenshtein@2.0.6": ":entry_fast_levenshtein_2_0_6_45c405680bb2",
             "fdir@6.5.0_picomatch@4.0.7": ":entry_fdir_6_5_0_picomatch_4_0_7_0e611784cb76",
-            "file-entry-cache@8.0.0": ":entry_file_entry_cache_8_0_0_cfd34b733a3c",
+            "file-entry-cache@11.1.5": ":entry_file_entry_cache_11_1_5_ac300dcb09f1",
             "fill-range@7.1.1": ":entry_fill_range_7_1_1_15fb888391f0",
             "find-up@5.0.0": ":entry_find_up_5_0_0_36b5efd728dd",
-            "flat-cache@4.0.1": ":entry_flat_cache_4_0_1_2a36811f99d5",
+            "flat-cache@6.1.23": ":entry_flat_cache_6_1_23_4b2ba8bae97d",
             "flatted@3.4.4": ":entry_flatted_3_4_4_57b7d7dc886d",
             "glob-parent@6.0.2": ":entry_glob_parent_6_0_2_7b90c3653564",
             "happy-dom@20.14.0": ":entry_happy_dom_20_14_0_02b00a98d4e4",
+            "hashery@1.5.1": ":entry_hashery_1_5_1_e1122633ff95",
+            "hookified@1.15.1": ":entry_hookified_1_15_1_e5243a6e8f47",
+            "hookified@2.2.0": ":entry_hookified_2_2_0_28f9e2a047fb",
             "ignore@5.3.2": ":entry_ignore_5_3_2_8280c55d2633",
             "imurmurhash@0.1.4": ":entry_imurmurhash_0_1_4_d1af6342e06c",
             "is-extglob@2.1.1": ":entry_is_extglob_2_1_1_9975757ae9e0",
@@ -30678,10 +30903,9 @@ pnpm_store_view(
             "is-number@7.0.0": ":entry_is_number_7_0_0_08fd04d109dd",
             "isexe@2.0.0": ":entry_isexe_2_0_0_2f62e711a692",
             "jiti@2.7.0": ":entry_jiti_2_7_0_443514e89728",
-            "json-buffer@3.0.1": ":entry_json_buffer_3_0_1_adbc921fc34d",
             "json-schema-traverse@0.4.1": ":entry_json_schema_traverse_0_4_1_224390b16484",
             "json-stable-stringify-without-jsonify@1.0.1": ":entry_json_stable_stringify_without_jsonify_1_0_1_0e74de0204bb",
-            "keyv@4.5.4": ":entry_keyv_4_5_4_b44ddb67514f",
+            "keyv@5.6.0": ":entry_keyv_5_6_0_b95898f12ca2",
             "levn@0.4.1": ":entry_levn_0_4_1_c90baa3b36b6",
             "lightningcss-linux-arm64-gnu@1.33.0": ":entry_lightningcss_linux_arm64_gnu_1_33_0_3c8fab71fd68",
             "lightningcss@1.33.0": ":entry_lightningcss_1_33_0_7129b0f44113",
@@ -30712,6 +30936,7 @@ pnpm_store_view(
             "postcss@8.5.26": ":entry_postcss_8_5_26_dd6223d49d4c",
             "prelude-ls@1.2.1": ":entry_prelude_ls_1_2_1_78fc019ae342",
             "punycode@2.3.1": ":entry_punycode_2_3_1_3fe331f5536b",
+            "qified@0.10.1": ":entry_qified_0_10_1_b3b25bd21152",
             "rolldown@1.2.7": ":entry_rolldown_1_2_7_f28636c54a2e",
             "semver@7.8.5": ":entry_semver_7_8_5_82a86616e50d",
             "shebang-command@2.0.0": ":entry_shebang_command_2_0_0_a9cba97b71b8",
@@ -30743,14 +30968,16 @@ pnpm_store_view(
         },
         "linux_x86_64": {
             "@blazediff+core@1.9.1": ":entry_blazediff_core_1_9_1_2c297fb3187d",
+            "@cacheable+memory@2.2.0": ":entry_cacheable_memory_2_2_0_ebfb4ac2b5f5",
+            "@cacheable+utils@2.5.0": ":entry_cacheable_utils_2_5_0_22620a8f2225",
             "@csstools+css-tokenizer@3.0.4": ":entry_csstools_css_tokenizer_3_0_4_1364f68e1d48",
             "@esbuild+linux-x64@0.28.2": ":entry_esbuild_linux_x64_0_28_2_a925772984e9",
             "@eslint+config-array@0.23.5": ":entry_eslint_config_array_0_23_5_c4003c9d3aa0",
-            "@eslint+config-helpers@0.6.0": ":entry_eslint_config_helpers_0_6_0_f9d65331f01d",
+            "@eslint+config-helpers@0.7.0": ":entry_eslint_config_helpers_0_7_0_5e96e6a5142e",
             "@eslint+core@1.2.1": ":entry_eslint_core_1_2_1_8011bd8ea054",
             "@eslint+object-schema@3.0.5": ":entry_eslint_object_schema_3_0_5_a42e0543fbb6",
-            "@eslint+plugin-kit@0.7.2": ":entry_eslint_plugin_kit_0_7_2_61f595114b42",
-            "@eslint-community+eslint-utils@4.10.1_eslint@10.5.0_jiti@2.7.0": ":entry_eslint_community_eslint_utils_4_10_1_eslint_10_5_0_jiti_2_7_0_f722ea313427",
+            "@eslint+plugin-kit@0.7.3": ":entry_eslint_plugin_kit_0_7_3_2d232f4b4408",
+            "@eslint-community+eslint-utils@4.10.1_eslint@10.10.0_jiti@2.7.0": ":entry_eslint_community_eslint_utils_4_10_1_eslint_10_10_0_jiti_2_7_0_002b1c3db5db",
             "@eslint-community+regexpp@4.12.2": ":entry_eslint_community_regexpp_4_12_2_1d1887a9bf30",
             "@humanfs+core@0.19.2": ":entry_humanfs_core_0_19_2_70b26b91b2ae",
             "@humanfs+node@0.16.8": ":entry_humanfs_node_0_16_8_f153f8244a2e",
@@ -30758,6 +30985,8 @@ pnpm_store_view(
             "@humanwhocodes+module-importer@1.0.1": ":entry_humanwhocodes_module_importer_1_0_1_2281c2232c28",
             "@humanwhocodes+retry@0.4.3": ":entry_humanwhocodes_retry_0_4_3_726321f5c138",
             "@jridgewell+sourcemap-codec@1.6.0": ":entry_jridgewell_sourcemap_codec_1_6_0_c92d70f5295d",
+            "@keyv+bigmap@1.3.1_keyv@5.6.0": ":entry_keyv_bigmap_1_3_1_keyv_5_6_0_cdc95803ccc6",
+            "@keyv+serialize@1.1.1": ":entry_keyv_serialize_1_1_1_aa477d4d1034",
             "@opentelemetry+api@1.9.1": ":entry_opentelemetry_api_1_9_1_65aff18a9fc4",
             "@oxc-project+types@0.148.0": ":entry_oxc_project_types_0_148_0_25bb4dfc3213",
             "@oxlint-tsgolint+linux-x64@7.0.2001": ":entry_oxlint_tsgolint_linux_x64_7_0_2001_bc3b288436e4",
@@ -30769,22 +30998,21 @@ pnpm_store_view(
             "@stylexjs+shared@0.19.0": ":entry_stylexjs_shared_0_19_0_cc10928d6623",
             "@types+chai@5.2.3": ":entry_types_chai_5_2_3_fee6bcdc2771",
             "@types+deep-eql@4.0.2": ":entry_types_deep_eql_4_0_2_1a2f07d7379e",
-            "@types+eslint@9.6.1": ":entry_types_eslint_9_6_1_5064d03d8c70",
             "@types+esrecurse@4.3.1": ":entry_types_esrecurse_4_3_1_fe5a4a38ec87",
             "@types+estree@1.0.9": ":entry_types_estree_1_0_9_ec29746adee7",
             "@types+json-schema@7.0.15": ":entry_types_json_schema_7_0_15_7a6781250b86",
             "@types+node@26.5.0": ":entry_types_node_26_5_0_a0142d056efc",
             "@types+whatwg-mimetype@3.0.2": ":entry_types_whatwg_mimetype_3_0_2_462b750ec991",
             "@types+ws@8.18.1": ":entry_types_ws_8_18_1_ee1128304b54",
-            "@typescript-eslint+parser@8.61.1_eslint@10.5.0_jiti@2.7.0_typescript@5.9.3": ":entry_typescript_eslint_parser_8_61_1_eslint_10_5_0_jiti_2_7_0_typescript_5_9__db10cd9d22ed",
-            "@typescript-eslint+project-service@8.61.1_typescript@5.9.3": ":entry_typescript_eslint_project_service_8_61_1_typescript_5_9_3_2e7be0af28e9",
-            "@typescript-eslint+rule-tester@8.61.1_eslint@10.5.0_jiti@2.7.0_typescript@5.9.3": ":entry_typescript_eslint_rule_tester_8_61_1_eslint_10_5_0_jiti_2_7_0_typescript_fd314d3a9ba4",
-            "@typescript-eslint+scope-manager@8.61.1": ":entry_typescript_eslint_scope_manager_8_61_1_377564d41d32",
-            "@typescript-eslint+tsconfig-utils@8.61.1_typescript@5.9.3": ":entry_typescript_eslint_tsconfig_utils_8_61_1_typescript_5_9_3_3082d785c130",
-            "@typescript-eslint+types@8.61.1": ":entry_typescript_eslint_types_8_61_1_a114619f393d",
-            "@typescript-eslint+typescript-estree@8.61.1_typescript@5.9.3": ":entry_typescript_eslint_typescript_estree_8_61_1_typescript_5_9_3_8637d48df218",
-            "@typescript-eslint+utils@8.61.1_eslint@10.5.0_jiti@2.7.0_typescript@5.9.3": ":entry_typescript_eslint_utils_8_61_1_eslint_10_5_0_jiti_2_7_0_typescript_5_9_3_db1f20e6f2e0",
-            "@typescript-eslint+visitor-keys@8.61.1": ":entry_typescript_eslint_visitor_keys_8_61_1_8533254a16ad",
+            "@typescript-eslint+parser@8.69.0_eslint@10.10.0_jiti@2.7.0_typescript@5.9.3": ":entry_typescript_eslint_parser_8_69_0_eslint_10_10_0_jiti_2_7_0_typescript_5_9_d9e60fd503d2",
+            "@typescript-eslint+project-service@8.69.0_typescript@5.9.3": ":entry_typescript_eslint_project_service_8_69_0_typescript_5_9_3_f94092ffe911",
+            "@typescript-eslint+rule-tester@8.69.0_eslint@10.10.0_jiti@2.7.0_typescript@5.9.3": ":entry_typescript_eslint_rule_tester_8_69_0_eslint_10_10_0_jiti_2_7_0_typescrip_98e25cc77e12",
+            "@typescript-eslint+scope-manager@8.69.0": ":entry_typescript_eslint_scope_manager_8_69_0_2028cc75233f",
+            "@typescript-eslint+tsconfig-utils@8.69.0_typescript@5.9.3": ":entry_typescript_eslint_tsconfig_utils_8_69_0_typescript_5_9_3_4c4d2fa014b7",
+            "@typescript-eslint+types@8.69.0": ":entry_typescript_eslint_types_8_69_0_33daa92e85d2",
+            "@typescript-eslint+typescript-estree@8.69.0_typescript@5.9.3": ":entry_typescript_eslint_typescript_estree_8_69_0_typescript_5_9_3_3ca384a764ff",
+            "@typescript-eslint+utils@8.69.0_eslint@10.10.0_jiti@2.7.0_typescript@5.9.3": ":entry_typescript_eslint_utils_8_69_0_eslint_10_10_0_jiti_2_7_0_typescript_5_9__82b3965462e6",
+            "@typescript-eslint+visitor-keys@8.69.0": ":entry_typescript_eslint_visitor_keys_8_69_0_9c87b69f53c8",
             "@vitest+browser-playwright@4.1.9_playwright@1.63.0_vite@8.2.2_@types+node@26.5.0_esbuild@0.28.2_jiti@2.7.0_vitest@4.1.9": ":entry_vitest_browser_playwright_4_1_9_playwright_1_63_0_vite_8_2_2_types_node__93bedb6b746a",
             "@vitest+browser@4.1.9_vite@8.2.2_@types+node@26.5.0_esbuild@0.28.2_jiti@2.7.0_vitest@4.1.9": ":entry_vitest_browser_4_1_9_vite_8_2_2_types_node_26_5_0_esbuild_0_28_2_jiti_2__b24a5721e00f",
             "@vitest+expect@4.1.9": ":entry_vitest_expect_4_1_9_ac26383f14b6",
@@ -30802,6 +31030,7 @@ pnpm_store_view(
             "brace-expansion@5.0.9": ":entry_brace_expansion_5_0_9_8d760e4ad257",
             "braces@3.0.3": ":entry_braces_3_0_3_ffc711d3f86d",
             "buffer-image-size@0.6.4": ":entry_buffer_image_size_0_6_4_22c01178368e",
+            "cacheable@2.5.0": ":entry_cacheable_2_5_0_0a9dd0dffb1a",
             "chai@6.2.2": ":entry_chai_6_2_2_558bd039a17f",
             "convert-source-map@2.0.0": ":entry_convert_source_map_2_0_0_46e32cfc1207",
             "cross-spawn@7.0.6": ":entry_cross_spawn_7_0_6_50cb51119b3e",
@@ -30815,7 +31044,7 @@ pnpm_store_view(
             "eslint-scope@9.1.2": ":entry_eslint_scope_9_1_2_1242bb0a2257",
             "eslint-visitor-keys@3.4.3": ":entry_eslint_visitor_keys_3_4_3_d73964c6d2eb",
             "eslint-visitor-keys@5.0.1": ":entry_eslint_visitor_keys_5_0_1_77649af58b26",
-            "eslint@10.5.0_jiti@2.7.0": ":entry_eslint_10_5_0_jiti_2_7_0_cb3b30c8d310",
+            "eslint@10.10.0_jiti@2.7.0": ":entry_eslint_10_10_0_jiti_2_7_0_beba109a7b3d",
             "espree@11.2.0": ":entry_espree_11_2_0_23d4e7a3725d",
             "esquery@1.7.0": ":entry_esquery_1_7_0_0e77450dbf69",
             "esrecurse@4.3.0": ":entry_esrecurse_4_3_0_19afb85871ec",
@@ -30827,13 +31056,16 @@ pnpm_store_view(
             "fast-json-stable-stringify@2.1.0": ":entry_fast_json_stable_stringify_2_1_0_a49874e94660",
             "fast-levenshtein@2.0.6": ":entry_fast_levenshtein_2_0_6_45c405680bb2",
             "fdir@6.5.0_picomatch@4.0.7": ":entry_fdir_6_5_0_picomatch_4_0_7_0e611784cb76",
-            "file-entry-cache@8.0.0": ":entry_file_entry_cache_8_0_0_cfd34b733a3c",
+            "file-entry-cache@11.1.5": ":entry_file_entry_cache_11_1_5_ac300dcb09f1",
             "fill-range@7.1.1": ":entry_fill_range_7_1_1_15fb888391f0",
             "find-up@5.0.0": ":entry_find_up_5_0_0_36b5efd728dd",
-            "flat-cache@4.0.1": ":entry_flat_cache_4_0_1_2a36811f99d5",
+            "flat-cache@6.1.23": ":entry_flat_cache_6_1_23_4b2ba8bae97d",
             "flatted@3.4.4": ":entry_flatted_3_4_4_57b7d7dc886d",
             "glob-parent@6.0.2": ":entry_glob_parent_6_0_2_7b90c3653564",
             "happy-dom@20.14.0": ":entry_happy_dom_20_14_0_02b00a98d4e4",
+            "hashery@1.5.1": ":entry_hashery_1_5_1_e1122633ff95",
+            "hookified@1.15.1": ":entry_hookified_1_15_1_e5243a6e8f47",
+            "hookified@2.2.0": ":entry_hookified_2_2_0_28f9e2a047fb",
             "ignore@5.3.2": ":entry_ignore_5_3_2_8280c55d2633",
             "imurmurhash@0.1.4": ":entry_imurmurhash_0_1_4_d1af6342e06c",
             "is-extglob@2.1.1": ":entry_is_extglob_2_1_1_9975757ae9e0",
@@ -30841,10 +31073,9 @@ pnpm_store_view(
             "is-number@7.0.0": ":entry_is_number_7_0_0_08fd04d109dd",
             "isexe@2.0.0": ":entry_isexe_2_0_0_2f62e711a692",
             "jiti@2.7.0": ":entry_jiti_2_7_0_443514e89728",
-            "json-buffer@3.0.1": ":entry_json_buffer_3_0_1_adbc921fc34d",
             "json-schema-traverse@0.4.1": ":entry_json_schema_traverse_0_4_1_224390b16484",
             "json-stable-stringify-without-jsonify@1.0.1": ":entry_json_stable_stringify_without_jsonify_1_0_1_0e74de0204bb",
-            "keyv@4.5.4": ":entry_keyv_4_5_4_b44ddb67514f",
+            "keyv@5.6.0": ":entry_keyv_5_6_0_b95898f12ca2",
             "levn@0.4.1": ":entry_levn_0_4_1_c90baa3b36b6",
             "lightningcss-linux-x64-gnu@1.33.0": ":entry_lightningcss_linux_x64_gnu_1_33_0_abda693e4089",
             "lightningcss@1.33.0": ":entry_lightningcss_1_33_0_7129b0f44113",
@@ -30875,6 +31106,7 @@ pnpm_store_view(
             "postcss@8.5.26": ":entry_postcss_8_5_26_dd6223d49d4c",
             "prelude-ls@1.2.1": ":entry_prelude_ls_1_2_1_78fc019ae342",
             "punycode@2.3.1": ":entry_punycode_2_3_1_3fe331f5536b",
+            "qified@0.10.1": ":entry_qified_0_10_1_b3b25bd21152",
             "rolldown@1.2.7": ":entry_rolldown_1_2_7_f28636c54a2e",
             "semver@7.8.5": ":entry_semver_7_8_5_82a86616e50d",
             "shebang-command@2.0.0": ":entry_shebang_command_2_0_0_a9cba97b71b8",
@@ -30906,14 +31138,16 @@ pnpm_store_view(
         },
         "macos_aarch64": {
             "@blazediff+core@1.9.1": ":entry_blazediff_core_1_9_1_2c297fb3187d",
+            "@cacheable+memory@2.2.0": ":entry_cacheable_memory_2_2_0_ebfb4ac2b5f5",
+            "@cacheable+utils@2.5.0": ":entry_cacheable_utils_2_5_0_22620a8f2225",
             "@csstools+css-tokenizer@3.0.4": ":entry_csstools_css_tokenizer_3_0_4_1364f68e1d48",
             "@esbuild+darwin-arm64@0.28.2": ":entry_esbuild_darwin_arm64_0_28_2_721282d04d4b",
             "@eslint+config-array@0.23.5": ":entry_eslint_config_array_0_23_5_c4003c9d3aa0",
-            "@eslint+config-helpers@0.6.0": ":entry_eslint_config_helpers_0_6_0_f9d65331f01d",
+            "@eslint+config-helpers@0.7.0": ":entry_eslint_config_helpers_0_7_0_5e96e6a5142e",
             "@eslint+core@1.2.1": ":entry_eslint_core_1_2_1_8011bd8ea054",
             "@eslint+object-schema@3.0.5": ":entry_eslint_object_schema_3_0_5_a42e0543fbb6",
-            "@eslint+plugin-kit@0.7.2": ":entry_eslint_plugin_kit_0_7_2_61f595114b42",
-            "@eslint-community+eslint-utils@4.10.1_eslint@10.5.0_jiti@2.7.0": ":entry_eslint_community_eslint_utils_4_10_1_eslint_10_5_0_jiti_2_7_0_f722ea313427",
+            "@eslint+plugin-kit@0.7.3": ":entry_eslint_plugin_kit_0_7_3_2d232f4b4408",
+            "@eslint-community+eslint-utils@4.10.1_eslint@10.10.0_jiti@2.7.0": ":entry_eslint_community_eslint_utils_4_10_1_eslint_10_10_0_jiti_2_7_0_002b1c3db5db",
             "@eslint-community+regexpp@4.12.2": ":entry_eslint_community_regexpp_4_12_2_1d1887a9bf30",
             "@humanfs+core@0.19.2": ":entry_humanfs_core_0_19_2_70b26b91b2ae",
             "@humanfs+node@0.16.8": ":entry_humanfs_node_0_16_8_f153f8244a2e",
@@ -30921,6 +31155,8 @@ pnpm_store_view(
             "@humanwhocodes+module-importer@1.0.1": ":entry_humanwhocodes_module_importer_1_0_1_2281c2232c28",
             "@humanwhocodes+retry@0.4.3": ":entry_humanwhocodes_retry_0_4_3_726321f5c138",
             "@jridgewell+sourcemap-codec@1.6.0": ":entry_jridgewell_sourcemap_codec_1_6_0_c92d70f5295d",
+            "@keyv+bigmap@1.3.1_keyv@5.6.0": ":entry_keyv_bigmap_1_3_1_keyv_5_6_0_cdc95803ccc6",
+            "@keyv+serialize@1.1.1": ":entry_keyv_serialize_1_1_1_aa477d4d1034",
             "@opentelemetry+api@1.9.1": ":entry_opentelemetry_api_1_9_1_65aff18a9fc4",
             "@oxc-project+types@0.148.0": ":entry_oxc_project_types_0_148_0_25bb4dfc3213",
             "@oxlint-tsgolint+darwin-arm64@7.0.2001": ":entry_oxlint_tsgolint_darwin_arm64_7_0_2001_b88d246c4f3c",
@@ -30932,22 +31168,21 @@ pnpm_store_view(
             "@stylexjs+shared@0.19.0": ":entry_stylexjs_shared_0_19_0_cc10928d6623",
             "@types+chai@5.2.3": ":entry_types_chai_5_2_3_fee6bcdc2771",
             "@types+deep-eql@4.0.2": ":entry_types_deep_eql_4_0_2_1a2f07d7379e",
-            "@types+eslint@9.6.1": ":entry_types_eslint_9_6_1_5064d03d8c70",
             "@types+esrecurse@4.3.1": ":entry_types_esrecurse_4_3_1_fe5a4a38ec87",
             "@types+estree@1.0.9": ":entry_types_estree_1_0_9_ec29746adee7",
             "@types+json-schema@7.0.15": ":entry_types_json_schema_7_0_15_7a6781250b86",
             "@types+node@26.5.0": ":entry_types_node_26_5_0_a0142d056efc",
             "@types+whatwg-mimetype@3.0.2": ":entry_types_whatwg_mimetype_3_0_2_462b750ec991",
             "@types+ws@8.18.1": ":entry_types_ws_8_18_1_ee1128304b54",
-            "@typescript-eslint+parser@8.61.1_eslint@10.5.0_jiti@2.7.0_typescript@5.9.3": ":entry_typescript_eslint_parser_8_61_1_eslint_10_5_0_jiti_2_7_0_typescript_5_9__db10cd9d22ed",
-            "@typescript-eslint+project-service@8.61.1_typescript@5.9.3": ":entry_typescript_eslint_project_service_8_61_1_typescript_5_9_3_2e7be0af28e9",
-            "@typescript-eslint+rule-tester@8.61.1_eslint@10.5.0_jiti@2.7.0_typescript@5.9.3": ":entry_typescript_eslint_rule_tester_8_61_1_eslint_10_5_0_jiti_2_7_0_typescript_fd314d3a9ba4",
-            "@typescript-eslint+scope-manager@8.61.1": ":entry_typescript_eslint_scope_manager_8_61_1_377564d41d32",
-            "@typescript-eslint+tsconfig-utils@8.61.1_typescript@5.9.3": ":entry_typescript_eslint_tsconfig_utils_8_61_1_typescript_5_9_3_3082d785c130",
-            "@typescript-eslint+types@8.61.1": ":entry_typescript_eslint_types_8_61_1_a114619f393d",
-            "@typescript-eslint+typescript-estree@8.61.1_typescript@5.9.3": ":entry_typescript_eslint_typescript_estree_8_61_1_typescript_5_9_3_8637d48df218",
-            "@typescript-eslint+utils@8.61.1_eslint@10.5.0_jiti@2.7.0_typescript@5.9.3": ":entry_typescript_eslint_utils_8_61_1_eslint_10_5_0_jiti_2_7_0_typescript_5_9_3_db1f20e6f2e0",
-            "@typescript-eslint+visitor-keys@8.61.1": ":entry_typescript_eslint_visitor_keys_8_61_1_8533254a16ad",
+            "@typescript-eslint+parser@8.69.0_eslint@10.10.0_jiti@2.7.0_typescript@5.9.3": ":entry_typescript_eslint_parser_8_69_0_eslint_10_10_0_jiti_2_7_0_typescript_5_9_d9e60fd503d2",
+            "@typescript-eslint+project-service@8.69.0_typescript@5.9.3": ":entry_typescript_eslint_project_service_8_69_0_typescript_5_9_3_f94092ffe911",
+            "@typescript-eslint+rule-tester@8.69.0_eslint@10.10.0_jiti@2.7.0_typescript@5.9.3": ":entry_typescript_eslint_rule_tester_8_69_0_eslint_10_10_0_jiti_2_7_0_typescrip_98e25cc77e12",
+            "@typescript-eslint+scope-manager@8.69.0": ":entry_typescript_eslint_scope_manager_8_69_0_2028cc75233f",
+            "@typescript-eslint+tsconfig-utils@8.69.0_typescript@5.9.3": ":entry_typescript_eslint_tsconfig_utils_8_69_0_typescript_5_9_3_4c4d2fa014b7",
+            "@typescript-eslint+types@8.69.0": ":entry_typescript_eslint_types_8_69_0_33daa92e85d2",
+            "@typescript-eslint+typescript-estree@8.69.0_typescript@5.9.3": ":entry_typescript_eslint_typescript_estree_8_69_0_typescript_5_9_3_3ca384a764ff",
+            "@typescript-eslint+utils@8.69.0_eslint@10.10.0_jiti@2.7.0_typescript@5.9.3": ":entry_typescript_eslint_utils_8_69_0_eslint_10_10_0_jiti_2_7_0_typescript_5_9__82b3965462e6",
+            "@typescript-eslint+visitor-keys@8.69.0": ":entry_typescript_eslint_visitor_keys_8_69_0_9c87b69f53c8",
             "@vitest+browser-playwright@4.1.9_playwright@1.63.0_vite@8.2.2_@types+node@26.5.0_esbuild@0.28.2_jiti@2.7.0_vitest@4.1.9": ":entry_vitest_browser_playwright_4_1_9_playwright_1_63_0_vite_8_2_2_types_node__93bedb6b746a",
             "@vitest+browser@4.1.9_vite@8.2.2_@types+node@26.5.0_esbuild@0.28.2_jiti@2.7.0_vitest@4.1.9": ":entry_vitest_browser_4_1_9_vite_8_2_2_types_node_26_5_0_esbuild_0_28_2_jiti_2__b24a5721e00f",
             "@vitest+expect@4.1.9": ":entry_vitest_expect_4_1_9_ac26383f14b6",
@@ -30965,6 +31200,7 @@ pnpm_store_view(
             "brace-expansion@5.0.9": ":entry_brace_expansion_5_0_9_8d760e4ad257",
             "braces@3.0.3": ":entry_braces_3_0_3_ffc711d3f86d",
             "buffer-image-size@0.6.4": ":entry_buffer_image_size_0_6_4_22c01178368e",
+            "cacheable@2.5.0": ":entry_cacheable_2_5_0_0a9dd0dffb1a",
             "chai@6.2.2": ":entry_chai_6_2_2_558bd039a17f",
             "convert-source-map@2.0.0": ":entry_convert_source_map_2_0_0_46e32cfc1207",
             "cross-spawn@7.0.6": ":entry_cross_spawn_7_0_6_50cb51119b3e",
@@ -30978,7 +31214,7 @@ pnpm_store_view(
             "eslint-scope@9.1.2": ":entry_eslint_scope_9_1_2_1242bb0a2257",
             "eslint-visitor-keys@3.4.3": ":entry_eslint_visitor_keys_3_4_3_d73964c6d2eb",
             "eslint-visitor-keys@5.0.1": ":entry_eslint_visitor_keys_5_0_1_77649af58b26",
-            "eslint@10.5.0_jiti@2.7.0": ":entry_eslint_10_5_0_jiti_2_7_0_cb3b30c8d310",
+            "eslint@10.10.0_jiti@2.7.0": ":entry_eslint_10_10_0_jiti_2_7_0_beba109a7b3d",
             "espree@11.2.0": ":entry_espree_11_2_0_23d4e7a3725d",
             "esquery@1.7.0": ":entry_esquery_1_7_0_0e77450dbf69",
             "esrecurse@4.3.0": ":entry_esrecurse_4_3_0_19afb85871ec",
@@ -30990,14 +31226,17 @@ pnpm_store_view(
             "fast-json-stable-stringify@2.1.0": ":entry_fast_json_stable_stringify_2_1_0_a49874e94660",
             "fast-levenshtein@2.0.6": ":entry_fast_levenshtein_2_0_6_45c405680bb2",
             "fdir@6.5.0_picomatch@4.0.7": ":entry_fdir_6_5_0_picomatch_4_0_7_0e611784cb76",
-            "file-entry-cache@8.0.0": ":entry_file_entry_cache_8_0_0_cfd34b733a3c",
+            "file-entry-cache@11.1.5": ":entry_file_entry_cache_11_1_5_ac300dcb09f1",
             "fill-range@7.1.1": ":entry_fill_range_7_1_1_15fb888391f0",
             "find-up@5.0.0": ":entry_find_up_5_0_0_36b5efd728dd",
-            "flat-cache@4.0.1": ":entry_flat_cache_4_0_1_2a36811f99d5",
+            "flat-cache@6.1.23": ":entry_flat_cache_6_1_23_4b2ba8bae97d",
             "flatted@3.4.4": ":entry_flatted_3_4_4_57b7d7dc886d",
             "fsevents@2.3.3": ":entry_fsevents_2_3_3_6dbcd7937292",
             "glob-parent@6.0.2": ":entry_glob_parent_6_0_2_7b90c3653564",
             "happy-dom@20.14.0": ":entry_happy_dom_20_14_0_02b00a98d4e4",
+            "hashery@1.5.1": ":entry_hashery_1_5_1_e1122633ff95",
+            "hookified@1.15.1": ":entry_hookified_1_15_1_e5243a6e8f47",
+            "hookified@2.2.0": ":entry_hookified_2_2_0_28f9e2a047fb",
             "ignore@5.3.2": ":entry_ignore_5_3_2_8280c55d2633",
             "imurmurhash@0.1.4": ":entry_imurmurhash_0_1_4_d1af6342e06c",
             "is-extglob@2.1.1": ":entry_is_extglob_2_1_1_9975757ae9e0",
@@ -31005,10 +31244,9 @@ pnpm_store_view(
             "is-number@7.0.0": ":entry_is_number_7_0_0_08fd04d109dd",
             "isexe@2.0.0": ":entry_isexe_2_0_0_2f62e711a692",
             "jiti@2.7.0": ":entry_jiti_2_7_0_443514e89728",
-            "json-buffer@3.0.1": ":entry_json_buffer_3_0_1_adbc921fc34d",
             "json-schema-traverse@0.4.1": ":entry_json_schema_traverse_0_4_1_224390b16484",
             "json-stable-stringify-without-jsonify@1.0.1": ":entry_json_stable_stringify_without_jsonify_1_0_1_0e74de0204bb",
-            "keyv@4.5.4": ":entry_keyv_4_5_4_b44ddb67514f",
+            "keyv@5.6.0": ":entry_keyv_5_6_0_b95898f12ca2",
             "levn@0.4.1": ":entry_levn_0_4_1_c90baa3b36b6",
             "lightningcss-darwin-arm64@1.33.0": ":entry_lightningcss_darwin_arm64_1_33_0_4e7915734c17",
             "lightningcss@1.33.0": ":entry_lightningcss_1_33_0_7129b0f44113",
@@ -31039,6 +31277,7 @@ pnpm_store_view(
             "postcss@8.5.26": ":entry_postcss_8_5_26_dd6223d49d4c",
             "prelude-ls@1.2.1": ":entry_prelude_ls_1_2_1_78fc019ae342",
             "punycode@2.3.1": ":entry_punycode_2_3_1_3fe331f5536b",
+            "qified@0.10.1": ":entry_qified_0_10_1_b3b25bd21152",
             "rolldown@1.2.7": ":entry_rolldown_1_2_7_f28636c54a2e",
             "semver@7.8.5": ":entry_semver_7_8_5_82a86616e50d",
             "shebang-command@2.0.0": ":entry_shebang_command_2_0_0_a9cba97b71b8",
@@ -31070,7 +31309,7 @@ pnpm_store_view(
         },
     },
     bins = {
-        "eslint": "eslint@10.5.0_jiti@2.7.0\tbin/eslint.js",
+        "eslint": "eslint@10.10.0_jiti@2.7.0\tbin/eslint.js",
         "tsc": "typescript@5.9.3\tbin/tsc",
         "tsgolint": "oxlint-tsgolint@7.0.2001\tbin/tsgolint.js",
         "tsserver": "typescript@5.9.3\tbin/tsserver",

--- a/buck2/dependencies/BUCK
+++ b/buck2/dependencies/BUCK
@@ -3,7 +3,7 @@
 
 # Generated file - DO NOT EDIT
 # Source: pnpm-lock.yaml
-# Store fingerprint: sha256:d296d1e76e7818347f8d13f0393fe6b8cc9c8cad01da38772d3a0cd953721621
+# Store fingerprint: sha256:383811c2535a542f96d9e46ea83e55d83c277f7c705a455910617b34c38f624d
 
 load("//buck2:materialization.bzl", "export_materialization_inputs")
 
@@ -7736,51 +7736,6 @@ pnpm_store_entry(
 )
 
 pnpm_store_entry(
-    name = "entry_opentui_core_0_5_11_typescript_5_9_3_web_tree_sitter_0_25_10_a10e00595b07",
-    package = ":package_opentui_core_0_5_11_520f91ec2257",
-    store_key = "@opentui+core@0.5.11_typescript@5.9.3_web-tree-sitter@0.25.10",
-    runtime = ":assemble-store.ts",
-    dependencies_by_platform = {
-        "javascript_portable": {
-            "bun-ffi-structs": ":entry_bun_ffi_structs_0_3_1_typescript_5_9_3_6c9acefa6d69",
-            "diff": ":entry_diff_9_0_0_5a9cf482041d",
-            "marked": ":entry_marked_17_0_1_ff2a6dda0662",
-            "string-width": ":entry_string_width_7_2_0_dd9742ed9e8e",
-            "strip-ansi": ":entry_strip_ansi_7_1_2_9d924b927a03",
-            "web-tree-sitter": ":entry_web_tree_sitter_0_25_10_634644d3bdf9",
-        },
-        "linux_aarch64": {
-            "@opentui/core-linux-arm64": ":entry_opentui_core_linux_arm64_0_5_11_c1c63b0c0df3",
-            "bun-ffi-structs": ":entry_bun_ffi_structs_0_3_1_typescript_5_9_3_6c9acefa6d69",
-            "diff": ":entry_diff_9_0_0_5a9cf482041d",
-            "marked": ":entry_marked_17_0_1_ff2a6dda0662",
-            "string-width": ":entry_string_width_7_2_0_dd9742ed9e8e",
-            "strip-ansi": ":entry_strip_ansi_7_1_2_9d924b927a03",
-            "web-tree-sitter": ":entry_web_tree_sitter_0_25_10_634644d3bdf9",
-        },
-        "linux_x86_64": {
-            "@opentui/core-linux-x64": ":entry_opentui_core_linux_x64_0_5_11_7bd266afe6f5",
-            "bun-ffi-structs": ":entry_bun_ffi_structs_0_3_1_typescript_5_9_3_6c9acefa6d69",
-            "diff": ":entry_diff_9_0_0_5a9cf482041d",
-            "marked": ":entry_marked_17_0_1_ff2a6dda0662",
-            "string-width": ":entry_string_width_7_2_0_dd9742ed9e8e",
-            "strip-ansi": ":entry_strip_ansi_7_1_2_9d924b927a03",
-            "web-tree-sitter": ":entry_web_tree_sitter_0_25_10_634644d3bdf9",
-        },
-        "macos_aarch64": {
-            "@opentui/core-darwin-arm64": ":entry_opentui_core_darwin_arm64_0_5_11_b33ab39400ed",
-            "bun-ffi-structs": ":entry_bun_ffi_structs_0_3_1_typescript_5_9_3_6c9acefa6d69",
-            "diff": ":entry_diff_9_0_0_5a9cf482041d",
-            "marked": ":entry_marked_17_0_1_ff2a6dda0662",
-            "string-width": ":entry_string_width_7_2_0_dd9742ed9e8e",
-            "strip-ansi": ":entry_strip_ansi_7_1_2_9d924b927a03",
-            "web-tree-sitter": ":entry_web_tree_sitter_0_25_10_634644d3bdf9",
-        },
-    },
-    visibility = ["PUBLIC"],
-)
-
-pnpm_store_entry(
     name = "entry_opentui_core_0_5_11_typescript_7_0_2_web_tree_sitter_0_25_10_8aedbdcd6736",
     package = ":package_opentui_core_0_5_11_520f91ec2257",
     store_key = "@opentui+core@0.5.11_typescript@7.0.2_web-tree-sitter@0.25.10",
@@ -7821,23 +7776,6 @@ pnpm_store_entry(
             "strip-ansi": ":entry_strip_ansi_7_1_2_9d924b927a03",
             "web-tree-sitter": ":entry_web_tree_sitter_0_25_10_634644d3bdf9",
         },
-    },
-    visibility = ["PUBLIC"],
-)
-
-pnpm_store_entry(
-    name = "entry_opentui_react_0_5_11_react_devtools_core_7_0_1_react_19_2_8_typescript_5_aca50de0a7c2",
-    package = ":package_opentui_react_0_5_11_f97ba836b99a",
-    store_key = "@opentui+react@0.5.11_react-devtools-core@7.0.1_react@19.2.8_typescript@5.9.3_web-tree-sitter@0.25.10_ws@8.21.3",
-    runtime = ":assemble-store.ts",
-    dependencies = {
-        "@opentui/core": ":entry_opentui_core_0_5_11_typescript_5_9_3_web_tree_sitter_0_25_10_a10e00595b07",
-        "@types/react": ":entry_types_react_19_2_18_231c43c28c72",
-        "@types/ws": ":entry_types_ws_8_18_1_ee1128304b54",
-        "react": ":entry_react_19_2_8_f0ed5178d6d7",
-        "react-devtools-core": ":entry_react_devtools_core_7_0_1_ac60f63532b4",
-        "react-reconciler": ":entry_react_reconciler_0_33_0_react_19_2_8_00837bbcd720",
-        "ws": ":entry_ws_8_21_3_d250ffc75a80",
     },
     visibility = ["PUBLIC"],
 )
@@ -10370,17 +10308,6 @@ pnpm_store_entry(
     runtime = ":assemble-store.ts",
     dependencies = {
         "@types/node": ":entry_types_node_26_5_0_a0142d056efc",
-    },
-    visibility = ["PUBLIC"],
-)
-
-pnpm_store_entry(
-    name = "entry_bun_ffi_structs_0_3_1_typescript_5_9_3_6c9acefa6d69",
-    package = ":package_bun_ffi_structs_0_3_1_b795c25b36d8",
-    store_key = "bun-ffi-structs@0.3.1_typescript@5.9.3",
-    runtime = ":assemble-store.ts",
-    dependencies = {
-        "typescript": ":entry_typescript_5_9_3_44bd9e04e2c2",
     },
     visibility = ["PUBLIC"],
 )
@@ -14360,24 +14287,25 @@ pnpm_store_view(
     runtime = ":assemble-store.ts",
     direct = {
         "@effect/atom-react": "@effect+atom-react@4.0.0-rc.111_effect@4.0.0-rc.111_react@19.2.8_scheduler@0.27.0",
-        "@opentui/core": "@opentui+core@0.5.11_typescript@5.9.3_web-tree-sitter@0.25.10",
-        "@opentui/react": "@opentui+react@0.5.11_react-devtools-core@7.0.1_react@19.2.8_typescript@5.9.3_web-tree-sitter@0.25.10_ws@8.21.3",
+        "@opentui/core": "@opentui+core@0.5.11_typescript@7.0.2_web-tree-sitter@0.25.10",
+        "@opentui/react": "@opentui+react@0.5.11_react-devtools-core@7.0.1_react@19.2.8_typescript@7.0.2_web-tree-sitter@0.25.10_ws@8.21.3",
         "@types/node": "@types+node@26.5.0",
         "@types/react": "@types+react@19.2.18",
         "effect": "effect@4.0.0-rc.111",
         "react": "react@19.2.8",
+        "typescript": "typescript@7.0.2",
     },
     closure_by_platform = {
         "javascript_portable": {
             "@effect+atom-react@4.0.0-rc.111_effect@4.0.0-rc.111_react@19.2.8_scheduler@0.27.0": ":entry_effect_atom_react_4_0_0_rc_111_effect_4_0_0_rc_111_react_19_2_8_schedule_879f75095f22",
-            "@opentui+core@0.5.11_typescript@5.9.3_web-tree-sitter@0.25.10": ":entry_opentui_core_0_5_11_typescript_5_9_3_web_tree_sitter_0_25_10_a10e00595b07",
-            "@opentui+react@0.5.11_react-devtools-core@7.0.1_react@19.2.8_typescript@5.9.3_web-tree-sitter@0.25.10_ws@8.21.3": ":entry_opentui_react_0_5_11_react_devtools_core_7_0_1_react_19_2_8_typescript_5_aca50de0a7c2",
+            "@opentui+core@0.5.11_typescript@7.0.2_web-tree-sitter@0.25.10": ":entry_opentui_core_0_5_11_typescript_7_0_2_web_tree_sitter_0_25_10_8aedbdcd6736",
+            "@opentui+react@0.5.11_react-devtools-core@7.0.1_react@19.2.8_typescript@7.0.2_web-tree-sitter@0.25.10_ws@8.21.3": ":entry_opentui_react_0_5_11_react_devtools_core_7_0_1_react_19_2_8_typescript_7_cb7918c1f170",
             "@standard-schema+spec@1.1.0": ":entry_standard_schema_spec_1_1_0_9bfb5ac2eb33",
             "@types+node@26.5.0": ":entry_types_node_26_5_0_a0142d056efc",
             "@types+react@19.2.18": ":entry_types_react_19_2_18_231c43c28c72",
             "@types+ws@8.18.1": ":entry_types_ws_8_18_1_ee1128304b54",
             "ansi-regex@6.3.0": ":entry_ansi_regex_6_3_0_87b6edc6ebb4",
-            "bun-ffi-structs@0.3.1_typescript@5.9.3": ":entry_bun_ffi_structs_0_3_1_typescript_5_9_3_6c9acefa6d69",
+            "bun-ffi-structs@0.3.1_typescript@7.0.2": ":entry_bun_ffi_structs_0_3_1_typescript_7_0_2_051e106cc9bb",
             "csstype@3.2.3": ":entry_csstype_3_2_3_d75166202534",
             "detect-libc@2.1.2": ":entry_detect_libc_2_1_2_a7155eec83d1",
             "diff@9.0.0": ":entry_diff_9_0_0_5a9cf482041d",
@@ -14398,7 +14326,7 @@ pnpm_store_view(
             "string-width@7.2.0": ":entry_string_width_7_2_0_dd9742ed9e8e",
             "strip-ansi@7.1.2": ":entry_strip_ansi_7_1_2_9d924b927a03",
             "strip-ansi@7.2.0": ":entry_strip_ansi_7_2_0_c04be5885def",
-            "typescript@5.9.3": ":entry_typescript_5_9_3_44bd9e04e2c2",
+            "typescript@7.0.2": ":entry_typescript_7_0_2_a7cefd323dc7",
             "undici-types@8.9.0": ":entry_undici_types_8_9_0_53cb0487b88b",
             "web-tree-sitter@0.25.10": ":entry_web_tree_sitter_0_25_10_634644d3bdf9",
             "ws@7.5.13": ":entry_ws_7_5_13_ccf43b94a1cd",
@@ -14408,14 +14336,15 @@ pnpm_store_view(
             "@effect+atom-react@4.0.0-rc.111_effect@4.0.0-rc.111_react@19.2.8_scheduler@0.27.0": ":entry_effect_atom_react_4_0_0_rc_111_effect_4_0_0_rc_111_react_19_2_8_schedule_879f75095f22",
             "@msgpackr-extract+msgpackr-extract-linux-arm64@3.0.4": ":entry_msgpackr_extract_msgpackr_extract_linux_arm64_3_0_4_cf31bccf54bd",
             "@opentui+core-linux-arm64@0.5.11": ":entry_opentui_core_linux_arm64_0_5_11_c1c63b0c0df3",
-            "@opentui+core@0.5.11_typescript@5.9.3_web-tree-sitter@0.25.10": ":entry_opentui_core_0_5_11_typescript_5_9_3_web_tree_sitter_0_25_10_a10e00595b07",
-            "@opentui+react@0.5.11_react-devtools-core@7.0.1_react@19.2.8_typescript@5.9.3_web-tree-sitter@0.25.10_ws@8.21.3": ":entry_opentui_react_0_5_11_react_devtools_core_7_0_1_react_19_2_8_typescript_5_aca50de0a7c2",
+            "@opentui+core@0.5.11_typescript@7.0.2_web-tree-sitter@0.25.10": ":entry_opentui_core_0_5_11_typescript_7_0_2_web_tree_sitter_0_25_10_8aedbdcd6736",
+            "@opentui+react@0.5.11_react-devtools-core@7.0.1_react@19.2.8_typescript@7.0.2_web-tree-sitter@0.25.10_ws@8.21.3": ":entry_opentui_react_0_5_11_react_devtools_core_7_0_1_react_19_2_8_typescript_7_cb7918c1f170",
             "@standard-schema+spec@1.1.0": ":entry_standard_schema_spec_1_1_0_9bfb5ac2eb33",
             "@types+node@26.5.0": ":entry_types_node_26_5_0_a0142d056efc",
             "@types+react@19.2.18": ":entry_types_react_19_2_18_231c43c28c72",
             "@types+ws@8.18.1": ":entry_types_ws_8_18_1_ee1128304b54",
+            "@typescript+typescript-linux-arm64@7.0.2": ":entry_typescript_typescript_linux_arm64_7_0_2_dbe899afde8f",
             "ansi-regex@6.3.0": ":entry_ansi_regex_6_3_0_87b6edc6ebb4",
-            "bun-ffi-structs@0.3.1_typescript@5.9.3": ":entry_bun_ffi_structs_0_3_1_typescript_5_9_3_6c9acefa6d69",
+            "bun-ffi-structs@0.3.1_typescript@7.0.2": ":entry_bun_ffi_structs_0_3_1_typescript_7_0_2_051e106cc9bb",
             "csstype@3.2.3": ":entry_csstype_3_2_3_d75166202534",
             "detect-libc@2.1.2": ":entry_detect_libc_2_1_2_a7155eec83d1",
             "diff@9.0.0": ":entry_diff_9_0_0_5a9cf482041d",
@@ -14436,7 +14365,7 @@ pnpm_store_view(
             "string-width@7.2.0": ":entry_string_width_7_2_0_dd9742ed9e8e",
             "strip-ansi@7.1.2": ":entry_strip_ansi_7_1_2_9d924b927a03",
             "strip-ansi@7.2.0": ":entry_strip_ansi_7_2_0_c04be5885def",
-            "typescript@5.9.3": ":entry_typescript_5_9_3_44bd9e04e2c2",
+            "typescript@7.0.2": ":entry_typescript_7_0_2_a7cefd323dc7",
             "undici-types@8.9.0": ":entry_undici_types_8_9_0_53cb0487b88b",
             "web-tree-sitter@0.25.10": ":entry_web_tree_sitter_0_25_10_634644d3bdf9",
             "ws@7.5.13": ":entry_ws_7_5_13_ccf43b94a1cd",
@@ -14446,14 +14375,15 @@ pnpm_store_view(
             "@effect+atom-react@4.0.0-rc.111_effect@4.0.0-rc.111_react@19.2.8_scheduler@0.27.0": ":entry_effect_atom_react_4_0_0_rc_111_effect_4_0_0_rc_111_react_19_2_8_schedule_879f75095f22",
             "@msgpackr-extract+msgpackr-extract-linux-x64@3.0.4": ":entry_msgpackr_extract_msgpackr_extract_linux_x64_3_0_4_d261ffc94c45",
             "@opentui+core-linux-x64@0.5.11": ":entry_opentui_core_linux_x64_0_5_11_7bd266afe6f5",
-            "@opentui+core@0.5.11_typescript@5.9.3_web-tree-sitter@0.25.10": ":entry_opentui_core_0_5_11_typescript_5_9_3_web_tree_sitter_0_25_10_a10e00595b07",
-            "@opentui+react@0.5.11_react-devtools-core@7.0.1_react@19.2.8_typescript@5.9.3_web-tree-sitter@0.25.10_ws@8.21.3": ":entry_opentui_react_0_5_11_react_devtools_core_7_0_1_react_19_2_8_typescript_5_aca50de0a7c2",
+            "@opentui+core@0.5.11_typescript@7.0.2_web-tree-sitter@0.25.10": ":entry_opentui_core_0_5_11_typescript_7_0_2_web_tree_sitter_0_25_10_8aedbdcd6736",
+            "@opentui+react@0.5.11_react-devtools-core@7.0.1_react@19.2.8_typescript@7.0.2_web-tree-sitter@0.25.10_ws@8.21.3": ":entry_opentui_react_0_5_11_react_devtools_core_7_0_1_react_19_2_8_typescript_7_cb7918c1f170",
             "@standard-schema+spec@1.1.0": ":entry_standard_schema_spec_1_1_0_9bfb5ac2eb33",
             "@types+node@26.5.0": ":entry_types_node_26_5_0_a0142d056efc",
             "@types+react@19.2.18": ":entry_types_react_19_2_18_231c43c28c72",
             "@types+ws@8.18.1": ":entry_types_ws_8_18_1_ee1128304b54",
+            "@typescript+typescript-linux-x64@7.0.2": ":entry_typescript_typescript_linux_x64_7_0_2_f03df44f666b",
             "ansi-regex@6.3.0": ":entry_ansi_regex_6_3_0_87b6edc6ebb4",
-            "bun-ffi-structs@0.3.1_typescript@5.9.3": ":entry_bun_ffi_structs_0_3_1_typescript_5_9_3_6c9acefa6d69",
+            "bun-ffi-structs@0.3.1_typescript@7.0.2": ":entry_bun_ffi_structs_0_3_1_typescript_7_0_2_051e106cc9bb",
             "csstype@3.2.3": ":entry_csstype_3_2_3_d75166202534",
             "detect-libc@2.1.2": ":entry_detect_libc_2_1_2_a7155eec83d1",
             "diff@9.0.0": ":entry_diff_9_0_0_5a9cf482041d",
@@ -14474,7 +14404,7 @@ pnpm_store_view(
             "string-width@7.2.0": ":entry_string_width_7_2_0_dd9742ed9e8e",
             "strip-ansi@7.1.2": ":entry_strip_ansi_7_1_2_9d924b927a03",
             "strip-ansi@7.2.0": ":entry_strip_ansi_7_2_0_c04be5885def",
-            "typescript@5.9.3": ":entry_typescript_5_9_3_44bd9e04e2c2",
+            "typescript@7.0.2": ":entry_typescript_7_0_2_a7cefd323dc7",
             "undici-types@8.9.0": ":entry_undici_types_8_9_0_53cb0487b88b",
             "web-tree-sitter@0.25.10": ":entry_web_tree_sitter_0_25_10_634644d3bdf9",
             "ws@7.5.13": ":entry_ws_7_5_13_ccf43b94a1cd",
@@ -14484,14 +14414,15 @@ pnpm_store_view(
             "@effect+atom-react@4.0.0-rc.111_effect@4.0.0-rc.111_react@19.2.8_scheduler@0.27.0": ":entry_effect_atom_react_4_0_0_rc_111_effect_4_0_0_rc_111_react_19_2_8_schedule_879f75095f22",
             "@msgpackr-extract+msgpackr-extract-darwin-arm64@3.0.4": ":entry_msgpackr_extract_msgpackr_extract_darwin_arm64_3_0_4_fa8bce50cc94",
             "@opentui+core-darwin-arm64@0.5.11": ":entry_opentui_core_darwin_arm64_0_5_11_b33ab39400ed",
-            "@opentui+core@0.5.11_typescript@5.9.3_web-tree-sitter@0.25.10": ":entry_opentui_core_0_5_11_typescript_5_9_3_web_tree_sitter_0_25_10_a10e00595b07",
-            "@opentui+react@0.5.11_react-devtools-core@7.0.1_react@19.2.8_typescript@5.9.3_web-tree-sitter@0.25.10_ws@8.21.3": ":entry_opentui_react_0_5_11_react_devtools_core_7_0_1_react_19_2_8_typescript_5_aca50de0a7c2",
+            "@opentui+core@0.5.11_typescript@7.0.2_web-tree-sitter@0.25.10": ":entry_opentui_core_0_5_11_typescript_7_0_2_web_tree_sitter_0_25_10_8aedbdcd6736",
+            "@opentui+react@0.5.11_react-devtools-core@7.0.1_react@19.2.8_typescript@7.0.2_web-tree-sitter@0.25.10_ws@8.21.3": ":entry_opentui_react_0_5_11_react_devtools_core_7_0_1_react_19_2_8_typescript_7_cb7918c1f170",
             "@standard-schema+spec@1.1.0": ":entry_standard_schema_spec_1_1_0_9bfb5ac2eb33",
             "@types+node@26.5.0": ":entry_types_node_26_5_0_a0142d056efc",
             "@types+react@19.2.18": ":entry_types_react_19_2_18_231c43c28c72",
             "@types+ws@8.18.1": ":entry_types_ws_8_18_1_ee1128304b54",
+            "@typescript+typescript-darwin-arm64@7.0.2": ":entry_typescript_typescript_darwin_arm64_7_0_2_38ca3d6d9939",
             "ansi-regex@6.3.0": ":entry_ansi_regex_6_3_0_87b6edc6ebb4",
-            "bun-ffi-structs@0.3.1_typescript@5.9.3": ":entry_bun_ffi_structs_0_3_1_typescript_5_9_3_6c9acefa6d69",
+            "bun-ffi-structs@0.3.1_typescript@7.0.2": ":entry_bun_ffi_structs_0_3_1_typescript_7_0_2_051e106cc9bb",
             "csstype@3.2.3": ":entry_csstype_3_2_3_d75166202534",
             "detect-libc@2.1.2": ":entry_detect_libc_2_1_2_a7155eec83d1",
             "diff@9.0.0": ":entry_diff_9_0_0_5a9cf482041d",
@@ -14512,7 +14443,7 @@ pnpm_store_view(
             "string-width@7.2.0": ":entry_string_width_7_2_0_dd9742ed9e8e",
             "strip-ansi@7.1.2": ":entry_strip_ansi_7_1_2_9d924b927a03",
             "strip-ansi@7.2.0": ":entry_strip_ansi_7_2_0_c04be5885def",
-            "typescript@5.9.3": ":entry_typescript_5_9_3_44bd9e04e2c2",
+            "typescript@7.0.2": ":entry_typescript_7_0_2_a7cefd323dc7",
             "undici-types@8.9.0": ":entry_undici_types_8_9_0_53cb0487b88b",
             "web-tree-sitter@0.25.10": ":entry_web_tree_sitter_0_25_10_634644d3bdf9",
             "ws@7.5.13": ":entry_ws_7_5_13_ccf43b94a1cd",
@@ -14520,6 +14451,7 @@ pnpm_store_view(
         },
     },
     bins = {
+        "tsc": "typescript@7.0.2\tbin/tsc",
     },
     workspace_trees = {
     },

--- a/buck2/dependencies/pnpm-lock.sha256.json
+++ b/buck2/dependencies/pnpm-lock.sha256.json
@@ -1,6 +1,6 @@
 {
   "schema": "effect-utils/buck2-pnpm-sha256/v1",
-  "lockfileFingerprint": "sha256:01037c49df868f16012acd284b6e9a02ceffaeccb87a4d3b2dd7f8cc43c05d6d",
+  "lockfileFingerprint": "sha256:50221e3b1e66a95f1ea57d8b4bba2c19ab6e6b73c5bcb62eab4b1e506ad5d9b0",
   "source": "pnpm-lock.yaml",
   "generator": "buck2/dependencies/pnpm-lock.sha256.json.genie.ts",
   "regenerate": "devenv tasks run genie:run",
@@ -3452,5 +3452,5 @@
       "sha256": "2c162e000f5fb5a816987d6f8ad7aad295203f777a5992d514ae4660778a51a4"
     }
   },
-  "fingerprint": "sha256:5e820158fc5cd86d0cb9cf0b8be2c875598de75a89f9c192cd1dc5722d5595df"
+  "fingerprint": "sha256:9abc87bb3e12557221d8a94beb8ce015e63960b16fe29555fb5dc17a7ab75da6"
 }

--- a/buck2/dependencies/pnpm-lock.sha256.json
+++ b/buck2/dependencies/pnpm-lock.sha256.json
@@ -1,6 +1,6 @@
 {
   "schema": "effect-utils/buck2-pnpm-sha256/v1",
-  "lockfileFingerprint": "sha256:1e2981cb1d38131c8933d08818fb7208e235d58a317cfd0589b0294cf5dccff3",
+  "lockfileFingerprint": "sha256:01037c49df868f16012acd284b6e9a02ceffaeccb87a4d3b2dd7f8cc43c05d6d",
   "source": "pnpm-lock.yaml",
   "generator": "buck2/dependencies/pnpm-lock.sha256.json.genie.ts",
   "regenerate": "devenv tasks run genie:run",
@@ -126,6 +126,16 @@
       "bins": {},
       "integrity": "sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==",
       "sha256": "d10e0acae6327276066fc6720dbd65bd372ba81cb4445e7f472ca50addab186a"
+    },
+    "@cacheable/memory@2.2.0": {
+      "bins": {},
+      "integrity": "sha512-CTLKqLItRCEixEAewD3/j9DB3/o96gpTPD4eJ1v+DGOlxZRZncRQkGYqqnAGCscYd6RNeXfGeiuCphsPtqyIfQ==",
+      "sha256": "9dffad84622ba74be37dcec88ba7537cc9d168551e349588757add056f5289b9"
+    },
+    "@cacheable/utils@2.5.0": {
+      "bins": {},
+      "integrity": "sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA==",
+      "sha256": "243841e7a895205b7984be00bfd162aab703423d878a4837367e617033689a02"
     },
     "@csstools/css-tokenizer@3.0.4": {
       "bins": {},
@@ -337,10 +347,10 @@
       "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
       "sha256": "e94ae1cfacadb9b669cd7e4c862fe9b4f844d32e2c1b783a966617f912a5d0f8"
     },
-    "@eslint/config-helpers@0.6.0": {
+    "@eslint/config-helpers@0.7.0": {
       "bins": {},
-      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
-      "sha256": "7cc51f23f4603beeff1e02d0dacacc8ca29a404d5cc112c779636feb20a97a7a"
+      "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
+      "sha256": "a4186192e9463523090de29e3e5256f6963ccdd126216219c56a17b6ca9f17ca"
     },
     "@eslint/core@1.2.1": {
       "bins": {},
@@ -352,10 +362,10 @@
       "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
       "sha256": "2dc9c1afb534793f6beba1c23b27e5a84a5a0677ae9b300b2b46b8a99a3725d9"
     },
-    "@eslint/plugin-kit@0.7.2": {
+    "@eslint/plugin-kit@0.7.3": {
       "bins": {},
-      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
-      "sha256": "50b22954f78c880d1de67c861725d430560a08f2c8c20ad13b65d4ab18dd6cbb"
+      "integrity": "sha512-IkO+/KEUvwbVpiURZg+P7zF74z5Jxe0UgJxVni+RtoHQ6IZieXaO02kmadomap/q+l6bc/jdPGGqTjhuZnuz1Q==",
+      "sha256": "8bd10d0644bb4e2c62424eb4e213888121affbc644339912f2869858f079a2b5"
     },
     "@humanfs/core@0.19.2": {
       "bins": {},
@@ -426,6 +436,16 @@
       "bins": {},
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "sha256": "c64c71a119630d5abe8246889edf334b2ca9ddad094e20d623332956b1453ccf"
+    },
+    "@keyv/bigmap@1.3.1": {
+      "bins": {},
+      "integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
+      "sha256": "054607db65aa02c4f2d82d81a9a5c4d0d00386e2af77135893ea067a834ffb79"
+    },
+    "@keyv/serialize@1.1.1": {
+      "bins": {},
+      "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
+      "sha256": "5730adf7d1edef7c84a7ce658c3a2915386529b4d795523265c30a2e94f91366"
     },
     "@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4": {
       "bins": {},
@@ -1266,11 +1286,6 @@
       "integrity": "sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==",
       "sha256": "30daa25047dd7ce1a4abc45e483c5dcbe5c48ca398eb5f9a1ce7302ad18aa4c1"
     },
-    "@types/eslint@9.6.1": {
-      "bins": {},
-      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
-      "sha256": "efdbf20891541064adf48c4b6e3cad1b0cc4e99a5d29620fdc5b724de88ee5d0"
-    },
     "@types/esrecurse@4.3.1": {
       "bins": {},
       "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
@@ -1351,50 +1366,50 @@
       "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "sha256": "dc2763952a24bf15dc920830a2d2884c23bccc08a853e8556e34771401254fa5"
     },
-    "@typescript-eslint/parser@8.61.1": {
+    "@typescript-eslint/parser@8.69.0": {
       "bins": {},
-      "integrity": "sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==",
-      "sha256": "2f702563464215a7097f902f2d69b9ceef43fc56fc760876bc529d813960662e"
+      "integrity": "sha512-l4b0DhWioGg6Gt2ebGlvfkFMOjRsauxtsnDRwUSRX1qHq3HdTfQHV8wW9zEXeciai6HfeaKOedQn2Zoofx3WBw==",
+      "sha256": "957fcddbdffd801b9015e7761337f611f31eee6b473fba42c1989995a72ae7de"
     },
-    "@typescript-eslint/project-service@8.61.1": {
+    "@typescript-eslint/project-service@8.69.0": {
       "bins": {},
-      "integrity": "sha512-PrC4JYGmR241lYnfhmKGTXkFqv8+ymbTFgSAY0fVXpY82/QkMw5TZPl+vGzuDDU2QYJk9fIDOBTntF+yDv9LEA==",
-      "sha256": "39260fd897790a0951f21862cb8434b1ebdcb12a30ba6f267c24e0a60c118fb0"
+      "integrity": "sha512-yi4obFrHMmnsesWehHbkg9zMA7Jt8cXT+mKM08G999pH1yT6nqgsHx7MYm0uY1wAj8CqiBXYRJ7WAT0QdQHQXg==",
+      "sha256": "5d7bb205ffdc1207d3de1316c812c18e0291d8e9214005a0dfea8e0a7e98d0ea"
     },
-    "@typescript-eslint/rule-tester@8.61.1": {
+    "@typescript-eslint/rule-tester@8.69.0": {
       "bins": {},
-      "integrity": "sha512-x7xp2GZaFcrXv2tuGN5Lcdd05BcPDaL2wSPpARPSbbRE7N2N46za+9NTAtb8NX5a9FfoDLkhLYDbJjngV8xYDA==",
-      "sha256": "e49c2077da2711492eb4588c17d6fed6e19d163fe42bf916bce25667ba6d046c"
+      "integrity": "sha512-VHKAWEzEeB+XgLzgvkP3eFAkNaKhF1TEBZvjuZ9G8ySp4u6iZjnfBVBwEtXocO/a+g/B32II+WaSf5OcikmAyg==",
+      "sha256": "d9e13fd84e456c1c90ecd3ba18a5d03a0e0b286c3b96c5b1b53d019b9a0a47f7"
     },
-    "@typescript-eslint/scope-manager@8.61.1": {
+    "@typescript-eslint/scope-manager@8.69.0": {
       "bins": {},
-      "integrity": "sha512-L2bdIeoQS8FlKAvONAr20w6OcLXeB+qiDKbAooS9A0Ben+iSIkBef0FxqwKWYqt5sa0i4KJtxVyVmhMylKzF5w==",
-      "sha256": "ab6ba6a21f675eb974b131098d94557569bb93c14deb0195806b48462f9437f5"
+      "integrity": "sha512-ewfspqWvSxKSOaplqAUNbaSFO0eB6w1EtQ+esfYFRm3614Ty4uNtExkcbgd6nWsXphbqKyf9ZYdbZdv2xEoWEQ==",
+      "sha256": "279aaf75556c1b94aac921ce974f9fc3f8b72ff1208ba3edd034bdb90b3b0a73"
     },
-    "@typescript-eslint/tsconfig-utils@8.61.1": {
+    "@typescript-eslint/tsconfig-utils@8.69.0": {
       "bins": {},
-      "integrity": "sha512-UN/H4di+OO7EWx2ovME+8t31YO+KVnK0RRKEHR3kOt21/Ay8BOq3M1OMvWs5vNiqcFCYGYoxK3MXPZzmMUE+yg==",
-      "sha256": "488c9043baf2be49ca088fea091289f118330d77a08828f00f9efa687895b2df"
+      "integrity": "sha512-xNqK7YTDZsLniQMV/4rpFR8Z5JlqeRvVjuG1YgF/mdPVH84HSD19L8CczMA0qg2RfwEV231GHH3VnToJDo4MfQ==",
+      "sha256": "6344c0366c934c508952ad64933073643f9189bdc45a1a850fc25cf6fc4e49f9"
     },
-    "@typescript-eslint/types@8.61.1": {
+    "@typescript-eslint/types@8.69.0": {
       "bins": {},
-      "integrity": "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA==",
-      "sha256": "aedff90199f8f750807cea8cb2120267ca879dbe794ad7111a7a3eb83914fb4b"
+      "integrity": "sha512-K3VrubUPhlo9VDBS6QdI8YB5j7ClpqLRdefcz6PFrhnwicehBweqQ9Evhl4l+FYz0HdDmMqIiSX0aldGRYtDCA==",
+      "sha256": "a00d6eed789a21302261164f79e335bd57a0f3bafb8619aa23177af59b97e377"
     },
-    "@typescript-eslint/typescript-estree@8.61.1": {
+    "@typescript-eslint/typescript-estree@8.69.0": {
       "bins": {},
-      "integrity": "sha512-u+oQD3BqYWPc8YV9Zab4vaJElJuwOLPRc10Jm1o/qS+6Qwen14HCWwx0Seo4LnSn2wxea2Ik8DxPt2/FHmuhrg==",
-      "sha256": "1eaaae4d873d13abcd7eb75645b4b23e2728137f8ce60a5e2f676294907d569f"
+      "integrity": "sha512-AdFkgqck3Vudb/kWnxlyafU/4aBhHrbQ9locP2N4psXTy5mOBg0SHJumnLvx7r6g1gV4DKvUFwV2nJZBoqOD8w==",
+      "sha256": "1b0e9f380f1533a016937018fb78ad348ca01633fff78af69142faa16c0b612f"
     },
-    "@typescript-eslint/utils@8.61.1": {
+    "@typescript-eslint/utils@8.69.0": {
       "bins": {},
-      "integrity": "sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA==",
-      "sha256": "5fce1c237ff15f4a480a4abd2bbf2cbb517765ce71981928140f73ad426b2157"
+      "integrity": "sha512-tUbx60BBqQa31kXF5MCsOOLL5E/WzUuxIn7YpAvq+eaUlqvk8/NXnXMBNAdLCr0icjkzem7iUA5QqWHe/hJ1aw==",
+      "sha256": "fb89448a616b8761e255de806682b9fe1c9a2705edcfac008bc5d21ae0bf7972"
     },
-    "@typescript-eslint/visitor-keys@8.61.1": {
+    "@typescript-eslint/visitor-keys@8.69.0": {
       "bins": {},
-      "integrity": "sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w==",
-      "sha256": "eee8972fd313747542440605a5d3ec7fd9863d66321c054ff87c1a5fb981b854"
+      "integrity": "sha512-+rmdgPA+EXkNgKYvHvFfhrs35utXbwaC5PGpDquSXcoXQDKUA5UjV0LmTucG/4JXkM31BTu4TilHtrN8IVBe8w==",
+      "sha256": "1e722561d1374b57180d8de3426389ac5aca97d3c17f840b9e85fc8fe3d37d1b"
     },
     "@typescript/typescript-aix-ppc64@7.0.2": {
       "bins": {},
@@ -1737,6 +1752,11 @@
       "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
       "sha256": "35e49d4240c91cbe4ca29926139feea848302e9eea317f31d9e81b972ce90911"
     },
+    "cacheable@2.5.0": {
+      "bins": {},
+      "integrity": "sha512-60cyAOytib/OzBw1JNSoSV/boK1AtHryDIjvVBk7XbN4ugfkM3+Sry7fEjNgPMGgOjuaZPAp8ruZ0Cxafwyq9g==",
+      "sha256": "69a2c0e6d81c1a38c601bf34bf0935998823043a219a01401455d23e29377bab"
+    },
     "caniuse-lite@1.0.30001810": {
       "bins": {},
       "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
@@ -1984,12 +2004,12 @@
       "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "sha256": "cc0945290fe3cc73aa7f04b03cdc0704ca7ac8d805ff19f43fa3f9e5e0b6728d"
     },
-    "eslint@10.5.0": {
+    "eslint@10.10.0": {
       "bins": {
         "eslint": "bin/eslint.js"
       },
-      "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
-      "sha256": "d2e5cae195d7660bb12c543d8faf3dfe762dafd6a39fac96ab4fbb1bb4a95412"
+      "integrity": "sha512-NPXn6r5zl4uET1DAVPaOwzX3rut4c0wcmw3dWJAfOsTM5+TogXo0DDjz8pwm/hL8cyVNpHqeK4JpN0NjnyFFNw==",
+      "sha256": "897c8ff1a16dbc0420d9815b59bfbad27d079c3ddaef6ee1099bb4b4593c0031"
     },
     "espree@11.2.0": {
       "bins": {},
@@ -2079,10 +2099,10 @@
       "integrity": "sha512-YoZjBdafyLIop9lSxXVI33oLD5kN31q4Td+CasofLLYeLXRFeOsuOw0Uo+XNRi9PZlbfdlN2GmRtm4tCEQ9/KA==",
       "sha256": "f595847384551d1de2ac23cc1bc761045db94041de0b15181b7a3129fd9045c2"
     },
-    "file-entry-cache@8.0.0": {
+    "file-entry-cache@11.1.5": {
       "bins": {},
-      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
-      "sha256": "67ac5a6cea2268114a1f8935ca3ad60fe634fed04dd7914939bf24ceaa2d57b8"
+      "integrity": "sha512-+PFTHITI08JIGhnNpGNI8T8inUpgZfk3GNEqfT9R2zZV2iFXg3CvqzSl/uEhs7TSGujYRELEANyDvS8Fj7+S7Q==",
+      "sha256": "941235c20a7060285e2d85777a03864d194b2f4bbe54b9730c8b026a62e2ace9"
     },
     "fill-range@7.1.1": {
       "bins": {},
@@ -2094,10 +2114,10 @@
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "sha256": "f4a64efb583769c09638d81963fd3f7aa883b632f9992a256de3fbe962ca75b4"
     },
-    "flat-cache@4.0.1": {
+    "flat-cache@6.1.23": {
       "bins": {},
-      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
-      "sha256": "e2085ae2b084792812a4f4102f6b4967e93cfda8457361b7debe610cf2aedaf0"
+      "integrity": "sha512-f++BY9pTk+983xK1FLzlLpmM0i0z+jHmx3QESGkURMXujQZz1k5wzwX6hjnQ8goaD0B+sYnDK1yZ6MTyZfUaqA==",
+      "sha256": "e1abb7dc35422099057cc42348a136336f4ca5ab88b118404d16d39122f77105"
     },
     "flatted@3.4.4": {
       "bins": {},
@@ -2146,6 +2166,11 @@
       "integrity": "sha512-4bRh1KzRvKDnFNTlLhzT1RZTpkKhQbQDl9j+7GXszWsvuspYdo29k6OHRf4PwiM6oLb8r/pMWeYiJjkfod5AvQ==",
       "sha256": "688a745ee428dfc3841ef8e76c77e55073e9d6f6703067feba18a2d74f849ae0"
     },
+    "hashery@1.5.1": {
+      "bins": {},
+      "integrity": "sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==",
+      "sha256": "9a174c770b98d20b26e16a6563b37f79d53d3bcef6dadcf08507dd4993158d0f"
+    },
     "hasown@2.0.4": {
       "bins": {},
       "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
@@ -2160,6 +2185,16 @@
       "bins": {},
       "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
       "sha256": "673f97f5bba3cac0184726f519a5750273e4434b839a769f4fbf09e4b4da2ceb"
+    },
+    "hookified@1.15.1": {
+      "bins": {},
+      "integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
+      "sha256": "7f96a9aa7ee1230008083deecaf2b512f9d2b9b8c08efe1a3252fccd09edca70"
+    },
+    "hookified@2.2.0": {
+      "bins": {},
+      "integrity": "sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==",
+      "sha256": "01aa4e32fec989b18ab2b7a6b593ec968efdd4db287d7fef94813678bc2b1564"
     },
     "html-void-elements@3.0.0": {
       "bins": {},
@@ -2286,11 +2321,6 @@
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "sha256": "0c712225ccca9a70bf83f2ac2f52a268c858c7df3b3df196f1623239d80d3c09"
     },
-    "json-buffer@3.0.1": {
-      "bins": {},
-      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "sha256": "d1f7464db9713c5f73c919da72de334fce0bcbd76fb08727d36712ef5dfef5a5"
-    },
     "json-schema-traverse@0.4.1": {
       "bins": {},
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
@@ -2320,10 +2350,10 @@
       "integrity": "sha512-Vdw0ATsQ9V+LuegM/BTwQqV/6cTl5lbGcIrU+BCgLxyf6bo38ybOr372tuSIxir3CN720flu1meYR6XzNMwQnw==",
       "sha256": "252efd48f892d178136fe3ba3530d3718b2b087ea81c3a40a877227bc61d5256"
     },
-    "keyv@4.5.4": {
+    "keyv@5.6.0": {
       "bins": {},
-      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-      "sha256": "eb26f1c561e57af4a4365e6b54f5f3e745e3963747a93845af1f000a747b6098"
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "sha256": "db982b7c83daadc135266141d1cb542443f26d42c72f25ee2d45644fc631e7e0"
     },
     "levn@0.4.1": {
       "bins": {},
@@ -2863,6 +2893,11 @@
       "bins": {},
       "integrity": "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==",
       "sha256": "3ce449c758cb2ea0db7ff30a1b378d381d9e74681acec74e1e2591ea6aa381ca"
+    },
+    "qified@0.10.1": {
+      "bins": {},
+      "integrity": "sha512-+Owyggi9IxT1ePKGafcI87ubSmxol6smwJ+RAHDQlx9+9cPwFWDiKFFCPuWhr9ignlGpZ9vDQLw67N4dcTVFEA==",
+      "sha256": "5acca41a42576ff888cf16cbcf505efbe3b0d4f55232edf3a931298a4b5ca662"
     },
     "react-aria-components@1.21.1": {
       "bins": {},
@@ -3417,5 +3452,5 @@
       "sha256": "2c162e000f5fb5a816987d6f8ad7aad295203f777a5992d514ae4660778a51a4"
     }
   },
-  "fingerprint": "sha256:ebd6453936ef9479061239a13c4cbd0d3c75004f8b1e74dc95a4644831600bb2"
+  "fingerprint": "sha256:5e820158fc5cd86d0cb9cf0b8be2c875598de75a89f9c192cd1dc5722d5595df"
 }

--- a/buck2/dependencies/pnpm-lock.unit.test.ts
+++ b/buck2/dependencies/pnpm-lock.unit.test.ts
@@ -184,8 +184,8 @@ describe('translatePnpmLock', () => {
     const second = translatePnpmLock(options)
 
     expect(second).toEqual(first)
-    expect(Object.keys(first.packages)).toHaveLength(665)
-    expect(Object.keys(first.snapshots)).toHaveLength(666)
+    expect(Object.keys(first.packages)).toHaveLength(672)
+    expect(Object.keys(first.snapshots)).toHaveLength(673)
     expect(Object.keys(first.importers)).toHaveLength(39)
     expect(first.packages['@myobie/pty@0.10.0']!.patch?.path).toBe(
       'packages/@overeng/utils/patches/@myobie__pty@0.10.0.patch',

--- a/buck2/dependencies/pnpm-store.unit.test.ts
+++ b/buck2/dependencies/pnpm-store.unit.test.ts
@@ -403,8 +403,8 @@ describe('normalized store projection of the real lockfile', () => {
     expect(projection.sccs.map((scc) => scc.members)).toEqual([
       ['@babel+core@7.29.7', '@babel+helper-module-transforms@7.29.7_@babel+core@7.29.7'],
       [
-        '@eslint-community+eslint-utils@4.10.1_eslint@10.5.0_jiti@2.7.0',
-        'eslint@10.5.0_jiti@2.7.0',
+        '@eslint-community+eslint-utils@4.10.1_eslint@10.10.0_jiti@2.7.0',
+        'eslint@10.10.0_jiti@2.7.0',
       ],
       [
         '@storybook+builder-vite@10.6.0_storybook@10.6.0_@types+react-dom@19.2.7_@types+react@19.2.18_@types+rea_27cb05be65527c5a',
@@ -486,8 +486,8 @@ describe('normalized store projection of the real lockfile', () => {
   })
 
   it('declares one entry per snapshot and one view per importer', () => {
-    expect(projection.entries).toHaveLength(666)
-    expect(new Set(projection.entries.map((entry) => entry.storeKey)).size).toBe(666)
+    expect(projection.entries).toHaveLength(673)
+    expect(new Set(projection.entries.map((entry) => entry.storeKey)).size).toBe(673)
     expect(projection.views).toHaveLength(Object.keys(metadata.importers).length)
     expect(computeStoreSccs({ metadata })).toEqual(projection.sccs.map((scc) => scc.members))
   })

--- a/genie/external.ts
+++ b/genie/external.ts
@@ -330,7 +330,6 @@ export const catalog = defineCatalog({
   '@types/react-dom': '19.2.7',
   '@types/node': '26.5.0',
   '@types/bun': '1.4.1',
-  '@types/eslint': '9.6.1',
   '@types/is-dom': '1.1.2',
   '@types/katex': '0.16.8',
 
@@ -441,12 +440,22 @@ export const catalog = defineCatalog({
   'happy-dom': '20.14.0',
 
   // Linting
-  /** Kept for rule-tester/types used by our custom lint rules even though runtime linting is oxlint. */
-  eslint: '10.5.0',
-  '@typescript-eslint/parser': '8.61.1',
-  '@typescript-eslint/rule-tester': '8.61.1',
-  '@typescript-eslint/utils': '8.61.1',
-  'typescript-eslint': '8.61.1',
+  /**
+   * Kept for the rule-tester/types used by our custom lint rules even though
+   * runtime linting is oxlint. ESLint itself ships its own `.d.ts` bundle, so
+   * there is deliberately no `@types/eslint` entry: the DefinitelyTyped package
+   * stopped at the ESLint 9 API in 2024 and TypeScript never consults it while
+   * `eslint/package.json` declares `types`.
+   *
+   * The three `@typescript-eslint/*` entries move as one weekly release train
+   * and stay one release behind the newest tag when that tag is younger than
+   * pnpm's release-age gate — taking a same-day release forces
+   * `minimumReleaseAgeExclude` entries into the generated workspace policy.
+   */
+  eslint: '10.10.0',
+  '@typescript-eslint/parser': '8.69.0',
+  '@typescript-eslint/rule-tester': '8.69.0',
+  '@typescript-eslint/utils': '8.69.0',
   prettier: '3.9.6',
   oxlint: '1.82.0',
   /** oxlint 1.82 requires the tsgolint peer at `>=7.0.2001` (the TS-7-aligned line). */

--- a/packages/@overeng/ci-tools/nix/build.nix
+++ b/packages/@overeng/ci-tools/nix/build.nix
@@ -19,7 +19,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-IssmDcgLdeU4JGZDDeundZjyniEzsbeA7RBO8pxH8zk=";
+      "." = mkSharedHash "sha256-FtRc4N1MYysrJazI0K9cjREEgVyKapEV5rso5t6Fa7w=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/ci-tools/nix/build.nix
+++ b/packages/@overeng/ci-tools/nix/build.nix
@@ -19,7 +19,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-FtRc4N1MYysrJazI0K9cjREEgVyKapEV5rso5t6Fa7w=";
+      "." = mkSharedHash "sha256-mWVhuFFO6Dxyics7N1mW+YDKWI0NsvibkCDL5ES0wzI=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/genie/nix/build.nix
+++ b/packages/@overeng/genie/nix/build.nix
@@ -31,7 +31,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-cPjl6mLVS77pL8Gukjolw9mpuymeB1ddMoz+uOcVVP4=";
+      "." = mkSharedHash "sha256-dzkq9usUwwExKY+LhFgbMpsHhjkbcLs7s4E4ZEHcSoY=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/genie/nix/build.nix
+++ b/packages/@overeng/genie/nix/build.nix
@@ -31,7 +31,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-NkXGnlS+81nvp03A6+N48aAAWh7nrLhSQCWf/X7QME0=";
+      "." = mkSharedHash "sha256-cPjl6mLVS77pL8Gukjolw9mpuymeB1ddMoz+uOcVVP4=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/megarepo/nix/build.nix
+++ b/packages/@overeng/megarepo/nix/build.nix
@@ -26,7 +26,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-/1ky9Vb60dMr4N3qiOlV8uXCBV9mOwepSCMr+sRdjvE=";
+      "." = mkSharedHash "sha256-bOSatoff1b73xWsCxRm31YwztOZukf3NUwhWlhkXWlg=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     smokeTestArgs = [ "--help" ];

--- a/packages/@overeng/megarepo/nix/build.nix
+++ b/packages/@overeng/megarepo/nix/build.nix
@@ -26,7 +26,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-bOSatoff1b73xWsCxRm31YwztOZukf3NUwhWlhkXWlg=";
+      "." = mkSharedHash "sha256-oWyrH1hcjn1kVoNg/tkRacDr2l0iJi/V0F599FQXljc=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     smokeTestArgs = [ "--help" ];

--- a/packages/@overeng/notion-cli/nix/build.nix
+++ b/packages/@overeng/notion-cli/nix/build.nix
@@ -33,7 +33,7 @@ let
     installRuntimeWorkspace = true;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-Hc6k6JdAZUI8PEveSx3VZBo0TKURvb63RP5W/A6nHW0=";
+      "." = mkSharedHash "sha256-1u+5EpUyZrUpICe8XwXYsqkKZtnr5DuZEGa3EYFKwqY=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/notion-cli/nix/build.nix
+++ b/packages/@overeng/notion-cli/nix/build.nix
@@ -33,7 +33,7 @@ let
     installRuntimeWorkspace = true;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-s9CL4wOBiUFTfS93wXh90M/Dn+Yi/1djTl1MXWIxoGU=";
+      "." = mkSharedHash "sha256-Hc6k6JdAZUI8PEveSx3VZBo0TKURvb63RP5W/A6nHW0=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/notion-md/nix/build.nix
+++ b/packages/@overeng/notion-md/nix/build.nix
@@ -20,7 +20,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-aTvaUvAg++CcxC4oiZ7MOVT1haAGDGdU64LkaxQgCxw=";
+      "." = mkSharedHash "sha256-NmxTdWmLV5AICr8WK+Ng+YLAvhqUJr/pAogsL++arz4=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/notion-md/nix/build.nix
+++ b/packages/@overeng/notion-md/nix/build.nix
@@ -20,7 +20,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-OTyQ3cQuery3j4mfTkhsFNvgdMzkTXltldpuzJX3N1I=";
+      "." = mkSharedHash "sha256-aTvaUvAg++CcxC4oiZ7MOVT1haAGDGdU64LkaxQgCxw=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/npm-release/nix/build.nix
+++ b/packages/@overeng/npm-release/nix/build.nix
@@ -20,7 +20,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-fO6alKQ+EtDFxs1VmDcLBR3GldSU5mrv/hNrbcjZ5a4=";
+      "." = mkSharedHash "sha256-ANCO5tBslpzsXN1k1KOI9WH48OAZcUs2yE5GFmVARIw=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/npm-release/nix/build.nix
+++ b/packages/@overeng/npm-release/nix/build.nix
@@ -20,7 +20,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-9ViwDsyhBa1CZ3vWvir0EVlDG80lglcOxq7rABPClSE=";
+      "." = mkSharedHash "sha256-fO6alKQ+EtDFxs1VmDcLBR3GldSU5mrv/hNrbcjZ5a4=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/oxc-config/nix/build.nix
+++ b/packages/@overeng/oxc-config/nix/build.nix
@@ -14,7 +14,7 @@ import ../../../../nix/oxc-config-plugin.nix {
     ;
   # Managed by Evergreen FOD refresh — do not edit manually.
   depsBuilds = {
-    "." = mkSharedHash "sha256-MLNREQJK+9hGgjngqkAuvBq7JHluY7W7idQ3FhbQW48=";
+    "." = mkSharedHash "sha256-SUnWuZbbqbGe4dJNrP236kdm1cLw/zoYT+GYnhktxFQ=";
   };
   hashSourcePath = "packages/@overeng/oxc-config/nix/build.nix";
 }

--- a/packages/@overeng/oxc-config/nix/build.nix
+++ b/packages/@overeng/oxc-config/nix/build.nix
@@ -14,7 +14,7 @@ import ../../../../nix/oxc-config-plugin.nix {
     ;
   # Managed by Evergreen FOD refresh — do not edit manually.
   depsBuilds = {
-    "." = mkSharedHash "sha256-Ynf/1Q0dNquIBgyLXXEOv1itWA8DpJeOMc5wRt/W6rg=";
+    "." = mkSharedHash "sha256-MLNREQJK+9hGgjngqkAuvBq7JHluY7W7idQ3FhbQW48=";
   };
   hashSourcePath = "packages/@overeng/oxc-config/nix/build.nix";
 }

--- a/packages/@overeng/oxc-config/package.json
+++ b/packages/@overeng/oxc-config/package.json
@@ -16,11 +16,10 @@
   },
   "devDependencies": {
     "@stylexjs/eslint-plugin": "0.19.0",
-    "@types/eslint": "9.6.1",
-    "@typescript-eslint/parser": "8.61.1",
-    "@typescript-eslint/rule-tester": "8.61.1",
-    "@typescript-eslint/utils": "8.61.1",
-    "eslint": "10.5.0",
+    "@typescript-eslint/parser": "8.69.0",
+    "@typescript-eslint/rule-tester": "8.69.0",
+    "@typescript-eslint/utils": "8.69.0",
+    "eslint": "10.10.0",
     "oxlint-tsgolint": "7.0.2001",
     "typescript": "5.9.3",
     "vitest": "4.1.9"

--- a/packages/@overeng/oxc-config/package.json.genie.ts
+++ b/packages/@overeng/oxc-config/package.json.genie.ts
@@ -24,7 +24,6 @@ const deps = catalog.compose({
     external: {
       ...catalog.pick(
         '@stylexjs/eslint-plugin',
-        '@types/eslint',
         '@typescript-eslint/parser',
         '@typescript-eslint/rule-tester',
         '@typescript-eslint/utils',

--- a/packages/@overeng/tui-stories/nix/build.nix
+++ b/packages/@overeng/tui-stories/nix/build.nix
@@ -21,7 +21,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-jroZtqrMBGoa3mtaFPYkIW7oVpQyRfhkvmrWcXIPsjQ=";
+      "." = mkSharedHash "sha256-R1dBwGM4sHXokZZ1Z3OTzGIX6JnCkIK+WcUYoWEBG3c=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/tui-stories/nix/build.nix
+++ b/packages/@overeng/tui-stories/nix/build.nix
@@ -21,7 +21,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-5/zLTTjEJy+9GxAr3CvCAodbLMCA0qciG/bpMJSd0Yc=";
+      "." = mkSharedHash "sha256-jroZtqrMBGoa3mtaFPYkIW7oVpQyRfhkvmrWcXIPsjQ=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1262,21 +1262,18 @@ importers:
       '@stylexjs/eslint-plugin':
         specifier: 0.19.0
         version: 0.19.0
-      '@types/eslint':
-        specifier: 9.6.1
-        version: 9.6.1
       '@typescript-eslint/parser':
-        specifier: 8.61.1
-        version: 8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@5.9.3)
+        specifier: 8.69.0
+        version: 8.69.0(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3)
       '@typescript-eslint/rule-tester':
-        specifier: 8.61.1
-        version: 8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@5.9.3)
+        specifier: 8.69.0
+        version: 8.69.0(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3)
       '@typescript-eslint/utils':
-        specifier: 8.61.1
-        version: 8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@5.9.3)
+        specifier: 8.69.0
+        version: 8.69.0(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3)
       eslint:
-        specifier: 10.5.0
-        version: 10.5.0(jiti@2.7.0)
+        specifier: 10.10.0
+        version: 10.10.0(jiti@2.7.0)
       oxlint-tsgolint:
         specifier: 7.0.2001
         version: 7.0.2001
@@ -1860,6 +1857,12 @@ packages:
   '@blazediff/core@1.9.1':
     resolution: {integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==}
 
+  '@cacheable/memory@2.2.0':
+    resolution: {integrity: sha512-CTLKqLItRCEixEAewD3/j9DB3/o96gpTPD4eJ1v+DGOlxZRZncRQkGYqqnAGCscYd6RNeXfGeiuCphsPtqyIfQ==}
+
+  '@cacheable/utils@2.5.0':
+    resolution: {integrity: sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA==}
+
   '@csstools/css-tokenizer@3.0.4':
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
@@ -2113,8 +2116,8 @@ packages:
     resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@eslint/config-helpers@0.6.0':
-    resolution: {integrity: sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==}
+  '@eslint/config-helpers@0.7.0':
+    resolution: {integrity: sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   '@eslint/core@1.2.1':
@@ -2125,8 +2128,8 @@ packages:
     resolution: {integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@eslint/plugin-kit@0.7.2':
-    resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
+  '@eslint/plugin-kit@0.7.3':
+    resolution: {integrity: sha512-IkO+/KEUvwbVpiURZg+P7zF74z5Jxe0UgJxVni+RtoHQ6IZieXaO02kmadomap/q+l6bc/jdPGGqTjhuZnuz1Q==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   '@humanfs/core@0.19.2':
@@ -2182,6 +2185,15 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@keyv/bigmap@1.3.1':
+    resolution: {integrity: sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      keyv: ^5.6.0
+
+  '@keyv/serialize@1.1.1':
+    resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
     resolution: {integrity: sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==}
@@ -3118,9 +3130,6 @@ packages:
   '@types/doctrine@0.0.9':
     resolution: {integrity: sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==}
 
-  '@types/eslint@9.6.1':
-    resolution: {integrity: sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==}
-
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
 
@@ -3173,55 +3182,55 @@ packages:
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
-  '@typescript-eslint/parser@8.61.1':
-    resolution: {integrity: sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==}
+  '@typescript-eslint/parser@8.69.0':
+    resolution: {integrity: sha512-l4b0DhWioGg6Gt2ebGlvfkFMOjRsauxtsnDRwUSRX1qHq3HdTfQHV8wW9zEXeciai6HfeaKOedQn2Zoofx3WBw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/project-service@8.61.1':
-    resolution: {integrity: sha512-PrC4JYGmR241lYnfhmKGTXkFqv8+ymbTFgSAY0fVXpY82/QkMw5TZPl+vGzuDDU2QYJk9fIDOBTntF+yDv9LEA==}
+  '@typescript-eslint/project-service@8.69.0':
+    resolution: {integrity: sha512-yi4obFrHMmnsesWehHbkg9zMA7Jt8cXT+mKM08G999pH1yT6nqgsHx7MYm0uY1wAj8CqiBXYRJ7WAT0QdQHQXg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/rule-tester@8.61.1':
-    resolution: {integrity: sha512-x7xp2GZaFcrXv2tuGN5Lcdd05BcPDaL2wSPpARPSbbRE7N2N46za+9NTAtb8NX5a9FfoDLkhLYDbJjngV8xYDA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/scope-manager@8.61.1':
-    resolution: {integrity: sha512-L2bdIeoQS8FlKAvONAr20w6OcLXeB+qiDKbAooS9A0Ben+iSIkBef0FxqwKWYqt5sa0i4KJtxVyVmhMylKzF5w==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/tsconfig-utils@8.61.1':
-    resolution: {integrity: sha512-UN/H4di+OO7EWx2ovME+8t31YO+KVnK0RRKEHR3kOt21/Ay8BOq3M1OMvWs5vNiqcFCYGYoxK3MXPZzmMUE+yg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/types@8.61.1':
-    resolution: {integrity: sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.61.1':
-    resolution: {integrity: sha512-u+oQD3BqYWPc8YV9Zab4vaJElJuwOLPRc10Jm1o/qS+6Qwen14HCWwx0Seo4LnSn2wxea2Ik8DxPt2/FHmuhrg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/utils@8.61.1':
-    resolution: {integrity: sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA==}
+  '@typescript-eslint/rule-tester@8.69.0':
+    resolution: {integrity: sha512-VHKAWEzEeB+XgLzgvkP3eFAkNaKhF1TEBZvjuZ9G8ySp4u6iZjnfBVBwEtXocO/a+g/B32II+WaSf5OcikmAyg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/visitor-keys@8.61.1':
-    resolution: {integrity: sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w==}
+  '@typescript-eslint/scope-manager@8.69.0':
+    resolution: {integrity: sha512-ewfspqWvSxKSOaplqAUNbaSFO0eB6w1EtQ+esfYFRm3614Ty4uNtExkcbgd6nWsXphbqKyf9ZYdbZdv2xEoWEQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.69.0':
+    resolution: {integrity: sha512-xNqK7YTDZsLniQMV/4rpFR8Z5JlqeRvVjuG1YgF/mdPVH84HSD19L8CczMA0qg2RfwEV231GHH3VnToJDo4MfQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/types@8.69.0':
+    resolution: {integrity: sha512-K3VrubUPhlo9VDBS6QdI8YB5j7ClpqLRdefcz6PFrhnwicehBweqQ9Evhl4l+FYz0HdDmMqIiSX0aldGRYtDCA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.69.0':
+    resolution: {integrity: sha512-AdFkgqck3Vudb/kWnxlyafU/4aBhHrbQ9locP2N4psXTy5mOBg0SHJumnLvx7r6g1gV4DKvUFwV2nJZBoqOD8w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.69.0':
+    resolution: {integrity: sha512-tUbx60BBqQa31kXF5MCsOOLL5E/WzUuxIn7YpAvq+eaUlqvk8/NXnXMBNAdLCr0icjkzem7iUA5QqWHe/hJ1aw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.69.0':
+    resolution: {integrity: sha512-+rmdgPA+EXkNgKYvHvFfhrs35utXbwaC5PGpDquSXcoXQDKUA5UjV0LmTucG/4JXkM31BTu4TilHtrN8IVBe8w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript/typescript-aix-ppc64@7.0.2':
@@ -3536,6 +3545,9 @@ packages:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
 
+  cacheable@2.5.0:
+    resolution: {integrity: sha512-60cyAOytib/OzBw1JNSoSV/boK1AtHryDIjvVBk7XbN4ugfkM3+Sry7fEjNgPMGgOjuaZPAp8ruZ0Cxafwyq9g==}
+
   caniuse-lite@1.0.30001810:
     resolution: {integrity: sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==}
 
@@ -3717,8 +3729,8 @@ packages:
     resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  eslint@10.5.0:
-    resolution: {integrity: sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==}
+  eslint@10.10.0:
+    resolution: {integrity: sha512-NPXn6r5zl4uET1DAVPaOwzX3rut4c0wcmw3dWJAfOsTM5+TogXo0DDjz8pwm/hL8cyVNpHqeK4JpN0NjnyFFNw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
     hasBin: true
     peerDependencies:
@@ -3793,9 +3805,8 @@ packages:
   fetchdts@0.1.7:
     resolution: {integrity: sha512-YoZjBdafyLIop9lSxXVI33oLD5kN31q4Td+CasofLLYeLXRFeOsuOw0Uo+XNRi9PZlbfdlN2GmRtm4tCEQ9/KA==}
 
-  file-entry-cache@8.0.0:
-    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
-    engines: {node: '>=16.0.0'}
+  file-entry-cache@11.1.5:
+    resolution: {integrity: sha512-+PFTHITI08JIGhnNpGNI8T8inUpgZfk3GNEqfT9R2zZV2iFXg3CvqzSl/uEhs7TSGujYRELEANyDvS8Fj7+S7Q==}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -3805,9 +3816,8 @@ packages:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
 
-  flat-cache@4.0.1:
-    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
-    engines: {node: '>=16'}
+  flat-cache@6.1.23:
+    resolution: {integrity: sha512-f++BY9pTk+983xK1FLzlLpmM0i0z+jHmx3QESGkURMXujQZz1k5wzwX6hjnQ8goaD0B+sYnDK1yZ6MTyZfUaqA==}
 
   flatted@3.4.4:
     resolution: {integrity: sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==}
@@ -3850,6 +3860,10 @@ packages:
     resolution: {integrity: sha512-4bRh1KzRvKDnFNTlLhzT1RZTpkKhQbQDl9j+7GXszWsvuspYdo29k6OHRf4PwiM6oLb8r/pMWeYiJjkfod5AvQ==}
     engines: {node: '>=20.0.0'}
 
+  hashery@1.5.1:
+    resolution: {integrity: sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==}
+    engines: {node: '>=20'}
+
   hasown@2.0.4:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
@@ -3859,6 +3873,12 @@ packages:
 
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  hookified@1.15.1:
+    resolution: {integrity: sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==}
+
+  hookified@2.2.0:
+    resolution: {integrity: sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==}
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
@@ -3948,9 +3968,6 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  json-buffer@3.0.1:
-    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
-
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
@@ -3969,8 +3986,8 @@ packages:
     resolution: {integrity: sha512-Vdw0ATsQ9V+LuegM/BTwQqV/6cTl5lbGcIrU+BCgLxyf6bo38ybOr372tuSIxir3CN720flu1meYR6XzNMwQnw==}
     hasBin: true
 
-  keyv@4.5.4:
-    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+  keyv@5.6.0:
+    resolution: {integrity: sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -4361,6 +4378,10 @@ packages:
 
   pure-rand@8.4.2:
     resolution: {integrity: sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==}
+
+  qified@0.10.1:
+    resolution: {integrity: sha512-+Owyggi9IxT1ePKGafcI87ubSmxol6smwJ+RAHDQlx9+9cPwFWDiKFFCPuWhr9ignlGpZ9vDQLw67N4dcTVFEA==}
+    engines: {node: '>=20'}
 
   react-aria-components@1.21.1:
     resolution: {integrity: sha512-J88WflYY0z+EhLX0ce+GjFlQ3ag3ubIgfUTjpKSrBQBu92Xtl4Ub9o118HItUddtbk1Ido0jzyPy94/klZy1hg==}
@@ -5041,6 +5062,18 @@ snapshots:
 
   '@blazediff/core@1.9.1': {}
 
+  '@cacheable/memory@2.2.0':
+    dependencies:
+      '@cacheable/utils': 2.5.0
+      '@keyv/bigmap': 1.3.1(keyv@5.6.0)
+      hookified: 1.15.1
+      keyv: 5.6.0
+
+  '@cacheable/utils@2.5.0':
+    dependencies:
+      hashery: 1.5.1
+      keyv: 5.6.0
+
   '@csstools/css-tokenizer@3.0.4': {}
 
   '@dual-bundle/import-meta-resolve@4.2.1': {}
@@ -5200,9 +5233,9 @@ snapshots:
   '@esbuild/win32-x64@0.28.2':
     optional: true
 
-  '@eslint-community/eslint-utils@4.10.1(eslint@10.5.0(jiti@2.7.0))':
+  '@eslint-community/eslint-utils@4.10.1(eslint@10.10.0(jiti@2.7.0))':
     dependencies:
-      eslint: 10.5.0(jiti@2.7.0)
+      eslint: 10.10.0(jiti@2.7.0)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
@@ -5215,7 +5248,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/config-helpers@0.6.0':
+  '@eslint/config-helpers@0.7.0':
     dependencies:
       '@eslint/core': 1.2.1
 
@@ -5225,7 +5258,7 @@ snapshots:
 
   '@eslint/object-schema@3.0.5': {}
 
-  '@eslint/plugin-kit@0.7.2':
+  '@eslint/plugin-kit@0.7.3':
     dependencies:
       '@eslint/core': 1.2.1
       levn: 0.4.1
@@ -5284,6 +5317,14 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.6.0
+
+  '@keyv/bigmap@1.3.1(keyv@5.6.0)':
+    dependencies:
+      hashery: 1.5.1
+      hookified: 1.15.1
+      keyv: 5.6.0
+
+  '@keyv/serialize@1.1.1': {}
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
     optional: true
@@ -6162,11 +6203,6 @@ snapshots:
 
   '@types/doctrine@0.0.9': {}
 
-  '@types/eslint@9.6.1':
-    dependencies:
-      '@types/estree': 1.0.9
-      '@types/json-schema': 7.0.15
-
   '@types/esrecurse@4.3.1': {}
 
   '@types/estree@1.0.9': {}
@@ -6213,34 +6249,34 @@ snapshots:
     dependencies:
       '@types/node': 26.5.0
 
-  '@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.69.0(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.61.1
-      '@typescript-eslint/types': 8.61.1
-      '@typescript-eslint/typescript-estree': 8.61.1(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.61.1
+      '@typescript-eslint/scope-manager': 8.69.0
+      '@typescript-eslint/types': 8.69.0
+      '@typescript-eslint/typescript-estree': 8.69.0(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.69.0
       debug: 4.4.3
-      eslint: 10.5.0(jiti@2.7.0)
+      eslint: 10.10.0(jiti@2.7.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.61.1(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.69.0(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.61.1(typescript@5.9.3)
-      '@typescript-eslint/types': 8.61.1
+      '@typescript-eslint/tsconfig-utils': 8.69.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.69.0
       debug: 4.4.3
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/rule-tester@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/rule-tester@8.69.0(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/parser': 8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.61.1(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.69.0(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.69.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.69.0(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3)
       ajv: 6.15.0
-      eslint: 10.5.0(jiti@2.7.0)
+      eslint: 10.10.0(jiti@2.7.0)
       json-stable-stringify-without-jsonify: 1.0.1
       lodash.merge: 4.6.2
       semver: 7.8.5
@@ -6248,23 +6284,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.61.1':
+  '@typescript-eslint/scope-manager@8.69.0':
     dependencies:
-      '@typescript-eslint/types': 8.61.1
-      '@typescript-eslint/visitor-keys': 8.61.1
+      '@typescript-eslint/types': 8.69.0
+      '@typescript-eslint/visitor-keys': 8.69.0
 
-  '@typescript-eslint/tsconfig-utils@8.61.1(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.69.0(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/types@8.61.1': {}
+  '@typescript-eslint/types@8.69.0': {}
 
-  '@typescript-eslint/typescript-estree@8.61.1(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.69.0(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.61.1(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.61.1(typescript@5.9.3)
-      '@typescript-eslint/types': 8.61.1
-      '@typescript-eslint/visitor-keys': 8.61.1
+      '@typescript-eslint/project-service': 8.69.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.69.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.69.0
+      '@typescript-eslint/visitor-keys': 8.69.0
       debug: 4.4.3
       minimatch: 10.2.6
       semver: 7.8.5
@@ -6274,20 +6310,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.69.0(eslint@10.10.0(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@10.5.0(jiti@2.7.0))
-      '@typescript-eslint/scope-manager': 8.61.1
-      '@typescript-eslint/types': 8.61.1
-      '@typescript-eslint/typescript-estree': 8.61.1(typescript@5.9.3)
-      eslint: 10.5.0(jiti@2.7.0)
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.10.0(jiti@2.7.0))
+      '@typescript-eslint/scope-manager': 8.69.0
+      '@typescript-eslint/types': 8.69.0
+      '@typescript-eslint/typescript-estree': 8.69.0(typescript@5.9.3)
+      eslint: 10.10.0(jiti@2.7.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/visitor-keys@8.61.1':
+  '@typescript-eslint/visitor-keys@8.69.0':
     dependencies:
-      '@typescript-eslint/types': 8.61.1
+      '@typescript-eslint/types': 8.69.0
       eslint-visitor-keys: 5.0.1
 
   '@typescript/typescript-aix-ppc64@7.0.2':
@@ -6552,6 +6588,14 @@ snapshots:
     dependencies:
       run-applescript: 7.1.0
 
+  cacheable@2.5.0:
+    dependencies:
+      '@cacheable/memory': 2.2.0
+      '@cacheable/utils': 2.5.0
+      hookified: 1.15.1
+      keyv: 5.6.0
+      qified: 0.10.1
+
   caniuse-lite@1.0.30001810: {}
 
   ccount@2.0.1: {}
@@ -6712,14 +6756,14 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.5.0(jiti@2.7.0):
+  eslint@10.10.0(jiti@2.7.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@10.5.0(jiti@2.7.0))
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.10.0(jiti@2.7.0))
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.23.5
-      '@eslint/config-helpers': 0.6.0
+      '@eslint/config-helpers': 0.7.0
       '@eslint/core': 1.2.1
-      '@eslint/plugin-kit': 0.7.2
+      '@eslint/plugin-kit': 0.7.3
       '@humanfs/node': 0.16.8
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
@@ -6734,7 +6778,7 @@ snapshots:
       esquery: 1.7.0
       esutils: 2.0.3
       fast-deep-equal: 3.1.3
-      file-entry-cache: 8.0.0
+      file-entry-cache: 11.1.5
       find-up: 5.0.0
       glob-parent: 6.0.2
       ignore: 5.3.2
@@ -6797,9 +6841,9 @@ snapshots:
 
   fetchdts@0.1.7: {}
 
-  file-entry-cache@8.0.0:
+  file-entry-cache@11.1.5:
     dependencies:
-      flat-cache: 4.0.1
+      flat-cache: 6.1.23
 
   fill-range@7.1.1:
     dependencies:
@@ -6810,10 +6854,11 @@ snapshots:
       locate-path: 6.0.0
       path-exists: 4.0.0
 
-  flat-cache@4.0.1:
+  flat-cache@6.1.23:
     dependencies:
+      cacheable: 2.5.0
       flatted: 3.4.4
-      keyv: 4.5.4
+      hookified: 1.15.1
 
   flatted@3.4.4: {}
 
@@ -6854,6 +6899,10 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  hashery@1.5.1:
+    dependencies:
+      hookified: 1.15.1
+
   hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
@@ -6875,6 +6924,10 @@ snapshots:
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.5
+
+  hookified@1.15.1: {}
+
+  hookified@2.2.0: {}
 
   html-void-elements@3.0.0: {}
 
@@ -6939,8 +6992,6 @@ snapshots:
 
   jsesc@3.1.0: {}
 
-  json-buffer@3.0.1: {}
-
   json-schema-traverse@0.4.1: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
@@ -6953,9 +7004,9 @@ snapshots:
     dependencies:
       commander: 8.3.0
 
-  keyv@4.5.4:
+  keyv@5.6.0:
     dependencies:
-      json-buffer: 3.0.1
+      '@keyv/serialize': 1.1.1
 
   levn@0.4.1:
     dependencies:
@@ -7476,6 +7527,10 @@ snapshots:
   punycode@2.3.1: {}
 
   pure-rand@8.4.2: {}
+
+  qified@0.10.1:
+    dependencies:
+      hookified: 2.2.0
 
   react-aria-components@1.21.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:


### PR DESCRIPTION
## Problem

The ESLint rule-testing cohort was behind the versions admitted by the updated Oxlint toolchain.

## Goal

Move ESLint to 10.10.0 and typescript-eslint to 8.69.0 while preserving `oxc-config` rule tests and the Nix-packaged lint toolchain.

## Decisions

This PR is stacked on the Oxlint alignment in #1234. ESLint and typescript-eslint move together because the rule tester and parser packages form one compatibility cohort. The isolated TypeScript 5.9.3 rule-test compiler from #1234 remains in effect. Effect stays at 4.0.0-rc.111 and Vitest stays at 4.1.9.

## Verification

- Exact reviewed head: `dba786f80424fd66be002551014b2d4f8625e87c`.
- GitHub Actions current-head CI: passed.
- Independent current-head review: approved with no blocking findings.
- Codex current-head review: no major issues.
- ESLint: 10.10.0; typescript-eslint: 8.69.0.
- `oxc-config`: 389 tests passed.
- Actual type-aware Oxlint gate: zero warnings and zero errors.
- Buck dependency tests: 56 passed; Genie Buck tests: 33 passed; catalog duplicate tests: 15 passed.
- Full Effect tsgo check, Genie check, oxfmt, and changed-file lint checks: passed.
- Lock/Buck/sidecar projections and all eight pnpm fixed-output derivations: verified.
- Removed `@types/eslint` and the unused `typescript-eslint` meta-package; regenerated dependency counts and strongly connected components match the lock.

The separate worktree-lifecycle repair is #1250 with downstream schickling/dotfiles#2647 and is outside this stack. That current-`main` defect prevents the normal project-wide local gate; focused gates and exact current-head CI cover this PR.

## Complexity

No new abstraction. This updates the existing rule-testing compatibility cohort.

## Concerns

The TypeScript compatibility boundary introduced in #1234 remains in effect for this toolchain.

## Follow-ups

Merge after #1234 and before the KaTeX update in #1242.

## References

- Preceding stacked PR: #1234
- Next stacked PR: #1242
- Separate lifecycle repair: #1250
- Downstream lifecycle adoption: schickling/dotfiles#2647

<!-- agent-footer:begin v=2 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | dev3.direct.omp.nsyk4mvc |
| `session` | dev3.nsyk4mvc |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.1.7 |
| `agent_runtime` | OMP 18.1.7 |
| `tooling_profile` | dotfiles@8d937c9 |
</details>
<!-- agent-footer:end -->