### PR TITLE
docs: remove retired tracker history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2772,15 +2772,9 @@ signal <NAME>`) on non-zero exit; bound `process.executable.name` / the span
 - **devenv/tasks/shared/ts.nix**: Fix `ts:emit` missing `--build` flag
   - `tscWithDiagnostics` was called without `--build`, causing tsc to treat `tsconfig.all.json` as a source file
   - Previously masked by `setup:opt:*` wrappers silently swallowing the failure
-- **beads packaging**: Avoid long emulated builds by using patched prebuilt `bd` release binaries (v0.55.4)
-  - `nix/beads.nix` now fetches release tarballs instead of compiling Go sources under QEMU
-  - Linux binaries are patched with Nix loader/RPATH (`icu74`) so Dolt-enabled `bd` runs correctly
 - **@overeng/genie**: `genie --check` now fails fast on fatal `.genie.ts` import/build errors and marks interrupted sibling checks as canceled
   - Prevents indefinite stalls when a sibling check remains in-flight after a fatal import/build failure
   - Final JSON/TUI failure state is reconciled from `GenieGenerationFailedError.files` to avoid stale `active` entries
-- **beads packaging/tasks**: Fix `bd` Dolt startup failures on macOS by building with CGO enabled and updating beads task/hook invocations for current CLI flags
-  - `nix/beads.nix` now builds `bd` from source (`buildGo126Module`) with CGO + ICU/SQLite inputs instead of prebuilt no-CGO release tarballs
-  - `nix/devenv-modules/tasks/shared/beads.nix` now uses Dolt-directory bootstrap checks and removes deprecated `--no-daemon/--no-db` flag usage
 
 ### Changed
 


### PR DESCRIPTION
## Problem

The changelog still described packaging and task integrations for the retired Beads issue tracker, although those integrations no longer exist.

## Goal

Remove the remaining tracker-specific references from current repository content.

## Decisions

This intentionally removes historical release-note entries. The cross-repository cleanup policy is to purge retired tracker-specific names and IDs while preserving unrelated terminology.

## Verification

- `git diff --check` passed.
- A tracked-content scan found no remaining tracker-specific references.
- `CI=1 devenv tasks run check:all --no-tui` did not complete: the existing `mr:apply` failure tracked in #2602 removed the active worktree and caused dependent tasks to fail because `packages/@overeng/megarepo/bin/mr.ts` disappeared. The one-file change was reapplied in a fresh branchy-managed worktree.

## Complexity

No new complexity. This deletes six changelog lines.

## Concerns

The full local gate remains blocked by #2602. This PR should stay draft until that gate can run safely.

## Friction & bottlenecks

The known #2602 worktree-deletion failure reproduced during validation.

## Follow-ups

- Re-run `check:all` after #2602 is resolved.

## References

- Refs #2602

<!-- agent-footer:begin v=2 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | dev3.direct.omp.wndc6qug |
| `session` | dev3.wndc6qug |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.1.14 |
| `agent_runtime` | OMP 18.1.14 |
| `tooling_profile` | dotfiles@2cf3530 |
</details>
<!-- agent-footer:end -->