### PR TITLE
docs(buck2): external-cells evaluation, decision 0030, proposed artifact composition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- **Buck2 (context)**: decision 0030 — git external cells are not a
+  member-mount mechanism (the physical `buck-out/.../git/<sha>` path enters
+  the input Merkle tree, so an external cell's action digests diverge from
+  the on-disk cell's) — with its evaluation experiments, plus the
+  `.proposed/` artifact-composition decision (artifact-granular
+  cross-repository reuse, cost ledger, falsification spikes), open for
+  acceptance or rejection. Roadmap Phase 6 and the composition open questions
+  reference the proposal; no ratified requirement changes.
+
 - **@overeng/megarepo**: composition-enabled branch worktrees are now created
   directly at their final `P/repos/<owned>` path and use Git registration as
   identity authority. Routine commands refuse legacy flat roots without

--- a/context/buck2/.decisions/.proposed/artifact-composition.md
+++ b/context/buck2/.decisions/.proposed/artifact-composition.md
@@ -65,13 +65,13 @@ establish what the composition machinery costs and who uses it:
 
 ## Options
 
-| Option                                                          | Tradeoff                                                                                                                         | Outcome  |
-| --------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| Cells for source deps (decision 0014/0020, status quo)          | Action-level reuse and source-granular invalidation across repos; pays L3 + the 0020 shape on every Buck-admitted consumer         | Reopened |
-| Git external cells as mounts                                    | Rejected in decision 0030                                                                                                        | Rejected |
-| Artifacts for effect-utils library edges; cells paused (this)   | Deletes the need for cross-repo cells; adds a publish layout + durable origin; keeps mounts for fork co-dev and generator sources | Proposed |
-| All edges as artifacts                                          | Needs per-commit fork-branch snapshots and a registry disposition nobody consumes; ruled out                                     | Rejected |
-| Thinner L3 implementation, same contract (decision-0020 projector) | Keeps criterion 6; unmeasured savings; the shape and its migration remain                                                      | Fallback |
+| Option                                                             | Tradeoff                                                                                                                          | Outcome  |
+| ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| Cells for source deps (decision 0014/0020, status quo)             | Action-level reuse and source-granular invalidation across repos; pays L3 + the 0020 shape on every Buck-admitted consumer        | Reopened |
+| Git external cells as mounts                                       | Rejected in decision 0030                                                                                                         | Rejected |
+| Artifacts for effect-utils library edges; cells paused (this)      | Deletes the need for cross-repo cells; adds a publish layout + durable origin; keeps mounts for fork co-dev and generator sources | Proposed |
+| All edges as artifacts                                             | Needs per-commit fork-branch snapshots and a registry disposition nobody consumes; ruled out                                      | Rejected |
+| Thinner L3 implementation, same contract (decision-0020 projector) | Keeps criterion 6; unmeasured savings; the shape and its migration remain                                                         | Fallback |
 
 ## Proposed Decision
 
@@ -130,15 +130,15 @@ establish what the composition machinery costs and who uses it:
 
 ## Cost Ledger (BUCK-R15 inputs; document-grounded unless marked measured)
 
-| Item | Exists today | Missing |
-| --- | --- | --- |
-| Tarball transport + pin + drift refusal | pnpm URL deps + integrity; CAS HTTP (measured) | — |
-| Dist layout per package | 12/35 packages `types → dist`; `publishConfig` names shapes nothing builds | tested pack contract for 35 packages; 23 src-only packages need a dist |
-| Durable origin | buck2-products publisher for CLIs (GitHub Releases) | library-module extension; retention policy |
-| Consumer fetch under Buck2 | decision-0022 closure for registry entries | custom tarball URL entries (spike) |
-| Consumer type shims | per-consumer `tsconfig` `paths` into sources | deleted per migrated package |
-| Repin step | `mr` lock-sync ↔ `flake.lock` (proven in dotfiles) | source commit ↔ artifact hash mapping in the consumer lockfile |
-| L3 deletion | — | none now (paused, not retired) |
+| Item                                    | Exists today                                                               | Missing                                                                |
+| --------------------------------------- | -------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| Tarball transport + pin + drift refusal | pnpm URL deps + integrity; CAS HTTP (measured)                             | —                                                                      |
+| Dist layout per package                 | 12/35 packages `types → dist`; `publishConfig` names shapes nothing builds | tested pack contract for 35 packages; 23 src-only packages need a dist |
+| Durable origin                          | buck2-products publisher for CLIs (GitHub Releases)                        | library-module extension; retention policy                             |
+| Consumer fetch under Buck2              | decision-0022 closure for registry entries                                 | custom tarball URL entries (spike)                                     |
+| Consumer type shims                     | per-consumer `tsconfig` `paths` into sources                               | deleted per migrated package                                           |
+| Repin step                              | `mr` lock-sync ↔ `flake.lock` (proven in dotfiles)                         | source commit ↔ artifact hash mapping in the consumer lockfile         |
+| L3 deletion                             | —                                                                          | none now (paused, not retired)                                         |
 
 ## Falsification Spikes (before acceptance)
 

--- a/context/buck2/.decisions/.proposed/artifact-composition.md
+++ b/context/buck2/.decisions/.proposed/artifact-composition.md
@@ -1,0 +1,162 @@
+# Proposed: Cross-Repository Reuse Through Artifacts, Not Composed Cells
+
+Status: proposed (PR-local; not in force). Reopens the "Product bridge only"
+row of [decision 0014](../0014-megarepo-cell-composition.md) with evidence
+that did not exist then.
+
+## Context
+
+The Buck2 adoption composes megarepo members as cells so that a consuming
+repository builds a producer's targets from the shared cache with
+source-granular invalidation (vision criterion 6; COMP-R01/R02; decision
+0020's one-writable-mount shape; decision 0027's composed-by-default
+worktrees). The investigation of 2026-09-12 asked whether a Buck2-native
+mechanism makes megarepo redundant. It does not (decision 0030). It did
+establish what the composition machinery costs and who uses it:
+
+- `mr` is three things. L1, the worktree fleet (store, worktree per ref, GC
+  with liveness veto): ~9.8k LOC, consumed by branchy, the agent-policy git
+  wrapper, st2 seats, evergreen, fleet disk hygiene. L2, pin and arrange
+  (`megarepo.kdl` → `megarepo.lock`, members at `repos/<name>`): ~4.4k LOC,
+  consumed by ~30 pnpm `link:`/`file:` edges into `repos/effect-utils/packages/*`
+  across 5 consumers, genie `#mr/` generator-source imports, Nix
+  `workspaceSources` staging, CLIs run from mounts. L3, Buck2 cell composition
+  (decision-0020 shape, cp -a/RENAME_EXCHANGE/R6 mounts, root generator,
+  capability projection per mount, dist overlays): up to ~13–14k LOC by
+  attribution (not a measured deletion), consumed today by effect-utils' own
+  composed root only. No repository authors an `effect_utils//` label; Phase 6
+  (dotfiles) has not started. 37 composed vs ~218 legacy workspace records
+  exist; the shape migration is mid-flight.
+- The practiced cross-repository flow is commit-mediated and upstream-first
+  (decision 0020: one deliberate cross-workspace branch-sharing event in
+  37,061 mutations; authoring through mounts vs member worktrees 1:820).
+- Zero `@overeng/*` packages are consumed from a registry. 34 of 35 top-level
+  effect-utils packages are `private: true` at placeholder `0.1.0`; 12 expose
+  `types → dist`, 23 expose `src`; every consumer resolves types through
+  per-consumer `tsconfig` `paths` shims into sources, not through `exports`.
+- Artifact channels that exist today: `nix/buck2-products/publish.sh`
+  publishes content-addressed CLI products to immutable GitHub Releases
+  (sha256-tagged, manifest with SRI + provenance); diffstream publishes to
+  GitHub Packages (restricted); livestore runs a full changeset + per-PR
+  snapshot npm program. effect-utils' `npm-release` is decision-layer only
+  (no I/O; DELTA-001).
+- The overeng → livestore co-development fork is a branch-pinned mount reached
+  through 86+ files (link: deps, tsconfigs into the mount's built dist, nested
+  livestore-contrib composition). No artifact channel covers a co-dev branch.
+
+## Evidence and Argument
+
+- [2026-09-12-dist-tarball-channel](../../05-composition/.experiments/2026-09-12-dist-tarball-channel.md):
+  an ordinary pnpm consumer installs `@overeng/tui-core` as a
+  content-addressed dist tarball from the shared CAS (URL + sha512 integrity
+  in `pnpm-lock.yaml`), tsgo resolves declarations from the installed dist,
+  cold install 1.75 s, warm 0.13 s, one-byte drift refused at install. Gaps it
+  exposed: `pnpm pack` produces an unusable artifact today (manifests describe
+  the source layout), and bazel-remote is an evictable cache, not an origin.
+- [2026-09-12-external-cell-key-stability](../../05-composition/.experiments/2026-09-12-external-cell-key-stability.md)
+  and decision 0030: there is no Buck2-native way to get criterion 6 without
+  mr's mount pipeline. The choice is therefore between keeping L3 and its
+  shape for criterion 6, or reinterpreting criterion 6.
+- Decision 0014 rejected artifact-only composition because "hot-path library
+  deps pay package/import cycles". The measured practice is that every
+  cross-repository change already pays a commit-and-repin cycle; what an
+  artifact adds is one publish step, which the buck2-products channel already
+  performs for CLIs without versions, changesets, or a registry.
+
+## Options
+
+| Option                                                          | Tradeoff                                                                                                                         | Outcome  |
+| --------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| Cells for source deps (decision 0014/0020, status quo)          | Action-level reuse and source-granular invalidation across repos; pays L3 + the 0020 shape on every Buck-admitted consumer         | Reopened |
+| Git external cells as mounts                                    | Rejected in decision 0030                                                                                                        | Rejected |
+| Artifacts for effect-utils library edges; cells paused (this)   | Deletes the need for cross-repo cells; adds a publish layout + durable origin; keeps mounts for fork co-dev and generator sources | Proposed |
+| All edges as artifacts                                          | Needs per-commit fork-branch snapshots and a registry disposition nobody consumes; ruled out                                     | Rejected |
+| Thinner L3 implementation, same contract (decision-0020 projector) | Keeps criterion 6; unmeasured savings; the shape and its migration remain                                                      | Fallback |
+
+## Proposed Decision
+
+1. Cross-repository reuse is artifact-granular. A consumer depends on a
+   producer's Buck-built dist as a content-addressed tarball pinned in its
+   `pnpm-lock.yaml` (URL + integrity) and fetched by the declared closure of
+   decision 0022, or on a `BuildProduct` through the Nix bridge (BUCK-R10).
+   The producer's action graph is not part of the consumer's graph.
+2. Scope: the effect-utils library edges (~30 `link:`/`file:` edges, 5
+   consumers) move to dist tarballs, package by package, each with a tested
+   dist layout (`exports` → `dist`) and a deletion-ledger entry for the
+   consumer's `link:` and `tsconfig` `paths` shim. Fork co-development
+   (overeng ↔ livestore, livestore-contrib) and genie generator-source imports
+   stay on L2 source mounts; they are outside Buck2 and outside this decision.
+3. Durable origin: extend the buck2-products publisher (immutable
+   content-addressed GitHub Release assets with manifest + provenance) to
+   library dist modules; the shared CAS remains a fast transport, never the
+   only home of a pinned artifact. A versioned npm registry is not required by
+   this decision and not precluded by it.
+4. Cross-repository Buck2 cell composition is paused, not retired: no new
+   composed worktrees by default (decision 0027's composed-by-default reverts
+   to standalone-by-default), the decision-0020 shape and its mr code stay
+   supported and on `main`, the shape migration stops where it is, and no
+   deletion-ledger entry is written for L3. Revisit trigger: a consumer that
+   needs action-level cross-repository reuse, or upstream content-based
+   external-cell keys (decision 0030).
+5. The capability projection moves to a root-owned `capabilities//` cell in
+   every root shape; the hub's three `//.buck2/capabilities` references become
+   cross-cell labels. This is independent of 1–4 and should land first.
+
+## What This Gives Up (explicitly)
+
+- Vision criterion 6 as ratified: a consumer no longer builds producer targets
+  from cache; it downloads a producer artifact. Reuse is whole-artifact, not
+  per-action; invalidation across the edge is per-artifact, not per-source.
+- Atomic cross-repository refactors within one composed graph. The flow is
+  producer commit → publish → consumer repin, which is the practiced flow
+  plus one publish step.
+- COMP-R01/R02 as fleet-wide rules ("synthesized root everywhere", "one cell
+  identity per repo across compositions") lose their reason; they would be
+  narrowed to the paused composed shape.
+
+## VRS Edits If Accepted
+
+- `vision.md` (human-only): criterion 6 rewritten as artifact reuse; problem
+  statement 4 ("composition does not compound") re-scoped.
+- `requirements.md`: BUCK-R05 "across composition shapes" and BUCK-R06 scoped
+  to one repository; BUCK-R08 gains the artifact-store obligation.
+- `05-composition/requirements.md`: COMP-R01/R02 narrowed to the paused
+  composed shape; a new requirement for the root-owned capability cell.
+- `context/megarepo/requirements.md`: MR-R11 (composed default) reverted to
+  standalone default; MR-R13 stays for the supported composed shape.
+- Amendments: decision 0014 (row outcome), 0020 (shape paused), 0027
+  (default reverted). Roadmap Phase 6 rewritten as "dotfiles consumes
+  effect-utils dist artifacts under its own Buck2 root".
+
+## Cost Ledger (BUCK-R15 inputs; document-grounded unless marked measured)
+
+| Item | Exists today | Missing |
+| --- | --- | --- |
+| Tarball transport + pin + drift refusal | pnpm URL deps + integrity; CAS HTTP (measured) | — |
+| Dist layout per package | 12/35 packages `types → dist`; `publishConfig` names shapes nothing builds | tested pack contract for 35 packages; 23 src-only packages need a dist |
+| Durable origin | buck2-products publisher for CLIs (GitHub Releases) | library-module extension; retention policy |
+| Consumer fetch under Buck2 | decision-0022 closure for registry entries | custom tarball URL entries (spike) |
+| Consumer type shims | per-consumer `tsconfig` `paths` into sources | deleted per migrated package |
+| Repin step | `mr` lock-sync ↔ `flake.lock` (proven in dotfiles) | source commit ↔ artifact hash mapping in the consumer lockfile |
+| L3 deletion | — | none now (paused, not retired) |
+
+## Falsification Spikes (before acceptance)
+
+1. Decision-0022 closure fetching a pnpm-lock tarball-URL entry into a Buck
+   `node_modules` assembly (the census notes 0022 covers registry entries).
+2. One src-only package (`@overeng/utils`) given a tested dist layout,
+   packed by a Buck target, published through buck2-products, consumed by
+   dotfiles with its `tsconfig` `paths` shim deleted, typechecked under
+   dotfiles' own Buck2 root. Measure fresh-context time against BUCK-R07.
+3. The root-owned `capabilities//` cell in effect-utils' own root (item 5).
+4. BUCK-R15 ledger for spike 2: lines added (pack target, publisher extension,
+   consumer lock change) vs lines deleted (shim, link:, overlay manifest entry).
+
+## Open Questions
+
+- Does any consumer need per-action reuse of effect-utils targets (tests,
+  rust products) rather than dist artifacts? None is known; this is the
+  revisit trigger of item 4.
+- Do `@overeng/*` packages ever leave the fleet (public registry) — if so the
+  content-addressed origin needs a versioned front, and livestore's program is
+  the template.

--- a/context/buck2/.decisions/.proposed/artifact-composition.md
+++ b/context/buck2/.decisions/.proposed/artifact-composition.md
@@ -36,10 +36,10 @@ establish what the composition machinery costs and who uses it:
   per-consumer `tsconfig` `paths` shims into sources, not through `exports`.
 - Artifact channels that exist today: `nix/buck2-products/publish.sh`
   publishes content-addressed CLI products to immutable GitHub Releases
-  (sha256-tagged, manifest with SRI + provenance); diffstream publishes to
-  GitHub Packages (restricted); livestore runs a full changeset + per-PR
-  snapshot npm program. effect-utils' `npm-release` is decision-layer only
-  (no I/O; DELTA-001).
+  (sha256-tagged, manifest with SRI + provenance); one private downstream
+  member publishes to a restricted GitHub Packages registry; livestore runs
+  a full changeset + per-PR snapshot npm program. effect-utils'
+  `npm-release` is decision-layer only (no I/O; DELTA-001).
 - The overeng → livestore co-development fork is a branch-pinned mount reached
   through 86+ files (link: deps, tsconfigs into the mount's built dist, nested
   livestore-contrib composition). No artifact channel covers a co-dev branch.

--- a/context/buck2/.decisions/0030-external-cells-are-not-a-composition-mechanism.md
+++ b/context/buck2/.decisions/0030-external-cells-are-not-a-composition-mechanism.md
@@ -46,16 +46,16 @@ of effect-utils from the local bare store exceeded 120 s.
 
 ## Options
 
-| Option                                                       | Tradeoff                                                                                      | Outcome  |
-| ------------------------------------------------------------ | --------------------------------------------------------------------------------------------- | -------- |
-| Keep cp -a mounts (decision 0020) for any cross-repo cell    | Content-real, key-stable, shared store; mr owns the mount pipeline                            | Accepted |
-| Git external cells as member mounts                          | Commit-keyed physical paths split the cache namespace; no store; no projection channel        | Rejected |
-| External cells for the hub's rules/platforms only            | Viable only after the capability projection moves to a root-owned cell; no action inputs read | Deferred |
+| Option                                                    | Tradeoff                                                                                      | Outcome  |
+| --------------------------------------------------------- | --------------------------------------------------------------------------------------------- | -------- |
+| Keep cp -a mounts (decision 0020) for any cross-repo cell | Content-real, key-stable, shared store; mr owns the mount pipeline                            | Accepted |
+| Git external cells as member mounts                       | Commit-keyed physical paths split the cache namespace; no store; no projection channel        | Rejected |
+| External cells for the hub's rules/platforms only         | Viable only after the capability projection moves to a root-owned cell; no action inputs read | Deferred |
 
 ## Decision
 
 Git external cells are not admitted as a member-mount mechanism under
-05-composition. Where a composition needs another repository's *sources* as
+05-composition. Where a composition needs another repository's _sources_ as
 action inputs, the mount is an on-disk content-real directory (COMP-R08/R10)
 and mr materializes it. External cells remain admissible in Buck2's designed
 role — the bundled prelude and immutable third-party inputs that no action
@@ -71,7 +71,7 @@ rules-distribution role.
 ## Consequences
 
 - No change to COMP-R08/R10, decision 0020, or mr's mount pipeline from this
-  decision alone. What changes the mount pipeline's *scope* is the separate
+  decision alone. What changes the mount pipeline's _scope_ is the separate
   proposal [.proposed/artifact-composition.md](./.proposed/artifact-composition.md),
   which asks whether Buck2 should compose cells across repositories at all.
 - The root-owned capability cell is recorded as an open question in

--- a/context/buck2/.decisions/0030-external-cells-are-not-a-composition-mechanism.md
+++ b/context/buck2/.decisions/0030-external-cells-are-not-a-composition-mechanism.md
@@ -1,0 +1,81 @@
+# 0030 Buck2 Git External Cells Are Not a Member-Mount Mechanism
+
+Status: accepted
+
+## Context
+
+The question "do we still need megarepo now that Buck2 is landing" has one
+Buck2-native candidate that decision 0020's adversarial review never
+evaluated: `[external_cells] <member> = git`, Buck2 fetching a member at a
+pinned `commit_hash` into `buck-out` instead of mr materializing a `cp -a`
+mount. If it worked under the composition contract it would delete mr's mount
+pipeline (cp -a, RENAME_EXCHANGE, R6, protection, teardown), the lock's
+mount-source role, and the per-mount capability and dist-overlay projections.
+
+## Evidence and Argument
+
+Four records of 2026-09-12 in
+[05-composition/.experiments](../05-composition/.experiments/):
+
+- [external-cells-source-facts](../05-composition/.experiments/2026-09-12-external-cells-source-facts.md):
+  at the pinned release, external-cell sources resolve to the physical
+  `buck-out/<iso>/external_cells/git/<commit>/…` path, which enters the input
+  Merkle tree; fetch is a PATH `git` subprocess per project root, whole tree,
+  no sharing, no submodules, no nested cells; upstream's own e2e test asserts
+  the resulting over-invalidation and defers a content-based fix with no
+  tracked plan.
+- [external-cells-fixture](../05-composition/.experiments/2026-09-12-external-cells-fixture.md):
+  cross-cell load and deps work; an unrelated commit bump reruns a member
+  action with identical output; a second project root refetches; no
+  accepted-and-content-real live override exists.
+- [external-cell-key-stability](../05-composition/.experiments/2026-09-12-external-cell-key-stability.md):
+  with cell name, path, label, platform, and isolation dir byte-identical, the
+  external cell's action digest differs from the on-disk cell's; the hidden
+  (non-argv) input case reruns on an unrelated bump while the on-disk cell runs
+  zero commands. This is the direct negation of COMP-R02 (one cache namespace
+  per repo) and vision criterion 6 for every source-consuming action.
+- [hub-as-external-cell](../05-composition/.experiments/2026-09-12-hub-as-external-cell.md):
+  the real hub's platforms package is consumable externally; its toolchains
+  package is not, because `buck2/toolchains/BUCK:1` and
+  `configured.bzl:5,59` load the per-host `//.buck2/capabilities` projection
+  from inside the member — a fetched cell has no channel for it.
+
+Two operational facts stand independently: the agent-policy git wrapper
+refuses Buck2's internal `git reset --hard FETCH_HEAD`, and a first cold fetch
+of effect-utils from the local bare store exceeded 120 s.
+
+## Options
+
+| Option                                                       | Tradeoff                                                                                      | Outcome  |
+| ------------------------------------------------------------ | --------------------------------------------------------------------------------------------- | -------- |
+| Keep cp -a mounts (decision 0020) for any cross-repo cell    | Content-real, key-stable, shared store; mr owns the mount pipeline                            | Accepted |
+| Git external cells as member mounts                          | Commit-keyed physical paths split the cache namespace; no store; no projection channel        | Rejected |
+| External cells for the hub's rules/platforms only            | Viable only after the capability projection moves to a root-owned cell; no action inputs read | Deferred |
+
+## Decision
+
+Git external cells are not admitted as a member-mount mechanism under
+05-composition. Where a composition needs another repository's *sources* as
+action inputs, the mount is an on-disk content-real directory (COMP-R08/R10)
+and mr materializes it. External cells remain admissible in Buck2's designed
+role — the bundled prelude and immutable third-party inputs that no action
+reads as `srcs` at member-mount scale — and become a candidate for
+rules-only hub distribution once the capability projection is root-owned.
+
+Revisit when either holds: upstream keys external-cell sources by content
+(the e2e assertion in `tests/core/external_cells/test_git.py` flips), or the
+hub's `//.buck2/capabilities` references move to a root-provided
+`capabilities//` cell. The first would reopen mounts; the second only the
+rules-distribution role.
+
+## Consequences
+
+- No change to COMP-R08/R10, decision 0020, or mr's mount pipeline from this
+  decision alone. What changes the mount pipeline's *scope* is the separate
+  proposal [.proposed/artifact-composition.md](./.proposed/artifact-composition.md),
+  which asks whether Buck2 should compose cells across repositories at all.
+- The root-owned capability cell is recorded as an open question in
+  05-composition; it is the right ownership boundary in every option and
+  should not wait for the rules-distribution use case.
+- The git-wrapper refusal of Buck2-spawned git is filed as agent-policy
+  friction; any future external-cell use needs that exemption first.

--- a/context/buck2/05-composition/.experiments/2026-09-12-dist-tarball-channel.md
+++ b/context/buck2/05-composition/.experiments/2026-09-12-dist-tarball-channel.md
@@ -32,17 +32,17 @@ empty store.
 
 ## Result
 
-| Measurement | Value |
-| --- | --- |
-| Tarball | 28,100 bytes; sha256 `c0dd8266…4875824`; integrity `sha512-T3t6…HNog==` |
-| CAS PUT / GET | 200 in 0.57 s / 200 in 1 ms; bytes identical (`cmp` exit 0) |
-| Lockfile | `resolution: {integrity: sha512-…, tarball: http://dev3:41046/cas/c0dd…}` recorded by pnpm |
-| Typecheck | `tsgo --noEmit` exit 0; resolution trace matched the `types` export → installed `dist/src/mod.d.ts` |
-| Cold install (empty store) | 1.75 s wall (9 downloaded, 1 reused) |
-| Warm rematerialization | 0.13 s wall (10 reused, 0 downloaded) |
-| `node_modules` | 55 MiB allocated / 50.3 MB apparent (dominated by `effect`) |
-| Drift | frozen install exit 1, `ERR_PNPM_TARBALL_INTEGRITY` naming wanted vs actual digest |
-| CAS state | `CurrSize` 3.44 GB of 500 GiB; LRU, not durable |
+| Measurement                | Value                                                                                               |
+| -------------------------- | --------------------------------------------------------------------------------------------------- |
+| Tarball                    | 28,100 bytes; sha256 `c0dd8266…4875824`; integrity `sha512-T3t6…HNog==`                             |
+| CAS PUT / GET              | 200 in 0.57 s / 200 in 1 ms; bytes identical (`cmp` exit 0)                                         |
+| Lockfile                   | `resolution: {integrity: sha512-…, tarball: http://dev3:41046/cas/c0dd…}` recorded by pnpm          |
+| Typecheck                  | `tsgo --noEmit` exit 0; resolution trace matched the `types` export → installed `dist/src/mod.d.ts` |
+| Cold install (empty store) | 1.75 s wall (9 downloaded, 1 reused)                                                                |
+| Warm rematerialization     | 0.13 s wall (10 reused, 0 downloaded)                                                               |
+| `node_modules`             | 55 MiB allocated / 50.3 MB apparent (dominated by `effect`)                                         |
+| Drift                      | frozen install exit 1, `ERR_PNPM_TARBALL_INTEGRITY` naming wanted vs actual digest                  |
+| CAS state                  | `CurrSize` 3.44 GB of 500 GiB; LRU, not durable                                                     |
 
 ## Conclusion
 

--- a/context/buck2/05-composition/.experiments/2026-09-12-dist-tarball-channel.md
+++ b/context/buck2/05-composition/.experiments/2026-09-12-dist-tarball-channel.md
@@ -1,0 +1,64 @@
+# Content-Addressed Dist Tarball as a Cross-Repository TypeScript Channel
+
+Date: 2026-09-12 — Host: dev3 — effect-utils
+`49dfa42eed70b6b9a117f58e210d8fab20ae8cf6`; pnpm 12.3.4; tsgo
+7.0.0-dev+effect-tsgo.0.14.5; transport bazel-remote 2.6.2 HTTP CAS at
+`dev3:41046`. Scratch retained at `/tmp/megarepo-vs-buck2/tarball-channel/`
+(27 log files); disposable.
+
+## Question
+
+For the proposed artifact-composition direction: can an ordinary pnpm
+consumer replace a `link:`/`file:` source edge into `repos/effect-utils` with
+a content-addressed dist tarball, keep declaration resolution and lockfile
+integrity, and refuse drift — using only existing infrastructure?
+
+## Method
+
+The canonical Buck-built `tui-core` dist (156 KiB) was copied out of the
+read-only main worktree (recursive diff exit 0). `pnpm pack` from the package
+dir omitted `dist/` (the manifest's `files`/`exports` describe the source
+layout), so an npm-shaped tarball was assembled with `tar` (`package/
+{package.json,dist/}`) and corrected `exports` (`types: ./dist/src/mod.d.ts`,
+`default: ./dist/src/mod.js`). The tarball was `PUT` to
+`http://dev3:41046/cas/<sha256>` and fetched back. A scratch consumer
+declared `"@overeng/tui-core": "http://dev3:41046/cas/<sha256>"`, ran
+`pnpm install` cold (empty store) and warm (store kept, `node_modules`
+removed, `--frozen-lockfile`), and typechecked `src/index.ts` importing
+`stripAnsi` and the `Terminal` type with `tsgo --noEmit`. Drift: one byte of
+the tarball XORed, `PUT` under its new sha256, lockfile `resolution.tarball`
+pointed at the new URL with the old integrity retained, frozen install with an
+empty store.
+
+## Result
+
+| Measurement | Value |
+| --- | --- |
+| Tarball | 28,100 bytes; sha256 `c0dd8266…4875824`; integrity `sha512-T3t6…HNog==` |
+| CAS PUT / GET | 200 in 0.57 s / 200 in 1 ms; bytes identical (`cmp` exit 0) |
+| Lockfile | `resolution: {integrity: sha512-…, tarball: http://dev3:41046/cas/c0dd…}` recorded by pnpm |
+| Typecheck | `tsgo --noEmit` exit 0; resolution trace matched the `types` export → installed `dist/src/mod.d.ts` |
+| Cold install (empty store) | 1.75 s wall (9 downloaded, 1 reused) |
+| Warm rematerialization | 0.13 s wall (10 reused, 0 downloaded) |
+| `node_modules` | 55 MiB allocated / 50.3 MB apparent (dominated by `effect`) |
+| Drift | frozen install exit 1, `ERR_PNPM_TARBALL_INTEGRITY` naming wanted vs actual digest |
+| CAS state | `CurrSize` 3.44 GB of 500 GiB; LRU, not durable |
+
+## Conclusion
+
+The channel works for this edge with zero new transport: pnpm pins URL +
+integrity, tsgo consumes declarations from the installed dist, and drift is
+refused at install. Two pieces of machinery it does not supply and the
+proposal must own: (1) a per-package publish layout — the current manifests
+(`exports` at `src`, `publishConfig` naming `./dist/mod.js`) do not describe
+the Buck-built `dist/src/*` layout, so `pnpm pack` produces an unusable
+artifact today; (2) a durable origin and retention policy — bazel-remote is
+an evictable cache and cannot be the only home of historical lockfile pins.
+
+## VRS Impact
+
+Evidence for the proposed decision `.proposed/artifact-composition.md`: one
+artifact-consumption edge is proven end to end. It does not show that the
+direction preserves vision criterion 6, source-granular invalidation across
+the edge, or atomic cross-repository refactors; those are what the proposal
+asks to give up, explicitly.

--- a/context/buck2/05-composition/.experiments/2026-09-12-external-cell-key-stability.md
+++ b/context/buck2/05-composition/.experiments/2026-09-12-external-cell-key-stability.md
@@ -1,0 +1,56 @@
+# External Cell vs On-Disk Cell: Exact Action-Digest Comparison
+
+Date: 2026-09-12 — Host: dev3 — Linux x86_64 — Buck2 pin 2026-09-01, isolation
+dir `key-stability`. Fixture retained at `/tmp/megarepo-vs-buck2/key-stability/`
+(81 log files, machine-extracted comparison `logs/71-digest-comparison.json`);
+disposable.
+
+## Question
+
+With cell name, `[cells]` path, target label, platform, and isolation dir held
+byte-identical, does a git external cell produce the same action digest as an
+on-disk cell holding the same committed tree? And does an unrelated commit
+bump invalidate an action whose input is not rendered into argv (isolating the
+input-tree mechanism from argv rendering)?
+
+## Method
+
+Variant D: `member_a = repos/member_a` populated with `git archive <commit> |
+tar -x` (a real directory). Variant E: the same `.buckconfig` line plus
+`[external_cells] member_a = git` pinned at the same commit. Per variant:
+`buck2 kill`, `rm -rf buck-out`, `buck2 build member_a//:out`, digest from
+`buck2 log show` (`action_digest` on `Execute` / `OmittedLocalCommand` /
+`BuildGraphInfo`; the event log carries no `command_digest` or
+`input_root_digest` field, so input-root attribution is inferred). Hidden-input
+case: commit `c` adds `genrule(name = "hidden", srcs = ["input.txt"], cmd =
+"cat input.txt > $OUT")` (no `$(location)`, argv contains no path); commit `d`
+adds an unrelated file. Argv and outputs compared across variants.
+
+## Result
+
+| Case | D (on-disk) | E (external) | Same? |
+| --- | --- | --- | --- |
+| `member_a//:out` at bb539116 | `723b2845…:142` | `e4d9e012…:141` | no (argv and output identical) |
+| `member_a//:hidden` at c | `c80cb008…:142` | `704e441e…:141` | no |
+| `hidden`, unrelated bump c→d | digest unchanged, 0 commands | `080ce414…:141`, 1 local rerun, argv/output unchanged | — |
+
+Source path as seen by Buck: `buck2 audit` reports the virtual `repos/member_a`;
+`what-ran` shows `././input.txt`; resolving the action input yields the physical
+`buck-out/key-stability/external_cells/git/<commit>/input.txt`.
+
+## Conclusion
+
+Proven: (1) an external-cell source cannot share an action key with an
+on-disk cell at the same path, name, and label — the physical commit-keyed
+path is what differs; (2) an unrelated commit bump invalidates actions whose
+inputs are not in argv, so the mechanism is the input tree, not command
+rendering. Together with the fixture record this closes the review's
+"not apples-to-apples" objection: under the current release, external cells
+are incompatible with COMP-R02's one-cache-namespace-per-repo and with
+vision criterion 6 for every action that reads member sources.
+
+## VRS Impact
+
+Grounds decision 0030 without the earlier hedge. Revisit condition 1 (upstream
+content-based external-cell keys) is the only thing that could change (1); (2)
+follows from (1).

--- a/context/buck2/05-composition/.experiments/2026-09-12-external-cell-key-stability.md
+++ b/context/buck2/05-composition/.experiments/2026-09-12-external-cell-key-stability.md
@@ -28,11 +28,11 @@ adds an unrelated file. Argv and outputs compared across variants.
 
 ## Result
 
-| Case | D (on-disk) | E (external) | Same? |
-| --- | --- | --- | --- |
-| `member_a//:out` at bb539116 | `723b2845…:142` | `e4d9e012…:141` | no (argv and output identical) |
-| `member_a//:hidden` at c | `c80cb008…:142` | `704e441e…:141` | no |
-| `hidden`, unrelated bump c→d | digest unchanged, 0 commands | `080ce414…:141`, 1 local rerun, argv/output unchanged | — |
+| Case                         | D (on-disk)                  | E (external)                                          | Same?                          |
+| ---------------------------- | ---------------------------- | ----------------------------------------------------- | ------------------------------ |
+| `member_a//:out` at bb539116 | `723b2845…:142`              | `e4d9e012…:141`                                       | no (argv and output identical) |
+| `member_a//:hidden` at c     | `c80cb008…:142`              | `704e441e…:141`                                       | no                             |
+| `hidden`, unrelated bump c→d | digest unchanged, 0 commands | `080ce414…:141`, 1 local rerun, argv/output unchanged | —                              |
 
 Source path as seen by Buck: `buck2 audit` reports the virtual `repos/member_a`;
 `what-ran` shows `././input.txt`; resolving the action input yields the physical

--- a/context/buck2/05-composition/.experiments/2026-09-12-external-cells-fixture.md
+++ b/context/buck2/05-composition/.experiments/2026-09-12-external-cells-fixture.md
@@ -28,22 +28,22 @@ internal `git reset --hard FETCH_HEAD` (recorded as friction).
 
 ## Result
 
-| Probe | Result |
-| --- | --- |
-| Build + cross-cell load/dep | succeeds; output `member-b-v1\nmember-a-v1` |
-| Leaf dir `repos/member_a` absent | builds; the parent `repos/` must exist (`read_dir` error otherwise) |
-| Storage | `consumer/buck-out/extcells-proto/external_cells/git/<commit>/`, no `.git` retained |
-| Fetch argv | `git init` → `git fetch file:///…/member_a.git <sha>` → `git reset --hard FETCH_HEAD` |
-| Source change (v1→v2) | action digest `5b44…` → `9b60…`, reruns (correct) |
-| Unrelated-file commit only | action digest `9b60…` → `c435…`, **reruns**; output digest unchanged (`7ac24f62`) |
-| `[cells]` path `repos/`→`mounts/`, same commit | digest identical `c435…`; no command ran after `clean` + rebuild |
-| Second consumer root | refetches both members (second init/fetch/reset sequence); 24 MiB `buck-out` each |
-| Offline (origins renamed, daemon killed) | builds; tracer shows zero new git calls |
-| Commit advance latency (warm, local origin) | 0.31–0.38 s wall including one rerun |
-| Absolute `[cells]` path outside the root | rejected (interpreted under the project root) |
-| Relative `..` symlink cell | rejected as unnormalized |
-| Absolute symlink cell | accepted; edit behind it → no rerun, stale output (content-blind, as COMP-R08 states) |
-| Watcher | `file_watcher = notify`, no watchman warning |
+| Probe                                          | Result                                                                                |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------- |
+| Build + cross-cell load/dep                    | succeeds; output `member-b-v1\nmember-a-v1`                                           |
+| Leaf dir `repos/member_a` absent               | builds; the parent `repos/` must exist (`read_dir` error otherwise)                   |
+| Storage                                        | `consumer/buck-out/extcells-proto/external_cells/git/<commit>/`, no `.git` retained   |
+| Fetch argv                                     | `git init` → `git fetch file:///…/member_a.git <sha>` → `git reset --hard FETCH_HEAD` |
+| Source change (v1→v2)                          | action digest `5b44…` → `9b60…`, reruns (correct)                                     |
+| Unrelated-file commit only                     | action digest `9b60…` → `c435…`, **reruns**; output digest unchanged (`7ac24f62`)     |
+| `[cells]` path `repos/`→`mounts/`, same commit | digest identical `c435…`; no command ran after `clean` + rebuild                      |
+| Second consumer root                           | refetches both members (second init/fetch/reset sequence); 24 MiB `buck-out` each     |
+| Offline (origins renamed, daemon killed)       | builds; tracer shows zero new git calls                                               |
+| Commit advance latency (warm, local origin)    | 0.31–0.38 s wall including one rerun                                                  |
+| Absolute `[cells]` path outside the root       | rejected (interpreted under the project root)                                         |
+| Relative `..` symlink cell                     | rejected as unnormalized                                                              |
+| Absolute symlink cell                          | accepted; edit behind it → no rerun, stale output (content-blind, as COMP-R08 states) |
+| Watcher                                        | `file_watcher = notify`, no watchman warning                                          |
 
 An on-disk control cell (`member_a_disk`) did not share the local action
 entry, but its name differs, so that comparison is not apples-to-apples; the

--- a/context/buck2/05-composition/.experiments/2026-09-12-external-cells-fixture.md
+++ b/context/buck2/05-composition/.experiments/2026-09-12-external-cells-fixture.md
@@ -1,0 +1,65 @@
+# Git External Cells: Two-Member Fixture
+
+Date: 2026-09-12 — Host: dev3 — Linux x86_64 — Buck2 pin 2026-09-01
+(`buck2 2026-08-31-be6971d47dcc835b7356e1698b23039ffee4f4c2`), isolation dir
+`extcells-proto`, `file_watcher = notify`. Fixture retained at
+`/tmp/megarepo-vs-buck2/extcells-fixture/` (origins, consumers, tracer,
+71 log files) on dev3; disposable.
+
+## Question
+
+Empirically: do git external cells build and cross-load; where is the content
+stored; does the virtual `[cells]` path or the pinned commit enter action
+identity; is the checkout shared across project roots; does it build offline;
+is there a safe live local override; and what does Buck2 actually run to
+fetch?
+
+## Method
+
+Two local bare origins (`member_a.git`, `member_b.git`), each with a
+`genrule`; `member_b//:out` is declared by a macro `load()`ed from
+`@member_a//:defs.bzl` and depends on `@member_a//:out` (cross-cell load and
+cross-cell action dep). Two consumer roots with identical external-cell
+config. Action digests extracted from `buck2 log show --trace-id`
+(`OmittedLocalCommand.action_digest`); execution from `buck2 log what-ran`.
+Git invocations captured by a PATH tracer that records argv and execs the
+real git — required because the agent-policy git wrapper refuses Buck2's
+internal `git reset --hard FETCH_HEAD` (recorded as friction).
+
+## Result
+
+| Probe | Result |
+| --- | --- |
+| Build + cross-cell load/dep | succeeds; output `member-b-v1\nmember-a-v1` |
+| Leaf dir `repos/member_a` absent | builds; the parent `repos/` must exist (`read_dir` error otherwise) |
+| Storage | `consumer/buck-out/extcells-proto/external_cells/git/<commit>/`, no `.git` retained |
+| Fetch argv | `git init` → `git fetch file:///…/member_a.git <sha>` → `git reset --hard FETCH_HEAD` |
+| Source change (v1→v2) | action digest `5b44…` → `9b60…`, reruns (correct) |
+| Unrelated-file commit only | action digest `9b60…` → `c435…`, **reruns**; output digest unchanged (`7ac24f62`) |
+| `[cells]` path `repos/`→`mounts/`, same commit | digest identical `c435…`; no command ran after `clean` + rebuild |
+| Second consumer root | refetches both members (second init/fetch/reset sequence); 24 MiB `buck-out` each |
+| Offline (origins renamed, daemon killed) | builds; tracer shows zero new git calls |
+| Commit advance latency (warm, local origin) | 0.31–0.38 s wall including one rerun |
+| Absolute `[cells]` path outside the root | rejected (interpreted under the project root) |
+| Relative `..` symlink cell | rejected as unnormalized |
+| Absolute symlink cell | accepted; edit behind it → no rerun, stale output (content-blind, as COMP-R08 states) |
+| Watcher | `file_watcher = notify`, no watchman warning |
+
+An on-disk control cell (`member_a_disk`) did not share the local action
+entry, but its name differs, so that comparison is not apples-to-apples; the
+exact same-name comparison is the companion record
+`2026-09-12-external-cell-key-stability.md`.
+
+## Conclusion
+
+Git external cells work as advertised for immutable one-cell inputs. For
+member mounts they fail the contract on two counts observed directly: an
+unrelated commit bump re-executes member actions (BUCK criterion 1 fails at
+the consumer), and there is no host-global sharing (each root fetches its
+own copy). There is no live local override shape that is both accepted and
+content-real.
+
+## VRS Impact
+
+Confirms the source read in `2026-09-12-external-cells-source-facts.md`;
+grounds decision 0030. No change to COMP-R08/R10.

--- a/context/buck2/05-composition/.experiments/2026-09-12-external-cells-source-facts.md
+++ b/context/buck2/05-composition/.experiments/2026-09-12-external-cells-source-facts.md
@@ -1,0 +1,87 @@
+# Buck2 Git External Cells: Source-Verified Facts at the Pinned Release
+
+Date: 2026-09-12 — Host: dev3 — Buck2 pin 2026-09-01
+(`be6971d47dcc835b7356e1698b23039ffee4f4c2`); upstream HEAD
+`f2e6296850382e1f802b71bfb2422b5d67313b14` (2026-09-11) diffed against the pin
+for the files below (behaviorally identical).
+
+## Question
+
+Could Buck2's own `external_cells` (git origin) replace mr's member mounts —
+the cp -a / RENAME_EXCHANGE / R6 pipeline of decision 0020 — and if so under
+what limits? Decision 0020's adversarial review surveyed submodules,
+EdenFS/Sapling, josh, and jj but never external cells.
+
+## Method
+
+Source read of the pinned tag: `app/buck2_common/src/legacy_configs/cells.rs`
+(config parsing), `app/buck2_core/src/cells/external.rs`,
+`app/buck2_core/src/fs/buck_out_path.rs` (physical layout),
+`app/buck2_core/src/fs/artifact_path_resolver.rs` (source resolution),
+`app/buck2_external_cells/src/git.rs` (fetch), `app/buck2_file_watcher/src/notify.rs`,
+`docs/users/advanced/external_cells.md`, and the upstream e2e test
+`tests/core/external_cells/test_git.py`. Release history via
+`git ls-remote --tags`. Issue tracker searched for `external_cells`,
+`git_origin`.
+
+## Result
+
+- Configuration: `[cells] <name> = <path>` plus `[external_cells] <name> = git`
+  plus `[external_cell_<name>] git_origin = … / commit_hash = <40-hex sha1>`
+  (`object_format = sha256` optional). Origins: `bundled`, `git`, `disabled`.
+  Only the project root may declare external cells; no transitive external
+  cells; no nested cells; the fetched repo's own `[cells]` is ignored, its
+  `[cell_aliases]` honored.
+- The `[cells]` path is virtual: files are not generated there; source
+  resolution bypasses it and resolves to
+  `buck-out/<isolation>/external_cells/git/<commit_hash>/<cell-relative>`
+  (`buck_out_path.rs:253-358`, `artifact_path_resolver.rs:64-83`). The path
+  string still matters for tree-file handling and `expand-external-cell`.
+- Fetch (`git.rs:121-170`): `git init [--object-format]`, `git fetch <origin>
+  <commit_hash>`, `git reset --hard FETCH_HEAD`, then `.git` is deleted
+  (`git.rs:200-208`). Git is a PATH subprocess (`background_command("git")`),
+  not libgit2 and not a Buck action. No `--depth`, `--filter`, sparse checkout,
+  or submodule handling. The checkout is per project root and isolation dir;
+  nothing is shared across roots or machines; `buck2 clean` deletes it.
+- Offline: once materialized, a fresh daemon builds without contacting the
+  origin (`git.rs:241-249`; e2e `test_git.py:142-159` deletes the origin and
+  rebuilds).
+- Invalidation: after checkout Buck2 fingerprints the tree and declares it a
+  materialized artifact (`git.rs:210-237`). Because `ArtifactFs::resolve_source`
+  inserts the physical `…/git/<commit>/…` path into the input Merkle tree,
+  every action consuming a source from the cell changes `input_root_digest`
+  when the commit changes, even if that file is unchanged; argv-rendered
+  inputs additionally change the command digest. The upstream e2e test asserts
+  exactly this over-invalidation and comments that the assertion should flip
+  "once caching becomes content-based" (`test_git.py:113-140`); no tracked
+  issue, PR, or schedule for that change was found.
+- File watching: the notify watcher drops every path under `buck-out`
+  (`notify.rs:99-108,298-300`); external checkouts are refreshed only through
+  config/materializer state.
+- History: functional git external cells first shipped in tag `2024-05-15`
+  (commit `8484862`, 2024-05-07). No `experimental`/`unstable` marker exists;
+  absence of the marker is not a stability promise.
+- Physical storage keys on commit hash only (not origin URL, cell name, or
+  mount path), so identical hashes from different origins alias inside one
+  buck-out.
+- `git_fetch` (prelude) and `http_archive` are action-output rules (shallow
+  `--depth=1`, optional submodules), not analysis-time cells.
+
+## Conclusion
+
+External cells are an elegant primitive for one job: making an immutable git
+commit visible to analysis as one cell — the prelude pattern and third-party
+sources. They are not a member-mount mechanism under the composition
+contract: they cannot share action keys with an on-disk cell (physical
+commit-keyed path in the input tree), they over-invalidate on every commit
+bump, they carry no host-global store, no editable worktree, no multi-cell
+topology, and no channel for per-host projections such as
+`.buck2/capabilities`.
+
+## VRS Impact
+
+Grounds decision 0030 (external cells are not a composition mechanism) and the
+two conditions under which it is revisited: upstream content-based external
+cell keys, and a root-owned capability cell. COMP-R08/R10 and decision 0020
+are unaffected. See the companion fixture and hub records of the same date for
+the empirical confirmation.

--- a/context/buck2/05-composition/.experiments/2026-09-12-external-cells-source-facts.md
+++ b/context/buck2/05-composition/.experiments/2026-09-12-external-cells-source-facts.md
@@ -38,7 +38,7 @@ Source read of the pinned tag: `app/buck2_common/src/legacy_configs/cells.rs`
   (`buck_out_path.rs:253-358`, `artifact_path_resolver.rs:64-83`). The path
   string still matters for tree-file handling and `expand-external-cell`.
 - Fetch (`git.rs:121-170`): `git init [--object-format]`, `git fetch <origin>
-  <commit_hash>`, `git reset --hard FETCH_HEAD`, then `.git` is deleted
+<commit_hash>`, `git reset --hard FETCH_HEAD`, then `.git` is deleted
   (`git.rs:200-208`). Git is a PATH subprocess (`background_command("git")`),
   not libgit2 and not a Buck action. No `--depth`, `--filter`, sparse checkout,
   or submodule handling. The checkout is per project root and isolation dir;

--- a/context/buck2/05-composition/.experiments/2026-09-12-hub-as-external-cell.md
+++ b/context/buck2/05-composition/.experiments/2026-09-12-hub-as-external-cell.md
@@ -1,0 +1,64 @@
+# effect-utils as a Git External Cell in the Hub Role
+
+Date: 2026-09-12 — Host: dev3 — Linux x86_64 — Buck2 pin 2026-09-01, isolation
+dir `hub-extcell`; effect-utils at `49dfa42eed70b6b9a117f58e210d8fab20ae8cf6`
+(main) fetched from the local bare store repo. Scratch root retained at
+`/tmp/megarepo-vs-buck2/hub-extcell/` on dev3 (16 log files); disposable.
+
+## Question
+
+Can the real effect-utils repository be consumed as a git external cell in
+the platform/toolchain hub role — the way the prelude is consumed — from a
+consumer root that owns the composition wiring? Which hub references block it?
+
+## Method
+
+Scratch root with the 05-composition root shape (`workspace = .`, bundled
+prelude, `effect_utils = repos/effect-utils` as a git external cell, detector
+spec and execution platform on `effect_utils//buck2/platforms:*`, a
+`toolchains` alias cell). Queries: `buck2 audit cell`, `buck2 targets
+effect_utils//buck2/platforms:`, `buck2 targets effect_utils//buck2/toolchains:`.
+Then `buck2 expand-external-cell effect_utils` plus a `cp -a` of an existing
+per-host `.buck2/capabilities` projection (read from a canonical composed
+workspace, unchanged) into the expanded cell, and `buck2 build
+effect_utils//packages/@overeng/tui-core:typecheck`. Remote cache disabled
+(no credentials in the scratch shell; upload off).
+
+## Result
+
+- Pure external cell: `audit cell` maps the virtual path without fetching
+  (0.22 s). The first cold fetch attempt exceeded 120 s and was interrupted;
+  a retry after daemon restart took 12.48 s (not a clean cold number). The
+  checkout tree is 37 MB. `buck2/platforms` lists all 15 targets purely
+  externally.
+- Pure external cell, toolchains: fails at parse —
+  `File not found: effect_utils//.buck2/capabilities/defs.bzl`, from
+  `buck2/toolchains/BUCK:1`. The complete set of generated-path references in
+  the hub: `buck2/toolchains/BUCK:1` (`load("//.buck2/capabilities:defs.bzl",
+  "CAPABILITIES", "GENERATION")`), `buck2/toolchains/configured.bzl:5` (same
+  load) and `configured.bzl:59` (label
+  `//.buck2/capabilities/generations/{generation}/{platform}/{tool_id}`).
+  `buck2/platforms` and the root `buck2/*.bzl` files contain none.
+- Expanded cell + copied projection (424 KB): all 14 toolchain targets load;
+  `tui-core:typecheck` builds — 139 actions, all local, 4.63 s, 0 cache hits
+  (cache not configured). `buck-out` 246 MB before cleanup.
+
+## Conclusion
+
+Half of the hub is external-cell consumable today (platforms); the other half
+(toolchains) is not, because the per-host capability projection is a
+cell-relative load inside the member. Making the hub a pure external cell
+requires a root-owned `capabilities` cell and rewriting the three references
+above to cross-cell labels — a change that is the right ownership boundary
+regardless (host-specific projected state belongs to the root, not inside a
+member mount). The expanded-cell result proves only "hub rules and toolchains
+work when the projection is present"; it does not prove pure external-cell
+consumption, and `expand-external-cell` forfeits immutability.
+
+## VRS Impact
+
+Names the concrete hub refactor (root-owned `capabilities//` cell) as the
+second condition of decision 0030's revisit clause and as an open question in
+05-composition. The mr projection contract in the 05-composition spec
+("exactly one producer, installed per mount") stands until that refactor is
+decided.

--- a/context/buck2/05-composition/.experiments/2026-09-12-hub-as-external-cell.md
+++ b/context/buck2/05-composition/.experiments/2026-09-12-hub-as-external-cell.md
@@ -35,7 +35,7 @@ effect_utils//packages/@overeng/tui-core:typecheck`. Remote cache disabled
   `File not found: effect_utils//.buck2/capabilities/defs.bzl`, from
   `buck2/toolchains/BUCK:1`. The complete set of generated-path references in
   the hub: `buck2/toolchains/BUCK:1` (`load("//.buck2/capabilities:defs.bzl",
-  "CAPABILITIES", "GENERATION")`), `buck2/toolchains/configured.bzl:5` (same
+"CAPABILITIES", "GENERATION")`), `buck2/toolchains/configured.bzl:5` (same
   load) and `configured.bzl:59` (label
   `//.buck2/capabilities/generations/{generation}/{platform}/{tool_id}`).
   `buck2/platforms` and the root `buck2/*.bzl` files contain none.

--- a/context/buck2/05-composition/open-questions.md
+++ b/context/buck2/05-composition/open-questions.md
@@ -1,5 +1,32 @@
 # Composition Open Questions
 
+## Open 2026-09-12: is cross-repository cell composition worth its shape?
+
+Composed cells exist for vision criterion 6 (a consumer builds producer
+targets from the shared cache with source-granular invalidation). The cost is
+the decision-0020 workspace shape and mr's mount pipeline (up to ~13–14k LOC
+by attribution), paid today by effect-utils alone: no repository authors an
+`effect_utils//` label and Phase 6 has not started. The only Buck2-native
+alternative, git external cells, is rejected
+([decision 0030](../.decisions/0030-external-cells-are-not-a-composition-mechanism.md)).
+[.proposed/artifact-composition.md](../.decisions/.proposed/artifact-composition.md)
+proposes artifact-granular reuse for the effect-utils library edges and pauses
+composed-by-default; it lists the VRS edits and falsification spikes. Blocked
+on: Johannes' decision on criterion 6, and spikes 1–2 of the proposal.
+
+## Open 2026-09-12: root-owned capability cell
+
+The hub loads the per-host capability projection from inside its own cell
+(`buck2/toolchains/BUCK:1`, `configured.bzl:5,59`:
+`//.buck2/capabilities/…`), so mr must write the projection into every mount
+and no fetched or read-only hub can carry it
+([2026-09-12-hub-as-external-cell](./.experiments/2026-09-12-hub-as-external-cell.md)).
+Moving it to a root-provided `capabilities//` cell (declared by the root
+generator, referenced by cross-cell labels) is the right ownership boundary in
+every option on the table and is a precondition for rules-only external-cell
+distribution of the hub. Blocked on: deciding the cell's contract (visibility,
+generation identity checks) and the mr change that declares it.
+
 ## Resolved 2026-08-30: consumers share the hub's toolchain pins
 
 The platform hub is the sole authority for Bun, pnpm, tsgo, and subsequent

