### PR TITLE
chore(pnpm): move ecosystem pin to pnpm 12.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -233,6 +233,22 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- **pnpm**: move the ecosystem pin from pnpm 12.3.4 to 12.4.1. pnpm 12.3.4
+  rejects `pnpm install --frozen-lockfile` with `ERR_PNPM_OUTDATED_LOCKFILE` on
+  workspaces whose root `overrides` carry a `file:` specifier consumed by a
+  nested importer: the root-relative override path is not rebased per importer,
+  so the recomputed importer specifier never matches the lockfile
+  (pnpm/pnpm#9216). 12.4.1 resolves the same tree cleanly, so the pin moves
+  forward rather than pinning downstream repos to a lockfile-rewriting
+  workaround. `nix/pnpm.nix` carries the new wrapper and all six
+  `@pnpm/exe.<target>` hashes, and the version is synced through
+  `DEFAULT_AGGREGATE_PACKAGE_MANAGER` (hence the generated root `package.json`
+  and `pnpm-install-contract.json`), the lock-mutator evaluation allowlist, and
+  the pnpm fixture manifests. Verified on the built package: `pnpm --version`
+  reports 12.4.1, the store layout stays `v11`, and `pnpm install
+  --frozen-lockfile --ignore-scripts` over all 39 workspace projects succeeds
+  with the lockfile unchanged.
+
 - **pnpm**: move the ecosystem pin from pnpm 11.8.0 to 12.3.4 and retire the
   separate lock mutator. pnpm 12 ships the CLI as a native Rust executable, so
   `nix/pnpm.nix` no longer overrides `pkgs.pnpm`: it assembles the published

--- a/nix/devenv-modules/tasks/shared/pnpm.nix
+++ b/nix/devenv-modules/tasks/shared/pnpm.nix
@@ -120,9 +120,9 @@ let
   # derivation here would force the module's `pkgs` argument while devenv is
   # still assembling `_module.args`, causing an evaluation recursion.
   pnpmLockMutatorOverrideVersion =
-    if pnpmLockMutatorPkg == null then "12.3.4" else pnpmLockMutatorPkg.version or "unknown";
+    if pnpmLockMutatorPkg == null then "12.4.1" else pnpmLockMutatorPkg.version or "unknown";
   pnpmLockMutatorOverrideIsSupported =
-    pnpmLockMutatorPkg == null || pnpmLockMutatorOverrideVersion == "12.3.4";
+    pnpmLockMutatorPkg == null || pnpmLockMutatorOverrideVersion == "12.4.1";
 
   flock = "${pkgs.flock}/bin/flock";
   installFlagsString = lib.escapeShellArgs installFlags;
@@ -836,7 +836,7 @@ let
 in
 assert lib.assertMsg pnpmLockMutatorOverrideIsSupported ''
   pnpm lock mutator version ${pnpmLockMutatorOverrideVersion} is not supported.
-  Set a derivation versioned as the verified-safe pnpm 12.3.4 pin;
+  Set a derivation versioned as the verified-safe pnpm 12.4.1 pin;
   other versions require explicit verification and an allowlist change.
 '';
 assert lib.assertMsg (!sourceInputPathsOverlap) "sourceInputPaths entries must not overlap";

--- a/nix/devenv-modules/tasks/shared/tests/pnpm-source-input-refresh.integration.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/pnpm-source-input-refresh.integration.test.sh
@@ -28,7 +28,7 @@ write_source_package() {
 }
 
 write_source_package one
-printf '{"name":"fixture-root","private":true,"packageManager":"pnpm@12.3.4","dependencies":{"source-package":"file:%s"}}\n' \
+printf '{"name":"fixture-root","private":true,"packageManager":"pnpm@12.4.1","dependencies":{"source-package":"file:%s"}}\n' \
   "$stable_stage_path" > "$workspace/package.json"
 
 install_fixture() {

--- a/nix/devenv-modules/tasks/shared/tests/pnpm-task-smoke.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/pnpm-task-smoke.test.sh
@@ -329,7 +329,7 @@ set -euo pipefail
 printf '%s\n' "$*" >> "${TEST_PNPM_MUTATOR_LOG:?}"
 printf 'PWD=%s\n' "$PWD" >> "${TEST_PNPM_MUTATOR_LOG:?}"
 if [ "${1:-}" = "--version" ]; then
-  echo "12.3.4"
+  echo "12.4.1"
   exit 0
 fi
 if [ "${1:-}" = "install" ]; then

--- a/nix/devenv-modules/tasks/shared/tests/pnpm-task-smoke.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/pnpm-task-smoke.test.sh
@@ -188,7 +188,7 @@ rewrite_unrealized_tool_paths() {
   perl -0pi -e '
     s#/nix/store/[^"\s]*/bin/flock#'"$tmpdir"'/bin/flock#g;
     s#/nix/store/[^"\s]*/bin/node#node#g;
-    s#/nix/store/[^"\s]*-pnpm-12\.3\.4/bin/pnpm#'"$tmpdir"'/bin/pnpm-lock-mutator#g;
+    s#/nix/store/[^"\s]*-pnpm-12\.4\.1/bin/pnpm#'"$tmpdir"'/bin/pnpm-lock-mutator#g;
     s#/nix/store/[^"\s]*-pnpm-task-helpers\.sh#'"$ROOT"'/nix/devenv-modules/tasks/shared/pnpm-task-helpers.sh#g;
     s#/nix/store/[^"\s]*-check-node-modules-projection-health\.cjs#'"$ROOT"'/nix/devenv-modules/tasks/shared/check-node-modules-projection-health.cjs#g;
     s#/nix/store/[^"\s]*-stage-pnpm-source-inputs\.mjs#'"$ROOT"'/nix/devenv-modules/tasks/shared/stage-pnpm-source-inputs.mjs#g;

--- a/nix/pnpm.nix
+++ b/nix/pnpm.nix
@@ -20,7 +20,7 @@
 # lifecycle script or network access at build time.
 let
   lib = pkgs.lib;
-  version = "12.3.4";
+  version = "12.4.1";
 
   platform = pkgs.stdenv.hostPlatform;
 
@@ -38,17 +38,17 @@ let
       unsupportedPlatform;
 
   exeHashes = {
-    "linux-x64" = "sha256-mxyV/EE2AMp1pR6+gzLXAZ3DVo/UGH9aXy30oVbvtlw=";
-    "linux-arm64" = "sha256-q1Nm6VLbwoETQhp8fd/bBMm7ZClYuPU+pVg4VEJr1I0=";
-    "linux-x64-musl" = "sha256-SsTn+4Czuk/7DkQ62rVTnedYHV2g8pUBhZsweFcxqg4=";
-    "linux-arm64-musl" = "sha256-CF9jicQSEF2+GKQgmsNaKzVehXRM1bhGlwvCH6pJoiw=";
-    "darwin-x64" = "sha256-3kEPwxUxsbekQMjoDeHPdmPMMp/lMKUjJIIT8bL5bK8=";
-    "darwin-arm64" = "sha256-9UrTZ9ikLa+dhIMOS9akXAlX4OMoekXaCMOguNBOx/c=";
+    "linux-x64" = "sha256-YU0YvcsSGoRMAmCzFddrc35oc0bAAbjgk/0KkyAsLWs=";
+    "linux-arm64" = "sha256-79UEsfvqNGHdoyIESBE3Q0VXz8HtcKsD8Nxvlt0r6EU=";
+    "linux-x64-musl" = "sha256-nfj+T4u+WBXRafC4cC2niEQtJplT4gZYawUYlSdCjJg=";
+    "linux-arm64-musl" = "sha256-mD9RMUbOd4mBXx2I8dXkN12zO4DkS+lUrBhtx0EdMrY=";
+    "darwin-x64" = "sha256-/4zVEgEpiwOvh/QkJ/w53LcA/w8dZCT6u9CF039RjLQ=";
+    "darwin-arm64" = "sha256-nI4gCXq7OtTzC/oxw+WT016REfuGdaBq1rOR/N17yKA=";
   };
 
   wrapperSrc = pkgs.fetchurl {
     url = "https://registry.npmjs.org/pnpm/-/pnpm-${version}.tgz";
-    hash = "sha256-CKPS1Tmzd6a36iRpthJnIlXKccMKYmmFMFgsudNcJo8=";
+    hash = "sha256-YnYpjpr1dren9ekES/r74meCCSUM0QsXBepdOqZNSII=";
   };
 
   exeSrc = pkgs.fetchurl {

--- a/nix/workspace-tools/lib/mk-pnpm-cli/tests/fixtures/downstream/fixture-workspace-invalid-stage-path/package.json
+++ b/nix/workspace-tools/lib/mk-pnpm-cli/tests/fixtures/downstream/fixture-workspace-invalid-stage-path/package.json
@@ -2,5 +2,5 @@
   "name": "mk-pnpm-cli-invalid-stage-path-fixture",
   "private": true,
   "version": "0.0.0",
-  "packageManager": "pnpm@12.3.4"
+  "packageManager": "pnpm@12.4.1"
 }

--- a/nix/workspace-tools/lib/mk-pnpm-cli/tests/fixtures/downstream/fixture-workspace/package.json
+++ b/nix/workspace-tools/lib/mk-pnpm-cli/tests/fixtures/downstream/fixture-workspace/package.json
@@ -2,5 +2,5 @@
   "name": "mk-pnpm-cli-downstream-fixture",
   "private": true,
   "version": "0.0.0",
-  "packageManager": "pnpm@12.3.4"
+  "packageManager": "pnpm@12.4.1"
 }

--- a/package.json
+++ b/package.json
@@ -45,5 +45,5 @@
     "packages/@overeng/utils",
     "packages/@overeng/utils-dev"
   ],
-  "packageManager": "pnpm@12.3.4"
+  "packageManager": "pnpm@12.4.1"
 }

