### PR TITLE
fix(megarepo): repair composed worktree creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,11 @@ All notable changes to this project will be documented in this file.
   compat link) rejected every branch member with `GitIdentityConflict` and
   `mr apply` silently materialized nothing. Non-existent store paths stay
   lexical, and realpath failures fall back to the lexical path.
+- **@overeng/megarepo**: make composed worktree creation transactional,
+  including interruption and stale Git lock cleanup; project unknown newer
+  top-level Buck member manifest fields while retaining strict validation of
+  known fields; generate composed roots during `store worktree new`; and
+  preserve failed `mr` exit codes in shared devenv tasks.
 - **CI**: keep draft assistant PRs mergeable by completing the auto-review job
   successfully when no review request is needed.
 - **CI**: stop requiring `main`-only Notion integration, live-deploy, and

--- a/nix/devenv-modules/tasks/shared/megarepo.nix
+++ b/nix/devenv-modules/tasks/shared/megarepo.nix
@@ -197,6 +197,8 @@ let
       guard = "mr";
       description = "Materialize committed root members without fetching or rewriting locks";
       exec = trace.exec "mr:setup" ''
+        set -euo pipefail
+
         if [ ! -f ./megarepo.kdl ] && [ ! -f ./megarepo.json ]; then
           exit 0
         fi
@@ -213,6 +215,8 @@ let
       guard = "mr";
       description = "Fetch latest refs and apply to workspace";
       exec = trace.exec "mr:fetch-apply" ''
+        set -euo pipefail
+
         if [ ! -f ./megarepo.kdl ] && [ ! -f ./megarepo.json ]; then
           exit 0
         fi
@@ -243,6 +247,8 @@ let
       guard = "mr";
       description = "Apply megarepo.lock to workspace";
       exec = trace.exec "mr:apply" ''
+        set -euo pipefail
+
         if [ ! -f ./megarepo.kdl ] && [ ! -f ./megarepo.json ]; then
           exit 0
         fi

--- a/nix/devenv-modules/tasks/shared/tests/megarepo-status.test.sh
+++ b/nix/devenv-modules/tasks/shared/tests/megarepo-status.test.sh
@@ -234,4 +234,16 @@ done
 echo "  ok: source-mode mr receives the canonical composition runtime"
 
 echo ""
+echo "Test 9: shared mutation tasks preserve mr failures"
+for task in mr:setup mr:fetch-apply mr:apply
+do
+  task_block="$(sed -n "/\"$task\" = {/,/status =/p" "$module_file")"
+  if ! grep -F 'set -euo pipefail' <<< "$task_block" >/dev/null; then
+    echo "FAIL: $task can mask a failed mr command"
+    exit 1
+  fi
+done
+echo "  ok: shared mutation tasks stop after a failed mr command"
+
+echo ""
 echo "All megarepo status tests passed"

--- a/packages/@overeng/megarepo/src/buck2-manifest.unit.test.ts
+++ b/packages/@overeng/megarepo/src/buck2-manifest.unit.test.ts
@@ -114,4 +114,17 @@ describe('@overeng/megarepo/buck2-manifest', () => {
       },
     ])
   })
+
+  it('projects unknown top-level fields from newer member manifests', () => {
+    const decoded = decodeBuckMemberManifest({
+      ...manifest,
+      newerProjection: { enabled: true },
+    })
+
+    expect(decoded).toEqual({
+      ...manifest,
+      projectIgnore: ['**/dist', 'target'],
+    })
+    expect(encodeBuckMemberManifestJson(decoded)).not.toContain('newerProjection')
+  })
 })

--- a/packages/@overeng/megarepo/src/cli/commands/composition.ts
+++ b/packages/@overeng/megarepo/src/cli/commands/composition.ts
@@ -608,7 +608,7 @@ const resolveComposedMembers = ({
   })
 
 /** Run one composition application against a validated composed root. */
