### PR TITLE
feat(gh-ci-utils): inspect Namespace runner jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ All notable changes to this project will be documented in this file.
 - **@overeng/gh-ci-utils**: Preserve runner identity and step details in
   status JSON and NDJSON output.
 
+- **@overeng/gh-ci-utils**: Add `inspect` to correlate GitHub job facts with
+  Namespace runner state and resource usage.
+
 - **Buck2 (context)**: decision 0030 — git external cells are not a
   member-mount mechanism (the physical `buck-out/.../git/<sha>` path enters
   the input Merkle tree, so an external cell's action digests diverge from

--- a/packages/@overeng/gh-ci-utils/src/cli.ts
+++ b/packages/@overeng/gh-ci-utils/src/cli.ts
@@ -6,6 +6,7 @@
 import * as Cli from 'effect/unstable/cli'
 
 import { authCommand } from './node/commands/auth.ts'
+import { inspectCommand } from './node/commands/inspect.ts'
 import { logsCommand } from './node/commands/logs.ts'
 import { cancelCommand, rerunCommand, runCommand } from './node/commands/rerun.ts'
 import { runnersCommand } from './node/commands/runners.ts'
@@ -20,6 +21,7 @@ export const ghCiUtilsCommand = Cli.Command.make('gh-ci-utils').pipe(
     rerunCommand,
     cancelCommand,
     authCommand,
+    inspectCommand,
     runnersCommand,
   ]),
   Cli.Command.withDescription(

--- a/packages/@overeng/gh-ci-utils/src/isomorphic/lib/inspectAssessment.ts
+++ b/packages/@overeng/gh-ci-utils/src/isomorphic/lib/inspectAssessment.ts
@@ -84,6 +84,16 @@ export const classifyInspection = ({
       : ` (reported as "${job.instanceStatusRaw}")`
   }.`
 
+  if (github.runnerInstance !== job.instanceId) {
+    return {
+      disposition: 'unknown',
+      evidence: [githubEvidence, instanceEvidence],
+      limitations: [
+        `GitHub identifies runner instance ${github.runnerInstance ?? '(none)'}, but Namespace reported ${job.instanceId}; the observations cannot be correlated.`,
+      ],
+    }
+  }
+
   /**
    * Pressure outranks liveness: a runner pinned at its allocation is the
    * actionable finding whether or not the job is still moving.

--- a/packages/@overeng/gh-ci-utils/src/isomorphic/lib/inspectAssessment.ts
+++ b/packages/@overeng/gh-ci-utils/src/isomorphic/lib/inspectAssessment.ts
@@ -1,0 +1,170 @@
+/**
+ * Pure classifier for `gh-ci-utils inspect`.
+ *
+ * The rule this file exists to enforce: a disposition may only be claimed from
+ * an observation that was actually made. Everything unobserved collapses to
+ * `unknown` with the reason recorded in `limitations`, so a missing `nsc`, a
+ * non-Namespace runner and a runner we genuinely cannot read are all reported
+ * as what they are instead of being rounded into a verdict.
+ *
+ * Precedence, highest first:
+ *   1. `resource-pressure` — a usage sample at or above the pressure threshold.
+ *   2. `active`            — GitHub and Namespace agree the job is running.
+ *   3. `idle`              — a live instance with no running GitHub job.
+ *   4. `unknown`           — anything missing, conflicting, or unobservable.
+ */
+import {
+  type InspectAssessment,
+  type InspectGitHubFacts,
+  type InspectNamespaceFacts,
+  type NamespaceUsageState,
+  RESOURCE_PRESSURE_FRACTION,
+} from './inspectFacts.ts'
+
+const percent = (fraction: number): string => `${(fraction * 100).toFixed(1)}%`
+
+/** The limitation to record when there is no usage sample to reason about. */
+const usageLimitation = (usage: NamespaceUsageState): string | null => {
+  switch (usage._tag) {
+    case 'sampled':
+      return null
+    case 'not-requested':
+      return 'No resource usage sampled (pass --with-usage); resource pressure cannot be claimed.'
+    case 'unavailable':
+      return `No resource usage sampled (${usage.reason}${usage.detail === null ? '' : `: ${usage.detail}`}); resource pressure cannot be claimed.`
+  }
+}
+
+/**
+ * Classify a runner from the GitHub and Namespace facts.
+ *
+ * Isomorphic and total: no I/O, no clock, no throwing.
+ */
+export const classifyInspection = ({
+  github,
+  namespace,
+}: {
+  readonly github: InspectGitHubFacts
+  readonly namespace: InspectNamespaceFacts
+}): InspectAssessment => {
+  /** Only `in_progress` means the job is executing on its runner right now. */
+  const githubRunning = github.status === 'in_progress'
+  const githubEvidence = `GitHub reports job ${github.jobId} as ${github.status}${
+    github.conclusion === null ? '' : ` (${github.conclusion})`
+  }.`
+
+  if (namespace._tag === 'not-namespace-job') {
+    return {
+      disposition: 'unknown',
+      evidence: [githubEvidence],
+      limitations: [
+        `Runner ${github.runnerName ?? '(none assigned)'} is ${
+          namespace.runnerKind === 'unknown' ? 'not assigned' : `a ${namespace.runnerKind} runner`
+        }, so Namespace holds no observation for it.`,
+      ],
+    }
+  }
+
+  if (namespace._tag === 'unavailable') {
+    return {
+      disposition: 'unknown',
+      evidence: [githubEvidence],
+      limitations: [
+        `No Namespace observation (${namespace.reason}${
+          namespace.detail === null ? '' : `: ${namespace.detail}`
+        }).`,
+      ],
+    }
+  }
+
+  const { job, usage } = namespace
+  const instanceEvidence = `Namespace instance ${job.instanceId} is ${job.instanceStatus}${
+    job.instanceStatusRaw === null || job.instanceStatusRaw === job.instanceStatus
+      ? ''
+      : ` (reported as "${job.instanceStatusRaw}")`
+  }.`
+
+  /**
+   * Pressure outranks liveness: a runner pinned at its allocation is the
+   * actionable finding whether or not the job is still moving.
+   */
+  if (usage._tag === 'sampled') {
+    const { sample } = usage
+    const cpuPressure = sample.cpuMaxFraction >= RESOURCE_PRESSURE_FRACTION
+    const ramPressure = sample.ramMaxFraction >= RESOURCE_PRESSURE_FRACTION
+    const usageEvidence = `Peak usage ${percent(sample.cpuMaxFraction)} of ${sample.allocatedCpu} allocated CPU and ${percent(sample.ramMaxFraction)} of ${sample.allocatedRamGb} GB allocated RAM.`
+
+    if (cpuPressure || ramPressure) {
+      return {
+        disposition: 'resource-pressure',
+        evidence: [
+          githubEvidence,
+          instanceEvidence,
+          usageEvidence,
+          `At or above the ${percent(RESOURCE_PRESSURE_FRACTION)} pressure threshold on ${
+            cpuPressure && ramPressure ? 'CPU and RAM' : cpuPressure ? 'CPU' : 'RAM'
+          }.`,
+        ],
+        limitations: [],
+      }
+    }
+
+    if (job.instanceStatus === 'running') {
+      return githubRunning
+        ? {
+            disposition: 'active',
+            evidence: [githubEvidence, instanceEvidence, usageEvidence],
+            limitations: [],
+          }
+        : {
+            disposition: 'idle',
+            evidence: [githubEvidence, instanceEvidence, usageEvidence],
+            limitations: [],
+          }
+    }
+
+    return {
+      disposition: 'unknown',
+      evidence: [githubEvidence, instanceEvidence, usageEvidence],
+      limitations: [unmatchedLiveness({ githubRunning, instanceStatus: job.instanceStatus })],
+    }
+  }
+
+  const noUsage = usageLimitation(usage)
+  const limitations = noUsage === null ? [] : [noUsage]
+
+  if (job.instanceStatus === 'running') {
+    return {
+      disposition: githubRunning ? 'active' : 'idle',
+      evidence: [githubEvidence, instanceEvidence],
+      limitations,
+    }
+  }
+
+  return {
+    disposition: 'unknown',
+    evidence: [githubEvidence, instanceEvidence],
+    limitations: [
+      unmatchedLiveness({ githubRunning, instanceStatus: job.instanceStatus }),
+      ...limitations,
+    ],
+  }
+}
+
+/** Why a live/not-live pairing cannot be turned into `active` or `idle`. */
+const unmatchedLiveness = ({
+  githubRunning,
+  instanceStatus,
+}: {
+  readonly githubRunning: boolean
+  readonly instanceStatus: 'destroyed' | 'unknown'
+}): string => {
+  if (instanceStatus === 'unknown') {
+    return githubRunning
+      ? 'Namespace did not report instance liveness, so a running GitHub job cannot be confirmed on the runner.'
+      : 'Namespace did not report instance liveness, so the runner cannot be called idle.'
+  }
+  return githubRunning
+    ? 'GitHub reports the job running but Namespace reports the instance destroyed; the two sources disagree.'
+    : 'The instance is gone, so there is no live runner to describe.'
+}

--- a/packages/@overeng/gh-ci-utils/src/isomorphic/lib/inspectFacts.ts
+++ b/packages/@overeng/gh-ci-utils/src/isomorphic/lib/inspectFacts.ts
@@ -1,0 +1,238 @@
+/**
+ * Fact schemas for `gh-ci-utils inspect --job <id>`.
+ *
+ * The command reports two independently-sourced fact groups and one derived
+ * verdict, and the JSON contract keeps them structurally apart:
+ *
+ * - `github` — what the GitHub Actions API said about the job.
+ * - `namespace` — what the local `nsc` session said about the instance that ran it.
+ * - `assessment` — the only derived value, carrying its own evidence and limitations.
+ *
+ * Nothing here transforms dates: timings stay verbatim ISO strings so a
+ * consumer can recompute anything we chose not to.
+ */
+import { Schema } from 'effect'
+
+import type { WorkflowJob } from '../GitHubSchemas.ts'
+import { computeDurationSeconds, parseRunnerIdentity } from './format.ts'
+import { RunnerKind, StepInfoSchema } from './viewModels.ts'
+
+// =============================================================================
+// GitHub facts
+// =============================================================================
+
+/**
+ * The single job GitHub reported, with its runner identity and step timings
+ * preserved rather than summarised away.
+ */
+export const InspectGitHubFactsSchema = Schema.Struct({
+  repo: Schema.String,
+  jobId: Schema.Finite,
+  runId: Schema.Finite,
+  name: Schema.String,
+  status: Schema.String,
+  conclusion: Schema.NullOr(Schema.String),
+  /** Verbatim `started_at` — `null` while the job is still queued. */
+  startedAt: Schema.NullOr(Schema.String),
+  /** Verbatim `completed_at` — `null` while the job is still running. */
+  completedAt: Schema.NullOr(Schema.String),
+  durationSeconds: Schema.Finite,
+  /** Raw `runner_name`, exactly as GitHub reported it. */
+  runnerName: Schema.NullOr(Schema.String),
+  runnerKind: RunnerKind,
+  runnerInstance: Schema.NullOr(Schema.String),
+  labels: Schema.Array(Schema.String),
+  steps: Schema.Array(StepInfoSchema),
+}).annotate({ identifier: 'Inspect.GitHubFacts' })
+export type InspectGitHubFacts = typeof InspectGitHubFactsSchema.Type
+
+// =============================================================================
+// Namespace facts
+// =============================================================================
+
+/**
+ * Liveness of the Namespace instance that ran the job.
+ *
+ * `unknown` is load-bearing: `nsc`'s JSON shape is not contractually stable, so
+ * a field we did not recognise must never be read as "destroyed".
+ */
+export const NamespaceInstanceStatus = Schema.Literals(['running', 'destroyed', 'unknown'])
+export type NamespaceInstanceStatus = typeof NamespaceInstanceStatus.Type
+
+/** What `nsc github job describe` told us about the instance behind a job. */
+export const NamespaceJobFactsSchema = Schema.Struct({
+  instanceId: Schema.String,
+  instanceStatus: NamespaceInstanceStatus,
+  /** The raw status string the CLI printed, kept even when unrecognised. */
+  instanceStatusRaw: Schema.NullOr(Schema.String),
+  runnerName: Schema.NullOr(Schema.String),
+  containerName: Schema.NullOr(Schema.String),
+  repository: Schema.NullOr(Schema.String),
+  workflow: Schema.NullOr(Schema.String),
+  jobName: Schema.NullOr(Schema.String),
+  destroyedAt: Schema.NullOr(Schema.String),
+}).annotate({ identifier: 'Inspect.NamespaceJobFacts' })
+export type NamespaceJobFacts = typeof NamespaceJobFactsSchema.Type
+
+/**
+ * One instance row from `nsc instance report`.
+ *
+ * `cpuMaxFraction` and `ramMaxFraction` are fractions of the *allocated*
+ * resources (the report's `resources_cpu_actual_max` and
+ * `resources_ram_gb_actual_max_percent`), so `0.95` means 95% of the allocation.
+ */
+export const NamespaceUsageSchema = Schema.Struct({
+  instanceId: Schema.String,
+  githubJobId: Schema.String,
+  allocatedCpu: Schema.Finite,
+  allocatedRamGb: Schema.Finite,
+  cpuMaxFraction: Schema.Finite,
+  ramMaxFraction: Schema.Finite,
+  createdAt: Schema.NullOr(Schema.String),
+  startedAt: Schema.NullOr(Schema.String),
+  destroyedAt: Schema.NullOr(Schema.String),
+}).annotate({ identifier: 'Inspect.NamespaceUsage' })
+export type NamespaceUsage = typeof NamespaceUsageSchema.Type
+
+/** Why a usage sample is missing. Never a reason to invent one. */
+export const NamespaceUsageUnavailableReason = Schema.Literals([
+  /** GitHub gave no timestamps, so no bounded report window could be derived. */
+  'no-window',
+  /** The report came back, but held no row for this job and instance. */
+  'no-matching-row',
+  'nsc-missing',
+  'not-authenticated',
+  'command-failed',
+  'timed-out',
+  'unrecognized-output',
+])
+export type NamespaceUsageUnavailableReason = typeof NamespaceUsageUnavailableReason.Type
+
+/** Usage evidence, or the reason there is none. */
+export const NamespaceUsageStateSchema = Schema.Union([
+  Schema.TaggedStruct('sampled', { sample: NamespaceUsageSchema }),
+  /** The caller did not pass `--with-usage`, so no report was requested. */
+  Schema.TaggedStruct('not-requested', {}),
+  Schema.TaggedStruct('unavailable', {
+    reason: NamespaceUsageUnavailableReason,
+    detail: Schema.NullOr(Schema.String),
+  }),
+]).annotate({ identifier: 'Inspect.NamespaceUsageState' })
+export type NamespaceUsageState = typeof NamespaceUsageStateSchema.Type
+
+/** Why the Namespace side holds no observation. All of these are ordinary data. */
+export const NamespaceUnavailableReason = Schema.Literals([
+  /** No `nsc` on PATH — expected on machines that never talk to Namespace. */
+  'nsc-missing',
+  /** `nsc auth check-login` refused: there is no usable ambient session. */
+  'not-authenticated',
+  'command-failed',
+  'timed-out',
+  /** `nsc` answered, but not in a shape we can read without guessing. */
+  'unrecognized-output',
+  /** `nsc` does not know this job id. */
+  'job-not-found',
+])
+export type NamespaceUnavailableReason = typeof NamespaceUnavailableReason.Type
+
+/**
+ * The Namespace observation, kept structurally separate from the assessment so
+ * a consumer can always tell an absent observation from a negative one.
+ */
+export const InspectNamespaceFactsSchema = Schema.Union([
+  Schema.TaggedStruct('reported', {
+    job: NamespaceJobFactsSchema,
+    usage: NamespaceUsageStateSchema,
+    /** Exactly the read-only argv this run executed, in order. */
+    commands: Schema.Array(Schema.Array(Schema.String)),
+  }),
+  /**
+   * GitHub says the job did not run on a Namespace runner, so no `nsc` command
+   * was executed at all.
+   */
+  Schema.TaggedStruct('not-namespace-job', { runnerKind: RunnerKind }),
+  Schema.TaggedStruct('unavailable', {
+    reason: NamespaceUnavailableReason,
+    detail: Schema.NullOr(Schema.String),
+    commands: Schema.Array(Schema.Array(Schema.String)),
+  }),
+]).annotate({ identifier: 'Inspect.NamespaceFacts' })
+export type InspectNamespaceFacts = typeof InspectNamespaceFactsSchema.Type
+
+// =============================================================================
+// Assessment
+// =============================================================================
+
+/**
+ * The only four things this command is willing to claim about a runner.
+ *
+ * There is deliberately no "healthy" or "stuck": both would need evidence
+ * neither GitHub nor `nsc` provides.
+ */
+export const InspectDisposition = Schema.Literals([
+  'active',
+  'idle',
+  'resource-pressure',
+  'unknown',
+])
+export type InspectDisposition = typeof InspectDisposition.Type
+
+/** A disposition plus what it rests on and what it could not see. */
+export const InspectAssessmentSchema = Schema.Struct({
+  disposition: InspectDisposition,
+  /** Observations that support the disposition. */
+  evidence: Schema.Array(Schema.String),
+  /** What was not observable, and therefore not claimed. */
+  limitations: Schema.Array(Schema.String),
+}).annotate({ identifier: 'Inspect.Assessment' })
+export type InspectAssessment = typeof InspectAssessmentSchema.Type
+
+/**
+ * Fraction of allocated CPU or RAM at or above which a runner is reported as
+ * under resource pressure.
+ */
+export const RESOURCE_PRESSURE_FRACTION = 0.95
+
+/**
+ * Map the raw GitHub job onto inspect's GitHub facts.
+ *
+ * The API's decoded `Date`s go back out as verbatim ISO strings, and every
+ * step is carried through with its own timings: this command exists to explain
+ * a runner, so throwing away the timing data it would be explained from
+ * defeats the point.
+ */
+export const toInspectGitHubFacts = ({
+  job,
+  repo,
+}: {
+  readonly job: WorkflowJob
+  readonly repo: string
+}): InspectGitHubFacts => {
+  const identity = parseRunnerIdentity(job.runner_name)
+  return {
+    repo,
+    jobId: job.id,
+    runId: job.run_id,
+    name: job.name,
+    status: job.status,
+    conclusion: job.conclusion,
+    startedAt: job.started_at?.toISOString() ?? null,
+    completedAt: job.completed_at?.toISOString() ?? null,
+    durationSeconds: computeDurationSeconds({
+      startedAt: job.started_at,
+      completedAt: job.completed_at,
+    }),
+    runnerName: job.runner_name,
+    runnerKind: identity._tag,
+    runnerInstance: identity.instance,
+    labels: job.labels,
+    steps: job.steps.map((step) => ({
+      name: step.name,
+      status: step.status,
+      conclusion: step.conclusion,
+      number: step.number,
+      startedAt: step.started_at?.toISOString() ?? null,
+      completedAt: step.completed_at?.toISOString() ?? null,
+    })),
+  }
+}

--- a/packages/@overeng/gh-ci-utils/src/isomorphic/lib/inspectFacts.ts
+++ b/packages/@overeng/gh-ci-utils/src/isomorphic/lib/inspectFacts.ts
@@ -208,7 +208,7 @@ export const toInspectGitHubFacts = ({
   readonly job: WorkflowJob
   readonly repo: string
 }): InspectGitHubFacts => {
-  const identity = parseRunnerIdentity(job.runner_name)
+  const identity = parseRunnerIdentity({ name: job.runner_name, labels: job.labels })
   return {
     repo,
     jobId: job.id,

--- a/packages/@overeng/gh-ci-utils/src/isomorphic/renderers/CiOutput/ndjson.ts
+++ b/packages/@overeng/gh-ci-utils/src/isomorphic/renderers/CiOutput/ndjson.ts
@@ -67,7 +67,6 @@ export const CiWatchTerminated = Schema.TaggedStruct('WatchTerminated', {
   reason: Schema.Literal('FirstFailure'),
   message: Schema.String,
 }).annotate({ identifier: 'CiNdjson.WatchTerminated' })
-
 /** Event emitted when PR health data is available or changes */
 export const CiPrHealth = Schema.TaggedStruct('PrHealth', {
   prNumber: Schema.Finite,
@@ -188,7 +187,6 @@ export const fromCiAction = ({
   if (action._tag === 'WatchTerminated') {
     return [{ _tag: 'WatchTerminated', reason: action.reason, message: action.message }] as const
   }
-
   if (action._tag !== 'SetLoaded') return [] as const
 
   const events: CiNdjsonEvent[] = []

--- a/packages/@overeng/gh-ci-utils/src/isomorphic/renderers/CiOutput/ndjson.ts
+++ b/packages/@overeng/gh-ci-utils/src/isomorphic/renderers/CiOutput/ndjson.ts
@@ -67,6 +67,7 @@ export const CiWatchTerminated = Schema.TaggedStruct('WatchTerminated', {
   reason: Schema.Literal('FirstFailure'),
   message: Schema.String,
 }).annotate({ identifier: 'CiNdjson.WatchTerminated' })
+
 /** Event emitted when PR health data is available or changes */
 export const CiPrHealth = Schema.TaggedStruct('PrHealth', {
   prNumber: Schema.Finite,
@@ -187,6 +188,7 @@ export const fromCiAction = ({
   if (action._tag === 'WatchTerminated') {
     return [{ _tag: 'WatchTerminated', reason: action.reason, message: action.message }] as const
   }
+
   if (action._tag !== 'SetLoaded') return [] as const
 
   const events: CiNdjsonEvent[] = []

--- a/packages/@overeng/gh-ci-utils/src/isomorphic/renderers/InspectOutput/app.ts
+++ b/packages/@overeng/gh-ci-utils/src/isomorphic/renderers/InspectOutput/app.ts
@@ -1,0 +1,27 @@
+import { createTuiApp } from '@overeng/tui-react'
+
+import {
+  type InspectState,
+  InspectActionSchema,
+  InspectStateSchema,
+  createInitialInspectState,
+  inspectReducer,
+} from './schema.ts'
+
+/**
+ * Exit code for an inspect run.
+ *
+ * Every loaded diagnosis exits 0 — including `unknown` and
+ * `resource-pressure`. A nonzero code would tell a caller its *command*
+ * failed, which is a different claim from what it observed about a runner.
+ */
+export const inspectExitCode = (state: InspectState): number => (state._tag === 'Error' ? 1 : 0)
+
+/** TUI app definition for inspect output */
+export const InspectApp = createTuiApp({
+  stateSchema: InspectStateSchema,
+  actionSchema: InspectActionSchema,
+  initial: createInitialInspectState(),
+  reducer: inspectReducer,
+  exitCode: inspectExitCode,
+})

--- a/packages/@overeng/gh-ci-utils/src/isomorphic/renderers/InspectOutput/mod.ts
+++ b/packages/@overeng/gh-ci-utils/src/isomorphic/renderers/InspectOutput/mod.ts
@@ -1,0 +1,12 @@
+export {
+  InspectActionSchema,
+  InspectStateSchema,
+  InspectionSchema,
+  createInitialInspectState,
+  inspectReducer,
+  type Inspection,
+  type InspectAction,
+  type InspectState,
+} from './schema.ts'
+export { InspectApp, inspectExitCode } from './app.ts'
+export { InspectView, type InspectViewProps } from './view.tsx'

--- a/packages/@overeng/gh-ci-utils/src/isomorphic/renderers/InspectOutput/schema.ts
+++ b/packages/@overeng/gh-ci-utils/src/isomorphic/renderers/InspectOutput/schema.ts
@@ -1,0 +1,89 @@
+/**
+ * Inspect command state machine.
+ *
+ * State transitions: Loading -> Loaded | Error
+ *
+ * `Loaded` is the diagnostic outcome and always exits 0, whatever the
+ * assessment says: "this runner could not be observed" is a successful
+ * diagnosis, not a command failure. Only a failure to run the command at all
+ * (no repo, GitHub unreachable, unknown job) reaches `Error`.
+ */
+import { Schema } from 'effect'
+
+import { ApiMetaSchema, defaultApiMeta } from '../../lib/apiMeta.ts'
+import {
+  InspectAssessmentSchema,
+  InspectGitHubFactsSchema,
+  InspectNamespaceFactsSchema,
+} from '../../lib/inspectFacts.ts'
+
+/**
+ * The three fact groups a consumer sees, kept apart on purpose: `github` and
+ * `namespace` are observations, `assessment` is the only derived value.
+ */
+export const InspectionSchema = Schema.Struct({
+  github: InspectGitHubFactsSchema,
+  namespace: InspectNamespaceFactsSchema,
+  assessment: InspectAssessmentSchema,
+}).annotate({ identifier: 'Inspect.Inspection' })
+export type Inspection = typeof InspectionSchema.Type
+
+/** Renderer state for the inspect view */
+export const InspectStateSchema = Schema.Union([
+  Schema.TaggedStruct('Loading', { message: Schema.String, _meta: ApiMetaSchema }),
+  Schema.TaggedStruct('Loaded', {
+    github: InspectGitHubFactsSchema,
+    namespace: InspectNamespaceFactsSchema,
+    assessment: InspectAssessmentSchema,
+    _meta: ApiMetaSchema,
+  }),
+  Schema.TaggedStruct('Error', {
+    error: Schema.String,
+    message: Schema.String,
+    _meta: ApiMetaSchema,
+  }),
+])
+export type InspectState = typeof InspectStateSchema.Type
+
+/** Actions dispatched to update the inspect state */
+export const InspectActionSchema = Schema.Union([
+  Schema.TaggedStruct('SetInspection', {
+    github: InspectGitHubFactsSchema,
+    namespace: InspectNamespaceFactsSchema,
+    assessment: InspectAssessmentSchema,
+  }),
+  Schema.TaggedStruct('SetError', { error: Schema.String, message: Schema.String }),
+  Schema.TaggedStruct('SetMeta', { _meta: ApiMetaSchema }),
+])
+export type InspectAction = typeof InspectActionSchema.Type
+
+/** State reducer for inspect view transitions */
+export const inspectReducer = ({
+  state,
+  action,
+}: {
+  state: InspectState
+  action: InspectAction
+}): InspectState => {
+  switch (action._tag) {
+    case 'SetInspection':
+      return {
+        _tag: 'Loaded',
+        github: action.github,
+        namespace: action.namespace,
+        assessment: action.assessment,
+        _meta: state._meta,
+      }
+    case 'SetError':
+      return { _tag: 'Error', error: action.error, message: action.message, _meta: state._meta }
+    case 'SetMeta':
+      return { ...state, _meta: action._meta }
+  }
+}
+
+/** Create the initial inspect state */
+export const createInitialInspectState = (): InspectState => ({
+  _tag: 'Loading',
+  message: 'Inspecting job...',
+  _meta: defaultApiMeta,
+})

--- a/packages/@overeng/gh-ci-utils/src/isomorphic/renderers/InspectOutput/stories/Active.stories.tsx
+++ b/packages/@overeng/gh-ci-utils/src/isomorphic/renderers/InspectOutput/stories/Active.stories.tsx
@@ -1,0 +1,53 @@
+/** A running job on a live Namespace instance: both sources agree. */
+
+import type { Meta, StoryObj } from '@storybook/react'
+import React, { useMemo } from 'react'
+
+import {
+  ALL_OUTPUT_TABS,
+  TuiStoryPreview,
+  commonArgTypes,
+  createInteractiveProps,
+  defaultStoryArgs,
+} from '@overeng/tui-react/storybook'
+
+import { InspectApp } from '../app.ts'
+import { InspectView } from '../view.tsx'
+import { activeState, createActiveTimeline, loadingState } from './_fixtures.ts'
+
+type StoryArgs = {
+  height: number
+  interactive: boolean
+  playbackSpeed: number
+}
+
+export default {
+  title: 'gh-ci-utils/Inspect/Active',
+  component: InspectView,
+  argTypes: { ...commonArgTypes },
+  args: { ...defaultStoryArgs },
+} satisfies Meta
+
+type Story = StoryObj<StoryArgs>
+
+export const Active: Story = {
+  render: function Render(args) {
+    const state = useMemo(() => activeState(), [])
+
+    return (
+      <TuiStoryPreview
+        View={InspectView}
+        app={InspectApp}
+        height={args.height}
+        tabs={ALL_OUTPUT_TABS}
+        command="gh-ci-utils inspect --job 69067527707 --with-usage"
+        {...createInteractiveProps({
+          args,
+          staticState: state,
+          idleState: loadingState(),
+          createTimeline: () => createActiveTimeline(),
+        })}
+      />
+    )
+  },
+}

--- a/packages/@overeng/gh-ci-utils/src/isomorphic/renderers/InspectOutput/stories/Active.stories.tsx
+++ b/packages/@overeng/gh-ci-utils/src/isomorphic/renderers/InspectOutput/stories/Active.stories.tsx
@@ -40,7 +40,7 @@ export const Active: Story = {
         app={InspectApp}
         height={args.height}
         tabs={ALL_OUTPUT_TABS}
-        command="gh-ci-utils inspect --job 69067527707 --with-usage"
+        command="gh-ci-utils inspect --job 1001 --with-usage"
         {...createInteractiveProps({
           args,
           staticState: state,

--- a/packages/@overeng/gh-ci-utils/src/isomorphic/renderers/InspectOutput/stories/Error.stories.tsx
+++ b/packages/@overeng/gh-ci-utils/src/isomorphic/renderers/InspectOutput/stories/Error.stories.tsx
@@ -1,0 +1,53 @@
+/** The command itself could not run: no repo to inspect against. */
+
+import type { Meta, StoryObj } from '@storybook/react'
+import React, { useMemo } from 'react'
+
+import {
+  ALL_OUTPUT_TABS,
+  TuiStoryPreview,
+  commonArgTypes,
+  createInteractiveProps,
+  defaultStoryArgs,
+} from '@overeng/tui-react/storybook'
+
+import { InspectApp } from '../app.ts'
+import { InspectView } from '../view.tsx'
+import { createErrorTimeline, errorState, loadingState } from './_fixtures.ts'
+
+type StoryArgs = {
+  height: number
+  interactive: boolean
+  playbackSpeed: number
+}
+
+export default {
+  title: 'gh-ci-utils/Inspect/Error',
+  component: InspectView,
+  argTypes: { ...commonArgTypes },
+  args: { ...defaultStoryArgs },
+} satisfies Meta
+
+type Story = StoryObj<StoryArgs>
+
+export const ErrorState: Story = {
+  render: function Render(args) {
+    const state = useMemo(() => errorState(), [])
+
+    return (
+      <TuiStoryPreview
+        View={InspectView}
+        app={InspectApp}
+        height={args.height}
+        tabs={ALL_OUTPUT_TABS}
+        command="gh-ci-utils inspect --job 69067527707"
+        {...createInteractiveProps({
+          args,
+          staticState: state,
+          idleState: loadingState(),
+          createTimeline: () => createErrorTimeline(),
+        })}
+      />
+    )
+  },
+}

--- a/packages/@overeng/gh-ci-utils/src/isomorphic/renderers/InspectOutput/stories/Error.stories.tsx
+++ b/packages/@overeng/gh-ci-utils/src/isomorphic/renderers/InspectOutput/stories/Error.stories.tsx
@@ -40,7 +40,7 @@ export const ErrorState: Story = {
         app={InspectApp}
         height={args.height}
         tabs={ALL_OUTPUT_TABS}
-        command="gh-ci-utils inspect --job 69067527707"
+        command="gh-ci-utils inspect --job 1001"
         {...createInteractiveProps({
           args,
           staticState: state,

--- a/packages/@overeng/gh-ci-utils/src/isomorphic/renderers/InspectOutput/stories/Idle.stories.tsx
+++ b/packages/@overeng/gh-ci-utils/src/isomorphic/renderers/InspectOutput/stories/Idle.stories.tsx
@@ -40,7 +40,7 @@ export const Idle: Story = {
         app={InspectApp}
         height={args.height}
         tabs={ALL_OUTPUT_TABS}
-        command="gh-ci-utils inspect --job 69067527707"
+        command="gh-ci-utils inspect --job 1001"
         {...createInteractiveProps({
           args,
           staticState: state,

--- a/packages/@overeng/gh-ci-utils/src/isomorphic/renderers/InspectOutput/stories/Idle.stories.tsx
+++ b/packages/@overeng/gh-ci-utils/src/isomorphic/renderers/InspectOutput/stories/Idle.stories.tsx
@@ -1,0 +1,53 @@
+/** A live instance with no running GitHub job. */
+
+import type { Meta, StoryObj } from '@storybook/react'
+import React, { useMemo } from 'react'
+
+import {
+  ALL_OUTPUT_TABS,
+  TuiStoryPreview,
+  commonArgTypes,
+  createInteractiveProps,
+  defaultStoryArgs,
+} from '@overeng/tui-react/storybook'
+
+import { InspectApp } from '../app.ts'
+import { InspectView } from '../view.tsx'
+import { createIdleTimeline, idleState, loadingState } from './_fixtures.ts'
+
+type StoryArgs = {
+  height: number
+  interactive: boolean
+  playbackSpeed: number
+}
+
+export default {
+  title: 'gh-ci-utils/Inspect/Idle',
+  component: InspectView,
+  argTypes: { ...commonArgTypes },
+  args: { ...defaultStoryArgs },
+} satisfies Meta
+
+type Story = StoryObj<StoryArgs>
+
+export const Idle: Story = {
+  render: function Render(args) {
+    const state = useMemo(() => idleState(), [])
+
+    return (
+      <TuiStoryPreview
+        View={InspectView}
+        app={InspectApp}
+        height={args.height}
+        tabs={ALL_OUTPUT_TABS}
+        command="gh-ci-utils inspect --job 69067527707"
+        {...createInteractiveProps({
+          args,
+          staticState: state,
+          idleState: loadingState(),
+          createTimeline: () => createIdleTimeline(),
+        })}
+      />
+    )
+  },
+}

--- a/packages/@overeng/gh-ci-utils/src/isomorphic/renderers/InspectOutput/stories/Loading.stories.tsx
+++ b/packages/@overeng/gh-ci-utils/src/isomorphic/renderers/InspectOutput/stories/Loading.stories.tsx
@@ -36,7 +36,7 @@ export const Loading: Story = {
       app={InspectApp}
       height={args.height}
       tabs={ALL_OUTPUT_TABS}
-      command="gh-ci-utils inspect --job 69067527707"
+      command="gh-ci-utils inspect --job 1001"
       initialState={loadingState()}
     />
   ),

--- a/packages/@overeng/gh-ci-utils/src/isomorphic/renderers/InspectOutput/stories/Loading.stories.tsx
+++ b/packages/@overeng/gh-ci-utils/src/isomorphic/renderers/InspectOutput/stories/Loading.stories.tsx
@@ -1,0 +1,43 @@
+/** Initial state while the job is being fetched. */
+
+import type { Meta, StoryObj } from '@storybook/react'
+import React from 'react'
+
+import {
+  ALL_OUTPUT_TABS,
+  TuiStoryPreview,
+  commonArgTypes,
+  defaultStoryArgs,
+} from '@overeng/tui-react/storybook'
+
+import { InspectApp } from '../app.ts'
+import { InspectView } from '../view.tsx'
+import { loadingState } from './_fixtures.ts'
+
+type StoryArgs = {
+  height: number
+  interactive: boolean
+  playbackSpeed: number
+}
+
+export default {
+  title: 'gh-ci-utils/Inspect/Loading',
+  component: InspectView,
+  argTypes: { ...commonArgTypes },
+  args: { ...defaultStoryArgs },
+} satisfies Meta
+
+type Story = StoryObj<StoryArgs>
+
+export const Loading: Story = {
+  render: (args) => (
+    <TuiStoryPreview
+      View={InspectView}
+      app={InspectApp}
+      height={args.height}
+      tabs={ALL_OUTPUT_TABS}
+      command="gh-ci-utils inspect --job 69067527707"
+      initialState={loadingState()}
+    />
+  ),
+}

--- a/packages/@overeng/gh-ci-utils/src/isomorphic/renderers/InspectOutput/stories/NotNamespaceRunner.stories.tsx
+++ b/packages/@overeng/gh-ci-utils/src/isomorphic/renderers/InspectOutput/stories/NotNamespaceRunner.stories.tsx
@@ -1,0 +1,53 @@
+/** A self-hosted runner, which Namespace was never asked about. */
+
+import type { Meta, StoryObj } from '@storybook/react'
+import React, { useMemo } from 'react'
+
+import {
+  ALL_OUTPUT_TABS,
+  TuiStoryPreview,
+  commonArgTypes,
+  createInteractiveProps,
+  defaultStoryArgs,
+} from '@overeng/tui-react/storybook'
+
+import { InspectApp } from '../app.ts'
+import { InspectView } from '../view.tsx'
+import { createNotNamespaceTimeline, loadingState, notNamespaceState } from './_fixtures.ts'
+
+type StoryArgs = {
+  height: number
+  interactive: boolean
+  playbackSpeed: number
+}
+
+export default {
+  title: 'gh-ci-utils/Inspect/NotNamespaceRunner',
+  component: InspectView,
+  argTypes: { ...commonArgTypes },
+  args: { ...defaultStoryArgs },
+} satisfies Meta
+
+type Story = StoryObj<StoryArgs>
+
+export const NotNamespaceRunner: Story = {
+  render: function Render(args) {
+    const state = useMemo(() => notNamespaceState(), [])
+
+    return (
+      <TuiStoryPreview
+        View={InspectView}
+        app={InspectApp}
+        height={args.height}
+        tabs={ALL_OUTPUT_TABS}
+        command="gh-ci-utils inspect --job 69067527707"
+        {...createInteractiveProps({
+          args,
+          staticState: state,
+          idleState: loadingState(),
+          createTimeline: () => createNotNamespaceTimeline(),
+        })}
+      />
+    )
+  },
+}

--- a/packages/@overeng/gh-ci-utils/src/isomorphic/renderers/InspectOutput/stories/NotNamespaceRunner.stories.tsx
+++ b/packages/@overeng/gh-ci-utils/src/isomorphic/renderers/InspectOutput/stories/NotNamespaceRunner.stories.tsx
@@ -40,7 +40,7 @@ export const NotNamespaceRunner: Story = {
         app={InspectApp}
         height={args.height}
         tabs={ALL_OUTPUT_TABS}
-        command="gh-ci-utils inspect --job 69067527707"
+        command="gh-ci-utils inspect --job 1001"
         {...createInteractiveProps({
           args,
           staticState: state,

--- a/packages/@overeng/gh-ci-utils/src/isomorphic/renderers/InspectOutput/stories/NscMissing.stories.tsx
+++ b/packages/@overeng/gh-ci-utils/src/isomorphic/renderers/InspectOutput/stories/NscMissing.stories.tsx
@@ -1,0 +1,53 @@
+/** No `nsc` on the machine: GitHub facts survive, the verdict degrades to unknown. */
+
+import type { Meta, StoryObj } from '@storybook/react'
+import React, { useMemo } from 'react'
+
+import {
+  ALL_OUTPUT_TABS,
+  TuiStoryPreview,
+  commonArgTypes,
+  createInteractiveProps,
+  defaultStoryArgs,
+} from '@overeng/tui-react/storybook'
+
+import { InspectApp } from '../app.ts'
+import { InspectView } from '../view.tsx'
+import { createNscMissingTimeline, loadingState, nscMissingState } from './_fixtures.ts'
+
+type StoryArgs = {
+  height: number
+  interactive: boolean
+  playbackSpeed: number
+}
+
+export default {
+  title: 'gh-ci-utils/Inspect/NscMissing',
+  component: InspectView,
+  argTypes: { ...commonArgTypes },
+  args: { ...defaultStoryArgs },
+} satisfies Meta
+
+type Story = StoryObj<StoryArgs>
+
+export const NscMissing: Story = {
+  render: function Render(args) {
+    const state = useMemo(() => nscMissingState(), [])
+
+    return (
+      <TuiStoryPreview
+        View={InspectView}
+        app={InspectApp}
+        height={args.height}
+        tabs={ALL_OUTPUT_TABS}
+        command="gh-ci-utils inspect --job 69067527707"
+        {...createInteractiveProps({
+          args,
+          staticState: state,
+          idleState: loadingState(),
+          createTimeline: () => createNscMissingTimeline(),
+        })}
+      />
+    )
+  },
+}

--- a/packages/@overeng/gh-ci-utils/src/isomorphic/renderers/InspectOutput/stories/NscMissing.stories.tsx
+++ b/packages/@overeng/gh-ci-utils/src/isomorphic/renderers/InspectOutput/stories/NscMissing.stories.tsx
@@ -40,7 +40,7 @@ export const NscMissing: Story = {
         app={InspectApp}
         height={args.height}
         tabs={ALL_OUTPUT_TABS}
-        command="gh-ci-utils inspect --job 69067527707"
+        command="gh-ci-utils inspect --job 1001"
         {...createInteractiveProps({
           args,
           staticState: state,

--- a/packages/@overeng/gh-ci-utils/src/isomorphic/renderers/InspectOutput/stories/ResourcePressure.stories.tsx
+++ b/packages/@overeng/gh-ci-utils/src/isomorphic/renderers/InspectOutput/stories/ResourcePressure.stories.tsx
@@ -1,0 +1,53 @@
+/** A runner pinned at its RAM allocation. */
+
+import type { Meta, StoryObj } from '@storybook/react'
+import React, { useMemo } from 'react'
+
+import {
+  ALL_OUTPUT_TABS,
+  TuiStoryPreview,
+  commonArgTypes,
+  createInteractiveProps,
+  defaultStoryArgs,
+} from '@overeng/tui-react/storybook'
+
+import { InspectApp } from '../app.ts'
+import { InspectView } from '../view.tsx'
+import { createResourcePressureTimeline, loadingState, resourcePressureState } from './_fixtures.ts'
+
+type StoryArgs = {
+  height: number
+  interactive: boolean
+  playbackSpeed: number
+}
+
+export default {
+  title: 'gh-ci-utils/Inspect/ResourcePressure',
+  component: InspectView,
+  argTypes: { ...commonArgTypes },
+  args: { ...defaultStoryArgs },
+} satisfies Meta
+
+type Story = StoryObj<StoryArgs>
+
+export const ResourcePressure: Story = {
+  render: function Render(args) {
+    const state = useMemo(() => resourcePressureState(), [])
+
+    return (
+      <TuiStoryPreview
+        View={InspectView}
+        app={InspectApp}
+        height={args.height}
+        tabs={ALL_OUTPUT_TABS}
+        command="gh-ci-utils inspect --job 69067527707 --with-usage"
+        {...createInteractiveProps({
+          args,
+          staticState: state,
+          idleState: loadingState(),
+          createTimeline: () => createResourcePressureTimeline(),
+        })}
+      />
+    )
+  },
+}

--- a/packages/@overeng/gh-ci-utils/src/isomorphic/renderers/InspectOutput/stories/ResourcePressure.stories.tsx
+++ b/packages/@overeng/gh-ci-utils/src/isomorphic/renderers/InspectOutput/stories/ResourcePressure.stories.tsx
@@ -40,7 +40,7 @@ export const ResourcePressure: Story = {
         app={InspectApp}
         height={args.height}
         tabs={ALL_OUTPUT_TABS}
-        command="gh-ci-utils inspect --job 69067527707 --with-usage"
+        command="gh-ci-utils inspect --job 1001 --with-usage"
         {...createInteractiveProps({
           args,
           staticState: state,

--- a/packages/@overeng/gh-ci-utils/src/isomorphic/renderers/InspectOutput/stories/_fixtures.ts
+++ b/packages/@overeng/gh-ci-utils/src/isomorphic/renderers/InspectOutput/stories/_fixtures.ts
@@ -1,0 +1,232 @@
+/**
+ * Test fixtures for Inspect stories.
+ *
+ * One factory per disposition, each built from facts that actually justify it,
+ * so a story cannot show a verdict the classifier would not produce.
+ */
+
+import { defaultApiMeta } from '../../../lib/apiMeta.ts'
+import { classifyInspection } from '../../../lib/inspectAssessment.ts'
+import type {
+  InspectGitHubFacts,
+  InspectNamespaceFacts,
+  NamespaceJobFacts,
+  NamespaceUsage,
+} from '../../../lib/inspectFacts.ts'
+import type { InspectAction, InspectState } from '../schema.ts'
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+const REPO = 'schickling/dotfiles'
+const INSTANCE = 'psmnb4mkjm3mq'
+
+const githubFacts = (overrides: Partial<InspectGitHubFacts> = {}): InspectGitHubFacts => ({
+  repo: REPO,
+  jobId: 69067527707,
+  runId: 23601797547,
+  name: 'build',
+  status: 'in_progress',
+  conclusion: null,
+  startedAt: '2026-09-10T11:00:00.000Z',
+  completedAt: null,
+  durationSeconds: 214,
+  runnerName: `nsc-runner-${INSTANCE}`,
+  runnerKind: 'namespace',
+  runnerInstance: INSTANCE,
+  labels: ['nscloud-ubuntu-24.04-amd64-8x16'],
+  steps: [
+    {
+      name: 'Set up job',
+      status: 'completed',
+      conclusion: 'success',
+      number: 1,
+      startedAt: '2026-09-10T11:00:00.000Z',
+      completedAt: '2026-09-10T11:00:06.000Z',
+    },
+    {
+      name: 'nix build',
+      status: 'in_progress',
+      conclusion: null,
+      number: 2,
+      startedAt: '2026-09-10T11:00:06.000Z',
+      completedAt: null,
+    },
+  ],
+  ...overrides,
+})
+
+const namespaceJob = (overrides: Partial<NamespaceJobFacts> = {}): NamespaceJobFacts => ({
+  instanceId: INSTANCE,
+  instanceStatus: 'running',
+  instanceStatusRaw: 'RUNNING',
+  runnerName: `nsc-runner-${INSTANCE}`,
+  containerName: 'runner',
+  repository: REPO,
+  workflow: 'CI',
+  jobName: 'build',
+  destroyedAt: null,
+  ...overrides,
+})
+
+const usageSample = (overrides: Partial<NamespaceUsage> = {}): NamespaceUsage => ({
+  instanceId: INSTANCE,
+  githubJobId: '69067527707',
+  allocatedCpu: 8,
+  allocatedRamGb: 16,
+  cpuMaxFraction: 0.61,
+  ramMaxFraction: 0.34,
+  createdAt: '2026-09-10 10:59:55 +0000 UTC',
+  startedAt: '2026-09-10 11:00:00 +0000 UTC',
+  destroyedAt: null,
+  ...overrides,
+})
+
+/** Build a `Loaded` state whose assessment comes from the real classifier. */
+const loaded = ({
+  github,
+  namespace,
+}: {
+  github: InspectGitHubFacts
+  namespace: InspectNamespaceFacts
+}): InspectState => ({
+  _tag: 'Loaded',
+  github,
+  namespace,
+  assessment: classifyInspection({ github, namespace }),
+  _meta: defaultApiMeta,
+})
+
+// =============================================================================
+// State Factories
+// =============================================================================
+
+/** Loading state. */
+export const loadingState = (): InspectState => ({
+  _tag: 'Loading',
+  message: 'Inspecting job...',
+  _meta: defaultApiMeta,
+})
+
+/** Error state — the command itself could not run. */
+export const errorState = (): InspectState => ({
+  _tag: 'Error',
+  error: 'No repo',
+  message: 'Could not detect a repo from the git remote. Pass --repo owner/name.',
+  _meta: defaultApiMeta,
+})
+
+/** A running job on a live instance: both sources agree. */
+export const activeState = (): InspectState =>
+  loaded({
+    github: githubFacts(),
+    namespace: {
+      _tag: 'reported',
+      job: namespaceJob(),
+      usage: { _tag: 'sampled', sample: usageSample() },
+      commands: [],
+    },
+  })
+
+/** A live instance with no running job. */
+export const idleState = (): InspectState =>
+  loaded({
+    github: githubFacts({
+      status: 'completed',
+      conclusion: 'success',
+      completedAt: '2026-09-10T11:03:34.000Z',
+    }),
+    namespace: {
+      _tag: 'reported',
+      job: namespaceJob(),
+      usage: { _tag: 'not-requested' },
+      commands: [],
+    },
+  })
+
+/** A runner pinned at its RAM allocation. */
+export const resourcePressureState = (): InspectState =>
+  loaded({
+    github: githubFacts(),
+    namespace: {
+      _tag: 'reported',
+      job: namespaceJob(),
+      usage: {
+        _tag: 'sampled',
+        sample: usageSample({ cpuMaxFraction: 0.72, ramMaxFraction: 0.987 }),
+      },
+      commands: [],
+    },
+  })
+
+/** No `nsc` on the machine: GitHub facts survive, the verdict does not. */
+export const nscMissingState = (): InspectState =>
+  loaded({
+    github: githubFacts(),
+    namespace: {
+      _tag: 'unavailable',
+      reason: 'nsc-missing',
+      detail: 'NotFound: nsc',
+      commands: [['auth', 'check-login']],
+    },
+  })
+
+/** A self-hosted runner, which Namespace was never asked about. */
+export const notNamespaceState = (): InspectState =>
+  loaded({
+    github: githubFacts({
+      runnerName: 'dev3-6038ddf9',
+      runnerKind: 'self-hosted',
+      runnerInstance: 'dev3',
+      labels: ['self-hosted', 'dev3'],
+    }),
+    namespace: { _tag: 'not-namespace-job', runnerKind: 'self-hosted' },
+  })
+
+// =============================================================================
+// Timeline Factory
+// =============================================================================
+
+const STEP_DURATION = 600
+
+const createTimeline = (
+  state: Extract<InspectState, { _tag: 'Loaded' }>,
+): Array<{ at: number; action: InspectAction }> => [
+  {
+    at: STEP_DURATION,
+    action: {
+      _tag: 'SetInspection',
+      github: state.github,
+      namespace: state.namespace,
+      assessment: state.assessment,
+    },
+  },
+]
+
+const loadedOrThrow = (state: InspectState): Extract<InspectState, { _tag: 'Loaded' }> => {
+  if (state._tag !== 'Loaded') throw new Error(`expected a Loaded fixture, got ${state._tag}`)
+  return state
+}
+
+export const createActiveTimeline = () => createTimeline(loadedOrThrow(activeState()))
+
+export const createIdleTimeline = () => createTimeline(loadedOrThrow(idleState()))
+
+export const createResourcePressureTimeline = () =>
+  createTimeline(loadedOrThrow(resourcePressureState()))
+
+export const createNscMissingTimeline = () => createTimeline(loadedOrThrow(nscMissingState()))
+
+export const createNotNamespaceTimeline = () => createTimeline(loadedOrThrow(notNamespaceState()))
+
+export const createErrorTimeline = (): Array<{ at: number; action: InspectAction }> => [
+  {
+    at: STEP_DURATION,
+    action: {
+      _tag: 'SetError',
+      error: 'No repo',
+      message: 'Could not detect a repo from the git remote. Pass --repo owner/name.',
+    },
+  },
+]

--- a/packages/@overeng/gh-ci-utils/src/isomorphic/renderers/InspectOutput/stories/_fixtures.ts
+++ b/packages/@overeng/gh-ci-utils/src/isomorphic/renderers/InspectOutput/stories/_fixtures.ts
@@ -19,17 +19,17 @@ import type { InspectAction, InspectState } from '../schema.ts'
 // Helpers
 // =============================================================================
 
-const REPO = 'schickling/dotfiles'
-const INSTANCE = 'psmnb4mkjm3mq'
+const REPO = 'example-org/example-repo'
+const INSTANCE = 'abc123example'
 
 const githubFacts = (overrides: Partial<InspectGitHubFacts> = {}): InspectGitHubFacts => ({
   repo: REPO,
-  jobId: 69067527707,
-  runId: 23601797547,
+  jobId: 1001,
+  runId: 2001,
   name: 'build',
   status: 'in_progress',
   conclusion: null,
-  startedAt: '2026-09-10T11:00:00.000Z',
+  startedAt: '2026-01-15T11:00:00.000Z',
   completedAt: null,
   durationSeconds: 214,
   runnerName: `nsc-runner-${INSTANCE}`,
@@ -42,15 +42,15 @@ const githubFacts = (overrides: Partial<InspectGitHubFacts> = {}): InspectGitHub
       status: 'completed',
       conclusion: 'success',
       number: 1,
-      startedAt: '2026-09-10T11:00:00.000Z',
-      completedAt: '2026-09-10T11:00:06.000Z',
+      startedAt: '2026-01-15T11:00:00.000Z',
+      completedAt: '2026-01-15T11:00:06.000Z',
     },
     {
       name: 'nix build',
       status: 'in_progress',
       conclusion: null,
       number: 2,
-      startedAt: '2026-09-10T11:00:06.000Z',
+      startedAt: '2026-01-15T11:00:06.000Z',
       completedAt: null,
     },
   ],
@@ -72,13 +72,13 @@ const namespaceJob = (overrides: Partial<NamespaceJobFacts> = {}): NamespaceJobF
 
 const usageSample = (overrides: Partial<NamespaceUsage> = {}): NamespaceUsage => ({
   instanceId: INSTANCE,
-  githubJobId: '69067527707',
+  githubJobId: '1001',
   allocatedCpu: 8,
   allocatedRamGb: 16,
   cpuMaxFraction: 0.61,
   ramMaxFraction: 0.34,
-  createdAt: '2026-09-10 10:59:55 +0000 UTC',
-  startedAt: '2026-09-10 11:00:00 +0000 UTC',
+  createdAt: '2026-01-15 10:59:55 +0000 UTC',
+  startedAt: '2026-01-15 11:00:00 +0000 UTC',
   destroyedAt: null,
   ...overrides,
 })
@@ -135,7 +135,7 @@ export const idleState = (): InspectState =>
     github: githubFacts({
       status: 'completed',
       conclusion: 'success',
-      completedAt: '2026-09-10T11:03:34.000Z',
+      completedAt: '2026-01-15T11:03:34.000Z',
     }),
     namespace: {
       _tag: 'reported',
@@ -176,10 +176,10 @@ export const nscMissingState = (): InspectState =>
 export const notNamespaceState = (): InspectState =>
   loaded({
     github: githubFacts({
-      runnerName: 'dev3-6038ddf9',
+      runnerName: 'runnera-1234abcd',
       runnerKind: 'self-hosted',
-      runnerInstance: 'dev3',
-      labels: ['self-hosted', 'dev3'],
+      runnerInstance: 'runnera',
+      labels: ['self-hosted', 'runnera'],
     }),
     namespace: { _tag: 'not-namespace-job', runnerKind: 'self-hosted' },
   })

--- a/packages/@overeng/gh-ci-utils/src/isomorphic/renderers/InspectOutput/view.tsx
+++ b/packages/@overeng/gh-ci-utils/src/isomorphic/renderers/InspectOutput/view.tsx
@@ -25,13 +25,6 @@ export interface InspectViewProps {
   readonly stateAtom: Atom.Atom<InspectState>
 }
 
-const DISPOSITION_COLOR = {
-  active: 'green',
-  idle: 'blue',
-  'resource-pressure': 'yellow',
-  unknown: 'gray',
-} as const satisfies Readonly<Record<InspectDisposition, string>>
-
 /** TUI view rendering a single job's runner diagnosis */
 export const InspectView = ({ stateAtom }: InspectViewProps) => {
   const state = useTuiAtomValue(stateAtom) as InspectState
@@ -72,6 +65,12 @@ export const InspectView = ({ stateAtom }: InspectViewProps) => {
     </Box>
   )
 }
+const DISPOSITION_COLOR = {
+  active: 'green',
+  idle: 'blue',
+  'resource-pressure': 'yellow',
+  unknown: 'gray',
+} as const satisfies Readonly<Record<InspectDisposition, string>>
 
 const AssessmentSection = ({ assessment }: { readonly assessment: InspectAssessment }) => {
   const symbols = useSymbols()

--- a/packages/@overeng/gh-ci-utils/src/isomorphic/renderers/InspectOutput/view.tsx
+++ b/packages/@overeng/gh-ci-utils/src/isomorphic/renderers/InspectOutput/view.tsx
@@ -1,0 +1,183 @@
+/**
+ * Inspect TUI view.
+ *
+ * The layout mirrors the JSON contract: the verdict first, then the two fact
+ * groups it was derived from, so a reader can always see which source said
+ * what — and, when nothing could be observed, that the GitHub facts survived.
+ */
+import type { Atom } from 'effect/unstable/reactivity'
+import React from 'react'
+
+import { Box, Text, useTuiAtomValue, useSymbols } from '@overeng/tui-react'
+
+import type { ApiMeta } from '../../lib/apiMeta.ts'
+import { formatDuration } from '../../lib/format.ts'
+import type {
+  InspectAssessment,
+  InspectDisposition,
+  InspectGitHubFacts,
+  InspectNamespaceFacts,
+} from '../../lib/inspectFacts.ts'
+import type { InspectState } from './schema.ts'
+
+/** Props for the InspectView component */
+export interface InspectViewProps {
+  readonly stateAtom: Atom.Atom<InspectState>
+}
+
+const DISPOSITION_COLOR = {
+  active: 'green',
+  idle: 'blue',
+  'resource-pressure': 'yellow',
+  unknown: 'gray',
+} as const satisfies Readonly<Record<InspectDisposition, string>>
+
+/** TUI view rendering a single job's runner diagnosis */
+export const InspectView = ({ stateAtom }: InspectViewProps) => {
+  const state = useTuiAtomValue(stateAtom) as InspectState
+  const symbols = useSymbols()
+
+  if (state._tag === 'Loading') {
+    return (
+      <Box flexDirection="row">
+        <Text color="blue">{symbols.status.circle}</Text>
+        <Text> {state.message}</Text>
+      </Box>
+    )
+  }
+
+  if (state._tag === 'Error') {
+    return (
+      <Box flexDirection="column">
+        <Box flexDirection="row">
+          <Text color="red">{symbols.status.cross}</Text>
+          <Text color="red" bold>
+            {' '}
+            Error: {state.error}
+          </Text>
+        </Box>
+        <Text color="gray">{state.message}</Text>
+      </Box>
+    )
+  }
+
+  return (
+    <Box flexDirection="column">
+      <AssessmentSection assessment={state.assessment} />
+      <Text> </Text>
+      <GitHubSection github={state.github} />
+      <Text> </Text>
+      <NamespaceSection namespace={state.namespace} />
+      <MetaFooter meta={state._meta} />
+    </Box>
+  )
+}
+
+const AssessmentSection = ({ assessment }: { readonly assessment: InspectAssessment }) => {
+  const symbols = useSymbols()
+  const color = DISPOSITION_COLOR[assessment.disposition]
+
+  return (
+    <Box flexDirection="column">
+      <Box flexDirection="row">
+        <Text color={color}>
+          {assessment.disposition === 'unknown' ? symbols.status.circle : symbols.status.check}
+        </Text>
+        <Text> </Text>
+        <Text color={color} bold>
+          {assessment.disposition}
+        </Text>
+      </Box>
+      {assessment.evidence.map((line) => (
+        <Box key={line} flexDirection="row">
+          <Text color="gray"> {symbols.status.dot} </Text>
+          <Text>{line}</Text>
+        </Box>
+      ))}
+      {assessment.limitations.map((line) => (
+        <Box key={line} flexDirection="row">
+          <Text color="yellow"> {symbols.status.warning} </Text>
+          <Text color="gray">{line}</Text>
+        </Box>
+      ))}
+    </Box>
+  )
+}
+
+const GitHubSection = ({ github }: { readonly github: InspectGitHubFacts }) => (
+  <Box flexDirection="column">
+    <Text bold>github</Text>
+    <Text color="gray">
+      {' '}
+      {github.repo} job {github.jobId} ({github.name}) in run {github.runId}
+    </Text>
+    <Text color="gray">
+      {' '}
+      {github.status}
+      {github.conclusion === null ? '' : ` / ${github.conclusion}`} ·{' '}
+      {formatDuration(github.durationSeconds)} · {github.steps.length} step(s)
+    </Text>
+    <Text color="gray">
+      {' '}
+      runner {github.runnerName ?? '(none assigned)'} · kind {github.runnerKind} · instance{' '}
+      {github.runnerInstance ?? '—'}
+    </Text>
+  </Box>
+)
+
+const NamespaceSection = ({ namespace }: { readonly namespace: InspectNamespaceFacts }) => {
+  if (namespace._tag === 'not-namespace-job') {
+    return (
+      <Box flexDirection="column">
+        <Text bold>namespace</Text>
+        <Text color="gray"> not a Namespace job ({namespace.runnerKind} runner); nsc not run</Text>
+      </Box>
+    )
+  }
+
+  if (namespace._tag === 'unavailable') {
+    return (
+      <Box flexDirection="column">
+        <Text bold>namespace</Text>
+        <Text color="gray">
+          {' '}
+          unavailable: {namespace.reason}
+          {namespace.detail === null ? '' : ` — ${namespace.detail}`}
+        </Text>
+      </Box>
+    )
+  }
+
+  const { job, usage } = namespace
+  return (
+    <Box flexDirection="column">
+      <Text bold>namespace</Text>
+      <Text color="gray">
+        {' '}
+        instance {job.instanceId} · {job.instanceStatus}
+        {job.runnerName === null ? '' : ` · runner ${job.runnerName}`}
+        {job.containerName === null ? '' : ` · container ${job.containerName}`}
+      </Text>
+      {usage._tag === 'sampled' ? (
+        <Text color="gray">
+          {' '}
+          peak {(usage.sample.cpuMaxFraction * 100).toFixed(1)}% of {usage.sample.allocatedCpu} CPU
+          · {(usage.sample.ramMaxFraction * 100).toFixed(1)}% of {usage.sample.allocatedRamGb} GB
+          RAM
+        </Text>
+      ) : (
+        <Text color="gray">
+          {' '}
+          usage {usage._tag === 'not-requested' ? 'not requested (--with-usage)' : usage.reason}
+        </Text>
+      )}
+    </Box>
+  )
+}
+
+const MetaFooter = ({ meta }: { readonly meta: ApiMeta }) =>
+  meta.apiRequests > 0 ? (
+    <Text color="gray">
+      {meta.apiRequests} reqs · {meta.rateLimitRemaining}/{meta.rateLimitLimit} rate limit
+    </Text>
+  ) : null

--- a/packages/@overeng/gh-ci-utils/src/mod.ts
+++ b/packages/@overeng/gh-ci-utils/src/mod.ts
@@ -30,6 +30,15 @@ export {
 } from './node/RunId.ts'
 export { resolveConfig, type CiUtilsConfig } from './node/Config.ts'
 export { fetchAllRunnerJobs, type ActiveJob } from './node/RunnerClient.ts'
+export { observeNamespaceJob, ALLOWED_ARGV as NSC_ALLOWED_ARGV } from './node/NamespaceClient.ts'
+export { classifyInspection } from './isomorphic/lib/inspectAssessment.ts'
+export {
+  toInspectGitHubFacts,
+  type InspectAssessment,
+  type InspectDisposition,
+  type InspectGitHubFacts,
+  type InspectNamespaceFacts,
+} from './isomorphic/lib/inspectFacts.ts'
 
 export type {
   WorkflowRun,

--- a/packages/@overeng/gh-ci-utils/src/node/GitHubClient.ts
+++ b/packages/@overeng/gh-ci-utils/src/node/GitHubClient.ts
@@ -821,7 +821,7 @@ const makeGitHubClient = Effect.gen(function* () {
       path: `/repos/${repo}/actions/jobs/${jobId}`,
       schema: GH.WorkflowJob,
       useETag: true,
-    }).pipe(Effect.withSpan('github-client.getWorkflowJob', { attributes: { repo, jobId } }))
+    }).pipe(withGitHubSpan({ name: 'github-client.getWorkflowJob', attributes: { repo, jobId } }))
 
   /** List all jobs for a workflow run (handles pagination). */
   const listWorkflowJobs = ({ repo, runId }: { repo: string; runId: number }) =>

--- a/packages/@overeng/gh-ci-utils/src/node/GitHubClient.ts
+++ b/packages/@overeng/gh-ci-utils/src/node/GitHubClient.ts
@@ -809,6 +809,20 @@ const makeGitHubClient = Effect.gen(function* () {
       useETag: true,
     }).pipe(withGitHubSpan({ name: 'github-client.getWorkflowRun', attributes: { repo, runId } }))
 
+  /**
+   * Get a single workflow job by its numeric id.
+   *
+   * `inspect` is addressed by job id, not run id, so listing a run's jobs to
+   * find one would cost a paginated fetch to discard nearly all of it.
+   */
+  const getWorkflowJob = ({ repo, jobId }: { repo: string; jobId: number }) =>
+    apiGet({
+      repo,
+      path: `/repos/${repo}/actions/jobs/${jobId}`,
+      schema: GH.WorkflowJob,
+      useETag: true,
+    }).pipe(Effect.withSpan('github-client.getWorkflowJob', { attributes: { repo, jobId } }))
+
   /** List all jobs for a workflow run (handles pagination). */
   const listWorkflowJobs = ({ repo, runId }: { repo: string; runId: number }) =>
     Effect.gen(function* () {
@@ -1358,6 +1372,7 @@ const makeGitHubClient = Effect.gen(function* () {
     listActiveRuns,
     listWorkflowRunsByStatus,
     getWorkflowRun,
+    getWorkflowJob,
     listWorkflowJobs,
     getJobLogs,
     getCheckAnnotations,

--- a/packages/@overeng/gh-ci-utils/src/node/NamespaceClient.ts
+++ b/packages/@overeng/gh-ci-utils/src/node/NamespaceClient.ts
@@ -563,12 +563,11 @@ const unavailableFromFailure = (
 }
 
 /** stderr that specifically says "`nsc` does not know this job". */
-const isJobNotFoundStderr = ({ stderr, jobId }: { stderr: string; jobId: number }): boolean => {
-  if (stderr.includes(String(jobId)) === false) return false
-  return /\bjob\b[^\n]*(?:not found|does not exist)|(?:no such|unknown)\s+(?:github\s+)?job\b/i.test(
-    stderr,
-  )
-}
+const isJobNotFoundStderr = ({ stderr, jobId }: { stderr: string; jobId: number }): boolean =>
+  new RegExp(
+    `(?:\\bjob\\s+#?${jobId}\\s+(?:not found|does not exist)\\b|\\b(?:no such|unknown)\\s+(?:github\\s+)?job\\s+#?${jobId}\\b)`,
+    'i',
+  ).test(stderr)
 
 // =============================================================================
 // The observation

--- a/packages/@overeng/gh-ci-utils/src/node/NamespaceClient.ts
+++ b/packages/@overeng/gh-ci-utils/src/node/NamespaceClient.ts
@@ -171,12 +171,14 @@ export type JobDescribeParse =
 const MAX_LOOKUP_DEPTH = 6
 
 /**
- * Find the first non-empty string stored under any of `keys`, at any depth.
+ * Find the first non-empty string stored under any of `keys` within one
+ * logical job/attempt record.
  *
  * `nsc` nests the runner/instance block differently across output versions, so
  * a fixed path would break on a rename that a search survives. Keys at the
- * current level are preferred over nested ones, so a top-level `status` is
- * never shadowed by a deeper one.
+ * current level are preferred over nested ones. Arrays delimit sibling
+ * attempts and are never crossed, so historical metadata cannot describe the
+ * selected runner.
  */
 const findString = ({
   root,
@@ -188,13 +190,7 @@ const findString = ({
   const visit = ({ node, depth }: { node: unknown; depth: number }): string | null => {
     if (depth > MAX_LOOKUP_DEPTH || typeof node !== 'object' || node === null) return null
 
-    if (Array.isArray(node)) {
-      for (const item of node) {
-        const found = visit({ node: item, depth: depth + 1 })
-        if (found !== null) return found
-      }
-      return null
-    }
+    if (Array.isArray(node)) return null
 
     const entries = Object.entries(node)
     for (const [key, value] of entries) {

--- a/packages/@overeng/gh-ci-utils/src/node/NamespaceClient.ts
+++ b/packages/@overeng/gh-ci-utils/src/node/NamespaceClient.ts
@@ -242,10 +242,10 @@ interface RecordSelection {
  * Find the object that directly owns a matching identity field.
  *
  * Each array item and singular history field starts a separate context. An
- * entry in an object-valued attempt collection additionally inherits the
- * enclosing job record, whose history fields are excluded by `findString`.
- * Keeping those scopes separate lets selected-attempt metadata win without
- * allowing metadata from a sibling attempt to leak into the result.
+ * entry in an attempt collection additionally inherits the enclosing job
+ * record, whose history fields are excluded by `findString`. Keeping those
+ * scopes separate lets selected-attempt metadata win without allowing metadata
+ * from a sibling attempt to leak into the result.
  */
 const findRecord = ({
   root,
@@ -290,12 +290,7 @@ const findRecord = ({
     }
 
     for (const [key, nested] of Object.entries(node)) {
-      if (
-        isAttemptCollectionKey(key) &&
-        typeof nested === 'object' &&
-        nested !== null &&
-        Array.isArray(nested) === false
-      ) {
+      if (isAttemptCollectionKey(key) && typeof nested === 'object' && nested !== null) {
         for (const attempt of Object.values(nested)) {
           if (typeof attempt !== 'object' || attempt === null) continue
           const found = visit({

--- a/packages/@overeng/gh-ci-utils/src/node/NamespaceClient.ts
+++ b/packages/@overeng/gh-ci-utils/src/node/NamespaceClient.ts
@@ -1,0 +1,661 @@
+/**
+ * Read-only Namespace (`nsc`) adapter for `gh-ci-utils inspect`.
+ *
+ * # Trust boundary
+ *
+ * This adapter uses the *ambient* `nsc` session and may only ever run these
+ * three commands, all of them read-only:
+ *
+ *   - `nsc auth check-login`
+ *   - `nsc github job describe <job-id> -o json`
+ *   - `nsc instance report --start … --end … --out - --repository … --jobname …`
+ *
+ * It must never log in, open an SSH session, start/stop/destroy an instance,
+ * mint a token, touch a vault, or execute anything remotely. `ALLOWED_ARGV`
+ * below is the whole permitted surface, every invocation is recorded in the
+ * returned facts, and a test asserts the recorded argv against that list.
+ *
+ * # Degradation
+ *
+ * A missing, unauthenticated, failing, slow or unreadable `nsc` is expected
+ * data, not an error: the adapter returns a tagged `unavailable` observation
+ * and the caller keeps every GitHub fact it already has.
+ *
+ * # Decoding
+ *
+ * `nsc github job describe -o json` has no stable published schema, so the
+ * decoder here is deliberately tolerant: it looks for known field names
+ * anywhere in the returned object graph and degrades anything it does not
+ * recognise to `null`/`unknown` rather than asserting a shape.
+ */
+import { Duration, Effect, Option, Stream } from 'effect'
+import type { PlatformError } from 'effect/PlatformError'
+import * as ChildProcess from 'effect/unstable/process/ChildProcess'
+import { ChildProcessSpawner } from 'effect/unstable/process/ChildProcessSpawner'
+
+import type {
+  InspectGitHubFacts,
+  InspectNamespaceFacts,
+  NamespaceInstanceStatus,
+  NamespaceJobFacts,
+  NamespaceUsage,
+  NamespaceUsageState,
+} from '../isomorphic/lib/inspectFacts.ts'
+
+/** The `nsc` executable. Resolved from PATH; absence is ordinary data. */
+const NSC = 'nsc'
+
+/** How long each `nsc` invocation may take before it counts as timed out. */
+const CHECK_LOGIN_TIMEOUT = Duration.seconds(10)
+const JOB_DESCRIBE_TIMEOUT = Duration.seconds(20)
+const INSTANCE_REPORT_TIMEOUT = Duration.seconds(60)
+
+/** Padding around the GitHub job's own timestamps when bounding a report. */
+const REPORT_WINDOW_PADDING_MS = 5 * 60 * 1000
+
+// =============================================================================
+// Approved argv — the entire permitted `nsc` surface
+// =============================================================================
+
+/** `nsc auth check-login` — asks whether the ambient session is usable. */
+export const authCheckLoginArgv = (): ReadonlyArray<string> => ['auth', 'check-login']
+
+/** `nsc github job describe <job-id> -o json` — one job, machine-readable. */
+export const jobDescribeArgv = (jobId: number): ReadonlyArray<string> => [
+  'github',
+  'job',
+  'describe',
+  String(jobId),
+  '-o',
+  'json',
+]
+
+/**
+ * `nsc instance report` bounded to this job's own window and narrowed with the
+ * documented repository and job-name filters, streamed to stdout.
+ */
+export const instanceReportArgv = ({
+  window,
+  repository,
+  jobName,
+}: {
+  readonly window: ReportWindow
+  readonly repository: string
+  readonly jobName: string
+}): ReadonlyArray<string> => [
+  'instance',
+  'report',
+  '--start',
+  window.start,
+  '--end',
+  window.end,
+  '--out',
+  '-',
+  '--repository',
+  repository,
+  '--jobname',
+  jobName,
+]
+
+/**
+ * Every argv prefix this adapter is allowed to run.
+ *
+ * Anything not matching one of these is a bug, and the adapter's own tests
+ * assert the recorded invocations against it.
+ */
+export const ALLOWED_ARGV: ReadonlyArray<ReadonlyArray<string>> = [
+  ['auth', 'check-login'],
+  ['github', 'job', 'describe'],
+  ['instance', 'report'],
+]
+
+/**
+ * Whether an argv is one of the approved read-only invocations.
+ *
+ * Exported as the single place that decides what this adapter may execute.
+ */
+export const isAllowedArgv = (argv: ReadonlyArray<string>): boolean =>
+  ALLOWED_ARGV.some((prefix) => prefix.every((segment, index) => argv[index] === segment))
+
+// =============================================================================
+// Report window
+// =============================================================================
+
+/** An inclusive `--start`/`--end` pair for `nsc instance report`. */
+export interface ReportWindow {
+  readonly start: string
+  readonly end: string
+}
+
+/**
+ * Bound a report to the job's own lifetime, padded on both sides.
+ *
+ * Returns `null` when GitHub never gave the job a start time: an unbounded or
+ * guessed window would either cost a full-workspace scan or return rows that
+ * are not this job's.
+ */
+export const deriveReportWindow = ({
+  startedAt,
+  completedAt,
+  now,
+}: {
+  readonly startedAt: string | null
+  readonly completedAt: string | null
+  readonly now: Date
+}): ReportWindow | null => {
+  if (startedAt === null) return null
+  const startMs = Date.parse(startedAt)
+  if (Number.isNaN(startMs)) return null
+
+  const parsedEnd = completedAt === null ? Number.NaN : Date.parse(completedAt)
+  const endMs = Number.isNaN(parsedEnd) ? now.getTime() : parsedEnd
+  /** A `completed_at` before `started_at` would invert the window; clamp it. */
+  const boundedEnd = Math.max(endMs, startMs)
+
+  return {
+    start: new Date(startMs - REPORT_WINDOW_PADDING_MS).toISOString(),
+    end: new Date(boundedEnd + REPORT_WINDOW_PADDING_MS).toISOString(),
+  }
+}
+
+// =============================================================================
+// `nsc github job describe -o json` decoding
+// =============================================================================
+
+/** Outcome of reading `nsc github job describe -o json` stdout. */
+export type JobDescribeParse =
+  | { readonly _tag: 'parsed'; readonly job: NamespaceJobFacts }
+  | { readonly _tag: 'unrecognized'; readonly detail: string }
+
+/** Maximum object-graph depth searched for a known field name. */
+const MAX_LOOKUP_DEPTH = 6
+
+/**
+ * Find the first non-empty string stored under any of `keys`, at any depth.
+ *
+ * `nsc` nests the runner/instance block differently across output versions, so
+ * a fixed path would break on a rename that a search survives. Keys at the
+ * current level are preferred over nested ones, so a top-level `status` is
+ * never shadowed by a deeper one.
+ */
+const findString = (root: unknown, keys: ReadonlyArray<string>): string | null => {
+  const visit = (node: unknown, depth: number): string | null => {
+    if (depth > MAX_LOOKUP_DEPTH || typeof node !== 'object' || node === null) return null
+
+    if (Array.isArray(node)) {
+      for (const item of node) {
+        const found = visit(item, depth + 1)
+        if (found !== null) return found
+      }
+      return null
+    }
+
+    const entries = Object.entries(node)
+    for (const [key, value] of entries) {
+      if (keys.includes(key) === false) continue
+      if (typeof value === 'string' && value.length > 0) return value
+      if (typeof value === 'number' && Number.isFinite(value)) return String(value)
+    }
+    for (const [, value] of entries) {
+      const found = visit(value, depth + 1)
+      if (found !== null) return found
+    }
+    return null
+  }
+  return visit(root, 0)
+}
+
+/** Status strings that positively establish a live instance. */
+const LIVE_STATUS = /^(running|live|ready|started|starting|active|in_use)$/i
+/** Status strings that positively establish a gone instance. */
+const GONE_STATUS = /^(destroyed|terminated|stopped|deleted|failed|expired)$/i
+
+/**
+ * Derive liveness conservatively.
+ *
+ * A recorded destruction time wins over any status string, and an unrecognised
+ * status stays `unknown` so it can never be read as either live or gone.
+ */
+export const deriveInstanceStatus = ({
+  statusRaw,
+  destroyedAt,
+}: {
+  readonly statusRaw: string | null
+  readonly destroyedAt: string | null
+}): NamespaceInstanceStatus => {
+  if (destroyedAt !== null) return 'destroyed'
+  if (statusRaw === null) return 'unknown'
+  if (LIVE_STATUS.test(statusRaw)) return 'running'
+  if (GONE_STATUS.test(statusRaw)) return 'destroyed'
+  return 'unknown'
+}
+
+/** Decode `nsc github job describe -o json` stdout into Namespace job facts. */
+export const parseJobDescribe = (stdout: string): JobDescribeParse => {
+  const trimmed = stdout.trim()
+  if (trimmed.length === 0) return { _tag: 'unrecognized', detail: 'empty stdout' }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(trimmed)
+  } catch (cause) {
+    return {
+      _tag: 'unrecognized',
+      detail: `stdout is not JSON: ${cause instanceof Error ? cause.message : String(cause)}`,
+    }
+  }
+
+  const instanceId = findString(parsed, ['instance_id', 'instanceId'])
+  if (instanceId === null) {
+    return { _tag: 'unrecognized', detail: 'no instance id in job description' }
+  }
+
+  const destroyedAt = findString(parsed, ['destroyed_at', 'destroyedAt'])
+  const statusRaw = findString(parsed, [
+    'instance_status',
+    'instanceStatus',
+    'status',
+    'phase',
+    'state',
+  ])
+
+  return {
+    _tag: 'parsed',
+    job: {
+      instanceId,
+      instanceStatus: deriveInstanceStatus({ statusRaw, destroyedAt }),
+      instanceStatusRaw: statusRaw,
+      runnerName: findString(parsed, ['runner_name', 'runnerName']),
+      containerName: findString(parsed, ['container_name', 'containerName']),
+      repository: findString(parsed, ['repository', 'github_repository', 'githubRepository']),
+      workflow: findString(parsed, [
+        'workflow',
+        'workflow_name',
+        'workflowName',
+        'github_job_workflow_name',
+      ]),
+      jobName: findString(parsed, ['job_name', 'jobName']),
+      destroyedAt,
+    },
+  }
+}
+
+// =============================================================================
+// `nsc instance report` CSV decoding
+// =============================================================================
+
+/** The column that identifies a report's header line. */
+const REPORT_HEADER_COLUMN = 'instance_id'
+
+/**
+ * Split one CSV line, honouring double-quoted fields and `""` escapes.
+ *
+ * Job names routinely contain commas (`build (linux, arm64)`), so a
+ * `split(',')` would silently shift every later column.
+ */
+export const splitCsvLine = (line: string): ReadonlyArray<string> => {
+  const fields: string[] = []
+  let field = ''
+  let quoted = false
+
+  for (let index = 0; index < line.length; index++) {
+    const char = line[index]
+    if (quoted) {
+      if (char !== '"') {
+        field += char
+      } else if (line[index + 1] === '"') {
+        field += '"'
+        index++
+      } else {
+        quoted = false
+      }
+      continue
+    }
+    if (char === '"') {
+      quoted = true
+    } else if (char === ',') {
+      fields.push(field)
+      field = ''
+    } else {
+      field += char
+    }
+  }
+  fields.push(field)
+  return fields
+}
+
+/** One report row, keyed by the report's own column names. */
+export type InstanceReportRow = Readonly<Record<string, string>>
+
+/** Outcome of reading `nsc instance report --out -` stdout. */
+export type InstanceReportParse =
+  | { readonly _tag: 'parsed'; readonly rows: ReadonlyArray<InstanceReportRow> }
+  | { readonly _tag: 'unrecognized'; readonly detail: string }
+
+/**
+ * Decode a report body into column-keyed rows.
+ *
+ * `--out -` prefixes the CSV with a `Writing output to path: stdout` line, so
+ * the header is located by its first column rather than by position.
+ */
+export const parseInstanceReport = (stdout: string): InstanceReportParse => {
+  const lines = stdout.split('\n').map((line) => line.replace(/\r$/, ''))
+  const headerIndex = lines.findIndex((line) => line.startsWith(`${REPORT_HEADER_COLUMN},`))
+  if (headerIndex === -1) {
+    return { _tag: 'unrecognized', detail: 'no CSV header in report output' }
+  }
+
+  const header = splitCsvLine(lines[headerIndex]!)
+  const rows: Array<InstanceReportRow> = []
+
+  for (const line of lines.slice(headerIndex + 1)) {
+    if (line.trim().length === 0) continue
+    const fields = splitCsvLine(line)
+    const row: Record<string, string> = {}
+    header.forEach((column, index) => {
+      row[column] = fields[index] ?? ''
+    })
+    rows.push(row)
+  }
+
+  return { _tag: 'parsed', rows }
+}
+
+/** Report numbers are optional and may be blank; a blank is not a zero. */
+const finiteOrNull = (raw: string | undefined): number | null => {
+  if (raw === undefined || raw.trim().length === 0) return null
+  const value = Number(raw)
+  return Number.isFinite(value) ? value : null
+}
+
+/**
+ * Pick the row that is exactly this job on exactly this instance.
+ *
+ * Both ids must match: a report window is time-bounded, not job-bounded, and a
+ * retried job reuses its id across instances.
+ */
+export const selectUsageRow = ({
+  rows,
+  jobId,
+  instanceId,
+}: {
+  readonly rows: ReadonlyArray<InstanceReportRow>
+  readonly jobId: number
+  readonly instanceId: string
+}): NamespaceUsage | null => {
+  const wantedJobId = String(jobId)
+  for (const row of rows) {
+    if (row['github_job_id'] !== wantedJobId) continue
+    if (row['instance_id'] !== instanceId) continue
+
+    const allocatedCpu = finiteOrNull(row['resources_cpu'])
+    const allocatedRamGb = finiteOrNull(row['resources_ram_gb'])
+    const cpuMaxFraction = finiteOrNull(row['resources_cpu_actual_max'])
+    const ramMaxFraction = finiteOrNull(row['resources_ram_gb_actual_max_percent'])
+    if (
+      allocatedCpu === null ||
+      allocatedRamGb === null ||
+      cpuMaxFraction === null ||
+      ramMaxFraction === null
+    ) {
+      /** A row missing the numbers we would reason about is not usage evidence. */
+      continue
+    }
+
+    const created = row['created_at']
+    const started = row['started_at']
+    const destroyed = row['destroyed_at']
+    return {
+      instanceId,
+      githubJobId: wantedJobId,
+      allocatedCpu,
+      allocatedRamGb,
+      cpuMaxFraction,
+      ramMaxFraction,
+      createdAt: created === undefined || created.length === 0 ? null : created,
+      startedAt: started === undefined || started.length === 0 ? null : started,
+      destroyedAt: destroyed === undefined || destroyed.length === 0 ? null : destroyed,
+    }
+  }
+  return null
+}
+
+// =============================================================================
+// Process execution
+// =============================================================================
+
+/** What a single `nsc` invocation produced. */
+interface NscRun {
+  readonly stdout: string
+  readonly stderr: string
+  readonly exitCode: number
+}
+
+/** Why an invocation produced no output at all. */
+type NscFailure =
+  | { readonly _tag: 'nsc-missing'; readonly detail: string }
+  | { readonly _tag: 'timed-out'; readonly detail: string }
+  | { readonly _tag: 'spawn-failed'; readonly detail: string }
+
+type NscOutcome =
+  | { readonly _tag: 'ran'; readonly run: NscRun }
+  | { readonly _tag: 'failed'; readonly failure: NscFailure }
+
+/**
+ * Run one approved `nsc` invocation, collecting stdout, stderr and the exit
+ * code concurrently.
+ *
+ * `spawner.string` would drop stderr and the exit code, turning a dead child
+ * into an empty success that then surfaces as a bogus decode failure. stderr is
+ * kept in its own field so diagnostics can never contaminate the JSON or CSV
+ * that gets parsed.
+ */
+const runNsc = ({
+  argv,
+  timeout,
+}: {
+  readonly argv: ReadonlyArray<string>
+  readonly timeout: Duration.Duration
+}): Effect.Effect<NscOutcome, never, ChildProcessSpawner> =>
+  Effect.gen(function* () {
+    const attempt: Effect.Effect<NscRun, PlatformError, ChildProcessSpawner> = Effect.scoped(
+      Effect.gen(function* () {
+        const handle = yield* ChildProcessSpawner.use((spawner) =>
+          spawner.spawn(ChildProcess.make(NSC, [...argv])),
+        )
+        const [stdout, stderr, exitCode] = yield* Effect.all(
+          [
+            Stream.mkString(Stream.decodeText(handle.stdout)),
+            Stream.mkString(Stream.decodeText(handle.stderr)),
+            handle.exitCode,
+          ],
+          { concurrency: 3 },
+        )
+        return { stdout, stderr: stderr.trim(), exitCode }
+      }),
+    )
+
+    const outcome = yield* Effect.result(attempt.pipe(Effect.timeoutOption(timeout)))
+
+    if (outcome._tag === 'Failure') {
+      const { reason } = outcome.failure
+      return {
+        _tag: 'failed',
+        failure:
+          /** `NotFound` from a spawn is `nsc` not being on PATH — expected data. */
+          reason._tag === 'NotFound'
+            ? { _tag: 'nsc-missing', detail: outcome.failure.message }
+            : { _tag: 'spawn-failed', detail: outcome.failure.message },
+      }
+    }
+
+    return Option.isNone(outcome.success)
+      ? {
+          _tag: 'failed',
+          failure: {
+            _tag: 'timed-out',
+            detail: `nsc ${argv.join(' ')} exceeded ${Duration.toSeconds(timeout)}s`,
+          },
+        }
+      : { _tag: 'ran', run: outcome.success.value }
+  })
+
+/** Map a process failure onto the reason vocabulary the facts expose. */
+const unavailableFromFailure = (
+  failure: NscFailure,
+): { readonly reason: 'nsc-missing' | 'timed-out' | 'command-failed'; readonly detail: string } => {
+  switch (failure._tag) {
+    case 'nsc-missing':
+      return { reason: 'nsc-missing', detail: failure.detail }
+    case 'timed-out':
+      return { reason: 'timed-out', detail: failure.detail }
+    case 'spawn-failed':
+      return { reason: 'command-failed', detail: failure.detail }
+  }
+}
+
+/** stderr that means "`nsc` does not know this job", rather than a real fault. */
+const NOT_FOUND_STDERR = /not found|no such|unknown job|does not exist/i
+
+// =============================================================================
+// The observation
+// =============================================================================
+
+/**
+ * Observe the Namespace side of a GitHub job.
+ *
+ * Runs no subprocess at all unless GitHub already identified the runner as a
+ * Namespace runner, and never fails: every problem is reported as a tagged
+ * `unavailable` observation so the caller's GitHub facts survive intact.
+ */
+export const observeNamespaceJob = ({
+  github,
+  withUsage,
+}: {
+  readonly github: InspectGitHubFacts
+  readonly withUsage: boolean
+}): Effect.Effect<InspectNamespaceFacts, never, ChildProcessSpawner> =>
+  Effect.gen(function* () {
+    if (github.runnerKind !== 'namespace') {
+      /** No Namespace runner, no `nsc` call: there is nothing for it to answer. */
+      return { _tag: 'not-namespace-job', runnerKind: github.runnerKind }
+    }
+
+    const commands: Array<ReadonlyArray<string>> = []
+
+    const checkLoginArgv = authCheckLoginArgv()
+    commands.push(checkLoginArgv)
+    const checkLogin = yield* runNsc({ argv: checkLoginArgv, timeout: CHECK_LOGIN_TIMEOUT })
+    if (checkLogin._tag === 'failed') {
+      const { reason, detail } = unavailableFromFailure(checkLogin.failure)
+      return { _tag: 'unavailable', reason, detail, commands }
+    }
+    if (checkLogin.run.exitCode !== 0) {
+      return {
+        _tag: 'unavailable',
+        reason: 'not-authenticated',
+        detail:
+          checkLogin.run.stderr.length > 0
+            ? checkLogin.run.stderr
+            : `nsc auth check-login exited with ${checkLogin.run.exitCode}`,
+        commands,
+      }
+    }
+
+    const describeArgv = jobDescribeArgv(github.jobId)
+    commands.push(describeArgv)
+    const describe = yield* runNsc({ argv: describeArgv, timeout: JOB_DESCRIBE_TIMEOUT })
+    if (describe._tag === 'failed') {
+      const { reason, detail } = unavailableFromFailure(describe.failure)
+      return { _tag: 'unavailable', reason, detail, commands }
+    }
+    if (describe.run.exitCode !== 0) {
+      return {
+        _tag: 'unavailable',
+        reason: NOT_FOUND_STDERR.test(describe.run.stderr) ? 'job-not-found' : 'command-failed',
+        detail:
+          describe.run.stderr.length > 0
+            ? describe.run.stderr
+            : `nsc github job describe exited with ${describe.run.exitCode}`,
+        commands,
+      }
+    }
+
+    const parsed = parseJobDescribe(describe.run.stdout)
+    if (parsed._tag === 'unrecognized') {
+      return { _tag: 'unavailable', reason: 'unrecognized-output', detail: parsed.detail, commands }
+    }
+
+    const usage = yield* observeUsage({ github, job: parsed.job, withUsage, commands })
+    return { _tag: 'reported', job: parsed.job, usage, commands }
+  })
+
+/** Sample the instance report for this job, or report why there is no sample. */
+const observeUsage = ({
+  github,
+  job,
+  withUsage,
+  commands,
+}: {
+  readonly github: InspectGitHubFacts
+  readonly job: NamespaceJobFacts
+  readonly withUsage: boolean
+  readonly commands: Array<ReadonlyArray<string>>
+}): Effect.Effect<NamespaceUsageState, never, ChildProcessSpawner> =>
+  Effect.gen(function* () {
+    if (withUsage === false) return { _tag: 'not-requested' }
+
+    const window = deriveReportWindow({
+      startedAt: github.startedAt,
+      completedAt: github.completedAt,
+      now: new Date(),
+    })
+    if (window === null) {
+      return {
+        _tag: 'unavailable',
+        reason: 'no-window',
+        detail: 'GitHub reported no start time for this job, so no bounded report window exists.',
+      }
+    }
+
+    const argv = instanceReportArgv({
+      window,
+      repository: github.repo,
+      /** Namespace records the GitHub job name, which is this job's own name. */
+      jobName: job.jobName ?? github.name,
+    })
+    commands.push(argv)
+    const report = yield* runNsc({ argv, timeout: INSTANCE_REPORT_TIMEOUT })
+    if (report._tag === 'failed') {
+      const { reason, detail } = unavailableFromFailure(report.failure)
+      return { _tag: 'unavailable', reason, detail }
+    }
+    if (report.run.exitCode !== 0) {
+      return {
+        _tag: 'unavailable',
+        reason: 'command-failed',
+        detail:
+          report.run.stderr.length > 0
+            ? report.run.stderr
+            : `nsc instance report exited with ${report.run.exitCode}`,
+      }
+    }
+
+    const parsed = parseInstanceReport(report.run.stdout)
+    if (parsed._tag === 'unrecognized') {
+      return { _tag: 'unavailable', reason: 'unrecognized-output', detail: parsed.detail }
+    }
+
+    const sample = selectUsageRow({
+      rows: parsed.rows,
+      jobId: github.jobId,
+      instanceId: job.instanceId,
+    })
+    return sample === null
+      ? {
+          _tag: 'unavailable',
+          reason: 'no-matching-row',
+          detail: `No report row for job ${github.jobId} on instance ${job.instanceId}.`,
+        }
+      : { _tag: 'sampled', sample }
+  })

--- a/packages/@overeng/gh-ci-utils/src/node/NamespaceClient.ts
+++ b/packages/@overeng/gh-ci-utils/src/node/NamespaceClient.ts
@@ -24,9 +24,9 @@
  * # Decoding
  *
  * `nsc github job describe -o json` has no stable published schema, so the
- * decoder here is deliberately tolerant: it looks for known field names
- * anywhere in the returned object graph and degrades anything it does not
- * recognise to `null`/`unknown` rather than asserting a shape.
+ * decoder here is deliberately tolerant: it locates the requested instance
+ * anywhere in the returned object graph, then limits fallback metadata to that
+ * instance's enclosing job/attempt context.
  */
 import { Duration, Effect, Option, Stream } from 'effect'
 import type { PlatformError } from 'effect/PlatformError'
@@ -227,7 +227,19 @@ const findOwnedString = ({
   return null
 }
 
-/** Find the object that directly owns a matching identity field. */
+/** A selected instance record and the array-delimited job/attempt context that encloses it. */
+interface RecordSelection {
+  readonly record: object
+  readonly context: object
+}
+
+/**
+ * Find the object that directly owns a matching identity field.
+ *
+ * Each array item starts a separate context. This keeps metadata fallback
+ * inside the selected attempt when a description contains attempt history,
+ * while a description with one top-level job still uses that whole job object.
+ */
 const findRecord = ({
   root,
   keys,
@@ -236,33 +248,43 @@ const findRecord = ({
   root: unknown
   keys: ReadonlyArray<string>
   value: string
-}): object | null => {
-  const visit = ({ node, depth }: { node: unknown; depth: number }): object | null => {
+}): RecordSelection | null => {
+  const visit = ({
+    node,
+    depth,
+    context,
+  }: {
+    node: unknown
+    depth: number
+    context: object | null
+  }): RecordSelection | null => {
     if (depth > MAX_LOOKUP_DEPTH || typeof node !== 'object' || node === null) return null
     if (Array.isArray(node)) {
       for (const item of node) {
-        const found = visit({ node: item, depth: depth + 1 })
+        const itemContext = typeof item === 'object' && item !== null ? item : context
+        const found = visit({ node: item, depth: depth + 1, context: itemContext })
         if (found !== null) return found
       }
       return null
     }
 
+    const enclosingContext = context ?? node
     if (
       keys.some((key) => {
         const candidate = Reflect.get(node, key)
         return candidate === value || (typeof candidate === 'number' && String(candidate) === value)
       })
     ) {
-      return node
+      return { record: node, context: enclosingContext }
     }
 
     for (const nested of Object.values(node)) {
-      const found = visit({ node: nested, depth: depth + 1 })
+      const found = visit({ node: nested, depth: depth + 1, context: enclosingContext })
       if (found !== null) return found
     }
     return null
   }
-  return visit({ node: root, depth: 0 })
+  return visit({ node: root, depth: 0, context: null })
 }
 
 /** Status strings that positively establish a live instance. */
@@ -311,20 +333,21 @@ export const parseJobDescribe = ({
     }
   }
 
-  const instanceRecord = findRecord({
+  const selection = findRecord({
     root: parsed,
     keys: ['instance_id', 'instanceId'],
     value: expectedInstanceId,
   })
-  if (instanceRecord === null) {
+  if (selection === null) {
     return {
       _tag: 'unrecognized',
       detail: `no record for expected instance ${expectedInstanceId} in job description`,
     }
   }
 
+  const { context: instanceContext, record: instanceRecord } = selection
   const findInstanceString = (keys: ReadonlyArray<string>): string | null =>
-    findOwnedString({ record: instanceRecord, keys }) ?? findString({ root: parsed, keys })
+    findOwnedString({ record: instanceRecord, keys }) ?? findString({ root: instanceContext, keys })
   const destroyedAt = findOwnedString({
     record: instanceRecord,
     keys: ['destroyed_at', 'destroyedAt'],

--- a/packages/@overeng/gh-ci-utils/src/node/NamespaceClient.ts
+++ b/packages/@overeng/gh-ci-utils/src/node/NamespaceClient.ts
@@ -170,15 +170,19 @@ export type JobDescribeParse =
 /** Maximum object-graph depth searched for a known field name. */
 const MAX_LOOKUP_DEPTH = 6
 
+/** Object field names whose contents describe attempts other than the enclosing one. */
+const isAttemptHistoryKey = (key: string): boolean =>
+  /^(?:attempts|previous[_-]?attempts?|attempt[_-]?history)$/i.test(key)
+
 /**
  * Find the first non-empty string stored under any of `keys` within one
  * logical job/attempt record.
  *
  * `nsc` nests the runner/instance block differently across output versions, so
  * a fixed path would break on a rename that a search survives. Keys at the
- * current level are preferred over nested ones. Arrays delimit sibling
- * attempts and are never crossed, so historical metadata cannot describe the
- * selected runner.
+ * current level are preferred over nested ones. Arrays and history-shaped
+ * object fields delimit sibling attempts and are never crossed, so historical
+ * metadata cannot describe the selected runner.
  */
 const findString = ({
   root,
@@ -198,7 +202,8 @@ const findString = ({
       if (typeof value === 'string' && value.length > 0) return value
       if (typeof value === 'number' && Number.isFinite(value)) return String(value)
     }
-    for (const [, value] of entries) {
+    for (const [key, value] of entries) {
+      if (isAttemptHistoryKey(key) && typeof value === 'object' && value !== null) continue
       const found = visit({ node: value, depth: depth + 1 })
       if (found !== null) return found
     }
@@ -223,7 +228,7 @@ const findOwnedString = ({
   return null
 }
 
-/** A selected instance record and the array-delimited job/attempt context that encloses it. */
+/** A selected instance record and the attempt-boundary context that encloses it. */
 interface RecordSelection {
   readonly record: object
   readonly context: object
@@ -232,9 +237,10 @@ interface RecordSelection {
 /**
  * Find the object that directly owns a matching identity field.
  *
- * Each array item starts a separate context. This keeps metadata fallback
- * inside the selected attempt when a description contains attempt history,
- * while a description with one top-level job still uses that whole job object.
+ * Each array item and history-shaped object field starts a separate context.
+ * This keeps metadata fallback inside the selected attempt when a description
+ * contains attempt history, while a description with one top-level job still
+ * uses that whole job object.
  */
 const findRecord = ({
   root,
@@ -274,8 +280,12 @@ const findRecord = ({
       return { record: node, context: enclosingContext }
     }
 
-    for (const nested of Object.values(node)) {
-      const found = visit({ node: nested, depth: depth + 1, context: enclosingContext })
+    for (const [key, nested] of Object.entries(node)) {
+      const nestedContext =
+        isAttemptHistoryKey(key) && typeof nested === 'object' && nested !== null
+          ? nested
+          : enclosingContext
+      const found = visit({ node: nested, depth: depth + 1, context: nestedContext })
       if (found !== null) return found
     }
     return null

--- a/packages/@overeng/gh-ci-utils/src/node/NamespaceClient.ts
+++ b/packages/@overeng/gh-ci-utils/src/node/NamespaceClient.ts
@@ -291,7 +291,13 @@ export const deriveInstanceStatus = ({
 }
 
 /** Decode `nsc github job describe -o json` stdout into Namespace job facts. */
-export const parseJobDescribe = (stdout: string): JobDescribeParse => {
+export const parseJobDescribe = ({
+  stdout,
+  expectedInstanceId,
+}: {
+  readonly stdout: string
+  readonly expectedInstanceId: string
+}): JobDescribeParse => {
   const trimmed = stdout.trim()
   if (trimmed.length === 0) return { _tag: 'unrecognized', detail: 'empty stdout' }
 
@@ -305,45 +311,45 @@ export const parseJobDescribe = (stdout: string): JobDescribeParse => {
     }
   }
 
-  const instanceId = findString({ root: parsed, keys: ['instance_id', 'instanceId'] })
-  if (instanceId === null) {
-    return { _tag: 'unrecognized', detail: 'no instance id in job description' }
-  }
-
   const instanceRecord = findRecord({
     root: parsed,
     keys: ['instance_id', 'instanceId'],
-    value: instanceId,
+    value: expectedInstanceId,
   })
-  const destroyedAt =
-    instanceRecord === null
-      ? null
-      : findOwnedString({ record: instanceRecord, keys: ['destroyed_at', 'destroyedAt'] })
-  const statusRaw =
-    instanceRecord === null
-      ? null
-      : findOwnedString({
-          record: instanceRecord,
-          keys: ['instance_status', 'instanceStatus', 'status', 'phase', 'state'],
-        })
+  if (instanceRecord === null) {
+    return {
+      _tag: 'unrecognized',
+      detail: `no record for expected instance ${expectedInstanceId} in job description`,
+    }
+  }
+
+  const findInstanceString = (keys: ReadonlyArray<string>): string | null =>
+    findOwnedString({ record: instanceRecord, keys }) ?? findString({ root: parsed, keys })
+  const destroyedAt = findOwnedString({
+    record: instanceRecord,
+    keys: ['destroyed_at', 'destroyedAt'],
+  })
+  const statusRaw = findOwnedString({
+    record: instanceRecord,
+    keys: ['instance_status', 'instanceStatus', 'status', 'phase', 'state'],
+  })
 
   return {
     _tag: 'parsed',
     job: {
-      instanceId,
+      instanceId: expectedInstanceId,
       instanceStatus: deriveInstanceStatus({ statusRaw, destroyedAt }),
       instanceStatusRaw: statusRaw,
-      runnerName: findString({ root: parsed, keys: ['runner_name', 'runnerName'] }),
-      containerName: findString({ root: parsed, keys: ['container_name', 'containerName'] }),
-      repository: findString({
-        root: parsed,
-        keys: ['repository', 'github_repository', 'githubRepository'],
-      }),
-      workflow: findString({
-        root: parsed,
-        keys: ['workflow', 'workflow_name', 'workflowName', 'github_job_workflow_name'],
-      }),
-      jobName: findString({ root: parsed, keys: ['job_name', 'jobName'] }),
+      runnerName: findInstanceString(['runner_name', 'runnerName']),
+      containerName: findInstanceString(['container_name', 'containerName']),
+      repository: findInstanceString(['repository', 'github_repository', 'githubRepository']),
+      workflow: findInstanceString([
+        'workflow',
+        'workflow_name',
+        'workflowName',
+        'github_job_workflow_name',
+      ]),
+      jobName: findInstanceString(['job_name', 'jobName']),
       destroyedAt,
     },
   }
@@ -616,6 +622,14 @@ export const observeNamespaceJob = ({
     }
 
     const commands: Array<ReadonlyArray<string>> = []
+    if (github.runnerInstance === null) {
+      return {
+        _tag: 'unavailable',
+        reason: 'unrecognized-output',
+        detail: 'GitHub identified a Namespace runner without an instance identity.',
+        commands,
+      }
+    }
 
     const checkLoginArgv = authCheckLoginArgv()
     commands.push(checkLoginArgv)
@@ -657,7 +671,10 @@ export const observeNamespaceJob = ({
       }
     }
 
-    const parsed = parseJobDescribe(describe.run.stdout)
+    const parsed = parseJobDescribe({
+      stdout: describe.run.stdout,
+      expectedInstanceId: github.runnerInstance,
+    })
     if (parsed._tag === 'unrecognized') {
       return { _tag: 'unavailable', reason: 'unrecognized-output', detail: parsed.detail, commands }
     }

--- a/packages/@overeng/gh-ci-utils/src/node/NamespaceClient.ts
+++ b/packages/@overeng/gh-ci-utils/src/node/NamespaceClient.ts
@@ -320,10 +320,12 @@ export const parseJobDescribe = (stdout: string): JobDescribeParse => {
       ? null
       : findOwnedString({ record: instanceRecord, keys: ['destroyed_at', 'destroyedAt'] })
   const statusRaw =
-    findString({ root: parsed, keys: ['instance_status', 'instanceStatus'] }) ??
-    (instanceRecord === null
+    instanceRecord === null
       ? null
-      : findString({ root: instanceRecord, keys: ['status', 'phase', 'state'] }))
+      : findOwnedString({
+          record: instanceRecord,
+          keys: ['instance_status', 'instanceStatus', 'status', 'phase', 'state'],
+        })
 
   return {
     _tag: 'parsed',

--- a/packages/@overeng/gh-ci-utils/src/node/NamespaceClient.ts
+++ b/packages/@overeng/gh-ci-utils/src/node/NamespaceClient.ts
@@ -174,6 +174,10 @@ const MAX_LOOKUP_DEPTH = 6
 const isAttemptHistoryKey = (key: string): boolean =>
   /^(?:attempts|previous[_-]?attempts?|attempt[_-]?history)$/i.test(key)
 
+/** Attempt-boundary fields whose object values are maps of sibling attempts. */
+const isAttemptCollectionKey = (key: string): boolean =>
+  /^(?:attempts|previous[_-]?attempts|attempt[_-]?history)$/i.test(key)
+
 /**
  * Find the first non-empty string stored under any of `keys` within one
  * logical job/attempt record.
@@ -237,10 +241,10 @@ interface RecordSelection {
 /**
  * Find the object that directly owns a matching identity field.
  *
- * Each array item and history-shaped object field starts a separate context.
- * This keeps metadata fallback inside the selected attempt when a description
- * contains attempt history, while a description with one top-level job still
- * uses that whole job object.
+ * Each array item, singular history field, and entry in an object-valued
+ * attempt collection starts a separate context. This keeps metadata fallback
+ * inside the selected attempt when a description contains attempt history,
+ * while a description with one top-level job still uses that whole job object.
  */
 const findRecord = ({
   root,
@@ -281,6 +285,20 @@ const findRecord = ({
     }
 
     for (const [key, nested] of Object.entries(node)) {
+      if (
+        isAttemptCollectionKey(key) &&
+        typeof nested === 'object' &&
+        nested !== null &&
+        Array.isArray(nested) === false
+      ) {
+        for (const attempt of Object.values(nested)) {
+          if (typeof attempt !== 'object' || attempt === null) continue
+          const found = visit({ node: attempt, depth: depth + 2, context: attempt })
+          if (found !== null) return found
+        }
+        continue
+      }
+
       const nestedContext =
         isAttemptHistoryKey(key) && typeof nested === 'object' && nested !== null
           ? nested

--- a/packages/@overeng/gh-ci-utils/src/node/NamespaceClient.ts
+++ b/packages/@overeng/gh-ci-utils/src/node/NamespaceClient.ts
@@ -211,6 +211,44 @@ const findString = ({
   return visit({ node: root, depth: 0 })
 }
 
+/** Find the object that directly owns a matching identity field. */
+const findRecord = ({
+  root,
+  keys,
+  value,
+}: {
+  root: unknown
+  keys: ReadonlyArray<string>
+  value: string
+}): object | null => {
+  const visit = ({ node, depth }: { node: unknown; depth: number }): object | null => {
+    if (depth > MAX_LOOKUP_DEPTH || typeof node !== 'object' || node === null) return null
+    if (Array.isArray(node)) {
+      for (const item of node) {
+        const found = visit({ node: item, depth: depth + 1 })
+        if (found !== null) return found
+      }
+      return null
+    }
+
+    if (
+      keys.some((key) => {
+        const candidate = Reflect.get(node, key)
+        return candidate === value || (typeof candidate === 'number' && String(candidate) === value)
+      })
+    ) {
+      return node
+    }
+
+    for (const nested of Object.values(node)) {
+      const found = visit({ node: nested, depth: depth + 1 })
+      if (found !== null) return found
+    }
+    return null
+  }
+  return visit({ node: root, depth: 0 })
+}
+
 /** Status strings that positively establish a live instance. */
 const LIVE_STATUS = /^(running|live|ready|started|starting|active|in_use)$/i
 /** Status strings that positively establish a gone instance. */
@@ -257,10 +295,16 @@ export const parseJobDescribe = (stdout: string): JobDescribeParse => {
   }
 
   const destroyedAt = findString({ root: parsed, keys: ['destroyed_at', 'destroyedAt'] })
-  const statusRaw = findString({
+  const instanceRecord = findRecord({
     root: parsed,
-    keys: ['instance_status', 'instanceStatus', 'status', 'phase', 'state'],
+    keys: ['instance_id', 'instanceId'],
+    value: instanceId,
   })
+  const statusRaw =
+    findString({ root: parsed, keys: ['instance_status', 'instanceStatus'] }) ??
+    (instanceRecord === null
+      ? null
+      : findString({ root: instanceRecord, keys: ['status', 'phase', 'state'] }))
 
   return {
     _tag: 'parsed',
@@ -518,8 +562,13 @@ const unavailableFromFailure = (
   }
 }
 
-/** stderr that means "`nsc` does not know this job", rather than a real fault. */
-const NOT_FOUND_STDERR = /not found|no such|unknown job|does not exist/i
+/** stderr that specifically says "`nsc` does not know this job". */
+const isJobNotFoundStderr = ({ stderr, jobId }: { stderr: string; jobId: number }): boolean => {
+  if (stderr.includes(String(jobId)) === false) return false
+  return /\bjob\b[^\n]*(?:not found|does not exist)|(?:no such|unknown)\s+(?:github\s+)?job\b/i.test(
+    stderr,
+  )
+}
 
 // =============================================================================
 // The observation
@@ -576,7 +625,9 @@ export const observeNamespaceJob = ({
     if (describe.run.exitCode !== 0) {
       return {
         _tag: 'unavailable',
-        reason: NOT_FOUND_STDERR.test(describe.run.stderr) ? 'job-not-found' : 'command-failed',
+        reason: isJobNotFoundStderr({ stderr: describe.run.stderr, jobId: github.jobId })
+          ? 'job-not-found'
+          : 'command-failed',
         detail:
           describe.run.stderr.length > 0
             ? describe.run.stderr

--- a/packages/@overeng/gh-ci-utils/src/node/NamespaceClient.ts
+++ b/packages/@overeng/gh-ci-utils/src/node/NamespaceClient.ts
@@ -459,15 +459,16 @@ export const selectUsageRow = ({
 
     const allocatedCpu = finiteOrNull(row['resources_cpu'])
     const allocatedRamGb = finiteOrNull(row['resources_ram_gb'])
-    const cpuMaxFraction = finiteOrNull(row['resources_cpu_actual_max'])
+    const cpuMaxCores = finiteOrNull(row['resources_cpu_actual_max'])
     const ramMaxFraction = finiteOrNull(row['resources_ram_gb_actual_max_percent'])
     if (
       allocatedCpu === null ||
+      allocatedCpu <= 0 ||
       allocatedRamGb === null ||
-      cpuMaxFraction === null ||
+      cpuMaxCores === null ||
       ramMaxFraction === null
     ) {
-      /** A row missing the numbers we would reason about is not usage evidence. */
+      /** A row missing usable numbers we would reason about is not usage evidence. */
       continue
     }
 
@@ -479,7 +480,7 @@ export const selectUsageRow = ({
       githubJobId: wantedJobId,
       allocatedCpu,
       allocatedRamGb,
-      cpuMaxFraction,
+      cpuMaxFraction: cpuMaxCores / allocatedCpu,
       ramMaxFraction,
       createdAt: created === undefined || created.length === 0 ? null : created,
       startedAt: started === undefined || started.length === 0 ? null : started,

--- a/packages/@overeng/gh-ci-utils/src/node/NamespaceClient.ts
+++ b/packages/@overeng/gh-ci-utils/src/node/NamespaceClient.ts
@@ -211,6 +211,22 @@ const findString = ({
   return visit({ node: root, depth: 0 })
 }
 
+/** Find a string field directly owned by a record, without traversing nested records. */
+const findOwnedString = ({
+  record,
+  keys,
+}: {
+  record: object
+  keys: ReadonlyArray<string>
+}): string | null => {
+  for (const key of keys) {
+    const value = Reflect.get(record, key)
+    if (typeof value === 'string' && value.length > 0) return value
+    if (typeof value === 'number' && Number.isFinite(value)) return String(value)
+  }
+  return null
+}
+
 /** Find the object that directly owns a matching identity field. */
 const findRecord = ({
   root,
@@ -294,12 +310,15 @@ export const parseJobDescribe = (stdout: string): JobDescribeParse => {
     return { _tag: 'unrecognized', detail: 'no instance id in job description' }
   }
 
-  const destroyedAt = findString({ root: parsed, keys: ['destroyed_at', 'destroyedAt'] })
   const instanceRecord = findRecord({
     root: parsed,
     keys: ['instance_id', 'instanceId'],
     value: instanceId,
   })
+  const destroyedAt =
+    instanceRecord === null
+      ? null
+      : findOwnedString({ record: instanceRecord, keys: ['destroyed_at', 'destroyedAt'] })
   const statusRaw =
     findString({ root: parsed, keys: ['instance_status', 'instanceStatus'] }) ??
     (instanceRecord === null

--- a/packages/@overeng/gh-ci-utils/src/node/NamespaceClient.ts
+++ b/packages/@overeng/gh-ci-utils/src/node/NamespaceClient.ts
@@ -178,13 +178,19 @@ const MAX_LOOKUP_DEPTH = 6
  * current level are preferred over nested ones, so a top-level `status` is
  * never shadowed by a deeper one.
  */
-const findString = (root: unknown, keys: ReadonlyArray<string>): string | null => {
-  const visit = (node: unknown, depth: number): string | null => {
+const findString = ({
+  root,
+  keys,
+}: {
+  root: unknown
+  keys: ReadonlyArray<string>
+}): string | null => {
+  const visit = ({ node, depth }: { node: unknown; depth: number }): string | null => {
     if (depth > MAX_LOOKUP_DEPTH || typeof node !== 'object' || node === null) return null
 
     if (Array.isArray(node)) {
       for (const item of node) {
-        const found = visit(item, depth + 1)
+        const found = visit({ node: item, depth: depth + 1 })
         if (found !== null) return found
       }
       return null
@@ -197,12 +203,12 @@ const findString = (root: unknown, keys: ReadonlyArray<string>): string | null =
       if (typeof value === 'number' && Number.isFinite(value)) return String(value)
     }
     for (const [, value] of entries) {
-      const found = visit(value, depth + 1)
+      const found = visit({ node: value, depth: depth + 1 })
       if (found !== null) return found
     }
     return null
   }
-  return visit(root, 0)
+  return visit({ node: root, depth: 0 })
 }
 
 /** Status strings that positively establish a live instance. */
@@ -245,19 +251,16 @@ export const parseJobDescribe = (stdout: string): JobDescribeParse => {
     }
   }
 
-  const instanceId = findString(parsed, ['instance_id', 'instanceId'])
+  const instanceId = findString({ root: parsed, keys: ['instance_id', 'instanceId'] })
   if (instanceId === null) {
     return { _tag: 'unrecognized', detail: 'no instance id in job description' }
   }
 
-  const destroyedAt = findString(parsed, ['destroyed_at', 'destroyedAt'])
-  const statusRaw = findString(parsed, [
-    'instance_status',
-    'instanceStatus',
-    'status',
-    'phase',
-    'state',
-  ])
+  const destroyedAt = findString({ root: parsed, keys: ['destroyed_at', 'destroyedAt'] })
+  const statusRaw = findString({
+    root: parsed,
+    keys: ['instance_status', 'instanceStatus', 'status', 'phase', 'state'],
+  })
 
   return {
     _tag: 'parsed',
@@ -265,16 +268,17 @@ export const parseJobDescribe = (stdout: string): JobDescribeParse => {
       instanceId,
       instanceStatus: deriveInstanceStatus({ statusRaw, destroyedAt }),
       instanceStatusRaw: statusRaw,
-      runnerName: findString(parsed, ['runner_name', 'runnerName']),
-      containerName: findString(parsed, ['container_name', 'containerName']),
-      repository: findString(parsed, ['repository', 'github_repository', 'githubRepository']),
-      workflow: findString(parsed, [
-        'workflow',
-        'workflow_name',
-        'workflowName',
-        'github_job_workflow_name',
-      ]),
-      jobName: findString(parsed, ['job_name', 'jobName']),
+      runnerName: findString({ root: parsed, keys: ['runner_name', 'runnerName'] }),
+      containerName: findString({ root: parsed, keys: ['container_name', 'containerName'] }),
+      repository: findString({
+        root: parsed,
+        keys: ['repository', 'github_repository', 'githubRepository'],
+      }),
+      workflow: findString({
+        root: parsed,
+        keys: ['workflow', 'workflow_name', 'workflowName', 'github_job_workflow_name'],
+      }),
+      jobName: findString({ root: parsed, keys: ['job_name', 'jobName'] }),
       destroyedAt,
     },
   }

--- a/packages/@overeng/gh-ci-utils/src/node/NamespaceClient.ts
+++ b/packages/@overeng/gh-ci-utils/src/node/NamespaceClient.ts
@@ -232,19 +232,20 @@ const findOwnedString = ({
   return null
 }
 
-/** A selected instance record and the attempt-boundary context that encloses it. */
+/** A selected instance record and its metadata scopes, ordered most-specific first. */
 interface RecordSelection {
   readonly record: object
-  readonly context: object
+  readonly metadataContexts: ReadonlyArray<object>
 }
 
 /**
  * Find the object that directly owns a matching identity field.
  *
- * Each array item, singular history field, and entry in an object-valued
- * attempt collection starts a separate context. This keeps metadata fallback
- * inside the selected attempt when a description contains attempt history,
- * while a description with one top-level job still uses that whole job object.
+ * Each array item and singular history field starts a separate context. An
+ * entry in an object-valued attempt collection additionally inherits the
+ * enclosing job record, whose history fields are excluded by `findString`.
+ * Keeping those scopes separate lets selected-attempt metadata win without
+ * allowing metadata from a sibling attempt to leak into the result.
  */
 const findRecord = ({
   root,
@@ -258,30 +259,34 @@ const findRecord = ({
   const visit = ({
     node,
     depth,
-    context,
+    metadataContexts,
   }: {
     node: unknown
     depth: number
-    context: object | null
+    metadataContexts: ReadonlyArray<object>
   }): RecordSelection | null => {
     if (depth > MAX_LOOKUP_DEPTH || typeof node !== 'object' || node === null) return null
     if (Array.isArray(node)) {
       for (const item of node) {
-        const itemContext = typeof item === 'object' && item !== null ? item : context
-        const found = visit({ node: item, depth: depth + 1, context: itemContext })
+        const itemContexts = typeof item === 'object' && item !== null ? [item] : metadataContexts
+        const found = visit({
+          node: item,
+          depth: depth + 1,
+          metadataContexts: itemContexts,
+        })
         if (found !== null) return found
       }
       return null
     }
 
-    const enclosingContext = context ?? node
+    const enclosingContexts = metadataContexts.length === 0 ? [node] : metadataContexts
     if (
       keys.some((key) => {
         const candidate = Reflect.get(node, key)
         return candidate === value || (typeof candidate === 'number' && String(candidate) === value)
       })
     ) {
-      return { record: node, context: enclosingContext }
+      return { record: node, metadataContexts: enclosingContexts }
     }
 
     for (const [key, nested] of Object.entries(node)) {
@@ -293,22 +298,30 @@ const findRecord = ({
       ) {
         for (const attempt of Object.values(nested)) {
           if (typeof attempt !== 'object' || attempt === null) continue
-          const found = visit({ node: attempt, depth: depth + 2, context: attempt })
+          const found = visit({
+            node: attempt,
+            depth: depth + 2,
+            metadataContexts: [attempt, ...enclosingContexts],
+          })
           if (found !== null) return found
         }
         continue
       }
 
-      const nestedContext =
+      const nestedContexts =
         isAttemptHistoryKey(key) && typeof nested === 'object' && nested !== null
-          ? nested
-          : enclosingContext
-      const found = visit({ node: nested, depth: depth + 1, context: nestedContext })
+          ? [nested]
+          : enclosingContexts
+      const found = visit({
+        node: nested,
+        depth: depth + 1,
+        metadataContexts: nestedContexts,
+      })
       if (found !== null) return found
     }
     return null
   }
-  return visit({ node: root, depth: 0, context: null })
+  return visit({ node: root, depth: 0, metadataContexts: [] })
 }
 
 /** Status strings that positively establish a live instance. */
@@ -369,9 +382,16 @@ export const parseJobDescribe = ({
     }
   }
 
-  const { context: instanceContext, record: instanceRecord } = selection
-  const findInstanceString = (keys: ReadonlyArray<string>): string | null =>
-    findOwnedString({ record: instanceRecord, keys }) ?? findString({ root: instanceContext, keys })
+  const { metadataContexts, record: instanceRecord } = selection
+  const findInstanceString = (keys: ReadonlyArray<string>): string | null => {
+    const owned = findOwnedString({ record: instanceRecord, keys })
+    if (owned !== null) return owned
+    for (const context of metadataContexts) {
+      const found = findString({ root: context, keys })
+      if (found !== null) return found
+    }
+    return null
+  }
   const destroyedAt = findOwnedString({
     record: instanceRecord,
     keys: ['destroyed_at', 'destroyedAt'],
@@ -760,7 +780,7 @@ const observeUsage = ({
 
     const argv = instanceReportArgv({
       window,
-      repository: github.repo,
+      repository: job.repository ?? github.repo,
       /** Namespace records the GitHub job name, which is this job's own name. */
       jobName: job.jobName ?? github.name,
     })

--- a/packages/@overeng/gh-ci-utils/src/node/commands/inspect.ts
+++ b/packages/@overeng/gh-ci-utils/src/node/commands/inspect.ts
@@ -76,6 +76,9 @@ export const inspectCommand = Cli.Command.make('inspect', {
           ),
           Effect.option,
         )
+        const meta = yield* collectApiMeta
+        tui.dispatch({ _tag: 'SetMeta', _meta: meta })
+
         if (Option.isNone(jobResult)) return
         const githubFacts = toInspectGitHubFacts({ job: jobResult.value, repo })
 
@@ -91,9 +94,6 @@ export const inspectCommand = Cli.Command.make('inspect', {
           namespace,
           assessment: classifyInspection({ github: githubFacts, namespace }),
         })
-
-        const meta = yield* collectApiMeta
-        tui.dispatch({ _tag: 'SetMeta', _meta: meta })
       }),
     ).pipe(Effect.provide(outputModeLayer(output))),
   ),

--- a/packages/@overeng/gh-ci-utils/src/node/commands/inspect.ts
+++ b/packages/@overeng/gh-ci-utils/src/node/commands/inspect.ts
@@ -64,8 +64,20 @@ export const inspectCommand = Cli.Command.make('inspect', {
         }
 
         const github = yield* GitHubClient
-        const job = yield* github.getWorkflowJob({ repo, jobId })
-        const githubFacts = toInspectGitHubFacts({ job, repo })
+        const jobResult = yield* github.getWorkflowJob({ repo, jobId }).pipe(
+          Effect.tapError((error) =>
+            Effect.sync(() =>
+              tui.dispatch({
+                _tag: 'SetError',
+                error: 'GitHub job unavailable',
+                message: error.message,
+              }),
+            ),
+          ),
+          Effect.option,
+        )
+        if (Option.isNone(jobResult)) return
+        const githubFacts = toInspectGitHubFacts({ job: jobResult.value, repo })
 
         /**
          * The Namespace observation is deliberately sequenced after the GitHub

--- a/packages/@overeng/gh-ci-utils/src/node/commands/inspect.ts
+++ b/packages/@overeng/gh-ci-utils/src/node/commands/inspect.ts
@@ -1,0 +1,96 @@
+import { Effect, Option } from 'effect'
+/**
+ * gh-ci-utils inspect --job <id> [--repo owner/name] [--with-usage]
+ *
+ * Explains one GitHub Actions job's runner: what GitHub saw, what the local
+ * `nsc` session saw, and the single conservative verdict derived from both.
+ *
+ * The GitHub facts are fetched first and are never discarded: a missing,
+ * unauthenticated or unreadable `nsc` downgrades the verdict to `unknown` and
+ * records why, it does not fail the command.
+ */
+import * as Cli from 'effect/unstable/cli'
+import React from 'react'
+
+import { outputModeLayer, outputOption } from '@overeng/tui-react/node'
+
+import { classifyInspection } from '../../isomorphic/lib/inspectAssessment.ts'
+import { toInspectGitHubFacts } from '../../isomorphic/lib/inspectFacts.ts'
+import { InspectApp, InspectView } from '../../isomorphic/renderers/InspectOutput/mod.ts'
+import { resolveConfig } from '../Config.ts'
+import { GitHubClient } from '../GitHubClient.ts'
+import { collectApiMeta } from '../lib/apiMeta.ts'
+import { observeNamespaceJob } from '../NamespaceClient.ts'
+
+const jobOption = Cli.Flag.integer('job').pipe(
+  Cli.Flag.withDescription('Numeric GitHub Actions job id to inspect'),
+)
+
+const repoOption = Cli.Flag.string('repo').pipe(
+  Cli.Flag.optional,
+  Cli.Flag.withDescription('owner/name (default: repo detected from the git remote)'),
+)
+
+const withUsageOption = Cli.Flag.boolean('with-usage').pipe(
+  Cli.Flag.withDefault(false),
+  Cli.Flag.withDescription(
+    'Also sample `nsc instance report` for observed CPU/RAM usage (extra Namespace query)',
+  ),
+)
+
+/** CLI subcommand to inspect the runner behind a single workflow job */
+export const inspectCommand = Cli.Command.make('inspect', {
+  output: outputOption,
+  job: jobOption,
+  repo: repoOption,
+  withUsage: withUsageOption,
+}).pipe(
+  Cli.Command.withHandler(({ output, job: jobId, repo: repoOpt, withUsage }) =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const tui = yield* InspectApp.run(
+          React.createElement(InspectView, { stateAtom: InspectApp.stateAtom }),
+        )
+
+        const config = yield* resolveConfig({})
+        const repo = Option.isSome(repoOpt) ? repoOpt.value : config.repos[0]
+        if (repo === undefined) {
+          tui.dispatch({
+            _tag: 'SetError',
+            error: 'No repo',
+            message: 'Could not detect a repo from the git remote. Pass --repo owner/name.',
+          })
+          return
+        }
+
+        const github = yield* GitHubClient
+        const job = yield* github.getWorkflowJob({ repo, jobId })
+        const githubFacts = toInspectGitHubFacts({ job, repo })
+
+        /**
+         * The Namespace observation is deliberately sequenced after the GitHub
+         * fetch: the runner kind decides whether `nsc` is consulted at all.
+         */
+        const namespace = yield* observeNamespaceJob({ github: githubFacts, withUsage })
+
+        tui.dispatch({
+          _tag: 'SetInspection',
+          github: githubFacts,
+          namespace,
+          assessment: classifyInspection({ github: githubFacts, namespace }),
+        })
+
+        const meta = yield* collectApiMeta
+        tui.dispatch({ _tag: 'SetMeta', _meta: meta })
+      }),
+    ).pipe(Effect.provide(outputModeLayer(output))),
+  ),
+  Cli.Command.withDescription(
+    `Explain the runner behind a single job (GitHub facts + Namespace facts + verdict)
+
+Examples:
+  gh-ci-utils inspect --job 69067527707              Current repo
+  gh-ci-utils inspect --job 69067527707 --with-usage Also sample observed CPU/RAM
+  gh-ci-utils inspect --job 69067527707 --repo owner/name`,
+  ),
+)

--- a/packages/@overeng/gh-ci-utils/src/node/commands/inspect.ts
+++ b/packages/@overeng/gh-ci-utils/src/node/commands/inspect.ts
@@ -101,8 +101,8 @@ export const inspectCommand = Cli.Command.make('inspect', {
     `Explain the runner behind a single job (GitHub facts + Namespace facts + verdict)
 
 Examples:
-  gh-ci-utils inspect --job 69067527707              Current repo
-  gh-ci-utils inspect --job 69067527707 --with-usage Also sample observed CPU/RAM
-  gh-ci-utils inspect --job 69067527707 --repo owner/name`,
+  gh-ci-utils inspect --job 1001              Current repo
+  gh-ci-utils inspect --job 1001 --with-usage Also sample observed CPU/RAM
+  gh-ci-utils inspect --job 1001 --repo owner/name`,
   ),
 )

--- a/packages/@overeng/gh-ci-utils/test/inspectAssessment.test.ts
+++ b/packages/@overeng/gh-ci-utils/test/inspectAssessment.test.ts
@@ -1,0 +1,209 @@
+/**
+ * `gh-ci-utils inspect` classification precedence.
+ *
+ * The classifier is the only place that turns two independent observations
+ * into a claim, so every row here is a claim it is allowed — or forbidden — to
+ * make. The forbidden ones matter most: a runner nobody could observe must
+ * never be reported as idle, and pressure must never be inferred without a
+ * usage sample.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { classifyInspection } from '../src/isomorphic/lib/inspectAssessment.ts'
+import type {
+  InspectGitHubFacts,
+  InspectNamespaceFacts,
+  NamespaceJobFacts,
+  NamespaceUsage,
+  NamespaceUsageState,
+} from '../src/isomorphic/lib/inspectFacts.ts'
+
+const INSTANCE = 'psmnb4mkjm3mq'
+
+const github = (overrides: Partial<InspectGitHubFacts> = {}): InspectGitHubFacts => ({
+  repo: 'schickling/dotfiles',
+  jobId: 69067527707,
+  runId: 23601797547,
+  name: 'build',
+  status: 'in_progress',
+  conclusion: null,
+  startedAt: '2026-09-10T11:00:00.000Z',
+  completedAt: null,
+  durationSeconds: 120,
+  runnerName: `nsc-runner-${INSTANCE}`,
+  runnerKind: 'namespace',
+  runnerInstance: INSTANCE,
+  labels: [],
+  steps: [],
+  ...overrides,
+})
+
+const usage = (overrides: Partial<NamespaceUsage> = {}): NamespaceUsageState => ({
+  _tag: 'sampled',
+  sample: {
+    instanceId: INSTANCE,
+    githubJobId: '69067527707',
+    allocatedCpu: 8,
+    allocatedRamGb: 16,
+    cpuMaxFraction: 0.5,
+    ramMaxFraction: 0.5,
+    createdAt: null,
+    startedAt: null,
+    destroyedAt: null,
+    ...overrides,
+  },
+})
+
+const reported = ({
+  job = {},
+  usageState = { _tag: 'not-requested' },
+}: {
+  job?: Partial<NamespaceJobFacts>
+  usageState?: NamespaceUsageState
+} = {}): InspectNamespaceFacts => ({
+  _tag: 'reported',
+  job: {
+    instanceId: INSTANCE,
+    instanceStatus: 'running',
+    instanceStatusRaw: 'RUNNING',
+    runnerName: `nsc-runner-${INSTANCE}`,
+    containerName: 'runner',
+    repository: 'schickling/dotfiles',
+    workflow: 'CI',
+    jobName: 'build',
+    destroyedAt: null,
+    ...job,
+  },
+  usage: usageState,
+  commands: [],
+})
+
+describe('classifyInspection precedence', () => {
+  it('reports resource-pressure over active when CPU is at the threshold', () => {
+    const assessment = classifyInspection({
+      github: github(),
+      namespace: reported({ usageState: usage({ cpuMaxFraction: 0.95 }) }),
+    })
+    expect(assessment.disposition).toBe('resource-pressure')
+    expect(assessment.limitations).toEqual([])
+  })
+
+  it('reports resource-pressure when RAM is at the threshold and the job already finished', () => {
+    expect(
+      classifyInspection({
+        github: github({ status: 'completed', conclusion: 'success' }),
+        namespace: reported({
+          job: { instanceStatus: 'destroyed', destroyedAt: '2026-09-10T11:05:00Z' },
+          usageState: usage({ ramMaxFraction: 0.96 }),
+        }),
+      }).disposition,
+    ).toBe('resource-pressure')
+  })
+
+  it('does not report resource-pressure just below the threshold', () =>
+    expect(
+      classifyInspection({
+        github: github(),
+        namespace: reported({
+          usageState: usage({ cpuMaxFraction: 0.9499, ramMaxFraction: 0.9499 }),
+        }),
+      }).disposition,
+    ).toBe('active'))
+
+  it('never claims resource-pressure without a usage sample, however loaded the runner looks', () => {
+    const assessment = classifyInspection({
+      github: github(),
+      namespace: reported({ usageState: { _tag: 'not-requested' } }),
+    })
+    expect(assessment.disposition).toBe('active')
+    expect(assessment.limitations.join(' ')).toContain('--with-usage')
+  })
+
+  it('reports active only when GitHub and Namespace agree the job is running', () =>
+    expect(classifyInspection({ github: github(), namespace: reported() }).disposition).toBe(
+      'active',
+    ))
+
+  it('reports idle from a live instance with no running GitHub job', () =>
+    expect(
+      classifyInspection({
+        github: github({ status: 'completed', conclusion: 'success' }),
+        namespace: reported(),
+      }).disposition,
+    ).toBe('idle'))
+
+  it('refuses idle without positive live-instance evidence', () => {
+    const assessment = classifyInspection({
+      github: github({ status: 'completed', conclusion: 'success' }),
+      namespace: reported({ job: { instanceStatus: 'unknown', instanceStatusRaw: 'Provisioned' } }),
+    })
+    expect(assessment.disposition).toBe('unknown')
+    expect(assessment.limitations.join(' ')).toContain('idle')
+  })
+
+  it('reports unknown for a completed job whose instance is gone', () =>
+    expect(
+      classifyInspection({
+        github: github({
+          status: 'completed',
+          conclusion: 'success',
+          completedAt: '2026-09-10T11:04:00.000Z',
+        }),
+        namespace: reported({
+          job: { instanceStatus: 'destroyed', destroyedAt: '2026-09-10T11:05:00Z' },
+        }),
+      }).disposition,
+    ).toBe('unknown'))
+
+  it('reports unknown, not active, when the two sources conflict', () => {
+    const assessment = classifyInspection({
+      github: github(),
+      namespace: reported({
+        job: { instanceStatus: 'destroyed', destroyedAt: '2026-09-10T11:05:00Z' },
+      }),
+    })
+    expect(assessment.disposition).toBe('unknown')
+    expect(assessment.limitations.join(' ')).toContain('disagree')
+  })
+
+  it('reports unknown for a non-Namespace runner and says why', () => {
+    const assessment = classifyInspection({
+      github: github({
+        runnerName: 'dev3-6038ddf9',
+        runnerKind: 'self-hosted',
+        runnerInstance: 'dev3',
+      }),
+      namespace: { _tag: 'not-namespace-job', runnerKind: 'self-hosted' },
+    })
+    expect(assessment.disposition).toBe('unknown')
+    expect(assessment.limitations.join(' ')).toContain('self-hosted')
+  })
+
+  it('reports unknown when nsc is missing, while keeping the GitHub observation as evidence', () => {
+    const assessment = classifyInspection({
+      github: github(),
+      namespace: {
+        _tag: 'unavailable',
+        reason: 'nsc-missing',
+        detail: 'NotFound: nsc',
+        commands: [],
+      },
+    })
+    expect(assessment.disposition).toBe('unknown')
+    expect(assessment.evidence.join(' ')).toContain('69067527707')
+    expect(assessment.limitations.join(' ')).toContain('nsc-missing')
+  })
+
+  it('reports unknown for an unauthenticated session rather than guessing liveness', () =>
+    expect(
+      classifyInspection({
+        github: github(),
+        namespace: {
+          _tag: 'unavailable',
+          reason: 'not-authenticated',
+          detail: null,
+          commands: [],
+        },
+      }).disposition,
+    ).toBe('unknown'))
+})

--- a/packages/@overeng/gh-ci-utils/test/inspectAssessment.test.ts
+++ b/packages/@overeng/gh-ci-utils/test/inspectAssessment.test.ts
@@ -18,16 +18,16 @@ import type {
   NamespaceUsageState,
 } from '../src/isomorphic/lib/inspectFacts.ts'
 
-const INSTANCE = 'psmnb4mkjm3mq'
+const INSTANCE = 'abc123example'
 
 const github = (overrides: Partial<InspectGitHubFacts> = {}): InspectGitHubFacts => ({
-  repo: 'schickling/dotfiles',
-  jobId: 69067527707,
-  runId: 23601797547,
+  repo: 'example-org/example-repo',
+  jobId: 1001,
+  runId: 2001,
   name: 'build',
   status: 'in_progress',
   conclusion: null,
-  startedAt: '2026-09-10T11:00:00.000Z',
+  startedAt: '2026-01-15T11:00:00.000Z',
   completedAt: null,
   durationSeconds: 120,
   runnerName: `nsc-runner-${INSTANCE}`,
@@ -42,7 +42,7 @@ const usage = (overrides: Partial<NamespaceUsage> = {}): NamespaceUsageState => 
   _tag: 'sampled',
   sample: {
     instanceId: INSTANCE,
-    githubJobId: '69067527707',
+    githubJobId: '1001',
     allocatedCpu: 8,
     allocatedRamGb: 16,
     cpuMaxFraction: 0.5,
@@ -68,7 +68,7 @@ const reported = ({
     instanceStatusRaw: 'RUNNING',
     runnerName: `nsc-runner-${INSTANCE}`,
     containerName: 'runner',
-    repository: 'schickling/dotfiles',
+    repository: 'example-org/example-repo',
     workflow: 'CI',
     jobName: 'build',
     destroyedAt: null,
@@ -93,7 +93,7 @@ describe('classifyInspection precedence', () => {
       classifyInspection({
         github: github({ status: 'completed', conclusion: 'success' }),
         namespace: reported({
-          job: { instanceStatus: 'destroyed', destroyedAt: '2026-09-10T11:05:00Z' },
+          job: { instanceStatus: 'destroyed', destroyedAt: '2026-01-15T11:05:00Z' },
           usageState: usage({ ramMaxFraction: 0.96 }),
         }),
       }).disposition,
@@ -147,10 +147,10 @@ describe('classifyInspection precedence', () => {
         github: github({
           status: 'completed',
           conclusion: 'success',
-          completedAt: '2026-09-10T11:04:00.000Z',
+          completedAt: '2026-01-15T11:04:00.000Z',
         }),
         namespace: reported({
-          job: { instanceStatus: 'destroyed', destroyedAt: '2026-09-10T11:05:00Z' },
+          job: { instanceStatus: 'destroyed', destroyedAt: '2026-01-15T11:05:00Z' },
         }),
       }).disposition,
     ).toBe('unknown'))
@@ -169,7 +169,7 @@ describe('classifyInspection precedence', () => {
     const assessment = classifyInspection({
       github: github(),
       namespace: reported({
-        job: { instanceStatus: 'destroyed', destroyedAt: '2026-09-10T11:05:00Z' },
+        job: { instanceStatus: 'destroyed', destroyedAt: '2026-01-15T11:05:00Z' },
       }),
     })
     expect(assessment.disposition).toBe('unknown')
@@ -179,9 +179,9 @@ describe('classifyInspection precedence', () => {
   it('reports unknown for a non-Namespace runner and says why', () => {
     const assessment = classifyInspection({
       github: github({
-        runnerName: 'dev3-6038ddf9',
+        runnerName: 'runnera-1234abcd',
         runnerKind: 'self-hosted',
-        runnerInstance: 'dev3',
+        runnerInstance: 'runnera',
       }),
       namespace: { _tag: 'not-namespace-job', runnerKind: 'self-hosted' },
     })
@@ -200,7 +200,7 @@ describe('classifyInspection precedence', () => {
       },
     })
     expect(assessment.disposition).toBe('unknown')
-    expect(assessment.evidence.join(' ')).toContain('69067527707')
+    expect(assessment.evidence.join(' ')).toContain('1001')
     expect(assessment.limitations.join(' ')).toContain('nsc-missing')
   })
 

--- a/packages/@overeng/gh-ci-utils/test/inspectAssessment.test.ts
+++ b/packages/@overeng/gh-ci-utils/test/inspectAssessment.test.ts
@@ -155,6 +155,16 @@ describe('classifyInspection precedence', () => {
       }).disposition,
     ).toBe('unknown'))
 
+  it('reports unknown when GitHub and Namespace identify different instances', () => {
+    const assessment = classifyInspection({
+      github: github(),
+      namespace: reported({ job: { instanceId: 'different-instance' } }),
+    })
+    expect(assessment.disposition).toBe('unknown')
+    expect(assessment.limitations.join(' ')).toContain(INSTANCE)
+    expect(assessment.limitations.join(' ')).toContain('different-instance')
+  })
+
   it('reports unknown, not active, when the two sources conflict', () => {
     const assessment = classifyInspection({
       github: github(),

--- a/packages/@overeng/gh-ci-utils/test/inspectJsonContract.test.ts
+++ b/packages/@overeng/gh-ci-utils/test/inspectJsonContract.test.ts
@@ -1,0 +1,202 @@
+/**
+ * `gh-ci-utils inspect --output json` contract.
+ *
+ * The contract an agent relies on is that `github` and `namespace` are
+ * observations and `assessment` is the only derived value, so a reader can
+ * always tell what was seen from what was concluded. These tests pin that
+ * separation, the preserved raw timing data, and the exit-code rule that a
+ * diagnosis — including `unknown` — is a successful run.
+ */
+import { Schema } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import type { WorkflowJob } from '../src/isomorphic/GitHubSchemas.ts'
+import { defaultApiMeta } from '../src/isomorphic/lib/apiMeta.ts'
+import { classifyInspection } from '../src/isomorphic/lib/inspectAssessment.ts'
+import {
+  type InspectDisposition,
+  type InspectNamespaceFacts,
+  toInspectGitHubFacts,
+} from '../src/isomorphic/lib/inspectFacts.ts'
+import { inspectExitCode } from '../src/isomorphic/renderers/InspectOutput/app.ts'
+import {
+  type InspectState,
+  InspectStateSchema,
+} from '../src/isomorphic/renderers/InspectOutput/schema.ts'
+
+const INSTANCE = 'psmnb4mkjm3mq'
+const REPO = 'schickling/dotfiles'
+
+const rawJob: WorkflowJob = {
+  id: 69067527707,
+  run_id: 23601797547,
+  name: 'build',
+  status: 'in_progress',
+  conclusion: null,
+  started_at: new Date('2026-09-10T11:00:00.000Z'),
+  completed_at: null,
+  runner_name: `nsc-runner-${INSTANCE}`,
+  labels: ['nscloud-ubuntu-24.04-amd64-8x16'],
+  steps: [
+    {
+      name: 'Set up job',
+      status: 'completed',
+      conclusion: 'success',
+      number: 1,
+      started_at: new Date('2026-09-10T11:00:00.000Z'),
+      completed_at: new Date('2026-09-10T11:00:06.000Z'),
+    },
+  ],
+}
+
+const reportedNamespace: InspectNamespaceFacts = {
+  _tag: 'reported',
+  job: {
+    instanceId: INSTANCE,
+    instanceStatus: 'running',
+    instanceStatusRaw: 'RUNNING',
+    runnerName: `nsc-runner-${INSTANCE}`,
+    containerName: 'runner',
+    repository: REPO,
+    workflow: 'CI',
+    jobName: 'build',
+    destroyedAt: null,
+  },
+  usage: { _tag: 'not-requested' },
+  commands: [
+    ['auth', 'check-login'],
+    ['github', 'job', 'describe', '69067527707', '-o', 'json'],
+  ],
+}
+
+const loadedState = (namespace: InspectNamespaceFacts): InspectState => {
+  const github = toInspectGitHubFacts({ job: rawJob, repo: REPO })
+  return {
+    _tag: 'Loaded',
+    github,
+    namespace,
+    assessment: classifyInspection({ github, namespace }),
+    _meta: defaultApiMeta,
+  }
+}
+
+const encodeJson = (state: InspectState) =>
+  Schema.encodeUnknownSync(Schema.fromJsonString(InspectStateSchema))(state)
+
+describe('inspect --output json contract', () => {
+  it('keeps github facts, namespace facts and the assessment in separate top-level groups', () => {
+    const encoded: unknown = JSON.parse(encodeJson(loadedState(reportedNamespace)))
+    expect(encoded).toMatchObject({
+      _tag: 'Loaded',
+      github: { repo: REPO, jobId: 69067527707, runnerKind: 'namespace' },
+      namespace: { _tag: 'reported', job: { instanceId: INSTANCE } },
+      assessment: { disposition: 'active' },
+    })
+  })
+
+  it('preserves raw runner identity and step timings rather than summarising them away', () => {
+    const state = loadedState(reportedNamespace)
+    if (state._tag !== 'Loaded') throw new Error('expected Loaded')
+    expect(state.github.runnerName).toBe(`nsc-runner-${INSTANCE}`)
+    expect(state.github.runnerInstance).toBe(INSTANCE)
+    expect(state.github.startedAt).toBe('2026-09-10T11:00:00.000Z')
+    expect(state.github.completedAt).toBeNull()
+    expect(state.github.labels).toEqual(['nscloud-ubuntu-24.04-amd64-8x16'])
+    expect(state.github.steps).toEqual([
+      {
+        name: 'Set up job',
+        status: 'completed',
+        conclusion: 'success',
+        number: 1,
+        startedAt: '2026-09-10T11:00:00.000Z',
+        completedAt: '2026-09-10T11:00:06.000Z',
+      },
+    ])
+  })
+
+  it('keeps every GitHub fact when nsc is absent, and says so in the assessment', () => {
+    const state = loadedState({
+      _tag: 'unavailable',
+      reason: 'nsc-missing',
+      detail: 'NotFound: nsc',
+      commands: [['auth', 'check-login']],
+    })
+    if (state._tag !== 'Loaded') throw new Error('expected Loaded')
+    expect(state.github.jobId).toBe(69067527707)
+    expect(state.github.steps).toHaveLength(1)
+    expect(state.assessment.disposition).toBe('unknown')
+    expect(state.namespace._tag).toBe('unavailable')
+    /** The encoded form must round-trip, so the reason vocabulary is in the schema. */
+    expect(JSON.parse(encodeJson(state))).toMatchObject({
+      namespace: { _tag: 'unavailable', reason: 'nsc-missing' },
+    })
+  })
+
+  it('records the read-only nsc argv it ran, so a reader can audit the observation', () => {
+    const encoded: unknown = JSON.parse(encodeJson(loadedState(reportedNamespace)))
+    expect(encoded).toMatchObject({
+      namespace: {
+        commands: [
+          ['auth', 'check-login'],
+          ['github', 'job', 'describe', '69067527707', '-o', 'json'],
+        ],
+      },
+    })
+  })
+
+  it('round-trips a loaded state through the schema unchanged', () => {
+    const state = loadedState(reportedNamespace)
+    expect(
+      Schema.decodeUnknownSync(Schema.fromJsonString(InspectStateSchema))(encodeJson(state)),
+    ).toEqual(state)
+  })
+
+  it('rejects a disposition outside the four it is allowed to claim', () => {
+    const encoded: unknown = JSON.parse(encodeJson(loadedState(reportedNamespace)))
+    const tampered = JSON.stringify({
+      ...(typeof encoded === 'object' && encoded !== null ? encoded : {}),
+      assessment: { disposition: 'healthy', evidence: [], limitations: [] },
+    })
+    expect(() =>
+      Schema.decodeUnknownSync(Schema.fromJsonString(InspectStateSchema))(tampered),
+    ).toThrow()
+  })
+})
+
+describe('inspect exit codes', () => {
+  const dispositions: ReadonlyArray<InspectDisposition> = [
+    'active',
+    'idle',
+    'resource-pressure',
+    'unknown',
+  ]
+
+  it('exits 0 for every loaded diagnosis, including unknown', () => {
+    for (const disposition of dispositions) {
+      const state: InspectState = {
+        ...loadedState(reportedNamespace),
+        _tag: 'Loaded',
+        assessment: { disposition, evidence: [], limitations: [] },
+        github: toInspectGitHubFacts({ job: rawJob, repo: REPO }),
+        namespace: reportedNamespace,
+        _meta: defaultApiMeta,
+      }
+      expect(inspectExitCode(state)).toBe(0)
+    }
+  })
+
+  it('exits 0 while still loading', () =>
+    expect(
+      inspectExitCode({ _tag: 'Loading', message: 'Inspecting job...', _meta: defaultApiMeta }),
+    ).toBe(0))
+
+  it('exits 1 only when the command itself failed', () =>
+    expect(
+      inspectExitCode({
+        _tag: 'Error',
+        error: 'No repo',
+        message: 'Could not detect a repo from the git remote.',
+        _meta: defaultApiMeta,
+      }),
+    ).toBe(1))
+})

--- a/packages/@overeng/gh-ci-utils/test/inspectJsonContract.test.ts
+++ b/packages/@overeng/gh-ci-utils/test/inspectJsonContract.test.ts
@@ -24,16 +24,16 @@ import {
   InspectStateSchema,
 } from '../src/isomorphic/renderers/InspectOutput/schema.ts'
 
-const INSTANCE = 'psmnb4mkjm3mq'
-const REPO = 'schickling/dotfiles'
+const INSTANCE = 'abc123example'
+const REPO = 'example-org/example-repo'
 
 const rawJob: WorkflowJob = {
-  id: 69067527707,
-  run_id: 23601797547,
+  id: 1001,
+  run_id: 2001,
   name: 'build',
   status: 'in_progress',
   conclusion: null,
-  started_at: new Date('2026-09-10T11:00:00.000Z'),
+  started_at: new Date('2026-01-15T11:00:00.000Z'),
   completed_at: null,
   runner_name: `nsc-runner-${INSTANCE}`,
   labels: ['nscloud-ubuntu-24.04-amd64-8x16'],
@@ -43,8 +43,8 @@ const rawJob: WorkflowJob = {
       status: 'completed',
       conclusion: 'success',
       number: 1,
-      started_at: new Date('2026-09-10T11:00:00.000Z'),
-      completed_at: new Date('2026-09-10T11:00:06.000Z'),
+      started_at: new Date('2026-01-15T11:00:00.000Z'),
+      completed_at: new Date('2026-01-15T11:00:06.000Z'),
     },
   ],
 }
@@ -65,7 +65,7 @@ const reportedNamespace: InspectNamespaceFacts = {
   usage: { _tag: 'not-requested' },
   commands: [
     ['auth', 'check-login'],
-    ['github', 'job', 'describe', '69067527707', '-o', 'json'],
+    ['github', 'job', 'describe', '1001', '-o', 'json'],
   ],
 }
 
@@ -88,7 +88,7 @@ describe('inspect --output json contract', () => {
     const encoded: unknown = JSON.parse(encodeJson(loadedState(reportedNamespace)))
     expect(encoded).toMatchObject({
       _tag: 'Loaded',
-      github: { repo: REPO, jobId: 69067527707, runnerKind: 'namespace' },
+      github: { repo: REPO, jobId: 1001, runnerKind: 'namespace' },
       namespace: { _tag: 'reported', job: { instanceId: INSTANCE } },
       assessment: { disposition: 'active' },
     })
@@ -99,7 +99,7 @@ describe('inspect --output json contract', () => {
     if (state._tag !== 'Loaded') throw new Error('expected Loaded')
     expect(state.github.runnerName).toBe(`nsc-runner-${INSTANCE}`)
     expect(state.github.runnerInstance).toBe(INSTANCE)
-    expect(state.github.startedAt).toBe('2026-09-10T11:00:00.000Z')
+    expect(state.github.startedAt).toBe('2026-01-15T11:00:00.000Z')
     expect(state.github.completedAt).toBeNull()
     expect(state.github.labels).toEqual(['nscloud-ubuntu-24.04-amd64-8x16'])
     expect(state.github.steps).toEqual([
@@ -108,8 +108,8 @@ describe('inspect --output json contract', () => {
         status: 'completed',
         conclusion: 'success',
         number: 1,
-        startedAt: '2026-09-10T11:00:00.000Z',
-        completedAt: '2026-09-10T11:00:06.000Z',
+        startedAt: '2026-01-15T11:00:00.000Z',
+        completedAt: '2026-01-15T11:00:06.000Z',
       },
     ])
   })
@@ -122,7 +122,7 @@ describe('inspect --output json contract', () => {
       commands: [['auth', 'check-login']],
     })
     if (state._tag !== 'Loaded') throw new Error('expected Loaded')
-    expect(state.github.jobId).toBe(69067527707)
+    expect(state.github.jobId).toBe(1001)
     expect(state.github.steps).toHaveLength(1)
     expect(state.assessment.disposition).toBe('unknown')
     expect(state.namespace._tag).toBe('unavailable')
@@ -138,7 +138,7 @@ describe('inspect --output json contract', () => {
       namespace: {
         commands: [
           ['auth', 'check-login'],
-          ['github', 'job', 'describe', '69067527707', '-o', 'json'],
+          ['github', 'job', 'describe', '1001', '-o', 'json'],
         ],
       },
     })

--- a/packages/@overeng/gh-ci-utils/test/namespaceAdapter.test.ts
+++ b/packages/@overeng/gh-ci-utils/test/namespaceAdapter.test.ts
@@ -193,6 +193,23 @@ describe('parseJobDescribe', () => {
     expect(parsed._tag === 'parsed' && parsed.job.instanceStatusRaw).toBe('RUNNING')
   })
 
+  it('ignores status owned by a nested previous attempt', () => {
+    const parsed = parseJobDescribe(
+      JSON.stringify({
+        runner: {
+          instance_id: INSTANCE,
+          status: 'RUNNING',
+          previous_attempt: {
+            instance_id: 'previous-instance',
+            instance_status: 'DESTROYED',
+          },
+        },
+      }),
+    )
+    expect(parsed._tag === 'parsed' && parsed.job.instanceStatus).toBe('running')
+    expect(parsed._tag === 'parsed' && parsed.job.instanceStatusRaw).toBe('RUNNING')
+  })
+
   it('ignores a destruction timestamp owned by an unrelated instance attempt', () => {
     const parsed = parseJobDescribe(
       JSON.stringify({

--- a/packages/@overeng/gh-ci-utils/test/namespaceAdapter.test.ts
+++ b/packages/@overeng/gh-ci-utils/test/namespaceAdapter.test.ts
@@ -601,6 +601,57 @@ describe('observeNamespaceJob', () => {
     expect(facts._tag === 'reported' && facts.job.runnerName).toBe(`nsc-runner-${INSTANCE}`)
   })
 
+  it('scopes fallback metadata to the selected attempt and uses the GitHub job name for usage', async () => {
+    const describe = JSON.stringify({
+      attempts: [
+        {
+          job: { job_name: 'previous build', workflow_name: 'Previous CI' },
+          repository: 'previous-org/previous-repo',
+          runner: {
+            instance_id: 'previous-instance',
+            instance_status: 'DESTROYED',
+            runner_name: 'nsc-runner-previous-instance',
+            container_name: 'previous-container',
+          },
+        },
+        {
+          job: { workflow_name: 'Current CI' },
+          repository: 'example-org/example-repo',
+          runner: {
+            instance_id: INSTANCE,
+            instance_status: 'RUNNING',
+            runner_name: `nsc-runner-${INSTANCE}`,
+          },
+        },
+      ],
+    })
+    const { facts, recorded } = await observe({
+      github: githubFacts(),
+      withUsage: true,
+      respond: (argv) =>
+        argv[0] === 'auth'
+          ? output('ok')
+          : argv[0] === 'github'
+            ? output(describe)
+            : argv[argv.indexOf('--jobname') + 1] === 'build'
+              ? output(REPORT_CSV)
+              : output('instance_id\n'),
+    })
+
+    expect(facts._tag).toBe('reported')
+    if (facts._tag !== 'reported') return
+    expect(facts.job).toMatchObject({
+      instanceId: INSTANCE,
+      runnerName: `nsc-runner-${INSTANCE}`,
+      containerName: null,
+      repository: 'example-org/example-repo',
+      workflow: 'Current CI',
+      jobName: null,
+    })
+    expect(facts.usage._tag).toBe('sampled')
+    expect(recorded.at(-1)?.slice(-2)).toEqual(['--jobname', 'build'])
+  })
+
   it('does not run the report at all without --with-usage', async () => {
     const { facts, recorded } = await observe({
       github: githubFacts(),

--- a/packages/@overeng/gh-ci-utils/test/namespaceAdapter.test.ts
+++ b/packages/@overeng/gh-ci-utils/test/namespaceAdapter.test.ts
@@ -38,18 +38,18 @@ import {
   splitCsvLine,
 } from '../src/node/NamespaceClient.ts'
 
-const INSTANCE = 'psmnb4mkjm3mq'
-const JOB_ID = 69067527707
+const INSTANCE = 'abc123example'
+const JOB_ID = 1001
 
 const githubFacts = (overrides: Partial<InspectGitHubFacts> = {}): InspectGitHubFacts => ({
-  repo: 'schickling/dotfiles',
+  repo: 'example-org/example-repo',
   jobId: JOB_ID,
-  runId: 23601797547,
+  runId: 2001,
   name: 'build',
   status: 'in_progress',
   conclusion: null,
-  startedAt: '2026-09-10T11:00:00.000Z',
-  completedAt: '2026-09-10T11:04:00.000Z',
+  startedAt: '2026-01-15T11:00:00.000Z',
+  completedAt: '2026-01-15T11:04:00.000Z',
   durationSeconds: 240,
   runnerName: `nsc-runner-${INSTANCE}`,
   runnerKind: 'namespace',
@@ -141,7 +141,7 @@ const forbiddenSpawner = Layer.succeed(
 
 const DESCRIBE_JSON = JSON.stringify({
   job: { id: String(JOB_ID), job_name: 'build', workflow_name: 'CI' },
-  repository: 'schickling/dotfiles',
+  repository: 'example-org/example-repo',
   runner: {
     instance_id: INSTANCE,
     instance_status: 'RUNNING',
@@ -153,7 +153,7 @@ const DESCRIBE_JSON = JSON.stringify({
 /** The documented report layout: a preamble line, then the CSV. */
 const REPORT_CSV = `Writing output to path: stdout
 instance_id,created_at,started_at,destroyed_at,resources_cpu,resources_ram_gb,resources_cpu_actual_max,resources_ram_gb_actual_max_percent,github_job_id,github_job_name,github_job_workflow_name,github_run_id,github_run_attempt,job_created_at,job_started_at,job_completed_at,github_profile,github_repository,github_branch,github_job_conclusion
-${INSTANCE},2026-09-10 10:59:55 +0000 UTC,2026-09-10 11:00:00 +0000 UTC,,8,16,0.97,0.31,${JOB_ID},"build (linux, amd64)",CI,23601797547,1,2026-09-10 10:59:50 +0000 UTC,2026-09-10 11:00:00 +0000 UTC,,,schickling/dotfiles,main,
+${INSTANCE},2026-01-15 10:59:55 +0000 UTC,2026-01-15 11:00:00 +0000 UTC,,8,16,0.97,0.31,${JOB_ID},"build (linux, amd64)",CI,2001,1,2026-01-15 10:59:50 +0000 UTC,2026-01-15 11:00:00 +0000 UTC,,,example-org/example-repo,main,
 `
 
 // =============================================================================
@@ -171,7 +171,7 @@ describe('parseJobDescribe', () => {
         instanceStatusRaw: 'RUNNING',
         runnerName: `nsc-runner-${INSTANCE}`,
         containerName: 'runner',
-        repository: 'schickling/dotfiles',
+        repository: 'example-org/example-repo',
         workflow: 'CI',
         jobName: 'build',
         destroyedAt: null,
@@ -222,7 +222,7 @@ describe('parseJobDescribe', () => {
 describe('deriveInstanceStatus', () => {
   it('lets a recorded destruction time override any status string', () =>
     expect(
-      deriveInstanceStatus({ statusRaw: 'RUNNING', destroyedAt: '2026-09-10T11:05:00Z' }),
+      deriveInstanceStatus({ statusRaw: 'RUNNING', destroyedAt: '2026-01-15T11:05:00Z' }),
     ).toBe('destroyed'))
 
   it('reports unknown when there is no status at all', () =>
@@ -247,7 +247,7 @@ describe('parseInstanceReport', () => {
     if (parsed._tag !== 'parsed') return
     expect(parsed.rows).toHaveLength(1)
     expect(parsed.rows[0]!['github_job_name']).toBe('build (linux, amd64)')
-    expect(parsed.rows[0]!['github_repository']).toBe('schickling/dotfiles')
+    expect(parsed.rows[0]!['github_repository']).toBe('example-org/example-repo')
   })
 
   it('reports output with no header as unreadable', () =>
@@ -268,8 +268,8 @@ describe('selectUsageRow', () => {
       allocatedRamGb: 16,
       cpuMaxFraction: 0.97,
       ramMaxFraction: 0.31,
-      createdAt: '2026-09-10 10:59:55 +0000 UTC',
-      startedAt: '2026-09-10 11:00:00 +0000 UTC',
+      createdAt: '2026-01-15 10:59:55 +0000 UTC',
+      startedAt: '2026-01-15 11:00:00 +0000 UTC',
       destroyedAt: null,
     }))
 
@@ -284,20 +284,20 @@ describe('deriveReportWindow', () => {
   it('brackets the job with padding on both sides', () =>
     expect(
       deriveReportWindow({
-        startedAt: '2026-09-10T11:00:00.000Z',
-        completedAt: '2026-09-10T11:04:00.000Z',
-        now: new Date('2026-09-10T12:00:00.000Z'),
+        startedAt: '2026-01-15T11:00:00.000Z',
+        completedAt: '2026-01-15T11:04:00.000Z',
+        now: new Date('2026-01-15T12:00:00.000Z'),
       }),
-    ).toEqual({ start: '2026-09-10T10:55:00.000Z', end: '2026-09-10T11:09:00.000Z' }))
+    ).toEqual({ start: '2026-01-15T10:55:00.000Z', end: '2026-01-15T11:09:00.000Z' }))
 
   it('ends a still-running job at now, not at an invented completion', () =>
     expect(
       deriveReportWindow({
-        startedAt: '2026-09-10T11:00:00.000Z',
+        startedAt: '2026-01-15T11:00:00.000Z',
         completedAt: null,
-        now: new Date('2026-09-10T11:02:00.000Z'),
+        now: new Date('2026-01-15T11:02:00.000Z'),
       })?.end,
-    ).toBe('2026-09-10T11:07:00.000Z'))
+    ).toBe('2026-01-15T11:07:00.000Z'))
 
   it('refuses a window when GitHub gave no start time', () =>
     expect(deriveReportWindow({ startedAt: null, completedAt: null, now: new Date() })).toBeNull())
@@ -354,9 +354,9 @@ describe('observeNamespaceJob', () => {
     const facts = await Effect.runPromise(
       observeNamespaceJob({
         github: githubFacts({
-          runnerName: 'dev3-6038ddf9',
+          runnerName: 'runnera-1234abcd',
           runnerKind: 'self-hosted',
-          runnerInstance: 'dev3',
+          runnerInstance: 'runnera',
         }),
         withUsage: true,
       }).pipe(Effect.provide(forbiddenSpawner)),
@@ -471,8 +471,8 @@ describe('observeNamespaceJob', () => {
     ).toBe(0.97)
 
     const window = deriveReportWindow({
-      startedAt: '2026-09-10T11:00:00.000Z',
-      completedAt: '2026-09-10T11:04:00.000Z',
+      startedAt: '2026-01-15T11:00:00.000Z',
+      completedAt: '2026-01-15T11:04:00.000Z',
       now: new Date(),
     })
     expect(recorded).toEqual([
@@ -489,7 +489,7 @@ describe('observeNamespaceJob', () => {
         '--out',
         '-',
         '--repository',
-        'schickling/dotfiles',
+        'example-org/example-repo',
         '--jobname',
         'build',
       ],

--- a/packages/@overeng/gh-ci-utils/test/namespaceAdapter.test.ts
+++ b/packages/@overeng/gh-ci-utils/test/namespaceAdapter.test.ts
@@ -193,6 +193,39 @@ describe('parseJobDescribe', () => {
     expect(parsed._tag === 'parsed' && parsed.job.instanceStatusRaw).toBe('RUNNING')
   })
 
+  it('ignores a destruction timestamp owned by an unrelated instance attempt', () => {
+    const parsed = parseJobDescribe(
+      JSON.stringify({
+        runner: {
+          instance_id: INSTANCE,
+          instance_status: 'RUNNING',
+        },
+        attempts: [
+          {
+            instance_id: 'unrelated-instance',
+            destroyed_at: '2026-01-15T10:55:00Z',
+          },
+        ],
+      }),
+    )
+    expect(parsed._tag === 'parsed' && parsed.job.instanceStatus).toBe('running')
+    expect(parsed._tag === 'parsed' && parsed.job.destroyedAt).toBeNull()
+  })
+
+  it('uses a destruction timestamp owned by the selected instance', () => {
+    const parsed = parseJobDescribe(
+      JSON.stringify({
+        runner: {
+          instance_id: INSTANCE,
+          instance_status: 'RUNNING',
+          destroyed_at: '2026-01-15T11:05:00Z',
+        },
+      }),
+    )
+    expect(parsed._tag === 'parsed' && parsed.job.instanceStatus).toBe('destroyed')
+    expect(parsed._tag === 'parsed' && parsed.job.destroyedAt).toBe('2026-01-15T11:05:00Z')
+  })
+
   it('reads camelCase field names too, since the CLI shape is not pinned', () => {
     const parsed = parseJobDescribe(
       JSON.stringify({ instanceId: INSTANCE, instanceStatus: 'running' }),

--- a/packages/@overeng/gh-ci-utils/test/namespaceAdapter.test.ts
+++ b/packages/@overeng/gh-ci-utils/test/namespaceAdapter.test.ts
@@ -162,10 +162,11 @@ ${INSTANCE},2026-01-15 10:59:55 +0000 UTC,2026-01-15 11:00:00 +0000 UTC,,8,16,0.
 // =============================================================================
 // Pure decoders
 // =============================================================================
+const parseDescribe = (stdout: string) => parseJobDescribe({ stdout, expectedInstanceId: INSTANCE })
 
 describe('parseJobDescribe', () => {
   it('finds the instance behind a nested runner block', () => {
-    const parsed = parseJobDescribe(DESCRIBE_JSON)
+    const parsed = parseDescribe(DESCRIBE_JSON)
     expect(parsed).toEqual({
       _tag: 'parsed',
       job: {
@@ -182,8 +183,50 @@ describe('parseJobDescribe', () => {
     })
   })
 
+  it('selects the expected instance regardless of attempt order', () => {
+    const previousAttempt = {
+      instance_id: 'previous-instance',
+      instance_status: 'DESTROYED',
+      destroyed_at: '2026-01-15T10:55:00Z',
+      runner_name: 'nsc-runner-previous-instance',
+      container_name: 'previous-container',
+      repository: 'previous-org/previous-repo',
+      workflow_name: 'Previous CI',
+      job_name: 'previous build',
+    }
+    const currentAttempt = {
+      instance_id: INSTANCE,
+      instance_status: 'RUNNING',
+      runner_name: `nsc-runner-${INSTANCE}`,
+      container_name: 'current-container',
+      repository: 'example-org/example-repo',
+      workflow_name: 'Current CI',
+      job_name: 'current build',
+    }
+
+    for (const attempts of [
+      [previousAttempt, currentAttempt],
+      [currentAttempt, previousAttempt],
+    ]) {
+      expect(parseDescribe(JSON.stringify({ attempts }))).toEqual({
+        _tag: 'parsed',
+        job: {
+          instanceId: INSTANCE,
+          instanceStatus: 'running',
+          instanceStatusRaw: 'RUNNING',
+          runnerName: `nsc-runner-${INSTANCE}`,
+          containerName: 'current-container',
+          repository: 'example-org/example-repo',
+          workflow: 'Current CI',
+          jobName: 'current build',
+          destroyedAt: null,
+        },
+      })
+    }
+  })
+
   it('reads generic status only from the record that owns the instance id', () => {
-    const parsed = parseJobDescribe(
+    const parsed = parseDescribe(
       JSON.stringify({
         status: 'completed',
         runner: {
@@ -197,7 +240,7 @@ describe('parseJobDescribe', () => {
   })
 
   it('ignores status owned by a nested previous attempt', () => {
-    const parsed = parseJobDescribe(
+    const parsed = parseDescribe(
       JSON.stringify({
         runner: {
           instance_id: INSTANCE,
@@ -214,7 +257,7 @@ describe('parseJobDescribe', () => {
   })
 
   it('ignores a destruction timestamp owned by an unrelated instance attempt', () => {
-    const parsed = parseJobDescribe(
+    const parsed = parseDescribe(
       JSON.stringify({
         runner: {
           instance_id: INSTANCE,
@@ -233,7 +276,7 @@ describe('parseJobDescribe', () => {
   })
 
   it('uses a destruction timestamp owned by the selected instance', () => {
-    const parsed = parseJobDescribe(
+    const parsed = parseDescribe(
       JSON.stringify({
         runner: {
           instance_id: INSTANCE,
@@ -247,7 +290,7 @@ describe('parseJobDescribe', () => {
   })
 
   it('reads camelCase field names too, since the CLI shape is not pinned', () => {
-    const parsed = parseJobDescribe(
+    const parsed = parseDescribe(
       JSON.stringify({ instanceId: INSTANCE, instanceStatus: 'running' }),
     )
     expect(parsed._tag === 'parsed' && parsed.job.instanceId).toBe(INSTANCE)
@@ -255,7 +298,7 @@ describe('parseJobDescribe', () => {
   })
 
   it('degrades an unrecognized status to unknown instead of assuming the instance is gone', () => {
-    const parsed = parseJobDescribe(
+    const parsed = parseDescribe(
       JSON.stringify({ instance_id: INSTANCE, instance_status: 'PROVISIONING_V2' }),
     )
     expect(parsed._tag === 'parsed' && parsed.job.instanceStatus).toBe('unknown')
@@ -263,13 +306,13 @@ describe('parseJobDescribe', () => {
   })
 
   it('treats a description with no instance id as unreadable rather than empty', () =>
-    expect(parseJobDescribe(JSON.stringify({ job: { name: 'build' } }))._tag).toBe('unrecognized'))
+    expect(parseDescribe(JSON.stringify({ job: { name: 'build' } }))._tag).toBe('unrecognized'))
 
   it('treats non-JSON stdout as unreadable', () =>
-    expect(parseJobDescribe('Error: something went wrong')._tag).toBe('unrecognized'))
+    expect(parseDescribe('Error: something went wrong')._tag).toBe('unrecognized'))
 
   it('treats empty stdout as unreadable', () =>
-    expect(parseJobDescribe('   ')._tag).toBe('unrecognized'))
+    expect(parseDescribe('   ')._tag).toBe('unrecognized'))
 })
 
 describe('deriveInstanceStatus', () => {
@@ -530,6 +573,32 @@ describe('observeNamespaceJob', () => {
     })
     expect(facts._tag).toBe('reported')
     expect(facts._tag === 'reported' && facts.job.instanceId).toBe(INSTANCE)
+  })
+
+  it('binds a multiple-attempt description to the GitHub runner instance', async () => {
+    const describe = JSON.stringify({
+      attempts: [
+        {
+          instance_id: 'previous-instance',
+          instance_status: 'DESTROYED',
+          runner_name: 'nsc-runner-previous-instance',
+        },
+        {
+          instance_id: INSTANCE,
+          instance_status: 'RUNNING',
+          runner_name: `nsc-runner-${INSTANCE}`,
+        },
+      ],
+    })
+    const { facts } = await observe({
+      github: githubFacts(),
+      respond: (argv) => (argv[0] === 'auth' ? output('ok') : output(describe)),
+    })
+
+    expect(facts._tag).toBe('reported')
+    expect(facts._tag === 'reported' && facts.job.instanceId).toBe(INSTANCE)
+    expect(facts._tag === 'reported' && facts.job.instanceStatusRaw).toBe('RUNNING')
+    expect(facts._tag === 'reported' && facts.job.runnerName).toBe(`nsc-runner-${INSTANCE}`)
   })
 
   it('does not run the report at all without --with-usage', async () => {

--- a/packages/@overeng/gh-ci-utils/test/namespaceAdapter.test.ts
+++ b/packages/@overeng/gh-ci-utils/test/namespaceAdapter.test.ts
@@ -696,6 +696,48 @@ describe('observeNamespaceJob', () => {
     expect(recorded.at(-1)?.slice(-2)).toEqual(['--jobname', 'build'])
   })
 
+  it('excludes object-valued previous-attempt metadata for a root runner', async () => {
+    const describe = JSON.stringify({
+      job: { workflow_name: 'Current CI' },
+      runner: {
+        instance_id: INSTANCE,
+        instance_status: 'RUNNING',
+        runner_name: `nsc-runner-${INSTANCE}`,
+      },
+      previous_attempt: {
+        job: { job_name: 'previous build', workflow_name: 'Previous CI' },
+        repository: 'previous-org/previous-repo',
+        runner: {
+          instance_id: 'previous-instance',
+          instance_status: 'DESTROYED',
+        },
+      },
+    })
+    const { facts, recorded } = await observe({
+      github: githubFacts(),
+      withUsage: true,
+      respond: (argv) =>
+        argv[0] === 'auth'
+          ? output('ok')
+          : argv[0] === 'github'
+            ? output(describe)
+            : argv[argv.indexOf('--jobname') + 1] === 'build'
+              ? output(REPORT_CSV)
+              : output('instance_id\n'),
+    })
+
+    expect(facts._tag).toBe('reported')
+    if (facts._tag !== 'reported') return
+    expect(facts.job).toMatchObject({
+      instanceId: INSTANCE,
+      repository: null,
+      workflow: 'Current CI',
+      jobName: null,
+    })
+    expect(facts.usage._tag).toBe('sampled')
+    expect(recorded.at(-1)?.slice(-2)).toEqual(['--jobname', 'build'])
+  })
+
   it('does not run the report at all without --with-usage', async () => {
     const { facts, recorded } = await observe({
       github: githubFacts(),

--- a/packages/@overeng/gh-ci-utils/test/namespaceAdapter.test.ts
+++ b/packages/@overeng/gh-ci-utils/test/namespaceAdapter.test.ts
@@ -23,7 +23,10 @@ import {
 } from 'effect/unstable/process/ChildProcessSpawner'
 import { describe, expect, it } from 'vitest'
 
-import type { InspectGitHubFacts } from '../src/isomorphic/lib/inspectFacts.ts'
+import {
+  RESOURCE_PRESSURE_FRACTION,
+  type InspectGitHubFacts,
+} from '../src/isomorphic/lib/inspectFacts.ts'
 import {
   authCheckLoginArgv,
   deriveInstanceStatus,
@@ -310,18 +313,58 @@ describe('selectUsageRow', () => {
     return parsed._tag === 'parsed' ? parsed.rows : []
   })()
 
-  it('reads the allocated and observed numbers off the matching row', () =>
-    expect(selectUsageRow({ rows, jobId: JOB_ID, instanceId: INSTANCE })).toEqual({
+  const selectCpuUsage = ({
+    allocatedCpu,
+    cpuMaxCores,
+  }: {
+    readonly allocatedCpu: string
+    readonly cpuMaxCores: string
+  }) =>
+    selectUsageRow({
+      rows: [
+        {
+          instance_id: INSTANCE,
+          github_job_id: String(JOB_ID),
+          resources_cpu: allocatedCpu,
+          resources_ram_gb: '16',
+          resources_cpu_actual_max: cpuMaxCores,
+          resources_ram_gb_actual_max_percent: '0.31',
+        },
+      ],
+      jobId: JOB_ID,
+      instanceId: INSTANCE,
+    })
+
+  it('normalizes peak cores against a multi-CPU allocation, avoiding false pressure', () => {
+    const usage = selectUsageRow({ rows, jobId: JOB_ID, instanceId: INSTANCE })
+
+    expect(usage).toEqual({
       instanceId: INSTANCE,
       githubJobId: String(JOB_ID),
       allocatedCpu: 8,
       allocatedRamGb: 16,
-      cpuMaxFraction: 0.97,
+      cpuMaxFraction: 0.97 / 8,
       ramMaxFraction: 0.31,
       createdAt: '2026-01-15 10:59:55 +0000 UTC',
       startedAt: '2026-01-15 11:00:00 +0000 UTC',
       destroyedAt: null,
-    }))
+    })
+    expect(usage?.cpuMaxFraction).toBeCloseTo(0.121)
+    expect(usage?.cpuMaxFraction).toBeLessThan(RESOURCE_PRESSURE_FRACTION)
+  })
+
+  it('normalizes peak cores against a fractional allocation, avoiding false negatives', () => {
+    const usage = selectCpuUsage({ allocatedCpu: '0.5', cpuMaxCores: '0.48' })
+
+    expect(usage?.allocatedCpu).toBe(0.5)
+    expect(usage?.cpuMaxFraction).toBeCloseTo(0.96)
+    expect(usage?.cpuMaxFraction).toBeGreaterThanOrEqual(RESOURCE_PRESSURE_FRACTION)
+  })
+
+  it('treats missing or zero CPU allocations as unavailable usage', () => {
+    expect(selectCpuUsage({ allocatedCpu: '', cpuMaxCores: '0.48' })).toBeNull()
+    expect(selectCpuUsage({ allocatedCpu: '0', cpuMaxCores: '0.48' })).toBeNull()
+  })
 
   it('requires the instance to match, not just the job', () =>
     expect(selectUsageRow({ rows, jobId: JOB_ID, instanceId: 'someotherinstance' })).toBeNull())
@@ -518,7 +561,7 @@ describe('observeNamespaceJob', () => {
       facts._tag === 'reported' && facts.usage._tag === 'sampled'
         ? facts.usage.sample.cpuMaxFraction
         : null,
-    ).toBe(0.97)
+    ).toBe(0.97 / 8)
 
     const window = deriveReportWindow({
       startedAt: '2026-01-15T11:00:00.000Z',

--- a/packages/@overeng/gh-ci-utils/test/namespaceAdapter.test.ts
+++ b/packages/@overeng/gh-ci-utils/test/namespaceAdapter.test.ts
@@ -412,7 +412,7 @@ describe('observeNamespaceJob', () => {
         argv[0] === 'auth'
           ? output('ok')
           : output('', {
-              stderr: 'workspace configuration not found',
+              stderr: `failed to describe job ${JOB_ID}: workspace configuration not found`,
               exitCode: 1,
             }),
     })

--- a/packages/@overeng/gh-ci-utils/test/namespaceAdapter.test.ts
+++ b/packages/@overeng/gh-ci-utils/test/namespaceAdapter.test.ts
@@ -225,6 +225,56 @@ describe('parseJobDescribe', () => {
     }
   })
 
+  it('inherits enclosing metadata for an array attempt without sibling leakage', () => {
+    const previous = {
+      job_name: 'previous build',
+      workflow_name: 'Previous CI',
+      repository: 'previous-org/previous-repo',
+      runner: {
+        instance_id: 'previous-instance',
+        instance_status: 'DESTROYED',
+        runner_name: 'nsc-runner-previous-instance',
+      },
+    }
+    const current = {
+      job: { workflow_name: 'Current CI' },
+      runner: {
+        instance_id: INSTANCE,
+        instance_status: 'RUNNING',
+        runner_name: `nsc-runner-${INSTANCE}`,
+      },
+    }
+
+    for (const attempts of [
+      [previous, current],
+      [current, previous],
+    ]) {
+      expect(
+        parseDescribe(
+          JSON.stringify({
+            job_name: 'parent build',
+            workflow_name: 'Parent CI',
+            repository: 'parent-org/parent-repo',
+            attempts,
+          }),
+        ),
+      ).toEqual({
+        _tag: 'parsed',
+        job: {
+          instanceId: INSTANCE,
+          instanceStatus: 'running',
+          instanceStatusRaw: 'RUNNING',
+          runnerName: `nsc-runner-${INSTANCE}`,
+          containerName: null,
+          repository: 'parent-org/parent-repo',
+          workflow: 'Current CI',
+          jobName: 'parent build',
+          destroyedAt: null,
+        },
+      })
+    }
+  })
+
   it('reads generic status only from the record that owns the instance id', () => {
     const parsed = parseDescribe(
       JSON.stringify({

--- a/packages/@overeng/gh-ci-utils/test/namespaceAdapter.test.ts
+++ b/packages/@overeng/gh-ci-utils/test/namespaceAdapter.test.ts
@@ -1,0 +1,522 @@
+/**
+ * `gh-ci-utils inspect` Namespace adapter.
+ *
+ * Two things are load-bearing here and both are asserted directly:
+ *
+ *  - the adapter only ever runs the three approved read-only `nsc` commands,
+ *    and runs none at all for a runner Namespace does not own;
+ *  - `nsc` being absent, unauthenticated, broken or unreadable degrades into
+ *    tagged data, never into a failure that would cost the GitHub facts.
+ *
+ * The decoders are exercised as pure functions because the live `nsc` JSON
+ * shape is not contractually stable: they must survive renames and nesting.
+ */
+import { Effect, Layer, Sink, Stream } from 'effect'
+import * as PlatformError from 'effect/PlatformError'
+import * as ChildProcess from 'effect/unstable/process/ChildProcess'
+import {
+  ChildProcessSpawner,
+  ExitCode,
+  ProcessId,
+  make as makeSpawner,
+  makeHandle,
+} from 'effect/unstable/process/ChildProcessSpawner'
+import { describe, expect, it } from 'vitest'
+
+import type { InspectGitHubFacts } from '../src/isomorphic/lib/inspectFacts.ts'
+import {
+  authCheckLoginArgv,
+  deriveInstanceStatus,
+  deriveReportWindow,
+  instanceReportArgv,
+  isAllowedArgv,
+  jobDescribeArgv,
+  observeNamespaceJob,
+  parseInstanceReport,
+  parseJobDescribe,
+  selectUsageRow,
+  splitCsvLine,
+} from '../src/node/NamespaceClient.ts'
+
+const INSTANCE = 'psmnb4mkjm3mq'
+const JOB_ID = 69067527707
+
+const githubFacts = (overrides: Partial<InspectGitHubFacts> = {}): InspectGitHubFacts => ({
+  repo: 'schickling/dotfiles',
+  jobId: JOB_ID,
+  runId: 23601797547,
+  name: 'build',
+  status: 'in_progress',
+  conclusion: null,
+  startedAt: '2026-09-10T11:00:00.000Z',
+  completedAt: '2026-09-10T11:04:00.000Z',
+  durationSeconds: 240,
+  runnerName: `nsc-runner-${INSTANCE}`,
+  runnerKind: 'namespace',
+  runnerInstance: INSTANCE,
+  labels: [],
+  steps: [],
+  ...overrides,
+})
+
+// =============================================================================
+// Fake spawner
+// =============================================================================
+
+/** What a faked `nsc` invocation returns. */
+type FakeResult =
+  | {
+      readonly _tag: 'output'
+      readonly stdout: string
+      readonly stderr: string
+      readonly exitCode: number
+    }
+  | { readonly _tag: 'not-on-path' }
+
+const output = (
+  stdout: string,
+  extra: { stderr?: string; exitCode?: number } = {},
+): FakeResult => ({
+  _tag: 'output',
+  stdout,
+  stderr: extra.stderr ?? '',
+  exitCode: extra.exitCode ?? 0,
+})
+
+const encode = (text: string) => Stream.make(new TextEncoder().encode(text))
+
+/**
+ * A spawner that answers from `respond` and records every argv it saw.
+ *
+ * Recording is the point: the adapter's whole security property is which argv
+ * it is capable of producing.
+ */
+const fakeSpawner = ({
+  respond,
+  recorded,
+}: {
+  respond: (argv: ReadonlyArray<string>) => FakeResult
+  recorded: Array<ReadonlyArray<string>>
+}) =>
+  Layer.succeed(
+    ChildProcessSpawner,
+    makeSpawner((command) =>
+      Effect.gen(function* () {
+        if (ChildProcess.isStandardCommand(command) === false) {
+          return yield* Effect.die(new Error('the inspect path must not build a piped command'))
+        }
+        const argv = [command.command, ...command.args]
+        recorded.push(argv)
+        const result = respond(command.args)
+        if (result._tag === 'not-on-path') {
+          return yield* PlatformError.systemError({
+            _tag: 'NotFound',
+            module: 'ChildProcess',
+            method: 'spawn',
+            description: 'nsc',
+          })
+        }
+        return makeHandle({
+          pid: ProcessId(4242),
+          exitCode: Effect.succeed(ExitCode(result.exitCode)),
+          isRunning: Effect.succeed(false),
+          kill: () => Effect.void,
+          stdin: Sink.drain,
+          stdout: encode(result.stdout),
+          stderr: encode(result.stderr),
+          all: encode(result.stdout + result.stderr),
+          getInputFd: () => Sink.drain,
+          getOutputFd: () => Stream.empty,
+          unref: Effect.succeed(Effect.void),
+        })
+      }),
+    ),
+  )
+
+/** A spawner that must never be touched. */
+const forbiddenSpawner = Layer.succeed(
+  ChildProcessSpawner,
+  makeSpawner(() => Effect.die(new Error('no subprocess may be spawned for this runner'))),
+)
+
+const DESCRIBE_JSON = JSON.stringify({
+  job: { id: String(JOB_ID), job_name: 'build', workflow_name: 'CI' },
+  repository: 'schickling/dotfiles',
+  runner: {
+    instance_id: INSTANCE,
+    instance_status: 'RUNNING',
+    runner_name: `nsc-runner-${INSTANCE}`,
+    container_name: 'runner',
+  },
+})
+
+/** The documented report layout: a preamble line, then the CSV. */
+const REPORT_CSV = `Writing output to path: stdout
+instance_id,created_at,started_at,destroyed_at,resources_cpu,resources_ram_gb,resources_cpu_actual_max,resources_ram_gb_actual_max_percent,github_job_id,github_job_name,github_job_workflow_name,github_run_id,github_run_attempt,job_created_at,job_started_at,job_completed_at,github_profile,github_repository,github_branch,github_job_conclusion
+${INSTANCE},2026-09-10 10:59:55 +0000 UTC,2026-09-10 11:00:00 +0000 UTC,,8,16,0.97,0.31,${JOB_ID},"build (linux, amd64)",CI,23601797547,1,2026-09-10 10:59:50 +0000 UTC,2026-09-10 11:00:00 +0000 UTC,,,schickling/dotfiles,main,
+`
+
+// =============================================================================
+// Pure decoders
+// =============================================================================
+
+describe('parseJobDescribe', () => {
+  it('finds the instance behind a nested runner block', () => {
+    const parsed = parseJobDescribe(DESCRIBE_JSON)
+    expect(parsed).toEqual({
+      _tag: 'parsed',
+      job: {
+        instanceId: INSTANCE,
+        instanceStatus: 'running',
+        instanceStatusRaw: 'RUNNING',
+        runnerName: `nsc-runner-${INSTANCE}`,
+        containerName: 'runner',
+        repository: 'schickling/dotfiles',
+        workflow: 'CI',
+        jobName: 'build',
+        destroyedAt: null,
+      },
+    })
+  })
+
+  it('reads camelCase field names too, since the CLI shape is not pinned', () => {
+    const parsed = parseJobDescribe(
+      JSON.stringify({ instanceId: INSTANCE, instanceStatus: 'running' }),
+    )
+    expect(parsed._tag === 'parsed' && parsed.job.instanceId).toBe(INSTANCE)
+    expect(parsed._tag === 'parsed' && parsed.job.instanceStatus).toBe('running')
+  })
+
+  it('degrades an unrecognized status to unknown instead of assuming the instance is gone', () => {
+    const parsed = parseJobDescribe(
+      JSON.stringify({ instance_id: INSTANCE, instance_status: 'PROVISIONING_V2' }),
+    )
+    expect(parsed._tag === 'parsed' && parsed.job.instanceStatus).toBe('unknown')
+    expect(parsed._tag === 'parsed' && parsed.job.instanceStatusRaw).toBe('PROVISIONING_V2')
+  })
+
+  it('treats a description with no instance id as unreadable rather than empty', () =>
+    expect(parseJobDescribe(JSON.stringify({ job: { name: 'build' } }))._tag).toBe('unrecognized'))
+
+  it('treats non-JSON stdout as unreadable', () =>
+    expect(parseJobDescribe('Error: something went wrong')._tag).toBe('unrecognized'))
+
+  it('treats empty stdout as unreadable', () =>
+    expect(parseJobDescribe('   ')._tag).toBe('unrecognized'))
+})
+
+describe('deriveInstanceStatus', () => {
+  it('lets a recorded destruction time override any status string', () =>
+    expect(
+      deriveInstanceStatus({ statusRaw: 'RUNNING', destroyedAt: '2026-09-10T11:05:00Z' }),
+    ).toBe('destroyed'))
+
+  it('reports unknown when there is no status at all', () =>
+    expect(deriveInstanceStatus({ statusRaw: null, destroyedAt: null })).toBe('unknown'))
+})
+
+describe('splitCsvLine', () => {
+  it('keeps commas inside quoted job names in one field', () =>
+    expect(splitCsvLine(`a,"build (linux, amd64)",c`)).toEqual(['a', 'build (linux, amd64)', 'c']))
+
+  it('unescapes doubled quotes', () =>
+    expect(splitCsvLine(`a,"say ""hi""",c`)).toEqual(['a', 'say "hi"', 'c']))
+
+  it('keeps trailing empty fields, so column positions never shift', () =>
+    expect(splitCsvLine('a,,')).toEqual(['a', '', '']))
+})
+
+describe('parseInstanceReport', () => {
+  it('skips the "Writing output to path" preamble and keys rows by column', () => {
+    const parsed = parseInstanceReport(REPORT_CSV)
+    expect(parsed._tag).toBe('parsed')
+    if (parsed._tag !== 'parsed') return
+    expect(parsed.rows).toHaveLength(1)
+    expect(parsed.rows[0]!['github_job_name']).toBe('build (linux, amd64)')
+    expect(parsed.rows[0]!['github_repository']).toBe('schickling/dotfiles')
+  })
+
+  it('reports output with no header as unreadable', () =>
+    expect(parseInstanceReport('Writing output to path: stdout\n')._tag).toBe('unrecognized'))
+})
+
+describe('selectUsageRow', () => {
+  const rows = (() => {
+    const parsed = parseInstanceReport(REPORT_CSV)
+    return parsed._tag === 'parsed' ? parsed.rows : []
+  })()
+
+  it('reads the allocated and observed numbers off the matching row', () =>
+    expect(selectUsageRow({ rows, jobId: JOB_ID, instanceId: INSTANCE })).toEqual({
+      instanceId: INSTANCE,
+      githubJobId: String(JOB_ID),
+      allocatedCpu: 8,
+      allocatedRamGb: 16,
+      cpuMaxFraction: 0.97,
+      ramMaxFraction: 0.31,
+      createdAt: '2026-09-10 10:59:55 +0000 UTC',
+      startedAt: '2026-09-10 11:00:00 +0000 UTC',
+      destroyedAt: null,
+    }))
+
+  it('requires the instance to match, not just the job', () =>
+    expect(selectUsageRow({ rows, jobId: JOB_ID, instanceId: 'someotherinstance' })).toBeNull())
+
+  it('requires the job to match, not just the instance', () =>
+    expect(selectUsageRow({ rows, jobId: 1, instanceId: INSTANCE })).toBeNull())
+})
+
+describe('deriveReportWindow', () => {
+  it('brackets the job with padding on both sides', () =>
+    expect(
+      deriveReportWindow({
+        startedAt: '2026-09-10T11:00:00.000Z',
+        completedAt: '2026-09-10T11:04:00.000Z',
+        now: new Date('2026-09-10T12:00:00.000Z'),
+      }),
+    ).toEqual({ start: '2026-09-10T10:55:00.000Z', end: '2026-09-10T11:09:00.000Z' }))
+
+  it('ends a still-running job at now, not at an invented completion', () =>
+    expect(
+      deriveReportWindow({
+        startedAt: '2026-09-10T11:00:00.000Z',
+        completedAt: null,
+        now: new Date('2026-09-10T11:02:00.000Z'),
+      })?.end,
+    ).toBe('2026-09-10T11:07:00.000Z'))
+
+  it('refuses a window when GitHub gave no start time', () =>
+    expect(deriveReportWindow({ startedAt: null, completedAt: null, now: new Date() })).toBeNull())
+})
+
+describe('isAllowedArgv', () => {
+  it('accepts exactly the three read-only invocations the adapter builds', () => {
+    expect(isAllowedArgv(authCheckLoginArgv())).toBe(true)
+    expect(isAllowedArgv(jobDescribeArgv(JOB_ID))).toBe(true)
+    expect(
+      isAllowedArgv(
+        instanceReportArgv({
+          window: { start: 'a', end: 'b' },
+          repository: 'o/r',
+          jobName: 'build',
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  it('rejects lifecycle, login and remote-execution commands', () => {
+    expect(isAllowedArgv(['auth', 'login'])).toBe(false)
+    expect(isAllowedArgv(['instance', 'destroy', INSTANCE])).toBe(false)
+    expect(isAllowedArgv(['ssh', INSTANCE])).toBe(false)
+    expect(isAllowedArgv(['run', 'sh'])).toBe(false)
+    expect(isAllowedArgv(['github', 'job', 'cancel', String(JOB_ID)])).toBe(false)
+  })
+})
+
+// =============================================================================
+// The observation
+// =============================================================================
+
+const observe = ({
+  github,
+  withUsage = false,
+  respond,
+}: {
+  github: InspectGitHubFacts
+  withUsage?: boolean
+  respond: (argv: ReadonlyArray<string>) => FakeResult
+}) => {
+  const recorded: Array<ReadonlyArray<string>> = []
+  return Effect.runPromise(
+    observeNamespaceJob({ github, withUsage }).pipe(
+      Effect.provide(fakeSpawner({ respond, recorded })),
+      Effect.map((facts) => ({ facts, recorded })),
+    ),
+  )
+}
+
+describe('observeNamespaceJob', () => {
+  it('spawns nothing at all for a self-hosted runner', async () => {
+    const facts = await Effect.runPromise(
+      observeNamespaceJob({
+        github: githubFacts({
+          runnerName: 'dev3-6038ddf9',
+          runnerKind: 'self-hosted',
+          runnerInstance: 'dev3',
+        }),
+        withUsage: true,
+      }).pipe(Effect.provide(forbiddenSpawner)),
+    )
+    expect(facts).toEqual({ _tag: 'not-namespace-job', runnerKind: 'self-hosted' })
+  })
+
+  it('spawns nothing for a job GitHub never assigned a runner to', async () => {
+    const facts = await Effect.runPromise(
+      observeNamespaceJob({
+        github: githubFacts({ runnerName: null, runnerKind: 'unknown', runnerInstance: null }),
+        withUsage: true,
+      }).pipe(Effect.provide(forbiddenSpawner)),
+    )
+    expect(facts).toEqual({ _tag: 'not-namespace-job', runnerKind: 'unknown' })
+  })
+
+  it('reports a missing nsc as data and gets no further than check-login', async () => {
+    const { facts, recorded } = await observe({
+      github: githubFacts(),
+      respond: () => ({ _tag: 'not-on-path' }),
+    })
+    expect(facts._tag).toBe('unavailable')
+    expect(facts._tag === 'unavailable' && facts.reason).toBe('nsc-missing')
+    expect(recorded).toEqual([['nsc', 'auth', 'check-login']])
+  })
+
+  it('reports an unusable session as not-authenticated without describing the job', async () => {
+    const { facts, recorded } = await observe({
+      github: githubFacts(),
+      respond: () => output('', { stderr: 'not logged in', exitCode: 1 }),
+    })
+    expect(facts._tag === 'unavailable' && facts.reason).toBe('not-authenticated')
+    expect(facts._tag === 'unavailable' && facts.detail).toBe('not logged in')
+    expect(recorded).toEqual([['nsc', 'auth', 'check-login']])
+  })
+
+  it('distinguishes an unknown job from a broken command', async () => {
+    const { facts } = await observe({
+      github: githubFacts(),
+      respond: (argv) =>
+        argv[0] === 'auth' ? output('ok') : output('', { stderr: 'job 1 not found', exitCode: 1 }),
+    })
+    expect(facts._tag === 'unavailable' && facts.reason).toBe('job-not-found')
+  })
+
+  it('reports output it cannot read as unrecognized rather than guessing', async () => {
+    const { facts } = await observe({
+      github: githubFacts(),
+      respond: (argv) => (argv[0] === 'auth' ? output('ok') : output('{"job":{"name":"build"}}')),
+    })
+    expect(facts._tag === 'unavailable' && facts.reason).toBe('unrecognized-output')
+  })
+
+  it('keeps stderr out of the JSON it parses', async () => {
+    const { facts } = await observe({
+      github: githubFacts(),
+      respond: (argv) =>
+        argv[0] === 'auth'
+          ? output('ok')
+          : output(DESCRIBE_JSON, { stderr: 'warning: using cached tenant token' }),
+    })
+    expect(facts._tag).toBe('reported')
+    expect(facts._tag === 'reported' && facts.job.instanceId).toBe(INSTANCE)
+  })
+
+  it('does not run the report at all without --with-usage', async () => {
+    const { facts, recorded } = await observe({
+      github: githubFacts(),
+      respond: (argv) => (argv[0] === 'auth' ? output('ok') : output(DESCRIBE_JSON)),
+    })
+    expect(facts._tag === 'reported' && facts.usage._tag).toBe('not-requested')
+    expect(recorded).toEqual([
+      ['nsc', 'auth', 'check-login'],
+      ['nsc', 'github', 'job', 'describe', String(JOB_ID), '-o', 'json'],
+    ])
+  })
+
+  it('samples usage with a bounded, filtered report and records only approved argv', async () => {
+    const { facts, recorded } = await observe({
+      github: githubFacts(),
+      withUsage: true,
+      respond: (argv) =>
+        argv[0] === 'auth'
+          ? output('ok')
+          : argv[0] === 'github'
+            ? output(DESCRIBE_JSON)
+            : output(REPORT_CSV),
+    })
+
+    expect(facts._tag === 'reported' && facts.usage._tag).toBe('sampled')
+    expect(
+      facts._tag === 'reported' && facts.usage._tag === 'sampled'
+        ? facts.usage.sample.cpuMaxFraction
+        : null,
+    ).toBe(0.97)
+
+    const window = deriveReportWindow({
+      startedAt: '2026-09-10T11:00:00.000Z',
+      completedAt: '2026-09-10T11:04:00.000Z',
+      now: new Date(),
+    })
+    expect(recorded).toEqual([
+      ['nsc', 'auth', 'check-login'],
+      ['nsc', 'github', 'job', 'describe', String(JOB_ID), '-o', 'json'],
+      [
+        'nsc',
+        'instance',
+        'report',
+        '--start',
+        window!.start,
+        '--end',
+        window!.end,
+        '--out',
+        '-',
+        '--repository',
+        'schickling/dotfiles',
+        '--jobname',
+        'build',
+      ],
+    ])
+    /** Every recorded invocation, argv[0] aside, is on the approved list. */
+    for (const argv of recorded) {
+      expect(argv[0]).toBe('nsc')
+      expect(isAllowedArgv(argv.slice(1))).toBe(true)
+    }
+    expect(facts._tag === 'reported' && facts.commands).toEqual(
+      recorded.map((argv) => argv.slice(1)),
+    )
+  })
+
+  it('keeps the job facts when only the usage report is unusable', async () => {
+    const { facts } = await observe({
+      github: githubFacts(),
+      withUsage: true,
+      respond: (argv) =>
+        argv[0] === 'auth'
+          ? output('ok')
+          : argv[0] === 'github'
+            ? output(DESCRIBE_JSON)
+            : output('', { stderr: 'report backend unavailable', exitCode: 2 }),
+    })
+    expect(facts._tag).toBe('reported')
+    expect(facts._tag === 'reported' && facts.job.instanceId).toBe(INSTANCE)
+    expect(
+      facts._tag === 'reported' && facts.usage._tag === 'unavailable' && facts.usage.reason,
+    ).toBe('command-failed')
+  })
+
+  it('refuses a report window it cannot bound instead of scanning the workspace', async () => {
+    const { facts, recorded } = await observe({
+      github: githubFacts({ startedAt: null, completedAt: null }),
+      withUsage: true,
+      respond: (argv) => (argv[0] === 'auth' ? output('ok') : output(DESCRIBE_JSON)),
+    })
+    expect(
+      facts._tag === 'reported' && facts.usage._tag === 'unavailable' && facts.usage.reason,
+    ).toBe('no-window')
+    expect(recorded.some((argv) => argv[1] === 'instance')).toBe(false)
+  })
+
+  it('reports a job absent from the report window as no-matching-row', async () => {
+    const { facts } = await observe({
+      github: githubFacts(),
+      withUsage: true,
+      respond: (argv) =>
+        argv[0] === 'auth'
+          ? output('ok')
+          : argv[0] === 'github'
+            ? output(DESCRIBE_JSON)
+            : output(REPORT_CSV.replace(String(JOB_ID), '11111111111')),
+    })
+    expect(
+      facts._tag === 'reported' && facts.usage._tag === 'unavailable' && facts.usage.reason,
+    ).toBe('no-matching-row')
+  })
+})

--- a/packages/@overeng/gh-ci-utils/test/namespaceAdapter.test.ts
+++ b/packages/@overeng/gh-ci-utils/test/namespaceAdapter.test.ts
@@ -652,6 +652,50 @@ describe('observeNamespaceJob', () => {
     expect(recorded.at(-1)?.slice(-2)).toEqual(['--jobname', 'build'])
   })
 
+  it('excludes sibling attempt metadata for a root runner and uses the GitHub job name', async () => {
+    const describe = JSON.stringify({
+      job: { workflow_name: 'Current CI' },
+      runner: {
+        instance_id: INSTANCE,
+        instance_status: 'RUNNING',
+        runner_name: `nsc-runner-${INSTANCE}`,
+      },
+      attempts: [
+        {
+          job: { job_name: 'previous build', workflow_name: 'Previous CI' },
+          repository: 'previous-org/previous-repo',
+          runner: {
+            instance_id: 'previous-instance',
+            instance_status: 'DESTROYED',
+          },
+        },
+      ],
+    })
+    const { facts, recorded } = await observe({
+      github: githubFacts(),
+      withUsage: true,
+      respond: (argv) =>
+        argv[0] === 'auth'
+          ? output('ok')
+          : argv[0] === 'github'
+            ? output(describe)
+            : argv[argv.indexOf('--jobname') + 1] === 'build'
+              ? output(REPORT_CSV)
+              : output('instance_id\n'),
+    })
+
+    expect(facts._tag).toBe('reported')
+    if (facts._tag !== 'reported') return
+    expect(facts.job).toMatchObject({
+      instanceId: INSTANCE,
+      repository: null,
+      workflow: 'Current CI',
+      jobName: null,
+    })
+    expect(facts.usage._tag).toBe('sampled')
+    expect(recorded.at(-1)?.slice(-2)).toEqual(['--jobname', 'build'])
+  })
+
   it('does not run the report at all without --with-usage', async () => {
     const { facts, recorded } = await observe({
       github: githubFacts(),

--- a/packages/@overeng/gh-ci-utils/test/namespaceAdapter.test.ts
+++ b/packages/@overeng/gh-ci-utils/test/namespaceAdapter.test.ts
@@ -179,6 +179,20 @@ describe('parseJobDescribe', () => {
     })
   })
 
+  it('reads generic status only from the record that owns the instance id', () => {
+    const parsed = parseJobDescribe(
+      JSON.stringify({
+        status: 'completed',
+        runner: {
+          instance_id: INSTANCE,
+          status: 'RUNNING',
+        },
+      }),
+    )
+    expect(parsed._tag === 'parsed' && parsed.job.instanceStatus).toBe('running')
+    expect(parsed._tag === 'parsed' && parsed.job.instanceStatusRaw).toBe('RUNNING')
+  })
+
   it('reads camelCase field names too, since the CLI shape is not pinned', () => {
     const parsed = parseJobDescribe(
       JSON.stringify({ instanceId: INSTANCE, instanceStatus: 'running' }),
@@ -384,9 +398,25 @@ describe('observeNamespaceJob', () => {
     const { facts } = await observe({
       github: githubFacts(),
       respond: (argv) =>
-        argv[0] === 'auth' ? output('ok') : output('', { stderr: 'job 1 not found', exitCode: 1 }),
+        argv[0] === 'auth'
+          ? output('ok')
+          : output('', { stderr: `job ${JOB_ID} not found`, exitCode: 1 }),
     })
     expect(facts._tag === 'unavailable' && facts.reason).toBe('job-not-found')
+  })
+
+  it('does not call an unrelated missing resource a missing GitHub job', async () => {
+    const { facts } = await observe({
+      github: githubFacts(),
+      respond: (argv) =>
+        argv[0] === 'auth'
+          ? output('ok')
+          : output('', {
+              stderr: 'workspace configuration not found',
+              exitCode: 1,
+            }),
+    })
+    expect(facts._tag === 'unavailable' && facts.reason).toBe('command-failed')
   })
 
   it('reports output it cannot read as unrecognized rather than guessing', async () => {

--- a/packages/@overeng/gh-ci-utils/test/namespaceAdapter.test.ts
+++ b/packages/@overeng/gh-ci-utils/test/namespaceAdapter.test.ts
@@ -708,6 +708,69 @@ describe('observeNamespaceJob', () => {
     }
   })
 
+  it('inherits enclosing metadata for an object-mapped attempt without sibling leakage', async () => {
+    const previous = {
+      job_name: 'previous build',
+      workflow: 'Previous CI',
+      repository: 'previous-org/previous-repo',
+      runner: {
+        instance_id: 'previous-instance',
+        instance_status: 'DESTROYED',
+        runner_name: 'nsc-runner-previous-instance',
+      },
+    }
+    const current = {
+      job: { workflow_name: 'Current CI' },
+      runner: {
+        instance_id: INSTANCE,
+        instance_status: 'RUNNING',
+        runner_name: `nsc-runner-${INSTANCE}`,
+      },
+    }
+
+    for (const attempts of [
+      { previous, current },
+      { current, previous },
+    ]) {
+      const { facts, recorded } = await observe({
+        github: githubFacts(),
+        withUsage: true,
+        respond: (argv) =>
+          argv[0] === 'auth'
+            ? output('ok')
+            : argv[0] === 'github'
+              ? output(
+                  JSON.stringify({
+                    job_name: 'parent build',
+                    workflow: 'Parent CI',
+                    repository: 'parent-org/parent-repo',
+                    attempts,
+                  }),
+                )
+              : argv[argv.indexOf('--jobname') + 1] === 'parent build'
+                ? output(REPORT_CSV)
+                : output('instance_id\n'),
+      })
+
+      expect(facts._tag).toBe('reported')
+      if (facts._tag !== 'reported') return
+      expect(facts.job).toMatchObject({
+        instanceId: INSTANCE,
+        runnerName: `nsc-runner-${INSTANCE}`,
+        repository: 'parent-org/parent-repo',
+        workflow: 'Current CI',
+        jobName: 'parent build',
+      })
+      expect(facts.usage._tag).toBe('sampled')
+      expect(recorded.at(-1)?.slice(-4)).toEqual([
+        '--repository',
+        'parent-org/parent-repo',
+        '--jobname',
+        'parent build',
+      ])
+    }
+  })
+
   it('excludes sibling attempt metadata for a root runner and uses the GitHub job name', async () => {
     const describe = JSON.stringify({
       job: { workflow_name: 'Current CI' },

--- a/packages/@overeng/gh-ci-utils/test/namespaceAdapter.test.ts
+++ b/packages/@overeng/gh-ci-utils/test/namespaceAdapter.test.ts
@@ -652,6 +652,62 @@ describe('observeNamespaceJob', () => {
     expect(recorded.at(-1)?.slice(-2)).toEqual(['--jobname', 'build'])
   })
 
+  it('isolates object-mapped attempts and falls back to the GitHub identity', async () => {
+    const previous = {
+      job: { job_name: 'previous build', workflow_name: 'Previous CI' },
+      repository: 'previous-org/previous-repo',
+      runner: {
+        instance_id: 'previous-instance',
+        instance_status: 'DESTROYED',
+        runner_name: 'nsc-runner-previous-instance',
+        container_name: 'previous-container',
+      },
+    }
+    const current = {
+      runner: {
+        instance_id: INSTANCE,
+        instance_status: 'RUNNING',
+        runner_name: `nsc-runner-${INSTANCE}`,
+      },
+    }
+
+    for (const attempts of [
+      { previous, current },
+      { current, previous },
+    ]) {
+      const { facts, recorded } = await observe({
+        github: githubFacts(),
+        withUsage: true,
+        respond: (argv) =>
+          argv[0] === 'auth'
+            ? output('ok')
+            : argv[0] === 'github'
+              ? output(JSON.stringify({ attempts }))
+              : argv[argv.indexOf('--jobname') + 1] === 'build'
+                ? output(REPORT_CSV)
+                : output('instance_id\n'),
+      })
+
+      expect(facts._tag).toBe('reported')
+      if (facts._tag !== 'reported') return
+      expect(facts.job).toMatchObject({
+        instanceId: INSTANCE,
+        runnerName: `nsc-runner-${INSTANCE}`,
+        containerName: null,
+        repository: null,
+        workflow: null,
+        jobName: null,
+      })
+      expect(facts.usage._tag).toBe('sampled')
+      expect(recorded.at(-1)?.slice(-4)).toEqual([
+        '--repository',
+        'example-org/example-repo',
+        '--jobname',
+        'build',
+      ])
+    }
+  })
+
   it('excludes sibling attempt metadata for a root runner and uses the GitHub job name', async () => {
     const describe = JSON.stringify({
       job: { workflow_name: 'Current CI' },


### PR DESCRIPTION
## Problem

GitHub Actions reports which Namespace runner executed a job, but it does not expose enough runner-side evidence to distinguish active work, idle allocation, resource pressure, or unknown state.

## Goal

Add a local, read-only `gh-ci-utils inspect --job <id>` command that keeps GitHub facts separate from Namespace observations and produces a conservative assessment.

## Decisions

- Use only `nsc auth check-login`, `nsc github job describe`, and optional `nsc instance report` commands.
- Never SSH, replay commands, manage runner lifecycle, or mutate Namespace state.
- Decode Namespace output tolerantly and preserve raw status evidence.
- Classify only `active`, `idle`, `resource-pressure`, or `unknown`.
- Claim resource pressure only when sampled CPU or RAM allocation is at least 95%.
- Preserve GitHub facts and return `unknown` when Namespace evidence is unavailable, contradictory, or identifies a different runner instance.
- Preserve API request and rate-limit metadata on GitHub failure paths.

## Verification

- Full package suite: 24 files, 354 tests passed.
- Package TypeScript, formatting, and lint checks passed.
- Storybook production build passed.
- Final `gh-ci-utils` Nix package build passed.
- A packaged live inspection of a running Namespace job returned GitHub facts, Namespace job facts, usage evidence, and a correlated assessment.
- A packaged live 404 returned structured Error JSON with nonzero API request and current rate-limit metadata.

The literal `devenv tasks run check:quick` entrypoint is not usable in this worktree because devenv recursively hashes the full source root before task execution; evidence is recorded in cachix/devenv#3154. The direct constituent gates above passed.

## Complexity

The command adds an explicit JSON schema, a pure classifier, a constrained Namespace process adapter, terminal rendering, and Storybook fixtures. The process boundary is isolated from the classifier.

## Follow-ups

SSH diagnostics, lifecycle actions, job replay, and Reader credential integration are deliberately out of scope.

## References

- Parent: #1256
- Namespace CLI job describe reference: https://namespace.so/docs/reference/cli/github-job-describe
- Namespace CLI instance report reference: https://namespace.so/docs/reference/cli/instance-report

<!-- agent-footer:begin v=3 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | dev3.direct.omp.7f5uvzmp |
| `session` | dev3.01a09b83 |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.1.14 |
| `agent_runtime` | OMP 18.1.14 |
| `agent_model` | openai-codex/gpt-5.6-sol |
| `worktree` | 2026-09-10-gh-ci-utils-inspect/2026-09-10-gh-ci-utils-inspect |
| `tooling_profile` | dotfiles@44ddd8a |
</details>
<!-- agent-footer:end -->