--- a/packages/@overeng/ci-tools/nix/build.nix
+++ b/packages/@overeng/ci-tools/nix/build.nix
@@ -19,7 +19,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-6beDKMIzyIaqNirWOGM1QSeEv6wE8i14X3fzyEepA2A=";
+      "." = mkSharedHash "sha256-wf027QsRxO318wq9wmr/F6IgG6OFo3RGDOjAfQBfwxk=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/genie/nix/build.nix
+++ b/packages/@overeng/genie/nix/build.nix
@@ -31,7 +31,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-LKAcHsE+iiWOTer0NLZryZGWeSgxAkqXXzlbkIFQ/t0=";
+      "." = mkSharedHash "sha256-UXm2+4h50O+yu7/TFVM9Tf1DM1r/lqjqoX0kdmG9/yk=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/genie/src/runtime/package-json/mod.ts
+++ b/packages/@overeng/genie/src/runtime/package-json/mod.ts
@@ -1146,7 +1146,7 @@ const mergePackageJsonOptions = ({
  * Aggregates are repository coordination files, not package-level authoring
  * surfaces, so this stays centralized instead of being repeated by callers.
  */
-const DEFAULT_AGGREGATE_PACKAGE_MANAGER = 'pnpm@12.3.4'
+const DEFAULT_AGGREGATE_PACKAGE_MANAGER = 'pnpm@12.4.1'
 
 /**
  * Project an aggregate manifest from package metadata for an explicit repo view.

--- a/packages/@overeng/genie/src/runtime/package-json/package-json.unit.test.ts
+++ b/packages/@overeng/genie/src/runtime/package-json/package-json.unit.test.ts
@@ -1559,7 +1559,7 @@ describe('packageJson.aggregateFromPackages', () => {
     expect(result.data).toEqual({
       name: 'my-monorepo',
       private: true,
-      packageManager: 'pnpm@12.3.4',
+      packageManager: 'pnpm@12.4.1',
       workspaces: ['packages/app', 'packages/utils'],
     })
     expect(typeof result.stringify).toBe('function')
@@ -1581,7 +1581,7 @@ describe('packageJson.aggregateFromPackages', () => {
     })
     expect(parsed.name).toBe('my-monorepo')
     expect(parsed.private).toBe(true)
-    expect(parsed.packageManager).toBe('pnpm@12.3.4')
+    expect(parsed.packageManager).toBe('pnpm@12.4.1')
     expect(parsed.workspaces).toEqual(['packages/app', 'packages/utils'])
   })
 

--- a/packages/@overeng/megarepo/nix/build.nix
+++ b/packages/@overeng/megarepo/nix/build.nix
@@ -26,7 +26,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-UCumijrFdvI/xi4q0ASWlpXVyDgMgBCyAWKtpKkQNS0=";
+      "." = mkSharedHash "sha256-rxwGucsK5ZinP1HnStSILWhc1KLtR27AD7CoWj1Q5LM=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     smokeTestArgs = [ "--help" ];

--- a/packages/@overeng/notion-cli/nix/build.nix
+++ b/packages/@overeng/notion-cli/nix/build.nix
@@ -33,7 +33,7 @@ let
     installRuntimeWorkspace = true;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-0SWP7gW2pRRJgLLR2axXPq0Xn5vlJ/iuhWTy1/LEl7U=";
+      "." = mkSharedHash "sha256-+86+40S4Rh131FVhPXGzSx9mX7NrhKAvARaK+TRcIU4=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/notion-md/nix/build.nix
+++ b/packages/@overeng/notion-md/nix/build.nix
@@ -20,7 +20,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-OotDzXiGgkxrR7UubZogwpZW762936gIRtl6wvJWHZs=";
+      "." = mkSharedHash "sha256-lY817qsiK5xs7GrJcKTu8cOBqUHX1dt8XO2UD/ovsU4=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/npm-release/nix/build.nix
+++ b/packages/@overeng/npm-release/nix/build.nix
@@ -20,7 +20,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-oulC6ok8tOhamdcTUFwIMqmv/3/0T71HdNkmqyaUOo8=";
+      "." = mkSharedHash "sha256-4Zn9Yb0t8JoVItmrIRYLbbt5rvyQ6BBwRWKARFkn86o=";
     };
     smokeTestArgs = [ "--help" ];
     inherit gitRev commitTs dirty;

--- a/packages/@overeng/oxc-config/nix/build.nix
+++ b/packages/@overeng/oxc-config/nix/build.nix
@@ -14,7 +14,7 @@ import ../../../../nix/oxc-config-plugin.nix {
     ;
   # Managed by Evergreen FOD refresh — do not edit manually.
   depsBuilds = {
-    "." = mkSharedHash "sha256-NFRkVu0iTXrQO341Tdy10etMt9UeZb6uaN6JXsDxpRE=";
+    "." = mkSharedHash "sha256-fqToFZThmrhPvEIPWYiHiWs6Igk5Z9xpJzGFMgamVZ4=";
   };
   hashSourcePath = "packages/@overeng/oxc-config/nix/build.nix";
 }

--- a/packages/@overeng/tui-stories/nix/build.nix
+++ b/packages/@overeng/tui-stories/nix/build.nix
@@ -21,7 +21,7 @@ let
     workspaceRoot = src;
     # Managed by the repo FOD refresh workflow — do not edit manually.
     depsBuilds = {
-      "." = mkSharedHash "sha256-6aEtvLDYPG+LyyyoASnIEoZwKX+jwMjtIf4WKEpUcVU=";
+      "." = mkSharedHash "sha256-m5HEaKGVanzccRtn35LnvF/Hj57lExHaWNRpAUtHvus=";
     };
     nativeNodePackages = opentuiCoreNative.packages;
     inherit gitRev commitTs dirty;

--- a/pnpm-install-contract.json
+++ b/pnpm-install-contract.json
@@ -22,7 +22,7 @@
     },
     "packageManager": {
       "name": "pnpm",
-      "version": "12.3.4"
+      "version": "12.4.1"
     }
   },
   "installPolicy": {
@@ -84,7 +84,7 @@
   },
   "packageManager": {
     "name": "pnpm",
-    "version": "12.3.4"
+    "version": "12.4.1"
   },
   "schemaVersion": 2,
   "storeContract": {


### PR DESCRIPTION
Refs overengineeringstudio/effect-utils#1266

## What changed

- `nix/pnpm.nix`: ecosystem pnpm pin `12.3.4` -> `12.4.1`, with the wrapper tarball hash and all six `@pnpm/exe.<target>` hashes recomputed by `nix store prefetch-file` (no hand-patched hashes).
- `DEFAULT_AGGREGATE_PACKAGE_MANAGER` (`packages/@overeng/genie/src/runtime/package-json/mod.ts`) synced to `pnpm@12.4.1` per the SSOT contract at the top of `nix/pnpm.nix`, plus its unit-test expectations.
- Genie-generated fallout regenerated (`genie` run produced no drift beyond these): root `package.json` `packageManager`, and `pnpm-install-contract.json` (`packageManager.version`, `dependencyGraphContract.packageManager.version`).
- Lock-mutator evaluation allowlist in `nix/devenv-modules/tasks/shared/pnpm.nix` moved to `12.4.1` — `nix/pnpm-lock-mutator.nix` imports `nix/pnpm.nix`, so the allowlist has to track the pin or an explicit `pnpmLockMutatorPkg = <default pin>` would fail the assert.
- pnpm fixture manifests / test stubs that pinned `pnpm@12.3.4` aligned to the pin (mk-pnpm-cli downstream fixtures, pnpm task smoke stub, source-input-refresh integration fixture).
- CHANGELOG entry under Unreleased / Changed.

## Why

pnpm 12.3.4 rejects `pnpm install --frozen-lockfile` with `ERR_PNPM_OUTDATED_LOCKFILE` on workspaces whose root `overrides` carry a `file:` specifier that a nested importer consumes: the root-relative override path is not rebased per importer, so the specifier pnpm recomputes for the nested importer never matches what the lockfile records — and under `--frozen-lockfile` there is no way to converge. On the identical tree, pnpm 11.8.0 and 12.4.1 both verify clean, which isolates the failure to the 12.3.x override-rebasing path (cf. pnpm/pnpm#9216).

Downstream repos on this pin cannot run a frozen install at all, so the pin has to move forward rather than have consumers carry a lockfile-rewriting workaround.

## Verification

- `nix build` of the pnpm attr (`lib.mkPnpm`) on `x86_64-linux`: builds to `pnpm-12.4.1`; `pnpm --version` -> `12.4.1`; `pnpm store path` -> `.../store/v11` (store layout unchanged).
- `nix eval` of `nix/pnpm-lock-mutator.nix` -> `"12.4.1"`, matching the bumped allowlist.
- `pnpm install --frozen-lockfile --lockfile-only --ignore-scripts` with the built 12.4.1: passes over all 39 workspace projects.
- `pnpm install --frozen-lockfile --ignore-scripts` with the built 12.4.1: full materialization (578 packages), "Lockfile is up to date", `pnpm-lock.yaml` unchanged afterwards.
- `genie` (write mode): no drift beyond the two generated files above.
- `vitest run src/runtime/package-json/package-json.unit.test.ts` in `@overeng/genie`: 52 passed, including both `packageManager: 'pnpm@12.4.1'` aggregate assertions. The 2 remaining failures (strict TypeScript-proof cache / isomorphic proof) are pre-existing and reproduce identically on a pristine `origin/main` worktree — they need a `tsgo`/`GENIE_EXPORT_TYPE_PROOF_COMPILER` compiler that is not on PATH in this environment.

Project-wide suites were intentionally not run; CI owns those.

<!-- agent-footer:begin v=2 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | dev3.direct.omp.dfu4q8g9 |
| `session` | dev3.dfu4q8g9 |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.1.14 |
| `agent_runtime` | OMP 18.1.14 |
| `tooling_profile` | dotfiles@88367be |
</details>
<!-- agent-footer:end -->