--- a/context/buck2/roadmap.md
+++ b/context/buck2/roadmap.md
@@ -239,6 +239,14 @@ RENAME_EXCHANGE advance.
   execution from the shared cache. The same admission deletes its source-mount
   CLI path, dependency writers, and live cross-workspace mutation paths; until
   then symlink compositions remain no-upload.
+- **Under proposal (2026-09-12):**
+  [.proposed/artifact-composition.md](./.decisions/.proposed/artifact-composition.md)
+  would rewrite this phase as "dotfiles consumes effect-utils dist artifacts
+  under its own Buck2 root" and pause composed-by-default worktrees below.
+  Buck2 git external cells were evaluated as a composition mechanism and
+  rejected ([decision 0030](./.decisions/0030-external-cells-are-not-a-composition-mechanism.md)).
+  Until the proposal is accepted or rejected, this phase and the commitment
+  below stand as written.
 
 ## Cross-phase commitments (ratified 2026-09-01)
 

--- a/context/megarepo/open-questions.md
+++ b/context/megarepo/open-questions.md
@@ -1,0 +1,21 @@
+# Megarepo Open Questions
+
+## Open 2026-09-12: which of mr's three layers survive the Buck2 adoption?
+
+The 2026-09-12 investigation split `mr` into a worktree fleet (store,
+worktree per ref, GC — consumed by branchy, the agent-policy git wrapper, st2
+seats, evergreen, fleet hygiene), pin-and-arrange (`megarepo.kdl` →
+`megarepo.lock`, members at `repos/<name>` — consumed by ~30 pnpm
+`link:`/`file:` edges, genie `#mr/` imports, Nix `workspaceSources`), and
+Buck2 cell composition (decision-0020 shape, cp -a mounts, root generator,
+capability projection, dist overlays — consumed by effect-utils' own composed
+root only). Buck2 replaces none of the first two; git external cells cannot
+replace the third
+([buck2 decision 0030](../buck2/.decisions/0030-external-cells-are-not-a-composition-mechanism.md)).
+[buck2 .proposed/artifact-composition.md](../buck2/.decisions/.proposed/artifact-composition.md)
+proposes to pause the third (composed-by-default reverted, MR-R11) and to
+move the effect-utils library edges from mounts to dist tarballs, leaving
+mounts for fork co-development and generator sources. Blocked on: that
+proposal's acceptance. If accepted, MR-R11 reverts, MR-R12/R13 stay for the
+supported composed shape, and no `mr` code is deleted until the revisit
+trigger in the proposal is settled.