-const applyCompositionAtRoot = ({
+export const applyCompositionAtRoot = ({
   context,
   env,
 }: {

--- a/packages/@overeng/megarepo/src/cli/commands/store/mod.ts
+++ b/packages/@overeng/megarepo/src/cli/commands/store/mod.ts
@@ -63,6 +63,7 @@ import { readWorktreeInUse, type InUseHolder } from '../../../store/store-inuse.
 import {
   collectStoreLiveSet,
   isPathProtected,
+  refreshWorkspaceRegistry,
   type StoreLiveSet,
 } from '../../../store/store-liveness.ts'
 import { StoreLock } from '../../../store/store-lock.ts'
@@ -91,6 +92,7 @@ import type {
   StoreWorktreeStatus,
   StoreWorktreeIssue,
 } from '../../renderers/StoreOutput/mod.ts'
+import { applyCompositionAtRoot } from '../composition.ts'
 
 /**
  * Entry returned by collectStoreWorktrees — `broken` indicates a directory that looks like a
@@ -3416,26 +3418,6 @@ const storeWorktreeNewCommand = Cli.Command.make(
       // Compute worktree path
       const worktreePath = store.getWorktreePath({ source, ref: targetRef, refType })
 
-      // Fail if worktree already exists
-      const worktreeExists = yield* store.hasWorktree({ source, ref: targetRef, refType })
-      if (worktreeExists === true) {
-        yield* run(
-          StoreApp,
-          (tui) =>
-            Effect.sync(() => {
-              tui.dispatch({
-                _tag: 'SetError',
-                error: 'worktree_exists',
-                message: `Worktree already exists at ${worktreePath}`,
-              })
-            }),
-          { view: React.createElement(StoreView, { stateAtom: StoreApp.stateAtom }) },
-        ).pipe(Effect.provide(outputModeLayer(output)))
-        return yield* new StoreCommandError({
-          message: `Worktree already exists at ${worktreePath}`,
-        })
-      }
-
       // Create parent directory
       const worktreeParent = EffectPath.ops.parent(worktreePath)
       if (worktreeParent !== undefined) {
@@ -3461,6 +3443,25 @@ const storeWorktreeNewCommand = Cli.Command.make(
               bareRepoPath,
               rev: compositionIntentRev,
             })
+      // Fail if worktree already exists
+      const worktreeExists = yield* store.hasWorktree({ source, ref: targetRef, refType })
+      if (worktreeExists === true && composedMember === undefined) {
+        yield* run(
+          StoreApp,
+          (tui) =>
+            Effect.sync(() => {
+              tui.dispatch({
+                _tag: 'SetError',
+                error: 'worktree_exists',
+                message: `Worktree already exists at ${worktreePath}`,
+              })
+            }),
+          { view: React.createElement(StoreView, { stateAtom: StoreApp.stateAtom }) },
+        ).pipe(Effect.provide(outputModeLayer(output)))
+        return yield* new StoreCommandError({
+          message: `Worktree already exists at ${worktreePath}`,
+        })
+      }
       const composedOwnedPath =
         composedMember === undefined
           ? undefined
@@ -3470,7 +3471,15 @@ const storeWorktreeNewCommand = Cli.Command.make(
               ownedMember: composedMember,
               branch: targetRef,
               ...(base === undefined ? {} : { startPoint: base }),
-              generate: () => Effect.void,
+              generate: (context) =>
+                Effect.gen(function* () {
+                  yield* refreshWorkspaceRegistry({
+                    workspaceRoot: context.workspaceRoot,
+                    store,
+                    now: yield* Clock.currentTimeMillis,
+                  })
+                  yield* applyCompositionAtRoot({ context, env: process.env })
+                }),
             }).pipe(
               Effect.mapError(
                 (cause) =>

--- a/packages/@overeng/megarepo/src/composition/acquisition/owned-worktree-acquisition.integration.test.ts
+++ b/packages/@overeng/megarepo/src/composition/acquisition/owned-worktree-acquisition.integration.test.ts
@@ -2,7 +2,7 @@ import * as NodePath from 'node:path'
 
 import { NodeServices } from '@effect/platform-node'
 import { describe, it } from '@effect/vitest'
-import { Effect } from 'effect'
+import { Deferred, Effect, Fiber } from 'effect'
 import * as FileSystem from 'effect/FileSystem'
 import { afterAll, beforeAll, expect } from 'vitest'
 
@@ -101,16 +101,104 @@ describe('direct composed worktree creation', () => {
     }).pipe(Effect.provide(NodeServices.layer), Effect.scoped),
   )
 
-  it.effect('retries an exact generation failure without moving or replacing W', () =>
+  it.effect('cleans an interrupted birth with a stale index lock and permits retry', () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem
       const fixture = yield* makeFixture
-      yield* create(fixture, () => Effect.fail('interrupted')).pipe(Effect.flip)
-      const before = yield* fs.stat(EffectPath.unsafe.absoluteDir(`${fixture.ownedWorktree}/`))
+      const failure = yield* create(fixture, ({ ownedWorktree }) =>
+        Effect.gen(function* () {
+          const dotGit = NodePath.join(ownedWorktree, '.git')
+          const pointer = (yield* fs.readFileString(EffectPath.unsafe.absoluteFile(dotGit))).trim()
+          const adminDir = NodePath.resolve(
+            NodePath.dirname(dotGit),
+            pointer.slice('gitdir: '.length),
+          )
+          yield* fs.writeFileString(
+            EffectPath.unsafe.absoluteFile(NodePath.join(adminDir, 'index.lock')),
+            '',
+          )
+          return yield* Effect.fail('interrupted')
+        }),
+      ).pipe(Effect.flip)
+      expect(failure.reason).toBe('GenerationFailed')
+      expect(yield* fs.exists(EffectPath.unsafe.absoluteDir(`${fixture.workspaceRoot}/`))).toBe(
+        true,
+      )
+      expect(yield* Git.listWorktrees(fixture.bareRepo)).toHaveLength(1)
+      expect(yield* Git.refExists({ repoPath: fixture.bareRepo, ref: 'refs/heads/feature' })).toBe(
+        true,
+      )
+      const dotGit = NodePath.join(fixture.ownedWorktree, '.git')
+      const pointer = (yield* fs.readFileString(EffectPath.unsafe.absoluteFile(dotGit))).trim()
+      const adminDir = NodePath.resolve(NodePath.dirname(dotGit), pointer.slice('gitdir: '.length))
+      expect(
+        yield* fs.exists(EffectPath.unsafe.absoluteFile(NodePath.join(adminDir, 'index.lock'))),
+      ).toBe(false)
+
       const result = yield* create(fixture, () => Effect.void)
-      const after = yield* fs.stat(EffectPath.unsafe.absoluteDir(`${fixture.ownedWorktree}/`))
       expect(result.ownedWorktree).toBe(fixture.ownedWorktree)
-      expect(after.ino).toStrictEqual(before.ino)
+    }).pipe(Effect.provide(NodeServices.layer), Effect.scoped),
+  )
+
+  it.effect('keeps an interrupted generation recoverable through the exact retry path', () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem
+      const fixture = yield* makeFixture
+      const generationStarted = yield* Deferred.make<void>()
+      const fiber = yield* Effect.forkChild(
+        create(fixture, () =>
+          Deferred.succeed(generationStarted, undefined).pipe(Effect.andThen(Effect.never)),
+        ),
+      )
+      yield* Deferred.await(generationStarted)
+      yield* Fiber.interrupt(fiber)
+
+      expect(yield* fs.exists(EffectPath.unsafe.absoluteDir(`${fixture.workspaceRoot}/`))).toBe(
+        true,
+      )
+      expect(yield* Git.listWorktrees(fixture.bareRepo)).toHaveLength(1)
+      expect(yield* Git.refExists({ repoPath: fixture.bareRepo, ref: 'refs/heads/feature' })).toBe(
+        true,
+      )
+      expect((yield* create(fixture, () => Effect.void)).ownedWorktree).toBe(fixture.ownedWorktree)
+    }).pipe(Effect.provide(NodeServices.layer), Effect.scoped),
+  )
+
+  it.effect('uses physical identity below a symlinked store root', () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem
+      const fixture = yield* makeFixture
+      const linkedStore = NodePath.join(fixture.tmp, 'linked-store')
+      yield* fs.symlink(fixture.tmp, linkedStore)
+      const linkedWorkspaceRoot = NodePath.join(linkedStore, 'workspace')
+      const linkedBareRepo = NodePath.join(linkedStore, 'repo.git')
+
+      const result = yield* createComposedOwnedWorkspace({
+        bareRepo: linkedBareRepo,
+        workspaceRoot: linkedWorkspaceRoot,
+        ownedMember: 'owner',
+        branch: 'feature',
+        startPoint: 'main',
+        generate: () => Effect.void,
+      })
+
+      expect(result.workspaceRoot).toBe(fixture.workspaceRoot)
+      expect(result.ownedWorktree).toBe(fixture.ownedWorktree)
+      expect(
+        yield* resolveStoreBranchWorktree({
+          bareRepo: linkedBareRepo,
+          workspaceRoot: linkedWorkspaceRoot,
+          branch: 'feature',
+        }),
+      ).toBe(`${fixture.ownedWorktree}/`)
+      expect(
+        (yield* assertComposedOwnedWorkspace({
+          bareRepo: linkedBareRepo,
+          workspaceRoot: linkedWorkspaceRoot,
+          ownedMember: 'owner',
+          branch: 'feature',
+        })).workspaceRoot,
+      ).toBe(fixture.workspaceRoot)
     }).pipe(Effect.provide(NodeServices.layer), Effect.scoped),
   )
 

--- a/packages/@overeng/megarepo/src/composition/acquisition/owned-worktree-acquisition.ts
+++ b/packages/@overeng/megarepo/src/composition/acquisition/owned-worktree-acquisition.ts
@@ -1,6 +1,6 @@
 import * as NodePath from 'node:path'
 
-import { Effect, Option } from 'effect'
+import { Effect, Exit, Option } from 'effect'
 import * as FileSystem from 'effect/FileSystem'
 import type { ChildProcessSpawner } from 'effect/unstable/process/ChildProcessSpawner'
 
@@ -41,6 +41,24 @@ const failure = ({
   })
 
 const normalizePath = (path: string): string => NodePath.resolve(path)
+
+/**
+ * Resolve the deepest existing ancestor so path identity matches Git even when the store root is
+ * a symlink and the final workspace path does not exist yet.
+ */
+const canonicalizePath = (path: string): Effect.Effect<string, never, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem
+    const normalized = normalizePath(path)
+    const segments = normalized.split(NodePath.sep)
+    for (let depth = segments.length; depth > 1; depth -= 1) {
+      const existing = segments.slice(0, depth).join(NodePath.sep) || NodePath.sep
+      const real = yield* fs.realPath(existing).pipe(Effect.orElseSucceed(() => undefined))
+      if (real === undefined) continue
+      return normalizePath(NodePath.join(real, ...segments.slice(depth)))
+    }
+    return normalized
+  })
 const asDir = (path: string): AbsoluteDirPath =>
   EffectPath.unsafe.absoluteDir(`${path.replace(/\/+$/u, '')}/`)
 const asFile = (path: string): AbsoluteFilePath => EffectPath.unsafe.absoluteFile(path)
@@ -186,6 +204,27 @@ const ensureRootConfig = ({
     return rootConfig
   })
 
+const linkedWorktreeAdminDir = ({
+  fs,
+  bareRepo,
+  worktree,
+}: {
+  readonly fs: FileSystem.FileSystem
+  readonly bareRepo: string
+  readonly worktree: string
+}) =>
+  Effect.gen(function* () {
+    const dotGit = NodePath.join(worktree, '.git')
+    const pointer = yield* fs.readFileString(asFile(dotGit)).pipe(Effect.orElseSucceed(() => ''))
+    const match = /^gitdir: (.+)$/u.exec(pointer.trim())
+    const adminDir =
+      match === null ? undefined : NodePath.resolve(NodePath.dirname(dotGit), match[1]!)
+    return adminDir !== undefined &&
+      NodePath.dirname(adminDir) === NodePath.join(bareRepo, 'worktrees')
+      ? adminDir
+      : undefined
+  })
+
 const assertGitIdentity = ({
   fs,
   bareRepo,
@@ -268,8 +307,8 @@ const assertGitIdentity = ({
 
 /** Validate an existing composed root from Git registration and its W `.git` identity. */
 export const assertComposedOwnedWorkspace = ({
-  bareRepo,
-  workspaceRoot,
+  bareRepo: rawBareRepo,
+  workspaceRoot: rawWorkspaceRoot,
   ownedMember,
   branch,
 }: {
@@ -284,6 +323,8 @@ export const assertComposedOwnedWorkspace = ({
 > =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem
+    const bareRepo = yield* canonicalizePath(rawBareRepo)
+    const workspaceRoot = yield* canonicalizePath(rawWorkspaceRoot)
     const paths = composedWorkspacePaths({ workspaceRoot, ownedMember })
     if (paths === undefined) {
       return yield* failure({
@@ -292,7 +333,7 @@ export const assertComposedOwnedWorkspace = ({
         message: `Invalid owned member '${ownedMember}'`,
       })
     }
-    yield* assertGitIdentity({ fs, bareRepo: normalizePath(bareRepo), branch, paths })
+    yield* assertGitIdentity({ fs, bareRepo, branch, paths })
     const { configPath, configName } = yield* readConfig(paths.ownedWorktree)
     yield* ensureRootConfig({ fs, paths, configName, createIfMissing: false })
     return {
@@ -302,7 +343,7 @@ export const assertComposedOwnedWorkspace = ({
       configPath,
       configName,
       ownedMember,
-      bareRepo: normalizePath(bareRepo),
+      bareRepo,
       branch,
     }
   }).pipe(
@@ -311,8 +352,8 @@ export const assertComposedOwnedWorkspace = ({
         ? cause
         : failure({
             reason: 'IoFailure',
-            path: workspaceRoot,
-            message: `Could not validate composed workspace '${workspaceRoot}'`,
+            path: rawWorkspaceRoot,
+            message: `Could not validate composed workspace '${rawWorkspaceRoot}'`,
             cause,
           }),
     ),
@@ -320,7 +361,7 @@ export const assertComposedOwnedWorkspace = ({
 
 /**
  * Create W directly at P/repos/<owned>, or resume that exact Git-authoritative birth.
- * No existing worktree is moved and no path is ever deleted on failure.
+ * A failed new birth removes only the workspace artifacts created by that invocation.
  */
 export const createComposedOwnedWorkspace = <R, E>({
   bareRepo: rawBareRepo,
@@ -343,8 +384,9 @@ export const createComposedOwnedWorkspace = <R, E>({
 > =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem
-    const bareRepo = normalizePath(rawBareRepo)
-    const paths = composedWorkspacePaths({ workspaceRoot: rawWorkspaceRoot, ownedMember })
+    const bareRepo = yield* canonicalizePath(rawBareRepo)
+    const workspaceRoot = yield* canonicalizePath(rawWorkspaceRoot)
+    const paths = composedWorkspacePaths({ workspaceRoot, ownedMember })
     if (paths === undefined || branch.length === 0 || branch.startsWith('-') === true) {
       return yield* failure({
         reason: 'InvalidRequest',
@@ -368,33 +410,160 @@ export const createComposedOwnedWorkspace = <R, E>({
       })
     }
 
-    if (exactRegistration.length === 0) {
-      if ((yield* fs.exists(asDir(paths.workspaceRoot))) === true) {
-        const canonicalRoot = (yield* fs.realPath(asDir(paths.workspaceRoot))).replace(/\/+$/u, '')
-        if (canonicalRoot !== paths.workspaceRoot) {
-          return yield* failure({
-            reason: 'ForeignRoot',
+    if (exactRegistration.length === 1) {
+      const { configName } = yield* readConfig(paths.ownedWorktree)
+      yield* ensureRootConfig({ fs, paths, configName, createIfMissing: true })
+      const composed = yield* assertComposedOwnedWorkspace({
+        bareRepo,
+        workspaceRoot: paths.workspaceRoot,
+        ownedMember,
+        branch,
+      })
+      const adminDir = yield* linkedWorktreeAdminDir({
+        fs,
+        bareRepo,
+        worktree: paths.ownedWorktree,
+      })
+      const clearIndexLock =
+        adminDir === undefined
+          ? Effect.void
+          : fs.remove(NodePath.join(adminDir, 'index.lock'), { force: true }).pipe(Effect.ignore)
+      yield* generate({
+        workspaceRoot: asDir(composed.workspaceRoot),
+        ownedWorktree: asDir(composed.ownedWorktree),
+        configPath: asFile(composed.configPath),
+        configName: composed.configName,
+      }).pipe(
+        Effect.mapError((cause) =>
+          failure({
+            reason: 'GenerationFailed',
             path: paths.workspaceRoot,
-            message: `Workspace root '${paths.workspaceRoot}' resolves to foreign path '${canonicalRoot}'`,
-          })
-        }
-        const rootStat = yield* fs.stat(asDir(paths.workspaceRoot))
-        if (rootStat.type !== 'Directory') {
-          return yield* failure({
-            reason: 'ForeignRoot',
-            path: paths.workspaceRoot,
-            message: `Workspace root '${paths.workspaceRoot}' is not a directory`,
-          })
-        }
-        const rootEntries = yield* fs.readDirectory(asDir(paths.workspaceRoot))
-        if (rootEntries.some((entry) => entry !== 'repos') === true) {
-          return yield* failure({
-            reason: 'ForeignRoot',
-            path: paths.workspaceRoot,
-            message: `Refusing existing workspace root '${paths.workspaceRoot}'; before Git registration it may contain only an empty 'repos' directory (found: ${rootEntries.join(', ')})`,
-          })
-        }
+            message: `Composition generation failed for '${paths.workspaceRoot}'`,
+            cause,
+          }),
+        ),
+        Effect.onExit((exit) => (Exit.isFailure(exit) === true ? clearIndexLock : Effect.void)),
+      )
+      return composed
+    }
+
+    const workspaceRootExisted = yield* fs.exists(asDir(paths.workspaceRoot))
+    if (workspaceRootExisted === true) {
+      const canonicalRoot = (yield* fs.realPath(asDir(paths.workspaceRoot))).replace(/\/+$/u, '')
+      if (canonicalRoot !== paths.workspaceRoot) {
+        return yield* failure({
+          reason: 'ForeignRoot',
+          path: paths.workspaceRoot,
+          message: `Workspace root '${paths.workspaceRoot}' resolves to foreign path '${canonicalRoot}'`,
+        })
       }
+      const rootStat = yield* fs.stat(asDir(paths.workspaceRoot))
+      if (rootStat.type !== 'Directory') {
+        return yield* failure({
+          reason: 'ForeignRoot',
+          path: paths.workspaceRoot,
+          message: `Workspace root '${paths.workspaceRoot}' is not a directory`,
+        })
+      }
+      const rootEntries = yield* fs.readDirectory(asDir(paths.workspaceRoot))
+      if (rootEntries.some((entry) => entry !== 'repos') === true) {
+        return yield* failure({
+          reason: 'ForeignRoot',
+          path: paths.workspaceRoot,
+          message: `Refusing existing workspace root '${paths.workspaceRoot}'; before Git registration it may contain only an empty 'repos' directory (found: ${rootEntries.join(', ')})`,
+        })
+      }
+    }
+    const reposExisted = yield* fs.exists(asDir(paths.reposPath))
+    const branchExisted =
+      startPoint === undefined
+        ? true
+        : yield* Git.refExists({ repoPath: bareRepo, ref: `refs/heads/${branch}` })
+
+    let createdWorktree = false
+    let generationStarted = false
+    let createdAdminDir: string | undefined
+    const rollback = Effect.gen(function* () {
+      if (createdWorktree === false) {
+        if (
+          reposExisted === false &&
+          (yield* fs.exists(asDir(paths.reposPath))) === true &&
+          (yield* fs.readDirectory(asDir(paths.reposPath))).length === 0
+        ) {
+          yield* fs.remove(asDir(paths.reposPath), { recursive: true })
+        }
+        if (
+          workspaceRootExisted === false &&
+          (yield* fs.exists(asDir(paths.workspaceRoot))) === true &&
+          (yield* fs.readDirectory(asDir(paths.workspaceRoot))).length === 0
+        ) {
+          yield* fs.remove(asDir(paths.workspaceRoot), { recursive: true })
+        }
+        return
+      }
+
+      const rootConfigs = ['megarepo.kdl', 'megarepo.json'] as const
+      for (const configName of rootConfigs) {
+        const rootConfig = NodePath.join(paths.workspaceRoot, configName)
+        const target = NodePath.join('repos', paths.ownedMember, configName)
+        const link = yield* fs.readLink(rootConfig).pipe(Effect.orElseSucceed(() => undefined))
+        if (link === target) yield* fs.remove(rootConfig)
+      }
+
+      const currentRegistrations = yield* command({
+        path: bareRepo,
+        effect: Git.listWorktrees(bareRepo),
+      })
+      const registeredHere = currentRegistrations.some(
+        (candidate) => normalizePath(candidate.path) === paths.ownedWorktree,
+      )
+      if (registeredHere === true) {
+        const removed = yield* Git.removeWorktree({
+          repoPath: bareRepo,
+          worktreePath: paths.ownedWorktree,
+          force: true,
+        }).pipe(Effect.result)
+        if (removed._tag === 'Failure') {
+          if (createdAdminDir !== undefined) {
+            yield* fs
+              .remove(NodePath.join(createdAdminDir, 'index.lock'), { force: true })
+              .pipe(Effect.ignore)
+          }
+          yield* Git.removeWorktree({
+            repoPath: bareRepo,
+            worktreePath: paths.ownedWorktree,
+            force: true,
+          })
+        }
+      } else if ((yield* fs.exists(asDir(paths.ownedWorktree))) === true) {
+        yield* fs.remove(asDir(paths.ownedWorktree), { recursive: true })
+        yield* Git.pruneWorktrees(bareRepo)
+      }
+
+      if (
+        startPoint !== undefined &&
+        branchExisted === false &&
+        (yield* Git.refExists({ repoPath: bareRepo, ref: `refs/heads/${branch}` })) === true
+      ) {
+        yield* Git.deleteBranch({ repoPath: bareRepo, branch, force: true })
+      }
+      if (
+        reposExisted === false &&
+        (yield* fs.exists(asDir(paths.reposPath))) === true &&
+        (yield* fs.readDirectory(asDir(paths.reposPath))).length === 0
+      ) {
+        yield* fs.remove(asDir(paths.reposPath), { recursive: true })
+      }
+      if (
+        workspaceRootExisted === false &&
+        (yield* fs.exists(asDir(paths.workspaceRoot))) === true &&
+        (yield* fs.readDirectory(asDir(paths.workspaceRoot))).length === 0
+      ) {
+        yield* fs.remove(asDir(paths.workspaceRoot), { recursive: true })
+      }
+    })
+
+    return yield* Effect.gen(function* () {
       yield* fs.makeDirectory(asDir(paths.reposPath), { recursive: true })
       const canonicalRepos = (yield* fs.realPath(asDir(paths.reposPath))).replace(/\/+$/u, '')
       if (canonicalRepos !== paths.reposPath) {
@@ -412,43 +581,68 @@ export const createComposedOwnedWorkspace = <R, E>({
           message: `Refusing non-empty unregistered repos directory '${paths.reposPath}' (found: ${repoEntries.join(', ')})`,
         })
       }
-      yield* command({
-        path: paths.ownedWorktree,
-        effect: Git.createWorktree({
-          repoPath: bareRepo,
-          worktreePath: paths.ownedWorktree,
-          branch,
-          createBranch: startPoint !== undefined,
-          ...(startPoint === undefined ? {} : { startPoint }),
-        }),
+      yield* Effect.uninterruptible(
+        command({
+          path: paths.ownedWorktree,
+          effect: Git.createWorktree({
+            repoPath: bareRepo,
+            worktreePath: paths.ownedWorktree,
+            branch,
+            createBranch: startPoint !== undefined,
+            ...(startPoint === undefined ? {} : { startPoint }),
+          }),
+        }).pipe(
+          Effect.tap(() =>
+            Effect.sync(() => {
+              createdWorktree = true
+            }),
+          ),
+        ),
+      )
+      createdAdminDir = yield* linkedWorktreeAdminDir({
+        fs,
+        bareRepo,
+        worktree: paths.ownedWorktree,
       })
-    }
 
-    const { configName } = yield* readConfig(paths.ownedWorktree)
-    yield* ensureRootConfig({ fs, paths, configName, createIfMissing: true })
-    const composed = yield* assertComposedOwnedWorkspace({
-      bareRepo,
-      workspaceRoot: paths.workspaceRoot,
-      ownedMember,
-      branch,
-    })
-    const context: OwnedWorkspaceGenerationContext = {
-      workspaceRoot: asDir(composed.workspaceRoot),
-      ownedWorktree: asDir(composed.ownedWorktree),
-      configPath: asFile(composed.configPath),
-      configName: composed.configName,
-    }
-    yield* generate(context).pipe(
-      Effect.mapError((cause) =>
-        failure({
-          reason: 'GenerationFailed',
-          path: paths.workspaceRoot,
-          message: `Composition generation failed for '${paths.workspaceRoot}'`,
-          cause,
-        }),
+      const { configName } = yield* readConfig(paths.ownedWorktree)
+      yield* ensureRootConfig({ fs, paths, configName, createIfMissing: true })
+      const composed = yield* assertComposedOwnedWorkspace({
+        bareRepo,
+        workspaceRoot: paths.workspaceRoot,
+        ownedMember,
+        branch,
+      })
+      generationStarted = true
+      yield* generate({
+        workspaceRoot: asDir(composed.workspaceRoot),
+        ownedWorktree: asDir(composed.ownedWorktree),
+        configPath: asFile(composed.configPath),
+        configName: composed.configName,
+      }).pipe(
+        Effect.mapError((cause) =>
+          failure({
+            reason: 'GenerationFailed',
+            path: paths.workspaceRoot,
+            message: `Composition generation failed for '${paths.workspaceRoot}'`,
+            cause,
+          }),
+        ),
+      )
+      return composed
+    }).pipe(
+      Effect.onExit((exit) =>
+        Exit.isFailure(exit) === false
+          ? Effect.void
+          : generationStarted === true
+            ? createdAdminDir === undefined
+              ? Effect.void
+              : fs
+                  .remove(NodePath.join(createdAdminDir, 'index.lock'), { force: true })
+                  .pipe(Effect.ignore)
+            : rollback,
       ),
     )
-    return composed
   }).pipe(
     Effect.mapError((cause) =>
       cause instanceof OwnedWorktreeAcquisitionError
@@ -464,8 +658,8 @@ export const createComposedOwnedWorkspace = <R, E>({
 
 /** Resolve a store branch root to W when Git registers the canonical composed shape. */
 export const resolveComposedStoreWorktree = ({
-  bareRepo,
-  workspaceRoot,
+  bareRepo: rawBareRepo,
+  workspaceRoot: rawWorkspaceRoot,
   branch,
 }: {
   readonly bareRepo: string
@@ -477,6 +671,8 @@ export const resolveComposedStoreWorktree = ({
   FileSystem.FileSystem | ChildProcessSpawner
 > =>
   Effect.gen(function* () {
+    const bareRepo = yield* canonicalizePath(rawBareRepo)
+    const workspaceRoot = yield* canonicalizePath(rawWorkspaceRoot)
     const registrations = yield* command({
       path: bareRepo,
       effect: Git.listWorktrees(bareRepo),
@@ -530,8 +726,8 @@ export const resolveStoreBranchWorktree = ({
 > =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem
-    const bareRepo = normalizePath(rawBareRepo)
-    const workspaceRoot = normalizePath(rawWorkspaceRoot)
+    const bareRepo = yield* canonicalizePath(rawBareRepo)
+    const workspaceRoot = yield* canonicalizePath(rawWorkspaceRoot)
     const registrations = yield* command({
       path: bareRepo,
       effect: Git.listWorktrees(bareRepo),

--- a/packages/@overeng/megarepo/src/composition/root/composition-root.ts
+++ b/packages/@overeng/megarepo/src/composition/root/composition-root.ts
@@ -22,6 +22,15 @@ export const COMPOSITION_ROOT_SCHEMA_VERSION = 1 as const
 export const DEFAULT_BUCK_ISOLATION_DIR = 'megarepo' as const
 
 const strictParseOptions = { errors: 'all', onExcessProperty: 'error' } as const
+const buckMemberManifestField: Readonly<Record<string, true>> = {
+  schemaVersion: true,
+  cell: true,
+  mount: true,
+  remoteCache: true,
+  projectIgnore: true,
+  distOverlays: true,
+  capabilities: true,
+}
 const textEncoder = new TextEncoder()
 
 const compareCodeUnits = ({
@@ -343,11 +352,18 @@ export const normalizeBuckMemberManifest = (manifest: BuckMemberManifest): BuckM
     ),
 })
 
-/** Strictly decode and canonically normalize an untrusted member manifest. */
-export const decodeBuckMemberManifest = (input: unknown): BuckMemberManifest =>
-  normalizeBuckMemberManifest(
-    Schema.decodeUnknownSync(BuckMemberManifestSchema, strictParseOptions)(input),
+/** Decode known top-level fields while preserving strict validation within each known field. */
+export const decodeBuckMemberManifest = (input: unknown): BuckMemberManifest => {
+  const projectedInput =
+    typeof input === 'object' && input !== null && Array.isArray(input) === false
+      ? Object.fromEntries(
+          Object.entries(input).filter(([field]) => buckMemberManifestField[field] === true),
+        )
+      : input
+  return normalizeBuckMemberManifest(
+    Schema.decodeUnknownSync(BuckMemberManifestSchema, strictParseOptions)(projectedInput),
   )
+}
 
 /** Strictly encode a member manifest with canonical arrays. */
 export const encodeBuckMemberManifest = (
@@ -358,11 +374,9 @@ export const encodeBuckMemberManifest = (
     strictParseOptions,
   )(normalizeBuckMemberManifest(manifest))
 
-/** Strictly decode the tracked JSON representation. */
+/** Decode the tracked JSON representation while projecting unknown newer top-level fields. */
 export const decodeBuckMemberManifestJson = (json: string): BuckMemberManifest =>
-  decodeBuckMemberManifest(
-    Schema.decodeSync(Schema.fromJsonString(Schema.Unknown), strictParseOptions)(json),
-  )
+  decodeBuckMemberManifest(Schema.decodeSync(Schema.fromJsonString(Schema.Unknown))(json))
 
 /** Canonical tracked JSON bytes, including one trailing newline. */
 export const encodeBuckMemberManifestJson = (manifest: BuckMemberManifest): string =>

--- a/packages/@overeng/megarepo/src/composition/root/composition-root.unit.test.ts
+++ b/packages/@overeng/megarepo/src/composition/root/composition-root.unit.test.ts
@@ -212,7 +212,6 @@ describe('buck2 member manifest', () => {
   })
 
   it.each([
-    ['unknown field', { ...manifest({ cell: 'alpha' }), unknown: true }],
     ['invalid cell', { ...manifest({ cell: 'bad/cell' }), cell: 'bad/cell' }],
     ['invalid mount', { ...manifest({ cell: 'alpha' }), mount: '/repos/alpha' }],
     ['parent ignore', { ...manifest({ cell: 'alpha' }), projectIgnore: ['../escape'] }],


### PR DESCRIPTION
## Problem

Fresh composition-enabled worktrees could fail in three connected ways: lexical store paths rejected a store reached through a symlink, installed `mr` rejected optional newer top-level `buck2-member.json` projections, and shared devenv tasks masked a failed `mr apply` with a later successful bookkeeping command. An interrupted birth could also leave Git state that normal creation could not safely resume.

## Goal

Make `mr store worktree new` create a usable composed root through the normal store path. Preserve Git-authoritative recovery when generation is interrupted. Make schema skew and legacy flat worktrees fail or recover explicitly instead of reporting false success.

## Decisions

- Canonicalize the deepest existing path ancestor at owned-worktree acquisition boundaries. This handles a non-existent final worktree below a symlinked store root.
- Project unknown top-level manifest fields only. Known fields and their nested schemas remain strict, so optional newer projections are forward-compatible without weakening validation.
- Roll back failures before generation. After generation starts, preserve the exact registered owned checkout, remove only an invocation-owned stale `index.lock`, and allow `store worktree new` to resume that exact target. Blanket removal of partially published member mounts would risk deleting foreign data.
- Run workspace registry refresh before composition application. This removes the fallible post-apply step while composition apply retains its ownership-checked recovery protocol.
- Add `set -euo pipefail` to shared mutation tasks so failed `mr` commands remain failed.

## Verification

Focused affected-path proof after the final rebase:

```text
4 test files passed
56 tests passed, 69 skipped
```

The task-shell regression also passes all 9 cases, including failed-`mr` exit propagation. `nixfmt --check` passes for the changed Nix module.

Fresh composed-root proof with `MEGAREPO_STORE` unset:

```text
nix run <candidate>#megarepo -- store worktree new ...   107.438s, exit 0
  root contained repos/<owned>, .megarepo/, BUCK, .buckroot, and .buckconfig

devenv tasks run mr:setup                                119.950s total
  mr:setup task                                            20.4s, exit 0

devenv tasks run check:quick                              67.790s, exit 1
  only failure: known main lint:nix:format issue
  nix/buck2-products/default.nix: not formatted
  TypeScript, Oxc lint, Genie, workspace, and megarepo checks passed
```

The full megarepo package suite completed 1,042 of 1,043 tests. The remaining unrelated store-GC fixture assertion is documented under Concerns.

## Complexity

Ledger proposal: **+226 build-machinery LOC** (tests, changelog, and generated/lock files excluded). The positive net is concentrated in explicit acquisition validation, interruption cleanup, and recoverable retry state. The operational leverage is immediate: this repairs the shared worktree path that every dependent migration row needs.

## Concerns

- Generation failure keeps the exact Git-authoritative checkout for safe retry instead of deleting partially published mounts without ownership proof.
- The full package suite consistently fails `should protect active worktrees registered by another workspace` because its `mr status` fixture exits 1 without captured stderr. The affected creation, acquisition, manifest, and task tests pass. This PR remains draft as requested.
- Running `check:quick` inside the intentionally supported legacy repair worktree additionally reaches the new loud recreate failure. The clean composed proof root reaches the expected main-only Nix formatting failure.

## Friction & bottlenecks

- Devenv shell evaluation took 86.2s in the fresh proof root and 1,007s in the legacy repair worktree. The latter dominates local feedback time.
- Commit signing did not complete non-interactively, so the commit was created unsigned after local verification.

## Follow-ups

- Diagnose the unrelated store-GC fixture failure before marking this draft ready.
- The existing Nix formatting failure on main remains outside this repair.

## References

Closes feedback rows FB-1707, FB-1736, and FB-1747.

Related: #1272

<!-- agent-footer:begin v=3 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | dev3.direct.omp.ppmuje7j |
| `session` | unknown |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.1.14 |
| `agent_runtime` | OMP 18.1.14 |
| `agent_model` | openai-codex/gpt-5.6-sol |
| `worktree` | 2026-09-12-worktree-repair/2026-09-12-worktree-repair |
| `tooling_profile` | dotfiles@4029a51-dirty |
</details>
<!-- agent-footer:end -->