### PR TITLE
fix(genie): drop stale peerDependencyRules allowedVersions for typescript, eslint, vitest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,14 @@ All notable changes to this project will be documented in this file.
 
 ### Removed
 
+- **genie**: the stale `peerDependencyRules.allowedVersions` entries for
+  `typescript`, `eslint`, and `vitest` are gone from
+  `commonPnpmPolicySettings` (and their restatements in `genie/internal.ts`).
+  The validator reported all three as suppressing no catalog conflict:
+  `typescript-eslint` ranges now cover catalog eslint 10 / TS 6, and
+  `@effect/vitest` peers cover catalog vitest 4. The live `unplugin`
+  entry is untouched. Regenerated `pnpm-workspace.yaml` accordingly.
+
 - **@overeng/megarepo**: the deprecated `MegarepoStore` members `getRepoPath`
   and `hasRepo` are gone. Both were aliases kept only for the rename:
   `getRepoPath` returned exactly what `getRepoBasePath` returns, and `hasRepo`

--- a/genie/external.ts
+++ b/genie/external.ts
@@ -502,11 +502,6 @@ export const commonPnpmPolicySettings = {
   strictPeerDependencies: true as const,
   peerDependencyRules: {
     allowedVersions: {
-      // bun-ffi-structs@0.2.3 (via @myobie/pty) declares typescript ^5 but the
-      // repo compiles with TS 6; resolution is proven fine.
-      typescript: '>=6.0.0',
-      eslint: '>=10.0.0',
-      vitest: '>=4.0.0',
       // @stylexjs/unplugin@0.19 declares unplugin ^2 but works with v3;
       // proven by the effect-schema-form-aria StyleX pilot (build + storybook).
       unplugin: '>=3.0.0',

--- a/genie/internal.ts
+++ b/genie/internal.ts
@@ -158,9 +158,6 @@ export const commonPnpmWorkspaceData = {
     // entries instead of shadowing them.
     allowedVersions: {
       ...commonPnpmPolicySettings.peerDependencyRules.allowedVersions,
-      typescript: '>=6.0.0',
-      eslint: '>=10.0.0',
-      vitest: '>=4.0.0',
     },
   },
 }

--- a/pnpm-install-contract.json
+++ b/pnpm-install-contract.json
@@ -46,10 +46,7 @@
     },
     "peerDependencyRules": {
       "allowedVersions": {
-        "eslint": ">=10.0.0",
-        "typescript": ">=6.0.0",
-        "unplugin": ">=3.0.0",
-        "vitest": ">=4.0.0"
+        "unplugin": ">=3.0.0"
       }
     },
     "pmOnFail": "ignore",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -53,9 +53,6 @@ packageExtensions:
 
 peerDependencyRules:
   allowedVersions:
-    typescript: '>=6.0.0'
-    eslint: '>=10.0.0'
-    vitest: '>=4.0.0'
     unplugin: '>=3.0.0'
 
 allowBuilds:


### PR DESCRIPTION
The catalog-peer-deps validator reports all three entries as suppressing no catalog conflict: typescript-eslint ranges now cover catalog eslint 10 / TS 6, and @effect/vitest peers cover catalog vitest 4. The live unplugin entry is untouched; pnpm-workspace.yaml regenerated.

Verified: genie:run validation clean of stale-entry warnings; catalog-peer-deps unit tests 10/10.

Note: full genie:check shell realization is blocked on main by a pre-existing unrelated oxc-config-pnpm-deps FOD drift (specified VF5g..., got V873...), untouched by this change — flagging in case CI trips on it. Happy to refresh that hash in this PR if preferred.