### PR DESCRIPTION
**Problem** — The Buck2 adoption composes megarepo members as cells (decisions 0014/0020/0027) so a consumer can build a producer's targets from the shared cache (vision criterion 6). That is the only reason the decision-0020 workspace shape and mr's mount pipeline exist, and it has no consumer yet: no repository authors an `effect_utils//` label, Phase 6 has not started, and 37 composed vs ~218 legacy workspace records show the shape migration mid-flight. Meanwhile the one Buck2-native alternative — git `external_cells` — was never evaluated (decision 0020's adversarial review covered submodules, EdenFS/Sapling, josh, jj). The question "do we still need megarepo, or is there something more elegant now" had no recorded answer.

**Goal** — Align on that question in the VRS: close the external-cells branch with evidence, and put the remaining choice (keep action-level cross-repo reuse vs. move to artifact-granular reuse) in front of the reviewer as a proposed decision with its cost ledger and falsification spikes. Nothing constitutional changes in this PR.

**Decisions**
- `0030` (accepted): git external cells are not a member-mount mechanism. Proven at the pinned release, not inferred: with cell name, path, label, platform, and isolation dir byte-identical, an external cell's action digest differs from the on-disk cell's, and an unrelated commit bump reruns non-argv-input actions (the physical `buck-out/…/git/<sha>/…` path enters the input Merkle tree). The hub additionally loads its per-host capability projection from inside its own cell, which a fetched cell cannot carry. Revisit conditions are named.
- `.proposed/artifact-composition.md` (PR-local, not in force): reopens decision 0014's rejected "product bridge only" row for the ~30 effect-utils library edges (dist tarballs pinned by URL + integrity in `pnpm-lock.yaml`, durable origin = the existing buck2-products publisher), keeps mounts for fork co-development and generator sources, and **pauses** composed-by-default rather than retiring the 0020 shape ("beginning of the migration; do not delete what we may need"). It lists what it gives up, the VRS edits it would require, a BUCK-R15 ledger, and the spikes that must pass before acceptance.
- Alternatives recorded and why: external cells for mounts (rejected, 0030); all edges as artifacts (ruled out — the overeng↔livestore fork edge spans 86+ files on a branch-pinned mount with no artifact channel); thinner L3 with the same contract (kept as fallback).
- Interview decisions with Johannes (Axe q1–q3): propose an amendment rather than findings-only; scope = library edges too; shape = pause, not retire (reframe recorded verbatim).

**Verification** — Five experiment records under `context/buck2/05-composition/.experiments/2026-09-12-*` carry the numbers; raw logs (≈230 files) are retained on the host at `/tmp/megarepo-vs-buck2/` for re-checking. Headlines:
- exact same-name comparison: on-disk `723b2845…:142` vs external `e4d9e012…:141`; unrelated bump → on-disk 0 commands, external 1 rerun with identical argv/output
- real hub as external cell: platforms load; toolchains fail at `buck2/toolchains/BUCK:1` (`File not found: effect_utils//.buck2/capabilities/defs.bzl`); with the projection copied in, `tui-core:typecheck` builds (139 actions)
- dist tarball channel: `@overeng/tui-core` from the shared CAS, lockfile URL + sha512, tsgo resolves `dist/src/mod.d.ts`, cold 1.75 s / warm 0.13 s, one-byte drift → `ERR_PNPM_TARBALL_INTEGRITY`
- `axe vrs check --profile strict context/buck2`: one expected error (`.proposed` records must not merge — see Concerns) and one pre-existing on `main` (`2026-09-03-go-lane-end-to-end.md` missing `## VRS Impact`); `context/megarepo`: ok
- `check:quick` was not run: the diff is `context/**/*.md` only and no `check:quick` task reads it; the branch worktree is a half-born composed root (see Friction). Reproduce the linter with the command above.
- Post-ready fixes on this branch: `2a09f317a` ran `lint:fix:format` over the
  seven context documents (CI lint had flagged exactly those; content
  unchanged), and `fdda971e7` genericized one private-downstream detail in the
  proposal (public-repo leak guard) and added the `[Unreleased]` changelog
  entry. `lint:check`, `ts:check`, and `genie:run` were re-run green locally on
  that tree. Local `check:quick` additionally fails on `lint:nix:format` for
  `nix/buck2-products/default.nix` — unformatted on `main` since `e00d1e108`
  and untouched by this PR (pre-existing, out of scope).

**Complexity** — no code; no new complexity. The proposal's ledger is explicit that it *adds* a publish layout + durable-origin extension and *deletes* nothing yet.

**Concerns**
- This PR cannot merge as-is by contract: `.decisions/.proposed/` is PR-local. The exit is either promote (→ `0031`, plus the listed amendments to 0014/0020/0027, requirements, roadmap, and a human edit of `vision.md` criterion 6) or delete the file and record the rejection in `05-composition/open-questions.md`. Both are one follow-up commit on this branch after review.
- The proposal's cost side is document-grounded (package census, npm-release VRS, buck2-products publisher) except for the one measured edge; the two spikes it names are the gate, not this PR.
- Experiment records cite `dev3` and the shared cache endpoint, consistent with existing records and `buck2-member.json` in this public repo.

**Friction & bottlenecks**
- `branchy new effect-utils …` fails with the dotfiles-pinned `mr` (`SchemaError … ["remoteCache"]`: manifest schema newer than the tool) and, with main's own `mr`, refuses the `~/.megarepo` path as "foreign" because the store is symlinked to `/srv/bulk`; from the resolved path it created the git worktree, then a git step failed and left a stale `index.lock` (3,515 uncheckedout paths, finished by hand). Filing as `axe feedback` next to the two already filed: the agent-policy git wrapper refuses Buck2's internal `git reset --hard FETCH_HEAD`, and scout/reviewer agents have no write tool.
- Bottleneck: the first cold external-cell fetch of effect-utils from the local bare repo exceeded 120 s (retry 12.5 s); `devenv shell` on `main` did not start within 300 s on the same host (dev3 root-disk pressure incidents #2293/#2706).

**Follow-ups**
- Spike 1: decision-0022 closure fetching a pnpm-lock tarball-URL entry.
- Spike 2: one src-only package (`@overeng/utils`) end to end — dist layout, Buck pack target, buck2-products publish, dotfiles consumption with its `tsconfig` `paths` shim deleted, BUCK-R07/R15 numbers.
- Root-owned `capabilities//` cell (open question; independent of the proposal's outcome).
- If accepted: the amendment set listed in the proposal; if rejected: the fallback (thinner L3, same contract).

**References** — decision 0014, 0020, 0027; `context/buck2/roadmap.md` Phase 6; dotfiles epic #2319 (Buck2 adoption); Axe decision records q1–q3 on seat `dev3.direct.omp.ypzntu6t`.

<!-- agent-footer:begin v=3 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | dev3.direct.omp.953dtfst |
| `session` | unknown |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.1.14 |
| `agent_runtime` | OMP 18.1.14 |
| `agent_model` | openai-codex/gpt-5.6-sol |
| `worktree` | effect-utils/2026-09-12-megarepo-vs-buck2-alignment |
| `tooling_profile` | dotfiles@44ddd8a |
</details>
<!-- agent-footer:end -->